### PR TITLE
add TypeScript section to docs Overview page

### DIFF
--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -32,12 +32,7 @@ Install the core package with an NPM client like `npm` or `yarn`, pulling in all
 npm install --save @blueprintjs/core
 ```
 
-If you are using TypeScript, you'll need to include ambient type definitions for React and ReactDOM in your
-project. See the TypeScript Handbook for [guidance on consuming these declaration files][handbook].
-Blueprint's own ambient type definitions are distributed in the NPM module and should be resolved
-automatically by the compiler with the default module resolution strategy.
-
-After installation, you'll be able to use the components as such:
+After installation, you'll be able to import the React components in your application:
 
 ```
 import { Spinner, DatePickerFactory } from "@blueprintjs/core";
@@ -54,9 +49,38 @@ const anotherSpinner = <Blueprint.Spinner/>;
 const myDatePicker = DatePickerFactory();
 ```
 
-[handbook]: https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html
+<div class="pt-callout pt-intent-warning pt-icon-warning-sign">
+  Don't forget to import the CSS file from each package!
+</div>
 
 Styleguide components.usage.npm
+*/
+
+/*
+TypeScript
+
+Blueprint is written in TypeScript and therefore its own `.d.ts` type definitions are distributed in the NPM package
+and should be resolved automatically by the compiler. However, you'll need to install typings for Blueprint's
+dependencies before you can consume it:
+
+```sh
+# required for all @blueprintjs packages:
+npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-dom @types/react-addons-css-transition-group
+
+# @blueprintjs/datetime requires:
+npm install --save @types/moment
+
+# @blueprintjs/table requires:
+npm install --save @types/es6-shim
+```
+
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+  For more information, see the TypeScript Handbook for [guidance on consuming declaration files][handbook].
+</div>
+
+[handbook]: https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html
+
+Styleguide components.usage.typescript
 */
 
 /*
@@ -93,26 +117,6 @@ ReactDOM.unmountComponentAtNode(myContainerElement);
 Check out the [React API docs](https://facebook.github.io/react/docs/react-api.html) for more details.
 
 Styleguide components.usage.vanilla
-*/
-
-/*
-TypeScript
-
-Blueprint is written in TypeScript and therefore includes its own `.d.ts` typings files in the NPM package.
-However you'll need to install typings for Blueprint's dependencies before you can consume it.
-
-```sh
-# required for all @blueprintjs packages:
-npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-dom @types/react-addons-css-transition-group
-
-# @blueprintjs/datetime requires:
-npm install --save @types/moment
-
-# @blueprintjs/table requires:
-npm install --save @types/es6-shim
-```
-
-Styleguide components.usage.typescript
 */
 
 @import "alert/alert";

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -56,8 +56,6 @@ const myDatePicker = DatePickerFactory();
 
 [handbook]: https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html
 
-Weight: 1
-
 Styleguide components.usage.npm
 */
 
@@ -94,9 +92,27 @@ ReactDOM.unmountComponentAtNode(myContainerElement);
 
 Check out the [React API docs](https://facebook.github.io/react/docs/react-api.html) for more details.
 
-Weight: 4
-
 Styleguide components.usage.vanilla
+*/
+
+/*
+TypeScript
+
+Blueprint is written in TypeScript and therefore includes its own `.d.ts` typings files in the NPM package.
+However you'll need to install typings for Blueprint's dependencies before you can consume it.
+
+```sh
+# required for all @blueprintjs packages:
+npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-addons-css-transition-group @types/react-addons-transition-group @types/react-dom
+
+# @blueprintjs/datetime requires:
+npm install --save @types/moment
+
+# @blueprintjs/table requires:
+npm install --save @types/es6-shim
+```
+
+Styleguide components.usage.typescript
 */
 
 @import "alert/alert";

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -103,7 +103,7 @@ However you'll need to install typings for Blueprint's dependencies before you c
 
 ```sh
 # required for all @blueprintjs packages:
-npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-addons-css-transition-group @types/react-addons-transition-group @types/react-dom
+npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-dom @types/react-addons-css-transition-group
 
 # @blueprintjs/datetime requires:
 npm install --save @types/moment

--- a/packages/docs/src/styleguide.md
+++ b/packages/docs/src/styleguide.md
@@ -31,6 +31,22 @@ in your application as you wish. For example:
 </html>
 ```
 
+### TypeScript
+
+Blueprint is written in TypeScript and therefore includes its own `.d.ts` typings files in the NPM package.
+However you'll need to install typings for Blueprint's dependencies before you can consume them.
+
+```bash
+# required for all @blueprintjs packages:
+npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-addons-css-transition-group @types/react-addons-transition-group @types/react-dom
+
+# @blueprintjs/datetime
+npm install --save @types/moment
+
+# @blueprintjs/table
+npm install --save @types/es6-shim
+```
+
 ### Beyond core styles
 
 The Blueprint team maintains multiple packages of styles and JavaScript components on NPM (in the scope

--- a/packages/docs/src/styleguide.md
+++ b/packages/docs/src/styleguide.md
@@ -31,22 +31,6 @@ in your application as you wish. For example:
 </html>
 ```
 
-### TypeScript
-
-Blueprint is written in TypeScript and therefore includes its own `.d.ts` typings files in the NPM package.
-However you'll need to install typings for Blueprint's dependencies before you can consume them.
-
-```bash
-# required for all @blueprintjs packages:
-npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-addons-css-transition-group @types/react-addons-transition-group @types/react-dom
-
-# @blueprintjs/datetime
-npm install --save @types/moment
-
-# @blueprintjs/table
-npm install --save @types/es6-shim
-```
-
 ### Beyond core styles
 
 The Blueprint team maintains multiple packages of styles and JavaScript components on NPM (in the scope


### PR DESCRIPTION
#### Fixes #133

#### Changes proposed in this pull request:

- list typings that must be installed for each package on Overview page

#### Focus on

- is this the best place for this section?
- is there a way to simply depend on these `@types` packages? maybe as `devDependencies`?