### PR TITLE
Fix daterangepicker initial value month

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -123,7 +123,7 @@ export class DateRangePicker
         if (props.initialMonth != null) {
             initialMonth = props.initialMonth;
         } else if (value[0] != null) {
-            initialMonth = new Date(value[0].getTime());
+            initialMonth = DateUtils.clone(value[0]);
         } else if (DateUtils.isDayInRange(today, [props.minDate, props.maxDate])) {
             initialMonth = today;
         } else {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -123,7 +123,7 @@ export class DateRangePicker
         if (props.initialMonth != null) {
             initialMonth = props.initialMonth;
         } else if (value[0] != null) {
-            initialMonth = value[0];
+            initialMonth = new Date(value[0].getTime());
         } else if (DateUtils.isDayInRange(today, [props.minDate, props.maxDate])) {
             initialMonth = today;
         } else {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -110,7 +110,7 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.displayMonth, NOVEMBER);
         });
 
-        it("is value - 1 if set and initialMonth not set and initialMonth === maxDate month", () => {
+        it("is value - 1 if set and initialMonth not set and value month === maxDate month", () => {
             const value = [new Date(2017, 9, 4), null] as DateRange;
             const maxDate = new Date(2017, 9, 15);
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -110,6 +110,15 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.displayMonth, NOVEMBER);
         });
 
+        it("is value - 1 if set and initialMonth not set and initialMonth === maxDate month", () => {
+            const value = [new Date(2017, 9, 4), null] as DateRange;
+            const maxDate = new Date(2017, 9, 15);
+
+            renderDateRangePicker({ maxDate, value });
+            assert.equal(dateRangePicker.state.displayYear, 2017);
+            assert.equal(dateRangePicker.state.displayMonth, 8);
+        });
+
         it("is initialMonth if initialMonth === minDate month and initialMonth === maxDate month", () => {
             const DECEMBER = 11;
             const YEAR = 2016;


### PR DESCRIPTION
#### Fixes #429 

#### Changes proposed in this pull request:

make a copy of the `value[0]` so that it doesn't get mutated in line 140.

#### Reviewers should focus on:

`props.initialMonth` can also be mutated from the first part of the if block, but I don't think that matters.