### PR TITLE
Use typed literals for RegionCardinality

### DIFF
--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -12,27 +12,31 @@ import { Utils } from "./common/utils";
  * example, between all cells within a column and the whole column itself.
  * The `RegionCardinality` enum represents these distinct types of `Region`s.
  */
-export enum RegionCardinality {
+export type RegionCardinality = "cells"
+    | "full-rows"
+    | "full-columns"
+    | "full-table";
+export const RegionCardinality = {
     /**
      * A region that contains a finite rectangular group of table cells
      */
-    CELLS,
-
-    /**
-     * A region that represents all cells within 1 or more rows.
-     */
-    FULL_ROWS,
+    CELLS: "cells" as RegionCardinality,
 
     /**
      * A region that represents all cells within 1 or more columns.
      */
-    FULL_COLUMNS,
+    FULL_COLUMNS: "full-columns" as RegionCardinality,
+
+    /**
+     * A region that represents all cells within 1 or more rows.
+     */
+    FULL_ROWS: "full-rows" as RegionCardinality,
 
     /**
      * A region that represents all cells in the table.
      */
-    FULL_TABLE,
-}
+    FULL_TABLE: "full-table" as RegionCardinality,
+};
 
 /**
  * A convenience object for subsets of `RegionCardinality` that are commonly


### PR DESCRIPTION
#### Changes proposed in this pull request:

Use string literal types instead of enums. This allows for greater flexibility when composing collections of types. For example, if we wanted to create a `LoadingOptions` type to extend `RegionCardinality`, after this change it might look something like this:

```ts
export type LoadingOption = "column-header" | RegionCardinality;
export const LoadingOption = Object.assign(RegionCardinality, {
    COLUMN_HEADER: "column-header" as LoadingOption,
});
```

A side-effect of this change is that users now no longer need to import the `RegionCardinality` enum and can directly use string literals if they don't care about type safety while developing (the compiler will still complain if the string is invalid). 


