### PR TITLE
fix watching files in src/ itself

### DIFF
--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -7,7 +7,8 @@ module.exports = (gulp, plugins, blueprint) => {
     const path = require("path");
 
     function createSrcGlob(project, filename) {
-        return `${project.cwd}/src/!(generated)/**/${filename}`;
+        // `src/` directory and non-`generated/` subdirs
+        return `${project.cwd}/src/{,!(generated)/**/}${filename}`;
     }
 
     gulp.task("connect", () => {


### PR DESCRIPTION
#### Fixes watching of `src/*.*`

#### Changes proposed in this pull request:

- the glob did not include files in `src/` itself; there had to be at least one subdirectory not named "generated"
- the new glob pattern also includes files with no subdirectory at all
- this fixes watching for a whole bunch of files, affecting all the packages 😱 
