### PR TITLE
Force Karma to serve ts/tsx files as typescript

### DIFF
--- a/gulp/karma.js
+++ b/gulp/karma.js
@@ -64,6 +64,9 @@ module.exports = (gulp, plugins, blueprint) => {
             },
             files: filesToInclude,
             frameworks: ["mocha", "chai", "phantomjs-shim", "sinon"],
+            mime: {
+                "text/x-typescript": ["ts", "tsx"],
+            },
             port: 9876,
             // coverage is instrumented in gulp/webpack.js
             preprocessors: {


### PR DESCRIPTION
The default mime type of these files is a QuickTime video format. This
change allows us to serve `*.ts` files to a Karma server and allow
them to be executed in a Chrome browser. PhantomJS doesn't seem have
strict mime-type checking, so this doesn't affect tests on CircleCI.