### PR TITLE
refactor sass watching so page reloads

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -85,7 +85,8 @@ module.exports = (gulp, plugins, blueprint) => {
             // see https://github.com/floridoo/vinyl-sourcemaps-apply/issues/11#issuecomment-231220574
             .pipe(plugins.sourcemaps.write(".", { sourceRoot: null }))
             .pipe(blueprint.dest(project))
-            .pipe(plugins.connect.reload());
+            // only bundled packages will reload the dev site
+            .pipe(project.sass === "bundle" ? plugins.connect.reload() : plugins.util.noop());
     });
 
     // concatenate all sass variables files together into one single exported list of variables

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -6,7 +6,7 @@
 module.exports = (gulp, plugins, blueprint) => {
     const path = require("path");
 
-    function srcGlob(project, filename) {
+    function createSrcGlob(project, filename) {
         return `${project.cwd}/src/!(generated)/**/${filename}`;
     }
 
@@ -26,11 +26,11 @@ module.exports = (gulp, plugins, blueprint) => {
             if (project.id !== "docs") {
                 tasks.push("sass-variables", "docs-kss");
             }
-            gulp.watch(srcGlob(project, "*.scss"), tasks);
+            gulp.watch(createSrcGlob(project, "*.scss"), tasks);
         });
 
         blueprint.projectsWithBlock("typescript").forEach((project) => {
-            gulp.watch(srcGlob(project, "*.ts{,x}"), [`typescript-compile-w-${project.id}`]);
+            gulp.watch(createSrcGlob(project, "*.ts{,x}"), [`typescript-compile-w-${project.id}`]);
         });
 
         const docsCwd = blueprint.findProject("docs").cwd;


### PR DESCRIPTION
#### Fixes #234 

#### Changes proposed in this pull request:

docs.scss imports all the compiled CSS files, which then gets compiled into docs.css. Changing a downstream package SCSS file (like `_buttons.scss`) updates blueprint.css but docs.scss does not pick up those changes.

this PR adds a watcher that recompiles docs.scss when any dist/*.css file changes. it also refactors sass and typescript watching to actually ignore generated files (which prevents a few unnecessary recompiles).