### PR TITLE
[table] Remove min width from editable components

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -57,6 +57,7 @@ export class EditableCell extends React.Component<IEditableCellProps, {}> {
                         className={"bp-table-editable-name"}
                         defaultValue={value}
                         intent={intent}
+                        minWidth={null}
                         onCancel={onCancel}
                         onChange={onChange}
                         onConfirm={onConfirm}

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -45,6 +45,7 @@ export class EditableName extends React.Component<IEditableNameProps, {}> {
                 className={classNames(className, "bp-table-editable-name")}
                 defaultValue={name}
                 intent={intent}
+                minWidth={null}
                 onCancel={onCancel}
                 onChange={onChange}
                 onConfirm={onConfirm}


### PR DESCRIPTION
#### Fixes #281

#### Changes proposed in this pull request:

`<EditableText>` has a default min-width of 80px,
which overflows the table cell.

Settings the minWidth prop to null will fix this.