### PR TITLE
moment-timezone compatability for DateInput

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -132,12 +132,12 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     public constructor(props?: IDateInputProps, context?: any) {
         super(props, context);
 
-        const defaultValue = this.props.defaultValue ? moment(this.props.defaultValue) : moment(null);
+        const defaultValue = this.props.defaultValue ? this.fromDateToMoment(this.props.defaultValue) : moment(null);
 
         this.state = {
             isInputFocused: false,
             isOpen: false,
-            value: this.props.value !== undefined ? moment(this.props.value) : defaultValue,
+            value: this.props.value !== undefined ? this.fromDateToMoment(this.props.value) : defaultValue,
             valueString: null,
         };
     }
@@ -152,7 +152,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 canClearSelection={this.props.canClearSelection}
                 defaultValue={null}
                 onChange={this.handleDateChange}
-                value={this.validAndInRange(this.state.value) ? this.state.value.toDate() : null}
+                value={this.validAndInRange(this.state.value) ? this.fromMomentToDate(this.state.value) : null}
             />
         );
 
@@ -200,7 +200,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     public componentWillReceiveProps(nextProps: IDateInputProps) {
         if (nextProps.value !== this.props.value) {
-            this.setState({ value: moment(nextProps.value) });
+            this.setState({ value: this.fromDateToMoment(nextProps.value) });
         }
 
         super.componentWillReceiveProps(nextProps);
@@ -237,15 +237,16 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private handleDateChange = (date: Date, hasUserManuallySelectedDate: boolean) => {
+        const momentDate = this.fromDateToMoment(date);
         const hasMonthChanged = date !== null && !this.isNull(this.state.value) && this.state.value.isValid() &&
-            date.getMonth() !== this.state.value.toDate().getMonth();
+            momentDate.month() !== this.state.value.month();
         const isOpen = !(this.props.closeOnSelection && hasUserManuallySelectedDate && !hasMonthChanged);
         if (this.props.value === undefined) {
-            this.setState({ isInputFocused: false, isOpen, value: moment(date) });
+            this.setState({ isInputFocused: false, isOpen, value: momentDate });
         } else {
             this.setState({ isInputFocused: false, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, date);
+        Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(momentDate));
     }
 
     private handleIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
@@ -288,7 +289,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             } else {
                 this.setState({ valueString });
             }
-            Utils.safeInvoke(this.props.onChange, value.toDate());
+            Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(value));
         } else {
             this.setState({ valueString });
         }
@@ -308,9 +309,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             if (!value.isValid()) {
                 Utils.safeInvoke(this.props.onError, new Date(undefined));
             } else if (!this.dateIsInRange(value)) {
-                Utils.safeInvoke(this.props.onError, value.toDate());
+                Utils.safeInvoke(this.props.onError, this.fromMomentToDate(value));
             } else {
-                Utils.safeInvoke(this.props.onChange, value.toDate());
+                Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(value));
             }
         } else {
             this.setState({ isInputFocused: false });
@@ -319,5 +320,37 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     private setInputRef = (el: HTMLElement) => {
         this.inputRef = el;
+    }
+
+    /**
+     * Translate a moment into a Date object, adjusting the moment timezone into the local one.
+     * This is a no-op unless moment-timezone's setDefault has been called.
+     */
+    private fromMomentToDate = (date: moment.Moment) => {
+        return new Date(
+            date.year(),
+            date.month(),
+            date.date(),
+            date.hours(),
+            date.minutes(),
+            date.seconds(),
+            date.milliseconds(),
+        );
+    }
+
+    /**
+     * Translate a Date object into a moment, adjusting the local timezone into the moment one.
+     * This is a no-op unless moment-timezone's setDefault has been called.
+     */
+    private fromDateToMoment = (date: Date) => {
+        return moment([
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes(),
+            date.getSeconds(),
+            date.getMilliseconds(),
+        ]);
     }
 }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -326,15 +326,15 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
      * Translate a moment into a Date object, adjusting the moment timezone into the local one.
      * This is a no-op unless moment-timezone's setDefault has been called.
      */
-    private fromMomentToDate = (date: moment.Moment) => {
+    private fromMomentToDate = (momentDate: moment.Moment) => {
         return new Date(
-            date.year(),
-            date.month(),
-            date.date(),
-            date.hours(),
-            date.minutes(),
-            date.seconds(),
-            date.milliseconds(),
+            momentDate.year(),
+            momentDate.month(),
+            momentDate.date(),
+            momentDate.hours(),
+            momentDate.minutes(),
+            momentDate.seconds(),
+            momentDate.milliseconds(),
         );
     }
 


### PR DESCRIPTION
#### Fixes #280 

#### Changes proposed in this pull request:

- Properly handle moment-timezone's setDefault
- DateInput accepts dates in the local timezone
- DateInput onChange returns dates in the local timezone

#### Reviewers should focus on:

- DateInput.handleDateChange method 
- Making sure this works in multiple timezones
- Making sure this works with and without moment-timezone

