### PR TITLE
Fix inline Popover closing via Escape keypress

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -468,7 +468,8 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     private handleOverlayClose = (e: React.SyntheticEvent<HTMLElement>) => {
         const eventTarget = e.target as HTMLElement;
         // if click was in target, target event listener will handle things, so don't close
-        if (!Utils.elementIsOrContains(this.targetElement, eventTarget)) {
+        if (!Utils.elementIsOrContains(this.targetElement, eventTarget)
+                || e.nativeEvent instanceof KeyboardEvent) {
             this.setOpenState(false, e);
         }
     }

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -175,6 +175,8 @@ describe("<Popover>", () => {
             assert.isTrue(wrapper.state("isOpen"));
             wrapper.setProps({ isOpen: false }).simulateTarget("click");
             assert.isFalse(wrapper.state("isOpen"));
+            wrapper = renderPopover({ canEscapeKeyClose: true, isOpen: true }).sendEscapeKey();
+            assert.isTrue(wrapper.state("isOpen"));
         });
 
         it("setting isDisabled=true throws error", () => {
@@ -320,6 +322,14 @@ describe("<Popover>", () => {
             assert.isFalse(wrapper.state("isOpen"));
         });
 
+        it("pressing Escape closes popover when canEscapeKeyClose=true and inline=true", () => {
+            wrapper = renderPopover({ canEscapeKeyClose: true, inline: true });
+            wrapper.simulateTarget("click");
+            assert.isTrue(wrapper.state("isOpen"));
+            wrapper.sendEscapeKey();
+            assert.isFalse(wrapper.state("isOpen"));
+        });
+
         it("setting isDisabled=true prevents opening popover", () => {
             wrapper = renderPopover({
                 interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
@@ -407,7 +417,10 @@ describe("<Popover>", () => {
             return wrapper;
         };
         wrapper.sendEscapeKey = () => {
-            wrapper.findClass(Classes.OVERLAY_OPEN).simulate("keydown", { which: Keys.ESCAPE });
+            wrapper.findClass(Classes.OVERLAY_OPEN).simulate("keydown", {
+                nativeEvent: new KeyboardEvent("keydown"),
+                which: Keys.ESCAPE,
+            });
             return wrapper;
         };
         return wrapper;


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: fixes #152
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests

#### What changes did you make?

When Overlay calls its onClose callback within `handleKeyDown`, an inline Popover's targetElement is contained within the eventTarget. Popover's `handleOverlayClose` should only disable closing for click events, so I added a case to allow the KeyboardEvent to trigger the close.