### PR TITLE
Fix overlay issues

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -78,6 +78,7 @@ export const NON_IDEAL_STATE_VISUAL = "pt-non-ideal-state-visual";
 
 export const OVERLAY = "pt-overlay";
 export const OVERLAY_BACKDROP = "pt-overlay-backdrop";
+export const OVERLAY_CONTENT = "pt-overlay-content";
 export const OVERLAY_INLINE = "pt-overlay-inline";
 export const OVERLAY_OPEN = "pt-overlay-open";
 export const OVERLAY_SCROLL_CONTAINER = "pt-overlay-scroll-container";

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -76,7 +76,9 @@ export const NON_IDEAL_STATE_ICON = "pt-non-ideal-state-icon";
 export const NON_IDEAL_STATE_TITLE = "pt-non-ideal-state-title";
 export const NON_IDEAL_STATE_VISUAL = "pt-non-ideal-state-visual";
 
+export const OVERLAY = "pt-overlay";
 export const OVERLAY_BACKDROP = "pt-overlay-backdrop";
+export const OVERLAY_INLINE = "pt-overlay-inline";
 export const OVERLAY_OPEN = "pt-overlay-open";
 export const OVERLAY_SCROLL_CONTAINER = "pt-overlay-scroll-container";
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -52,9 +52,11 @@ Markup:
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
       <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
-      <button class="pt-button pt-minimal pt-intent-primary">
-        can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
-      </button>
+      <div class="pt-input-action">
+        <button class="pt-button pt-minimal pt-intent-primary">
+          can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
+        </button>
+      </div>
     </div>
     <button class="pt-button pt-intent-primary">Add</button>
   </div>

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -52,11 +52,9 @@ Markup:
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
       <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
-      <div class="pt-input-action">
-        <button class="pt-button pt-minimal pt-intent-primary">
-          can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
-        </button>
-      </div>
+      <button class="pt-button pt-minimal pt-intent-primary">
+        can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
+      </button>
     </div>
     <button class="pt-button pt-intent-primary">Add</button>
   </div>
@@ -128,10 +126,13 @@ Styleguide components.forms.control-group
     position: relative;
   }
 
+  .pt-input-group .pt-button:focus {
+    position: absolute;
+  }
+
   // input group contents appear above input always
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
-  .pt-input-group > .pt-input-action,
   .pt-select::after {
     z-index: 3;
   }

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -131,6 +131,7 @@ Styleguide components.forms.control-group
   // input group contents appear above input always
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
+  .pt-input-group > .pt-input-action,
   .pt-select::after {
     z-index: 3;
   }
@@ -139,9 +140,6 @@ Styleguide components.forms.control-group
   // lock the button in place so that it remains visible
   // and in place when the input field receives focus
   .pt-input-group .pt-button {
-    position: absolute;
-    right: 0;
-    z-index: 3;
     border-radius: $pt-border-radius;
   }
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -139,10 +139,10 @@ Styleguide components.forms.control-group
   // lock the button in place so that it remains visible
   // and in place when the input field receives focus
   .pt-input-group .pt-button {
-    border-radius: $pt-border-radius;
     position: absolute;
     right: 0;
     z-index: 3;
+    border-radius: $pt-border-radius;
   }
 
   /*

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -126,10 +126,6 @@ Styleguide components.forms.control-group
     position: relative;
   }
 
-  .pt-input-group .pt-button:focus {
-    position: absolute;
-  }
-
   // input group contents appear above input always
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
@@ -137,9 +133,14 @@ Styleguide components.forms.control-group
     z-index: 3;
   }
 
-  // bring back border radius on these buttons
+  // bring back border radius on these buttons, and
+  // lock the button in place so that it remains visible
+  // and in place when the input field receives focus
   .pt-input-group .pt-button {
     border-radius: $pt-border-radius;
+    position: absolute;
+    right: 0;
+    z-index: 3;
   }
 
   /*

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -136,9 +136,7 @@ Styleguide components.forms.control-group
     z-index: 3;
   }
 
-  // bring back border radius on these buttons, and
-  // lock the button in place so that it remains visible
-  // and in place when the input field receives focus
+  // bring back border radius on these buttons
   .pt-input-group .pt-button {
     border-radius: $pt-border-radius;
   }

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -74,7 +74,7 @@ $overlay-background-color: rgba($black, 0.7);
 
 // scroll container for non-inline overlay
 .pt-overlay-scroll-container.pt-overlay-open {
-  @include position(absolute, 0);
+  @include position(fixed, 0);
   overflow: auto;
 
   .pt-overlay-backdrop {
@@ -84,7 +84,7 @@ $overlay-background-color: rgba($black, 0.7);
 }
 
 .pt-overlay-backdrop {
-  @include position(absolute, 0);
+  @include position(fixed, 0);
   @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
 
   z-index: $pt-z-index-overlay;

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -41,8 +41,8 @@ but your application is responsible for updating the state that actually closes 
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>A note about overlay content positioning</h5>
-  **Do not** specify a `position` rule for your overlay content. Your content's `position` will
-  automatically be set to `fixed` or `absolute` depending on the `inline` prop.
+  When rendered inline, content will automatically be set to `position:absolute` to respect
+  document flow. Otherwise, content will be set to `position:fixed` to cover the entire viewport.
 </div>
 
 ```

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -77,17 +77,7 @@ body.pt-overlay-open {
   overflow: hidden;
 }
 
-// scroll container for non-inline overlay
-.pt-overlay-scroll-container.pt-overlay-open {
-  @include position(fixed, 0);
-  overflow: auto;
-
-  .pt-overlay-backdrop {
-    // fixed position so it won't scroll under the overlay
-    position: fixed;
-  }
-}
-
+// fixed position so it won't scroll underneath the overlay content
 .pt-overlay-backdrop {
   @include position(fixed, 0);
   @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
@@ -99,18 +89,36 @@ body.pt-overlay-open {
   &:focus {
     outline: none;
   }
+}
 
-  // when rendered inline, we want the overlay to position itself relative to
-  // its parent container, not relative to the whole window.
-  .pt-overlay-inline & {
+// we surreptitiously add this class to the overlay content container so that
+// users won't need to explicitly manage the position mode for inline and
+// non-inline rendering.
+.pt-overlay-content {
+  position: fixed;
+}
+
+// when rendered inline, we want the overlay to position itself relative to
+// its parent container, not relative to the whole window. thus, we change
+// to position:absolute.
+.pt-overlay-inline {
+  .pt-overlay-backdrop,
+  .pt-overlay-content {
     position: absolute;
   }
 }
 
-.pt-overlay-content {
-  position: fixed;
+// scroll container for non-inline overlay. it needs an explicit z-index to
+// ensure that the backdrop renders on top of any navbars.
+.pt-overlay-scroll-container.pt-overlay-open {
+  @include position(fixed, 0);
+  z-index: $pt-z-index-overlay;
+  overflow: auto;
 
-  .pt-overlay-inline & {
+  // if content extends off the bottom of the page, it will not be
+  // scrollable if it's position:fixed. scrolling works as expected if
+  // it's position:absolute though.
+  .pt-overlay-content {
     position: absolute;
   }
 }

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -106,3 +106,11 @@ body.pt-overlay-open {
     position: absolute;
   }
 }
+
+.pt-overlay-content {
+  position: fixed;
+
+  .pt-overlay-inline & {
+    position: absolute;
+  }
+}

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -39,13 +39,10 @@ optional backdrop element will be inserted before the children if `hasBackdrop={
 The `onClose` callback prop is invoked when user interaction causes the overlay to close,
 but your application is responsible for updating the state that actually closes the overlay.
 
-<div class="pt-callout pt-intent-warning pt-icon-warning-sign">
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>A note about overlay content positioning</h5>
-  **Do not specify a `position` rule for your overlay content.** By default, the overlay backdrop and content are rendered
-  with `position: fixed` so that those elements will stay fixed in place above the application. If the overlay is rendered
-  inline, however, the backdrop and content will render with `position: absolute` so that those elements will render relative
-  to their parent container. These position rules are handled for you under the hood. Setting an explicit `position` rule in
-  your own CSS could override these defaults and produce undesired results.
+  **Do not** specify a `position` rule for your overlay content. Your content's `position` will
+  automatically be set to `fixed` or `absolute` depending on the `inline` prop.
 </div>
 
 ```

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -103,6 +103,6 @@ body.pt-overlay-open {
   // when rendered inline, we want the overlay to position itself relative to
   // its parent container, not relative to the whole window.
   .pt-overlay-inline & {
-    @include position(absolute, 0);
+    position: absolute;
   }
 }

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -77,35 +77,32 @@ body.pt-overlay-open {
   overflow: hidden;
 }
 
-.pt-overlay {
-
-  // scroll container for non-inline overlay
-  &.pt-overlay-scroll-container.pt-overlay-open {
-    @include position(fixed, 0);
-    overflow: auto;
-
-    .pt-overlay-backdrop {
-      // fixed position so it won't scroll under the overlay
-      position: fixed;
-    }
-  }
-
-  &.pt-overlay-inline {
-    .pt-overlay-backdrop {
-      @include position(absolute, 0);
-    }
-  }
+// scroll container for non-inline overlay
+.pt-overlay-scroll-container.pt-overlay-open {
+  @include position(fixed, 0);
+  overflow: auto;
 
   .pt-overlay-backdrop {
-    @include position(fixed, 0);
-    @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
+    // fixed position so it won't scroll under the overlay
+    position: fixed;
+  }
+}
 
-    z-index: $pt-z-index-overlay;
-    background-color: $overlay-background-color;
-    overflow: auto;
+.pt-overlay-backdrop {
+  @include position(fixed, 0);
+  @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
 
-    &:focus {
-      outline: none;
-    }
+  z-index: $pt-z-index-overlay;
+  background-color: $overlay-background-color;
+  overflow: auto;
+
+  &:focus {
+    outline: none;
+  }
+
+  // when rendered inline, we want the overlay to position itself relative to
+  // its parent container, not relative to the whole window.
+  .pt-overlay-inline & {
+    @include position(absolute, 0);
   }
 }

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -41,8 +41,8 @@ but your application is responsible for updating the state that actually closes 
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>A note about overlay content positioning</h5>
-  When rendered inline, content will automatically be set to `position:absolute` to respect
-  document flow. Otherwise, content will be set to `position:fixed` to cover the entire viewport.
+  When rendered inline, content will automatically be set to `position: absolute` to respect
+  document flow. Otherwise, content will be set to `position: fixed` to cover the entire viewport.
 </div>
 
 ```

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -39,6 +39,15 @@ optional backdrop element will be inserted before the children if `hasBackdrop={
 The `onClose` callback prop is invoked when user interaction causes the overlay to close,
 but your application is responsible for updating the state that actually closes the overlay.
 
+<div class="pt-callout pt-intent-warning pt-icon-warning-sign">
+  <h5>A note about overlay content positioning</h5>
+  **Do not specify a `position` rule for your overlay content.** By default, the overlay backdrop and content are rendered
+  with `position: fixed` so that those elements will stay fixed in place above the application. If the overlay is rendered
+  inline, however, the backdrop and content will render with `position: absolute` so that those elements will render relative
+  to their parent container. These position rules are handled for you under the hood. Setting an explicit `position` rule in
+  your own CSS could override these defaults and produce undesired results.
+</div>
+
 ```
 <div>
     <Button text="Show overlay" onClick={this.toggleOverlay} />
@@ -48,6 +57,7 @@ but your application is responsible for updating the state that actually closes 
 </div>
 ```
 
+
 @interface IOverlayProps
 
 Styleguide components.overlay.js
@@ -56,9 +66,9 @@ Styleguide components.overlay.js
 /*
 Scrollable overlays
 
-Overlays rely heavily on absolute positioning so by default a large overlay will not cause
-the page to scroll and any overflow will be hidden. Fortunately, Blueprint makes scrolling
-support very easy. Simply pass `"pt-overlay-scroll-container"` as the Overlay `className` and
+Overlays rely heavily on fixed and absolute positioning. By default, a large overlay will not cause
+the page to scroll, and any overflowing content will be hidden. Fortunately, Blueprint makes scrolling
+support very easy: simply pass `"pt-overlay-scroll-container"` as the Overlay `className`, and
 we'll take care of the rest.
 
 ```
@@ -77,7 +87,7 @@ body.pt-overlay-open {
   overflow: hidden;
 }
 
-// fixed position so it won't scroll underneath the overlay content
+// fixed position so the backdrop forecefully covers the whole screen
 .pt-overlay-backdrop {
   @include position(fixed, 0);
   @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -72,26 +72,40 @@ Styleguide components.overlay.scroll
 
 $overlay-background-color: rgba($black, 0.7);
 
-// scroll container for non-inline overlay
-.pt-overlay-scroll-container.pt-overlay-open {
-  @include position(fixed, 0);
-  overflow: auto;
-
-  .pt-overlay-backdrop {
-    // fixed position so it won't scroll under the overlay
-    position: fixed;
-  }
+// restricts scrolling of underlying content while the overlay is open
+body.pt-overlay-open {
+  overflow: hidden;
 }
 
-.pt-overlay-backdrop {
-  @include position(fixed, 0);
-  @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
-
+.pt-overlay {
   z-index: $pt-z-index-overlay;
-  background-color: $overlay-background-color;
-  overflow: auto;
 
-  &:focus {
-    outline: none;
+  // scroll container for non-inline overlay
+  &.pt-overlay-scroll-container.pt-overlay-open {
+    @include position(fixed, 0);
+    overflow: auto;
+
+    .pt-overlay-backdrop {
+      // fixed position so it won't scroll under the overlay
+      position: fixed;
+    }
+  }
+
+  &.pt-overlay-inline {
+    .pt-overlay-backdrop {
+      @include position(absolute, 0);
+    }
+  }
+
+  .pt-overlay-backdrop {
+    @include position(fixed, 0);
+    @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
+
+    background-color: $overlay-background-color;
+    overflow: auto;
+
+    &:focus {
+      outline: none;
+    }
   }
 }

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -78,7 +78,6 @@ body.pt-overlay-open {
 }
 
 .pt-overlay {
-  z-index: $pt-z-index-overlay;
 
   // scroll container for non-inline overlay
   &.pt-overlay-scroll-container.pt-overlay-open {
@@ -101,6 +100,7 @@ body.pt-overlay-open {
     @include position(fixed, 0);
     @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
 
+    z-index: $pt-z-index-overlay;
     background-color: $overlay-background-color;
     overflow: auto;
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -160,15 +160,10 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         const { children, className, inline, isOpen, transitionDuration, transitionName } = this.props;
 
         // add a special class to each child that will automatically set the appropriate
-        // CSS position mode under the hood. we add this class *after* the existing classes
-        // so that our class will override the position style of other classes that might
-        // have set unnecessary position rules (note that CSS specificity plays a role here;
-        // our class will only override an existing position rule if it has the same or
-        // greater selector specificity).
-        const decoratedChildren = React.Children.map(children, (child: React.ReactChild) => {
-            const childEl = child as React.ReactElement<any>;
-            return React.cloneElement(childEl, {
-                className: classNames(childEl.props.className, Classes.OVERLAY_CONTENT),
+        // CSS position mode under the hood.
+        const decoratedChildren = React.Children.map(children, (child: React.ReactElement<any>) => {
+            return React.cloneElement(child, {
+                className: classNames(child.props.className, Classes.OVERLAY_CONTENT),
             });
         });
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -84,6 +84,11 @@ export interface IBackdropProps {
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
     /**
+     * Whether the background-content scrolling should be disabled while the overlay is visible.
+     */
+    backgroundScrollingEnabled?: boolean;
+
+    /**
      * Whether clicking outside the overlay element (either on backdrop when present or on document)
      * should invoke `onClose`.
      * @default true
@@ -172,8 +177,14 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             </CSSTransitionGroup>
         );
 
+        const mergedClassName = classNames({
+            [Classes.OVERLAY]: true,
+            [Classes.OVERLAY_OPEN]: isOpen,
+            [Classes.OVERLAY_INLINE]: inline,
+        }, className);
+
         const elementProps = {
-            className: classNames({ [Classes.OVERLAY_OPEN]: isOpen }, className),
+            className: mergedClassName,
             onKeyDown: this.handleKeyDown,
             // make the container focusable so we can trap focus inside it (via `persistentFocus()`)
             tabIndex: 0,
@@ -236,6 +247,8 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         document.removeEventListener("focus", this.handleDocumentFocus, /* useCapture */ true);
         document.removeEventListener("mousedown", this.handleDocumentClick);
 
+        document.body.classList.remove(Classes.OVERLAY_OPEN);
+
         const { openStack } = Overlay;
         const idx = openStack.indexOf(this);
         if (idx > 0) {
@@ -265,6 +278,9 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             if (this.props.autoFocus) {
                 this.bringFocusInsideOverlay();
             }
+        } else {
+            // add a class to the body to prevent scrolling of content below the overlay
+            document.body.classList.add(Classes.OVERLAY_OPEN);
         }
     }
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -159,6 +159,19 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
 
         const { children, className, inline, isOpen, transitionDuration, transitionName } = this.props;
 
+        // add a special class to each child that will automatically set the appropriate
+        // CSS position mode under the hood. we add this class *after* the existing classes
+        // so that our class will override the position style of other classes that might
+        // have set unnecessary position rules (note that CSS specificity plays a role here;
+        // our class will only override an existing position rule if it has the same or
+        // greater selector specificity).
+        const decoratedChildren = React.Children.map(children, (child: React.ReactChild) => {
+            const childEl = child as React.ReactElement<any>;
+            return React.cloneElement(childEl, {
+                className: classNames(childEl.props.className, Classes.OVERLAY_CONTENT),
+            });
+        });
+
         const transitionGroup = (
             <CSSTransitionGroup
                 transitionAppear={true}
@@ -168,7 +181,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
                 transitionName={transitionName}
             >
                 {this.maybeRenderBackdrop()}
-                {isOpen ? children : null}
+                {isOpen ? decoratedChildren : null}
             </CSSTransitionGroup>
         );
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -272,7 +272,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             if (this.props.autoFocus) {
                 this.bringFocusInsideOverlay();
             }
-        } else {
+        } else if (this.props.hasBackdrop) {
             // add a class to the body to prevent scrolling of content below the overlay
             document.body.classList.add(Classes.OVERLAY_OPEN);
         }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -172,8 +172,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             </CSSTransitionGroup>
         );
 
-        const mergedClassName = classNames({
-            [Classes.OVERLAY]: true,
+        const mergedClassName = classNames(Classes.OVERLAY, {
             [Classes.OVERLAY_OPEN]: isOpen,
             [Classes.OVERLAY_INLINE]: inline,
         }, className);

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -84,9 +84,9 @@ export interface IBackdropProps {
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
     /**
-     * Whether the background-content scrolling should be disabled while the overlay is visible.
+     * Whether underlying content should be scrollable while the backdrop is visible.
      */
-    backgroundScrollingEnabled?: boolean;
+    backgroundScrollingDisabled?: boolean;
 
     /**
      * Whether clicking outside the overlay element (either on backdrop when present or on document)
@@ -129,6 +129,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
     public static defaultProps: IOverlayProps = {
         autoFocus: true,
         backdropProps: {},
+        backgroundScrollingDisabled: true,
         canEscapeKeyClose: true,
         canOutsideClickClose: true,
         enforceFocus: true,
@@ -278,7 +279,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             if (this.props.autoFocus) {
                 this.bringFocusInsideOverlay();
             }
-        } else {
+        } else if (this.props.backgroundScrollingDisabled) {
             // add a class to the body to prevent scrolling of content below the overlay
             document.body.classList.add(Classes.OVERLAY_OPEN);
         }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -84,11 +84,6 @@ export interface IBackdropProps {
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
     /**
-     * Whether underlying content should be scrollable while the backdrop is visible.
-     */
-    backgroundScrollingDisabled?: boolean;
-
-    /**
      * Whether clicking outside the overlay element (either on backdrop when present or on document)
      * should invoke `onClose`.
      * @default true
@@ -129,7 +124,6 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
     public static defaultProps: IOverlayProps = {
         autoFocus: true,
         backdropProps: {},
-        backgroundScrollingDisabled: true,
         canEscapeKeyClose: true,
         canOutsideClickClose: true,
         enforceFocus: true,
@@ -279,7 +273,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             if (this.props.autoFocus) {
                 this.bringFocusInsideOverlay();
             }
-        } else if (this.props.backgroundScrollingDisabled) {
+        } else {
             // add a class to the body to prevent scrolling of content below the overlay
             document.body.classList.add(Classes.OVERLAY_OPEN);
         }

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -280,23 +280,42 @@ describe("<Overlay>", () => {
 
     describe("Background scrolling", () => {
 
-        it("adds a .pt-overlay-open class to document.body when non-inline overlay opens", () => {
-            wrapper = mount(
-                <Overlay inline={false} isOpen={true}>
-                    <div>Some overlay content</div>
-                </Overlay>,
-            );
-            assert.isTrue(document.body.classList.contains(Classes.OVERLAY_OPEN));
+        it("disables document scrolling by default", () => {
+            wrapper = mountOverlay(undefined, undefined);
+            assert.isTrue(isBodyScrollingDisabled());
         });
 
-        it("does not add a .pt-overlay-open class to document.body when inline overlay opens", () => {
-            wrapper = mount(
-                <Overlay inline={true} isOpen={true}>
+        it("disables document scrolling if inline=false and hasBackdrop=true", () => {
+            wrapper = mountOverlay(false, true);
+            assert.isTrue(isBodyScrollingDisabled());
+        });
+
+        it("does not disable document scrolling if inline=false and hasBackdrop=false", () => {
+            wrapper = mountOverlay(false, false);
+            assert.isFalse(isBodyScrollingDisabled());
+        });
+
+        it("does not disable document scrolling if inline=true and hasBackdrop=true", () => {
+            wrapper = mountOverlay(true, true);
+            assert.isFalse(isBodyScrollingDisabled());
+        });
+
+        it("does not disable document scrolling if inline=true and hasBackdrop=false", () => {
+            wrapper = mountOverlay(true, false);
+            assert.isFalse(isBodyScrollingDisabled());
+        });
+
+        function mountOverlay(inline?: boolean, hasBackdrop?: boolean) {
+            return mount(
+                <Overlay hasBackdrop={hasBackdrop} inline={inline} isOpen={true}>
                     <div>Some overlay content</div>
                 </Overlay>,
             );
-            assert.isFalse(document.body.classList.contains(Classes.OVERLAY_OPEN));
-        });
+        }
+
+        function isBodyScrollingDisabled() {
+            return document.body.classList.contains(Classes.OVERLAY_OPEN);
+        }
     });
 
     let index = 0;

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -19,7 +19,6 @@ describe("<Overlay>", () => {
     let wrapper: ReactWrapper<IOverlayProps, any>;
 
     afterEach(() => {
-        document.body.classList.remove(Classes.OVERLAY_OPEN);
         if (wrapper != null) {
             wrapper.unmount();
             wrapper = null;

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -19,6 +19,7 @@ describe("<Overlay>", () => {
     let wrapper: ReactWrapper<IOverlayProps, any>;
 
     afterEach(() => {
+        document.body.classList.remove(Classes.OVERLAY_OPEN);
         if (wrapper != null) {
             wrapper.unmount();
             wrapper = null;
@@ -153,7 +154,7 @@ describe("<Overlay>", () => {
         });
     });
 
-    describe("focus management:", () => {
+    describe("Focus management", () => {
         const testsContainerElement = document.createElement("div");
         document.documentElement.appendChild(testsContainerElement);
 
@@ -164,7 +165,7 @@ describe("<Overlay>", () => {
                 </Overlay>,
                 { attachTo: testsContainerElement },
             );
-            assert.equal(document.querySelector(".pt-overlay-open"), document.activeElement);
+            assert.equal(document.body.querySelector(".pt-overlay-open"), document.activeElement);
         });
 
         it("does not bring focus to overlay if autoFocus=false", () => {
@@ -276,6 +277,27 @@ describe("<Overlay>", () => {
             assert.equal(document.querySelector("button"), document.activeElement);
         });
         /* tslint:enable:jsx-no-lambda */
+    });
+
+    describe("Background scrolling", () => {
+
+        it("adds a .pt-overlay-open class to document.body when non-inline overlay opens", () => {
+            wrapper = mount(
+                <Overlay inline={false} isOpen={true}>
+                    <div>Some overlay content</div>
+                </Overlay>,
+            );
+            assert.isTrue(document.body.classList.contains(Classes.OVERLAY_OPEN));
+        });
+
+        it("does not add a .pt-overlay-open class to document.body when inline overlay opens", () => {
+            wrapper = mount(
+                <Overlay inline={true} isOpen={true}>
+                    <div>Some overlay content</div>
+                </Overlay>,
+            );
+            assert.isFalse(document.body.classList.contains(Classes.OVERLAY_OPEN));
+        });
     });
 
     let index = 0;

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -305,7 +305,7 @@ describe("<Overlay>", () => {
             assert.isFalse(isBodyScrollingDisabled());
         });
 
-        function mountOverlay(inline?: boolean, hasBackdrop?: boolean) {
+        function mountOverlay(inline: boolean, hasBackdrop: boolean) {
             return mount(
                 <Overlay hasBackdrop={hasBackdrop} inline={inline} isOpen={true}>
                     <div>Some overlay content</div>

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -6,15 +6,22 @@
  */
 
 import { assert } from "chai";
-import { mount } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
-import { Classes, Portal } from "../../src";
+import { Classes, IPortalProps, Portal } from "../../src";
 
 describe("<Portal>", () => {
+
+    let portal: ReactWrapper<IPortalProps, {}>;
+
+    afterEach(() => {
+        portal.unmount();
+    });
+
     it("attaches contents to document.body", () => {
         const CLASS_TO_TEST = "bp-test-content";
-        const portal = mount(
+        portal = mount(
             <Portal>
                 <p className={CLASS_TO_TEST}>test</p>
             </Portal>,
@@ -22,11 +29,13 @@ describe("<Portal>", () => {
 
         assert.lengthOf(portal.find(`.${CLASS_TO_TEST}`), 0);
         assert.lengthOf(document.getElementsByClassName(CLASS_TO_TEST), 1);
+
+        portal.unmount();
     });
 
     it("propagates class names", () => {
         const CLASS_TO_TEST = "bp-test-klass";
-        mount(
+        portal = mount(
             <Portal className={CLASS_TO_TEST}>
                 <p>test</p>
             </Portal>,

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -16,7 +16,10 @@ describe("<Portal>", () => {
     let portal: ReactWrapper<IPortalProps, {}>;
 
     afterEach(() => {
-        portal.unmount();
+        if (portal != null) {
+            portal.unmount();
+            portal = null;
+        }
     });
 
     it("attaches contents to document.body", () => {
@@ -29,8 +32,6 @@ describe("<Portal>", () => {
 
         assert.lengthOf(portal.find(`.${CLASS_TO_TEST}`), 0);
         assert.lengthOf(document.getElementsByClassName(CLASS_TO_TEST), 1);
-
-        portal.unmount();
     });
 
     it("propagates class names", () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -91,6 +91,8 @@ describe("<Tooltip>", () => {
 
         assert.lengthOf(svgTooltip.find("span"), 0);
         assert.lengthOf(svgTooltip.find(`.${TEST_CLASS_NAME}`), 1);
+
+        svgTooltip.unmount();
     });
 
     function renderTooltip(props?: any) {

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -263,15 +263,10 @@
 .docs-overlay-example-transition {
   $overlay-example-width: $pt-grid-size * 40;
 
-  position: fixed;
   top: $overlay-example-width / 2;
   left: calc(50% - #{$overlay-example-width / 2});
   z-index: $pt-z-index-overlay + 1;
   width: $overlay-example-width;
-
-  .pt-overlay-inline & {
-    position: absolute;
-  }
 }
 
 #{section-name("Non-ideal State")} {

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -263,11 +263,15 @@
 .docs-overlay-example-transition {
   $overlay-example-width: $pt-grid-size * 40;
 
-  position: absolute;
+  position: fixed;
   top: $overlay-example-width / 2;
   left: calc(50% - #{$overlay-example-width / 2});
   z-index: $pt-z-index-overlay + 1;
   width: $overlay-example-width;
+
+  .pt-overlay-inline & {
+    position: absolute;
+  }
 }
 
 #{section-name("Non-ideal State")} {


### PR DESCRIPTION
#### PR checklist

- [x] Fixes #183
- [x] Bugfix
- [x] Includes tests
- [x] Documentation update

#### What changes did you make?

- Introduce a `pt-overlay` class to serve as the top-level wrapper descriptor for the overlay component.
_As a consumer of Blueprint in the past, I was always much happier when everything had a clear CSS class attached to it. CSS rules downstream are much easier to grok and maintain when applied to meaningfully named elements, rather than opaque HTML tag names._

- Introduce a `.pt-overlay-inline` class and apply it to the `.pt-overlay` element iff the overlay is being rendered inline.
_This allows us to set `.pt-overlay-backdrop` and/or overlay content to `position: absolute` when the overlay is rendered inline, so that the overlay intuitively positions itself relative to its parent in that case._  

- Introduce a `.pt-overlay-content` class that we apply under-the-hood to overlay content containers to manage CSS position mode on behalf of the developer.
_Otherwise, Blueprint users would have to explicitly set `position:fixed` for non-inline and `position:absolute` for inline rendering. That'd be brittle._

- Set `.pt-overlay-backdrop` to `position:fixed` if the overlay is not rendered inline.
_This is the crucial fix for #183._

- Disable document scrolling beneath the overlay backdrop when `hasBackdrop` is `true`.

- Reorganize CSS a bit to ensure that overflow-scrolling still works.

- Tweaked unit tests:
  - Added tests for the new body scrolling behavior
  - Explicitly unmount an errant tooltip that was causing `.pt-overlay-open` to stay on the `body` after all the tests ran via `gulp karma-unit-core` 
  - Bonus: Noticed that some `<Portal>` tests aren't properly detaching containers after they run. Fixed.

__Abandoned Changes__:

- ~Introduce a `backgroundScrollingDisabled` prop on `IBackdropProps` that, when `true`, disables scrolling of content beneath the overlay backdrop. _Underneath the hood, this adds a `.pt-overlay-open` class to the document `body` that sets `overflow: hidden` when applied._~

#### Is there anything you'd like reviewers to focus on?

- Does this approach make sense?
- Could anything be named more clearly?