### PR TITLE
resolve examples "cannot find module" errors

### DIFF
--- a/gulp/aliases.js
+++ b/gulp/aliases.js
@@ -23,7 +23,7 @@ module.exports = (gulp) =>{
     gulp.task("docs", ["docs-interfaces", "docs-kss", "docs-versions", "docs-releases"]);
 
     // perform a full build of the code and then finish
-    gulp.task("build", (done) => rs("clean", "compile", "docs", "webpack-compile-docs", done));
+    gulp.task("build", (done) => rs("clean", "compile", "webpack-compile-docs", done));
 
     // build code, run unit tests, terminate
     gulp.task("test", ["karma"]);

--- a/gulp/webpack.js
+++ b/gulp/webpack.js
@@ -11,7 +11,7 @@ module.exports = (gulp, plugins, blueprint) => {
 
     const configuration = webpackConfig.generateWebpackTypescriptConfig(docsProject);
 
-    gulp.task("webpack-compile-docs", (callback) => {
+    gulp.task("webpack-compile-docs", ["docs"], (callback) => {
         webpack(configuration, webpackConfig.webpackDone(callback));
     });
 

--- a/packages/core/examples/tsconfig.json
+++ b/packages/core/examples/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "version": "2.0.0",
     "compilerOptions": {
+        "baseUrl": ".",
         "declaration": true,
         "experimentalDecorators": true,
         "jsx": "react",
@@ -14,6 +15,9 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5"
+        "target": "es5",
+        "paths": {
+            "@blueprintjs/core": ["../dist/index"]
+        }
     }
 }

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "version": "2.0.0",
     "compilerOptions": {
+        "baseUrl": ".",
         "declaration": false,
         "experimentalDecorators": true,
         "jsx": "react",
@@ -13,7 +14,10 @@
         "outDir": "dist/",
         "removeComments": true,
         "sourceMap": false,
-        "target": "es5"
+        "target": "es5",
+        "paths": {
+            "@blueprintjs/*": ["node_modules/@blueprintjs/*"]
+        }
     },
     "include": [
         "typings/tsd.d.ts",


### PR DESCRIPTION
#### Changes proposed in this pull request:

- added `baseUrl` and `paths` to docs `tsconfig.json` so it always looks in `docs/node_modules` for `@blueprintjs` packages. (thanks @ericanderson!)
- `webpack-compile-docs` depends on `docs` alias to generate necessary data (allows standalone usage).