### PR TITLE
Make dark nav shadow inset inside light themed app

### DIFF
--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -64,10 +64,12 @@ $dark-navbar-background-color: $dark-gray5;
     background-color: $dark-navbar-background-color;
   }
 
+  // shadow for dark navbar in light theme apps
   &.pt-dark {
     box-shadow: inset $pt-dark-elevation-shadow-1;
   }
 
+  // shadow for dark navbar in dark theme apps
   .pt-dark & {
     box-shadow: $pt-dark-elevation-shadow-1;
   }

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -61,8 +61,15 @@ $dark-navbar-background-color: $dark-gray5;
 
   &.pt-dark,
   .pt-dark & {
-    box-shadow: inset $pt-dark-elevation-shadow-1;
     background-color: $dark-navbar-background-color;
+  }
+
+  &.pt-dark {
+    box-shadow: inset $pt-dark-elevation-shadow-1;
+  }
+
+  .pt-dark & {
+    box-shadow: $pt-dark-elevation-shadow-1;
   }
 
   &.pt-fixed-top {


### PR DESCRIPTION
To avoid blurriness, the dark nav shadow should only be inset when the app is light themed. When the app is dark themed, it's always outset.

Before (blurry edge):
![image](https://cloud.githubusercontent.com/assets/199754/20331099/158c59e6-ab58-11e6-8e00-67a3b0a32077.png)

After (sharp):
![image](https://cloud.githubusercontent.com/assets/199754/20331111/1fe14514-ab58-11e6-8a02-03e028878be6.png)
