### PR TITLE
IntentSelect uses Intent as value.

### DIFF
--- a/packages/core/examples/common/intentSelect.tsx
+++ b/packages/core/examples/common/intentSelect.tsx
@@ -6,10 +6,13 @@
 import { Intent } from "../../src/common/intent";
 import * as React from "react";
 
-const INTENTS = ["Primary", "Success", "Warning", "Danger"].map((label) => (
-    { label, value: (Intent as any)[label.toUpperCase()] }
-));
-INTENTS.unshift({ label: "None", value: "-1" });
+const INTENTS = [
+    { label: "None", value: Intent.NONE },
+    { label: "Primary", value: Intent.PRIMARY },
+    { label: "Success", value: Intent.SUCCESS },
+    { label: "Warning", value: Intent.WARNING },
+    { label: "Danger", value: Intent.DANGER },
+];
 
 export interface IIntentSelectProps {
     intent: Intent;
@@ -20,7 +23,7 @@ export const IntentSelect: React.SFC<IIntentSelectProps> = (props) => (
     <label className="pt-label">
         Intent
         <div className="pt-select">
-            <select value={Intent[props.intent]} onChange={props.onChange}>
+            <select value={props.intent} onChange={props.onChange}>
                 {INTENTS.map((opt, i) => <option key={i} value={opt.value}>{opt.label}</option>)}
             </select>
         </div>

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -136,8 +136,8 @@ export function iconClass(iconName: string) {
     return iconName.indexOf("pt-icon-") === 0 ? iconName : `pt-icon-${iconName}`;
 }
 
-export function intentClass(intent: Intent) {
-    if (intent == null || Intent[intent] == null) {
+export function intentClass(intent = Intent.NONE) {
+    if (intent === Intent.NONE || Intent[intent] == null) {
         return undefined;
     }
     return `pt-intent-${Intent[intent].toLowerCase()}`;

--- a/packages/core/src/common/intent.ts
+++ b/packages/core/src/common/intent.ts
@@ -7,6 +7,7 @@
  * The four basic intents.
  */
 export enum Intent {
+    NONE = -1,
     PRIMARY,
     SUCCESS,
     WARNING,


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #154 

#### What changes did you make?

`IntentSelect` uses the `Intent` as its `value` so it'll update as the value is changed.

Also added `Intent.NONE` which can be used instead of null values when you don't want an intent.