### PR TITLE
Fix date-range picker wraparound behavior

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -134,7 +134,9 @@ export class DateRangePicker
         // allowable range, the react-day-picker library will show
         // the max month on the left and the *min* month on the right.
         // subtracting one avoids that weird, wraparound state (#289).
-        if (initialMonth.getMonth() === props.maxDate.getMonth()) {
+        const initialMonthEqualsMinMonth = initialMonth.getMonth() === props.minDate.getMonth();
+        const initalMonthEqualsMaxMonth = initialMonth.getMonth() === props.maxDate.getMonth();
+        if (!initialMonthEqualsMinMonth && initalMonthEqualsMaxMonth) {
             initialMonth.setMonth(initialMonth.getMonth() - 1);
         }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -119,6 +119,7 @@ export class DateRangePicker
 
         let initialMonth: Date;
         const today = new Date();
+
         if (props.initialMonth != null) {
             initialMonth = props.initialMonth;
         } else if (value[0] != null) {
@@ -127,6 +128,14 @@ export class DateRangePicker
             initialMonth = today;
         } else {
             initialMonth = DateUtils.getDateBetween([props.minDate, props.maxDate]);
+        }
+
+        // if the initial month is the last month of the picker's
+        // allowable range, the react-day-picker library will show
+        // the max month on the left and the *min* month on the right.
+        // subtracting one avoids that weird, wraparound state (#289).
+        if (initialMonth.getMonth() === props.maxDate.getMonth()) {
+            initialMonth.setMonth(initialMonth.getMonth() - 1);
         }
 
         this.state = {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -94,6 +94,22 @@ describe("<DateRangePicker>", () => {
             const { displayMonth, displayYear } = dateRangePicker.state;
             assert.isTrue(DateUtils.isDayInRange(new Date(displayYear, displayMonth), [minDate, maxDate]));
         });
+
+        it("is initialMonth - 1 if initialMonth === maxDate month", () => {
+            // months are 0-indexed
+            const NOVEMBER = 10;
+            const DECEMBER = 11;
+            const MAX_YEAR = 2016;
+
+            const initialMonth = new Date(MAX_YEAR, DECEMBER, 1);
+            const maxDate = new Date(MAX_YEAR, DECEMBER, 31);
+            const minDate = new Date(2000, 0);
+
+            renderDateRangePicker({ initialMonth, maxDate, minDate });
+
+            assert.equal(dateRangePicker.state.displayYear, MAX_YEAR);
+            assert.equal(dateRangePicker.state.displayMonth, NOVEMBER);
+        });
     });
 
     describe("minDate/maxDate bounds", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -96,7 +96,6 @@ describe("<DateRangePicker>", () => {
         });
 
         it("is initialMonth - 1 if initialMonth === maxDate month", () => {
-            // months are 0-indexed
             const NOVEMBER = 10;
             const DECEMBER = 11;
             const MAX_YEAR = 2016;
@@ -109,6 +108,20 @@ describe("<DateRangePicker>", () => {
 
             assert.equal(dateRangePicker.state.displayYear, MAX_YEAR);
             assert.equal(dateRangePicker.state.displayMonth, NOVEMBER);
+        });
+
+        it("is initialMonth if initialMonth === minDate month and initialMonth === maxDate month", () => {
+            const DECEMBER = 11;
+            const YEAR = 2016;
+
+            const initialMonth = new Date(YEAR, DECEMBER, 11);
+            const maxDate = new Date(YEAR, DECEMBER, 15);
+            const minDate = new Date(YEAR, DECEMBER, 1);
+
+            renderDateRangePicker({ initialMonth, maxDate, minDate });
+
+            assert.equal(dateRangePicker.state.displayYear, YEAR);
+            assert.equal(dateRangePicker.state.displayMonth, DECEMBER);
         });
     });
 


### PR DESCRIPTION
#### Fixes #289 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Set the `displayMonth` to `initialMonth - 1` if the initial month is at the end of the allowable range. This keeps the max month on the _right_ side of the date-range picker, which you aren't able to proceed past anyway.
- Edge case: if the initial month is the same as the min _and_ max month, don't change it. 

#### Reviewers should focus on:

- Pretty simple change. Does it look sane?

