### PR TITLE
tsconfig updates for NPM consumption

### DIFF
--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -10,6 +10,8 @@ module.exports = (gulp, plugins, blueprint) => {
     function createTypescriptProject(tsConfigPath) {
         return plugins.typescript.createProject(tsConfigPath, {
             typescript: require("typescript"),
+            // ensure that only @types from this project are used (instead of from local symlinked blueprint)
+            typeRoots: ["node_modules/@types"],
         });
     }
 

--- a/gulp/util/webpack-config.js
+++ b/gulp/util/webpack-config.js
@@ -29,7 +29,10 @@ const TYPESCRIPT_CONFIG = {
     resolve: { extensions: ["", ".js", ".ts", ".tsx"] },
     ts: {
         // do not emit declarations since we are bundling
-        compilerOptions: { declaration: false },
+        compilerOptions: {
+            declaration: false,
+            typeRoots: ["node_modules/@types"],
+        },
     },
     module: {
         loaders: [

--- a/gulp/util/webpack-config.js
+++ b/gulp/util/webpack-config.js
@@ -28,9 +28,10 @@ const TYPESCRIPT_CONFIG = {
     devtool: "source-map",
     resolve: { extensions: ["", ".js", ".ts", ".tsx"] },
     ts: {
-        // do not emit declarations since we are bundling
         compilerOptions: {
+            // do not emit declarations since we are bundling
             declaration: false,
+            // ensure that only @types from this project are used (instead of from local symlinked blueprint)
             typeRoots: ["node_modules/@types"],
         },
     },

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -2,5 +2,4 @@ coverage/
 resources/
 test/
 typings/
-
-tsconfig.json
+tsd.json

--- a/packages/core/examples/tsconfig.json
+++ b/packages/core/examples/tsconfig.json
@@ -14,9 +14,6 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5",
-        "typeRoots": [
-            "../../../node_modules/@types"
-        ]
+        "target": "es5"
     }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -15,10 +15,7 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5",
-        "typeRoots": [
-            "../../node_modules/@types"
-        ]
+        "target": "es5"
     },
     "include": [
         "src/**/*"

--- a/packages/datetime/.npmignore
+++ b/packages/datetime/.npmignore
@@ -2,6 +2,4 @@ coverage/
 resources/
 test/
 typings/
-
-tsconfig.json
 tsd.json

--- a/packages/datetime/examples/tsconfig.json
+++ b/packages/datetime/examples/tsconfig.json
@@ -14,9 +14,6 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5",
-        "typeRoots": [
-            "../../../node_modules/@types"
-        ]
+        "target": "es5"
     }
 }

--- a/packages/datetime/tsconfig.json
+++ b/packages/datetime/tsconfig.json
@@ -16,10 +16,7 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5",
-        "typeRoots": [
-            "../../node_modules/@types"
-        ]
+        "target": "es5"
     },
     "include": [
         "typings/tsd.d.ts",

--- a/packages/landing/tsconfig.json
+++ b/packages/landing/tsconfig.json
@@ -14,10 +14,7 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5",
-        "typeRoots": [
-            "../node_modules/@types"
-        ]
+        "target": "es5"
     },
     "include": [
         "src/**/*"

--- a/packages/table/.npmignore
+++ b/packages/table/.npmignore
@@ -4,6 +4,4 @@ resources/
 preview/
 test/
 typings/
-
-tsconfig.json
 typings.json


### PR DESCRIPTION
#### PR checklist

- [x] New bugfix/enhancement

#### What changes did you make?

- include tsconfig.json in npm packages because it's useful for development (particularly in the internal repo where we actually want to build _these_ projects)
  - i had originally excluded it cuz i thought it wouldn't be useful and the `typeRoots` relative path was too brittle for public distribution
- so here I remove `typeRoots` from tsconfig.json files and instead set it much more reliably in `gulp-typescript` and `ts-loader` config where the relative paths are perfectly at home

