### PR TITLE
fix Dialog header height w/o icon or close button

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -139,8 +139,8 @@ $dialog-padding: $pt-grid-size * 2 !default;
   border-radius: $dialog-border-radius $dialog-border-radius 0 0;
   box-shadow: 0 1px 0 $pt-divider-black;
   background: $white;
-  padding-left: $dialog-padding;
   min-height: $pt-icon-size-large + $dialog-padding;
+  padding-left: $dialog-padding;
 
   .pt-icon-large {
     flex: 0 0 auto;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -139,12 +139,12 @@ $dialog-padding: $pt-grid-size * 2 !default;
   border-radius: $dialog-border-radius $dialog-border-radius 0 0;
   box-shadow: 0 1px 0 $pt-divider-black;
   background: $white;
-  padding-left: $dialog-padding / 2;
+  padding-left: $dialog-padding;
+  min-height: $pt-icon-size-large + $dialog-padding;
 
   .pt-icon-large {
     flex: 0 0 auto;
-    margin: $dialog-padding / 2;
-    margin-right: 0;
+    margin-right: $dialog-padding / 2;
     color: $pt-icon-color;
   }
 
@@ -152,7 +152,7 @@ $dialog-padding: $pt-grid-size * 2 !default;
     @include overflow-ellipsis();
 
     flex: 1 1 auto;
-    margin: 0 0 0 ($dialog-padding / 2);
+    margin: 0;
     line-height: inherit;
   }
 

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -154,6 +154,10 @@ $dialog-padding: $pt-grid-size * 2 !default;
     flex: 1 1 auto;
     margin: 0;
     line-height: inherit;
+
+    &:last-child {
+      margin-right: $dialog-padding;
+    }
   }
 
   .pt-dark & {


### PR DESCRIPTION
#### Fixes #425

#### Changes proposed in this pull request:

- set `min-height` on Dialog header so it always occupies the expected space regardless of contents.
- simplify margins of header children
- add margin-right to `h5` when it's last-child so text won't run to the edge