### PR TITLE
Consider table header content when double-clicking to resize column

### DIFF
--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -60,7 +60,6 @@ export class Locator implements ILocator {
         const cellClasses = [
             `.bp-table-cell-col-${columnIndex}`,
             ".bp-table-column-name",
-            ".bp-table-header-content",
         ];
         const cells = this.tableElement.querySelectorAll(cellClasses.join(", "));
         let max = 0;


### PR DESCRIPTION
**Before:**
Only body content is considered when auto-resizing a column on double-click.
![before](https://cloud.githubusercontent.com/assets/443450/20159553/40bc4e4e-a696-11e6-8d45-cd33c2226385.gif)

**After:**
(No header content)
![after3](https://cloud.githubusercontent.com/assets/443450/20200098/e1b01c68-a763-11e6-806f-5b6555c186df.gif)

(With header content, which we ignore when recalculating column width)
![after](https://cloud.githubusercontent.com/assets/443450/20200075/bfbce5f0-a763-11e6-9056-c6610db79f06.gif)
![after2](https://cloud.githubusercontent.com/assets/443450/20200113/f2eb96a6-a763-11e6-85b8-808c0692275c.gif)
