### PR TITLE
package can't depend on itself...

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -77,6 +77,11 @@ const projects = [
             entry: "src/index.tsx",
             dest: "dist",
             localResolve: [
+                // locally resolve @blueprintjs packages so example components will compile
+                // (they all import @blueprint/* but don't actually have themselves in their node_modules)
+                "@blueprintjs/core",
+                "@blueprintjs/datetime",
+                "@blueprintjs/table",
                 "dom4",
                 "jquery",
                 "normalize.css",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,6 @@
     "react-dom": "^15.0.1 || ^0.14"
   },
   "devDependencies": {
-    "@blueprintjs/core": "^1.0.1",
     "bourbon": "4.2.6",
     "react": "15.1.0",
     "react-addons-css-transition-group": "15.1.0",


### PR DESCRIPTION
#### PR checklist

- [x] fixes an issue from #206 

#### What changes did you make?

locally resolve @blueprintjs packages in docs so examples will compile.
remove circular dependency from `core` package.