### PR TITLE
Permit hotkey behavior within checkboxes and radio buttons

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -93,7 +93,26 @@ export class HotkeysEvents {
         if (elem == null || elem.closest == null) {
             return false;
         }
+
         const editable = elem.closest("input, textarea, [contenteditable=true]");
-        return editable != null && !(editable as HTMLInputElement).readOnly;
+
+        if (editable == null) {
+            return false;
+        }
+
+        // don't let checkboxes, switches, and radio buttons prevent hotkey behavior
+        if (editable.tagName.toLowerCase() === "input") {
+            const inputType = (editable as HTMLInputElement).type;
+            if (inputType === "checkbox" || inputType === "radio") {
+                return false;
+            }
+        }
+
+        // don't let read-only fields prevent hotkey behavior
+        if ((editable as HTMLInputElement).readOnly) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -53,21 +53,6 @@ describe("Hotkeys", () => {
             }
         }
 
-        function assertInputAllowsKeys(type: string, allowsKeys: boolean) {
-            comp = mount(<TestComponent />, { attachTo });
-
-            const selector = "input[type='" + type + "']";
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector(selector);
-
-            (input as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.equal(allowsKeys);
-
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.equal(allowsKeys);
-        }
-
         beforeEach(() => {
             localHotkeySpy = sinon.spy();
             globalHotkeySpy = sinon.spy();
@@ -167,6 +152,21 @@ describe("Hotkeys", () => {
             const testCombo = getKeyComboString(handleKeyDown.firstCall.args[0]);
             expect(testCombo).to.equal(combo);
         });
+
+        function assertInputAllowsKeys(type: string, allowsKeys: boolean) {
+            comp = mount(<TestComponent />, { attachTo });
+
+            const selector = "input[type='" + type + "']";
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector(selector);
+
+            (input as HTMLElement).focus();
+
+            dispatchTestKeyboardEvent(input, "keydown", "1");
+            expect(localHotkeySpy.called).to.equal(allowsKeys);
+
+            dispatchTestKeyboardEvent(input, "keydown", "2");
+            expect(globalHotkeySpy.called).to.equal(allowsKeys);
+        }
     });
 
     describe("KeyCombo parser", () => {

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -53,6 +53,21 @@ describe("Hotkeys", () => {
             }
         }
 
+        function assertInputAllowsKeys(type: string, allowsKeys: boolean) {
+            comp = mount(<TestComponent />, { attachTo });
+
+            const selector = "input[type='" + type + "']";
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector(selector);
+
+            (input as HTMLElement).focus();
+
+            dispatchTestKeyboardEvent(input, "keydown", "1");
+            expect(localHotkeySpy.called).to.equal(allowsKeys);
+
+            dispatchTestKeyboardEvent(input, "keydown", "2");
+            expect(globalHotkeySpy.called).to.equal(allowsKeys);
+        }
+
         beforeEach(() => {
             localHotkeySpy = sinon.spy();
             globalHotkeySpy = sinon.spy();
@@ -90,63 +105,23 @@ describe("Hotkeys", () => {
         });
 
         it("ignores hotkeys when inside text input", () => {
-            comp = mount(<TestComponent />, { attachTo });
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='text']");
-            (input as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.false;
-
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.false;
+            assertInputAllowsKeys("text", false);
         });
 
         it("ignores hotkeys when inside number input", () => {
-            comp = mount(<TestComponent />, { attachTo });
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='number']");
-            (input as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.false;
-
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.false;
+            assertInputAllowsKeys("number", false);
         });
 
         it("ignores hotkeys when inside password input", () => {
-            comp = mount(<TestComponent />, { attachTo });
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='password']");
-            (input as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.false;
-
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.false;
+            assertInputAllowsKeys("password", false);
         });
 
         it("triggers hotkeys when inside checkbox input", () => {
-            comp = mount(<TestComponent />, { attachTo });
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='checkbox']");
-            (input as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.true;
-
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.true;
+            assertInputAllowsKeys("checkbox", true);
         });
 
         it("triggers hotkeys when inside radio input", () => {
-            comp = mount(<TestComponent />, { attachTo });
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='radio']");
-            (input as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.true;
-
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.true;
+            assertInputAllowsKeys("radio", true);
         });
 
         it("triggers hotkey dialog with \"?\"", (done) => {

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -40,7 +40,16 @@ describe("Hotkeys", () => {
             }
 
             public render() {
-                return <div><input type="text" /><div>Other stuff</div></div>;
+                return (
+                    <div>
+                        <input type="text" />
+                        <input type="number" />
+                        <input type="password" />
+                        <input type="checkbox" />
+                        <input type="radio" />
+                        <div>Other stuff</div>
+                    </div>
+                );
             }
         }
 
@@ -82,7 +91,7 @@ describe("Hotkeys", () => {
 
         it("ignores hotkeys when inside text input", () => {
             comp = mount(<TestComponent />, { attachTo });
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input");
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='text']");
             (input as HTMLElement).focus();
 
             dispatchTestKeyboardEvent(input, "keydown", "1");
@@ -90,6 +99,54 @@ describe("Hotkeys", () => {
 
             dispatchTestKeyboardEvent(input, "keydown", "2");
             expect(globalHotkeySpy.called).to.be.false;
+        });
+
+        it("ignores hotkeys when inside number input", () => {
+            comp = mount(<TestComponent />, { attachTo });
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='number']");
+            (input as HTMLElement).focus();
+
+            dispatchTestKeyboardEvent(input, "keydown", "1");
+            expect(localHotkeySpy.called).to.be.false;
+
+            dispatchTestKeyboardEvent(input, "keydown", "2");
+            expect(globalHotkeySpy.called).to.be.false;
+        });
+
+        it("ignores hotkeys when inside password input", () => {
+            comp = mount(<TestComponent />, { attachTo });
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='password']");
+            (input as HTMLElement).focus();
+
+            dispatchTestKeyboardEvent(input, "keydown", "1");
+            expect(localHotkeySpy.called).to.be.false;
+
+            dispatchTestKeyboardEvent(input, "keydown", "2");
+            expect(globalHotkeySpy.called).to.be.false;
+        });
+
+        it("triggers hotkeys when inside checkbox input", () => {
+            comp = mount(<TestComponent />, { attachTo });
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='checkbox']");
+            (input as HTMLElement).focus();
+
+            dispatchTestKeyboardEvent(input, "keydown", "1");
+            expect(localHotkeySpy.called).to.be.true;
+
+            dispatchTestKeyboardEvent(input, "keydown", "2");
+            expect(globalHotkeySpy.called).to.be.true;
+        });
+
+        it("triggers hotkeys when inside radio input", () => {
+            comp = mount(<TestComponent />, { attachTo });
+            const input = ReactDOM.findDOMNode(comp.instance()).querySelector("input[type='radio']");
+            (input as HTMLElement).focus();
+
+            dispatchTestKeyboardEvent(input, "keydown", "1");
+            expect(localHotkeySpy.called).to.be.true;
+
+            dispatchTestKeyboardEvent(input, "keydown", "2");
+            expect(globalHotkeySpy.called).to.be.true;
         });
 
         it("triggers hotkey dialog with \"?\"", (done) => {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #145 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### What changes did you make?

Hotkey behavior is now properly triggered when the user is focused within a checkbox or radio button. (Previously, the hotkey behavior was prevented unnecessarily.) Also added new unit tests to verify this behavior.

#### Is there anything you'd like reviewers to focus on?

Nothing in particular.