### PR TITLE
Fix portal/popover position and scrolling issues

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "dom4": "^1.8",
     "normalize.css": "4.1.1",
     "pure-render-decorator": "^1.1",
-    "tether": "^1.2"
+    "tether": "^1.4"
   },
   "peerDependencies": {
     "react": "^15.0.1 || ^0.14",

--- a/packages/core/src/common/_resets.scss
+++ b/packages/core/src/common/_resets.scss
@@ -8,12 +8,6 @@ html {
   box-sizing: border-box;
 }
 
-// required for tethers to work properly when the body
-// is the application scroll container.
-body {
-  position: relative;
-}
-
 // adjust box-sizing for every element ever
 // stylelint-disable selector-no-universal
 *,

--- a/packages/core/src/common/_resets.scss
+++ b/packages/core/src/common/_resets.scss
@@ -8,6 +8,12 @@ html {
   box-sizing: border-box;
 }
 
+// required for tethers to work properly when the body
+// is the application scroll container.
+body {
+  position: relative;
+}
+
 // adjust box-sizing for every element ever
 // stylelint-disable selector-no-universal
 *,

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -14,6 +14,10 @@ const DEFAULT_CONSTRAINTS = {
     to: "scrollParent",
 };
 
+const fauxHTMLElement = ({
+    appendChild : () => { /* no-op */ },
+} as any) as HTMLElement;
+
 export interface ITetherConstraint {
     attachment?: string;
     outOfBoundsClass?: string;
@@ -34,6 +38,7 @@ export function createTetherOptions(element: Element,
 
     const options: Tether.ITetherOptions = {
         attachment: getPopoverAttachment(position),
+        bodyElement: fauxHTMLElement,
         classPrefix: "pt-tether",
         constraints,
         element,

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -23,7 +23,7 @@ const DEFAULT_CONSTRAINTS = {
 // thus, we pass a fake HTML bodyElement to Tether,
 // with a no-op `appendChild` function (the only
 // function the library uses from bodyElement.)
-const fauxHtmlElement = ({
+const fakeHtmlElement = ({
     appendChild : () => { /* No-op */ },
 } as any) as HTMLElement;
 
@@ -47,7 +47,7 @@ export function createTetherOptions(element: Element,
 
     const options: Tether.ITetherOptions = {
         attachment: getPopoverAttachment(position),
-        bodyElement: fauxHtmlElement,
+        bodyElement: fakeHtmlElement,
         classPrefix: "pt-tether",
         constraints,
         element,

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -37,6 +37,9 @@ export function createTetherOptions(element: Element,
         classPrefix: "pt-tether",
         constraints,
         element,
+        optimizations: {
+            moveElement: false,
+        },
         target,
         targetAttachment: getTargetAttachment(position),
     };

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -35,7 +35,6 @@ export interface ITetherConstraint {
     to?: string | HTMLElement | number[];
 }
 
-
 /** @internal */
 export function createTetherOptions(element: Element,
                                     target: Node,
@@ -52,9 +51,6 @@ export function createTetherOptions(element: Element,
         classPrefix: "pt-tether",
         constraints,
         element,
-        optimizations: {
-            moveElement: false,
-        },
         target,
         targetAttachment: getTargetAttachment(position),
     };

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -14,6 +14,19 @@ const DEFAULT_CONSTRAINTS = {
     to: "scrollParent",
 };
 
+// per https://github.com/HubSpot/tether/pull/204,
+// Tether now exposes a `bodyElement` option that,
+// when present, gets the tethered element injected
+// into *it* instead of into the document body. but
+// both approaches still cause React to freak out,
+// because it loses its handle on the DOM element.
+// thus, we pass a fake HTML bodyElement to Tether,
+// with a no-op `appendChild` function (the only
+// function the library uses from bodyElement.)
+const fauxHtmlElement = ({
+    appendChild : () => { /* No-op */ },
+} as any) as HTMLElement;
+
 export interface ITetherConstraint {
     attachment?: string;
     outOfBoundsClass?: string;
@@ -21,6 +34,7 @@ export interface ITetherConstraint {
     pinnedClass?: string;
     to?: string | HTMLElement | number[];
 }
+
 
 /** @internal */
 export function createTetherOptions(element: Element,
@@ -34,6 +48,7 @@ export function createTetherOptions(element: Element,
 
     const options: Tether.ITetherOptions = {
         attachment: getPopoverAttachment(position),
+        bodyElement: fauxHtmlElement,
         classPrefix: "pt-tether",
         constraints,
         element,

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -14,10 +14,6 @@ const DEFAULT_CONSTRAINTS = {
     to: "scrollParent",
 };
 
-const fauxHTMLElement = ({
-    appendChild : () => { /* no-op */ },
-} as any) as HTMLElement;
-
 export interface ITetherConstraint {
     attachment?: string;
     outOfBoundsClass?: string;
@@ -38,7 +34,6 @@ export function createTetherOptions(element: Element,
 
     const options: Tether.ITetherOptions = {
         attachment: getPopoverAttachment(position),
-        bodyElement: fauxHTMLElement,
         classPrefix: "pt-tether",
         constraints,
         element,

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -14,15 +14,11 @@ const DEFAULT_CONSTRAINTS = {
     to: "scrollParent",
 };
 
-// per https://github.com/HubSpot/tether/pull/204,
-// Tether now exposes a `bodyElement` option that,
-// when present, gets the tethered element injected
-// into *it* instead of into the document body. but
-// both approaches still cause React to freak out,
-// because it loses its handle on the DOM element.
-// thus, we pass a fake HTML bodyElement to Tether,
-// with a no-op `appendChild` function (the only
-// function the library uses from bodyElement.)
+// per https://github.com/HubSpot/tether/pull/204, Tether now exposes a `bodyElement` option that,
+// when present, gets the tethered element injected into *it* instead of into the document body.
+// but both approaches still cause React to freak out, because it loses its handle on the DOM
+// element. thus, we pass a fake HTML bodyElement to Tether, with a no-op `appendChild` function
+// (the only function the library uses from bodyElement).
 const fakeHtmlElement = ({
     appendChild : () => { /* No-op */ },
 } as any) as HTMLElement;

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -5,6 +5,14 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+// TODO: shim for new option added in Tether 1.4.0
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13142
+declare module "tether" {
+    interface ITetherOptions {
+        bodyElement?: HTMLElement;
+    }
+}
+
 import * as Tether from "tether";
 
 import { Position } from "./position";

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -162,10 +162,10 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         // add a special class to each child that will automatically set the appropriate
         // CSS position mode under the hood. also, make the container focusable so we can
         // trap focus inside it (via `persistentFocus()`).
-        const decoratedChildren = React.Children.map(children, (child: React.ReactElement<any>, index: number) => {
+        const decoratedChildren = React.Children.map(children, (child: React.ReactElement<any>) => {
             return React.cloneElement(child, {
                 className: classNames(child.props.className, Classes.OVERLAY_CONTENT),
-                tabIndex: index,
+                tabIndex: 0,
             });
         });
 
@@ -298,11 +298,12 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         const isFocusOutsideModal = !containerElement.contains(document.activeElement);
         if (isFocusOutsideModal) {
             // element marked autofocus has higher priority than the other clowns
-            let autofocusElement = containerElement.query("[autofocus]") as HTMLElement;
+            const autofocusElement = containerElement.query("[autofocus]") as HTMLElement;
+            const wrapperElement = containerElement.query("[tabindex]") as HTMLElement;
             if (autofocusElement != null) {
                 autofocusElement.focus();
-            } else {
-                containerElement.focus();
+            } else if (wrapperElement != null) {
+                wrapperElement.focus();
             }
         }
     }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -160,10 +160,12 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         const { children, className, inline, isOpen, transitionDuration, transitionName } = this.props;
 
         // add a special class to each child that will automatically set the appropriate
-        // CSS position mode under the hood.
-        const decoratedChildren = React.Children.map(children, (child: React.ReactElement<any>) => {
+        // CSS position mode under the hood. also, make the container focusable so we can
+        // trap focus inside it (via `persistentFocus()`).
+        const decoratedChildren = React.Children.map(children, (child: React.ReactElement<any>, index: number) => {
             return React.cloneElement(child, {
                 className: classNames(child.props.className, Classes.OVERLAY_CONTENT),
+                tabIndex: index,
             });
         });
 
@@ -188,8 +190,6 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         const elementProps = {
             className: mergedClassName,
             onKeyDown: this.handleKeyDown,
-            // make the container focusable so we can trap focus inside it (via `persistentFocus()`)
-            tabIndex: 0,
         };
 
         if (inline) {

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -38,6 +38,8 @@ Styleguide components.portal.js
 */
 
 .pt-portal {
-  position: fixed;
+  position: absolute;
   top: 0;
+  right: 0;
+  left: 0;
 }

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -36,3 +36,8 @@ The children of a `Portal` component are appended to the `<body>` element.
 
 Styleguide components.portal.js
 */
+
+.pt-portal {
+  position: fixed;
+  top: 0;
+}

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -36,10 +36,3 @@ The children of a `Portal` component are appended to the `<body>` element.
 
 Styleguide components.portal.js
 */
-
-.pt-portal {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-}

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -36,3 +36,18 @@ The children of a `Portal` component are appended to the `<body>` element.
 
 Styleguide components.portal.js
 */
+
+.pt-portal {
+  // take the portal out of the document flow to prevent
+  // browsers from autoscrolling to the bottom of the document
+  // (where portals are appended) when programmatically
+  // .focus()'ing within a portal child element. also, don't
+  // use `fixed`, because then Tether'd elements won't
+  // reposition themselves properly as the document scrolls.
+  position: absolute;
+  // ensure content still offsets from the top of the document
+  top: 0;
+  // ensure content won't be horizontally scrunched
+  right: 0;
+  left: 0;
+}

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -38,12 +38,10 @@ Styleguide components.portal.js
 */
 
 .pt-portal {
-  // take the portal out of the document flow to prevent
-  // browsers from autoscrolling to the bottom of the document
-  // (where portals are appended) when programmatically
-  // .focus()'ing within a portal child element. also, don't
-  // use `fixed`, because then Tether'd elements won't
-  // reposition themselves properly as the document scrolls.
+  // take the portal out of the document flow to prevent browsers from autoscrolling to the bottom
+  // of the document (where portals are appended) when programmatically focusing within a portal
+  // child element. also, don't use `fixed`, because then Tether'd elements won't reposition
+  // themselves properly as the document scrolls.
   position: absolute;
   // ensure content still offsets from the top of the document
   top: 0;

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -164,7 +164,7 @@ describe("<Overlay>", () => {
                 </Overlay>,
                 { attachTo: testsContainerElement },
             );
-            assert.equal(document.body.querySelector(".pt-overlay-open"), document.activeElement);
+            assert.equal(document.body.querySelector(".pt-overlay-backdrop"), document.activeElement);
         });
 
         it("does not bring focus to overlay if autoFocus=false", () => {


### PR DESCRIPTION
#### Fixes #231, Fixes #240

#### Changes proposed in this pull request:

- Change `.pt-portal` to `position:absolute` to take it out of document flow.
_This prevents browsers from autoscrolling to the bottom of the document (where portals are appended) when programmatically .focus()'ing within a portal child element._
- Stick `.pt-portal` to the top, left, and right of the `body`.
_This ensures that content still calculates offsets from the top of the document and that content won't be horizontally scrunched._
- Move `tabindex` from the `.pt-overlay` wrapper down to the overlay's immediate **children**.
_Despite the CSS changes above, programmatically `.focus()`'ing on the overlay can still cause autoscrolling to the bottom of the page in some cases. Moving the `tabindex` to the overlay content ensures that the browser will scroll to the content itself if need be, not to some hidden parent element._ 
- Upgrade Tether from v1.2.0 to v1.4.0 to pick up [this crucial PR](https://github.com/HubSpot/tether/pull/204).
_This helps us solve an issue wherein Tether was removing portal content nodes and reinserting them as immediate children of the `body` if any ancestor was not `position: static`. This in turn severed React's handles on the original DOM nodes._

#### Reviewers should focus on:

- **Before merging this, we'll need to wait on [this DefinitelyTyped PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13142) to merge;** that'll give us the type declaration for Tether's new `bodyElement` option. 
- We should open an issue on Tether after this, explaining why we needed such a horrible workaround with the `fakeHtmlElement`. 
- Testing on different browsers (I checked on Safari, Firefox, and Chrome on Mac OS X).