### PR TITLE
Tweak tab styles so we don't forcefully style deeply nested tabs

### DIFF
--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -160,27 +160,33 @@ $tab-indicator-width: 3px;
 .pt-tabs.pt-vertical {
   display: flex;
 
-  .pt-tab-list {
+  // include '>' to ensure we're only modifying
+  // these tabs, not tabs that might be further
+  // down the DOM hierarchy (i.e. tabs in tabs)
+  > .pt-tab-list {
     flex-direction: column;
     align-items: flex-start;
+
+    .pt-tab {
+      width: 100%;
+      padding: 0 $pt-grid-size;
+    }
+
+    .pt-tab-indicator-wrapper .pt-tab-indicator {
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      border-radius: $pt-border-radius;
+      background-color: rgba($pt-intent-primary, 0.2);
+      height: auto;
+    }
   }
 
-  .pt-tab {
-    width: 100%;
-    padding: 0 $pt-grid-size;
-  }
-
-  .pt-tab-indicator-wrapper .pt-tab-indicator {
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    border-radius: $pt-border-radius;
-    background-color: rgba($pt-intent-primary, 0.2);
-    height: auto;
-  }
-
-  .pt-tab-panel {
+  // same consideration here: avoid styling any
+  // other tabs that might be contained in this
+  // vertical tab component
+  > .pt-tab-panel {
     margin-top: 0;
     padding-left: $pt-grid-size * 2;
   }


### PR DESCRIPTION
#### Fixes #222 

#### What changes did you make?

Restrict `.pt-vertical` style modifications to immediate children only when applied to a `<Tabs>` component.

**Before:**
Nested tabs unexpectedly inherit the `pt-vertical` styles and generally behave weirdly.

![tabs-before](https://cloud.githubusercontent.com/assets/443450/20639249/fcdb85b6-b372-11e6-8afa-080f430ac46f.gif)

**After:**
Nested tabs do not inherit `.pt-vertical` styles applied to a parent tab container. Everything works as expected.

![tabs-after](https://cloud.githubusercontent.com/assets/443450/20639250/0081eb1a-b373-11e6-9261-7568e5bf3ec7.gif)

#### Is there anything you'd like reviewers to focus on?

A fix for this issue necessarily involves increasing the specificity of `.pt-vertical` styles on certain CSS selectors (in particular, on `.pt-tab` and `.pt-tab-indicator`). This might break consumers' styles. Should we wait for a major-version bump, or are we okay with the slightly broken API?