### PR TITLE
MenuItem disabled=true now prevents submenu and click interaction

### DIFF
--- a/packages/core/examples/menuExample.tsx
+++ b/packages/core/examples/menuExample.tsx
@@ -31,7 +31,7 @@ export class MenuExample extends BaseExample<{}> {
                     <MenuItem iconName="duplicate" text="Copy" label="⌘C" />
                     <MenuItem iconName="clipboard" text="Paste" label="⌘V" disabled={true} />
                     <MenuDivider title="Text" />
-                    <MenuItem iconName="align-left" text="Alignment">
+                    <MenuItem disabled iconName="align-left" text="Alignment">
                         <MenuItem iconName="align-left" text="Left" />
                         <MenuItem iconName="align-center" text="Center" />
                         <MenuItem iconName="align-right" text="Right" />

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -87,15 +87,15 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
     private liElement: HTMLElement;
 
     public render() {
-        const { children, label, submenu } = this.props;
+        const { children, disabled, label, submenu } = this.props;
         const hasSubmenu = children != null || submenu != null;
         const liClasses = classNames({
             [Classes.MENU_SUBMENU]: hasSubmenu,
         });
         const anchorClasses = classNames(Classes.MENU_ITEM, Classes.intentClass(this.props.intent), {
-            [Classes.DISABLED]: this.props.disabled,
+            [Classes.DISABLED]: disabled,
             // prevent popover from closing when clicking on submenu trigger or disabled item
-            [Classes.POPOVER_DISMISS]: this.props.shouldDismissPopover && !this.props.disabled && !hasSubmenu,
+            [Classes.POPOVER_DISMISS]: this.props.shouldDismissPopover && !disabled && !hasSubmenu,
         }, Classes.iconClass(this.props.iconName), this.props.className);
 
         let labelElement: JSX.Element;
@@ -106,9 +106,9 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
         let content = (
             <a
                 className={anchorClasses}
-                href={this.props.href}
-                onClick={this.props.disabled ? null : this.props.onClick}
-                tabIndex={this.props.disabled ? -1 : 0}
+                href={disabled ? undefined : this.props.href}
+                onClick={disabled ? undefined : this.props.onClick}
+                tabIndex={disabled ? undefined : 0}
                 target={this.props.target}
             >
                 {labelElement}
@@ -126,6 +126,7 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
             content = (
                 <Popover
                     content={submenuElement}
+                    isDisabled={disabled}
                     enforceFocus={false}
                     hoverCloseDelay={0}
                     inline={true}

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -45,6 +45,17 @@ describe("MenuItem", () => {
         assert.lengthOf(submenu.props.children, items.length);
     });
 
+    it("disabled MenuItem will not show its submenu", () => {
+        const wrapper = shallow(
+            <MenuItem disabled iconName="style" text="Style">
+                <MenuItem iconName="bold" text="Bold" />
+                <MenuItem iconName="italic" text="Italic" />
+                <MenuItem iconName="underline" text="Underline" />
+            </MenuItem>,
+        );
+        assert.isTrue(wrapper.find(Popover).prop("isDisabled"));
+    })
+
     it("throws error if given children and submenu", () => {
         assert.throws(() => shallow(
             <MenuItem iconName="style" text="Style" submenu={[{text: "foo"}]}>

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -54,7 +54,7 @@ describe("MenuItem", () => {
             </MenuItem>,
         );
         assert.isTrue(wrapper.find(Popover).prop("isDisabled"));
-    })
+    });
 
     it("throws error if given children and submenu", () => {
         assert.throws(() => shallow(


### PR DESCRIPTION
#### Fixes #398

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Include tests

#### Changes proposed in this pull request:

- `<MenuItem disabled />` disables its submenu Popover and removes `href`