### PR TITLE
remove docs versions selector

### DIFF
--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -191,18 +191,17 @@ module.exports = (gulp, plugins, blueprint) => {
         child.stdout.setEncoding("utf8");
         child.stdout.on("data", data => { stdout += data; });
         child.on("close", () => {
-            const versions = stdout
-                .split("\n")
+            /** @type {Map<string, string>} */
+            const majorVersionMap = stdout.split("\n")
                 .filter(val => /release-[1-9]\d*\.\d+\.\d+.*/.test(val))
-                .map(val => val.slice(8));
-            // reduce to only the latest release of each major version
-            const majorVersionMap = versions.reduce((map, version) => {
-                const major = semver.major(version);
-                if (!map.has(major) || semver.gt(version, map.get(major))) {
-                    map.set(major, version);
-                }
-                return map;
-            }, new Map());
+                .map(val => val.slice(8))
+                .reduce((map, version) => {
+                    const major = semver.major(version);
+                    if (!map.has(major) || semver.gt(version, map.get(major))) {
+                        map.set(major, version);
+                    }
+                    return map;
+                }, new Map());
             // sort in reverse order (so latest is first)
             const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
             text.fileStream(filenames.versions, JSON.stringify(majorVersions, null, 2))

--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -185,22 +185,29 @@ module.exports = (gulp, plugins, blueprint) => {
     });
 
     // create a JSON file containing published versions of the documentation
-    gulp.task("docs-versions", () => {
-        var stdout = "";
-        var child = spawn("git", ["tag"]);
+    gulp.task("docs-versions", (done) => {
+        let stdout = "";
+        const child = spawn("git", ["tag"]);
         child.stdout.setEncoding("utf8");
         child.stdout.on("data", data => { stdout += data; });
         child.on("close", () => {
-            // static list of versions to include prior to being captured by `git tag`
-            // TODO remove when published
-            var INCLUDE_LIST = ["1.0.0"];
-            var versions = stdout
+            const versions = stdout
                 .split("\n")
-                .filter(val => /release-\d+\.\d+\.\d+.*/.test(val))
+                .filter(val => /release-[1-9]\d*\.\d+\.\d+.*/.test(val))
                 .map(val => val.slice(8));
-            versions = INCLUDE_LIST.concat(versions).sort(semver.compare);
-            return text.fileStream(filenames.versions, JSON.stringify(versions, null, 2))
+            // reduce to only the latest release of each major version
+            const majorVersionMap = versions.reduce((map, version) => {
+                const major = semver.major(version);
+                if (!map.has(major) || semver.gt(version, map.get(major))) {
+                    map.set(major, version);
+                }
+                return map;
+            }, new Map());
+            // sort in reverse order (so latest is first)
+            const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
+            text.fileStream(filenames.versions, JSON.stringify(majorVersions, null, 2))
                 .pipe(gulp.dest(config.data));
+            done();
         });
     });
 };

--- a/packages/docs/src/components/navbar.tsx
+++ b/packages/docs/src/components/navbar.tsx
@@ -35,7 +35,11 @@ export class Navbar extends React.Component<INavbarProps, {}> {
     public render() {
         return (
             <div className="pt-navbar docs-navbar docs-flex-row">
-                {this.renderVersionsMenu()}
+                <div className="pt-navbar-group">
+                    <div className="docs-logo" />
+                    <div className="pt-navbar-heading docs-heading">Blueprint</div>
+                    {this.renderVersionsMenu()}
+                </div>
                 <div className="pt-navbar-group">
                     {this.props.children}
                 </div>
@@ -101,6 +105,10 @@ export class Navbar extends React.Component<INavbarProps, {}> {
 
     private renderVersionsMenu() {
         const { versions } = this.props;
+        if (versions.length === 1) {
+            return <div className="pt-text-muted">v{versions[0].version}</div>;
+        }
+
         const match = /releases\/([^\/]+)\/dist/.exec(location.href);
         // default to latest release if we can't find a tag in the URL
         const currentRelease = (match == null ? versions[0].version : match[1]);
@@ -110,15 +118,11 @@ export class Navbar extends React.Component<INavbarProps, {}> {
         const menu = <Menu className="docs-version-list">{releaseItems}</Menu>;
 
         return (
-            <div className="pt-navbar-group">
-                <div className="docs-logo" />
-                <div className="pt-navbar-heading docs-heading">Blueprint</div>
-                <Popover content={menu} position={Position.BOTTOM}>
-                    <button className="docs-version-selector pt-text-muted">
-                        v{currentRelease} <span className="pt-icon-standard pt-icon-caret-down" />
-                    </button>
-                </Popover>
-            </div>
+            <Popover content={menu} position={Position.BOTTOM}>
+                <button className="docs-version-selector pt-text-muted">
+                    v{currentRelease} <span className="pt-icon-standard pt-icon-caret-down" />
+                </button>
+            </Popover>
         );
     }
 

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -22,7 +22,7 @@ const releases = require<IPackageInfo[]>("./generated/releases.json")
         pkg.url = `https://www.npmjs.com/package/${pkg.name}`;
         return pkg;
     });
-const versions = require<string[]>("./generated/versions.json").reverse()
+const versions = require<string[]>("./generated/versions.json")
     .map((version) => ({
         url: `https://palantir.github.io/blueprint/docs/${version}`,
         version,


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: closes #129

#### What changes did you make?

- `docs-versions` gulp task outputs latest release of each major version (instead of all tags) in reverse order (latest first)
- hide versions menu if there's only one version
- as there's only one major version here, this PR ends up hiding the version selector which fixes #129 (as you can't get to those broken links)
