### PR TITLE
Clear previous delayed timeouts when opening or closing collapse

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -101,6 +101,7 @@ export class Collapse extends AbstractComponent<ICollapseProps, ICollapseState> 
             this.height = this.contents.clientHeight;
         }
         if (this.props.isOpen !== nextProps.isOpen) {
+            this.clearTimeouts();
             if (this.state.animationState !== AnimationStates.CLOSED && !nextProps.isOpen) {
                 this.setState({
                     animationState: AnimationStates.CLOSING_START,


### PR DESCRIPTION
#### Fixes #217 

#### Changes proposed in this pull request:

Clear previous timeouts when `isOpen` prop changes

#### Reviewers should focus on:

Previous timeouts are not still triggered when `isOpen` is changed faster than the transition duration.