### PR TITLE
DatePickerCaption shows out-of-bounds year

### DIFF
--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -57,6 +57,12 @@ export class DatePickerCaption extends React.Component<IDatePickerCaptionProps, 
         const yearOptionElements = years.map((year, i) => {
             return <option key={i} value={year.toString()}>{year}</option>;
         });
+        // allow out-of-bounds years but disable the option. this handles the Dec 2016 case in #391.
+        if (displayYear > maxYear) {
+            yearOptionElements.push(
+                <option key="next" disabled value={displayYear.toString()}>{displayYear}</option>,
+            );
+        }
 
         this.displayedMonthText = months[displayMonth];
         this.displayedYearText = displayYear.toString();

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -9,10 +9,10 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { DatePickerCaption } from "../src/datePickerCaption";
+import { DatePickerCaption, IDatePickerCaptionProps } from "../src/datePickerCaption";
 import { Classes, IDatePickerLocaleUtils } from "../src/index";
 
-describe("<DatePickerCaption>", () => {
+describe.only("<DatePickerCaption>", () => {
     const LOCALE_UTILS: IDatePickerLocaleUtils = {
         getMonths: () => ["January", "February", "March", "April", "May", "June", "July",
                           "August", "September", "October", "November", "December"],
@@ -46,6 +46,16 @@ describe("<DatePickerCaption>", () => {
         const { month, year } = renderDatePickerCaption({ maxDate, minDate });
         assert.deepEqual(month.find("option").map((mo) => mo.text()), ["January"]);
         assert.deepEqual(year.find("option").map((yr) => yr.text()), ["2014", "2015"]);
+    });
+
+    it("out-of-bounds year adds disabled year option", () => {
+        const date = new Date(2017, 0, 6);
+        const minDate = new Date(2015, 0, 1);
+        const maxDate = new Date(2016, 11, 31);
+        const { year } = renderDatePickerCaption({ date, maxDate, minDate });
+        const options = year.find("option");
+        assert.deepEqual(options.map((yr) => yr.text()), ["2015", "2016", "2017"]);
+        assert.isTrue(options.last().prop("disabled"), "2017 is not disabled");
     });
 
     function renderDatePickerCaption(props?: any) {

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -9,10 +9,10 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { DatePickerCaption, IDatePickerCaptionProps } from "../src/datePickerCaption";
+import { DatePickerCaption } from "../src/datePickerCaption";
 import { Classes, IDatePickerLocaleUtils } from "../src/index";
 
-describe.only("<DatePickerCaption>", () => {
+describe("<DatePickerCaption>", () => {
     const LOCALE_UTILS: IDatePickerLocaleUtils = {
         getMonths: () => ["January", "February", "March", "April", "May", "June", "July",
                           "August", "September", "October", "November", "December"],


### PR DESCRIPTION
#### Fixes #391 

#### Changes proposed in this pull request:

- DatePickerCaption allows out-of-bounds year but disables the option, so it's for display only. 
- this handles the last-month-of-max-year case.
