### PR TITLE
fix require path to icons.json

### DIFF
--- a/gulp/icons.js
+++ b/gulp/icons.js
@@ -18,7 +18,7 @@ module.exports = (gulp, plugins, blueprint) => {
 
     // generate sass and typescript files containing icon variables, driven by docs/src/icons.json
     gulp.task("icons", () => {
-        const ICONS = require(path.join("..", blueprint.findProject("core").cwd, "resources", "icons", "icons.json"));
+        const ICONS = require(path.resolve(blueprint.findProject("core").cwd, "resources", "icons", "icons.json"));
 
         function toEnumName(icon) {
             return icon.className.replace("pt-icon-", "").replace(/-/g, "_").toUpperCase();

--- a/gulp/karma.js
+++ b/gulp/karma.js
@@ -10,6 +10,8 @@ module.exports = (gulp, plugins, blueprint) => {
 
     function createConfig (project) {
         const webpackConfig = webpackConfigGenerator.generateWebpackKarmaConfig(project);
+        // must delete this key in order to resolve root @types packages correctly.
+        delete webpackConfig.ts.compilerOptions.typeRoots;
 
         const resourcesGlob = (project.id === "core" ? "." : "node_modules/@blueprintjs/*");
         const filesToInclude = [


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: failing require icons.json in internal build

#### What changes did you make?

use `path.resolve` instead of `path.join` for icons.json because the path gets passed to `require()`.

also fix karma `typeRoots` to resolve all those missing typings. see output from `gulp test` on this circle build: https://circleci.com/gh/palantir/blueprint/499 for repro.
