### PR TITLE
Add timeout management to AbstractComponent

### DIFF
--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -14,6 +14,7 @@ import * as React from "react";
 export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
     public displayName: string;
 
+    // Not bothering to remove entries when their timeouts finish because clearing finished timeout is no-op
     private timeoutHandles: number[] = [];
 
     constructor(props?: P, context?: any) {
@@ -32,6 +33,7 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
     /**
      * Set a timeout and remember its ID.
      * All stored timeouts will be cleared when component unmounts.
+     * @returns a "cancel" function that will clear timeout when invoked.
      */
     public setTimeout(handler: Function, timeout?: number) {
         const handle = setTimeout(handler, timeout);
@@ -44,11 +46,8 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
      */
     public clearTimeouts = () => {
         if (this.timeoutHandles.length > 0) {
-            for (const handle of this.timeoutHandles) {
-                // clearing an expired timeout is a no-op
-                clearTimeout(handle);
-            }
-            this.timeoutHandles = [];
+            // always produces empty list cuz clearTimeout returns void
+            this.timeoutHandles = this.timeoutHandles.filter(clearTimeout);
         }
     }
 

--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -12,6 +12,10 @@ import * as React from "react";
  * in order to add some common functionality like runtime props validation.
  */
 export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
+    public displayName: string;
+
+    private timeoutHandles: number[] = [];
+
     constructor(props?: P, context?: any) {
         super(props, context);
         this.validateProps(this.props);
@@ -19,6 +23,33 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
 
     public componentWillReceiveProps(nextProps: P & {children?: React.ReactNode}) {
         this.validateProps(nextProps);
+    }
+
+    public componentWillUnmount() {
+        this.clearTimeouts();
+    }
+
+    /**
+     * Set a timeout and remember its ID.
+     * All stored timeouts will be cleared when component unmounts.
+     */
+    public setTimeout(handler: Function, timeout?: number) {
+        const handle = setTimeout(handler, timeout);
+        this.timeoutHandles.push(handle);
+        return () => clearTimeout(handle);
+    }
+
+    /**
+     * Clear all known timeouts.
+     */
+    public clearTimeouts = () => {
+        if (this.timeoutHandles.length > 0) {
+            for (const handle of this.timeoutHandles) {
+                // clearing an expired timeout is a no-op
+                clearTimeout(handle);
+            }
+            this.timeoutHandles = [];
+        }
     }
 
    /**

--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -14,8 +14,8 @@ import * as React from "react";
 export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
     public displayName: string;
 
-    // Not bothering to remove entries when their timeouts finish because clearing finished timeout is no-op
-    private timeoutHandles: number[] = [];
+    // Not bothering to remove entries when their timeouts finish because clearing invalid ID is a no-op
+    private timeoutIds: number[] = [];
 
     constructor(props?: P, context?: any) {
         super(props, context);
@@ -37,7 +37,7 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
      */
     public setTimeout(handler: Function, timeout?: number) {
         const handle = setTimeout(handler, timeout);
-        this.timeoutHandles.push(handle);
+        this.timeoutIds.push(handle);
         return () => clearTimeout(handle);
     }
 
@@ -45,9 +45,11 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
      * Clear all known timeouts.
      */
     public clearTimeouts = () => {
-        if (this.timeoutHandles.length > 0) {
-            // always produces empty list cuz clearTimeout returns void
-            this.timeoutHandles = this.timeoutHandles.filter(clearTimeout);
+        if (this.timeoutIds.length > 0) {
+            for (const timeoutId of this.timeoutIds) {
+                clearTimeout(timeoutId);
+            }
+            this.timeoutIds = [];
         }
     }
 

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -8,6 +8,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
+import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
@@ -76,7 +77,7 @@ export enum AnimationStates {
  * isOpen = false: OPEN -> CLOSING_START -> CLOSING_END -> CLOSED
  * These are all animated.
  */
-export class Collapse extends React.Component<ICollapseProps, ICollapseState> {
+export class Collapse extends AbstractComponent<ICollapseProps, ICollapseState> {
     public static displayName = "Blueprint.Collapse";
 
     public static defaultProps: ICollapseProps = {
@@ -95,9 +96,6 @@ export class Collapse extends React.Component<ICollapseProps, ICollapseState> {
     // The most recent non-0 height (once a height has been measured - is 0 until then)
     private height: number = 0;
 
-    private closingTimeout: number;
-    private delayedTimeout: number;
-
     public componentWillReceiveProps(nextProps: ICollapseProps) {
         if (this.contents != null && this.contents.clientHeight !== 0) {
             this.height = this.contents.clientHeight;
@@ -113,7 +111,7 @@ export class Collapse extends React.Component<ICollapseProps, ICollapseState> {
                     animationState: AnimationStates.OPENING,
                     height: `${this.height}px`,
                 });
-                this.delayedTimeout = setTimeout(() => this.onDelayedStateChange(), this.props.transitionDuration);
+                this.setTimeout(() => this.onDelayedStateChange(), this.props.transitionDuration);
             }
         }
     }
@@ -156,15 +154,12 @@ export class Collapse extends React.Component<ICollapseProps, ICollapseState> {
 
     public componentDidUpdate() {
         if (this.state.animationState === AnimationStates.CLOSING_START) {
-            this.closingTimeout =
-                setTimeout(() => this.setState({ animationState: AnimationStates.CLOSING_END, height: "0px" }));
-            this.delayedTimeout = setTimeout(() => this.onDelayedStateChange(), this.props.transitionDuration);
+            this.setTimeout(() => this.setState({
+                animationState: AnimationStates.CLOSING_END,
+                height: "0px",
+            }));
+            this.setTimeout(() => this.onDelayedStateChange(), this.props.transitionDuration);
         }
-    }
-
-    public componentWillUnmount() {
-        clearTimeout(this.closingTimeout);
-        clearTimeout(this.delayedTimeout);
     }
 
     private contentsRefHandler = (el: HTMLElement) => {

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -8,6 +8,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
 import { Position } from "../../common/position";
 import { safeInvoke } from "../../common/utils";
@@ -28,7 +29,7 @@ interface IContextMenuState {
 const CONSTRAINTS = [ { attachment: "together", pin: true, to: "window" } ];
 const TRANSITION_DURATION = 100;
 
-class ContextMenu extends React.Component<{}, IContextMenuState> {
+class ContextMenu extends AbstractComponent<{}, IContextMenuState> {
     public state: IContextMenuState = {
         isOpen: false,
     };
@@ -73,7 +74,7 @@ class ContextMenu extends React.Component<{}, IContextMenuState> {
         e.preventDefault();
         // wait for backdrop to disappear so we can find the "real" element at event coordinates.
         // timeout duration is equivalent to transition duration so we know it's animated out.
-        setTimeout(() => {
+        this.setTimeout(() => {
             // retrigger context menu event at the element beneath the backdrop.
             // if it has a `contextmenu` event handler then it'll be invoked.
             // if it doesn't, no native menu will show (at least on OSX) :(

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -9,6 +9,7 @@ import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
+import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IIntentProps, IProps } from "../../common/props";
@@ -93,7 +94,7 @@ export interface IEditableTextState {
 const BUFFER_WIDTH = 30;
 
 @PureRender
-export class EditableText extends React.Component<IEditableTextProps, IEditableTextState> {
+export class EditableText extends AbstractComponent<IEditableTextProps, IEditableTextState> {
     public static defaultProps: IEditableTextProps = {
         defaultValue: "",
         disabled: false,
@@ -284,7 +285,7 @@ export class EditableText extends React.Component<IEditableTextProps, IEditableT
             });
             // synchronizes the ::before pseudo-element's height while editing for Chrome 53
             if (multiline && this.state.isEditing) {
-                setTimeout(() => parentElement.style.height = `${scrollHeight}px`);
+                this.setTimeout(() => parentElement.style.height = `${scrollHeight}px`);
             }
         }
     }

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -210,7 +210,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     private hasDarkParent = false;
     // a flag that is set to true while we are waiting for the underlying Portal to complete rendering
     private isContentMounting = false;
-    private openStateTimeout: number;
+    private cancelOpenTimeout: () => void;
     private popoverElement: HTMLElement;
     private targetElement: HTMLElement;
     private tether: Tether;
@@ -328,7 +328,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     public componentWillUnmount() {
-        this.clearTimeout();
+        super.componentWillUnmount();
         this.destroyTether();
     }
 
@@ -540,9 +540,9 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     // starts a timeout to delay changing the state if a non-zero duration is provided.
     private setOpenState(isOpen: boolean, e?: React.SyntheticEvent<HTMLElement>, timeout?: number) {
         // cancel any existing timeout because we have new state
-        this.clearTimeout();
+        Utils.safeInvoke(this.cancelOpenTimeout);
         if (timeout > 0) {
-            this.openStateTimeout = setTimeout(() => this.setOpenState(isOpen, e), timeout);
+            this.cancelOpenTimeout = this.setTimeout(() => this.setOpenState(isOpen, e), timeout);
         } else {
             if (this.props.isOpen == null) {
                 this.setState({ isOpen });
@@ -553,12 +553,6 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
                 Utils.safeInvoke(this.props.onClose, e);
             }
         }
-    }
-
-    // clear the timeout that might be started by setOpenState()
-    private clearTimeout() {
-        clearTimeout(this.openStateTimeout);
-        this.openStateTimeout = null;
     }
 
     private isElementInPopover(element: Element) {

--- a/packages/core/src/components/tabs/tabList.tsx
+++ b/packages/core/src/components/tabs/tabList.tsx
@@ -9,6 +9,7 @@ import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
+import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
@@ -28,7 +29,7 @@ export interface ITabListState {
 }
 
 @PureRender
-export class TabList extends React.Component<ITabListProps, {}> {
+export class TabList extends AbstractComponent<ITabListProps, {}> {
     public displayName = "Blueprint.TabList";
     public state: ITabListState = {
         shouldAnimate: false,
@@ -53,7 +54,7 @@ export class TabList extends React.Component<ITabListProps, {}> {
 
     public componentDidUpdate(prevProps: ITabListProps) {
         if (prevProps.indicatorWrapperStyle == null) {
-            setTimeout(() => this.setState({ shouldAnimate: true }));
+            this.setTimeout(() => this.setState({ shouldAnimate: true }));
         }
     }
 }

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -72,8 +72,6 @@ export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
     private panelIds: string[] = [];
     private tabIds: string[] = [];
 
-    private moveTimeout: number;
-
     constructor(props?: ITabsProps, context?: any) {
         super(props, context);
         this.state = this.getStateFromProps(this.props);
@@ -103,7 +101,7 @@ export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
 
     public componentDidMount() {
         const selectedTab = findDOMNode(this.refs[`tabs-${this.state.selectedTabIndex}`]) as HTMLElement;
-        this.moveTimeout = setTimeout(() => this.moveIndicator(selectedTab));
+        this.setTimeout(() => this.moveIndicator(selectedTab));
     }
 
     public componentDidUpdate(_: ITabsProps, prevState: ITabsState) {
@@ -111,12 +109,8 @@ export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
         if (newIndex !== prevState.selectedTabIndex) {
             const tabElement = findDOMNode(this.refs[`tabs-${newIndex}`]) as HTMLElement;
             // need to measure on the next frame in case the Tab children simultaneously change
-            this.moveTimeout = setTimeout(() => this.moveIndicator(tabElement));
+            this.setTimeout(() => this.moveIndicator(tabElement));
         }
-    }
-
-    public componentWillUnmount() {
-        clearTimeout(this.moveTimeout);
     }
 
     protected validateProps(props: ITabsProps & {children?: React.ReactNode}) {

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -9,6 +9,7 @@ import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
+import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
 import { IActionProps, IIntentProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
@@ -44,7 +45,7 @@ export interface IToastProps extends IProps, IIntentProps {
 }
 
 @PureRender
-export class Toast extends React.Component<IToastProps, {}> {
+export class Toast extends AbstractComponent<IToastProps, {}> {
     public static defaultProps: IToastProps = {
         className: "",
         message: "",
@@ -53,16 +54,14 @@ export class Toast extends React.Component<IToastProps, {}> {
 
     public displayName = "Blueprint.Toast";
 
-    private timeoutId: number;
-
     public render(): JSX.Element {
         const { className, intent, message } = this.props;
         return (
             <div
                 className={classNames(Classes.TOAST, Classes.intentClass(intent), className)}
                 onBlur={this.startTimeout}
-                onFocus={this.clearTimeout}
-                onMouseEnter={this.clearTimeout}
+                onFocus={this.clearTimeouts}
+                onMouseEnter={this.clearTimeouts}
                 onMouseLeave={this.startTimeout}
             >
                 {this.maybeRenderIcon()}
@@ -83,12 +82,12 @@ export class Toast extends React.Component<IToastProps, {}> {
         if (prevProps.timeout <= 0 && this.props.timeout > 0) {
             this.startTimeout();
         } else if (prevProps.timeout > 0 && this.props.timeout <= 0) {
-            this.clearTimeout();
+            this.clearTimeouts();
         }
     }
 
     public componentWillUnmount() {
-        this.clearTimeout();
+        this.clearTimeouts();
     }
 
     private maybeRenderActionButton() {
@@ -114,18 +113,13 @@ export class Toast extends React.Component<IToastProps, {}> {
 
     private triggerDismiss(didTimeoutExpire: boolean) {
         safeInvoke(this.props.onDismiss, didTimeoutExpire);
-        this.clearTimeout();
+        this.clearTimeouts();
     }
 
     private startTimeout = () => {
         if (this.props.timeout > 0) {
-            this.timeoutId = setTimeout(() => this.triggerDismiss(true), this.props.timeout);
+            this.setTimeout(() => this.triggerDismiss(true), this.props.timeout);
         }
-    }
-
-    private clearTimeout = () => {
-        clearTimeout(this.timeoutId);
-        this.timeoutId = null;
     }
 }
 


### PR DESCRIPTION
#### 🕙 Fixes #275 and several other unreported instances of potential uncleared timeouts triggering after unmount.

#### Changes proposed in this pull request:

- add timeout management to `AbstractComponent`
  - a simple list of timeouts started by this instance
  - a way to set a timeout
  - a way to clear them all
  - and auto-clear when unmounting
- refactor components that used `setTimeout`
  - the only remaining instance of `window.setTimeout` is `HotkeyDialog` which is not a React Component and therefore can't use this feature.

#### Focus testing on:

- [ ] Collapse
- [ ] ContextMenu
- [ ] EditableText
- [ ] Popover
- [ ] Tabs
- [ ] Tooltip

They should all behave exactly the same as before.