### PR TITLE
Add obvious docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Blueprint is a React UI toolkit for the web.
 It is optimized for building complex, data-dense web interfaces for _desktop applications_.
 If you rely heavily on mobile interactions and are looking for a mobile-first UI toolkit, this may not be for you.
 
-[**View the full documentation →**](http://blueprintjs.com/docs)
+[**View the full documentation ▸**](http://blueprintjs.com/docs)
 
-[**Read our FAQ on the wiki →**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
+[**Read our FAQ on the wiki ▸**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Blueprint is a React UI toolkit for the web.
 It is optimized for building complex, data-dense web interfaces for _desktop applications_.
 If you rely heavily on mobile interactions and are looking for a mobile-first UI toolkit, this may not be for you.
 
-[More frequently asked questions are answered on the wiki](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions).
+[**View the full documentation →**](http://blueprintjs.com/docs)
+
+[**Read our FAQ on the wiki →**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 
 ## Packages
 


### PR DESCRIPTION
Got some feedback that it'd be great to have a direct link to the docs when viewing https://github.com/palantir/blueprint