### PR TITLE
more !default Sass variables

### DIFF
--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -62,7 +62,7 @@ Styleguide components.breadcrumbs.js
 */
 
 // shaving off 1px for perfect centering (... icon is 5px high)
-$breadcrumb-line-height: $pt-icon-size-large - 1px;
+$breadcrumb-line-height: $pt-icon-size-large - 1px !default;
 
 .pt-breadcrumbs {
   // ensure that the childrens' floats do not leak outside

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -56,10 +56,10 @@ $button-intents: (
   "success": ($pt-intent-success, $green2, $green1),
   "warning": ($pt-intent-warning, $orange2, $orange1),
   "danger": ($pt-intent-danger, $red2, $red1)
-);
+) !default;
 
 // matches default buttons only -- used to remove border-right in button groups and control groups
-$non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*=\"pt-intent-\"]";
+$non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*=\"pt-intent-\"]" !default;
 
 @mixin pt-button-base() {
   display: inline-block;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -274,8 +274,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   Styleguide components.forms.radio.js
   */
 
-  $radio-indicator-font-size: $pt-grid-size * 0.6;
-  $radio-indicator-font-size-large: $pt-grid-size * 0.8;
+  $radio-indicator-font-size: $pt-grid-size * 0.6 !default;
+  $radio-indicator-font-size-large: $pt-grid-size * 0.8 !default;
 
   &.pt-radio {
     .pt-control-indicator {
@@ -353,33 +353,35 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   Styleguide components.forms.switch.js
   */
 
-  $switch-height: $control-indicator-size;
-  $switch-width: $pt-grid-size * 2.8;
-  $switch-indicator-margin: $pt-grid-size * 0.2;
+  $switch-height: $control-indicator-size !default;
+  $switch-height-large: $pt-grid-size * 2 !default;
+  $switch-width: $pt-grid-size * 2.8 !default;
+  $switch-width-large: $pt-grid-size * 3.2 !default;
+  $switch-indicator-margin: $pt-grid-size * 0.2 !default;
 
-  $switch-background-color: rgba($gray4, 0.5);
-  $switch-background-color-hover: rgba($gray2, 0.5);
-  $switch-background-color-active: rgba($gray1, 0.5);
-  $switch-background-color-disabled: $button-background-color-disabled;
-  $switch-checked-background-color: $control-checked-background-color;
-  $switch-checked-background-color-hover: $control-checked-background-color-hover;
-  $switch-checked-background-color-active: $control-checked-background-color-active;
-  $switch-checked-background-color-disabled: rgba($blue3, 0.5);
-  $dark-switch-background-color: rgba($black, 0.5);
-  $dark-switch-background-color-hover: rgba($black, 0.7);
-  $dark-switch-background-color-active: rgba($black, 0.9);
-  $dark-switch-background-color-disabled: $dark-button-background-color-disabled;
-  $dark-switch-checked-background-color: $control-checked-background-color;
-  $dark-switch-checked-background-color-hover: $blue4;
-  $dark-switch-checked-background-color-active: $blue5;
-  $dark-switch-checked-background-color-disabled: rgba($blue1, 0.5);
+  $switch-background-color: rgba($gray4, 0.5) !default;
+  $switch-background-color-hover: rgba($gray2, 0.5) !default;
+  $switch-background-color-active: rgba($gray1, 0.5) !default;
+  $switch-background-color-disabled: $button-background-color-disabled !default;
+  $switch-checked-background-color: $control-checked-background-color !default;
+  $switch-checked-background-color-hover: $control-checked-background-color-hover !default;
+  $switch-checked-background-color-active: $control-checked-background-color-active !default;
+  $switch-checked-background-color-disabled: rgba($blue3, 0.5) !default;
+  $dark-switch-background-color: rgba($black, 0.5) !default;
+  $dark-switch-background-color-hover: rgba($black, 0.7) !default;
+  $dark-switch-background-color-active: rgba($black, 0.9) !default;
+  $dark-switch-background-color-disabled: $dark-button-background-color-disabled !default;
+  $dark-switch-checked-background-color: $control-checked-background-color !default;
+  $dark-switch-checked-background-color-hover: $blue4 !default;
+  $dark-switch-checked-background-color-active: $blue5 !default;
+  $dark-switch-checked-background-color-disabled: rgba($blue1, 0.5) !default;
 
-  $switch-indicator-border: border-shadow($pt-border-shadow-opacity);
-  $switch-indicator-background-color: $white;
-  $switch-indicator-background-color-disabled: rgba($white, 0.8);
-  $dark-switch-indicator-border: border-shadow($pt-dark-border-shadow-opacity);
-  $dark-switch-indicator-background-color: $dark-gray4;
-  $dark-switch-indicator-background-color-disabled: rgba($black, 0.4);
+  $switch-indicator-border: border-shadow($pt-border-shadow-opacity) !default;
+  $switch-indicator-background-color: $white !default;
+  $switch-indicator-background-color-disabled: rgba($white, 0.8) !default;
+  $dark-switch-indicator-border: border-shadow($pt-dark-border-shadow-opacity) !default;
+  $dark-switch-indicator-background-color: $dark-gray4 !default;
+  $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.pt-switch {
     padding-left: $switch-width + $pt-grid-size;
@@ -491,9 +493,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     }
 
     &.pt-switch {
-      $switch-height-large: $pt-grid-size * 2;
-      $switch-width-large: $pt-grid-size * 3.2;
-
       padding-left: $switch-width-large + $pt-grid-size;
 
       .pt-control-indicator {

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -57,9 +57,9 @@ Styleguide components.forms.input-group.css
 */
 
 // 3px space between small button and regular input
-$input-button-height: $pt-button-height - 6px;
+$input-button-height: $pt-button-height - 6px !default;
 // 5px space between regular button and large input
-$input-button-height-large: $pt-button-height;
+$input-button-height-large: $pt-button-height !default;
 
 .pt-input-group {
   display: block;

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -260,7 +260,7 @@ fast workflows. You can see an example in the [Context Menus](#components.contex
 Styleguide components.popover.js.minimal
 */
 
-$popover-width: $pt-grid-size * 35;
+$popover-width: $pt-grid-size * 35 !default;
 
 .pt-popover {
   @include popover-sizing(

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -103,25 +103,25 @@ Styleguide components.progress.spinner.js.svg
   }
 }
 
-$spinner-track-color: rgba($gray1, 0.2);
-$spinner-head-color: rgba($gray1, 0.8);
-$dark-spinner-track-color: rgba($gray5, 0.2);
-$dark-spinner-head-color: $gray1;
+$spinner-track-color: rgba($gray1, 0.2) !default;
+$spinner-head-color: rgba($gray1, 0.8) !default;
+$dark-spinner-track-color: rgba($gray5, 0.2) !default;
+$dark-spinner-head-color: $gray1 !default;
 
-$spinner-width: $pt-grid-size * 10;
-$spinner-width-factor: 0.5;
-$spinner-width-factor-small: 0.24;
-$spinner-width-factor-large: 1;
-$spinner-stroke-width: 5;
-$spinner-stroke-width-small: 12;
-$spinner-stroke-width-large: 3;
+$spinner-width: $pt-grid-size * 10 !default;
+$spinner-width-factor: 0.5 !default;
+$spinner-width-factor-small: 0.24 !default;
+$spinner-width-factor-large: 1 !default;
+$spinner-stroke-width: 5 !default;
+$spinner-stroke-width-small: 12 !default;
+$spinner-stroke-width-large: 3 !default;
 
-$spinner-speed: $pt-transition-duration * 4;
-$spinner-speed-small: $pt-transition-duration * 4;
-$spinner-speed-large: $pt-transition-duration * 4.5;
+$spinner-speed: $pt-transition-duration * 4 !default;
+$spinner-speed-small: $pt-transition-duration * 4 !default;
+$spinner-speed-large: $pt-transition-duration * 4.5 !default;
 
 // the relative path from blueprint.css to resources in the distribution package
-$resources-path: "./resources";
+$resources-path: "./resources" !default;
 
 // see https://css-tricks.com/scale-svg/
 // how to Scale SVG to Fit the Available Width (and adjust the height to match) Option 4

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -153,10 +153,10 @@ class MyComponent extends React.Component<{}, {}> {
 Styleguide components.toaster.js.react
 */
 
-$toast-height: $pt-button-height-large;
-$toast-min-width: $pt-grid-size * 30;
-$toast-max-width: $pt-grid-size * 50;
-$toast-margin: $pt-grid-size * 1.5;
+$toast-height: $pt-button-height-large !default;
+$toast-min-width: $pt-grid-size * 30 !default;
+$toast-max-width: $pt-grid-size * 50 !default;
+$toast-margin: $pt-grid-size * 1.5 !default;
 
 .pt-toast {
   // toast transition properties

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -93,8 +93,8 @@ Markup:
 Styleguide components.tree.css
 */
 
-$row-height: $pt-grid-size * 3;
-$icon-spacing: ($row-height - $pt-icon-size-standard) / 2;
+$tree-row-height: $pt-grid-size * 3 !default;
+$tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
 
 .pt-tree-node-list {
   margin: 0;
@@ -112,7 +112,7 @@ $icon-spacing: ($row-height - $pt-icon-size-standard) / 2;
 
 @for $i from 0 through 20 {
   .pt-tree-node-content-#{$i} {
-    padding-left: ($row-height - $icon-spacing) * $i;
+    padding-left: ($tree-row-height - $tree-icon-spacing) * $i;
   }
 }
 
@@ -120,7 +120,7 @@ $icon-spacing: ($row-height - $pt-icon-size-standard) / 2;
   display: flex;
   align-items: center;
   width: 100%;
-  height: $row-height;
+  height: $tree-row-height;
   padding-right: $pt-grid-size / 2;
 
   &:hover {
@@ -133,7 +133,7 @@ $icon-spacing: ($row-height - $pt-icon-size-standard) / 2;
   position: relative;
   min-width: $pt-grid-size * 3;
   // override default icon styles, which appear first for some reason
-  line-height: $row-height !important; // stylelint-disable-line declaration-no-important
+  line-height: $tree-row-height !important; // stylelint-disable-line declaration-no-important
 }
 
 .pt-tree-node-caret {
@@ -155,7 +155,7 @@ $icon-spacing: ($row-height - $pt-icon-size-standard) / 2;
 
 .pt-tree-node-icon {
   position: relative;
-  margin-right: $icon-spacing;
+  margin-right: $tree-icon-spacing;
   color: $pt-icon-color;
 }
 
@@ -174,7 +174,7 @@ $icon-spacing: ($row-height - $pt-icon-size-standard) / 2;
 
 .pt-tree-node-secondary-label {
   padding: 0 ($pt-grid-size / 2);
-  line-height: $row-height;
+  line-height: $tree-row-height;
   user-select: none;
 }
 

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -11,6 +11,7 @@ $cell-height: $pt-grid-size * 2 !default;
 $large-cell-height: $pt-grid-size * 3 !default;
 
 $cell-background-color: $white !default;
+$cell-background-color-opacity: 0.1 !default;
 $cell-border-color: $pt-divider-black !default;
 $cell-text-color: $pt-text-color !default;
 $dark-cell-background-color: $dark-gray3 !default;
@@ -31,15 +32,13 @@ $dark-cell-text-color: $pt-dark-text-color !default;
   }
 
   @each $intent, $color in $pt-intent-colors {
-    $background-color-opacity: 0.1;
-
     &.pt-intent-#{$intent} {
-      background-color: rgba($color, $background-color-opacity);
+      background-color: rgba($color, $cell-background-color-opacity);
       color: map-get($pt-intent-text-colors, $intent);
     }
 
     .pt-dark &.pt-intent-#{$intent} {
-      background: rgba($color, $background-color-opacity);
+      background: rgba($color, $cell-background-color-opacity);
       color: map-get($pt-dark-intent-text-colors, $intent);
     }
   }

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -11,10 +11,10 @@
 @import "./interactions/interactions";
 @import "./layers/layers";
 
-$body-z-index: $pt-z-index-content;
-$column-z-index: $body-z-index + 1;
-$row-z-index: $column-z-index + 1;
-$menu-z-index: $row-z-index + 1;
+$body-z-index: $pt-z-index-content !default;
+$column-z-index: $body-z-index + 1 !default;
+$row-z-index: $column-z-index + 1 !default;
+$menu-z-index: $row-z-index + 1 !default;
 
 .bp-table-container {
   display: flex;


### PR DESCRIPTION
found a host of Sass variables that were missing `!default` declarations, now they aren't!

this should support easier checkbox styling (#396).

addresses #194 and #377 