### PR TITLE
Tone down moon/sun theme switcher

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -305,6 +305,7 @@ $non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*
   &.pt-active {
     box-shadow: none;
     background: none;
+    color: $text-color;
   }
 
   &:hover {
@@ -328,6 +329,7 @@ $non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*
 
     &:hover {
       background: rgba($intent-color, 0.2);
+      color: $dark-text-color;
     }
 
     &:active,

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -152,10 +152,14 @@ $logo-width: $pt-grid-size * 2.8;
 
   &.pt-icon-moon {
     @include pt-button-minimal-intent($indigo3, $indigo3, $indigo4);
+
+    color: $pt-icon-color;
   }
 
   .pt-dark &.pt-icon-flash {
     @include pt-button-minimal-intent($gold4, $gold4, $gold5);
+
+    color: $pt-dark-icon-color;
   }
 }
 


### PR DESCRIPTION
Keep it standard icon color, but retain the nice colors on `:hover` and `:active`