### PR TITLE
Popover onClose only when disabled changes to true

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -304,7 +304,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     public componentWillReceiveProps(nextProps: IPopoverProps) {
         super.componentWillReceiveProps(nextProps);
 
-        if (nextProps.isDisabled) {
+        if (nextProps.isDisabled && !this.props.isDisabled) {
             // ok to use setOpenState here because isDisabled and isOpen are mutex.
             this.setOpenState(false);
         } else if (nextProps.isOpen !== this.props.isOpen) {


### PR DESCRIPTION
#### Fixes issue described by @markwongsk and @k-simons 

#### Changes proposed in this pull request:

- only invoke `onClose` when `Popover` `isDisabled` changes from false to true (not every update when it is true)