### PR TITLE
sass "bundle" option to copy assets

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,23 +9,59 @@
 //   no-op copy task. This allows other packages that depend on yours to contain
 //   a copy task without failing the gulp build.
 
+/*
+interface IProject {
+    id: string;
+
+    // working directory of this project
+    cwd: string;
+
+    // ids of dependent projects. each task will run corresponding dependency task first.
+    dependencies: string[];
+
+    // copy files `to` directories, with given base. false value creates no-op task (for dependency).
+    copy?: false | { [glob: string]: { to: string[], base?: string } };
+
+    // whether to run karma unit tests
+    karma?: true;
+
+    // whether to compile sass sources.
+    // "compile" simply runs sassc + autoprefixer.
+    // "bundle" also inlines all imports and copies url() assets to the output directory such that
+    //   all styles are in one file and all necessary assets are within the dist/ directory.
+    sass: "compile" | "bundle";
+
+    // whether to compile typescript sources
+    typescript?: true;
+
+    webpack?: {
+        // webpack bundle config:
+        entry: string;
+        dest: string;
+
+        // package names to resolve to the locally installed npm package
+        localResolve?: string[];
+    }
+}
+*/
+
 const projects = [
     {
         id: "core",
         cwd: "packages/core/",
         dependencies: [],
-        sass: true,
-        typescript: true,
-        karma: true,
         copy: false,
+        karma: true,
+        sass: "compile",
+        typescript: true,
     }, {
         id: "datetime",
         cwd: "packages/datetime/",
         dependencies: ["core"],
-        sass: true,
-        typescript: true,
-        karma: true,
         copy: false,
+        karma: true,
+        sass: "compile",
+        typescript: true,
     }, {
         id: "docs",
         cwd: "packages/docs/",
@@ -36,7 +72,7 @@ const projects = [
             "datetime",
             "table",
         ],
-        sass: true,
+        sass: "bundle",
         webpack: {
             entry: "src/index.tsx",
             dest: "dist",
@@ -57,14 +93,14 @@ const projects = [
         id: "landing",
         cwd: "packages/landing/",
         dependencies: ["core"],
-        sass: true,
+        sass: "bundle",
     }, {
         id: "table",
         cwd: "packages/table/",
         dependencies: ["core"],
         copy: false,
         karma: true,
-        sass: true,
+        sass: "compile",
         typescript: true,
     },
 ];

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -3,7 +3,6 @@
  */
 "use strict";
 
-
 module.exports = (gulp, plugins, blueprint) => {
     const autoprefixer = require("autoprefixer");
     const path = require("path");

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -3,11 +3,13 @@
  */
 "use strict";
 
-const autoprefixer = require("autoprefixer");
-const postcssUrl = require("postcss-url");
 
 module.exports = (gulp, plugins, blueprint) => {
+    const autoprefixer = require("autoprefixer");
     const path = require("path");
+    const postcssCopyAssets = require("postcss-copy-assets");
+    const postcssImport = require("postcss-import");
+    const postcssUrl = require("postcss-url");
     const COPYRIGHT_HEADER = require("./util/text").COPYRIGHT_HEADER;
 
     const blueprintCwd = blueprint.findProject("core").cwd;
@@ -43,7 +45,7 @@ module.exports = (gulp, plugins, blueprint) => {
             .pipe(plugins.count(`${project.id}: ## stylesheets linted`))
     ));
 
-    blueprint.task("sass", "compile", [], (project, isDevMode) => {
+    blueprint.task("sass", "compile", ["icons", "sass-variables"], (project, isDevMode) => {
         const sassCompiler = plugins.sass();
         if (isDevMode) {
             sassCompiler.on("error", plugins.sass.logError);
@@ -53,11 +55,24 @@ module.exports = (gulp, plugins, blueprint) => {
             to : blueprint.destPath(project, "dist.css"),
             map: { inline: false },
         };
-        const postcssPlugins = [
+        const postcssPlugins = project.sass === "bundle" ? [
+            // inline all imports
+            postcssImport(),
             // rebase all urls due to inlining
             postcssUrl({ url: "rebase" }),
-            autoprefixer(config.autoprefixer),
-        ];
+            // copy assets to dist folder, respecting rebase
+            postcssCopyAssets({
+                pathTransform: (_newPath, origPath) => {
+                    return path.resolve(
+                        blueprint.destPath(project),
+                        "assets",
+                        path.basename(origPath)
+                    );
+                },
+            }),
+        ] : [];
+        // always run autoprefixer
+        postcssPlugins.push(autoprefixer(config.autoprefixer));
 
         return gulp.src(config.srcGlob(project, true))
             .pipe(plugins.sourcemaps.init())

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -4,8 +4,6 @@
 "use strict";
 
 const autoprefixer = require("autoprefixer");
-const postcssCopyAssets = require("postcss-copy-assets");
-const postcssImport = require("postcss-import");
 const postcssUrl = require("postcss-url");
 
 module.exports = (gulp, plugins, blueprint) => {
@@ -56,20 +54,8 @@ module.exports = (gulp, plugins, blueprint) => {
             map: { inline: false },
         };
         const postcssPlugins = [
-            // inline all imports
-            postcssImport(),
             // rebase all urls due to inlining
             postcssUrl({ url: "rebase" }),
-            // copy assets to dist folder, respecting rebase
-            postcssCopyAssets({
-                pathTransform: (_newPath, origPath) => {
-                    return path.resolve(
-                        blueprint.destPath(project),
-                        "assets",
-                        path.basename(origPath)
-                    );
-                },
-            }),
             autoprefixer(config.autoprefixer),
         ];
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean:docs": "rm -rf docs && git checkout docs/CNAME",
     "copy:docs": "cp -rf packages/docs/dist docs/docs",
     "copy:landing": "cp -rf packages/landing/dist/* docs/.",
-    "delete:doc-source-maps" : "find docs -name '*.map' -type f -delete",
+    "delete:doc-source-maps": "find docs -name '*.map' -type f -delete",
     "gulp": "gulp",
     "serve": "http-server docs"
   },
@@ -81,6 +81,8 @@
     "mocha": "3.1.2",
     "npm-run-all": "3.1.1",
     "phantomjs-prebuilt": "2.1.13",
+    "postcss-copy-assets": "0.3.0",
+    "postcss-import": "8.2.0",
     "postcss-url": "5.1.2",
     "react": "15.3.1",
     "react-addons-test-utils": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "mocha": "3.1.2",
     "npm-run-all": "3.1.1",
     "phantomjs-prebuilt": "2.1.13",
-    "postcss-copy-assets": "0.3.0",
-    "postcss-import": "8.1.3",
     "postcss-url": "5.1.2",
     "react": "15.3.1",
     "react-addons-test-utils": "15.3.1",

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,5 +1,4 @@
 coverage/
-resources/
 test/
 typings/
 tsd.json

--- a/packages/datetime/.npmignore
+++ b/packages/datetime/.npmignore
@@ -1,5 +1,4 @@
 coverage/
-resources/
 test/
 typings/
 tsd.json

--- a/packages/table/.npmignore
+++ b/packages/table/.npmignore
@@ -1,6 +1,5 @@
 config/
 coverage/
-resources/
 preview/
 test/
 typings/


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: `npm install palantir/blueprint` ignores resources

#### What changes did you make?

1. remove `resources` from `.npmignore` so those files can at least be installed.
2. add a new option "bundle" for `sass-compile` task that enables the import inlining and asset copying functionality
  - published packages use the default "compile" behavior
  - only the `docs` and `landing` packages need to "bundle" because they need to produce deployable `dist/` directories.