### PR TITLE
Fix input-popover bug in docs

### DIFF
--- a/packages/core/examples/popoverExample.tsx
+++ b/packages/core/examples/popoverExample.tsx
@@ -243,8 +243,7 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                 max={10}
                 onChange={this.handleSliderChange}
                 value={this.state.sliderValue}
-            />
-            ,
+            />,
             <Menu>
                 <MenuDivider title="Edit" />
                 <MenuItem iconName="cut" text="Cut" label="⌘X" />

--- a/packages/core/examples/popoverExample.tsx
+++ b/packages/core/examples/popoverExample.tsx
@@ -20,7 +20,7 @@ import {
     RadioGroup,
     Slider,
     Switch,
-} from "@blueprintjs/core";
+} from "../";
 import BaseExample, { handleBooleanChange, handleNumberChange } from "./common/baseExample";
 
 const INTERACTION_KINDS = [
@@ -238,12 +238,14 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                     />
                 </label>
             </div>,
-            <Slider
-                min={0}
-                max={10}
-                onChange={this.handleSliderChange}
-                value={this.state.sliderValue}
-            />,
+            <div style={{ width: "300px" }}>
+                <Slider
+                    min={0}
+                    max={10}
+                    onChange={this.handleSliderChange}
+                    value={this.state.sliderValue}
+                />
+            </div>,
             <Menu>
                 <MenuDivider title="Edit" />
                 <MenuItem iconName="cut" text="Cut" label="⌘X" />

--- a/packages/core/examples/popoverExample.tsx
+++ b/packages/core/examples/popoverExample.tsx
@@ -238,14 +238,13 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                     />
                 </label>
             </div>,
-            <div style={{ width: "300px" }}>
-                <Slider
-                    min={0}
-                    max={10}
-                    onChange={this.handleSliderChange}
-                    value={this.state.sliderValue}
-                />
-            </div>,
+            <Slider
+                min={0}
+                max={10}
+                onChange={this.handleSliderChange}
+                value={this.state.sliderValue}
+            />
+            ,
             <Menu>
                 <MenuDivider title="Edit" />
                 <MenuItem iconName="cut" text="Cut" label="⌘X" />

--- a/packages/core/examples/popoverExample.tsx
+++ b/packages/core/examples/popoverExample.tsx
@@ -20,7 +20,7 @@ import {
     RadioGroup,
     Slider,
     Switch,
-} from "../";
+} from "@blueprintjs/core";
 import BaseExample, { handleBooleanChange, handleNumberChange } from "./common/baseExample";
 
 const INTERACTION_KINDS = [
@@ -232,7 +232,7 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                 <label className={Classes.LABEL}>
                     Enter some text
                     <input
-                        autoFocus={true}
+                        autoFocus={false}
                         className={Classes.INPUT}
                         type="text"
                     />


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #240 
- [x] Bugfix
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

In the Blueprint docs for `<Popover>`s:
- Disabled `autofocus` in the "Input" example to fix a weird scrolling bug

![expected](https://cloud.githubusercontent.com/assets/443450/20617080/98025304-b29b-11e6-9f41-19af070ecaf8.gif)

#### Is there anything you'd like reviewers to focus on?
