### PR TITLE
brilliant docs anchors!

### DIFF
--- a/packages/docs/src/components/section.tsx
+++ b/packages/docs/src/components/section.tsx
@@ -28,8 +28,9 @@ export interface ISectionProps extends IStyleguideExtensionProps, IProps {
 export const SectionHeading: React.SFC<{ depth: number, header: string, reference: string }> =
     ({ depth, header, reference }) => (
         // use createElement so we can dynamically choose tag based on depth
-        React.createElement(`h${depth}`, { className: "kss-title", id: reference },
-            <a className="kss-anchor" href={"#" + reference} key={0}>
+        React.createElement(`h${depth}`, { className: "kss-title" },
+            <a className="docs-anchor" key="anchor" name={reference} />,
+            <a className="docs-anchor-link" href={"#" + reference} key="link">
                 <span className="pt-icon-standard pt-icon-link" />
             </a>,
             header

--- a/packages/docs/src/components/styleguide.tsx
+++ b/packages/docs/src/components/styleguide.tsx
@@ -230,8 +230,8 @@ export class Styleguide extends React.Component<IStyleguideProps, IStyleguideSta
         const { offsetLeft } = this.contentElement;
         // horizontal offset comes from section left padding, vertical offset from navbar height + 10px
         // test twice to ignore little blank zones that resolve to the parent section
-        const refA = getReferenceAt(offsetLeft + 50, 60);
-        const refB = getReferenceAt(offsetLeft + 50, 70);
+        const refA = getReferenceAt(offsetLeft + 50, 90);
+        const refB = getReferenceAt(offsetLeft + 50, 100);
         if (refA == null || refB == null) { return; }
         // use the longer (deeper) name to avoid jumping up between sections
         const activeSectionId = (refA.length > refB.length ? refA : refB);

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -58,8 +58,8 @@ ReactDOM.render(
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
-// scroll down a bit when loading on a hash anchor so it appears below the fixed navbar.
+// scroll down a bit when the page loads so the first heading appears below the fixed navbar.
 // i think this is necessary because the negative margin trick doesn't work on page load
 // with react (might work via SSR where HTML is already there).
 // (80px = navbar height + content padding)
-if (location.hash) { scrollBy(0, -80); }
+scrollBy(0, -80);

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -57,3 +57,9 @@ ReactDOM.render(
 // tslint:enable:jsx-no-lambda
 
 FocusStyleManager.onlyShowFocusOnTabs();
+
+// scroll down a bit when loading on a hash anchor so it appears below the fixed navbar.
+// i think this is necessary because the negative margin trick doesn't work on page load
+// with react (might work via SSR where HTML is already there).
+// (80px = navbar height + content padding)
+if (location.hash) { scrollBy(0, -80); }

--- a/packages/docs/src/styles/_content.scss
+++ b/packages/docs/src/styles/_content.scss
@@ -25,18 +25,25 @@ $dark-example-background-color: $dark-content-background-color;
 .kss-description > h6 {
   position: relative;
   // always override header margins
-  margin: 0 0 ($heading-margin / 2) !important; // stylelint-disable-line declaration-no-important
-  padding-top: $content-padding;
+  margin: $heading-margin 0 ($heading-margin / 2) !important; // stylelint-disable-line declaration-no-important
 }
 
-.kss-anchor {
+// this element inside the <h*> tag creates extra space above when it is targeted by the location hash
+// but it doesn't change the bounds of the element or interfere with interactions. (thanks React docs site!)
+// so the heading will appear _below_ the navbar (since the navbar covers the top 50px of window).
+.docs-anchor {
+  position: absolute;
+  margin-top: -$pt-navbar-height - $content-padding;
+}
+
+.docs-anchor-link {
   @include pt-icon-colors();
   position: absolute;
   top: 50%;
   left: 0;
   transform: translate(-100%, -50%);
   opacity: 0;
-  padding: ($link-icon-padding + $content-padding) $link-icon-padding $link-icon-padding;
+  padding: $link-icon-padding;
   line-height: $pt-icon-size-standard;
 
   .pt-icon-standard {

--- a/packages/docs/src/styles/_content.scss
+++ b/packages/docs/src/styles/_content.scss
@@ -24,11 +24,9 @@ $dark-example-background-color: $dark-content-background-color;
 .kss-description > h5,
 .kss-description > h6 {
   position: relative;
-  // add navbar height to top padding, then subtract from top margin, so titles will anchor below the navbar.
   // always override header margins
-  margin: -$pt-navbar-height 0 $pt-grid-size * 2 !important; // stylelint-disable-line declaration-no-important
-  // use padding-top on section titles so jumping to anchor link includes the padding
-  padding-top: $content-padding + $pt-navbar-height;
+  margin: 0 0 ($header-margin / 2) !important; // stylelint-disable-line declaration-no-important
+  padding-top: $content-padding;
 }
 
 .kss-anchor {
@@ -38,7 +36,7 @@ $dark-example-background-color: $dark-content-background-color;
   left: 0;
   transform: translate(-100%, -50%);
   opacity: 0;
-  padding: ($link-icon-padding + $content-padding + $pt-navbar-height) $link-icon-padding $link-icon-padding;
+  padding: ($link-icon-padding + $content-padding) $link-icon-padding $link-icon-padding;
   line-height: $pt-icon-size-standard;
 
   .pt-icon-standard {

--- a/packages/docs/src/styles/_content.scss
+++ b/packages/docs/src/styles/_content.scss
@@ -4,7 +4,7 @@
 @import "variables";
 @import "../../../core/src/common/icons";
 
-$header-margin: $pt-grid-size * 3;
+$heading-margin: $pt-grid-size * 4;
 $link-icon-padding: $pt-grid-size;
 
 $class-modifier-color: $rose4;
@@ -25,7 +25,7 @@ $dark-example-background-color: $dark-content-background-color;
 .kss-description > h6 {
   position: relative;
   // always override header margins
-  margin: 0 0 ($header-margin / 2) !important; // stylelint-disable-line declaration-no-important
+  margin: 0 0 ($heading-margin / 2) !important; // stylelint-disable-line declaration-no-important
   padding-top: $content-padding;
 }
 
@@ -56,8 +56,8 @@ $dark-example-background-color: $dark-content-background-color;
 
 // modifiers table
 .kss-modifiers {
-  margin-top: $header-margin;
-  margin-bottom: $header-margin / 2;
+  margin-top: $heading-margin;
+  margin-bottom: $heading-margin / 2;
 
   th:first-child,
   td:first-child {

--- a/packages/docs/src/styles/_content.scss
+++ b/packages/docs/src/styles/_content.scss
@@ -17,8 +17,12 @@ $dark-example-background-color: $dark-content-background-color;
 // title of a section
 .kss-title {
   position: relative;
-  // always override header margins
-  margin: $heading-margin 0 ($heading-margin / 2) !important; // stylelint-disable-line declaration-no-important
+  margin: $heading-margin 0 ($heading-margin / 2);
+
+  // first heading (the h1 at the top) needs smaller top margin to avoid extra scrolling
+  .depth-1 > & {
+    margin-top: $content-padding;
+  }
 }
 
 // this element inside the <h*> tag creates extra space above when it is targeted by the location hash


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #167 

#### What changes did you make?

- revert anchor padding trick for section positioning (see 06d41ab)
- invisible `<a name="" />` with negative margin solves all our anchor woes!
- can even use only margins on the headings! adjust margins a bit to account for collapsing and descenders.
- adjust some params for the scroll spy algorithm to account for new styles.

this one little change cleans up every hack in these headings!
(discovered by inspecting styles of React docs site)
