### PR TITLE
add .eslintignore like .stylelintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,5 @@
-.sass-cache
 /docs
 build
 coverage
 dist
-generated
 node_modules


### PR DESCRIPTION
#### Changes proposed in this pull request:

- no need to lint compiled or external JS files as they'll never pass our muster
- alphabetize entries in both linter ignore files.