### PR TITLE
Make HotkeysDialog not inline

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -91,7 +91,6 @@ class HotkeysDialog {
             <Dialog
                 {...this.componentProps}
                 className={classNames(this.componentProps.className, "pt-hotkey-dialog")}
-                inline
                 isOpen={this.isDialogShowing}
                 onClose={this.hide}
             >

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -113,7 +113,7 @@ describe("Hotkeys", () => {
             assertInputAllowsKeys("radio", true);
         });
 
-        it("triggers hotkey dialog with \"?\"", (done) => {
+        it("triggers non-inline hotkey dialog with \"?\"", (done) => {
             const TEST_TIMEOUT_DURATION = 30;
 
             comp = mount(<TestComponent />, { attachTo });
@@ -124,6 +124,7 @@ describe("Hotkeys", () => {
             // wait for the dialog to animate in
             setTimeout(() => {
                 expect(document.querySelector(".pt-hotkey-column")).to.exist;
+                expect(document.querySelector(".pt-overlay-open").classList.contains("pt-overlay-inline")).to.be.false;
                 hideHotkeysDialog();
                 comp.detach();
                 attachTo.remove();


### PR DESCRIPTION
#### Fixes #359 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Make `HotkeysDialog` **not** inline
- Add a unit test to verify that the `HotkeysDialog` doesn't render inline 

_BEFORE:_

![before](https://cloud.githubusercontent.com/assets/443450/21278234/e1dc2a1e-c38e-11e6-8820-3e1c1ae05996.gif)

_AFTER:_

![after](https://cloud.githubusercontent.com/assets/443450/21278239/e5cc285e-c38e-11e6-8df6-218f40c3094f.gif)

#### Reviewers should focus on:

I've verified that the dialog closes when you click the background and/or when you press <kbd>Esc</kbd>.