### PR TITLE
more explicit usage docs

### DIFF
--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -26,34 +26,78 @@ Styleguide components.usage
 /*
 NPM installation
 
-Install the core package with an NPM client like `npm` or `yarn`, pulling in all relevant dependencies:
+1. Install the core package with an NPM client like `npm` or `yarn`, pulling in all relevant dependencies:
 
-```sh
-npm install --save @blueprintjs/core
-```
+  ```sh
+  npm install --save @blueprintjs/core
+  ```
 
-After installation, you'll be able to import the React components in your application:
+1. If you see `UNMET PEER DEPENDENCY` errors, you should manually install React:
 
-```
-import { Spinner, DatePickerFactory } from "@blueprintjs/core";
-// or
-import * as Blueprint from "@blueprintjs/core";
+  ```sh
+  npm install --save react react-dom react-addons-css-transition-group
+  ```
 
-// JSX works
-const mySpinner = <Spinner/>;
+1. After installation, you'll be able to import the React JS components in your application:
 
-// using the namespace import
-const anotherSpinner = <Blueprint.Spinner/>;
+  ```
+  // extract specific components
+  import { Intent, Spinner, DatePickerFactory } from "@blueprintjs/core";
+  // or just take everything!
+  import * as Blueprint from "@blueprintjs/core";
 
-// use factories for React.createElement shorthand if you're not using JSX
-const myDatePicker = DatePickerFactory();
-```
+  // using JSX:
+  const mySpinner = <Spinner intent={Intent.PRIMARY} />;
 
-<div class="pt-callout pt-intent-warning pt-icon-warning-sign">
-  Don't forget to import the CSS file from each package!
-</div>
+  // using the namespace import:
+  const anotherSpinner = <Blueprint.Spinner intent={Blueprint.Intent.PRIMARY}/>;
+
+  // use factories for React.createElement shorthand if you're not using JSX.
+  // every component provides a corresponding <Name>Factory.
+  const myDatePicker = DatePickerFactory();
+  ```
+
+1. Don't forget to include the main CSS file from each Blueprint package! Additionally, the `resources/`
+directory contains supporting media such as fonts and images.
+
+  ```html
+  <!-- in plain old reliable HTML -->
+  <!DOCTYPE HTML>
+  <html>
+    <head>
+      ...
+      <!-- include dependencies manually -->
+      <link href="path/to/node_modules/normalize.css/normalize.css" rel="stylesheet" />
+      <link href="path/to/node_modules/@blueprintjs/core/dist/blueprint.css" rel="stylesheet" />
+      ...
+    </head>
+    ...
+  </html>
+  ```
+
+  ```scss
+  // or, using node-style package resolution in a CSS file:
+  // (dependencies' stylesheets should be resolved automatically)
+  @import "~@blueprintjs/core";
+  ```
+
+Weight: -1
 
 Styleguide components.usage.npm
+*/
+
+/*
+DOM4
+
+Blueprint relies on a handful of DOM Level 4 API methods: `el.query`, `el.queryAll`, and `el.closest()`.
+We depend on a [polyfill library called `dom4`][dom4] to ensure these methods are always available.
+
+If you consume Blueprint through a module bundler such as Webpack then everything should work swimmingly.
+Otherwise, ensure that `dom4` is included in your application.
+
+[dom4]: https://webreflection.github.io/dom4/
+
+Styleguide components.usage.dom4
 */
 
 /*
@@ -65,7 +109,7 @@ dependencies before you can consume it:
 
 ```sh
 # required for all @blueprintjs packages:
-npm install --save @types/dom4 @types/pure-render-decorator @types/react @types/react-dom @types/react-addons-css-transition-group
+npm install --save @types/pure-render-decorator @types/react @types/react-dom @types/react-addons-css-transition-group
 
 # @blueprintjs/datetime requires:
 npm install --save @types/moment

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -90,12 +90,8 @@ Styleguide components.usage.npm
 DOM4
 
 Blueprint relies on a handful of DOM Level 4 API methods: `el.query`, `el.queryAll`, and `el.closest()`.
-We depend on a [polyfill library called `dom4`][dom4] to ensure these methods are always available.
-
-If you consume Blueprint through a module bundler such as Webpack then everything should work swimmingly.
-Otherwise, ensure that `dom4` is included in your application.
-
-[dom4]: https://webreflection.github.io/dom4/
+`@blueprintjs/core` depends on a [polyfill library called `dom4`](https://webreflection.github.io/dom4/) to ensure
+these methods are available. This module is conditionally loaded if Blueprint is used in a browser environment.
 
 Styleguide components.usage.dom4
 */

--- a/packages/docs/src/styleguide.md
+++ b/packages/docs/src/styleguide.md
@@ -10,26 +10,16 @@ Releases are tagged and documented [here](https://github.com/palantir/blueprint/
 
 Blueprint is available as a collection of NPM packages under the `@blueprintjs` scope.
 
+You'll need to install React alongside Blueprint. We support `v15.x` (latest) and `v0.14.x`.
+
 ```sh
-npm install --save @blueprintjs/core
+npm install --save @blueprintjs/core react react-dom react-addons-css-transition-group
 ```
 
-Import the `@blueprintjs/core` module into your project.
+Import components from the `@blueprintjs/core` module into your project.
+Don't forget to include the main CSS stylesheet too!
 
-You can then include these styles (`blueprint.css` along with its associated resources in the `resources` directory)
-in your application as you wish. For example:
-
-```html
-<!DOCTYPE HTML>
-<html>
-  <head>
-    ...
-    <link href="path/to/node_modules/@blueprintjs/core/dist/blueprint.css" rel="stylesheet" />
-    ...
-  </head>
-  ...
-</html>
-```
+**[See Components Usage for more complete installation instructions.](#components.usage)**
 
 ### Beyond core styles
 


### PR DESCRIPTION
#### Fixes #190, Fixes #201

#### Changes proposed in this pull request:

- a significant refactor of the two Usage sections
- Overview Usage is now mostly a link to Components Usage that scratches the peer dep itch
- Components Usage steps through setting up BP with peer deps and CSS imports
- new section about DOM4 so we can point folks to it

#### Reviewers should focus on:

- copy editing! the DOM4 section feels pretty awkward
