### PR TITLE
Move focus style manager to its own file

### DIFF
--- a/packages/core/src/accessibility/focusStyleManager.ts
+++ b/packages/core/src/accessibility/focusStyleManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
  * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
@@ -11,6 +11,8 @@ export const FOCUS_DISABLED_CLASS = "pt-focus-disabled";
 
 const focusEngine = new InteractionModeEngine(document.documentElement, FOCUS_DISABLED_CLASS);
 
+// this is basically meaningless to unit test; it requires manual UI testing
+/* istanbul ignore next */
 export const FocusStyleManager = {
     alwaysShowFocus: () => focusEngine.stop(),
     isActive: () => focusEngine.isActive(),

--- a/packages/core/src/accessibility/focusStyleManager.ts
+++ b/packages/core/src/accessibility/focusStyleManager.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { InteractionModeEngine } from "../common/interactionMode";
+
+export const FOCUS_DISABLED_CLASS = "pt-focus-disabled";
+
+const focusEngine = new InteractionModeEngine(document.documentElement, FOCUS_DISABLED_CLASS);
+
+export const FocusStyleManager = {
+    alwaysShowFocus: () => focusEngine.stop(),
+    isActive: () => focusEngine.isActive(),
+    onlyShowFocusOnTabs: () => focusEngine.start(),
+};

--- a/packages/core/src/accessibility/index.ts
+++ b/packages/core/src/accessibility/index.ts
@@ -5,8 +5,4 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-export * from "./accessibility";
-export * from "./common"
-export * from "./components";
-export { IconClasses } from "./generated/iconClasses";
-export { IconContents } from "./generated/iconStrings";
+export * from "./focusStyleManager";

--- a/packages/core/src/accessibility/index.ts
+++ b/packages/core/src/accessibility/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
  * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
  * and https://github.com/palantir/blueprint/blob/master/PATENTS


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Create a `core/src/accessibility/` folder
- Move the focus style manager into this folder

This is mostly just for good hygiene. Feels weird to have the focus stuff in index.ts.