### PR TITLE
Add tsconfig to table/examples folder

### DIFF
--- a/packages/table/examples/tsconfig.json
+++ b/packages/table/examples/tsconfig.json
@@ -15,9 +15,6 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5",
-        "paths": {
-            "@blueprintjs/core": ["../../core/dist/index"]
-        }
+        "target": "es5"
     }
 }

--- a/packages/table/examples/tsconfig.json
+++ b/packages/table/examples/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "declaration": true,
+        "experimentalDecorators": true,
+        "jsx": "react",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "removeComments": false,
+        "sourceMap": false,
+        "stripInternal": true,
+        "target": "es5",
+        "paths": {
+            "@blueprintjs/core": ["../../core/dist/index"]
+        }
+    }
+}


### PR DESCRIPTION
Without a tsconfig in the `packages/table/examples` folder, VSCode isn't able to include 'react' in the example files.