### PR TITLE
Fix table height in docs

### DIFF
--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -244,13 +244,7 @@
 
 #{section-id("components.table-js")} {
   .kss-example {
-    height: auto;
-  }
-}
-
-#{section-id("components.table-js.example-sortable")} {
-  .kss-example {
-    height: $pt-grid-size * 40;
+    height: $pt-grid-size * 30;
   }
 }
 

--- a/packages/table/src/_docs.scss
+++ b/packages/table/src/_docs.scss
@@ -12,18 +12,16 @@ Table (React)
 A highly interactive table React component.
 
 <div class="pt-callout pt-large pt-intent-primary pt-icon-info-sign">
-  <p>
   If you are looking instead for the Blueprint-styled HTML table, see [**the previous section**](#components.table).
-  </p>
 </div>
 
 ### Features
 
-* High scale, data-agnostic
+* High-scale, data-agnostic
 * Customizable cell and header rendering
 * Virtualized viewport rendering
-* Selectable rows/columns/cells
-* Resizable rows/columns
+* Selectable rows, columns and cells
+* Resizable rows and columns
 * Editable headers and cells
 * Integrated header and context menus
 

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -22,7 +22,7 @@ $menu-z-index: $row-z-index + 1;
   background-color: $table-background-color;
   max-width: 100%;
   height: 100%; // IE 11
-  min-height: 60px; // For unit tests, we make sure at least one row is visible
+  min-height: $pt-grid-size * 6; // For unit tests, we make sure at least one row is visible
   max-height: 100%;
   overflow: hidden;
   will-change: transform; // Create stacking context to isolate z-indices
@@ -148,7 +148,7 @@ $menu-z-index: $row-z-index + 1;
 .bp-table-scrollbar-measure {
   position: absolute;
   top: -9999px;
-  width: 100px;
-  height: 100px;
+  width: $pt-grid-size * 10;
+  height: $pt-grid-size * 10;
   overflow: scroll;
 }


### PR DESCRIPTION
Fixes #203

#### What changes did you make?

Give all table examples a fixed height of 300px
