### PR TITLE
Landing: put description and buttons on top of components image

### DIFF
--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -106,6 +106,9 @@ header {
     padding: $pt-grid-size * 9 0;
 
     .pt-container {
+      position: relative;
+      z-index: $pt-z-index-content;
+
       h2 {
         margin-bottom: $pt-grid-size * 3;
         max-width: calc(50% - #{$pt-grid-size * 5});


### PR DESCRIPTION
Fixes this issue:
<img width="642" alt="screen shot 2016-11-12 at 1 35 56 pm" src="https://cloud.githubusercontent.com/assets/199754/20242255/f4f7f4e2-a8dc-11e6-9479-de4b42cd246b.png">
