### PR TITLE
Export Draggable components from Table

### DIFF
--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -10,22 +10,22 @@ import "es6-shim";
 export {
     Cell,
     ICellProps,
-    ICellRenderer
+    ICellRenderer,
 } from "./cell/cell";
 
 export {
     EditableCell,
-    IEditableCellProps
+    IEditableCellProps,
 } from "./cell/editableCell";
 
 export {
     JSONFormat,
-    IJSONFormatProps
+    IJSONFormatProps,
 } from "./cell/formats/jsonFormat";
 
 export {
     TruncatedFormat,
-    ITruncatedFormatProps
+    ITruncatedFormatProps,
 } from "./cell/formats/truncatedFormat";
 
 export {
@@ -38,8 +38,15 @@ export {
     Clipboard,
     Grid,
     Rect,
-    Utils
+    Utils,
 } from "./common/index";
+
+export {
+    ICoordinateData,
+    IDragHandler,
+    IDraggableProps,
+    Draggable,
+} from "./interactions/draggable";
 
 export {
     CopyCellsMenuItem,
@@ -51,24 +58,30 @@ export {
     ILockableLayout,
     IResizeHandleProps,
     Orientation,
-    ResizeHandle
+    ResizeHandle,
 } from "./interactions/resizeHandle";
+
+export {
+    ISelectableProps,
+    IDragSelectableProps,
+    DragSelectable,
+} from "./interactions/selectable";
 
 export {
     ColumnHeaderCell,
     IColumnHeaderCellProps,
     IColumnHeaderRenderer,
-    HorizontalCellDivider
+    HorizontalCellDivider,
 } from "./headers/columnHeaderCell";
 
 export {
     IRowHeaderCellProps,
-    RowHeaderCell
+    RowHeaderCell,
 } from "./headers/rowHeaderCell";
 
 export {
     IEditableNameProps,
-    EditableName
+    EditableName,
 } from "./headers/editableName";
 
 export {
@@ -77,10 +90,10 @@ export {
     IStyledRegionGroup,
     RegionCardinality,
     Regions,
-    SelectionModes
+    SelectionModes,
 } from "./regions";
 
 export {
     ITableProps,
-    Table
+    Table,
 } from "./table";


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #251

#### What changes did you make?

Adds exports for Draggable and DragSelectable (and
supporting interfaces) to public API.