### PR TITLE
Remove meta viewport tag from docs

### DIFF
--- a/packages/docs/src/index.html
+++ b/packages/docs/src/index.html
@@ -10,7 +10,6 @@
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="stylesheet" href="docs.css">
   <link rel="icon" href="../resources/favicon.png" sizes="32x32" type="image/png" />


### PR DESCRIPTION
This makes the docs work better on mobile. It's not a full solution, but it's an improvement over the way it is now