### PR TITLE
Fix possibly mis-measured text width in DatePicker

### DIFF
--- a/packages/datetime/src/common/utils.ts
+++ b/packages/datetime/src/common/utils.ts
@@ -9,12 +9,12 @@
  * Measure width of a string displayed with styles provided by `className`.
  * Should only be used if measuring can't be done with existing DOM elements.
  */
-export function measureTextWidth(text: string, className = "") {
+export function measureTextWidth(text: string, className = "", containerElement = document.body) {
     const span = document.createElement("span");
     span.classList.add(className);
     span.innerHTML = text;
 
-    document.body.appendChild(span);
+    containerElement.appendChild(span);
     const spanWidth = span.offsetWidth;
     span.remove();
 

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -31,8 +31,9 @@ export class DatePickerCaption extends React.Component<IDatePickerCaptionProps, 
     private displayedMonthText: string;
     private displayedYearText: string;
 
-    private monthArrow: HTMLElement;
-    private yearArrow: HTMLElement;
+    private containerElement: HTMLElement;
+    private monthArrowElement: HTMLElement;
+    private yearArrowElement: HTMLElement;
 
     public render() {
         const { date, locale, localeUtils, minDate, maxDate } = this.props;
@@ -62,7 +63,10 @@ export class DatePickerCaption extends React.Component<IDatePickerCaptionProps, 
 
         const caretClasses = classNames("pt-icon-standard", "pt-icon-caret-down", Classes.DATEPICKER_CAPTION_CARET);
         return (
-            <div className={Classes.DATEPICKER_CAPTION}>
+            <div
+                className={Classes.DATEPICKER_CAPTION}
+                ref={this.containerRefHandler}
+            >
                 <div className={Classes.DATEPICKER_CAPTION_SELECT}>
                     <select
                         className={Classes.DATEPICKER_MONTH_SELECT}
@@ -101,16 +105,19 @@ export class DatePickerCaption extends React.Component<IDatePickerCaptionProps, 
         this.positionArrows();
     }
 
-    private monthArrowRefHandler = (r: HTMLElement) => this.monthArrow = r;
-    private yearArrowRefHandler = (r: HTMLElement) => this.yearArrow = r;
+    private containerRefHandler = (r: HTMLElement) => this.containerElement = r;
+    private monthArrowRefHandler = (r: HTMLElement) => this.monthArrowElement = r;
+    private yearArrowRefHandler = (r: HTMLElement) => this.yearArrowElement = r;
 
     private positionArrows() {
+        // pass our container element to the measureTextWidth utility to ensure
+        // that we're measuring the width of text as sized within this component.
         const textClass = "pt-datepicker-caption-measure";
-        const monthWidth = Utils.measureTextWidth(this.displayedMonthText, textClass);
-        this.monthArrow.setAttribute("style", `left:${monthWidth}`);
+        const monthWidth = Utils.measureTextWidth(this.displayedMonthText, textClass, this.containerElement);
+        this.monthArrowElement.setAttribute("style", `left:${monthWidth}`);
 
-        const yearWidth = Utils.measureTextWidth(this.displayedYearText, textClass);
-        this.yearArrow.setAttribute("style", `left:${yearWidth}`);
+        const yearWidth = Utils.measureTextWidth(this.displayedYearText, textClass, this.containerElement);
+        this.yearArrowElement.setAttribute("style", `left:${yearWidth}`);
     }
 
     private handleMonthSelectChange = (e: React.FormEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
#### Fixes #316 

#### Changes proposed in this pull request:

- Add an optional third `containerElement` parameter to `Utils.measureTextWidth` (defaults to `document.body`)
- Leverage this in `DatePicker` to ensure we're measuring text as sized within that component 

#### Reviewers should focus on:

- FYI: I added `*Element` suffixes to each of the elements for clarity and consistency. The type handles that, but this makes things easier to read quickly at a glance.
- FYI: Verified that this works by changing body text size to `100px` and observing that the `<DatePicker>` dropdown arrows still appeared in the expected place.