### PR TITLE
update stylelint rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,10 @@
     "stylelint-config-palantir/sass.js"
   ],
   "rules": {
-    "max-line-length": 130,
+    "max-line-length": [
+      100,
+      { "ignore": ["comments"] }
+    ],
     "selector-no-attribute": null
   }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,11 +1,10 @@
 {
   "extends": [
     "stylelint-config-palantir",
-    "stylelint-config-palantir/sass.js",
+    "stylelint-config-palantir/sass.js"
   ],
   "rules": {
     "max-line-length": 130,
-    "selector-no-attribute": null,
-    "scss/at-extend-no-missing-placeholder": null
-  },
+    "selector-no-attribute": null
+  }
 }

--- a/packages/core/src/_accessibility.scss
+++ b/packages/core/src/_accessibility.scss
@@ -20,9 +20,10 @@ navigation to indicate which element is currently active. They are less importan
 occasionally outright intrusive, when using a mouse because you can click wherever you want at
 any time.
 
-Blueprint includes a utility that manages the appearance of focus styles. When enabled, focus
-styles will be hidden while the user interacts using the mouse and will appear when the <kbd class="pt-key">tab</kbd> key
-is pressed to begin keyboard navigation. Try this out for yourself below.
+Blueprint includes a utility that manages the appearance of focus styles. When enabled, focus styles
+will be hidden while the user interacts using the mouse and will appear when the
+<kbd class="pt-key">tab</kbd> key is pressed to begin keyboard navigation. Try this out for yourself
+below.
 
 **You must explictly enable this feature in your app (and you probably want to):**
 
@@ -71,9 +72,9 @@ Styleguide a11y.focus.js
 /*
 Color contrast
 
-Colors have been designed to be accessible to as many people as possible, even those who are visually impaired or
-experiencing any kind of colorblindness. Our colors have not only been chosen to go well together but to also adhere to
-[WCAG 2.0](https://www.w3.org/TR/WCAG20/) standards.
+Colors have been designed to be accessible to as many people as possible, even those who are
+visually impaired or experiencing any kind of colorblindness. Our colors have not only been chosen
+to go well together but to also adhere to [WCAG 2.0](https://www.w3.org/TR/WCAG20/) standards.
 
 Weight: 1
 

--- a/packages/core/src/_dark-theme.scss
+++ b/packages/core/src/_dark-theme.scss
@@ -6,19 +6,19 @@
 /*
 Dark theme
 
-Blueprint provides two UI color themes: light and dark. The light theme is active by default.
-The dark theme can be applied by adding the class `pt-dark` to a container element to theme
-all nested elements.
+Blueprint provides two UI color themes: light and dark. The light theme is active by default. The
+dark theme can be applied by adding the class `pt-dark` to a container element to theme all nested
+elements.
 
-Once applied, the dark theme will cascade to nested `.pt-*` elements inside a `.pt-dark`
-container. There is no way to nest light-themed elements inside a dark container.
+Once applied, the dark theme will cascade to nested `.pt-*` elements inside a `.pt-dark` container.
+There is no way to nest light-themed elements inside a dark container.
 
 Most elements only support the dark theme when nested inside a `.pt-dark` container because it does
-not make sense to mark individual elements as dark. The dark container is therefore responsible for setting
-a dark background color.
+not make sense to mark individual elements as dark. The dark container is therefore responsible for
+setting a dark background color.
 
-The following elements and components support the `.pt-dark` class directly (i.e,
-`.pt-app.pt-dark`) and can be used as a container for nested dark children:
+The following elements and components support the `.pt-dark` class directly (i.e, `.pt-app.pt-dark`)
+and can be used as a container for nested dark children:
 
 - `.pt-app`
 - `.pt-card`
@@ -26,8 +26,8 @@ The following elements and components support the `.pt-dark` class directly (i.e
   - `Popover` and `Tooltip` will automatically detect when their trigger is inside a `.pt-dark`
     container and add the same class to themselves.
 
-Rather than illustrating dark components inline, this documentation site provides a site-wide
-switch in the top right corner of the page to enable the dark theme. Try it out as you read the docs.
+Rather than illustrating dark components inline, this documentation site provides a site-wide switch
+in the top right corner of the page to enable the dark theme. Try it out as you read the docs.
 
 Weight: 10
 

--- a/packages/core/src/_icons.scss
+++ b/packages/core/src/_icons.scss
@@ -17,7 +17,8 @@ Styleguide icons
 UI icons
 
 Blueprint UI icons are implemented via an icon font. They can be used anywhere text is
-used. It's easy to change their color or apply effects like text shadows via standard CSS properties.
+used. It's easy to change their color or apply effects like text shadows via standard CSS
+properties.
 
 To use Blueprint UI icons, you need to apply two classes to a `<span>` element:
 - a __sizing class__, either `pt-icon-standard` (16px) or `pt-icon-large` (20px)
@@ -29,8 +30,8 @@ To use Blueprint UI icons, you need to apply two classes to a `<span>` element:
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>Non-standard sizes</h5>
-  Generally, icons should only be used at either 16px or 20px. However if a non-standard size is necessary,
-  set a `font-size` that is whole multiple of 16 or 20 with the relevant size class.
+  Generally, icons should only be used at either 16px or 20px. However if a non-standard size is
+  necessary, set a `font-size` that is whole multiple of 16 or 20 with the relevant size class.
   You can instead use the class `pt-icon` to make the icon inherit its size from surrounding text.
 </div>
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -37,12 +37,13 @@ Usage
 
 Keep in mind these general web typography guidelines when building your applications.
 
-- The default text color in all components is compliant with the recommended [WCAG 2.0](https://www.w3.org/TR/WCAG20/)
-  minimum contrast ratio.
+- The default text color in all components is compliant with the recommended
+  [WCAG 2.0](https://www.w3.org/TR/WCAG20/) minimum contrast ratio.
 - If you choose to go with a custom text color, make sure the background behind it provides
   proper contrast.
-- Try not to explicitly write pixel values for your font-size or line-height CSS rules. Instead, reference
-  the classes and variables we provide in Blueprint (`.pt-ui-text`, `$pt-font-size-large`, etc.).
+- Try not to explicitly write pixel values for your font-size or line-height CSS rules.
+  Instead, reference the classes and variables we provide in Blueprint (`.pt-ui-text`,
+  `$pt-font-size-large`, etc.).
 
 Weight: 2
 
@@ -62,8 +63,8 @@ small {
 /*
 Fonts
 
-Blueprint does not include any fonts of its own; it will use the default sans-serif operating system font.
-We provide a class to use the default monospace font instead.
+Blueprint does not include any fonts of its own; it will use the default sans-serif operating system
+font. We provide a class to use the default monospace font instead.
 
 Markup:
 <div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
@@ -148,9 +149,10 @@ Running text
 
 Large blocks of _running text_ should use `.pt-running-text` styles.
 
-Note that `<p>` elements by default don't add any styles; they just inherit the base typography. This is a
-conservative design; `<p>` elements are so ubiquitous that they're more often used for UI text than long form text.
-It's up to the user to decide which blocks of text in an application should get running text styles.
+Note that `<p>` elements by default don't add any styles; they just inherit the base typography.
+This is a conservative design; `<p>` elements are so ubiquitous that they're more often used for UI
+text than long form text. It's up to the user to decide which blocks of text in an application
+should get running text styles.
 
 Markup:
 <p>
@@ -159,9 +161,10 @@ Markup:
 <p class="pt-running-text">
   Running text is larger and more spaced out.
   <br />
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-  magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+  labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+  nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+  esse cillum dolore eu fugiat nulla pariatur.
   <br />
   <a href="#">Excepteur sint occaecat cupidatat non proident.</a>
 </p>
@@ -198,8 +201,8 @@ p {
 /*
 Links
 
-Simply use an `<a href="">` tag as you normally would. No class is necessary for Blueprint styles. Links are
-underlined only when hovered.
+Simply use an `<a href="">` tag as you normally would. No class is necessary for Blueprint styles.
+Links are underlined only when hovered.
 
 Putting an icon inside a link will cause it to inherit the link's text color.
 
@@ -329,14 +332,16 @@ Block quotes are treated as running text.
 Markup:
 <blockquote>
   <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   </p>
   <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   </p>
 </blockquote>
 
@@ -425,7 +430,8 @@ ul {
 /*
 Text utilities
 
-Blueprint provides a small handful of class-based text utilities which can applied to any element that contains text.
+Blueprint provides a small handful of class-based text utilities which can applied to any element
+that contains text.
 
 Markup:
 <div class="{{.modifier}}" style="width: 320px;">
@@ -433,7 +439,8 @@ Markup:
 </div>
 
 .pt-text-muted - Changes text color to a gentler gray.
-.pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its container.
+.pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
+  container.
 
 Weight: 9
 

--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -6,8 +6,8 @@
 /*
 Color aliases
 
-These variables are semantic aliases of our [colors](#colors). They are used throughout Blueprint itself to ensure
-consistent color usage across components.
+These variables are semantic aliases of our [colors](#colors). They are used throughout Blueprint
+itself to ensure consistent color usage across components.
 
 <table class=pt-table>
   <thead>

--- a/packages/core/src/common/_icons.scss
+++ b/packages/core/src/common/_icons.scss
@@ -18,7 +18,10 @@ $icon-classes: (
   -webkit-font-smoothing: antialiased;
 }
 
-@mixin pt-icon-sized($font-size: $pt-icon-size-standard, $font-family-size: strip-units($font-size)) {
+@mixin pt-icon-sized(
+  $font-size: $pt-icon-size-standard,
+  $font-family-size: strip-units($font-size)
+) {
   line-height: 1;
   font-family: "Icons#{$font-family-size}", sans-serif;
   font-size: $font-size;
@@ -42,7 +45,10 @@ $icon-classes: (
   }
 }
 
-@mixin pt-icon($font-size: $pt-icon-size-standard, $font-family-size: strip-units($font-size)) {
+@mixin pt-icon(
+  $font-size: $pt-icon-size-standard,
+  $font-family-size: strip-units($font-size)
+) {
   @include pt-icon-sized($font-size, $font-family-size);
   @include pt-icon-font-smoothing();
 }

--- a/packages/core/src/common/_react-transition.scss
+++ b/packages/core/src/common/_react-transition.scss
@@ -34,8 +34,18 @@ $after: selector text to insert after transiton name (to select children)
   $after: ""
 ) {
   @include each-prop($properties, 2);
-  @include react-transition-phase($name, "enter", $properties, $duration, $easing, $delay, $before, $after);
-  @include react-transition-phase($name, "leave", $properties, $duration, $easing, $delay, $before, $after);
+
+  @include react-transition-phase(
+    $name, "enter", $properties,
+    $duration, $easing, $delay,
+    $before, $after
+  );
+
+  @include react-transition-phase(
+    $name, "leave", $properties,
+    $duration, $easing, $delay,
+    $before, $after
+  );
 }
 
 /*
@@ -46,7 +56,8 @@ If `leave` phase is given then property values are animated in reverse, from fin
 
 **Example:**
 @include react-transition-phase(pt-toast, enter, $enter-translate, $before: "&");
-@include react-transition-phase(pt-toast, leave, $leave-blur, $pt-transition-duration * 3, $before: "&");
+@include react-transition-phase(pt-toast, leave, $leave-blur,
+  $pt-transition-duration * 3, $before: "&");
 */
 @mixin react-transition-phase(
   $name,

--- a/packages/core/src/common/_react-transition.scss
+++ b/packages/core/src/common/_react-transition.scss
@@ -4,12 +4,12 @@
 // and https://github.com/palantir/blueprint/blob/master/PATENTS
 
 /*
-A mixin to generate the classes for a React CSSTransitionGroup which animates any number of CSS properties at once.
+A mixin to generate the classes for a React CSSTransitionGroup which animates any number of CSS
+properties at once.
 
-Transitioned properties are specificed as a map of property names to lists of (inital value,
-final value). For enter & appear transitions, each property will transition from its initial to
-its final value. For leave transitions, each property will transition in reverse, from final to
-initial.
+Transitioned properties are specificed as a map of property names to lists of (inital value, final
+value). For enter & appear transitions, each property will transition from its initial to its final
+value. For leave transitions, each property will transition in reverse, from final to initial.
 
 **Simple example:**
 `@include react-transition("pt-popover", (opacity: 0 1), $before: "&");`
@@ -21,6 +21,7 @@ $name: React transitionName prop
 $properties: map of CSS property to (initial, final) values
 $duration: transition duration
 $easing: transition easing function
+$delay: transition delay
 $before: selector text to insert before transition name (often to select self: &)
 $after: selector text to insert after transiton name (to select children)
 */
@@ -56,8 +57,7 @@ If `leave` phase is given then property values are animated in reverse, from fin
 
 **Example:**
 @include react-transition-phase(pt-toast, enter, $enter-translate, $before: "&");
-@include react-transition-phase(pt-toast, leave, $leave-blur,
-  $pt-transition-duration * 3, $before: "&");
+@include react-transition-phase(pt-toast, leave, $leave-blur, $pt-transition-duration * 3, $before: "&");
 */
 @mixin react-transition-phase(
   $name,
@@ -105,7 +105,8 @@ Example: `each-prop((opacity: 0 1), 2)` will print "opacity: 1"
 }
 
 /*
-Format transition class name with all the bits. "enter" phase will include "appear" phase in returned name.
+Format transition class name with all the bits.
+"enter" phase will include "appear" phase in returned name.
 */
 @function transition-name($phase, $name, $before, $after) {
   $full-name: "#{$before}.#{$name}-#{$phase}#{$after}";

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -132,25 +132,25 @@ $pt-navbar-height: $pt-grid-size * 5 !default;
 /*
 Grid system
 
-Blueprint doesn't provide a grid system. In general, you should try to use the `$pt-grid-size` variable
-to generate layout & sizing style rules in your CSS codebase.
+Blueprint doesn't provide a grid system. In general, you should try to use the `$pt-grid-size`
+variable to generate layout & sizing style rules in your CSS codebase.
 
-In lieu of a full grid system, you should try to use the __CSS3 Flexible Box
-layout model__ (a.k.a. "flexbox"). It's quite powerful on its own and allows you to build robust,
-responsive layouts without writing much CSS. Here are some resources for learning flexbox:
+In lieu of a full grid system, you should try to use the __CSS3 Flexible Box layout model__ (a.k.a.
+"flexbox"). It's quite powerful on its own and allows you to build robust, responsive layouts
+without writing much CSS. Here are some resources for learning flexbox:
    - [MDN guide](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes)
    - [CSS Tricks guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 
 Styleguide variables.dimensions.grid
 */
 
-
 /*
 Layering
 
-Blueprint provides variables for three z-index layers. This should be enough for most use cases, especially if you
-make correct use of [stacking context][MDN]. [Overlay](#components.overlay) components such as dialogs and popovers use these
-z-index values to configure their stacking contexts.
+Blueprint provides variables for three z-index layers. This should be enough for most use cases,
+especially if you make correct use of [stacking context][MDN]. [Overlay](#components.overlay)
+components such as dialogs and popovers use these z-index values to configure their stacking
+contexts.
 
 - `$pt-z-index-base`
 - `$pt-z-index-content`

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -27,7 +27,8 @@ Styleguide components.usage
 /*
 NPM installation
 
-1. Install the core package with an NPM client like `npm` or `yarn`, pulling in all relevant dependencies:
+1. Install the core package with an NPM client like `npm` or `yarn`, pulling in all relevant
+dependencies:
 
   ```sh
   npm install --save @blueprintjs/core
@@ -58,8 +59,8 @@ NPM installation
   const myDatePicker = DatePickerFactory();
   ```
 
-1. Don't forget to include the main CSS file from each Blueprint package! Additionally, the `resources/`
-directory contains supporting media such as fonts and images.
+1. Don't forget to include the main CSS file from each Blueprint package! Additionally, the
+`resources/` directory contains supporting media such as fonts and images.
 
   ```html
   <!-- in plain old reliable HTML -->
@@ -90,9 +91,12 @@ Styleguide components.usage.npm
 /*
 DOM4
 
-Blueprint relies on a handful of DOM Level 4 API methods: `el.query`, `el.queryAll`, and `el.closest()`.
-`@blueprintjs/core` depends on a [polyfill library called `dom4`](https://webreflection.github.io/dom4/) to ensure
-these methods are available. This module is conditionally loaded if Blueprint is used in a browser environment.
+Blueprint relies on a handful of DOM Level 4 API methods: `el.query`, `el.queryAll`, and
+`el.closest()`. `@blueprintjs/core` depends on a [polyfill library called `dom4`][dom4] to ensure
+these methods are available. This module is conditionally loaded if Blueprint is used in a browser
+environment.
+
+[dom4]: https://webreflection.github.io/dom4/
 
 Styleguide components.usage.dom4
 */

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -6,7 +6,8 @@
 /*
 Components
 
-Blueprint's JavaScript components are stable and their APIs adhere to [semantic versioning](http://semver.org/).
+Blueprint's JavaScript components are stable and their APIs adhere to
+[semantic versioning](http://semver.org/).
 They are distributed in the __@blueprintjs/core__ package and can be consumed as CommonJS modules
 [via NPM](https://www.npmjs.com/package/@blueprintjs/core).
 
@@ -26,7 +27,8 @@ Styleguide components.usage
 /*
 NPM installation
 
-Install the core package with an NPM client like `npm` or `yarn`, pulling in all relevant dependencies:
+Install the core package with an NPM client like `npm` or `yarn`, pulling in all relevant
+dependencies:
 
 ```sh
 npm install --save @blueprintjs/core
@@ -59,9 +61,9 @@ Styleguide components.usage.npm
 /*
 TypeScript
 
-Blueprint is written in TypeScript and therefore its own `.d.ts` type definitions are distributed in the NPM package
-and should be resolved automatically by the compiler. However, you'll need to install typings for Blueprint's
-dependencies before you can consume it:
+Blueprint is written in TypeScript and therefore its own `.d.ts` type definitions are distributed in
+the NPM package and should be resolved automatically by the compiler. However, you'll need to
+install typings for Blueprint's dependencies before you can consume it:
 
 ```sh
 # required for all @blueprintjs packages:
@@ -75,7 +77,8 @@ npm install --save @types/es6-shim
 ```
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
-  For more information, see the TypeScript Handbook for [guidance on consuming declaration files][handbook].
+  For more information, see the TypeScript Handbook for
+  [guidance on consuming declaration files][handbook].
 </div>
 
 [handbook]: https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -8,14 +8,17 @@
 /*
 Alerts
 
-Alerts notify users of important information and force them to acknowledge the alert content before continuing.
+Alerts notify users of important information and force them to acknowledge the alert content before
+continuing.
 
-Although similar to [dialogs](#components.dialog), alerts are more restrictive and should
-only be used for important notifications. The user can only exit the alert by clicking one of the confirmation
-buttons — clicking the overlay or pressing the <kbd class="pt-key">esc</kbd> key will not close the alert.
+Although similar to [dialogs](#components.dialog), alerts are more restrictive and should only be
+used for important notifications. The user can only exit the alert by clicking one of the
+confirmation buttons — clicking the overlay or pressing the <kbd class="pt-key">esc</kbd> key will
+not close the alert.
 
-You can only use this component in controlled mode. Use the `onClick` handlers in the primary and secondary action props to handle
-closing the `Alert`. Optionally, display an icon next to the body to show the type of the alert.
+You can only use this component in controlled mode. Use the `onClick` handlers in the primary and
+secondary action props to handle closing the `Alert`. Optionally, display an icon next to the body
+to show the type of the alert.
 
 @react-example AlertExample
 

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -19,8 +19,8 @@ Styleguide components.breadcrumbs
 CSS API
 
 * Begin with a `ul.pt-breadcrumbs`; each crumb should be in its own `li` as a direct descendant.
-* Breadcrumbs are typically navigation links (for example, to the parent folder in a file path), and therefore
-  should use `<a>` tags (except for the final breadcrumb).
+* Breadcrumbs are typically navigation links (for example, to the parent folder in a file path), and
+  therefore should use `<a>` tags (except for the final breadcrumb).
 * Each navigation breadcrumb should use `.pt-breadcrumb`.
 * Make a breadcrumb non-interactive with the `.pt-disabled` class. You should only use this
   state when you want to indicate that the user cannot navigate to the breadcrumb (for example, if
@@ -29,8 +29,8 @@ CSS API
 * Mark the final breadcrumb `.pt-breadcrumb-current` for an emphasized appearance.
 * The `.pt-breadcrumbs-collapsed` button-like element can be used as the target for a dropdown menu
   containing breadcrumbs that are collapsed due to layout constraints.
-* When adding another element (such as a [tooltip](#components.tooltip) or [popover](#components.popover)) to a
-  breadcrumb, wrap it around the contents of the `li`.
+* When adding another element (such as a [tooltip](#components.tooltip) or
+  [popover](#components.popover)) to a breadcrumb, wrap it around the contents of the `li`.
 
 
 Markup:
@@ -53,8 +53,8 @@ Make sure to review the [general usage docs for JS components](#components.usage
 
 The component renders an `a.pt-breadcrumb`.
 You are responsible for constructing the `ul.pt-breadcrumbs` list.
-The [CollapsibleList component](#components.collapsiblelist) works nicely with this component because its props
-are a subset of `IMenuItemProps`.
+The [CollapsibleList component](#components.collapsiblelist) works nicely with this component
+because its props are a subset of `IMenuItemProps`.
 
 @interface IBreadcrumbProps
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -114,7 +114,8 @@ Styleguide components.button-group.css
 
       margin-right: $pt-grid-size + $minimal-button-divider-width;
       // always round the borders on minimal buttons
-      border-radius: $pt-border-radius !important; // stylelint-disable-line declaration-no-important
+      // stylelint-disable-next-line declaration-no-important
+      border-radius: $pt-border-radius !important;
       // so the ::after divider is visible outside bounds of button
       // however, this prevents ellipsizing of button text :(
       overflow: visible;

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -25,8 +25,8 @@ Use the `pt-button` class to access button styles. You should implement buttons 
   `<form>`) and `role="button"` on `<a>` tags for accessibility.
 - Add the attribute `tabindex="0"` to make `<a>` tags focusable. `<button>` elements are
   focusable by default.
-- For buttons implemented with `<a>` tags, add `tabindex="-1"` to disabled buttons to prevent the user
-  from focusing them by pressing <kbd class="pt-key">tab</kbd> on the keyboard.
+- For buttons implemented with `<a>` tags, add `tabindex="-1"` to disabled buttons to prevent the
+  user from focusing them by pressing <kbd class="pt-key">tab</kbd> on the keyboard.
 - Note that `<a>` tags do not respond to the `:disabled` attribute; use `.pt-disabled` instead.
 
 Markup:
@@ -271,18 +271,19 @@ Make sure to review the [general usage docs for JS components](#components.usage
 Button components render buttons with Blueprint classes and attributes.
 See the [Buttons CSS docs](#components.button.css) for styling options.
 
-You can provide your own props to these components as if they were regular JSX HTML elements.
-If you provide a `className` prop, the class names you provide will be added alongside of
-the default Blueprint class name. If you specify other attributes that the component provides, such as
-a `role` for an `<AnchorButton>`, you'll overide the default value.
+You can provide your own props to these components as if they were regular JSX HTML elements. If you
+provide a `className` prop, the class names you provide will be added alongside of the default
+Blueprint class name. If you specify other attributes that the component provides, such as a `role`
+for an `<AnchorButton>`, you'll overide the default value.
 
 <div class="pt-callout pt-intent-danger pt-icon-error">
   <h5>Interactions with disabled buttons</h5>
   Use `AnchorButton` if you need mouse interaction events (such as hovering) on a disabled button.
-  This is because `Button` and `AnchorButton` handle the `disabled` prop differently: `Button` uses the native
-  `disabled` attribute on the `<button>` tag so the browser disables all interactions, but `AnchorButton` uses
-  the class `.pt-disabled` because `<a>` tags do not support the `disabled` attribute. As a result, the `AnchorButton`
-  component will prevent *only* the `onClick` handler when disabled but permit other events.
+  This is because `Button` and `AnchorButton` handle the `disabled` prop differently: `Button` uses
+  the native `disabled` attribute on the `<button>` tag so the browser disables all interactions,
+  but `AnchorButton` uses the class `.pt-disabled` because `<a>` tags do not support the `disabled`
+  attribute. As a result, the `AnchorButton` component will prevent *only* the `onClick` handler
+  when disabled but permit other events.
 </div>
 
 @react-example ButtonsExample

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -240,9 +240,9 @@ a.pt-button {
   @extend %pt-button-link;
 }
 
-// we want to extend all instances of .pt-button:active
-// so that the .pt-active class has the same effect
 .pt-button.pt-active {
+  // we want to extend all instances of .pt-button:active so that the .pt-active class has the same effect
+  // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
   @extend .pt-button:active;
 
   &.pt-disabled,
@@ -255,8 +255,9 @@ a.pt-button {
   }
 }
 
-// make .pt-disabled class have same effect as :disabled state
 .pt-button.pt-disabled {
+  // make .pt-disabled class have same effect as :disabled state
+  // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
   @extend .pt-button:disabled;
 }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -241,7 +241,7 @@ a.pt-button {
 }
 
 .pt-button.pt-active {
-  // we want to extend all instances of .pt-button:active so that the .pt-active class has the same effect
+  // .pt-active should function identically to :active pseudo-class
   // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
   @extend .pt-button:active;
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -17,16 +17,21 @@ $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) / 2 
 $button-color-disabled: $pt-text-color-disabled !default;
 $dark-button-color-disabled: $pt-dark-text-color-disabled !default;
 
-$button-border-color: rgba($black, 0.1) rgba($black, 0.1) rgba($black, 0.17) rgba($black, 0.1) !default;
-$button-border-color-hover: rgba($black, 0.2) rgba($black, 0.2) rgba($black, 0.27) rgba($black, 0.2) !default;
-$button-border-color-active: rgba($black, 0.35) rgba($black, 0.25) rgba($black, 0.25) rgba($black, 0.25) !default;
+$button-border-color:
+  rgba($black, 0.1) rgba($black, 0.1) rgba($black, 0.17) rgba($black, 0.1) !default;
+$button-border-color-hover:
+  rgba($black, 0.2) rgba($black, 0.2) rgba($black, 0.27) rgba($black, 0.2) !default;
+$button-border-color-active:
+  rgba($black, 0.35) rgba($black, 0.25) rgba($black, 0.25) rgba($black, 0.25) !default;
 $button-box-shadow: 0 1px 1px rgba($black, 0.1) !default;
 $dark-button-border-color: rgba($black, 0.6) !default;
 $dark-button-border-color-hover: rgba($black, 0.8) !default;
 $dark-button-box-shadow: 0 1px 1px rgba($black, 0.2) !default;
 
-$button-intent-border-color: rgba($black, 0.1) rgba($black, 0.1) rgba($black, 0.3) rgba($black, 0.1) !default;
-$button-intent-border-color-active: rgba($black, 0.6) rgba($black, 0.2) rgba($black, 0.2) rgba($black, 0.2) !default;
+$button-intent-border-color:
+  rgba($black, 0.1) rgba($black, 0.1) rgba($black, 0.3) rgba($black, 0.1) !default;
+$button-intent-border-color-active:
+  rgba($black, 0.6) rgba($black, 0.2) rgba($black, 0.2) rgba($black, 0.2) !default;
 $button-intent-box-shadow: 0 1px 1px rgba($black, 0.2) !default;
 $dark-button-intent-border-color: rgba($black, 0.6) !default;
 $dark-button-intent-box-shadow: 0 1px 1px rgba($black, 0.2) !default;
@@ -59,7 +64,8 @@ $button-intents: (
 ) !default;
 
 // matches default buttons only -- used to remove border-right in button groups and control groups
-$non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*=\"pt-intent-\"]" !default;
+$non-default-state-selectors:
+  ":last-child, :hover, :active, .pt-active, [class*=\"pt-intent-\"]" !default;
 
 @mixin pt-button-base() {
   display: inline-block;
@@ -108,7 +114,11 @@ $non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*
 
 
 @mixin pt-button-hover() {
-  @include linear-gradient-with-fallback(rgba($white, 0.5), $white-transparent, $button-background-color-hover);
+  @include linear-gradient-with-fallback(
+    rgba($white, 0.5),
+    $white-transparent,
+    $button-background-color-hover
+  );
 
   border-color: $button-border-color-hover;
   box-shadow: $button-box-shadow;
@@ -157,7 +167,11 @@ $non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*
 }
 
 @mixin pt-dark-button() {
-  @include linear-gradient-with-fallback(rgba($white, 0.1), rgba($white, 0.06), $dark-button-background-color);
+  @include linear-gradient-with-fallback(
+    rgba($white, 0.1),
+    rgba($white, 0.06),
+    $dark-button-background-color
+  );
 
   border-color: $dark-button-border-color;
   box-shadow: $dark-button-box-shadow;
@@ -187,7 +201,11 @@ $non-default-state-selectors: ":last-child, :hover, :active, .pt-active, [class*
 }
 
 @mixin pt-dark-button-hover() {
-  @include linear-gradient-with-fallback(rgba($black, 0.1), rgba($black, 0.2), $dark-button-background-color-hover);
+  @include linear-gradient-with-fallback(
+    rgba($black, 0.1),
+    rgba($black, 0.2),
+    $dark-button-background-color-hover
+  );
 
   border-color: $dark-button-border-color-hover;
   box-shadow: $dark-button-box-shadow;

--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -16,13 +16,16 @@ Styleguide components.card
 /*
 CSS API
 
-Start with `.pt-card` and add an elevation modifier class to apply a drop shadow that simulates height in the UI.
+Start with `.pt-card` and add an elevation modifier class to apply a drop shadow that simulates
+height in the UI.
 
-You can also use the `.pt-elevation-*` classes by themselves to apply shadows to any arbitrary element.
+You can also use the `.pt-elevation-*` classes by themselves to apply shadows to any arbitrary
+element.
 
 Markup:
 <div class="pt-card {{.modifier}}">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec dapibus et mauris, vitae dictum metus.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec dapibus et mauris,
+  vitae dictum metus.
 </div>
 
 .pt-elevation-0 - Ground floor. This level provides just a gentle border shadow.
@@ -83,9 +86,9 @@ $dark-elevation-shadows: (
 /*
 Interactive cards
 
-Add the `.pt-interactive` modifier class to make a `.pt-card` respond to user interactions.
-When you hover over cards with this class applied, the mouse changes to a pointer and the elevation shadow
-on the card increases by two levels.
+Add the `.pt-interactive` modifier class to make a `.pt-card` respond to user interactions. When you
+hover over cards with this class applied, the mouse changes to a pointer and the elevation shadow on
+the card increases by two levels.
 
 Users expect an interactive card to be a single clickable unit.
 

--- a/packages/core/src/components/collapsible-list/_collapsible-list.scss
+++ b/packages/core/src/components/collapsible-list/_collapsible-list.scss
@@ -6,9 +6,10 @@
 /*
 Collapsible list
 
-The `CollapsibleList` React component accepts a list of menu items and a count of visible items. It shows precisely that
-many items and collapses the rest into a dropdown menu. The required `renderVisibleItem` callback prop allows for
-customizing the appearance of visible items, using the props from the `MenuItem` children.
+The `CollapsibleList` React component accepts a list of menu items and a count of visible items. It
+shows precisely that many items and collapses the rest into a dropdown menu. The required
+`renderVisibleItem` callback prop allows for customizing the appearance of visible items, using the
+props from the `MenuItem` children.
 
 @react-example CollapsibleListExample
 

--- a/packages/core/src/components/context-menu/_context-menu.scss
+++ b/packages/core/src/components/context-menu/_context-menu.scss
@@ -10,10 +10,10 @@ Context menus present the user with a custom list of actions upon right-click.
 
 You can create context menus in either of the following ways:
 
-- by adding the `@ContextMenuTarget` [decorator](#components.context-menu.decorator) to a React Component that implements
-`renderContextMenu(): JSX.Element`.
-- via the [imperative](#components.context-menu.js) `ContextMenu.show` and `ContextMenu.hide` API methods, ideal for
-non-React-based applications.
+- by adding the `@ContextMenuTarget` [decorator](#components.context-menu.decorator) to a React
+  Component that implements `renderContextMenu(): JSX.Element`.
+- via the [imperative](#components.context-menu.js) `ContextMenu.show` and `ContextMenu.hide` API
+  methods, ideal for non-React-based applications.
 
 @react-example ContextMenuExample
 
@@ -26,19 +26,20 @@ JavaScript API: decorator
 The `ContextMenuTarget` decorator is available in the __@blueprintjs/core__ package.
 Make sure to review the [general usage docs for JS components](#components.usage).
 
-The `@ContextMenuTarget` [class decorator][ts-decorator] can be applied to any `React.Component` class that meets the
-following requirements:
+The `@ContextMenuTarget` [class decorator][ts-decorator] can be applied to any `React.Component`
+class that meets the following requirements:
 
-- It defines an instance method called `renderContextMenu()` that returns a single `JSX.Element` (most likely a
-  [`Menu`](#components.menu)).
+- It defines an instance method called `renderContextMenu()` that returns a single `JSX.Element`
+  (most likely a [`Menu`](#components.menu)).
 - Its root element supports the `"contextmenu"` event and the `onContextMenu` prop.
 
-  This is always true if the decorated class uses an intrinsic element, such as `<div>`, as its root. If it uses a
-  custom element as its root, you must ensure that the prop is implemented correctly for that element.
+  This is always true if the decorated class uses an intrinsic element, such as `<div>`, as its
+  root. If it uses a custom element as its root, you must ensure that the prop is implemented
+  correctly for that element.
 
-When the user triggers the `"contextmenu"` event on the decorated class, `renderContextMenu()` is called. If
-`renderContextMenu()` returns an element, the browser's native [context menu][wiki-cm] is blocked and the returned
-element is displayed instead in a `Popover` at the cursor's location.
+When the user triggers the `"contextmenu"` event on the decorated class, `renderContextMenu()` is
+called. If `renderContextMenu()` returns an element, the browser's native [context menu][wiki-cm] is
+blocked and the returned element is displayed instead in a `Popover` at the cursor's location.
 
 ```
 import { ContextMenuTarget, Menu, MenuItem } from "@blueprintjs/core";
@@ -74,14 +75,15 @@ JavaScript API: imperative
 The `ContextMenu` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [general usage docs for JS components](#components.usage).
 
-The imperative API provides a single static `ContextMenu` object, enforcing the principle that only one context menu
-can be open at a time.
+The imperative API provides a single static `ContextMenu` object, enforcing the principle that only
+one context menu can be open at a time.
 
-- `ContextMenu.show(menu: JSX.Element, offset: IOffset, onClose?: () => void): void` &ndash; Show the given element at
-  the given offset from the top-left corner of the viewport. Showing a menu closes the previously shown one automatically.
+- `ContextMenu.show(menu: JSX.Element, offset: IOffset, onClose?: () => void): void` &ndash;
+  Show the given element at the given offset from the top-left corner of the viewport.
+  Showing a menu closes the previously shown one automatically.
 
-  The menu appears below-right of this point, but will flip to below-left instead if there is not enough room onscreen.
-  The optional callback is invoked when this menu closes.
+  The menu appears below-right of this point, but will flip to below-left instead if there is not
+  enough room onscreen. The optional callback is invoked when this menu closes.
 
 - `ContextMenu.hide(): void` &ndash; Hide the context menu, if it is open.
 - `ContextMenu.isOpen(): boolean` &ndash; Whether a context menu is currently visible.

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -16,8 +16,8 @@ Dialogs present content overlaid over other parts of the UI.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>Terminology note</h5>
-  The term "modal" is sometimes used to mean "dialog," but this is a misnomer. _Modal_ is an adjective
-  that describes parts of a UI.
+  The term "modal" is sometimes used to mean "dialog," but this is a misnomer.
+  _Modal_ is an adjective that describes parts of a UI.
   An element is considered modal if it
   [blocks interaction with the rest of the application](https://en.wikipedia.org/wiki/Modal_window).
   We use the term "dialog" to avoid confusion with the adjective.
@@ -35,7 +35,8 @@ Make sure to review the [general usage docs for JS components](#components.usage
 There are two ways to render dialogs:
 
 - in-place in the DOM tree. This is the default behavior.
-- injected into a newly created element attached to `document.body`. Set `inline={false}` to enable this.
+- injected into a newly created element attached to `document.body`.
+  Set `inline={false}` to enable this.
 
 `Dialog` is implemented as a stateless React component. The children you provide to this component
 are rendered as contents inside the `.pt-dialog` element.
@@ -64,7 +65,11 @@ class DialogExample extends React.Component<{}, IDialogExampleState> {
                     <div className="pt-dialog-footer">
                         <div className="pt-dialog-footer-actions">
                             <Button text="Secondary" />
-                            <Button intent={Intent.PRIMARY} onClick={this.toggleDialog} text="Primary" />
+                            <Button
+                                intent={Intent.PRIMARY}
+                                onClick={this.toggleDialog}
+                                text="Primary"
+                            />
                         </div>
                     </div>
                 </Dialog>

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -100,7 +100,8 @@ Styleguide components.editable.multiline
   }
 
   &:hover::before {
-    box-shadow: input-transition-shadow($input-focus-shadow-color), inset 0 0 0 1px $pt-divider-black;
+    box-shadow: input-transition-shadow($input-focus-shadow-color),
+                inset 0 0 0 1px $pt-divider-black;
   }
 
   &.pt-editable-editing::before {
@@ -131,11 +132,13 @@ Styleguide components.editable.multiline
 
   .pt-dark & {
     &:hover::before {
-      box-shadow: input-transition-shadow($dark-input-focus-shadow-color), inset 0 0 0 1px $pt-dark-divider-white;
+      box-shadow: input-transition-shadow($dark-input-focus-shadow-color),
+                  inset 0 0 0 1px $pt-dark-divider-white;
     }
 
     &.pt-editable-editing::before {
-      box-shadow: input-transition-shadow($dark-input-focus-shadow-color, true), $pt-dark-input-box-shadow;
+      box-shadow: input-transition-shadow($dark-input-focus-shadow-color, true),
+                  $pt-dark-input-box-shadow;
       background-color: $dark-input-background-color;
     }
 

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -35,19 +35,20 @@ Styleguide components.editable
 /*
 JavaScript API
 
-The `EditableText` component is available in the __@blueprintjs/core__ package.
-Make sure to review the [general usage docs for JS components](#components.usage).
+The `EditableText` component is available in the __@blueprintjs/core__ package. Make sure to review
+the [general usage docs for JS components](#components.usage).
 
-`EditableText` can be used like an [`input` element](https://facebook.github.io/react/docs/forms.html)
-and supports controlled or uncontrolled usage through the `value` or `defaultValue` props, respectively.
+`EditableText` can be used like an [`input`
+element](https://facebook.github.io/react/docs/forms.html) and supports controlled or uncontrolled
+usage through the `value` or `defaultValue` props, respectively.
 
-The `onConfirm` and `onCancel` callbacks are invoked based on user interaction.
-The user presses <kbd class="pt-key">enter</kbd> or blurs the input to confirm the current value,
-or presses <kbd class="pt-key">esc</kbd> to cancel.
-Canceling resets the field to the last confirmed value.
+The `onConfirm` and `onCancel` callbacks are invoked based on user interaction. The user presses
+<kbd class="pt-key">enter</kbd> or blurs the input to confirm the current value, or presses <kbd
+class="pt-key">esc</kbd> to cancel. Canceling resets the field to the last confirmed value.
 
-`EditableText` by default supports _exactly one line of text_ and will grow or shrink horizontally based
-on the length of text. See below for information on [multiline support](#components.editable.multiline).
+`EditableText` by default supports _exactly one line of text_ and will grow or shrink horizontally
+based on the length of text. See below for information on [multiline
+support](#components.editable.multiline).
 
 @interface IEditableTextProps
 
@@ -61,22 +62,25 @@ Multiline mode
 <EditableText multiline minLines={3} maxLines={12} {...props} />
 ```
 
-Provide the `multiline` prop to create an `EditableText` field that spans multiple lines. Multiline mode uses a
-`<textarea>` instead of an `<input type="text">` to support multiple lines of text.
+Provide the `multiline` prop to create an `EditableText` field that spans multiple lines. Multiline
+mode uses a `<textarea>` instead of an `<input type="text">` to support multiple lines of text.
 
-Users confirm text in multiline mode by pressing <kbd class="pt-key">ctrl</kbd> <kbd class="pt-key">enter</kbd> or
-<kbd class="pt-key">cmd</kbd> <kbd class="pt-key">enter</kbd> rather than simply <kbd class="pt-key">enter</kbd>.
-(Pressing the <kbd class="pt-key">enter</kbd> key by itself moves the cursor to the next line.)
+Users confirm text in multiline mode by pressing <kbd class="pt-key">ctrl</kbd> <kbd
+class="pt-key">enter</kbd> or
+<kbd class="pt-key">cmd</kbd> <kbd class="pt-key">enter</kbd> rather than simply <kbd
+class="pt-key">enter</kbd>. (Pressing the <kbd class="pt-key">enter</kbd> key by itself moves the
+cursor to the next line.)
 
-Additionally, in multiline mode the component's width is fixed at 100%. It grows or shrinks _vertically_ instead,
-based on the number of lines of text. You can use the `minLines` and `maxLines` props to constrain the vertical size
-of the component.
+Additionally, in multiline mode the component's width is fixed at 100%. It grows or shrinks
+_vertically_ instead, based on the number of lines of text. You can use the `minLines` and
+`maxLines` props to constrain the vertical size of the component.
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
   <h5>Multiline prop format</h5>
-  You should declare `multiline` as a valueless boolean prop, as in the example above (`<EditableText multiline ...>`).
-  This prevents you from changing the value after declaring it, which would provide a sub-optimal experience for users
-  (multiline text does not always render cleanly into a single line).
+  You should declare `multiline` as a valueless boolean prop, as in the example above
+  (`<EditableText multiline ...>`). This prevents you from changing the value after declaring it,
+  which would provide a sub-optimal experience for users (multiline text does not always render
+  cleanly into a single line).
 </div>
 
 Styleguide components.editable.multiline

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -112,7 +112,8 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
 }
 
 @mixin pt-dark-input() {
-  box-shadow: dark-input-transition-shadow($dark-input-focus-shadow-color), $pt-dark-input-box-shadow;
+  box-shadow: dark-input-transition-shadow($dark-input-focus-shadow-color),
+              $pt-dark-input-box-shadow;
   background: $dark-input-background-color;
   color: $pt-dark-text-color;
 
@@ -121,7 +122,8 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   }
 
   &:focus {
-    box-shadow: dark-input-transition-shadow($dark-input-focus-shadow-color, true), $pt-dark-input-box-shadow;
+    box-shadow: dark-input-transition-shadow($dark-input-focus-shadow-color, true),
+                $pt-dark-input-box-shadow;
   }
 
   &:disabled,
@@ -137,10 +139,13 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
 }
 
 @mixin pt-input-intent($color) {
-  box-shadow: input-transition-shadow($color), inset border-shadow(1, $color), $pt-input-box-shadow;
+  box-shadow: input-transition-shadow($color),
+              inset border-shadow(1, $color),
+              $pt-input-box-shadow;
 
   &:focus {
-    box-shadow: input-transition-shadow($color, true), $input-focus-box-shadow;
+    box-shadow: input-transition-shadow($color, true),
+                $input-focus-box-shadow;
   }
 
   &[readonly] {
@@ -149,10 +154,13 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
 }
 
 @mixin pt-dark-input-intent($color) {
-  box-shadow: dark-input-transition-shadow($color), inset border-shadow(1, $color), $pt-dark-input-box-shadow;
+  box-shadow: dark-input-transition-shadow($color),
+              inset border-shadow(1, $color),
+              $pt-dark-input-box-shadow;
 
   &:focus {
-    box-shadow: dark-input-transition-shadow($color, true), $pt-dark-input-box-shadow;
+    box-shadow: dark-input-transition-shadow($color, true),
+                $pt-dark-input-box-shadow;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -10,11 +10,11 @@
 Control groups
 
 A `.pt-control-group` renders several distinct controls as one unit, squaring the borders between
-them. It supports any number of `.pt-button`, `.pt-input`, `.pt-input-group`, and `.pt-select` elements
-as direct children.
+them. It supports any number of `.pt-button`, `.pt-input`, `.pt-input-group`, and `.pt-select`
+elements as direct children.
 
-Note that `.pt-control-group` does not cascade any modifiers to its children. For example, each child must
-be marked individually as `.pt-large` for uniform large appearance.
+Note that `.pt-control-group` does not cascade any modifiers to its children. For example, each
+child must be marked individually as `.pt-large` for uniform large appearance.
 
 <div class="pt-callout pt-intent-success pt-icon-comparison">
   <h5>Control group vs. input group</h5>

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -145,11 +145,13 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   /*
   Checkboxes
 
-  Blueprint's custom checkboxes use an extra `.pt-control-indicator` element after the `<input>` to achieve
-  their custom styling. You should then wrap the whole thing in a `<label>` with the classes `.pt-control.pt-checkbox`.
+  Blueprint's custom checkboxes use an extra `.pt-control-indicator` element after the `<input>` to
+  achieve their custom styling. You should then wrap the whole thing in a `<label>` with the classes
+  `.pt-control.pt-checkbox`.
 
-  Note that attribute modifiers (`:checked`, `:disabled`) are applied on the internal `<input>` element. Further note
-  that `:indeterminate` can only be set via JavaScript (the `Checkbox` React component supports it handily with a prop).
+  Note that attribute modifiers (`:checked`, `:disabled`) are applied on the internal `<input>`
+  element. Further note that `:indeterminate` can only be set via JavaScript (the `Checkbox` React
+  component supports it handily with a prop).
 
   Weight: 2
 
@@ -227,10 +229,12 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   /*
   Radios
 
-  Blueprint's custom radio buttons use an extra `.pt-control-indicator` element after the `<input>` to achieve
-  their custom styling. You should then wrap the whole thing in a `<label>` with the classes `.pt-control.pt-radio`.
+  Blueprint's custom radio buttons use an extra `.pt-control-indicator` element after the `<input>`
+  to achieve their custom styling. You should then wrap the whole thing in a `<label>` with the
+  classes `.pt-control.pt-radio`.
 
-  Note that attribute modifiers (`:checked`, `:disabled`) are applied on the internal `<input>` element.
+  Note that attribute modifiers (`:checked`, `:disabled`) are applied on the internal `<input>`
+  element.
 
   Weight: 2
 
@@ -258,12 +262,12 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   /*
   JavaScript API
 
-  The `Radio` and `RadioGroup` components are available in the __@blueprintjs/core__ package.
-  Make sure to review the [general usage docs for JS components](#components.usage).
+  The `Radio` and `RadioGroup` components are available in the __@blueprintjs/core__ package. Make
+  sure to review the [general usage docs for JS components](#components.usage).
 
-  Typically, radio buttons are used in a group to choose one option from several, similar to how a `<select>`
-  tag contains several `<option>` tags. As such, you can use the `RadioGroup` component with a series of
-  `Radio` children. `RadioGroup` is responsible for managing state and interaction.
+  Typically, radio buttons are used in a group to choose one option from several, similar to how a
+  `<select>` tag contains several `<option>` tags. As such, you can use the `RadioGroup` component
+  with a series of `Radio` children. `RadioGroup` is responsible for managing state and interaction.
 
   ```
   <RadioGroup
@@ -320,8 +324,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   /*
   Switches
 
-  A switch is simply an alternate appearance for a [checkbox](#components.forms.checkbox) that simulates on/off
-  instead of checked/unchecked.
+  A switch is simply an alternate appearance for a [checkbox](#components.forms.checkbox) that
+  simulates on/off instead of checked/unchecked.
 
   Weight: 2
 
@@ -666,9 +670,10 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   /*
   Inline controls
 
-  Checkboxes, radios, and switches all support the `.pt-inline` modifier to make them `display: inline-block`.
-  Note that this modifier functions slightly differently on these elements than it does on `.pt-label`.
-  On `.pt-label`, it only adjusts the layout of text _within_ the label and not the display of the label itself.
+  Checkboxes, radios, and switches all support the `.pt-inline` modifier to make them `display:
+  inline-block`. Note that this modifier functions slightly differently on these elements than it
+  does on `.pt-label`. On `.pt-label`, it only adjusts the layout of text _within_ the label and not
+  the display of the label itself.
 
   Here's an example of how you might group together some controls and label them.
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -72,7 +72,11 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   input:checked ~ .pt-control-indicator {
-    @include linear-gradient-with-fallback(rgba($white, 0.1), $white-transparent, $control-checked-background-color);
+    @include linear-gradient-with-fallback(
+      rgba($white, 0.1),
+      $white-transparent,
+      $control-checked-background-color
+    );
 
     border-color: $button-intent-border-color;
     box-shadow: $button-intent-box-shadow;
@@ -82,14 +86,22 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
   &:hover {
     .pt-control-indicator {
-      @include linear-gradient-with-fallback(rgba($white, 0.5), $white-transparent, $control-background-color-hover);
+      @include linear-gradient-with-fallback(
+        rgba($white, 0.5),
+        $white-transparent,
+        $control-background-color-hover
+      );
 
       border-color: $button-border-color-hover;
       background-clip: padding-box;
     }
 
     input:checked ~ .pt-control-indicator {
-      @include linear-gradient-with-fallback(rgba($white, 0.1), $white-transparent, $control-checked-background-color-hover);
+      @include linear-gradient-with-fallback(
+        rgba($white, 0.1),
+        $white-transparent,
+        $control-checked-background-color-hover
+      );
 
       border-color: $button-intent-border-color;
       box-shadow: $button-intent-box-shadow;
@@ -519,7 +531,11 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     color: $pt-dark-text-color;
 
     .pt-control-indicator {
-      @include linear-gradient-with-fallback(rgba($white, 0.1), rgba($white, 0.06), $dark-control-background-color);
+      @include linear-gradient-with-fallback(
+        rgba($white, 0.1),
+        rgba($white, 0.06),
+        $dark-control-background-color
+      );
 
       border-color: $dark-button-border-color;
       box-shadow: $dark-button-box-shadow;
@@ -533,7 +549,11 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
     &:hover {
       .pt-control-indicator {
-        @include linear-gradient-with-fallback(rgba($black, 0.1), rgba($black, 0.2), $dark-control-background-color-hover);
+        @include linear-gradient-with-fallback(
+          rgba($black, 0.1),
+          rgba($black, 0.2),
+          $dark-control-background-color-hover
+        );
 
         border-color: $dark-button-border-color-hover;
       }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -196,20 +196,19 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       font-size: $control-indicator-size;
     }
 
+    input:indeterminate,
+    &:hover input:indeterminate {
+      // :indeterminate should behave like :checked with different icon
+      // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
+      @extend input:checked;
+    }
+
     input:checked ~ .pt-control-indicator::before {
       content: $pt-icon-small-tick;
     }
 
-    input:indeterminate {
-      @extend input:checked;
-
-      ~ .pt-control-indicator::before {
-        content: $pt-icon-small-minus;
-      }
-    }
-
-    &:hover input:indeterminate {
-      @extend input:checked;
+    input:indeterminate ~ .pt-control-indicator::before {
+      content: $pt-icon-small-minus;
     }
   }
 

--- a/packages/core/src/components/forms/_index.scss
+++ b/packages/core/src/components/forms/_index.scss
@@ -19,13 +19,14 @@
 /*
 Form controls
 
-The following controls often appear inside HTML forms. Blueprint does not strictly require the
-use of any `<form>` elements, so you can use these controls anywhere in the UI.
+The following controls often appear inside HTML forms. Blueprint does not strictly require the use
+of any `<form>` elements, so you can use these controls anywhere in the UI.
 
-Many of the components in this section provide React components for simpler idiomatic usage. These React components try
-to transparently mirror the underlying HTML element, so they support the full range of appropriate HTML props. If you
-provide a `className` prop, the class names you provide will be added to the default Blueprint class name. If you
-specify other attributes that the component provides, you'll overide the default value.
+Many of the components in this section provide React components for simpler idiomatic usage. These
+React components try to transparently mirror the underlying HTML element, so they support the full
+range of appropriate HTML props. If you provide a `className` prop, the class names you provide will
+be added to the default Blueprint class name. If you specify other attributes that the component
+provides, you'll overide the default value.
 
 Styleguide components.forms
 */

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -9,8 +9,9 @@
 /*
 Text input groups
 
-An input group allows you to add icons and buttons _within_ a text input to expand its functionality.
-For example, you might use an input group to build a visibility toggle for a password field.
+An input group allows you to add icons and buttons _within_ a text input to expand its
+functionality. For example, you might use an input group to build a visibility toggle for a password
+field.
 
 Weight: 3
 
@@ -20,17 +21,19 @@ Styleguide components.forms.input-group
 /*
 CSS API
 
-You can place a single `.pt-icon` or `.pt-button.pt-icon-*` on either end of the input. The order
-is dictated by the HTML markup: an element specified before the `input` appears on the left edge, and vice versa.
-You do not need to apply sizing classes to the children&mdash;they inherit the size of the parent input.
+You can place a single `.pt-icon` or `.pt-button.pt-icon-*` on either end of the input. The order is
+dictated by the HTML markup: an element specified before the `input` appears on the left edge, and
+vice versa. You do not need to apply sizing classes to the children&mdash;they inherit the size of
+the parent input.
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
   <h5>Icons only</h5>
-  <p>You cannot use buttons with text in the CSS API for input groups. The padding for text inputs in CSS
-  cannot accomodate buttons whose width varies due to text content. You should use icons on buttons instead.</p>
+  <p>You cannot use buttons with text in the CSS API for input groups. The padding for text inputs
+  in CSS cannot accomodate buttons whose width varies due to text content. You should use icons on
+  buttons instead.</p>
 
-  Conversely, the [`InputGroup`](#components.forms.input-group.js) React component _does_ support arbitrary
-  content in its right element.
+  Conversely, the [`InputGroup`](#components.forms.input-group.js) React component _does_ support
+  arbitrary content in its right element.
 </div>
 
 Markup:
@@ -186,19 +189,18 @@ $input-button-height-large: $pt-button-height !default;
 /*
 JavaScript API
 
-The `InputGroup` component is available in the __@blueprintjs/core__ package.
-Make sure to review the [general usage docs for JS components](#components.usage).
+The `InputGroup` component is available in the __@blueprintjs/core__ package. Make sure to review
+the [general usage docs for JS components](#components.usage).
 
-The `InputGroup` React Component encapsulates the `.pt-input-group` [CSS API](#components.forms.input-group.css):
-it supports one non-interactive icon on the left side and one arbitrary element on the right
-side. Unlike the CSS API, the React Component supports _content of any length_ on the right side,
-not just icon buttons, because it is able to measure the content and ensure there is always space
-for it.
+The `InputGroup` React Component encapsulates the `.pt-input-group`
+[CSS API](#components.forms.input-group.css): it supports one non-interactive icon on the left side
+and one arbitrary element on the right side. Unlike the CSS API, the React Component supports
+_content of any length_ on the right side, not just icon buttons, because it is able to measure the
+content and ensure there is always space for it.
 
-`InputGroup` can be used just like a standard React `input` element, in controlled or
-uncontrolled fashion. In addition to its own content props, it supports all valid props for HTML
-`input` elements and proxies them to that element in the DOM; the most common ones are detailed
-below.
+`InputGroup` can be used just like a standard React `input` element, in controlled or uncontrolled
+fashion. In addition to its own content props, it supports all valid props for HTML `input` elements
+and proxies them to that element in the DOM; the most common ones are detailed below.
 
 @interface IInputGroupProps
 

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -8,9 +8,9 @@
 /*
 Text inputs
 
-Use the `pt-input` class on an `input[type="text"]`. You should also specify
-`dir="auto"` [to better support RTL languages](http://www.w3.org/International/questions/qa-html-dir#dirauto)
-(in all browsers except Internet Explorer).
+Use the `pt-input` class on an `input[type="text"]`. You should also specify `dir="auto"` [to better
+support RTL languages](http://www.w3.org/International/questions/qa-html-dir#dirauto) (in all
+browsers except Internet Explorer).
 
 Markup:
 <input class="pt-input {{.modifier}}" {{:modifier}} type="text" placeholder="Text input" dir="auto" />
@@ -63,12 +63,12 @@ Styleguide components.forms.input
 /*
 Search field
 
-Changing the `<input>` element's `type` attribute to `"search"` styles it to look like a search field,
-giving it a rounded appearance. This style is equivalent to the `.pt-round` modifier, but it is applied
-automatically for `[type="search"]` inputs.
+Changing the `<input>` element's `type` attribute to `"search"` styles it to look like a search
+field, giving it a rounded appearance. This style is equivalent to the `.pt-round` modifier, but it
+is applied automatically for `[type="search"]` inputs.
 
-Note that some browsers also implement a handler for the <kbd class="pt-key">esc</kbd> key to clear the
-text in a search field.
+Note that some browsers also implement a handler for the <kbd class="pt-key">esc</kbd> key to clear
+the text in a search field.
 
 Markup:
 <div class="pt-input-group {{.modifier}}">

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -10,8 +10,9 @@ Labels
 
 Add labels to inputs to enhance the usability of your forms.
 
-Putting the `<input>` element _inside_ a `<label>` element also increases the area where the user can click
-to activate the control. Notice how in the example below, clicking a `<label>` below focuses its `<input>`.
+Putting the `<input>` element _inside_ a `<label>` element also increases the area where the user
+can click to activate the control. Notice how in the example below, clicking a `<label>` below
+focuses its `<input>`.
 
 Markup:
 <label class="pt-label {{.modifier}}">
@@ -36,10 +37,12 @@ Styleguide components.forms.label
 /*
 Disabled labels
 
-Add the `.pt-label` and `.pt-disabled` class modifiers to a `<label>` to make the label appear disabled.
+Add the `.pt-label` and `.pt-disabled` class modifiers to a `<label>` to make the label appear
+disabled.
 
-This styles the label text, but does not disable any nested children like inputs or selects. You must add
-the `:disabled` attribute directly to any nested elements to disable them. See the examples below.
+This styles the label text, but does not disable any nested children like inputs or selects. You
+must add the `:disabled` attribute directly to any nested elements to disable them. See the examples
+below.
 
 Markup:
 <label class="pt-label pt-disabled">

--- a/packages/core/src/components/forms/_select.scss
+++ b/packages/core/src/components/forms/_select.scss
@@ -13,7 +13,8 @@ Styling `<select>` tags requires a wrapper element to customize the dropdown car
 modifiers on the wrapper and attribute modifiers directly on the `<select>`.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
-  Check out [Dropdown Menus](#components.menu.js.dropdown) for a simple JavaScript alternative to the `<select>` tag.
+  Check out [Dropdown Menus](#components.menu.js.dropdown) for a simple JavaScript alternative
+  to the `<select>` tag.
 </div>
 
 Markup:

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -27,7 +27,8 @@ Additionally, any keyboard input that occurs inside a text input (such as a
 
 If you define hotkeys for your page, you'll want to display the hotkeys in a
 nice format for the user. If you register any global or local hotkeys, we
-automatically attach a hotkey for <kbd class="pt-key">?</kbd>, which will display the hotkeys dialog.
+automatically attach a hotkey for <kbd class="pt-key">?</kbd>, which will
+display the hotkeys dialog.
 
 The dialog will always include all available global hotkeys, and if you are
 focused on an element that has any hotkeys, those will be shown as well.

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -21,8 +21,8 @@ Styleguide components.menu
 /*
 JavaScript API
 
-The `Menu`, `MenuItem`, and `MenuDivider` components are available in the __@blueprintjs/core__ package.
-Make sure to review the [general usage docs for JS components](#components.usage).
+The `Menu`, `MenuItem`, and `MenuDivider` components are available in the __@blueprintjs/core__
+package. Make sure to review the [general usage docs for JS components](#components.usage).
 
 The Menu API includes three stateless React components:
 
@@ -111,8 +111,8 @@ Styleguide components.menu.js.menu-divider
 /*
 Dropdown menus
 
-The `Menu` component by itself simply renders a menu list. To make a dropdown menu, use a `Menu` element
-as the `content` property of a `Popover`:
+The `Menu` component by itself simply renders a menu list. To make a dropdown menu, use a `Menu`
+element as the `content` property of a `Popover`:
 
 ```
 <Popover content={<Menu>...</Menu>} position={Position.RIGHT_TOP}>
@@ -121,13 +121,13 @@ as the `content` property of a `Popover`:
 ```
 
 When the user clicks a menu item that is not disabled and is not part of a submenu, the popover is
-automatically dismissed (in other words, the menu closes).
-This is because the `MenuItem` component adds the `pt-popover-dismiss` class to these items by default
-(see [Popover JavaScript API](#components.popover.js) for more information).
-If you want to opt out of this behavior, you can add the `shouldDismissPopover` prop to a `MenuItem`.
+automatically dismissed (in other words, the menu closes). This is because the `MenuItem` component
+adds the `pt-popover-dismiss` class to these items by default (see [Popover JavaScript
+API](#components.popover.js) for more information). If you want to opt out of this behavior, you can
+add the `shouldDismissPopover` prop to a `MenuItem`.
 
-Notice that selecting the menu item labeled **Table** in the example below does not automatically dismiss the `Popover`.
-Selecting other menu items does dismiss the popover.
+Notice that selecting the menu item labeled **Table** in the example below does not automatically
+dismiss the `Popover`. Selecting other menu items does dismiss the popover.
 
 @react-example DropdownMenuExample
 
@@ -140,15 +140,16 @@ Styleguide components.menu.js.dropdown
 CSS API
 
 Menus can be constructed manually using the HTML markup and `pt-menu-*` classes below. However, you
-should use the menu [React components](#components.menu.js) instead wherever possible, as they abstract
-away the tedious parts of implementing a menu.
+should use the menu [React components](#components.menu.js) instead wherever possible, as they
+abstract away the tedious parts of implementing a menu.
 
 - Begin with a `ul.pt-menu`. Each `li` child denotes a single entry in the menu.
 
-- Put a `.pt-menu-item` element inside an `li` to create a clickable entry. Use either `<button>`
-or `<a>` tags for menu items to denote interactivity.
+- Put a `.pt-menu-item` element inside an `li` to create a clickable entry. Use either `<button>` or
+`<a>` tags for menu items to denote interactivity.
 
-- Add icons to menu items the same way you would to buttons: simply add the appropriate `pt-icon-<name>` class*.
+- Add icons to menu items the same way you would to buttons: simply add the appropriate
+`pt-icon-<name>` class*.
 
 - Make menu items non-interactive with the class `pt-disabled`.
 
@@ -161,15 +162,15 @@ element (`pt-icon-standard` size is recommended).
 
 - Add a divider between items with `li.pt-menu-divider`.
 
-- If you want the popover to close when the user clicks a menu item, add the class `pt-popover-dismiss`
-to any relevant menu items.
+- If you want the popover to close when the user clicks a menu item, add the class
+`pt-popover-dismiss` to any relevant menu items.
 
 <small>\* You do not need to add a `pt-icon-<sizing>` class to menu items&mdash;icon sizing is
 defined as part of `.pt-menu-item`.</small>
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   Note that the following examples are `display: inline-block`; you may need to adjust
-menu width in your own usage.
+  menu width in your own usage.
 </div>
 
 Markup:

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -67,8 +67,9 @@ Styleguide components.menu.js.submenu
     }
   }
 
-  // keep a trail of hovered items as submenus are opened
   > .pt-popover-open > .pt-menu-item {
+    // keep a trail of hovered items as submenus are opened
+    // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
     @extend .pt-menu-item:hover;
   }
 

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -38,8 +38,8 @@ React.createElement(MenuItem, {
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
   <h5>JavaScript only</h5>
-  Submenus are only supported in the React components. They cannot be created with CSS alone because they
-  rely on the [`Popover`](#components.popover) component for positioning and transitions.
+  Submenus are only supported in the React components. They cannot be created with CSS alone because
+  they rely on the [`Popover`](#components.popover) component for positioning and transitions.
 </div>
 
 Weight: 2

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -11,8 +11,8 @@ Navbars
 
 Navbars present useful navigation controls at the top of an application.
 
-The `Navbar` component can have up to two groups of elements: a left-aligned group and a right-aligned group.
-These groups can contain multiple elements, which are laid out horizontally.
+The `Navbar` component can have up to two groups of elements: a left-aligned group and a
+right-aligned group. These groups can contain multiple elements, which are laid out horizontally.
 
 Styleguide components.navbar
 */
@@ -122,8 +122,9 @@ This modifier is not illustrated here because it breaks the documentation flow.
 
 <div class="pt-callout pt-intent-danger pt-icon-error">
   <h5>Body padding required</h5>
-  The fixed navbar will lie on top of your other content unless you add padding to the top of the `<body>` element equal
-  to the height of the navbar. Use the `$pt-navbar-height` Sass variable to access the height of the navbar (50px).
+  The fixed navbar will lie on top of your other content unless you add padding to the top of the
+  `<body>` element equal to the height of the navbar. Use the `$pt-navbar-height` Sass variable to
+  access the height of the navbar (50px).
 </div>
 
 Styleguide components.navbar.css.fixed-top
@@ -132,10 +133,11 @@ Styleguide components.navbar.css.fixed-top
 /*
 Fixed width
 
-If your application is inside a fixed-width container (instead of spanning the entire viewport), you can
-align the navbar to match.
+If your application is inside a fixed-width container (instead of spanning the entire viewport), you
+can align the navbar to match.
 
-Wrap your `.pt-navbar-group`s in an element with your desired `width` and `margin: 0 auto;` to horizontally center it.
+Wrap your `.pt-navbar-group`s in an element with your desired `width` and `margin: 0 auto;` to
+horizontally center it.
 
 Markup:
 <nav class="pt-navbar pt-dark">

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -11,12 +11,14 @@
 Non-ideal state
 
 [Non-ideal UI states](https://github.com/palantir/blueprint/wiki/Non-ideal-UI-states)
-inform the user that some content is unavailable. There are several types of non-ideal states, including:
+inform the user that some content is unavailable. There are several types of non-ideal states,
+including:
 
 * blank states (when a container has just been created and has no data in it yet,
   or when a container's contents have been intentionally removed)
 * loading states (when a container is preparing to populate with data).
-  A good practice is to show a spinner for this state, with optional explanatory text below the spinner.
+  A good practice is to show a spinner for this state, with optional explanatory text
+  below the spinner.
 * error states (when something went wrong&mdash;for instance, 404 and 500 HTTP errors).
   In this case, a good practice is to add a call to action directing the user what to do next.
 
@@ -26,7 +28,8 @@ Styleguide components.nonidealstate
 /*
 CSS API
 
-You may use the provided styles without using the [React component](#components.nonidealstate.js). See the example below.
+You may use the provided styles without using the [React component](#components.nonidealstate.js).
+See the example below.
 
 Markup:
 <div class="pt-non-ideal-state">

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -8,19 +8,20 @@
 /*
 Overlays
 
-`Overlay` is a generic low-level component for rendering content _above_ its siblings, or above the entire
-application.
+`Overlay` is a generic low-level component for rendering content _above_ its siblings, or above the
+entire application.
 
-It combines a [`Portal`](#components.portal.js), which allows the JSX children to be rendered at a different
-place in the DOM tree, with a [`CSSTransitionGroup`](https://facebook.github.io/react/docs/animation.html) to support
-elegant enter and leave transitions.
+It combines a [`Portal`](#components.portal.js), which allows the JSX children to be rendered at a
+different place in the DOM tree, with a
+[`CSSTransitionGroup`](https://facebook.github.io/react/docs/animation.html) to support elegant
+enter and leave transitions.
 
 An optional "backdrop" element can be rendered behind the overlaid children to provide modal
 behavior, whereby the overlay prevents interaction with anything behind it.
 
-`Overlay` is the backbone of the [`Dialog`](#components.dialog) component.
-In most use cases, the `Dialog` component should be sufficient; only use `Overlay` directly if an
-existing component _truly does not_ meet your needs.
+`Overlay` is the backbone of the [`Dialog`](#components.dialog) component. In most use cases, the
+`Dialog` component should be sufficient; only use `Overlay` directly if an existing component _truly
+does not_ meet your needs.
 
 @react-example OverlayExample
 
@@ -64,9 +65,9 @@ Styleguide components.overlay.js
 Scrollable overlays
 
 Overlays rely heavily on fixed and absolute positioning. By default, a large overlay will not cause
-the page to scroll, and any overflowing content will be hidden. Fortunately, Blueprint makes scrolling
-support very easy: simply pass `"pt-overlay-scroll-container"` as the Overlay `className`, and
-we'll take care of the rest.
+the page to scroll, and any overflowing content will be hidden. Fortunately, Blueprint makes
+scrolling support very easy: simply pass `"pt-overlay-scroll-container"` as the Overlay `className`,
+and we'll take care of the rest.
 
 ```
 <Overlay className="pt-overlay-scroll-container" ... />

--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -87,7 +87,12 @@ body.pt-overlay-open {
 // fixed position so the backdrop forecefully covers the whole screen
 .pt-overlay-backdrop {
   @include position(fixed, 0);
-  @include react-transition("pt-overlay", (opacity: 0 1), $pt-transition-duration * 2, $before: "&");
+  @include react-transition(
+    "pt-overlay",
+    (opacity: 0 1),
+    $pt-transition-duration * 2,
+    $before: "&"
+  );
 
   z-index: $pt-z-index-overlay;
   background-color: $overlay-background-color;

--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -106,6 +106,8 @@ $dark-popover-background-color: $dark-gray4 !default;
 
   // offset arrow away from corner spots so it appears centered in target
   @each $side in (top, right, left, bottom) {
+    // giant selector is 1 character too long :(
+    // stylelint-disable-next-line max-line-length
     .pt-tether-element-attached-#{$side}.pt-tether-target-attached-#{$side} > & > .pt-popover-arrow {
       #{$side}: $computed-arrow-offset;
     }

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -28,14 +28,14 @@ When creating a popover, you must specify both:
 The target acts as the trigger for the popover. The popover's position on the page is based on the
 location of the target.
 
-Internally, the child of a `Popover` component is wrapped in a `<span>` and rendered inline in the HTML
-in the component's place.
+Internally, the child of a `Popover` component is wrapped in a `<span>` and rendered inline in the
+HTML in the component's place.
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
   <h5>Button targets</h5>
-  Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all events,
-  which interferes with the popover functioning. If you need to disable a button that triggers a
-  popover, you should use [`AnchorButton`](#components.button.js.anchor-button) instead.
+  Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
+  events, which interferes with the popover functioning. If you need to disable a button that
+  triggers a popover, you should use [`AnchorButton`](#components.button.js.anchor-button) instead.
   See the [callout here](#components.button.js) for more details.
 </div>
 
@@ -79,8 +79,9 @@ Styleguide components.popover.js
 /*
 Controlled mode
 
-If you prefer to have more control over your popover's behavior, you can specify the `isOpen` property
-to use the component in __controlled mode__. You are now in charge of the component's state.
+If you prefer to have more control over your popover's behavior, you can specify the `isOpen`
+property to use the component in __controlled mode__. You are now in charge of the component's
+state.
 
 Providing a non-null value for `isOpen` disables all automatic interaction and instead invokes
 the `onInteraction` callback prop any time the opened state _would have changed_ in response to
@@ -139,20 +140,20 @@ Inline popovers
 
 By default, popover contents are rendered in a newly created element appended to `document.body`.
 
-This works well for most layouts, because you want popovers to appear above everything else in
-your application without having to manually adjust z-indices. For these "detached" popovers, we use the
-[Tether](http://github.hubspot.com/tether/) library to handle positioning popovers correctly relative to
-their targets. Tether is great at maintaining position in complex, dynamic UIs.
+This works well for most layouts, because you want popovers to appear above everything else in your
+application without having to manually adjust z-indices. For these "detached" popovers, we use the
+[Tether](http://github.hubspot.com/tether/) library to handle positioning popovers correctly
+relative to their targets. Tether is great at maintaining position in complex, dynamic UIs.
 
 However, there are cases where it's preferable to render the popover contents inline.
 
-Take, for example, a scrolling table where certain cells have tooltips attached to them. As row items go out
-of view, you want their tooltips to slide out of the viewport as well. This is best accomplished
-with inline popovers. Enable this feature by setting `inline={true}`.
+Take, for example, a scrolling table where certain cells have tooltips attached to them. As row
+items go out of view, you want their tooltips to slide out of the viewport as well. This is best
+accomplished with inline popovers. Enable this feature by setting `inline={true}`.
 
-It is also important to note that "inline" popovers are much more performant than "detached"
-ones, particularly in response to page scrolling, because their position does not need to be
-recomputed on every interaction.
+It is also important to note that "inline" popovers are much more performant than "detached" ones,
+particularly in response to page scrolling, because their position does not need to be recomputed on
+every interaction.
 
 Weight: -9
 
@@ -168,9 +169,9 @@ Opening & closing popovers
   You can use this to style the target differently depending on whether the popover is open.
 </div>
 
-The different interaction kinds specify whether the popover closes when the user interacts
-with the target or the rest of the document, but by default, a user interacting with a popover's
-*contents* does __not__ close the popover.
+The different interaction kinds specify whether the popover closes when the user interacts with the
+target or the rest of the document, but by default, a user interacting with a popover's *contents*
+does __not__ close the popover.
 
 To enable click-to-close behavior on an element inside a popover, simply add the class
 `pt-popover-dismiss` to that element. The "Dismiss" button in the demo [above](#components.popover)
@@ -178,8 +179,8 @@ has this class. To enable this behavior on the entire popover, pass the
 `popoverClassName="pt-popover-dismiss"` prop.
 
 Note that dismiss elements won't have any effect in a popover with
-`PopoverInteractionKind.HOVER_TARGET_ONLY` because there is no way to interact with
-the popover content itself (the popover is dismissed the moment the user mouses away from the target).
+`PopoverInteractionKind.HOVER_TARGET_ONLY` because there is no way to interact with the popover
+content itself (the popover is dismissed the moment the user mouses away from the target).
 
 Styleguide components.popover.js.closing
 */
@@ -211,8 +212,8 @@ The backdrop element has the same opacity fade transition as the `Dialog` backdr
 <div class="pt-callout pt-intent-danger pt-icon-error">
   <h5>Dangerous edge case</h5>
   Rendering a `<Popover isOpen={true} isModal={true}>` outside the viewport bounds can easily break
-  your application by covering the UI with an invisible non-interactive backdrop. This edge case must
-  be handled by your application code or simply avoided if possible.
+  your application by covering the UI with an invisible non-interactive backdrop. This edge case
+  must be handled by your application code or simply avoided if possible.
 </div>
 
 Styleguide components.popover.js.modal
@@ -238,8 +239,8 @@ Styleguide components.popover.js.sizing
 /*
 SVG popover
 
-`SVGPopover` is a convenience component provided for SVG contexts. It is a simple wrapper around `Popover`
-that sets `rootElementTag="g"`.
+`SVGPopover` is a convenience component provided for SVG contexts. It is a simple wrapper around
+`Popover` that sets `rootElementTag="g"`.
 
 Styleguide components.popover.js.svg
 */
@@ -250,12 +251,13 @@ Minimal popovers
 You can create a minimal popover with the `pt-minimal` modifier: `popoverClassName="pt-minimal"`.
 This removes the arrow from the popover and makes the transitions more subtle.
 
-This minimal style is recommended for popovers that are not triggered by an obvious
-action like the user clicking or hovering over something. For example, a minimal popover is useful
-for making typeahead menus where the menu appears almost instantly after the user starts typing.
+This minimal style is recommended for popovers that are not triggered by an obvious action like the
+user clicking or hovering over something. For example, a minimal popover is useful for making
+typeahead menus where the menu appears almost instantly after the user starts typing.
 
-Minimal popovers are also useful for context menus that require quick enter and leave animations to support
-fast workflows. You can see an example in the [Context Menus](#components.context-menu) documentation.
+Minimal popovers are also useful for context menus that require quick enter and leave animations to
+support fast workflows. You can see an example in the [Context Menus](#components.context-menu)
+documentation.
 
 Styleguide components.popover.js.minimal
 */
@@ -322,15 +324,16 @@ $popover-width: $pt-grid-size * 35 !default;
   /*
   Dark theme
 
-  The `Popover` component automatically detects whether its trigger is nested inside a `.pt-dark` container
-  and applies the same class to itself. You can also explicitly apply the dark theme to the React
-  component by providing the prop `popoverClassName="pt-dark"`.
+  The `Popover` component automatically detects whether its trigger is nested inside a `.pt-dark`
+  container and applies the same class to itself. You can also explicitly apply the dark theme to
+  the React component by providing the prop `popoverClassName="pt-dark"`.
 
   As a result, any component that you place inside a `Popover` (such as a `Menu`) automatically
   inherits the dark theme styles. Note that `Tooltip` uses `Popover` internally, so it also benefits
   from this behavior.
 
-  This behavior can be disabled when the `Popover` is not rendered inline via the `inheritDarkTheme` prop.
+  This behavior can be disabled when the `Popover` is not rendered inline via the `inheritDarkTheme`
+  prop.
 
   Weight: 10
 

--- a/packages/core/src/components/portal/_portal.scss
+++ b/packages/core/src/components/portal/_portal.scss
@@ -6,10 +6,10 @@
 /*
 Portals
 
-The `Portal` component renders its children into a new "subtree" outside of the current component hierarchy.
-It is essential piece of [`Overlay`](#components.overlay), responsible for ensuring that the overlay contents
-cover the application below. In most cases you do not need to use a `Portal` directly; this documentation
-is provided simply for reference.
+The `Portal` component renders its children into a new "subtree" outside of the current component
+hierarchy. It is essential piece of [`Overlay`](#components.overlay), responsible for ensuring that
+the overlay contents cover the application below. In most cases you do not need to use a `Portal`
+directly; this documentation is provided simply for reference.
 
 Styleguide components.portal
 */
@@ -17,19 +17,20 @@ Styleguide components.portal
 /*
 JavaScript API
 
-The `Portal` component is available in the __@blueprintjs/core__ package.
-Make sure to review the [general usage docs for JS components](#components.usage).
+The `Portal` component is available in the __@blueprintjs/core__ package. Make sure to review the
+[general usage docs for JS components](#components.usage).
 
 The `Portal` component functions like a declarative `appendChild()`, or jQuery's `$.fn.appendTo()`.
 The children of a `Portal` component are appended to the `<body>` element.
 
-`Portal` is used inside [`Overlay`](#components.overlay) to actually overlay the content on the application.
+`Portal` is used inside [`Overlay`](#components.overlay) to actually overlay the content on the
+application.
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
   <h5>A note about responsive layouts</h5>
-  For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal` may take up extra
-  whitespace and cause the window to undesirably scroll. To fix this, instead apply `position: absolute` to
-  the `<body>` tag.
+  For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal`
+  may take up extra whitespace and cause the window to undesirably scroll. To fix this, instead
+  apply `position: absolute` to the `<body>` tag.
 </div>
 
 @interface IPortalProps

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -123,7 +123,9 @@ $dark-progress-meter-color: $gray1 !default;
   }
 
   &:not(.pt-no-animation):not(.pt-no-stripes) .pt-progress-meter {
-    @include animation(linear-progress-bar-stripes ($pt-transition-duration * 3) linear infinite reverse);
+    @include animation(
+      linear-progress-bar-stripes ($pt-transition-duration * 3) linear infinite reverse
+    );
   }
 
   &.pt-no-stripes .pt-progress-meter {

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -17,7 +17,8 @@ Styleguide components.progress
 /*
 Progress bars
 
-Progress bars can indicate determinate progress towards the completion of a task or an indeterminate loading state.
+Progress bars can indicate determinate progress towards the completion of a task or an indeterminate
+loading state.
 
 Styleguide components.progress.bar
 */
@@ -25,9 +26,9 @@ Styleguide components.progress.bar
 /*
 CSS API
 
-Set the current progress of the bar via a `width` style rule on the inner `.pt-progress-meter` element.
-This is a very simple CSS-only component, and input validation for `width` values is limited:
-values above `100%` appear as 100% progress and values below `0%` appear as 0%.
+Set the current progress of the bar via a `width` style rule on the inner `.pt-progress-meter`
+element. This is a very simple CSS-only component, and input validation for `width` values is
+limited: values above `100%` appear as 100% progress and values below `0%` appear as 0%.
 
 Omitting `width` will result in an "indeterminate" progress meter that fills the entire bar.
 

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -115,13 +115,12 @@ Styleguide components.slider.range
 /*
 JavaScript API
 
-The `RangeSlider` component is available in the __@blueprintjs/core__ package.
-Make sure to review the [general usage docs for JS components](#components.usage).
+The `RangeSlider` component is available in the __@blueprintjs/core__ package. Make sure to review
+the [general usage docs for JS components](#components.usage).
 
 `RangeSlider` is a controlled component, so the `value` prop determines its current appearance.
-Provide an `onChange` handler to receive updates and an `onRelease` handler to determine when the user has
-stopped interacting with the slider.
-
+Provide an `onChange` handler to receive updates and an `onRelease` handler to determine when the
+user has stopped interacting with the slider.
 
 @interface IRangeSliderProps
 

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -18,7 +18,8 @@ Styleguide components.progress.spinner
 CSS API
 
 You can create spinners manually by inserting their whole markup into your HTML.
-Spinners created via markup use same modifier classes as the [React `Spinner` component](#components.progress.spinner.js).
+Spinners created via markup use same modifier classes as the
+[React `Spinner` component](#components.progress.spinner.js).
 
 Markup:
 <div class="pt-spinner {{.modifier}}">
@@ -43,19 +44,19 @@ The `Spinner` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [general usage docs for JS components](#components.usage).
 
 A `Spinner` is a simple stateless component that renders HTML/SVG markup.
-It supports a `value` prop between 0 and 1 that determines how much of the track is filled by the head.
-When this prop is defined, the spinner head will not spin but it will smoothly animate as `value` updates.
-Omitting `value` will result in an "indeterminate" spinner where the head spins indefinitely
-(this is the default appearance).
+It supports a `value` prop between 0 and 1 that determines how much of the track is filled by the
+head. When this prop is defined, the spinner head will not spin but it will smoothly animate as
+`value` updates. Omitting `value` will result in an "indeterminate" spinner where the head spins
+indefinitely (this is the default appearance).
 
 Note that the CSS modifiers described in the [CSS API](#components.progress.spinner.css)
 are supported via the `className` prop.
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
   <h5>IE11 compatibility note</h5>
-  IE11 [does not support CSS transitions on SVG elements][msdn-css-svg] so spinners with known `value` will not smoothly
-  transition as `value` changes. Indeterminate spinners still animate correctly because they rely on CSS animations, not
-  transitions.
+  IE11 [does not support CSS transitions on SVG elements][msdn-css-svg] so spinners with known
+  `value` will not smoothly transition as `value` changes. Indeterminate spinners still animate
+  correctly because they rely on CSS animations, not transitions.
 </div>
 
 @interface ISpinnerProps
@@ -74,8 +75,8 @@ Use the `SVGSpinner` component to render a spinner inside an SVG element.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>Sizing note</h5>
-  Because of the way SVG elements are sized, you may need to manually scale the spinner inside your SVG
-  to make it an appropriate size.
+  Because of the way SVG elements are sized, you may need to manually scale the spinner inside your
+  SVG to make it an appropriate size.
 </div>
 
 Styleguide components.progress.spinner.js.svg

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -144,11 +144,19 @@ $resources-path: "./resources" !default;
   }
 
   &.pt-small {
-    @include spinner-size($spinner-width-factor-small, $spinner-stroke-width-small, $spinner-speed-small);
+    @include spinner-size(
+      $spinner-width-factor-small,
+      $spinner-stroke-width-small,
+      $spinner-speed-small
+    );
   }
 
   &.pt-large {
-    @include spinner-size($spinner-width-factor-large, $spinner-stroke-width-large, $spinner-speed-large);
+    @include spinner-size(
+      $spinner-width-factor-large,
+      $spinner-stroke-width-large,
+      $spinner-speed-large
+    );
   }
 }
 

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -17,9 +17,9 @@ Styleguide components.tabs
 /*
 CSS API
 
-In addition to the [JavaScript API](#components.tabs.js), Blueprint also offers tab styles with the class
-`pt-tabs`. You should add the proper accessibility attributes (`role`, `aria-selected`, and `aria-hidden`)
-if you choose to implement tabs with CSS.
+In addition to the [JavaScript API](#components.tabs.js), Blueprint also offers tab styles with the
+class `pt-tabs`. You should add the proper accessibility attributes (`role`, `aria-selected`, and
+`aria-hidden`) if you choose to implement tabs with CSS.
 
 `.pt-tab-panel` elements with `aria-hidden="true"` are hidden automatically by the Blueprint CSS.
 You may also simply omit hidden tabs from your markup to improve performance (the `Tabs`
@@ -45,14 +45,14 @@ Styleguide components.tabs.css
 /*
 JavaScript API
 
-The `Tabs`, `TabList`, `Tab`, and `TabPanel` components are available in the __@blueprintjs/core__ package.
-Make sure to review the [general usage docs for JS components](#components.usage).
+The `Tabs`, `TabList`, `Tab`, and `TabPanel` components are available in the __@blueprintjs/core__
+package. Make sure to review the [general usage docs for JS components](#components.usage).
 
 Four components are necessary to render tabs: `Tabs`, `TabList`, `Tab`, and `TabPanel`.
 
-For performance reasons, only the currently active `TabPanel` is rendered into the DOM. When the user
-switches tabs, data stored in the DOM is lost. This is not an issue in React applications because
-of how the library manages the virtual DOM for you.
+For performance reasons, only the currently active `TabPanel` is rendered into the DOM. When the
+user switches tabs, data stored in the DOM is lost. This is not an issue in React applications
+because of how the library manages the virtual DOM for you.
 
 ### Sample Usage
 
@@ -79,11 +79,11 @@ of how the library manages the virtual DOM for you.
 </Tabs>
 ```
 
-Every component accepts a `className` prop that can be used to set additional classes on the component's root
-element. You can get larger tabs by using the `pt-large` class on `TabList`.
+Every component accepts a `className` prop that can be used to set additional classes on the
+component's root element. You can get larger tabs by using the `pt-large` class on `TabList`.
 
-You can use the `Tabs` API in controlled or uncontrolled mode. The props you supply will differ between
-these approaches.
+You can use the `Tabs` API in controlled or uncontrolled mode. The props you supply will differ
+between these approaches.
 
 @react-example TabsExample
 
@@ -110,8 +110,8 @@ Styleguide components.tabs.js.tab
 Usage with React Router
 
 Often, you'll want to link tab navigation to overall app navigation, including updating the URL.
-[react-router](https://github.com/reactjs/react-router) is the standard routing solution for React applications.
-Here's how you might configure tabs to work with it:
+[react-router](https://github.com/reactjs/react-router) is the standard routing solution for React
+applications. Here's how you might configure tabs to work with it:
 
 ```
 import { render } from "react-dom";

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -61,16 +61,16 @@ OurToaster.update(key, { message: "Still toasted!" });
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>Working with multiple toasters</h5>
-  You can have multiple toasters in a single application, but you must ensure that each has a unique `position`
-  to prevent overlap.
+  You can have multiple toasters in a single application, but you must ensure that each has a unique
+  `position` to prevent overlap.
 </div>
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>Toaster focus</h5>
-  `Toaster` always disables `Overlay`'s `enforceFocus` behavior (meaning that you're not blocked from
-  accessing other parts of the application while a toast is active), and by default also disables `autoFocus`
-  (meaning that focus will not switch to a toast when it appears). You can enable `autoFocus` for a `Toaster`
-  via a prop, if desired.
+  `Toaster` always disables `Overlay`'s `enforceFocus` behavior (meaning that you're not blocked
+  from accessing other parts of the application while a toast is active), and by default also
+  disables `autoFocus` (meaning that focus will not switch to a toast when it appears). You can
+  enable `autoFocus` for a `Toaster` via a prop, if desired.
 </div>
 
 Styleguide components.toaster.js
@@ -83,13 +83,13 @@ Static method
 Toaster.create(props?: IToasterProps, container = document.body): IToaster
 ```
 
-Create a new `Toaster` instance. The `Toaster` will be rendered into a new element appended to the given `container`.
-The `container` determines which element toasts are positioned relative to; the default value of `<body>` allows them
-to use the entire viewport.
+Create a new `Toaster` instance. The `Toaster` will be rendered into a new element appended to the
+given `container`. The `container` determines which element toasts are positioned relative to; the
+default value of `<body>` allows them to use the entire viewport.
 
-Note that the return type is `IToaster`, which is a minimal interface that exposes only the instance methods detailed
-below. It can be thought of as `Toaster` minus the `React.Component` methods, because the `Toaster` should not be
-treated as a normal React component.
+Note that the return type is `IToaster`, which is a minimal interface that exposes only the instance
+methods detailed below. It can be thought of as `Toaster` minus the `React.Component` methods,
+because the `Toaster` should not be treated as a normal React component.
 
 @interface IToasterProps
 
@@ -102,10 +102,10 @@ Instance methods
 <div class="docs-interface-name">IToaster</div>
 
 - `show(props: IToastProps): string` &ndash; Show a new toast to the user.
-   Returns the unique key of the new toast.
+  Returns the unique key of the new toast.
 - `update(key: string, props: IToastProps): void` &ndash;
-Updates the toast with the given key to use the new props.
-   Updating a key that does not exist is effectively a no-op.
+  Updates the toast with the given key to use the new props.
+  Updating a key that does not exist is effectively a no-op.
 - `dismiss(key: string): void` &ndash; Dismiss the given toast instantly.
 - `clear(): void` &ndash; Dismiss all toasts instantly.
 - `getToasts(): IToastProps[]` &ndash; Returns the options for all current toasts.
@@ -118,10 +118,10 @@ Styleguide components.toaster.js.instance
 /*
 React component
 
-The `Toaster` React component is a stateful container for a single list of toasts. Internally, it uses
-[`Overlay`](#components.overlay) to manage children and transitions. It can be vertically aligned along the top or bottom
-edge of its container (new toasts will slide in from that edge) and horizontally aligned along the left edge, center,
-or right edge of its container.
+The `Toaster` React component is a stateful container for a single list of toasts. Internally, it
+uses [`Overlay`](#components.overlay) to manage children and transitions. It can be vertically
+aligned along the top or bottom edge of its container (new toasts will slide in from that edge) and
+horizontally aligned along the left edge, center, or right edge of its container.
 
 You should use [`Toaster.create`](#components.toaster.js.create), rather than using the `Toaster`
 component API directly in React, to avoid having to use `ref` to access the instance.

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -50,8 +50,9 @@ Styleguide components.tooltip.js
 /*
 Controlled mode
 
-The `Tooltip` component supports controlled mode in exactly the same way the `Popover` component does. Please refer to the
-[controlled mode documentation](#components.popover.js.controlled) for `Popover` for details.
+The `Tooltip` component supports controlled mode in exactly the same way the `Popover` component
+does. Please refer to the [controlled mode documentation](#components.popover.js.controlled) for
+`Popover` for details.
 
 Styleguide components.tooltip.js.controlled
 */
@@ -59,11 +60,11 @@ Styleguide components.tooltip.js.controlled
 /*
 Inline tooltips
 
-Inline tooltips (with `inline={true}`) do not have a set width, and therefore will not break long content into multiple lines.
-This is enforced with `white-space: nowrap`.
+Inline tooltips (with `inline={true}`) do not have a set width, and therefore will not break long
+content into multiple lines. This is enforced with `white-space: nowrap`.
 
-If you want to create an inline tooltip with content spanning multiple lines, you must override the default styles and
-set an appropriate size for `.pt-tooltip`.
+If you want to create an inline tooltip with content spanning multiple lines, you must override the
+default styles and set an appropriate size for `.pt-tooltip`.
 
 Styleguide components.tooltip.js.inline
 */
@@ -71,11 +72,11 @@ Styleguide components.tooltip.js.inline
 /*
 Combining with popover
 
-You can give a single target both a popover and a tooltip. You must put the `Tooltip` inside the `Popover` (and the
-target inside the `Tooltip`).
+You can give a single target both a popover and a tooltip. You must put the `Tooltip` inside the
+`Popover` (and the target inside the `Tooltip`).
 
-This order is required because when the popover is open, the tooltip is disabled, to prevent both elements from
-appearing at the same time.
+This order is required because when the popover is open, the tooltip is disabled, to prevent both
+elements from appearing at the same time.
 
 ```
 <Popover content={<h1>Popover!</h1>} position={Position.RIGHT}>
@@ -91,8 +92,8 @@ Styleguide components.tooltip.js.popover
 /*
 SVG tooltip
 
-`SVGTooltip` is a convenience component provided for SVG contexts. It is a simple wrapper around `Tooltip`
-that sets `rootElementTag="g"`.
+`SVGTooltip` is a convenience component provided for SVG contexts. It is a simple wrapper around
+`Tooltip` that sets `rootElementTag="g"`.
 
 Styleguide components.tooltip.js.svg
 */
@@ -127,10 +128,11 @@ Styleguide components.tooltip.js.svg
   /*
   Dark theme
 
-  If the trigger for a tooltip is nested inside a `.pt-dark` container, the tooltip will automatically have the
-  dark theme applied as well.
+  If the trigger for a tooltip is nested inside a `.pt-dark` container, the tooltip will
+  automatically have the dark theme applied as well.
 
-  You can also explicitly apply the dark theme to a tooltip by adding the prop `tooltipClassName="pt-dark"`.
+  You can also explicitly apply the dark theme to a tooltip by adding the prop
+  `tooltipClassName="pt-dark"`.
 
   Weight: 10
 

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -21,13 +21,13 @@ JavaScript API
 The `Tree` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [general usage docs for JS components](#components.usage).
 
-`Tree` is a stateless component. Its contents are dictated by the `contents` prop, which is an array of
-`ITreeNode`s (see [below](#components.tree.js.treenode)). The tree is multi-rooted if `contents`
+`Tree` is a stateless component. Its contents are dictated by the `contents` prop, which is an array
+of `ITreeNode`s (see [below](#components.tree.js.treenode)). The tree is multi-rooted if `contents`
 contains more than one top-level object.
 
-A variety of interaction callbacks are also exposed as props. All interaction callbacks supply a parameter
-`nodePath`, which is an array of numbers representing a node's position in the tree.
-For example, `[2, 0]` represents the first child (`0`) of the third top-level node (`2`).
+A variety of interaction callbacks are also exposed as props. All interaction callbacks supply a
+parameter `nodePath`, which is an array of numbers representing a node's position in the tree. For
+example, `[2, 0]` represents the first child (`0`) of the third top-level node (`2`).
 
 @interface ITreeProps
 
@@ -41,8 +41,8 @@ Tree node interface
 
 `ITreeNode` objects determine the contents, appearance, and state of each node in the tree.
 
-For example, `iconName` controls the icon displayed for the node, and `isExpanded` determines whether
-the node's children are shown.
+For example, `iconName` controls the icon displayed for the node, and `isExpanded` determines
+whether the node's children are shown.
 
 @interface ITreeNodeProps
 

--- a/packages/datetime/src/_dateinput.scss
+++ b/packages/datetime/src/_dateinput.scss
@@ -6,8 +6,8 @@
 /*
 Date input
 
-The `DateInput` component is an [input group](#components.forms.input-group) with a calendar button that shows a
-[`DatePicker`](#components.datetime.datepicker) in a [`Popover`](#components.popover).
+The `DateInput` component is an [input group](#components.forms.input-group) with a calendar button
+that shows a [`DatePicker`](#components.datetime.datepicker) in a [`Popover`](#components.popover).
 
 Use the `onChange` function to listen for changes to the selected date. Use `onError` to listen for
 invalid entered dates.

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -19,8 +19,8 @@ Use the `onChange` prop to listen for changes to the selected day.
 You can control the selected day by setting the `value` prop, or use the component in uncontrolled
 mode and specify an initial day by setting `defaultValue`.
 
-`DatePicker` uses [Moment.js](http://momentjs.com/) to handle localization. You can use `locale` and the `localeUtils`
-functions to specify a locale. See
+`DatePicker` uses [Moment.js](http://momentjs.com/) to handle localization. You can use `locale` and
+the `localeUtils` functions to specify a locale. See
 [this file](https://github.com/gpbl/react-day-picker/blob/master/src/addons/MomentLocaleUtils.js)
 for an example of defining `localeUtils` functions using Moment.js.
 
@@ -51,8 +51,8 @@ Styleguide components.datetime.datepicker.js
 /*
 Using modifiers
 
-You can use the `modifiers` prop to conditionally apply styles to days. Modifiers are documented in full
-in the [**react-day-picker** documentation](http://react-day-picker.js.org/Modifiers.html).
+You can use the `modifiers` prop to conditionally apply styles to days. Modifiers are documented in
+full in the [**react-day-picker** documentation](http://react-day-picker.js.org/Modifiers.html).
 
 The example below creates a `DatePicker` that prevents the user from selecting any Sundays,
 by using the component in controlled mode and with the `modifiers` prop:

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -8,11 +8,12 @@
 /*
 Date range picker
 
-A `DateRangePicker` shows two sequential month calendars and lets the user select a single range of days.
+A `DateRangePicker` shows two sequential month calendars and lets the user select a single range of
+days.
 
-Use the `onChange` prop to listen for changes to the set date range.
-You can control the selected date range by setting the `value` prop, or use the component in uncontrolled
-mode and specify an initial date range by setting `defaultValue`.
+Use the `onChange` prop to listen for changes to the set date range. You can control the selected
+date range by setting the `value` prop, or use the component in uncontrolled mode and specify an
+initial date range by setting `defaultValue`.
 
 `DateRangePicker` uses the `DateRange` type across its API.
 This is an alias for the tuple type `[Date, Date]`.

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -67,6 +67,9 @@ Styleguide components.datetime.daterangepicker.js
     background-color: $light-gray4;
   }
 
+  // very long selectors ahead!
+  // stylelint-disable max-line-length
+
   .DayPicker-Day--selected-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -76,6 +79,8 @@ Styleguide components.datetime.daterangepicker.js
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
+
+  // stylelint-enable max-line-length
 
   .pt-dark & {
     .DayPicker-Day--selected-range:not(.DayPicker-Day--outside) {

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -10,15 +10,14 @@ Time picker
 
 A `TimePicker` allows the user to specify a time.
 
-
 `TimePicker`s behave similarly to standard [React form inputs](https://facebook.github.io/react/docs/forms.html).
 
-Use the `onChange` prop to listen for changes to the set time.
-You can control the selected time by setting the `value` prop, or use the component in uncontrolled
-mode and specify an initial time by setting `defaultValue`.
+Use the `onChange` prop to listen for changes to the set time. You can control the selected time by
+setting the `value` prop, or use the component in uncontrolled mode and specify an initial time by
+setting `defaultValue`.
 
-`TimePicker` has no direct localization support. You should handle localization directly in your application
-if needed.
+`TimePicker` has no direct localization support. You should handle localization directly in your
+application if needed.
 
 `TimePicker` uses `Date` objects across its API but ignores their year, month, and day fields.
 

--- a/packages/datetime/src/blueprint-datetime.scss
+++ b/packages/datetime/src/blueprint-datetime.scss
@@ -17,14 +17,20 @@ Date & time
 This package provides several components for interacting with dates and times:
 
 - [`DatePicker`](#components.datetime.datepicker) for selecting a single date (day, month, year).
-- [`DateRangePicker`](#components.datetime.daterangepicker) for selecting date ranges.
-- [`TimePicker`](#components.datetime.timepicker) for selecting a time (hour, minute, second, millisecond) selection.
-- [`DateTimePicker`](#components.datetime.datetimepicker), which composes `DatePicker` and `TimePicker` to
-select a date and time together.
-- [`DateInput`](#components.datetime.dateinput), which composes a text input with a `DatePicker` in a
-`Popover`, for use in forms.
 
-They are available in the __@blueprintjs/datetime__ package on [NPM](https://www.npmjs.com/package/@blueprintjs/datetime).
+- [`DateRangePicker`](#components.datetime.daterangepicker) for selecting date ranges.
+
+- [`TimePicker`](#components.datetime.timepicker) for selecting a time (hour, minute, second,
+  millisecond).
+
+- [`DateTimePicker`](#components.datetime.datetimepicker), which composes `DatePicker` and
+  `TimePicker` to select a date and time together.
+
+- [`DateInput`](#components.datetime.dateinput), which composes a text input with a `DatePicker` in
+  a `Popover`, for use in forms.
+
+They are available in the __@blueprintjs/datetime__ package on
+[NPM](https://www.npmjs.com/package/@blueprintjs/datetime).
 
 Make sure to review the [general usage docs for JS components](#components.usage).
 

--- a/packages/datetime/src/blueprint-datetime.scss
+++ b/packages/datetime/src/blueprint-datetime.scss
@@ -1,22 +1,17 @@
 /*
  * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
-// Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
-// of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
-// and https://github.com/palantir/blueprint/blob/master/PATENTS
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
-
-// huge urls ahead
-// stylelint-disable max-line-length
 
 /*
 Date & time
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
   <h5>Separate package required</h5>
-  <p>
-  The date and time components do not ship with the `@blueprintjs/core`
-  package, and must be installed separately as `@blueprintjs/datetime`.
-  </p>
+  The date and time components do not ship with the `@blueprintjs/core` package,
+  and must be installed separately as `@blueprintjs/datetime`.
 </div>
 
 This package provides several components for interacting with dates and times:
@@ -39,8 +34,6 @@ npm install --save @blueprintjs/datetime
 
 Styleguide components.datetime
 */
-
-// stylelint-enable max-line-length
 
 @import "datepicker";
 @import "daterangepicker";

--- a/packages/docs/src/styles/_navbar.scss
+++ b/packages/docs/src/styles/_navbar.scss
@@ -70,6 +70,8 @@ All the components that live *inside* the navbar.
   }
 
   .pt-popover-open & {
+    // make button look hovered when popover is open
+    // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
     @extend :hover;
   }
 }
@@ -83,7 +85,8 @@ All the components that live *inside* the navbar.
 .pt-button.docs-dark-switch {
   &::before {
     // override all icon colors
-    color: inherit !important; // stylelint-disable-line declaration-no-important
+    // stylelint-disable-next-line declaration-no-important
+    color: inherit !important;
   }
 
   &.pt-icon-moon {


### PR DESCRIPTION
#### Fixes #411

#### Changes proposed in this pull request:

- enable `scss/at-extend-no-missing-placeholder` globally and disable it in code as necessary
- `max-line-length` of 100 but ignore comments because all the worst offenders are in doc comments (huge URLs or HTML tags)

❓ **Should I rewrap the docs to 100 characters?** Docs comments are no longer linted for length, but they are more legible when kept a little shorter.
