### PR TITLE
Replace pure-render-decorator with React.PureComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@types/dom4": "1.5.20",
     "@types/enzyme": "2.4.36",
     "@types/mocha": "2.2.32",
-    "@types/pure-render-decorator": "0.2.27",
     "@types/react": "0.14.40",
     "@types/react-addons-css-transition-group": "0.14.17",
     "@types/react-addons-test-utils": "0.14.15",

--- a/packages/core/examples/common/baseExample.tsx
+++ b/packages/core/examples/common/baseExample.tsx
@@ -5,15 +5,13 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 /**
  * Starter class for all React example components.
  * Examples and options are rendered into separate containers.
  */
-@PureRender
-export default class BaseExample<S> extends React.Component<{ getTheme: () => string }, S> {
+export default class BaseExample<S> extends React.PureComponent<{ getTheme: () => string }, S> {
     /** Define this prop to add a className to the example container */
     protected className: string;
 

--- a/packages/core/examples/contextMenuExample.tsx
+++ b/packages/core/examples/contextMenuExample.tsx
@@ -8,7 +8,6 @@
 // tslint:disable max-classes-per-file
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { ContextMenu, ContextMenuTarget, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
@@ -17,8 +16,8 @@ import BaseExample from "./common/baseExample";
 /**
  * This component uses the imperative ContextMenu API.
  */
-@PureRender
-class GraphNode extends React.Component<{}, { isContextMenuOpen: boolean }> {
+
+class GraphNode extends React.PureComponent<{}, { isContextMenuOpen: boolean }> {
     public state = { isContextMenuOpen: false };
 
     public render() {

--- a/packages/core/examples/treeExample.tsx
+++ b/packages/core/examples/treeExample.tsx
@@ -59,7 +59,7 @@ export class TreeExample extends BaseExample<ITreeExampleState> {
         this.forEachNode(this.state.nodes, (n) => n.id = i++);
     }
 
-    // override @PureRender because nodes are not a primitive type and therefore aren't included in
+    // override PureComponent because nodes are not a primitive type and therefore aren't included in
     // shallow prop comparison
     public shouldComponentUpdate() {
         return true;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,6 @@
     "classnames": "^2.2",
     "dom4": "^1.8",
     "normalize.css": "4.1.1",
-    "pure-render-decorator": "^1.1",
     "tether": "^1.4"
   },
   "peerDependencies": {

--- a/packages/core/src/common/abstractPureComponent.ts
+++ b/packages/core/src/common/abstractPureComponent.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import * as React from "react";
+
+/**
+ * A pure abstract component that Blueprint components can extend
+ * in order to add some common functionality like runtime props validation.
+ */
+export abstract class AbstractPureComponent<P, S> extends React.PureComponent<P, S> {
+    public displayName: string;
+
+    // Not bothering to remove entries when their timeouts finish because clearing invalid ID is a no-op
+    private timeoutIds: number[] = [];
+
+    constructor(props?: P, context?: any) {
+        super(props, context);
+        this.validateProps(this.props);
+    }
+
+    public componentWillReceiveProps(nextProps: P & {children?: React.ReactNode}) {
+        this.validateProps(nextProps);
+    }
+
+    public componentWillUnmount() {
+        this.clearTimeouts();
+    }
+
+    /**
+     * Set a timeout and remember its ID.
+     * All stored timeouts will be cleared when component unmounts.
+     * @returns a "cancel" function that will clear timeout when invoked.
+     */
+    public setTimeout(handler: Function, timeout?: number) {
+        const handle = setTimeout(handler, timeout);
+        this.timeoutIds.push(handle);
+        return () => clearTimeout(handle);
+    }
+
+    /**
+     * Clear all known timeouts.
+     */
+    public clearTimeouts = () => {
+        if (this.timeoutIds.length > 0) {
+            for (const timeoutId of this.timeoutIds) {
+                clearTimeout(timeoutId);
+            }
+            this.timeoutIds = [];
+        }
+    }
+
+   /**
+    * Ensures that the props specified for a component are valid.
+    * Implementations should check that props are valid and usually throw an Error if they are not.
+    * Implementations should not duplicate checks that the type system already guarantees.
+    *
+    * This method should be used instead of React's
+    * [propTypes](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) feature.
+    * In contrast to propTypes, these runtime checks are _always_ run, not just in development mode.
+    */
+    protected validateProps(_: P & {children?: React.ReactNode}) {
+        // implement in subclass
+    };
+}

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from "./abstractComponent";
+export * from "./abstractPureComponent";
 export * from "./colors";
 export * from "./intent";
 export * from "./position";

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -65,7 +65,7 @@ dependencies before you can consume it:
 
 ```sh
 # required for all @blueprintjs packages:
-npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-dom @types/react-addons-css-transition-group
+npm install --save @types/dom4 @types/react @types/react-dom @types/react-addons-css-transition-group
 
 # @blueprintjs/datetime requires:
 npm install --save @types/moment

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -7,8 +7,7 @@
 
 import * as classNames from "classnames";
 import * as React from "react";
-
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IIntentProps, IProps } from "../../common/props";
@@ -92,7 +91,7 @@ export interface IEditableTextState {
 
 const BUFFER_WIDTH = 30;
 
-export class EditableText extends AbstractComponent<IEditableTextProps, IEditableTextState> {
+export class EditableText extends AbstractPureComponent<IEditableTextProps, IEditableTextState> {
     public static defaultProps: IEditableTextProps = {
         defaultValue: "",
         disabled: false,

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { AbstractComponent } from "../../common/abstractComponent";
@@ -93,7 +92,6 @@ export interface IEditableTextState {
 
 const BUFFER_WIDTH = 30;
 
-@PureRender
 export class EditableText extends AbstractComponent<IEditableTextProps, IEditableTextState> {
     public static defaultProps: IEditableTextProps = {
         defaultValue: "",

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -46,8 +45,7 @@ export interface IInputGroupState {
     rightElementWidth?: number;
 }
 
-@PureRender
-export class InputGroup extends React.Component<HTMLInputProps & IInputGroupProps, IInputGroupState> {
+export class InputGroup extends React.PureComponent<HTMLInputProps & IInputGroupProps, IInputGroupState> {
     public static displayName = "Blueprint.InputGroup";
 
     public state: IInputGroupState = {

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -34,8 +33,7 @@ export interface INonIdealStateProps extends IProps {
     visual?: string | JSX.Element;
 }
 
-@PureRender
-export class NonIdealState extends React.Component<INonIdealStateProps, {}> {
+export class NonIdealState extends React.PureComponent<INonIdealStateProps, {}> {
     public render() {
         return (
             <div className={classNames(Classes.NON_IDEAL_STATE, this.props.className)}>

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as CSSTransitionGroup from "react-addons-css-transition-group";
 
@@ -119,8 +118,7 @@ export interface IOverlayState {
     hasEverOpened?: boolean;
 }
 
-@PureRender
-export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
+export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
     public static defaultProps: IOverlayProps = {
         autoFocus: true,
         backdropProps: {},

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -6,12 +6,11 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { findDOMNode } from "react-dom";
 import * as Tether from "tether";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import * as PosUtils from "../../common/position";
@@ -183,8 +182,7 @@ export interface IPopoverState {
     targetWidth?: number;
 }
 
-@PureRender
-export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
+export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState> {
     public static defaultProps: IPopoverProps = {
         arrowSize: 30,
         className: "",

--- a/packages/core/src/components/progress/progressBar.tsx
+++ b/packages/core/src/components/progress/progressBar.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -22,8 +21,7 @@ export interface IProgressBarProps extends IProps, IIntentProps {
     value?: number;
 }
 
-@PureRender
-export class ProgressBar extends React.Component<IProgressBarProps, {}> {
+export class ProgressBar extends React.PureComponent<IProgressBarProps, {}> {
     public static displayName = "Blueprint.ProgressBar";
 
     public render() {

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -6,10 +6,9 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 import { approxEqual, isFunction } from "../../common/utils";
@@ -65,8 +64,7 @@ export interface ISliderState {
     tickSize?: number;
 }
 
-@PureRender
-export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractComponent<P, ISliderState> {
+export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPureComponent<P, ISliderState> {
     public state: ISliderState = {
         tickSize: 0,
     };

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -6,10 +6,9 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IProps } from "../../common/props";
@@ -35,8 +34,7 @@ export interface IHandleState {
 // props that require number values, for validation
 const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"];
 
-@PureRender
-export class Handle extends AbstractComponent<IHandleProps, IHandleState> {
+export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
     public displayName = "Blueprint.SliderHandle";
     public state = {
         isMoving: false,

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -30,8 +29,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
     value?: number;
 }
 
-@PureRender
-export class Spinner extends React.Component<ISpinnerProps, {}> {
+export class Spinner extends React.PureComponent<ISpinnerProps, {}> {
     public static displayName = "Blueprint.Spinner";
 
     public render() {

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -38,8 +37,7 @@ export interface ITabProps extends IProps {
     panelId?: string;
 }
 
-@PureRender
-export class Tab extends React.Component<ITabProps, {}> {
+export class Tab extends React.PureComponent<ITabProps, {}> {
     public static defaultProps: ITabProps = {
         isDisabled: false,
         isSelected: false,

--- a/packages/core/src/components/tabs/tabList.tsx
+++ b/packages/core/src/components/tabs/tabList.tsx
@@ -6,10 +6,9 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
@@ -28,8 +27,7 @@ export interface ITabListState {
     shouldAnimate?: boolean;
 }
 
-@PureRender
-export class TabList extends AbstractComponent<ITabListProps, {}> {
+export class TabList extends AbstractPureComponent<ITabListProps, {}> {
     public displayName = "Blueprint.TabList";
     public state: ITabListState = {
         shouldAnimate: false,

--- a/packages/core/src/components/tabs/tabPanel.tsx
+++ b/packages/core/src/components/tabs/tabPanel.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -25,8 +24,7 @@ export interface ITabPanelProps extends IProps {
     _tabId?: string;
 }
 
-@PureRender
-export class TabPanel extends React.Component<ITabPanelProps, {}> {
+export class TabPanel extends React.PureComponent<ITabPanelProps, {}> {
     public displayName = "Blueprint.TabPanel";
 
     public render() {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -6,11 +6,10 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { findDOMNode } from "react-dom";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import * as Keys from "../../common/keys";
@@ -59,8 +58,7 @@ export interface ITabsState {
 
 const TAB_CSS_SELECTOR = "li[role=tab]";
 
-@PureRender
-export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
+export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
     public static defaultProps: ITabsProps = {
         initialSelectedTabIndex: 0,
     };

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { IIntentProps, IProps, removeNonHTMLProps } from "../../common/props";
@@ -22,8 +21,7 @@ export interface ITagProps extends IProps, IIntentProps, React.HTMLProps<HTMLSpa
     onRemove?: (e: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
-@PureRender
-export class Tag extends React.Component<ITagProps, {}> {
+export class Tag extends React.PureComponent<ITagProps, {}> {
     public displayName = "Blueprint.Tag";
 
     public render() {

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -6,10 +6,9 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { IActionProps, IIntentProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
@@ -44,8 +43,7 @@ export interface IToastProps extends IProps, IIntentProps {
     timeout?: number;
 }
 
-@PureRender
-export class Toast extends AbstractComponent<IToastProps, {}> {
+export class Toast extends AbstractPureComponent<IToastProps, {}> {
     public static defaultProps: IToastProps = {
         className: "",
         message: "",

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -6,11 +6,10 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
@@ -75,8 +74,7 @@ export interface IToasterState {
     toasts: IToastOptions[];
 }
 
-@PureRender
-export class Toaster extends AbstractComponent<IToasterProps, IToasterState> implements IToaster {
+export class Toaster extends AbstractPureComponent<IToasterProps, IToasterState> implements IToaster {
     public static defaultProps: IToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -123,8 +122,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
     useSmartPositioning?: boolean;
 }
 
-@PureRender
-export class Tooltip extends React.Component<ITooltipProps, {}> {
+export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
     public static defaultProps: ITooltipProps = {
         className: "",
         content: "",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,7 +14,6 @@
     "fuzzaldrin-plus": "0.3.1",
     "moment": "2.15.1",
     "normalize.css": "4.1.1",
-    "pure-render-decorator": "1.1.1",
     "react": "15.4.0",
     "react-addons-css-transition-group": "15.4.0",
     "react-dom": "15.4.0"

--- a/packages/docs/src/common/clickToCopy.tsx
+++ b/packages/docs/src/common/clickToCopy.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { IProps, Keys, removeNonHTMLProps, Utils } from "@blueprintjs/core";
@@ -38,8 +37,8 @@ export interface IClickToCopyState {
  *  - `[data-copied-message="<message>"]` will be shown when the element has been copied.
  * The message is reset to default when the user mouses off the element after copying it.
  */
-@PureRender
-export class ClickToCopy extends React.Component<IClickToCopyProps, IClickToCopyState> {
+
+export class ClickToCopy extends React.PureComponent<IClickToCopyProps, IClickToCopyState> {
     public static defaultProps: IClickToCopyProps = {
         copiedClassName: "docs-clipboard-copied",
         value: "",

--- a/packages/docs/src/common/pureComponent.tsx
+++ b/packages/docs/src/common/pureComponent.tsx
@@ -2,11 +2,9 @@
  * @license Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  */
 
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
-@PureRender
-export abstract class PureComponent<P, S> extends React.Component<P, S> {
+export abstract class PureComponent<P, S> extends React.PureComponent<P, S> {
     // define this method so that subclasses can call super to invoke the shallow compare behavior as needed
     public shouldComponentUpdate(_nextProps: P, _nextState: S): boolean {
         // filled in by pure render decorator

--- a/packages/docs/src/components/colorSchemes.tsx
+++ b/packages/docs/src/components/colorSchemes.tsx
@@ -7,7 +7,6 @@
 
 import * as chroma from "chroma-js";
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Classes, Keys, RadioGroup } from "@blueprintjs/core";
@@ -68,8 +67,7 @@ export interface IColorSchemeState {
     steps?: number;
 }
 
-@PureRender
-export class ColorScheme extends React.Component<IColorSchemeProps, IColorSchemeState> {
+export class ColorScheme extends React.PureComponent<IColorSchemeProps, IColorSchemeState> {
     public state: IColorSchemeState = {
         activePalette: 0,
         activeSchema: 0,

--- a/packages/docs/src/components/icon.tsx
+++ b/packages/docs/src/components/icon.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { ContextMenuTarget, Menu, MenuItem } from "@blueprintjs/core";
@@ -29,9 +28,8 @@ export interface IIconProps {
 
 const GITHUB_PATH = "https://github.com/palantir/blueprint/blob/master/resources/icons";
 
-@PureRender
 @ContextMenuTarget
-export class Icon extends React.Component<IIconProps, {}> {
+export class Icon extends React.PureComponent<IIconProps, {}> {
     public render() {
         const { className, name, tags } = this.props.icon;
 

--- a/packages/docs/src/components/icons.tsx
+++ b/packages/docs/src/components/icons.tsx
@@ -5,7 +5,6 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { smartSearch } from "../common/utils";
@@ -26,8 +25,7 @@ export interface IIconsProps {
     icons?: IIcon[];
 }
 
-@PureRender
-export class Icons extends React.Component<IIconsProps, IIconsState> {
+export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
     public static defaultProps: IIconsProps = {
         iconFilter: isIconFiltered,
         iconRenderer: renderIcon,

--- a/packages/docs/src/components/navbar.tsx
+++ b/packages/docs/src/components/navbar.tsx
@@ -19,7 +19,6 @@ import {
 } from "@blueprintjs/core";
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { IPackageInfo } from "./styleguide";
@@ -31,9 +30,8 @@ export interface INavbarProps {
     versions: IPackageInfo[];
 }
 
-@PureRender
 @HotkeysTarget
-export class Navbar extends React.Component<INavbarProps, {}> {
+export class Navbar extends React.PureComponent<INavbarProps, {}> {
     public render() {
         return (
             <div className="pt-navbar docs-navbar docs-flex-row">

--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -21,7 +21,6 @@ import { handleStringChange } from "@blueprintjs/core/examples/common/baseExampl
 
 import * as classNames from "classnames";
 import { filter } from "fuzzaldrin-plus";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { findDOMNode } from "react-dom";
 
@@ -45,9 +44,8 @@ interface INavigationSection {
     reference: string;
 }
 
-@PureRender
 @HotkeysTarget
-export class Navigator extends React.Component<INavigatorProps, INavigatorState> {
+export class Navigator extends React.PureComponent<INavigatorProps, INavigatorState> {
     public state: INavigatorState = {
         query: "",
         selectedIndex: 0,

--- a/packages/docs/src/components/section.tsx
+++ b/packages/docs/src/components/section.tsx
@@ -7,7 +7,6 @@
 
 import { IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { IPropertyEntry } from "ts-quick-docs/src/interfaces";
 
@@ -50,8 +49,8 @@ export const SectionHeading: React.SFC<{ depth: number, header: string, referenc
  * 5. HTML markup template, rendered as text
  * 6. Any React children, usually sub-sections
  */
-@PureRender
-export class Section extends React.Component<ISectionProps, {}> {
+
+export class Section extends React.PureComponent<ISectionProps, {}> {
     private interfaceProps: IPropertyEntry[];
 
     public render() {

--- a/packages/docs/src/components/styleguide.tsx
+++ b/packages/docs/src/components/styleguide.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { IPropertyEntry } from "ts-quick-docs/src/interfaces";
 
@@ -95,8 +94,7 @@ export interface IStyleguideState {
 const DEFAULT_PAGE = "overview";
 
 @HotkeysTarget
-@PureRender
-export class Styleguide extends React.Component<IStyleguideProps, IStyleguideState> {
+export class Styleguide extends React.PureComponent<IStyleguideProps, IStyleguideState> {
     private contentElement: HTMLElement;
     private navElement: HTMLElement;
     private refHandlers = {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "@blueprintjs/core": "^1.2.0",
     "classnames": "^2.2",
-    "es6-shim": "^0.35",
-    "pure-render-decorator": "^1.1"
+    "es6-shim": "^0.35"
   },
   "devDependencies": {
     "css-loader": "0.26.0",

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Classes, IIntentProps, IProps } from "@blueprintjs/core";
@@ -26,8 +25,7 @@ export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.Rea
 
 export const emptyCellRenderer = (_rowIndex: number, _columnIndex: number) => <Cell />;
 
-@PureRender
-export class Cell extends React.Component<ICellProps, {}> {
+export class Cell extends React.PureComponent<ICellProps, {}> {
     public render() {
         const { style, tooltip, className } = this.props;
         const content = (<div className="bp-table-truncated-text">{this.props.children}</div>);

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { ITruncatedFormatProps, TruncatedFormat, TruncatedPopoverMode } from "./truncatedFormat";
 
@@ -29,8 +28,7 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     stringify?: (obj: any) => string;
 }
 
-@PureRender
-export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
+export class JSONFormat extends React.PureComponent<IJSONFormatProps, {}> {
     public static defaultProps: IJSONFormatProps = {
         omitQuotesOnStrings: true,
         stringify: (obj: any) => (JSON.stringify(obj, null, 2)),

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -7,7 +7,6 @@
 
 import { IProps, Popover, Position } from "@blueprintjs/core";
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 export enum TruncatedPopoverMode {
@@ -50,8 +49,7 @@ export interface ITruncatedFormatProps extends IProps {
     truncationSuffix?: string;
 }
 
-@PureRender
-export class TruncatedFormat extends React.Component<ITruncatedFormatProps, {}> {
+export class TruncatedFormat extends React.PureComponent<ITruncatedFormatProps, {}> {
     public static defaultProps: ITruncatedFormatProps = {
         preformatted: true,
         showPopover: TruncatedPopoverMode.ALWAYS,

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { Grid, IColumnIndices } from "../common/grid";
 import { Rect, Utils } from "../common/index";
@@ -69,8 +68,7 @@ export interface IColumnHeaderProps extends ISelectableProps, IColumnIndices, IC
     onResizeGuide: (guides: number[]) => void;
 }
 
-@PureRender
-export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
+export class ColumnHeader extends React.PureComponent<IColumnHeaderProps, {}> {
     public static defaultProps = {
         isResizable: true,
     };

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { Grid, IRowIndices } from "../common/grid";
 import { Rect } from "../common/rect";
@@ -69,8 +68,7 @@ export interface IRowHeaderProps extends ISelectableProps, IRowIndices, IRowHeig
     viewportRect: Rect;
 }
 
-@PureRender
-export class RowHeader extends React.Component<IRowHeaderProps, {}> {
+export class RowHeader extends React.PureComponent<IRowHeaderProps, {}> {
     public static defaultProps = {
         isResizable: false,
         renderRowHeader: renderDefaultRowHeader,

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -6,7 +6,6 @@
  */
 
 import { IProps } from "@blueprintjs/core";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
@@ -116,8 +115,8 @@ export interface IDraggableProps extends IProps, IDragHandler {
  * If `false` is returned from the onActivate callback, no further events
  * will be fired until the next activation.
  */
-@PureRender
-export class Draggable extends React.Component<IDraggableProps, {}> {
+
+export class Draggable extends React.PureComponent<IDraggableProps, {}> {
     private events: DragEvents;
 
     public render() {

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -5,7 +5,6 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { DragEvents } from "../interactions/dragEvents";
 import { Draggable, ICoordinateData, IDraggableProps } from "../interactions/draggable";
@@ -60,8 +59,7 @@ export interface IDragSelectableProps extends ISelectableProps {
     locateDrag: (event: MouseEvent, coords: ICoordinateData) => IRegion;
 }
 
-@PureRender
-export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
+export class DragSelectable extends React.PureComponent<IDragSelectableProps, {}> {
     public static isLeftClick(event: MouseEvent) {
         return event.button === 0;
     }

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -7,7 +7,6 @@
 
 import { IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { IRegion } from "../regions";
 
@@ -27,8 +26,7 @@ export interface IRegionLayerProps extends IProps {
     getRegionStyle: IRegionStyler;
 }
 
-@PureRender
-export class RegionLayer extends React.Component<IRegionLayerProps, {}> {
+export class RegionLayer extends React.PureComponent<IRegionLayerProps, {}> {
     public render() {
         return <div className="bp-table-overlay-layer">{this.renderRegionChildren()}</div>;
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -5,9 +5,8 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { AbstractComponent, IProps } from "@blueprintjs/core";
+import { AbstractPureComponent, IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Column, IColumnProps } from "./column";
@@ -228,8 +227,7 @@ export interface ITableState {
     selectedRegions?: IRegion[];
 }
 
-@PureRender
-export class Table extends AbstractComponent<ITableProps, ITableState> {
+export class Table extends AbstractPureComponent<ITableProps, ITableState> {
     public static defaultProps: ITableProps = {
         allowMultipleSelection: true,
         defaultColumnWidth: 150,
@@ -634,7 +632,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
     /**
      * Renders a `RegionLayer`, applying styles to the regions using the
-     * supplied `IRegionStyler`. `RegionLayer` is a `PureRender` component, so
+     * supplied `IRegionStyler`. `RegionLayer` is a `PureComponent`, so
      * the `IRegionStyler` should be a new instance on every render if we
      * intend to redraw the region layer.
      */


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/144

#### Changes proposed in this pull request:

- Replace all uses of `@PureRender` decorator with `React.PureComponent`
- Create `AbstractPureComponent` in order to cover components that were leveraging both `@PureRender` and `AbstractComponent`. [One example of this](https://github.com/palantir/blueprint/pull/386/files#diff-526f9b7061d074b106ee2b67a5dafc14L187)

#### Reviewers should focus on:
- The creation of the `AbstractPureComponent`. Especially in regards to imports like [this](https://github.com/palantir/blueprint/compare/master...jxodwyer:master#diff-6bc89efba539cc29af0dae9b17c57f75R8)
