### PR TITLE
Fix cursor jumping when editing EditableText within Dialog

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -130,10 +130,7 @@ export class EditableText extends React.Component<IEditableTextProps, IEditableT
 
     public render() {
         const { disabled, multiline } = this.props;
-        // the constructor and componentWillReceiveProps handle controlled case
-        // handleTextChange handles uncontrolled case
-        // rendered value should never depend on this.props.value
-        const value = this.state.value;
+        const value = (this.props.value == null ? this.state.value : this.props.value);
         const hasValue = (value != null && value !== "");
 
         const classes = classNames(

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -98,14 +98,18 @@ describe("<EditableText>", () => {
             assert.strictEqual(input.selectionEnd, 8);
         });
 
-        it("even when controlled via external value, should render with the most up-to-date state value", () => {
-            const wrapper = mount(<EditableText isEditing value="ello" />);
-            const expected = "Hello";
-            // simulating an internal state value change while the external prop is still explicitly set
-            wrapper.setState({ value: expected });
+        it("controlled mode can only change value via props", () => {
+            let expected = "alphabet";
+            const wrapper = mount(<EditableText isEditing={true} value={expected} />);
+            const inputElement = ReactDOM.findDOMNode(wrapper.instance()).query("input") as HTMLInputElement;
 
-            let actual = ReactDOM.findDOMNode(wrapper.instance()).query("input").value;
-            assert.strictEqual(actual, expected, "should never render with a stale prop value");
+            const input = wrapper.find("input");
+            input.simulate("change", { target: { value: "hello" } });
+            assert.strictEqual(inputElement.value, expected, "controlled mode can only change via props");
+
+            expected = "hello world";
+            wrapper.setProps({ value: expected });
+            assert.strictEqual(inputElement.value, expected, "controlled mode should be changeable via props");
         });
 
         // TODO: does not work in Phantom, only in Chrome (input.selectionStart is also equal to 8)


### PR DESCRIPTION
Fixes #15.

Basic summary of the fix:
- In controlled mode, handleTextChange was incorrectly setting state (instead of relying on the external onChange to pass a new value prop down).
- This would result in a render where the displayed value would be set to this.props.value, even though this.state.value contained the actual correct value.
- Immediately following this render, external onChange would finally send in a new value prop.
- Causing a flicker in the value set to the input while typing, last value followed by new value.
- Cursor would therefore jump to the end.