### PR TITLE
Add a min-width to sliders

### DIFF
--- a/packages/core/src/components/slider/_common.scss
+++ b/packages/core/src/components/slider/_common.scss
@@ -12,6 +12,7 @@
   position: relative;
   cursor: default;
   width: 100%;
+  min-width: 15 * $pt-grid-size;
   height: $height;
 
   &:hover {

--- a/packages/core/src/components/slider/_common.scss
+++ b/packages/core/src/components/slider/_common.scss
@@ -12,7 +12,7 @@
   position: relative;
   cursor: default;
   width: 100%;
-  min-width: 15 * $pt-grid-size;
+  min-width: $pt-grid-size * 15;
   height: $height;
 
   &:hover {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #200
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Add a `min-width` of `150px` to sliders. This fixes the documentation popover bug mentioned in the issue (the popover wasn't specifying an explicit `width`, so it was rendering with zero width before):

![image](https://cloud.githubusercontent.com/assets/443450/20729702/081ddbb4-b638-11e6-8fe6-26d83437c734.png)

#### Is there anything you'd like reviewers to focus on?

(optional)

