### PR TITLE
Fix icon menu bugs

### DIFF
--- a/packages/docs/src/components/icon.tsx
+++ b/packages/docs/src/components/icon.tsx
@@ -27,7 +27,7 @@ export interface IIconProps {
     icon?: IFontIcon;
 }
 
-const GITHUB_PATH = "https://github.com/palantir/blueprint/blob/develop/resources/icons";
+const GITHUB_PATH = "https://github.com/palantir/blueprint/blob/master/resources/icons";
 
 @PureRender
 @ContextMenuTarget


### PR DESCRIPTION
#### PR checklist

- [x] Fixes #268 and #205
- [x] Bugfix

#### What changes did you make?

- Changed the download link to reference icon files in the `master` branch instead of `develop`, which doesn't exist.
- The context menu already dismisses as expected when I click on the document. Not sure when that got fixed, but this PR does nothing in particular to address it.  
