### PR TITLE
Fix CSS for button inside .pt-control-group > .pt-input-group

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -52,9 +52,11 @@ Markup:
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
       <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
-      <button class="pt-button pt-minimal pt-intent-primary">
-        can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
-      </button>
+      <div class="pt-input-action">
+        <button class="pt-button pt-minimal pt-intent-primary">
+          can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
+        </button>
+      </div>
     </div>
     <button class="pt-button pt-intent-primary">Add</button>
   </div>

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -131,6 +131,7 @@ Styleguide components.forms.control-group
   // input group contents appear above input always
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
+  .pt-input-group > .pt-input-action,
   .pt-select::after {
     z-index: 3;
   }
@@ -139,9 +140,6 @@ Styleguide components.forms.control-group
   // lock the button in place so that it remains visible
   // and in place when the input field receives focus
   .pt-input-group .pt-button {
-    position: absolute;
-    right: 0;
-    z-index: 3;
     border-radius: $pt-border-radius;
   }
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -139,10 +139,10 @@ Styleguide components.forms.control-group
   // lock the button in place so that it remains visible
   // and in place when the input field receives focus
   .pt-input-group .pt-button {
-    border-radius: $pt-border-radius;
     position: absolute;
     right: 0;
     z-index: 3;
+    border-radius: $pt-border-radius;
   }
 
   /*

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -126,10 +126,6 @@ Styleguide components.forms.control-group
     position: relative;
   }
 
-  .pt-input-group .pt-button:focus {
-    position: absolute;
-  }
-
   // input group contents appear above input always
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
@@ -137,9 +133,14 @@ Styleguide components.forms.control-group
     z-index: 3;
   }
 
-  // bring back border radius on these buttons
+  // bring back border radius on these buttons, and
+  // lock the button in place so that it remains visible
+  // and in place when the input field receives focus
   .pt-input-group .pt-button {
     border-radius: $pt-border-radius;
+    position: absolute;
+    right: 0;
+    z-index: 3;
   }
 
   /*

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -136,9 +136,7 @@ Styleguide components.forms.control-group
     z-index: 3;
   }
 
-  // bring back border radius on these buttons, and
-  // lock the button in place so that it remains visible
-  // and in place when the input field receives focus
+  // bring back border radius on these buttons
   .pt-input-group .pt-button {
     border-radius: $pt-border-radius;
   }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #236 and #237 
- [x] Bugfix
- [x] Documentation update (tweaked the example)

#### What changes did you make?

Super subtle bug here. In the docs, we currently have the following example for `.pt-control-group`:

![okay](https://cloud.githubusercontent.com/assets/443450/20615769/b5e4fdae-b291-11e6-9d25-afebfd3fbff4.gif)

```
<div class="pt-control-group">
  <button class="pt-button pt-intent-primary">Add</button><div class="pt-input-group">
    <span class="pt-icon pt-icon-people"></span>
    <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px">
    <button class="pt-button pt-minimal pt-intent-primary">
      can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
    </button>
  </div>
</div>
```

This presumably shows a control group being composed with a button and an `<InputGroup>`. But this isn't the HTML emitted by such a composition. The real HTML looks like this:

```
<div class="pt-control-group">
  <button class="pt-button pt-intent-primary">Add</button><div class="pt-input-group">
    <span class="pt-icon pt-icon-people"></span>
    <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px">
    

    <div class="pt-input-action">
      <button class="pt-button pt-minimal pt-intent-primary">
        can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
      </button>
    </div>

  </div>
</div>
```

The button is contained with a `.pt-input-action` wrapper. This produces the following behavior:

![repro2](https://cloud.githubusercontent.com/assets/443450/20615856/605ea23a-b292-11e6-86e3-bb0036a1525f.gif)

This PR contains a CSS fix. Alternatively, we could simply forego wrapping the right-side button in a `.pt-input-action` parent, which might be a cleaner fix.

#### Is there anything you'd like reviewers to focus on?

Help decide on the choice above (last sentence). 