### PR TITLE
Select timepicker text on focus

### DIFF
--- a/packages/datetime/examples/timePickerExample.tsx
+++ b/packages/datetime/examples/timePickerExample.tsx
@@ -13,12 +13,14 @@ import { TimePicker, TimePickerPrecision } from "../src";
 
 export interface ITimePickerExampleState {
     precision?: TimePickerPrecision;
+    selectOnFocus?: boolean;
     showArrowButtons?: boolean;
 }
 
 export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     public state = {
         precision: TimePickerPrecision.MINUTE,
+        selectOnFocus: false,
         showArrowButtons: false,
     };
 
@@ -45,16 +47,26 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                     </div>
                 </label>,
                 <Switch
+                    checked={this.state.selectOnFocus}
+                    label="Select on focus"
+                    key="focus"
+                    onChange={this.toggleSelectOnFocus}
+                />,
+                <Switch
                     checked={this.state.showArrowButtons}
                     label="Show arrow buttons"
                     key="arrows"
-                    onChange={this.toggleshowArrowButtons}
+                    onChange={this.toggleShowArrowButtons}
                 />,
             ],
         ];
     }
 
-    private toggleshowArrowButtons = () => {
+    private toggleShowArrowButtons = () => {
         this.setState({ showArrowButtons: !this.state.showArrowButtons });
+    }
+
+    private toggleSelectOnFocus = () => {
+        this.setState({ selectOnFocus: !this.state.selectOnFocus });
     }
 }

--- a/packages/datetime/examples/timePickerExample.tsx
+++ b/packages/datetime/examples/timePickerExample.tsx
@@ -13,14 +13,14 @@ import { TimePicker, TimePickerPrecision } from "../src";
 
 export interface ITimePickerExampleState {
     precision?: TimePickerPrecision;
-    selectOnFocus?: boolean;
+    selectAllOnFocus?: boolean;
     showArrowButtons?: boolean;
 }
 
 export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     public state = {
         precision: TimePickerPrecision.MINUTE,
-        selectOnFocus: false,
+        selectAllOnFocus: false,
         showArrowButtons: false,
     };
 
@@ -47,10 +47,10 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                     </div>
                 </label>,
                 <Switch
-                    checked={this.state.selectOnFocus}
-                    label="Select on focus"
+                    checked={this.state.selectAllOnFocus}
+                    label="Select all on focus"
                     key="focus"
-                    onChange={this.toggleSelectOnFocus}
+                    onChange={this.toggleSelectAllOnFocus}
                 />,
                 <Switch
                     checked={this.state.showArrowButtons}
@@ -66,7 +66,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
         this.setState({ showArrowButtons: !this.state.showArrowButtons });
     }
 
-    private toggleSelectOnFocus = () => {
-        this.setState({ selectOnFocus: !this.state.selectOnFocus });
+    private toggleSelectAllOnFocus = () => {
+        this.setState({ selectAllOnFocus: !this.state.selectAllOnFocus });
     }
 }

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -38,10 +38,10 @@ export interface ITimePickerProps extends IProps {
     precision?: TimePickerPrecision;
 
     /**
-     * Whether the inputs should be selected on focus.
+     * Whether all the text in each input should be selected on focus.
      * @default false
      */
-    selectOnFocus?: boolean;
+    selectAllOnFocus?: boolean;
 
    /**
     * Whether to show arrows buttons for changing the time.
@@ -67,7 +67,7 @@ export interface ITimePickerState {
 export class TimePicker extends React.Component<ITimePickerProps, ITimePickerState> {
     public static defaultProps: ITimePickerProps = {
         precision: TimePickerPrecision.MINUTE,
-        selectOnFocus: false,
+        selectAllOnFocus: false,
         showArrowButtons: false,
     };
 
@@ -148,7 +148,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 className={classNames(Classes.TIMEPICKER_INPUT, className)}
                 onBlur={this.getInputBlurHandler(unit)}
                 onChange={this.getInputChangeHandler(unit)}
-                onFocus={this.getInputFocusHandler()}
+                onFocus={this.handleFocus}
                 onKeyDown={this.getInputKeyDownHandler(unit)}
                 value={value}
             />
@@ -192,12 +192,6 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         }
     }
 
-    private getInputFocusHandler = () => (e: React.SyntheticEvent<HTMLInputElement>) => {
-        if (this.props.selectOnFocus) {
-            (e.currentTarget as HTMLInputElement).select();
-        }
-    }
-
     private getInputKeyDownHandler = (unit: TimeUnit) => (e: React.KeyboardEvent<HTMLInputElement>) => {
         handleKeyEvent(e, {
             [Keys.ARROW_UP]: () => this.incrementTime(unit),
@@ -206,6 +200,12 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 (e.currentTarget as HTMLInputElement).blur();
             },
         });
+    }
+
+    private handleFocus = (e: React.SyntheticEvent<HTMLInputElement>) => {
+        if (this.props.selectAllOnFocus) {
+            (e.currentTarget as HTMLInputElement).select();
+        }
     }
 
     // begin method definitions: state modification

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -204,7 +204,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
 
     private handleFocus = (e: React.SyntheticEvent<HTMLInputElement>) => {
         if (this.props.selectAllOnFocus) {
-            (e.currentTarget as HTMLInputElement).select();
+            e.currentTarget.select();
         }
     }
 

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -37,6 +37,12 @@ export interface ITimePickerProps extends IProps {
     */
     precision?: TimePickerPrecision;
 
+    /**
+     * Whether the inputs should be selected on focus.
+     * @default false
+     */
+    selectOnFocus?: boolean;
+
    /**
     * Whether to show arrows buttons for changing the time.
     * @default false
@@ -61,6 +67,7 @@ export interface ITimePickerState {
 export class TimePicker extends React.Component<ITimePickerProps, ITimePickerState> {
     public static defaultProps: ITimePickerProps = {
         precision: TimePickerPrecision.MINUTE,
+        selectOnFocus: false,
         showArrowButtons: false,
     };
 
@@ -141,6 +148,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 className={classNames(Classes.TIMEPICKER_INPUT, className)}
                 onBlur={this.getInputBlurHandler(unit)}
                 onChange={this.getInputChangeHandler(unit)}
+                onFocus={this.getInputFocusHandler()}
                 onKeyDown={this.getInputKeyDownHandler(unit)}
                 value={value}
             />
@@ -181,6 +189,12 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 case TimeUnit.MS: this.updateState({ millisecondText: text }); break;
                 default: throw Error("Invalid TimeUnit");
             }
+        }
+    }
+
+    private getInputFocusHandler = () => (e: React.SyntheticEvent<HTMLInputElement>) => {
+        if (this.props.selectOnFocus) {
+            (e.currentTarget as HTMLInputElement).select();
         }
     }
 

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -153,6 +153,16 @@ describe("<TimePicker>", () => {
         assert.lengthOf(document.getElementsByClassName(Classes.TIMEPICKER_ARROW_BUTTON), 4);
     });
 
+    it("text is selected on focus when selectOnFocus is true", () => {
+        renderTimePicker({ selectOnFocus: true });
+
+        focusOnInput(Classes.TIMEPICKER_HOUR);
+        assert.equal(window.getSelection().toString(), "0");
+
+        focusOnInput(Classes.TIMEPICKER_MINUTE);
+        assert.equal(window.getSelection().toString(), "00");
+    });
+
     describe("when uncontrolled", () => {
         it("defaultValue sets the initialTime", () => {
             renderTimePicker({
@@ -336,6 +346,10 @@ describe("<TimePicker>", () => {
     function clickDecrementBtn(className: string) {
         const arrowBtns = document.querySelectorAll(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${className}`);
         TestUtils.Simulate.click(arrowBtns[1]);
+    }
+
+    function focusOnInput(className: string) {
+        TestUtils.Simulate.focus(findInputElement(className));
     }
 
     function keyDownOnInput(className: string, key: number) {

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -154,7 +154,7 @@ describe("<TimePicker>", () => {
     });
 
     it("text is selected on focus when selectOnFocus is true", () => {
-        renderTimePicker({ selectOnFocus: true });
+        renderTimePicker({ selectAllOnFocus: true });
 
         focusOnInput(Classes.TIMEPICKER_HOUR);
         assert.equal(window.getSelection().toString(), "0");


### PR DESCRIPTION
#### Fixes #383 

#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Added `selectOnFocus` prop to `TimePicker` component - auto highlights text if enabled, defaults to false.
