### PR TITLE
node_modules support for sass imports

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -72,7 +72,7 @@ const projects = [
             "datetime",
             "table",
         ],
-        sass: "compile",
+        sass: "bundle",
         webpack: {
             entry: "src/index.tsx",
             dest: "dist",

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -72,7 +72,7 @@ const projects = [
             "datetime",
             "table",
         ],
-        sass: "bundle",
+        sass: "compile",
         webpack: {
             entry: "src/index.tsx",
             dest: "dist",

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ general:
     - packages/core/coverage
     - packages/datetime/coverage
     - packages/docs/dist
+    - packages/docs/node_modules/normalize.css
+    - packages/docs/node_modules/@blueprintjs
     - packages/landing/dist
     - packages/table/preview
     - docs

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,6 @@ general:
     - packages/core/coverage
     - packages/datetime/coverage
     - packages/docs/dist
-    - packages/docs/node_modules/normalize.css
-    - packages/docs/node_modules/@blueprintjs
     - packages/landing/dist
     - packages/table/preview
     - docs

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -45,7 +45,9 @@ module.exports = (gulp, plugins, blueprint) => {
     ));
 
     blueprint.task("sass", "compile", ["icons", "sass-variables"], (project, isDevMode) => {
-        const sassCompiler = plugins.sass();
+        const sassCompiler = plugins.sass({
+            importer: require("node-sass-import"),
+        });
         if (isDevMode) {
             sassCompiler.on("error", plugins.sass.logError);
         }

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -6,6 +6,7 @@
 module.exports = (gulp, plugins, blueprint) => {
     const autoprefixer = require("autoprefixer");
     const path = require("path");
+    const packageImporter = require("node-sass-package-importer");
     const postcssCopyAssets = require("postcss-copy-assets");
     const postcssImport = require("postcss-import");
     const postcssUrl = require("postcss-url");
@@ -46,7 +47,7 @@ module.exports = (gulp, plugins, blueprint) => {
 
     blueprint.task("sass", "compile", ["icons", "sass-variables"], (project, isDevMode) => {
         const sassCompiler = plugins.sass({
-            importer: require("node-sass-package-importer")({ cwd: project.cwd }),
+            importer: packageImporter({ cwd: project.cwd }),
         });
         if (isDevMode) {
             sassCompiler.on("error", plugins.sass.logError);

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -46,7 +46,7 @@ module.exports = (gulp, plugins, blueprint) => {
 
     blueprint.task("sass", "compile", ["icons", "sass-variables"], (project, isDevMode) => {
         const sassCompiler = plugins.sass({
-            importer: require("node-sass-import"),
+            importer: require("@giladgray/node-sass-import"),
         });
         if (isDevMode) {
             sassCompiler.on("error", plugins.sass.logError);

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -46,7 +46,7 @@ module.exports = (gulp, plugins, blueprint) => {
 
     blueprint.task("sass", "compile", ["icons", "sass-variables"], (project, isDevMode) => {
         const sassCompiler = plugins.sass({
-            importer: require("@giladgray/node-sass-import"),
+            importer: require("node-sass-package-importer")({ cwd: project.cwd }),
         });
         if (isDevMode) {
             sassCompiler.on("error", plugins.sass.logError);

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "marked": "0.3.6",
     "merge-stream": "1.0.0",
     "mocha": "3.1.2",
+    "node-sass-import": "1.1.1",
     "npm-run-all": "3.1.1",
     "phantomjs-prebuilt": "2.1.13",
     "postcss-copy-assets": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "marked": "0.3.6",
     "merge-stream": "1.0.0",
     "mocha": "3.1.2",
+    "node-sass-package-importer": "3.0.0",
     "npm-run-all": "3.1.1",
     "phantomjs-prebuilt": "2.1.13",
     "postcss-copy-assets": "0.3.0",
@@ -111,5 +112,5 @@
     "url": "git@github.com:palantir/blueprint.git"
   },
   "author": "Palantir Technologies",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "serve": "http-server docs"
   },
   "dependencies": {
-    "@giladgray/node-sass-import": "1.2.0",
     "@types/assertion-error": "1.0.30",
     "@types/chai": "3.4.34",
     "@types/classnames": "0.0.31",
@@ -112,5 +111,5 @@
     "url": "git@github.com:palantir/blueprint.git"
   },
   "author": "Palantir Technologies",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "serve": "http-server docs"
   },
   "dependencies": {
+    "@giladgray/node-sass-import": "1.2.0",
     "@types/assertion-error": "1.0.30",
     "@types/chai": "3.4.34",
     "@types/classnames": "0.0.31",
@@ -79,7 +80,6 @@
     "marked": "0.3.6",
     "merge-stream": "1.0.0",
     "mocha": "3.1.2",
-    "node-sass-import": "1.1.1",
     "npm-run-all": "3.1.1",
     "phantomjs-prebuilt": "2.1.13",
     "postcss-copy-assets": "0.3.0",

--- a/packages/core/src/common/_font-imports.scss
+++ b/packages/core/src/common/_font-imports.scss
@@ -1,8 +1,8 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../node_modules/bourbon/app/assets/stylesheets/bourbon";
-@import "common/variables";
+@import "bourbon/app/assets/stylesheets/bourbon";
+@import "variables";
 
 $icon-font-path: "../resources/icons";
 $icon-font-formats: eot woff ttf;

--- a/packages/core/src/common/_font-imports.scss
+++ b/packages/core/src/common/_font-imports.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "variables";
 
 $icon-font-path: "../resources/icons";

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/icons";
 @import "../../common/variables";
 

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/icons";
 @import "../../common/variables";
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "./common";
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "./common";
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "./common";
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "./common";
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/icons";
 @import "../../common/mixins";
 @import "../../common/react-transition";

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/icons";
 @import "../../common/mixins";
 @import "../../common/react-transition";

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -1,7 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../forms/common";
 

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -1,7 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../forms/common";
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/icons";
 @import "../../common/variables";
 @import "../button/common";

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/icons";
 @import "../../common/variables";
 @import "../button/common";

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../../common/react-transition";
 

--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../../common/react-transition";
 

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 
 /*

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -1,7 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../../common/react-transition";
 

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -1,7 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../../common/react-transition";
 

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../popover/common";
 @import "./common";

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
 @import "../popover/common";
 @import "./common";

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../core/src/common/icons";
 @import "../../core/src/common/variables";
 

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -1,7 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../core/src/common/icons";
 @import "../../core/src/common/variables";
 

--- a/packages/docs/src/docs.scss
+++ b/packages/docs/src/docs.scss
@@ -3,9 +3,9 @@
 
 @import "normalize.css/normalize.css";
 
-@import "@blueprintjs/core/dist/blueprint.css";
-@import "@blueprintjs/datetime/dist/blueprint-datetime.css";
-@import "@blueprintjs/table/dist/table.css";
+@import "~@blueprintjs/core/dist/blueprint.css";
+@import "~@blueprintjs/datetime/dist/blueprint-datetime.css";
+@import "~@blueprintjs/table/dist/table.css";
 
 // TODO publish and re-enable
 // @import "blueprint-syntax/dist/atom-blueprint-syntax-light.css";

--- a/packages/docs/src/docs.scss
+++ b/packages/docs/src/docs.scss
@@ -1,15 +1,15 @@
 /** Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0 */
 
-@import "../node_modules/normalize.css/normalize.css";
+@import "normalize.css/normalize.css";
 
-@import "../node_modules/@blueprintjs/core/dist/blueprint.css";
-@import "../node_modules/@blueprintjs/datetime/dist/blueprint-datetime.css";
-@import "../node_modules/@blueprintjs/table/dist/table.css";
+@import "@blueprintjs/core/dist/blueprint.css";
+@import "@blueprintjs/datetime/dist/blueprint-datetime.css";
+@import "@blueprintjs/table/dist/table.css";
 
 // TODO publish and re-enable
-// @import "../node_modules/blueprint-syntax/dist/atom-blueprint-syntax-light.css";
-// @import "../node_modules/blueprint-syntax/dist/atom-blueprint-syntax-dark.css";
+// @import "blueprint-syntax/dist/atom-blueprint-syntax-light.css";
+// @import "blueprint-syntax/dist/atom-blueprint-syntax-dark.css";
 
 @import "styles/colors";
 @import "styles/content";

--- a/packages/docs/src/docs.scss
+++ b/packages/docs/src/docs.scss
@@ -1,11 +1,11 @@
 /** Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0 */
 
-@import "normalize.css/normalize.css";
+@import "~normalize.css";
 
-@import "~@blueprintjs/core/dist/blueprint.css";
-@import "~@blueprintjs/datetime/dist/blueprint-datetime.css";
-@import "~@blueprintjs/table/dist/table.css";
+@import "~@blueprintjs/core";
+@import "~@blueprintjs/datetime";
+@import "~@blueprintjs/table";
 
 // TODO publish and re-enable
 // @import "blueprint-syntax/dist/atom-blueprint-syntax-light.css";

--- a/packages/docs/src/styles/_colors.scss
+++ b/packages/docs/src/styles/_colors.scss
@@ -3,7 +3,7 @@
 
 @import "variables";
 
-@import "../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "bourbon/app/assets/stylesheets/bourbon";
 @import "../../../core/src/common/icons";
 
 $palette-spacing: $pt-grid-size * 2;

--- a/packages/docs/src/styles/_colors.scss
+++ b/packages/docs/src/styles/_colors.scss
@@ -3,7 +3,7 @@
 
 @import "variables";
 
-@import "bourbon/app/assets/stylesheets/bourbon";
+@import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../../core/src/common/icons";
 
 $palette-spacing: $pt-grid-size * 2;

--- a/packages/landing/src/_overrides.scss
+++ b/packages/landing/src/_overrides.scss
@@ -1,5 +1,5 @@
-@import "@blueprintjs/core/dist/blueprint.css";
-@import "@blueprintjs/core/dist/variables";
+@import "~@blueprintjs/core/dist/blueprint.css";
+@import "~@blueprintjs/core/dist/variables";
 
 body,
 h1,

--- a/packages/landing/src/_overrides.scss
+++ b/packages/landing/src/_overrides.scss
@@ -1,5 +1,5 @@
-@import "../node_modules/@blueprintjs/core/dist/blueprint.css";
-@import "../node_modules/@blueprintjs/core/dist/variables";
+@import "@blueprintjs/core/dist/blueprint.css";
+@import "@blueprintjs/core/dist/variables";
 
 body,
 h1,

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -1,5 +1,5 @@
-@import "../node_modules/@blueprintjs/core/dist/blueprint.css";
-@import "../node_modules/@blueprintjs/core/dist/variables";
+@import "@blueprintjs/core/dist/blueprint.css";
+@import "@blueprintjs/core/dist/variables";
 @import "svgs";
 @import "overrides";
 

--- a/packages/landing/src/landing.scss
+++ b/packages/landing/src/landing.scss
@@ -1,5 +1,5 @@
-@import "@blueprintjs/core/dist/blueprint.css";
-@import "@blueprintjs/core/dist/variables";
+@import "~@blueprintjs/core/dist/blueprint.css";
+@import "~@blueprintjs/core/dist/variables";
 @import "svgs";
 @import "overrides";
 

--- a/packages/table/src/common/_variables.scss
+++ b/packages/table/src/common/_variables.scss
@@ -1,6 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
-@import "../../node_modules/@blueprintjs/core/src/common/variables";
+@import "@blueprintjs/core/src/common/variables";
 
 // TODO: use Blueprint intents instead of duplicating...
 $pt-intent-colors: (

--- a/packages/table/src/common/_variables.scss
+++ b/packages/table/src/common/_variables.scss
@@ -1,6 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
-@import "@blueprintjs/core/src/common/variables";
+@import "~@blueprintjs/core/src/common/variables";
 
 // TODO: use Blueprint intents instead of duplicating...
 $pt-intent-colors: (


### PR DESCRIPTION
#### PR checklist

- [x] (partially) addresses an existing issue: #123 

#### What changes did you make?

use [`node-sass-package-importer`](https://github.com/maoberlehner/node-sass-package-importer) to support package names in sass imports instead of relative paths, which break when trying to compile sass APIs outside the monorepo. package paths must begin with the `~` character, like webpack sass-loader: `@import "~@blueprintjs/core/dist/blueprint.css"`.

update relevant `@import` paths.