### PR TITLE
Expose months value mapping in datetime package

### DIFF
--- a/packages/datetime/src/common/months.ts
+++ b/packages/datetime/src/common/months.ts
@@ -5,18 +5,17 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-// tslint:disable object-literal-sort-keys
-export const Months = {
-    JANUARY: 0,
-    FEBRUARY: 1,
-    MARCH: 2,
-    APRIL: 3,
-    MAY: 4,
-    JUNE: 5,
-    JULY: 6,
-    AUGUST: 7,
-    SEPTEMBER: 8,
-    OCTOBER: 9,
-    NOVEMBER: 10,
-    DECEMBER: 11,
+export const enum Months {
+    JANUARY,
+    FEBRUARY,
+    MARCH,
+    APRIL,
+    MAY,
+    JUNE,
+    JULY,
+    AUGUST,
+    SEPTEMBER,
+    OCTOBER,
+    NOVEMBER,
+    DECEMBER,
 };

--- a/packages/datetime/src/common/months.ts
+++ b/packages/datetime/src/common/months.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+// tslint:disable object-literal-sort-keys
+export const Months = {
+    JANUARY: 0,
+    FEBRUARY: 1,
+    MARCH: 2,
+    APRIL: 3,
+    MAY: 4,
+    JUNE: 5,
+    JULY: 6,
+    AUGUST: 7,
+    SEPTEMBER: 8,
+    OCTOBER: 9,
+    NOVEMBER: 10,
+    DECEMBER: 11,
+};

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -5,6 +5,8 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import { Months } from "./common/months";
+
 export interface IDatePickerLocaleUtils {
     formatDay: (day: Date, locale: string) => string;
     formatMonthTitle: (month: Date, locale: string) => string;
@@ -70,14 +72,14 @@ export const DISALLOWED_MODIFIERS = [DISABLED_MODIFIER, OUTSIDE_MODIFIER, SELECT
 export function getDefaultMaxDate() {
     const date = new Date();
     date.setFullYear(date.getFullYear());
-    date.setMonth(11, 31);
+    date.setMonth(Months.DECEMBER, 31);
     return date;
 }
 
 export function getDefaultMinDate() {
     const date = new Date();
     date.setFullYear(date.getFullYear() - 20);
-    date.setMonth(0, 1);
+    date.setMonth(Months.JANUARY, 1);
     return date;
 }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -14,6 +14,7 @@ import * as DateClasses from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
 import { DateRange } from "./common/dateUtils";
 import * as Errors from "./common/errors";
+import { Months } from "./common/months";
 
 import { DatePickerCaption } from "./datePickerCaption";
 import {
@@ -399,7 +400,7 @@ function getStateChange(value: DateRange,
 type DisplayMonth = [number, number];
 
 function getNextMonth([month, year]: DisplayMonth): DisplayMonth {
-    return month === 12 ? [0, year + 1] : [month + 1, year];
+    return month === Months.DECEMBER ? [0, year + 1] : [month + 1, year];
 }
 
 function areSameMonth([month, year]: DisplayMonth, [month2, year2]: DisplayMonth) {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -400,7 +400,7 @@ function getStateChange(value: DateRange,
 type DisplayMonth = [number, number];
 
 function getNextMonth([month, year]: DisplayMonth): DisplayMonth {
-    return month === Months.DECEMBER ? [0, year + 1] : [month + 1, year];
+    return month === Months.DECEMBER ? [Months.JANUARY, year + 1] : [month + 1, year];
 }
 
 function areSameMonth([month, year]: DisplayMonth, [month2, year2]: DisplayMonth) {

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -10,6 +10,7 @@ import * as classes from "./common/classes";
 export const Classes = classes;
 
 export { DateRange } from "./common/dateUtils";
+export { Months } from "./common/months";
 export { DateInput } from "./dateInput";
 export { DatePicker, DatePickerFactory, IDatePickerProps } from "./datePicker";
 export { IDatePickerLocaleUtils, IDatePickerModifiers } from "./datePickerCore";

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { Button } from "@blueprintjs/core";
 import * as DateUtils from "../src/common/dateUtils";
 import * as Errors from "../src/common/errors";
+import { Months } from "../src/common/months";
 import { Classes, DatePicker } from "../src/index";
 
 describe("<DatePicker>", () => {
@@ -40,25 +41,25 @@ describe("<DatePicker>", () => {
 
     describe("initially displayed month", () => {
         it("is defaultValue", () => {
-            const defaultValue = new Date(2007, 3, 4);
+            const defaultValue = new Date(2007, Months.APRIL, 4);
             const { root } = wrap(<DatePicker defaultValue={defaultValue} />);
             assert.equal(root.state("displayYear"), 2007);
-            assert.equal(root.state("displayMonth"), 3);
+            assert.equal(root.state("displayMonth"), Months.APRIL);
         });
 
         it("is initialMonth if set (overrides defaultValue)", () => {
-            const defaultValue = new Date(2007, 3, 4);
-            const initialMonth = new Date(2002, 2, 1);
+            const defaultValue = new Date(2007, Months.APRIL, 4);
+            const initialMonth = new Date(2002, Months.MARCH, 1);
             const { root } = wrap(<DatePicker defaultValue={defaultValue} initialMonth={initialMonth} />);
             assert.equal(root.state("displayYear"), 2002);
-            assert.equal(root.state("displayMonth"), 2);
+            assert.equal(root.state("displayMonth"), Months.MARCH);
         });
 
         it("is value if set and initialMonth not set", () => {
-            const value = new Date(2007, 3, 4);
+            const value = new Date(2007, Months.APRIL, 4);
             const { root } = wrap(<DatePicker value={value} />);
             assert.equal(root.state("displayYear"), 2007);
-            assert.equal(root.state("displayMonth"), 3);
+            assert.equal(root.state("displayMonth"), Months.APRIL);
         });
 
         it("is today if today is within date range", () => {
@@ -69,8 +70,8 @@ describe("<DatePicker>", () => {
         });
 
         it("is a day between minDate and maxDate if today is not in range", () => {
-            const maxDate = new Date(2005, 0);
-            const minDate = new Date(2000, 0);
+            const maxDate = new Date(2005, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
             const { root } = wrap(<DatePicker maxDate={maxDate} minDate={minDate} />);
             assert.isTrue(DateUtils.isDayInRange(
                 new Date(root.state("displayYear"), root.state("displayMonth")),
@@ -79,21 +80,21 @@ describe("<DatePicker>", () => {
         });
 
         it("selectedDay is set to the day of the value", () => {
-            const value = new Date(2007, 3, 4);
+            const value = new Date(2007, Months.APRIL, 4);
             const { root } = wrap(<DatePicker value={value} />);
             assert.strictEqual(root.state("selectedDay"), value.getDate());
         });
 
         it("selectedDay is set to the day of the defaultValue", () => {
-            const defaultValue = new Date(2007, 3, 4);
+            const defaultValue = new Date(2007, Months.APRIL, 4);
             const { root } = wrap(<DatePicker defaultValue={defaultValue} />);
             assert.strictEqual(root.state("selectedDay"), defaultValue.getDate());
         });
     });
 
     describe("minDate/maxDate bounds", () => {
-        const MIN_DATE = new Date(2015, 0, 7);
-        const MAX_DATE = new Date(2015, 0, 12);
+        const MIN_DATE = new Date(2015, Months.JANUARY, 7);
+        const MAX_DATE = new Date(2015, Months.JANUARY, 12);
         it("maxDate must be later than minDate", () => {
             assert.throws(() => wrap(
                 <DatePicker maxDate={MIN_DATE} minDate={MAX_DATE} />,
@@ -102,30 +103,30 @@ describe("<DatePicker>", () => {
 
         it("an error is thrown if defaultValue is outside bounds", () => {
             assert.throws(() => wrap(
-                <DatePicker defaultValue={new Date(2015, 0, 5)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
+                <DatePicker defaultValue={new Date(2015, Months.JANUARY, 5)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
             ), Errors.DATEPICKER_DEFAULT_VALUE_INVALID);
         });
 
         it("an error is thrown if value is outside bounds", () => {
             assert.throws(() => wrap(
-                <DatePicker value={new Date(2015, 0, 20)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
+                <DatePicker value={new Date(2015, Months.JANUARY, 20)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
             ), Errors.DATEPICKER_VALUE_INVALID);
         });
 
         it("an error is thrown if initialMonth is outside month bounds", () => {
             assert.throws(() => wrap(
-                <DatePicker initialMonth={new Date(2015, 1, 12)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
+                <DatePicker initialMonth={new Date(2015, Months.FEBRUARY, 12)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
             ), Errors.DATEPICKER_INITIAL_MONTH_INVALID);
         });
 
         it("an error is not thrown if initialMonth is outside day bounds but inside month bounds", () => {
             assert.doesNotThrow(() => wrap(
-                <DatePicker initialMonth={new Date(2015, 0, 12)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
+                <DatePicker initialMonth={new Date(2015, Months.JANUARY, 12)} minDate={MIN_DATE} maxDate={MAX_DATE} />,
             ));
         });
 
         it("only days outside bounds have disabled class", () => {
-            const minDate = new Date(2000, 0, 10);
+            const minDate = new Date(2000, Months.JANUARY, 10);
             const { getDay } = wrap(<DatePicker initialMonth={minDate} minDate={minDate} />);
             // 8 is before min date, 12 is after
             assert.isTrue(getDay(8).hasClass(Classes.DATEPICKER_DAY_DISABLED));
@@ -146,9 +147,9 @@ describe("<DatePicker>", () => {
 
     describe("when controlled", () => {
         it("value initially selects a day", () => {
-            const value = new Date(2010, 0, 1);
+            const value = new Date(2010, Months.JANUARY, 1);
             const { getSelectedDays } = wrap(
-                <DatePicker defaultValue={new Date(2010, 1, 2)} value={value} />,
+                <DatePicker defaultValue={new Date(2010, Months.FEBRUARY, 2)} value={value} />,
             );
             assert.lengthOf(getSelectedDays(), 1);
             assert.equal(getSelectedDays().at(0).text(), value.getDate());
@@ -162,13 +163,13 @@ describe("<DatePicker>", () => {
         });
 
         it("selected day doesn't update on current month view change", () => {
-            const value = new Date(2010, 0, 2);
+            const value = new Date(2010, Months.JANUARY, 2);
             const { months, root, getSelectedDays, years } = wrap(<DatePicker value={value} />);
             root.find(".DayPicker-NavButton--prev").simulate("click");
 
             assert.lengthOf(getSelectedDays(), 1);
 
-            months.simulate("change", { target: { value: 5 } });
+            months.simulate("change", { target: { value: Months.JUNE } });
             assert.lengthOf(getSelectedDays(), 0);
 
             years.simulate("change", { target: { value: 2014 } });
@@ -184,7 +185,7 @@ describe("<DatePicker>", () => {
         });
 
         it("onChange fired when month is changed", () => {
-            const value = new Date(2010, 0, 2);
+            const value = new Date(2010, Months.JANUARY, 2);
             const onChange = sinon.spy();
             const { months, root } = wrap(<DatePicker onChange={onChange} value={value} />);
 
@@ -192,19 +193,19 @@ describe("<DatePicker>", () => {
             assert.isTrue(onChange.calledOnce, "expected onChange called");
             assert.isFalse(onChange.firstCall.args[1], "expected hasUserManuallySelectedDate to be false");
 
-            months.simulate("change", { target: { value: 5 } });
+            months.simulate("change", { target: { value: Months.JUNE } });
             assert.isTrue(onChange.calledTwice, "expected onChange called again");
             assert.isFalse(onChange.secondCall.args[1], "expected hasUserManuallySelectedDate to be false again");
         });
 
         it("can change displayed date with the dropdowns in the caption", () => {
-            const { months, root, years } = wrap(<DatePicker initialMonth={new Date(2015, 2, 2)} value={null} />);
-            assert.equal(root.state("displayMonth"), 2);
+            const { months, root, years } = wrap(<DatePicker initialMonth={new Date(2015, Months.MARCH, 2)} value={null} />);
+            assert.equal(root.state("displayMonth"), Months.MARCH);
             assert.equal(root.state("displayYear"), 2015);
 
-            months.simulate("change", { target: { value: 0 } });
+            months.simulate("change", { target: { value: Months.JANUARY } });
             years.simulate("change", { target: { value: 2014 } });
-            assert.equal(root.state("displayMonth"), 0);
+            assert.equal(root.state("displayMonth"), Months.JANUARY);
             assert.equal(root.state("displayYear"), 2014);
         });
     });
@@ -233,15 +234,15 @@ describe("<DatePicker>", () => {
         });
 
         it("selected day is preserved when selections are changed", () => {
-            const initialMonth = new Date(2015, 6, 1);
+            const initialMonth = new Date(2015, Months.JULY, 1);
             const { getDay, getSelectedDays, months } = wrap(<DatePicker initialMonth={initialMonth} />);
             getDay(31).simulate("click");
-            months.simulate("change", { target: { value: 7 } });
+            months.simulate("change", { target: { value: Months.AUGUST } });
             assert.deepEqual(getSelectedDays().map((d) => d.text()), ["31"]);
         });
 
         it("selected day is changed if necessary when selections are changed", () => {
-            const initialMonth = new Date(2015, 6, 1);
+            const initialMonth = new Date(2015, Months.JULY, 1);
             const { getDay, getSelectedDays, root } = wrap(<DatePicker initialMonth={initialMonth} />);
             getDay(31).simulate("click");
             root.find(".DayPicker-NavButton--prev").simulate("click");
@@ -249,34 +250,34 @@ describe("<DatePicker>", () => {
         });
 
         it("selected day is changed to minDate or maxDate if selections are changed outside bounds", () => {
-            const initialMonth = new Date(2015, 6, 1);
-            const minDate = new Date(2015, 2, 13);
-            const maxDate = new Date(2015, 10, 21);
+            const initialMonth = new Date(2015, Months.JULY, 1);
+            const minDate = new Date(2015, Months.MARCH, 13);
+            const maxDate = new Date(2015, Months.NOVEMBER, 21);
             const { getDay, getSelectedDays, months } = wrap(
                 <DatePicker initialMonth={initialMonth} minDate={minDate} maxDate={maxDate} />,
             );
 
             getDay(1).simulate("click");
-            months.simulate("change", { target: { value: 2 } });
+            months.simulate("change", { target: { value: Months.MARCH } });
             let selectedDayElements = getSelectedDays();
             assert.lengthOf(selectedDayElements, 1);
             assert.equal(selectedDayElements.at(0).text(), minDate.getDate());
 
             getDay(25).simulate("click");
-            months.simulate("change", { target: { value: 10 } });
+            months.simulate("change", { target: { value: Months.NOVEMBER } });
             selectedDayElements = getSelectedDays();
             assert.lengthOf(selectedDayElements, 1);
             assert.equal(selectedDayElements.at(0).text(), maxDate.getDate());
         });
 
         it("can change displayed date with the dropdowns in the caption", () => {
-            const { months, root, years } = wrap(<DatePicker initialMonth={new Date(2015, 2, 2)} />);
-            assert.equal(root.state("displayMonth"), 2);
+            const { months, root, years } = wrap(<DatePicker initialMonth={new Date(2015, Months.MARCH, 2)} />);
+            assert.equal(root.state("displayMonth"), Months.MARCH);
             assert.equal(root.state("displayYear"), 2015);
 
-            months.simulate("change", { target: { value: 0 } });
+            months.simulate("change", { target: { value: Months.JANUARY } });
             years.simulate("change", { target: { value: 2014 } });
-            assert.equal(root.state("displayMonth"), 0);
+            assert.equal(root.state("displayMonth"), Months.JANUARY);
             assert.equal(root.state("displayYear"), 2014);
         });
     });

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -199,7 +199,8 @@ describe("<DatePicker>", () => {
         });
 
         it("can change displayed date with the dropdowns in the caption", () => {
-            const { months, root, years } = wrap(<DatePicker initialMonth={new Date(2015, Months.MARCH, 2)} value={null} />);
+            const { months, root, years } = wrap(
+                <DatePicker initialMonth={new Date(2015, Months.MARCH, 2)} value={null} />);
             assert.equal(root.state("displayMonth"), Months.MARCH);
             assert.equal(root.state("displayYear"), 2015);
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -13,6 +13,7 @@ import * as ReactDOM from "react-dom";
 
 import * as DateUtils from "../src/common/dateUtils";
 import * as Errors from "../src/common/errors";
+import { Months } from "../src/common/months";
 import { Classes as DateClasses, DateRange, DateRangePicker, IDateRangePickerProps } from "../src/index";
 
 describe("<DateRangePicker>", () => {
@@ -51,36 +52,36 @@ describe("<DateRangePicker>", () => {
 
     describe("initially displayed month", () => {
         it("is initialMonth if set", () => {
-            const defaultValue = [new Date(2007, 3, 4), null] as DateRange;
-            const initialMonth = new Date(2002, 2, 1);
-            const maxDate = new Date(2020, 0);
-            const minDate = new Date(2000, 0);
+            const defaultValue = [new Date(2007, Months.APRIL, 4), null] as DateRange;
+            const initialMonth = new Date(2002, Months.MARCH, 1);
+            const maxDate = new Date(2020, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
             renderDateRangePicker({ defaultValue, initialMonth, maxDate, minDate });
             assert.equal(dateRangePicker.state.displayYear, 2002);
-            assert.equal(dateRangePicker.state.displayMonth, 2);
+            assert.equal(dateRangePicker.state.displayMonth, Months.MARCH);
         });
 
         it("is defaultValue if set and initialMonth not set", () => {
-            const defaultValue = [new Date(2007, 3, 4), null] as DateRange;
-            const maxDate = new Date(2020, 0);
-            const minDate = new Date(2000, 0);
+            const defaultValue = [new Date(2007, Months.APRIL, 4), null] as DateRange;
+            const maxDate = new Date(2020, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
             renderDateRangePicker({ defaultValue, maxDate, minDate });
             assert.equal(dateRangePicker.state.displayYear, 2007);
-            assert.equal(dateRangePicker.state.displayMonth, 3);
+            assert.equal(dateRangePicker.state.displayMonth, Months.APRIL);
         });
 
         it("is value if set and initialMonth not set", () => {
-            const maxDate = new Date(2020, 0);
-            const minDate = new Date(2000, 0);
-            const value = [new Date(2007, 3, 4), null] as DateRange;
+            const maxDate = new Date(2020, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const value = [new Date(2007, Months.APRIL, 4), null] as DateRange;
             renderDateRangePicker({ maxDate, minDate, value });
             assert.equal(dateRangePicker.state.displayYear, 2007);
-            assert.equal(dateRangePicker.state.displayMonth, 3);
+            assert.equal(dateRangePicker.state.displayMonth, Months.APRIL);
         });
 
         it("is today if only maxDate/minDate set and today is in date range", () => {
-            const maxDate = new Date(2020, 0);
-            const minDate = new Date(2000, 0);
+            const maxDate = new Date(2020, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
             const today = new Date();
             renderDateRangePicker({ maxDate, minDate});
             assert.equal(dateRangePicker.state.displayYear, today.getFullYear());
@@ -88,54 +89,51 @@ describe("<DateRangePicker>", () => {
         });
 
         it("is a day between minDate and maxDate if only maxDate/minDate set and today is not in range", () => {
-            const maxDate = new Date(2005, 0);
-            const minDate = new Date(2000, 0);
+            const maxDate = new Date(2005, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
             renderDateRangePicker({ maxDate, minDate });
             const { displayMonth, displayYear } = dateRangePicker.state;
             assert.isTrue(DateUtils.isDayInRange(new Date(displayYear, displayMonth), [minDate, maxDate]));
         });
 
         it("is initialMonth - 1 if initialMonth === maxDate month", () => {
-            const NOVEMBER = 10;
-            const DECEMBER = 11;
             const MAX_YEAR = 2016;
 
-            const initialMonth = new Date(MAX_YEAR, DECEMBER, 1);
-            const maxDate = new Date(MAX_YEAR, DECEMBER, 31);
+            const initialMonth = new Date(MAX_YEAR, Months.DECEMBER, 1);
+            const maxDate = new Date(MAX_YEAR, Months.DECEMBER, 31);
             const minDate = new Date(2000, 0);
 
             renderDateRangePicker({ initialMonth, maxDate, minDate });
 
             assert.equal(dateRangePicker.state.displayYear, MAX_YEAR);
-            assert.equal(dateRangePicker.state.displayMonth, NOVEMBER);
+            assert.equal(dateRangePicker.state.displayMonth, Months.NOVEMBER);
         });
 
         it("is initialMonth if initialMonth === minDate month and initialMonth === maxDate month", () => {
-            const DECEMBER = 11;
             const YEAR = 2016;
 
-            const initialMonth = new Date(YEAR, DECEMBER, 11);
-            const maxDate = new Date(YEAR, DECEMBER, 15);
-            const minDate = new Date(YEAR, DECEMBER, 1);
+            const initialMonth = new Date(YEAR, Months.DECEMBER, 11);
+            const maxDate = new Date(YEAR, Months.DECEMBER, 15);
+            const minDate = new Date(YEAR, Months.DECEMBER, 1);
 
             renderDateRangePicker({ initialMonth, maxDate, minDate });
 
             assert.equal(dateRangePicker.state.displayYear, YEAR);
-            assert.equal(dateRangePicker.state.displayMonth, DECEMBER);
+            assert.equal(dateRangePicker.state.displayMonth, Months.DECEMBER);
         });
     });
 
     describe("minDate/maxDate bounds", () => {
         it("maxDate must be later than minDate", () => {
-            const minDate = new Date(2000, 0, 10);
-            const maxDate = new Date(2000, 0, 8);
+            const minDate = new Date(2000, Months.JANUARY, 10);
+            const maxDate = new Date(2000, Months.JANUARY, 8);
             assert.throws(() => {
                 renderDateRangePicker({ minDate, maxDate });
             }, Errors.DATERANGEPICKER_MAX_DATE_INVALID);
         });
 
         it("only days outside bounds have disabled class", () => {
-            const minDate = new Date(2000, 0, 10);
+            const minDate = new Date(2000, Months.JANUARY, 10);
             const initialMonth = minDate;
             renderDateRangePicker({ initialMonth, minDate });
             const disabledDay = getDayElement(8);
@@ -145,44 +143,44 @@ describe("<DateRangePicker>", () => {
         });
 
         it("an error is thrown if defaultValue is outside bounds", () => {
-            const minDate = new Date(2015, 0, 5);
-            const maxDate = new Date(2015, 0, 7);
-            const defaultValue = [new Date(2015, 0, 12), null] as DateRange;
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
+            const defaultValue = [new Date(2015, Months.JANUARY, 12), null] as DateRange;
             assert.throws(() => {
                 renderDateRangePicker({ defaultValue, minDate, maxDate });
             }, Errors.DATERANGEPICKER_DEFAULT_VALUE_INVALID);
         });
 
         it("an error is thrown if initialMonth is outside month bounds", () => {
-            const minDate = new Date(2015, 0, 5);
-            const maxDate = new Date(2015, 0, 7);
-            const initialMonth = new Date(2015, 1, 12);
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
+            const initialMonth = new Date(2015, Months.FEBRUARY, 12);
             assert.throws(() => {
                 renderDateRangePicker({ initialMonth, minDate, maxDate });
             }, Errors.DATERANGEPICKER_INITIAL_MONTH_INVALID);
         });
 
         it("an error is not thrown if initialMonth is outside day bounds but inside month bounds", () => {
-            const minDate = new Date(2015, 0, 5);
-            const maxDate = new Date(2015, 0, 7);
-            const initialMonth = new Date(2015, 0, 12);
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
+            const initialMonth = new Date(2015, Months.JANUARY, 12);
             assert.doesNotThrow(() => {
                 renderDateRangePicker({ initialMonth, minDate, maxDate });
             });
         });
 
         it("an error is thrown if value is outside bounds", () => {
-            const minDate = new Date(2015, 0, 5);
-            const maxDate = new Date(2015, 0, 7);
-            const value = [new Date(2015, 0, 12), null] as DateRange;
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
+            const value = [new Date(2015, Months.JANUARY, 12), null] as DateRange;
             assert.throws(() => {
                 renderDateRangePicker({ value, minDate, maxDate });
             }, Errors.DATERANGEPICKER_VALUE_INVALID);
         });
 
         it("onChange not fired when a day outside of bounds is clicked", () => {
-            const minDate = new Date(2015, 0, 5);
-            const maxDate = new Date(2015, 0, 7);
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
             renderDateRangePicker({ minDate, maxDate });
             assert.isTrue(onDateRangePickerChangeSpy.notCalled);
             clickDay(10);
@@ -190,8 +188,8 @@ describe("<DateRangePicker>", () => {
         });
 
         it("caption options are only displayed for possible months and years", () => {
-            const minDate = new Date(2015, 0, 5);
-            const maxDate = new Date(2015, 0, 7);
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
             renderDateRangePicker({ minDate, maxDate });
             const monthOptions = getOptionsText(DateClasses.DATEPICKER_MONTH_SELECT);
             const yearOptions = getOptionsText(DateClasses.DATEPICKER_YEAR_SELECT);
@@ -202,15 +200,15 @@ describe("<DateRangePicker>", () => {
         });
 
         it("can change month down to start date with arrow button", () => {
-            const minDate = new Date(2015, 0, 5);
-            const initialMonth = new Date(2015, 1, 5);
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const initialMonth = new Date(2015, Months.FEBRUARY, 5);
             renderDateRangePicker({ initialMonth, minDate });
-            assert.strictEqual(dateRangePicker.state.displayMonth, 1);
+            assert.strictEqual(dateRangePicker.state.displayMonth, Months.FEBRUARY);
             let prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             assert.lengthOf(prevBtn, 1);
 
             TestUtils.Simulate.click(prevBtn[0]);
-            assert.strictEqual(dateRangePicker.state.displayMonth, 0);
+            assert.strictEqual(dateRangePicker.state.displayMonth, Months.JANUARY);
             prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             assert.lengthOf(prevBtn, 0);
         });
@@ -218,8 +216,8 @@ describe("<DateRangePicker>", () => {
 
     describe("when controlled", () => {
         it("value initially selects a day", () => {
-            const defaultValue = [new Date(2010, 1, 2), null] as DateRange;
-            const value = [new Date(2010, 0, 1), null] as DateRange;
+            const defaultValue = [new Date(2010, Months.FEBRUARY, 2), null] as DateRange;
+            const value = [new Date(2010, Months.JANUARY, 1), null] as DateRange;
             renderDateRangePicker({ defaultValue, value });
             const selectedDays = getSelectedDayElements();
             assert.lengthOf(selectedDays, 1);
@@ -246,13 +244,13 @@ describe("<DateRangePicker>", () => {
         });
 
         it("can change displayed date with the dropdowns in the caption", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 2, 2), value: [null, null] });
-            assert.equal(dateRangePicker.state.displayMonth, 2);
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.MARCH, 2), value: [null, null] });
+            assert.equal(dateRangePicker.state.displayMonth, Months.MARCH);
             assert.equal(dateRangePicker.state.displayYear, 2015);
 
-            TestUtils.Simulate.change(getMonthSelect(), { target: { value: 0 } } as any);
+            TestUtils.Simulate.change(getMonthSelect(), { target: { value: Months.JANUARY } } as any);
             TestUtils.Simulate.change(getYearSelect(), { target: { value: 2014 } } as any);
-            assert.equal(dateRangePicker.state.displayMonth, 0);
+            assert.equal(dateRangePicker.state.displayMonth, Months.JANUARY);
             assert.equal(dateRangePicker.state.displayYear, 2014);
         });
 
@@ -270,9 +268,9 @@ describe("<DateRangePicker>", () => {
         });
 
         it("custom shortcuts select the correct values", () => {
-            const dateRange = [new Date(2015, 0, 1), new Date(2015, 0, 5)] as DateRange;
+            const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)] as DateRange;
             renderDateRangePicker({
-                initialMonth: new Date(2015, 0, 1),
+                initialMonth: new Date(2015, Months.JANUARY, 1),
                 shortcuts: [{label: "custom shortcut", dateRange}],
             });
 
@@ -314,7 +312,7 @@ describe("<DateRangePicker>", () => {
         });
 
         it("selects a range of dates when two days are clicked", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 0, 1) });
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             assert.lengthOf(getSelectedDayElements(), 0);
             assert.lengthOf(getSelectedRangeDayElements(), 0);
 
@@ -325,7 +323,7 @@ describe("<DateRangePicker>", () => {
         });
 
         it("selects a range of dates when days are clicked in reverse", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 0, 1) });
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             assert.lengthOf(getSelectedDayElements(), 0);
             assert.lengthOf(getSelectedRangeDayElements(), 0);
 
@@ -336,7 +334,7 @@ describe("<DateRangePicker>", () => {
         });
 
         it("deselects everything when only selected day is clicked", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 0, 1) });
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             assert.lengthOf(getSelectedDayElements(), 0);
             assert.lengthOf(getSelectedRangeDayElements(), 0);
 
@@ -350,7 +348,7 @@ describe("<DateRangePicker>", () => {
         });
 
         it("starts a new selection when a non-endpoint is clicked in the current selection", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 0, 1) });
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             clickDay(10);
             clickDay(14);
 
@@ -361,7 +359,7 @@ describe("<DateRangePicker>", () => {
         });
 
         it("deselects endpoint when an endpoint of the current selection is clicked", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 0, 1) });
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             clickDay(10);
             clickDay(14);
 
@@ -378,7 +376,7 @@ describe("<DateRangePicker>", () => {
         });
 
         it("allowSingleDayRange={true} allows start and end to be the same day", () => {
-            renderDateRangePicker({ allowSingleDayRange: true, initialMonth: new Date(2015, 0, 1) });
+            renderDateRangePicker({ allowSingleDayRange: true, initialMonth: new Date(2015, Months.JANUARY, 1) });
             clickDay(10);
             clickDay(10);
 
@@ -401,9 +399,9 @@ describe("<DateRangePicker>", () => {
         });
 
         it("custom shortcuts select the correct values", () => {
-            const dateRange = [new Date(2015, 0, 1), new Date(2015, 0, 5)] as DateRange;
+            const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)] as DateRange;
             renderDateRangePicker({
-                initialMonth: new Date(2015, 0, 1),
+                initialMonth: new Date(2015, Months.JANUARY, 1),
                 shortcuts: [{label: "custom shortcut", dateRange}],
             });
 
@@ -415,13 +413,13 @@ describe("<DateRangePicker>", () => {
         });
 
         it("can change displayed date with the dropdowns in the caption", () => {
-            renderDateRangePicker({ initialMonth: new Date(2015, 2, 2) });
-            assert.equal(dateRangePicker.state.displayMonth, 2);
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            assert.equal(dateRangePicker.state.displayMonth, Months.MARCH);
             assert.equal(dateRangePicker.state.displayYear, 2015);
 
-            TestUtils.Simulate.change(getMonthSelect(), ({ target: { value: 0 } } as any));
+            TestUtils.Simulate.change(getMonthSelect(), ({ target: { value: Months.JANUARY } } as any));
             TestUtils.Simulate.change(getYearSelect(), ({ target: { value: 2014 } } as any));
-            assert.equal(dateRangePicker.state.displayMonth, 0);
+            assert.equal(dateRangePicker.state.displayMonth, Months.JANUARY);
             assert.equal(dateRangePicker.state.displayYear, 2014);
         });
     });

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -422,6 +422,44 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.displayMonth, Months.JANUARY);
             assert.equal(dateRangePicker.state.displayYear, 2014);
         });
+
+        it("does not change display month when selecting dates from left month", () => {
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            clickDay(2);
+            clickDay(15, false);
+
+            assert.equal(dateRangePicker.state.displayMonth, Months.MARCH);
+            assert.equal(dateRangePicker.state.displayYear, 2015);
+        });
+
+        it("does not change display month when selecting dates from right month", () => {
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            clickDay(2, false);
+            clickDay(15, false);
+
+            assert.equal(dateRangePicker.state.displayMonth, Months.MARCH);
+            assert.equal(dateRangePicker.state.displayYear, 2015);
+        });
+
+        it("does not change display month when selecting dates from left and right month", () => {
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            clickDay(2);
+            clickDay(15, false);
+
+            assert.equal(dateRangePicker.state.displayMonth, Months.MARCH);
+            assert.equal(dateRangePicker.state.displayYear, 2015);
+        });
+
+        it("does not change display month when selecting dates across December (left) and January (right)", () => {
+            renderDateRangePicker();
+            TestUtils.Simulate.change(getMonthSelect(), ({ target: { value: Months.DECEMBER } } as any));
+            TestUtils.Simulate.change(getYearSelect(), ({ target: { value: 2015 } } as any));
+            clickDay(15);
+            clickDay(2, false);
+
+            assert.equal(dateRangePicker.state.displayMonth, Months.DECEMBER);
+            assert.equal(dateRangePicker.state.displayYear, 2015);
+        });
     });
 
     function renderDateRangePicker(props?: IDateRangePickerProps) {


### PR DESCRIPTION
#### Fixes #431 

#### Checklist

- [x] Include tests (covers the edge case in the issue as well as general usage)

#### Changes proposed in this pull request:

- Expose months mapping in datetime for more verbose code
- Fixes changing displayMonth when selecting dates across years

#### Reviewers should focus on:

- should`Months` be an enum (could be inconsistent if we make a 1-indexed variant as @cmslewis mentions in the issue)?
- the problem from the issue can be reproduced by selecting December on the left hand calendar, then select a start date in December and an end date in January (the displayed months will change unnecessarily)
