### PR TITLE
Fixes menu divider title typographic descender being cut off

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -93,7 +93,7 @@ $dark-menu-background-color: $dark-gray4 !default;
 
   margin: 0;
   padding: $pt-grid-size $menu-item-padding 0 1px;
-  line-height: $pt-icon-size-standard;
+  line-height: $pt-grid-size * 1.7;
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -93,7 +93,8 @@ $dark-menu-background-color: $dark-gray4 !default;
 
   margin: 0;
   padding: $pt-grid-size $menu-item-padding 0 1px;
-  line-height: $pt-grid-size * 1.7;
+  // a little extra space to avoid clipping descenders (because overflow hidden)
+  line-height: $pt-icon-size-standard + 1px;
 }
 
 @mixin menu-header-large($heading-selector) {


### PR DESCRIPTION
#### Fixes #374

#### Changes proposed in this pull request:

Increase the line height to see the typographic descenders