### PR TITLE
Remove flexbox usage in landing to fix mobile layout

### DIFF
--- a/packages/landing/src/index.html
+++ b/packages/landing/src/index.html
@@ -87,6 +87,7 @@
             Color combinations and keyboard interactions have been carefully crafted to be accessible.
           </div>
         </div>
+        <div class="clear"></div>
       </div>
     </div>
     <div class="pt-getting-started pt-dark">

--- a/packages/landing/src/index.html
+++ b/packages/landing/src/index.html
@@ -87,7 +87,6 @@
             Color combinations and keyboard interactions have been carefully crafted to be accessible.
           </div>
         </div>
-        <div class="clear"></div>
       </div>
     </div>
     <div class="pt-getting-started pt-dark">

--- a/packages/landing/src/index.html
+++ b/packages/landing/src/index.html
@@ -87,6 +87,7 @@
             Color combinations and keyboard interactions have been carefully crafted to be accessible.
           </div>
         </div>
+        <div class="pt-clear"></div>
       </div>
     </div>
     <div class="pt-getting-started pt-dark">

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -491,7 +491,3 @@ header {
     }
   }
 }
-
-.clear {
-  clear: both;
-}

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -145,20 +145,16 @@ header {
     }
   }
 
-  .pt-features {
-    display: flex;
+  .pt-feature-column:nth-child(1) {
+    float: left;
+    width: calc((100% - (#{$pt-grid-size} * 4)) / 2);
+    max-width: $pt-grid-size * 36.4;
   }
 
-  .pt-feature-column {
-    flex: 0 0 50%;
-
-    &:not(:first-child) {
-      padding-left: $pt-grid-size * 4;
-    }
-
-    &:not(:last-child) {
-      padding-right: $pt-grid-size * 4;
-    }
+  .pt-feature-column:nth-child(2) {
+    float: right;
+    width: calc((100% - (#{$pt-grid-size} * 4)) / 2);
+    max-width: $pt-grid-size * 36.4;
   }
 
   .pt-feature {
@@ -384,9 +380,25 @@ header {
     .pt-feature {
       img {
         float: none;
+        margin-right: 0;
         margin-bottom: $pt-grid-size / 2;
         margin-left: -$pt-grid-size / 2;
       }
+    }
+  }
+
+  .pt-features {
+    padding: 0 25%;
+
+    .pt-feature-column:nth-child(1),
+    .pt-feature-column:nth-child(2) {
+      float: none;
+      width: auto;
+      text-align: center;
+    }
+
+    .pt-feature-column:nth-child(2) {
+      padding-top: $pt-grid-size * 6;
     }
   }
 }
@@ -420,10 +432,12 @@ header {
   }
 
   .pt-features {
-    flex-direction: column;
     padding: 0 0 $pt-grid-size * 5;
 
-    .pt-feature-column {
+    .pt-feature-column:nth-child(1),
+    .pt-feature-column:nth-child(2) {
+      text-align: start;
+
       &:not(:first-child),
       &:not(:last-child) {
         padding: 0 $pt-grid-size * 2;
@@ -436,6 +450,7 @@ header {
 
       img {
         float: none;
+        margin-right: $pt-grid-size * 3;
         margin-bottom: $pt-grid-size / 2;
         margin-left: -$pt-grid-size / 2;
       }
@@ -469,4 +484,8 @@ header {
       background: $pt-dark-divider-white;
     }
   }
+}
+
+.clear {
+  clear: both;
 }

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -145,16 +145,17 @@ header {
     }
   }
 
-  .pt-feature-column:nth-child(1) {
-    float: left;
+  .pt-feature-column {
     width: calc((100% - (#{$pt-grid-size} * 4)) / 2);
     max-width: $pt-grid-size * 36.4;
-  }
 
-  .pt-feature-column:nth-child(2) {
-    float: right;
-    width: calc((100% - (#{$pt-grid-size} * 4)) / 2);
-    max-width: $pt-grid-size * 36.4;
+    &:nth-child(1) {
+      float: left;
+    }
+
+    &:nth-child(2) {
+      float: right;
+    }
   }
 
   .pt-feature {
@@ -390,15 +391,18 @@ header {
   .pt-features {
     padding: 0 25%;
 
-    .pt-feature-column:nth-child(1),
-    .pt-feature-column:nth-child(2) {
-      float: none;
+    .pt-feature-column {
       width: auto;
       text-align: center;
-    }
 
-    .pt-feature-column:nth-child(2) {
-      padding-top: $pt-grid-size * 6;
+      &:nth-child(1),
+      &:nth-child(2) {
+        float: none;
+      }
+
+      &:nth-child(2) {
+        padding-top: $pt-grid-size * 6;
+      }
     }
   }
 }
@@ -434,8 +438,7 @@ header {
   .pt-features {
     padding: 0 0 $pt-grid-size * 5;
 
-    .pt-feature-column:nth-child(1),
-    .pt-feature-column:nth-child(2) {
+    .pt-feature-column {
       text-align: start;
 
       &:not(:first-child),

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -468,6 +468,7 @@ header {
   }
 
   .pt-about {
+    clear: both;
     padding: $pt-grid-size * 5 0 0;
 
     .pt-hiring {

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -332,6 +332,10 @@ header {
   }
 }
 
+.pt-clear {
+  clear: both;
+}
+
 // no need create variables for these
 // stylelint-disable media-feature-name-no-vendor-prefix, scss/media-feature-value-dollar-variable
 // for greater resolution than retina
@@ -402,10 +406,6 @@ header {
       }
     }
   }
-
-  .pt-getting-started {
-    clear: both;
-  }
 }
 
 @media (max-width: $mobile-breakpoint) {
@@ -468,7 +468,6 @@ header {
   }
 
   .pt-about {
-    clear: both;
     padding: $pt-grid-size * 5 0 0;
 
     .pt-hiring {

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -396,12 +396,10 @@ header {
       width: calc(50% - #{$pt-grid-size * 2});
 
       &:nth-child(1) {
-        float: left;
         margin-right: $pt-grid-size * 2;
       }
 
       &:nth-child(2) {
-        float: right;
         margin-left: $pt-grid-size * 2;
       }
     }

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -146,8 +146,7 @@ header {
   }
 
   .pt-feature-column {
-    width: calc((100% - (#{$pt-grid-size} * 4)) / 2);
-    max-width: $pt-grid-size * 36.4;
+    max-width: calc(50% - #{$pt-grid-size} * 4);
 
     &:nth-child(1) {
       float: left;
@@ -389,21 +388,23 @@ header {
   }
 
   .pt-features {
-    padding: 0 25%;
-
     .pt-feature-column {
-      width: auto;
-      text-align: center;
+      width: calc(50% - #{$pt-grid-size * 2});
 
-      &:nth-child(1),
-      &:nth-child(2) {
-        float: none;
+      &:nth-child(1) {
+        float: left;
+        margin-right: $pt-grid-size * 2;
       }
 
       &:nth-child(2) {
-        padding-top: $pt-grid-size * 6;
+        float: right;
+        margin-left: $pt-grid-size * 2;
       }
     }
+  }
+
+  .pt-getting-started {
+    clear: both;
   }
 }
 
@@ -436,14 +437,16 @@ header {
   }
 
   .pt-features {
-    padding: 0 0 $pt-grid-size * 5;
+    padding-bottom: $pt-grid-size * 5;
 
     .pt-feature-column {
-      text-align: start;
+      width: auto;
+      max-width: none;
 
       &:not(:first-child),
       &:not(:last-child) {
-        padding: 0 $pt-grid-size * 2;
+        float: none;
+        margin: 0;
       }
     }
 


### PR DESCRIPTION
#### PR checklist

- [x] Fixes sub-issue mentioned in #105 remarks by @sixinli
- [x] Landing update

#### What changes did you make?

Removed flexbox usage on the landing page and switched to floats for the column features.

#### Is there anything you'd like reviewers to focus on?

I'm not super experienced in responsive design, so any comments greatly appreciated. 

Please test in browser at full screen, 768 vs 769 width as well as 425 vs 426 width, as well as with the iPhone simulator. My original repro is from iPhone 6, iOS 9.2:
![screen shot 2016-11-14 at 6 25 20 pm](https://cloud.githubusercontent.com/assets/2013545/20311801/f6b4d54a-ab05-11e6-85a3-741ba57fa33f.png)

Screen recording of new behavior, specifically chose to center when viewing at the tablet width:
![desktop](https://cloud.githubusercontent.com/assets/2013545/20311871/3bac329c-ab06-11e6-9635-c4f0bd50ca67.gif)

![mobile](https://cloud.githubusercontent.com/assets/2013545/20312056/de146176-ab06-11e6-9783-18fb89adc33c.gif)

P.S. May need @llorca or @cmslewis to assist getting this past the review process, as I'm about to lose internet over the next day while in the air so I won't be able to follow up until later. If not, I'll take care of it as soon as possible.