### PR TITLE
Use same colors for progress bars and spinners

### DIFF
--- a/packages/core/src/components/progress/_common.scss
+++ b/packages/core/src/components/progress/_common.scss
@@ -1,0 +1,11 @@
+// Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+// of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+// and https://github.com/palantir/blueprint/blob/master/PATENTS
+
+@import "../../common/variables";
+
+$progress-track-color: rgba($gray1, 0.2) !default;
+$progress-head-color: rgba($gray1, 0.8) !default;
+$dark-progress-track-color: rgba($black, 0.5) !default;
+$dark-progress-head-color: $gray3 !default;

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -5,6 +5,7 @@
 
 @import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
+@import "../progress/common";
 
 /*
 Progress
@@ -72,15 +73,11 @@ are supported via the `className` prop.
 Styleguide components.progress.bar.js
 */
 
+$progress-bar-stripes-color: rgba($white, 0.2) !default;
+
 $progress-bar-height: round($pt-grid-size * 0.8) !default;
 $progress-bar-stripes-size: $pt-grid-size * 3 !default;
 $progress-bar-border-radius: $pt-grid-size * 4 !default;
-
-$progress-bar-stripes-color: rgba($white, 0.2) !default;
-$progress-bar-track-color: rgba($gray1, 0.2) !default;
-$progress-meter-color: rgba($gray1, 0.8) !default;
-$dark-progress-bar-track-color: rgba($black, 0.3) !default;
-$dark-progress-meter-color: $gray1 !default;
 
 @include keyframes(linear-progress-bar-stripes) {
   from {
@@ -96,7 +93,7 @@ $dark-progress-meter-color: $gray1 !default;
   display: block;
   position: relative;
   border-radius: $progress-bar-border-radius;
-  background: $progress-bar-track-color;
+  background: $progress-track-color;
   width: 100%;
   height: $progress-bar-height;
   overflow: hidden;
@@ -115,7 +112,7 @@ $dark-progress-meter-color: $gray1 !default;
     display: inline-block;
     position: absolute;
     border-radius: $progress-bar-border-radius;
-    background-color: $progress-meter-color;
+    background-color: $progress-head-color;
     background-size: $progress-bar-stripes-size $progress-bar-stripes-size;
     // initial state is a full bar, a la "indeterminate"
     width: 100%;
@@ -136,10 +133,10 @@ $dark-progress-meter-color: $gray1 !default;
 
 .pt-dark .pt-progress-bar,
 .pt-progress-bar.pt-dark {
-  background: $dark-progress-bar-track-color;
+  background: $dark-progress-track-color;
 
   .pt-progress-meter {
-    background-color: $dark-progress-meter-color;
+    background-color: $dark-progress-head-color;
   }
 }
 

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -5,6 +5,7 @@
 
 @import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
+@import "../progress/common";
 
 /*
 Spinners
@@ -104,11 +105,6 @@ Styleguide components.progress.spinner.js.svg
   }
 }
 
-$spinner-track-color: rgba($gray1, 0.2) !default;
-$spinner-head-color: rgba($gray1, 0.8) !default;
-$dark-spinner-track-color: rgba($black, 0.5) !default;
-$dark-spinner-head-color: $gray3 !default;
-
 $spinner-width: $pt-grid-size * 10 !default;
 $spinner-width-factor: 0.5 !default;
 $spinner-width-factor-small: 0.24 !default;
@@ -136,12 +132,12 @@ $resources-path: "./resources" !default;
 
   .pt-spinner-head {
     transition: stroke-dashoffset ($pt-transition-duration * 2) $pt-transition-ease;
-    stroke: $spinner-head-color;
+    stroke: $progress-head-color;
     stroke-linecap: round;
   }
 
   .pt-spinner-track {
-    stroke: $spinner-track-color;
+    stroke: $progress-track-color;
   }
 
   &.pt-small {
@@ -201,11 +197,11 @@ $resources-path: "./resources" !default;
 
 .pt-dark .pt-spinner {
   .pt-spinner-head {
-    stroke: $dark-spinner-head-color;
+    stroke: $dark-progress-head-color;
   }
 
   .pt-spinner-track {
-    stroke: $dark-spinner-track-color;
+    stroke: $dark-progress-track-color;
   }
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add a Sass file for common progress bars and spinners variables
- Use the same colors for progress bars and spinners

#### Reviewers should focus on:

- Make sure it looks good on both themes.
- A bit out of scope: should we move `spinner/` and `skeleton/` folders into `progress/`? It would also reflect the hierarchy of the docs