### PR TITLE
smarter sass watcher

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -2,6 +2,6 @@
 node_modules
 build
 dist
-docs
+/docs
 generated
 coverage

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -111,14 +111,4 @@ module.exports = (gulp, plugins, blueprint) => {
     });
 
     gulp.task("sass", ["sass-lint", "sass-compile"]);
-
-    blueprint.task("sass", "watch", (project) => {
-        // compute watch dependencies (this task has no body)
-        const sassDeps = [`sass-compile-w-${project.id}`];
-        if (project.id !== "docs") {
-            // docs project does not need these dependencies
-            sassDeps.push("sass-variables", "docs-kss");
-        }
-        return sassDeps;
-    }, () => {});
 };

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -18,9 +18,13 @@ module.exports = (gulp, plugins, blueprint) => {
 
     gulp.task("watch-files", ["connect"], () => {
         blueprint.projectsWithBlock("sass").forEach((project) => {
+            const tasks = [`sass-compile-w-${project.id}`];
+            if (project.id !== "docs") {
+                tasks.push("sass-variables", "docs-kss");
+            }
             gulp.watch(
                 [`${project.cwd}/src/**/*.scss`, `!${project.cwd}/src/**/generated/*.scss`],
-                [`sass-watch-${project.id}`]
+                tasks
             );
         });
 


### PR DESCRIPTION
- [x] Sass watching bugfix

- remove `sass-watch-*` tasks
- determine tasks to run when calling `gulp.watch` instead of inside
  the `sass-watch-*` task
- this fixes an issue where changing docs scss files would recompile
  almost everything else (due to docs project deps in gulp file)