### PR TITLE
[POC] use .docs-root as scroll container

### DIFF
--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -37,6 +37,11 @@ Flex utils
 Page layout elements
 */
 
+body {
+  @include position(absolute, 0);
+  overflow: auto;
+}
+
 .docs-root {
   background-color: $content-background-color;
 

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -37,13 +37,10 @@ Flex utils
 Page layout elements
 */
 
-body {
-  @include position(absolute, 0);
-  overflow: auto;
-}
-
 .docs-root {
+  @include position(absolute, 0);
   background-color: $content-background-color;
+  overflow: auto;
 
   &.pt-dark {
     background-color: $dark-content-background-color;


### PR DESCRIPTION
## ⚠️  this is a proof-of-concept and should not be merged as-is

this PR uses `.docs-root` as the scroll container for the documentation app, as a tool for exploring the issues in #183. note that `page up`/`down` keys do not work immediately on page load in this PR, whereas they do work on the current docs site.