### PR TITLE
Fix breadcrumb trailing arrow

### DIFF
--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -155,7 +155,7 @@ $breadcrumb-line-height: $pt-icon-size-large - 1px;
     color: $pt-dark-text-color-muted;
   }
 
-  .pt-breadcrumbs > li::after {
+  .pt-breadcrumbs > li:not(:last-of-type)::after {
     color: $pt-dark-icon-color;
   }
 


### PR DESCRIPTION
React sometimes injects a script tag as a placeholder.