### PR TITLE
Add an npm task and instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Read about our [contribution guidelines](https://github.com/palantir/blueprint/b
 [development practices](https://github.com/palantir/blueprint/wiki/Development-Practices) to give your PR
 its best chance at getting merged.
 
+## Tests
+
+Run `npm run test` after following the development instructions above to run the Blueprint test suite.
+
 ## License
 
 This project is made available under the [BSD License](https://github.com/palantir/blueprint/blob/master/LICENSE).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "copy:landing": "cp -rf packages/landing/dist/* docs/.",
     "delete:doc-source-maps": "find docs -name '*.map' -type f -delete",
     "gulp": "gulp",
-    "serve": "http-server docs"
+    "serve": "http-server docs",
+    "test": "gulp test"
   },
   "dependencies": {
     "@types/assertion-error": "1.0.30",


### PR DESCRIPTION
In producing my previous PR I had to work out how to run the tests. 

Since the first place I looked for the incantation was the root `package.json` and the second was the root `README`, I thought we should cover those bases.