### PR TITLE
fix Toast stacking

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -40,6 +40,8 @@ export const RANGESLIDER_NULL_VALUE = `${ns} <RangeSlider> value prop must be an
 export const TABS_FIRST_CHILD = `${ns} First child of <Tabs> component should be a <TabList>`;
 export const TABS_MISMATCH = `${ns} Number of <Tab> components should equal number of <TabPanel> components`;
 
+export const TOASTER_INLINE_WARNING = `${ns} Toaster.create() ignores inline prop as it always creates a new element`;
+
 export const WARNING_DIALOG_NO_HEADER_ICON = `${ns} Warning: Dialog iconName prop is ignored if title prop is omitted`;
 export const WARNING_DIALOG_NO_HEADER_CLOSE_BUTTON =
     `${ns} Warning: Dialog isCloseButtonShown prop is ignored if title prop is omitted`;

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -202,7 +202,9 @@ $toast-margin: $pt-grid-size * 1.5 !default;
   display: flex;
   align-items: flex-start;
 
-  position: relative;
+  // toasts rely on relative positioning for stacking; override inline overlay styles (#367)
+  // stylelint-disable-next-line declaration-no-important
+  position: relative !important;
   margin: $toast-margin 0 0;
   border-radius: $pt-border-radius;
   box-shadow: $pt-elevation-shadow-3;

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -12,6 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
+import { TOASTER_INLINE_WARNING } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
@@ -59,6 +60,9 @@ export interface IToasterProps extends IProps {
     /**
      * Whether the toaster should be rendered inline or into a new element on `document.body`.
      * If `true`, then positioning will be relative to the parent element.
+     *
+     * This prop is ignored by `Toaster.create()` as that method always appends a new element
+     * to the container.
      * @default false
      */
     inline?: boolean;
@@ -89,6 +93,9 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
      * The `Toaster` will be rendered into a new element appended to the given container.
      */
     public static create(props?: IToasterProps, container = document.body): IToaster {
+        if (props != null && props.inline != null) {
+            console.warn(TOASTER_INLINE_WARNING);
+        }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
         return ReactDOM.render(<Toaster {...props} inline /> , containerElement) as Toaster;

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -15,7 +15,7 @@ import * as Classes from "../../common/classes";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
+import { safeInvoke, shallowClone } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { IToastProps, Toast } from "./toast";
 
@@ -102,8 +102,7 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
     private toastId = 0;
 
     public show(props: IToastProps) {
-        const options = props as IToastOptions;
-        options.key = `toast-${this.toastId++}`;
+        const options = this.createToastOptions(props);
         this.setState((prevState) => ({
             toasts: [options, ...prevState.toasts],
         }));
@@ -111,8 +110,7 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
     }
 
     public update(key: string, props: IToastProps) {
-        const options = props as IToastOptions;
-        options.key = key;
+        const options = this.createToastOptions(props, key);
         this.setState((prevState) => ({
             toasts: prevState.toasts.map((t) => t.key === key ? options : t),
         }));
@@ -169,6 +167,13 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
 
     private renderToast(toast: IToastOptions) {
         return <Toast {...toast} onDismiss={this.getDismissHandler(toast)} />;
+    }
+
+    private createToastOptions(props: IToastProps, key = `toast-${this.toastId++}`) {
+        // clone the object before adding the key prop to avoid leaking the mutation
+        const options = shallowClone<IToastOptions>(props);
+        options.key = key;
+        return options;
     }
 
     private getPositionClasses() {

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -118,7 +118,7 @@ describe("Toaster", () => {
         toaster.show(toast);
         assert.isFalse(
             errorSpy.calledWithMatch("two children with the same key"),
-            "mutation side effect!"
+            "mutation side effect!",
         );
     });
 });

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -107,4 +107,18 @@ describe("Toaster", () => {
         toaster.clear();
         assert.isTrue(onDismiss.calledOnce, "onDismiss not called");
     });
+
+    it("reusing props object does not produce React errors", () => {
+        const errorSpy = sinon.spy(console, "error");
+        // if Toaster doesn't clone the props object before injecting key then there will be a
+        // React error that both toasts have the same key, because both instances refer to the
+        // same object.
+        const toast = { message: "repeat" };
+        toaster.show(toast);
+        toaster.show(toast);
+        assert.isFalse(
+            errorSpy.calledWithMatch("two children with the same key"),
+            "mutation side effect!"
+        );
+    });
 });


### PR DESCRIPTION
#### Fixes #367

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- clone Toast props before mutating. this avoids leaking the mutation and allows more than one of each Toast to appear in the example.
- ensure Toasts are always `position: relative` so they also stack when `inline`.
- warn when passing inline prop to Toaster.create()

#### Reviewers should focus on:

- are you into this new warning or is it overkill? i updated the props docs with the same content.
