### PR TITLE
remove skeleton line-height

### DIFF
--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -32,9 +32,8 @@ Markup:
 <div class="pt-card">
   <h5><a class="{{.modifier}}" href="#" tabindex="-1">My Card Title</a></h5>
   <p class="{{.modifier}}">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eget tortor felis. Fusce dapibus metus in dapibus mollis.
-    Quisque eget ex diam. Vivamus mattis nisi ut nisl rhoncus convallis. Curabitur id tristique mi, quis elementum dolor. In
-    suscipit ut sapien ac tempor. Aenean quis fringilla felis.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eget tortor felis.
+    Fusce dapibus metus in dapibus mollis. Quisque eget ex diam.
   </p>
   <button type="button" class="pt-button {{.modifier}}" tabindex="-1">Submit</button>
 </div>

--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -75,7 +75,6 @@ $skeleton-color-end: rgba($gray1, 0.2) !default;
   background-clip: padding-box !important;
 
   cursor: default;
-  line-height: 1;
 
   // Transparent text will occupy space but be invisible to the user
   color: transparent !important;

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -70,7 +70,8 @@
 
 #{section-name("Labels")},
 #{section-id("components.tag.css")},
-#{section-id("components.menu.css")} {
+#{section-id("components.menu.css")},
+#{section-id("components.progress.skeleton.css")} {
   @include examples-per-row(2);
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- make skeleton cards fit on the same line
- this revealed a bug where the two cards were not the same height, so...
- remove .pt-skeleton line-height to preserve original dimensions
