### PR TITLE
Button remove disabled props

### DIFF
--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -29,7 +29,18 @@ export class Button extends React.Component<React.HTMLProps<HTMLButtonElement> &
     public static displayName = "Blueprint.Button";
 
     public render() {
-        return <button type="button" {...getButtonHTMLProps(this.props)} {...getButtonProps(this.props)} />;
+        return (
+            <button
+                type="button"
+                {...removeNonHTMLProps(this.props, this.props.disabled ? DISABLED_PROPS : [], true)}
+                className={getButtonClasses(this.props)}
+                ref={this.props.elementRef}
+            >
+                {this.props.text}
+                {this.props.children}
+                {maybeRenderRightIcon(this.props.rightIconName)}
+            </button>
+        );
     }
 }
 
@@ -37,25 +48,19 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
     public static displayName = "Blueprint.AnchorButton";
 
     public render() {
-        return <a role="button" {...getButtonHTMLProps(this.props)} {...getButtonProps(this.props)} />;
+        return (
+            <a
+                role="button"
+                {...removeNonHTMLProps(this.props, this.props.disabled ? DISABLED_PROPS : [], true)}
+                className={getButtonClasses(this.props)}
+                ref={this.props.elementRef}
+            >
+                {this.props.text}
+                {this.props.children}
+                {maybeRenderRightIcon(this.props.rightIconName)}
+            </a>
+        );
     }
-}
-
-function getButtonHTMLProps(props: IButtonProps) {
-    return removeNonHTMLProps(props, props.disabled ? DISABLED_PROPS : [], true);
-}
-
-// spread this after HTML props to override `className`
-function getButtonProps(props: IButtonProps & { children?: React.ReactNode }) {
-    return {
-        children: [
-            props.text,
-            props.children,
-            maybeRenderRightIcon(props.rightIconName),
-        ],
-        className: getButtonClasses(props),
-        ref: props.elementRef,
-    };
 }
 
 function getButtonClasses(props: IButtonProps) {
@@ -70,7 +75,7 @@ function getButtonClasses(props: IButtonProps) {
 
 function maybeRenderRightIcon(iconName: string) {
     if (iconName == null) {
-        return null;
+        return undefined;
     } else {
         return <span className={classNames(Classes.ICON_STANDARD, Classes.iconClass(iconName), Classes.ALIGN_RIGHT)} />;
     }

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -11,6 +11,11 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IActionProps, removeNonHTMLProps } from "../../common/props";
 
+// props that should be removed when `disabled`, to prevent interaction.
+const DISABLED_PROPS = [
+    "href",
+    "onClick",
+]
 
 export interface IButtonProps extends IActionProps {
     /** A ref handler that receives the native HTML element backing this component. */
@@ -24,18 +29,7 @@ export class Button extends React.Component<React.HTMLProps<HTMLButtonElement> &
     public static displayName = "Blueprint.Button";
 
     public render() {
-        return (
-            <button
-                type="button"
-                {...removeNonHTMLProps(this.props)}
-                className={getButtonClasses(this.props)}
-                ref={this.props.elementRef}
-            >
-                {this.props.text}
-                {this.props.children}
-                {maybeRenderRightIcon(this.props.rightIconName)}
-            </button>
-        );
+        return <button type="button" {...getButtonHTMLProps(this.props)} {...getButtonProps(this.props)} />;
     }
 }
 
@@ -43,22 +37,24 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
     public static displayName = "Blueprint.AnchorButton";
 
     public render() {
-        const { children, disabled, href, onClick, rightIconName, text } = this.props;
-        return (
-            <a
-                {...removeNonHTMLProps(this.props)}
-                className={getButtonClasses(this.props)}
-                href={disabled ? null : href}
-                onClick={disabled ? null : onClick}
-                ref={this.props.elementRef}
-                role="button"
-                tabIndex={disabled ? null : 0}
-            >
-                {text}
-                {children}
-                {maybeRenderRightIcon(rightIconName)}
-            </a>
-        );
+        return <a role="button" {...getButtonHTMLProps(this.props)} {...getButtonProps(this.props)} />;
+    }
+}
+
+function getButtonHTMLProps(props: IButtonProps) {
+    return removeNonHTMLProps(props, props.disabled ? DISABLED_PROPS : [], true)
+}
+
+// spread this after HTML props to override `className`
+function getButtonProps(props: IButtonProps & { children?: React.ReactNode }) {
+    return {
+        children: [
+            props.text,
+            props.children,
+            maybeRenderRightIcon(props.rightIconName),
+        ],
+        className: getButtonClasses(props),
+        ref: props.elementRef,
     }
 }
 

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -15,7 +15,7 @@ import { IActionProps, removeNonHTMLProps } from "../../common/props";
 const DISABLED_PROPS = [
     "href",
     "onClick",
-]
+];
 
 export interface IButtonProps extends IActionProps {
     /** A ref handler that receives the native HTML element backing this component. */
@@ -42,7 +42,7 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
 }
 
 function getButtonHTMLProps(props: IButtonProps) {
-    return removeNonHTMLProps(props, props.disabled ? DISABLED_PROPS : [], true)
+    return removeNonHTMLProps(props, props.disabled ? DISABLED_PROPS : [], true);
 }
 
 // spread this after HTML props to override `className`
@@ -55,7 +55,7 @@ function getButtonProps(props: IButtonProps & { children?: React.ReactNode }) {
         ],
         className: getButtonClasses(props),
         ref: props.elementRef,
-    }
+    };
 }
 
 function getButtonClasses(props: IButtonProps) {

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -11,23 +11,6 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IActionProps, removeNonHTMLProps } from "../../common/props";
 
-function getButtonClasses(props: IButtonProps) {
-    return classNames(
-        Classes.BUTTON,
-        { [Classes.DISABLED]: props.disabled },
-        Classes.iconClass(props.iconName),
-        Classes.intentClass(props.intent),
-        props.className
-    );
-}
-
-function maybeRenderRightIcon(iconName: string) {
-    if (iconName == null) {
-        return null;
-    } else {
-        return <span className={classNames(Classes.ICON_STANDARD, Classes.iconClass(iconName), Classes.ALIGN_RIGHT)} />;
-    }
-}
 
 export interface IButtonProps extends IActionProps {
     /** A ref handler that receives the native HTML element backing this component. */
@@ -76,6 +59,24 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
                 {maybeRenderRightIcon(rightIconName)}
             </a>
         );
+    }
+}
+
+function getButtonClasses(props: IButtonProps) {
+    return classNames(
+        Classes.BUTTON,
+        { [Classes.DISABLED]: props.disabled },
+        Classes.iconClass(props.iconName),
+        Classes.intentClass(props.intent),
+        props.className
+    );
+}
+
+function maybeRenderRightIcon(iconName: string) {
+    if (iconName == null) {
+        return null;
+    } else {
+        return <span className={classNames(Classes.ICON_STANDARD, Classes.iconClass(iconName), Classes.ALIGN_RIGHT)} />;
     }
 }
 

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -25,14 +25,14 @@ function buttonTests(classType: React.ComponentClass<any>, tagName: string, more
 
         it("renders its contents", () => {
             const wrapper = button({ className: "foo" });
-            assert.isTrue(wrapper.is(tagName));
-            assert.isTrue(wrapper.hasClass(Classes.BUTTON));
-            assert.isTrue(wrapper.hasClass("foo"));
+            assert.isTrue(wrapper.is(tagName), "<button>");
+            assert.isTrue(wrapper.hasClass(Classes.BUTTON), ".pt-button");
+            assert.isTrue(wrapper.hasClass("foo"), ".foo");
         });
 
         it("iconName=\"style\" gets icon class", () => {
             const wrapper = button({ iconName: "style" });
-            assert.isTrue(wrapper.hasClass(Classes.iconClass("style")));
+            assert.isTrue(wrapper.hasClass(Classes.iconClass("style")), "icon class");
         });
 
         it("clicking button triggers onClick prop", () => {
@@ -45,14 +45,14 @@ function buttonTests(classType: React.ComponentClass<any>, tagName: string, more
             const onClick = sinon.spy();
             // full DOM mount so `button` element will ignore click
             button({ disabled: true, onClick }, true).simulate("click");
-            assert.equal(onClick.callCount, 0);
+            assert.equal(onClick.callCount, 0, "onClick called");
         });
 
         it("elementRef receives reference to HTML element", () => {
             const elementRef = sinon.spy();
             // full DOM rendering here so the ref handler is invoked
             button({ elementRef }, true);
-            assert.isTrue(elementRef.calledOnce);
+            assert.isTrue(elementRef.calledOnce, "onClick not called once");
             assert.instanceOf(elementRef.args[0][0], HTMLElement);
         });
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses the unit test failure in #227 

#### What changes did you make?

- refactor `Button` and `AnchorButton` to share basically everything.
- remove a set of disabled props along with HTML props when button is disabled to prevent interaction.
