### PR TITLE
Fix line-wrap flicker when hovering over color swatches

### DIFF
--- a/packages/docs/src/styles/_colors.scss
+++ b/packages/docs/src/styles/_colors.scss
@@ -203,8 +203,8 @@ label.docs-color-scheme-label { margin: ($pt-grid-size * 2) 0; }
   cursor: pointer;
   padding: 0 $pt-grid-size;
   line-height: 1;
-  font-size: $pt-font-size-small;
   white-space: nowrap;
+  font-size: $pt-font-size-small;
   transition: all $pt-transition-duration $pt-transition-ease;
 }
 


### PR DESCRIPTION
We reduced the container width on the external docs site. This caused color swatch on-hover text to line-break on the initial hover. Simple fix is to prevent line breaks via `white-space: nowrap`; that's what this PR does.

**Before:**
![before](https://cloud.githubusercontent.com/assets/443450/20078214/85b32ea8-a4f4-11e6-8da9-bb451f6238d9.gif)

**After:**
![after](https://cloud.githubusercontent.com/assets/443450/20078216/86d97d6e-a4f4-11e6-96fe-3f632360226f.gif)

Also, this is what happens on click. Close call, but it's workable:

**On Click:**
![on-click](https://cloud.githubusercontent.com/assets/443450/20078354/11d7c416-a4f5-11e6-84c6-d8292646caed.gif)
