### PR TITLE
decrease running text heading margin

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -177,9 +177,9 @@ Styleguide typography.running-text
   @include running-typography();
 
   @each $header, $props in $headers {
-    #{$header}:not(:first-child) {
-      margin-top: $pt-grid-size * 5;
-      margin-bottom: $pt-grid-size * 3;
+    #{$header} {
+      margin-top: $pt-grid-size * 4;
+      margin-bottom: $pt-grid-size * 2;
     }
   }
 }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -57,6 +57,7 @@ Styleguide components.callout.css
   }
 
   h5 {
+    margin-top: 0;
     margin-bottom: $pt-grid-size / 2;
     line-height: $pt-icon-size-large;
   }

--- a/packages/docs/src/styles/_content.scss
+++ b/packages/docs/src/styles/_content.scss
@@ -15,14 +15,7 @@ $example-background-color: $content-background-color;
 $dark-example-background-color: $dark-content-background-color;
 
 // title of a section
-.kss-title,
-// headings inside markdown description
-.kss-description > h1,
-.kss-description > h2,
-.kss-description > h3,
-.kss-description > h4,
-.kss-description > h5,
-.kss-description > h6 {
+.kss-title {
   position: relative;
   // add navbar height to top padding, then subtract from top margin, so titles will anchor below the navbar.
   // always override header margins


### PR DESCRIPTION
#### PR checklist

- [x] Enhancement: decrease running text heading margin

#### What changes did you make?
Take 10px off the top and the bottom of heading margin so they flow better. 
These new values are already used in the docs, so we can remove a selector override.