### PR TITLE
fix portal display issues

### DIFF
--- a/packages/core/src/components/context-menu/_context-menu.scss
+++ b/packages/core/src/components/context-menu/_context-menu.scss
@@ -110,6 +110,10 @@ rightClickMe.oncontextmenu = (e: MouseEvent) => {
 Styleguide components.context-menu.js
 */
 
+.pt-context-menu .pt-popover-target {
+  display: block;
+}
+
 .pt-context-menu-popover-target {
   position: fixed;
 }

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -34,7 +34,3 @@ The children of a `Portal` component are appended to the `<body>` element.
 
 Styleguide components.portal.js
 */
-
-.pt-portal {
-  display: inline-block;
-}

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -38,14 +38,11 @@ Page layout elements
 */
 
 .docs-root {
+  background-color: $content-background-color;
+
   // usually this element is _way_ longer than the viewport, but sometimes it isn't.
   // this ensures that it'll always at least fill the viewport so white page doesn't show through.
   min-height: 100vh;
-}
-
-.docs-root,
-.docs-navbar {
-  background-color: $content-background-color;
 
   &.pt-dark {
     background-color: $dark-content-background-color;

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -38,6 +38,13 @@ Page layout elements
 */
 
 .docs-root {
+  // usually this element is _way_ longer than the viewport, but sometimes it isn't.
+  // this ensures that it'll always at least fill the viewport so white page doesn't show through.
+  min-height: 100vh;
+}
+
+.docs-root,
+.docs-navbar {
   background-color: $content-background-color;
 
   &.pt-dark {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #147 

#### What changes did you make?

- set `min-height` on docs page so the white background never shows through. resolves issue in https://github.com/palantir/blueprint/issues/183#issuecomment-261070996
- use `display: block` for portals and context menus so their appended elements don't take up space at the end of the page.

#### Is there anything you'd like reviewers to focus on?

test the Overlay family and ensure that when opened they do not add ~20px of white space at bottom of page.