### PR TITLE
npmignore TS json files

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -2,3 +2,5 @@ coverage/
 resources/
 test/
 typings/
+
+tsconfig.json

--- a/packages/datetime/.npmignore
+++ b/packages/datetime/.npmignore
@@ -2,3 +2,6 @@ coverage/
 resources/
 test/
 typings/
+
+tsconfig.json
+tsd.json

--- a/packages/table/.npmignore
+++ b/packages/table/.npmignore
@@ -4,3 +4,6 @@ resources/
 preview/
 test/
 typings/
+
+tsconfig.json
+typings.json


### PR DESCRIPTION
not needed for consumption and potentially error-prone to reuse our tsconfigs outside of this project