### PR TITLE
Controllable selection

### DIFF
--- a/packages/table/preview/index.html
+++ b/packages/table/preview/index.html
@@ -78,6 +78,10 @@
   <div id="table-2"></div>
   <br /><br />
 
+  <h4>Row Transformed Controlled Selection</h4>
+  <div id="table-select-rows"></div>
+  <br /><br />
+
   <h4>Ghost Inline</h4>
   <div id="table-inline-ghost" style="display: inline-block;"></div>
   <br /><br />

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -9,7 +9,14 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { Intent, Menu, MenuItem, MenuDivider } from "@blueprintjs/core";
+
+import {
+    Button,
+    Intent,
+    Menu,
+    MenuItem,
+    MenuDivider,
+} from "@blueprintjs/core";
 
 import {
     Cell,
@@ -20,6 +27,7 @@ import {
     EditableName,
     IColumnHeaderCellProps,
     IColumnProps,
+    ICoordinateData,
     HorizontalCellDivider,
     IMenuContext,
     IRegion,
@@ -255,6 +263,52 @@ ReactDOM.render(
         selectionModes: SelectionModes.ALL,
     }),
     document.getElementById("table-big")
+);
+
+class RowSelectableTable extends React.Component<{}, {}> {
+    public state = {
+        selectedRegions: [ Regions.row(2) ],
+    };
+
+    public render() {
+        return (<div>
+            <Table
+                numRows={7}
+                isRowHeaderShown={false}
+                onSelection={this.handleSelection}
+                selectedRegions={this.state.selectedRegions}
+                selectedRegionTransform={this.selectedRegionTransform}
+            >
+                <Column name="Cells" />
+                <Column name="Select" />
+                <Column name="Rows" />
+            </Table>
+            <br/>
+            <Button onClick={this.handleClear} intent={Intent.PRIMARY}>Clear Selection</Button>
+        </div>);
+    }
+
+    private handleClear = () => {
+        this.setState({ selectedRegions: [] });
+    }
+
+    private handleSelection = (selectedRegions: IRegion[]) => {
+        this.setState({ selectedRegions });
+    }
+
+    private selectedRegionTransform = (region: IRegion) => {
+        // convert cell selection to row selection
+        if (Regions.getRegionCardinality(region) === RegionCardinality.CELLS) {
+            return Regions.row(region.rows[0], region.rows[1]);
+        }
+
+        return region;
+    }
+}
+
+ReactDOM.render(
+    <RowSelectableTable/>,
+    document.getElementById("table-select-rows")
 );
 
 document.getElementById("table-ledger").classList.add("bp-table-striped");

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -129,6 +129,7 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
             onResizeGuide,
             onSelection,
             selectedRegions,
+            selectedRegionTransform,
         } = this.props;
 
         const rect = grid.getColumnRect(columnIndex);
@@ -162,6 +163,7 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
                 locateDrag={this.locateDrag}
                 onSelection={onSelection}
                 selectedRegions={selectedRegions}
+                selectedRegionTransform={selectedRegionTransform}
             >
                 <Resizable
                     isResizable={isResizable}

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -128,6 +128,7 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
             onSelection,
             renderRowHeader,
             selectedRegions,
+            selectedRegionTransform,
         } = this.props;
 
         const rect = grid.getRowRect(rowIndex);
@@ -155,6 +156,7 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
                 locateDrag={this.locateDrag}
                 onSelection={onSelection}
                 selectedRegions={selectedRegions}
+                selectedRegionTransform={selectedRegionTransform}
             >
                 <Resizable
                     isResizable={isResizable}

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -48,6 +48,11 @@ export {
 } from "./interactions/menus";
 
 export {
+    IClientCoordinates,
+    ICoordinateData,
+} from "./interactions/draggable";
+
+export {
     ILockableLayout,
     IResizeHandleProps,
     Orientation,

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -20,6 +20,7 @@ import { IRowHeaderRenderer, IRowHeights, renderDefaultRowHeader, RowHeader } fr
 import { IContextMenuRenderer } from "./interactions/menus";
 import { IIndexedResizeCallback } from "./interactions/resizable";
 import { ResizeSensor } from "./interactions/resizeSensor";
+import { ISelectedRegionTransform } from "./interactions/selectable";
 import { GuideLayer } from "./layers/guides";
 import { IRegionStyler, RegionLayer } from "./layers/regions";
 import { Locator } from "./locator";
@@ -118,6 +119,29 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * The number of rows in the table.
      */
     numRows?: number;
+
+    /**
+     * If defined, will set the selected regions in the cells. If defined, this
+     * changes table selection to "controlled" mode, meaning you in charge of
+     * setting the selections in response to events in the `onSelection`
+     * callback.
+     *
+     * Note that the `selectionModes` prop controls which types of events are
+     * triggered to the `onSelection` callback, but does not restrict what
+     * selection you can pass to the `selectedRegions` prop. Therefore you can,
+     * for example, convert cell clicks into row selections.
+     */
+    selectedRegions?: IRegion[];
+
+    /**
+     * An optional transform function that will be applied to the located
+     * `Region`.
+     *
+     * This allows you to, for example, convert cell `Region`s into row
+     * `Region`s while maintaining the existing multi-select and meta-click
+     * functionality.
+     */
+    selectedRegionTransform?: ISelectedRegionTransform;
 
     /**
      * A `SelectionModes` enum value indicating the selection mode. You may
@@ -254,16 +278,26 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         let newRowHeights = Utils.times(numRows, () => defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
 
+        const selectedRegions = (props.selectedRegions == null) ? [] as IRegion[] : props.selectedRegions;
+
         this.state = {
             columnWidths: newColumnWidths,
             isLayoutLocked: false,
             rowHeights: newRowHeights,
-            selectedRegions: [],
+            selectedRegions,
         };
     }
 
     public componentWillReceiveProps(nextProps: ITableProps) {
-        const { defaultRowHeight, defaultColumnWidth, columnWidths, rowHeights, children, numRows } = nextProps;
+        const {
+            defaultRowHeight,
+            defaultColumnWidth,
+            columnWidths,
+            rowHeights,
+            children,
+            numRows,
+            selectedRegions,
+        } = nextProps;
         const newChildArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
 
         // Try to maintain widths of columns by looking up the width of the
@@ -286,12 +320,15 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
 
+        const newselectedRegions = (selectedRegions == null) ? this.state.selectedRegions : selectedRegions;
+
         this.childrenArray = newChildArray;
         this.columnIdToIndex = Table.createColumnIdIndex(this.childrenArray);
         this.invalidateGrid();
         this.setState({
             columnWidths: newColumnWidths,
             rowHeights: newRowHeights,
+            selectedRegions: newselectedRegions,
         });
     }
 
@@ -414,6 +451,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             isColumnResizable,
             maxColumnWidth,
             minColumnWidth,
+            selectedRegionTransform,
         } = this.props;
         const classes = classNames("bp-table-column-headers", {
             "bp-table-selection-enabled": this.isSelectionModeEnabled(RegionCardinality.FULL_COLUMNS),
@@ -435,6 +473,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     onResizeGuide={this.handleColumnResizeGuide}
                     onSelection={this.getEnabledSelectionHandler(RegionCardinality.FULL_COLUMNS)}
                     selectedRegions={selectedRegions}
+                    selectedRegionTransform={selectedRegionTransform}
                     viewportRect={viewportRect}
                     {...columnIndices}
                 >
@@ -456,6 +495,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             maxRowHeight,
             minRowHeight,
             renderRowHeader,
+            selectedRegionTransform,
         } = this.props;
         const classes = classNames("bp-table-row-headers", {
             "bp-table-selection-enabled": this.isSelectionModeEnabled(RegionCardinality.FULL_ROWS),
@@ -479,6 +519,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     onSelection={this.getEnabledSelectionHandler(RegionCardinality.FULL_ROWS)}
                     renderRowHeader={renderRowHeader}
                     selectedRegions={selectedRegions}
+                    selectedRegionTransform={selectedRegionTransform}
                     viewportRect={viewportRect}
                     {...rowIndices}
                 />
@@ -494,7 +535,12 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
     private renderBody() {
         const { grid } = this;
-        const { allowMultipleSelection, fillBodyWithGhostCells, renderBodyContextMenu } = this.props;
+        const {
+            allowMultipleSelection,
+            fillBodyWithGhostCells,
+            renderBodyContextMenu,
+            selectedRegionTransform,
+        } = this.props;
         const { locator, selectedRegions, viewportRect, verticalGuides, horizontalGuides } = this.state;
 
         const style = grid.getRect().sizeStyle();
@@ -528,6 +574,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                         onSelection={this.getEnabledSelectionHandler(RegionCardinality.CELLS)}
                         renderBodyContextMenu={renderBodyContextMenu}
                         selectedRegions={selectedRegions}
+                        selectedRegionTransform={selectedRegionTransform}
                         viewportRect={viewportRect}
                         {...rowIndices}
                         {...columnIndices}
@@ -741,7 +788,10 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private handleSelection = (selectedRegions: IRegion[]) => {
-        this.setState({ selectedRegions } as ITableState);
+        // only set selectedRegions state if not specified in props
+        if (this.props.selectedRegions == null) {
+            this.setState({ selectedRegions } as ITableState);
+        }
 
         const { onSelection } = this.props;
         if (onSelection != null) {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -320,7 +320,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
 
-        const newselectedRegions = (selectedRegions == null) ? this.state.selectedRegions : selectedRegions;
+        const newSelectedRegions = (selectedRegions == null) ? this.state.selectedRegions : selectedRegions;
 
         this.childrenArray = newChildArray;
         this.columnIdToIndex = Table.createColumnIdIndex(this.childrenArray);
@@ -328,7 +328,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.setState({
             columnWidths: newColumnWidths,
             rowHeights: newRowHeights,
-            selectedRegions: newselectedRegions,
+            selectedRegions: newSelectedRegions,
         });
     }
 

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -141,7 +141,14 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
     }
 
     private renderCell = (rowIndex: number, columnIndex: number, extremaClasses: string[]) => {
-        const { allowMultipleSelection, grid, cellRenderer, selectedRegions, onSelection } = this.props;
+        const {
+            allowMultipleSelection,
+            grid,
+            cellRenderer,
+            onSelection,
+            selectedRegions,
+            selectedRegionTransform,
+        } = this.props;
         const cell = Utils.assignClasses(
             cellRenderer(rowIndex, columnIndex),
             TableBody.cellClassNames(rowIndex, columnIndex),
@@ -160,6 +167,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
                 locateDrag={this.locateDrag}
                 onSelection={onSelection}
                 selectedRegions={selectedRegions}
+                selectedRegionTransform={selectedRegionTransform}
             >
                 {React.cloneElement(cell, { style } as ICellProps)}
             </DragSelectable>

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -15,6 +15,7 @@ describe("Selection", () => {
     let harness = new ReactHarness();
     const TH_SELECTOR = ".bp-table-column-headers .bp-table-header";
     const ROW_TH_SELECTOR = ".bp-table-row-headers .bp-table-header";
+    const CELL_SELECTOR = ".bp-table-cell-row-2.bp-table-cell-col-0";
 
     afterEach(() => {
         harness.unmount();
@@ -94,6 +95,26 @@ describe("Selection", () => {
         table.find(TH_SELECTOR).mouse("mousedown", 0, 0, isMetaKeyDown).mouse("mouseup", 0, 0, isMetaKeyDown);
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[]], "meta key clear");
+    });
+
+    it("Transforms regions on selections", () => {
+        const selectedRegionTransform = () => {
+            return Regions.row(1);
+        };
+        const onSelection = sinon.spy();
+        const table = harness.mount(createTableOfSize(3, 7, {}, {onSelection, selectedRegionTransform}));
+
+        // clicking adds transformed selection
+        table.find(CELL_SELECTOR).mouse("mousedown").mouse("mouseup");
+
+        expect(onSelection.called).to.equal(true);
+        expect(onSelection.lastCall.args).to.deep.equal([[Regions.row(1)]]);
+    });
+
+    it("Accepts controlled selection", () => {
+        const table = harness.mount(createTableOfSize(3, 7, {}, { selectedRegions: [ Regions.row(0) ]}));
+        const selectionRegion = table.find(".bp-table-selection-region");
+        expect(selectionRegion.element).to.exist;
     });
 
     // TODO fix these tests on CircleCI.

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -107,7 +107,7 @@ describe("Selection", () => {
         // clicking adds transformed selection
         table.find(CELL_SELECTOR).mouse("mousedown").mouse("mouseup");
 
-        expect(onSelection.called).to.equal(true);
+        expect(onSelection.called).to.be.true;
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.row(1)]]);
     });
 


### PR DESCRIPTION
#### PR checklist

- [x] New Feature
- [x] Includes tests

Related: #191

#### What changes did you make?

Adds "selectedRegions" prop to Table to allow to user to take over
control of selection. If defined, the user will be responsible for
updating the selection and should probable add a "onSelection"
callback.

Adds "selectedRegionTransform" prop to table to allow users to
transform the selection region. This allows users to, for example,
select a whole row when the user clicks on a single cell. Using
a transform is advantageous because we can still handle interaction
semantics like multiselect, meta-click, and click-to-deselect.