### PR TITLE
add `disabled` to IControlProps so it appears in props table

### DIFF
--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -21,6 +21,9 @@ export interface IControlProps extends IProps {
     /** Whether the control is initially checked (uncontrolled) */
     defaultChecked?: boolean;
 
+    /** Whether the control is non-interactive. */
+    disabled?: boolean;
+
     /** Ref handler that receives HTML `<input>` element backing this component. */
     inputRef?: (ref: HTMLInputElement) => any;
 


### PR DESCRIPTION
#### Fixes #396 

This is purely a documentation/usability improvement. `disabled` was already supported from `HTMLProps` but now the prop will be documented in the props table to avoid any potential confusion.