### PR TITLE
Improve time picker focus box-shadow

### DIFF
--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -109,7 +109,7 @@ Styleguide components.editable.multiline
   }
 
   &.pt-editable-editing::before {
-    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-focus-box-shadow;
+    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
     background-color: $input-background-color;
   }
 
@@ -129,7 +129,7 @@ Styleguide components.editable.multiline
       }
 
       &.pt-editable-editing::before {
-        box-shadow: input-transition-shadow($color, true), $input-focus-box-shadow;
+        box-shadow: input-transition-shadow($color, true), $input-box-shadow-focus;
       }
     }
   }

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -104,12 +104,12 @@ Styleguide components.editable.multiline
   }
 
   &:hover::before {
-    box-shadow: input-transition-shadow($input-focus-shadow-color),
+    box-shadow: input-transition-shadow($input-shadow-color-focus),
                 inset 0 0 0 1px $pt-divider-black;
   }
 
   &.pt-editable-editing::before {
-    box-shadow: input-transition-shadow($input-focus-shadow-color, true), $input-focus-box-shadow;
+    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-focus-box-shadow;
     background-color: $input-background-color;
   }
 
@@ -136,12 +136,12 @@ Styleguide components.editable.multiline
 
   .pt-dark & {
     &:hover::before {
-      box-shadow: input-transition-shadow($dark-input-focus-shadow-color),
+      box-shadow: input-transition-shadow($dark-input-shadow-color-focus),
                   inset 0 0 0 1px $pt-dark-divider-white;
     }
 
     &.pt-editable-editing::before {
-      box-shadow: input-transition-shadow($dark-input-focus-shadow-color, true),
+      box-shadow: input-transition-shadow($dark-input-shadow-color-focus, true),
                   $pt-dark-input-box-shadow;
       background-color: $dark-input-background-color;
     }

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -13,21 +13,21 @@ $input-font-weight: 400 !default;
 $input-transition: box-shadow $pt-transition-duration $pt-transition-ease;
 
 $input-background-color: $white !default;
-$input-placeholder-color: $pt-text-color-disabled !default;
 $input-background-color-disabled: rgba($light-gray1, 0.5) !default;
-$input-focus-shadow-color: $pt-intent-primary !default;
+$input-placeholder-color: $pt-text-color-disabled !default;
+$input-shadow-color-focus: $pt-intent-primary !default;
 
 $dark-input-background-color: rgba($black, 0.3) !default;
-$dark-input-placeholder-color: $pt-dark-text-color-disabled !default;
 $dark-input-background-color-disabled: rgba($light-gray2, 0.1) !default;
-$dark-input-focus-shadow-color: $pt-intent-primary !default;
+$dark-input-placeholder-color: $pt-dark-text-color-disabled !default;
+$dark-input-shadow-color-focus: $pt-intent-primary !default;
 
 // avoids edge blurriness for light theme focused default input
 // second box-shadow of $pt-input-box-shadow
 $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
 
 // animating shadows requires the same number of shadows in different states
-@function input-transition-shadow($color: $input-focus-shadow-color, $focus: false) {
+@function input-transition-shadow($color: $input-shadow-color-focus, $focus: false) {
   @if $focus {
     @return
       border-shadow(1, $color, 1px),
@@ -39,7 +39,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   }
 }
 
-@function dark-input-transition-shadow($color: $dark-input-focus-shadow-color, $focus: false) {
+@function dark-input-transition-shadow($color: $dark-input-shadow-color-focus, $focus: false) {
   @if $focus {
     @return
       border-shadow(1, $color, 1px),
@@ -57,7 +57,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   outline: none;
   border: none;
   border-radius: $pt-border-radius;
-  box-shadow: input-transition-shadow($input-focus-shadow-color), $pt-input-box-shadow;
+  box-shadow: input-transition-shadow($input-shadow-color-focus), $pt-input-box-shadow;
   background: $input-background-color;
   height: $pt-input-height;
   padding: 0 $input-padding-horizontal;
@@ -76,7 +76,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   }
 
   &:focus {
-    box-shadow: input-transition-shadow($input-focus-shadow-color, true), $input-focus-box-shadow;
+    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-focus-box-shadow;
   }
 
   &:disabled,
@@ -113,7 +113,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
 }
 
 @mixin pt-dark-input() {
-  box-shadow: dark-input-transition-shadow($dark-input-focus-shadow-color),
+  box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus),
               $pt-dark-input-box-shadow;
   background: $dark-input-background-color;
   color: $pt-dark-text-color;
@@ -123,7 +123,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   }
 
   &:focus {
-    box-shadow: dark-input-transition-shadow($dark-input-focus-shadow-color, true),
+    box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true),
                 $pt-dark-input-box-shadow;
   }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -24,7 +24,7 @@ $dark-input-shadow-color-focus: $pt-intent-primary !default;
 
 // avoids edge blurriness for light theme focused default input
 // second box-shadow of $pt-input-box-shadow
-$input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
+$input-box-shadow-focus: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
 
 // animating shadows requires the same number of shadows in different states
 @function input-transition-shadow($color: $input-shadow-color-focus, $focus: false) {
@@ -76,7 +76,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   }
 
   &:focus {
-    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-focus-box-shadow;
+    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
   }
 
   &:disabled,
@@ -146,7 +146,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
 
   &:focus {
     box-shadow: input-transition-shadow($color, true),
-                $input-focus-box-shadow;
+                $input-box-shadow-focus;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -10,6 +10,7 @@
 
 $input-padding-horizontal: $pt-grid-size !default;
 $input-font-weight: 400 !default;
+$input-transition: box-shadow $pt-transition-duration $pt-transition-ease;
 
 $input-background-color: $white !default;
 $input-placeholder-color: $pt-text-color-disabled !default;
@@ -66,7 +67,7 @@ $input-focus-box-shadow: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
   font-family: $pt-font-family;
   font-size: $pt-font-size;
   font-weight: $input-font-weight;
-  transition: box-shadow $pt-transition-duration $pt-transition-ease;
+  transition: $input-transition;
 
   @include placeholder {
     // normalize.css sets an opacity less than 1, we don't want this

--- a/packages/datetime/examples/timePickerExample.tsx
+++ b/packages/datetime/examples/timePickerExample.tsx
@@ -32,7 +32,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
         return [
             [
                 <label className={Classes.LABEL} key="precision">
-                    TimePicker precision
+                    Time picker precision
                     <div className={Classes.SELECT}>
                         <select
                             value={this.state.precision.toString()}

--- a/packages/datetime/examples/timePickerExample.tsx
+++ b/packages/datetime/examples/timePickerExample.tsx
@@ -32,7 +32,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
         return [
             [
                 <label className={Classes.LABEL} key="precision">
-                    Time picker precision
+                    Precision
                     <div className={Classes.SELECT}>
                         <select
                             value={this.state.precision.toString()}

--- a/packages/datetime/src/_dateinput.scss
+++ b/packages/datetime/src/_dateinput.scss
@@ -28,7 +28,7 @@ Styleguide components.datetime.dateinput
 JavaScript API
 
 The `DateInput` component is available in the __@blueprintjs/datetime__ package.
-Make sure to review the [general usage docs for DateTime components](#components.datetime).
+Make sure to review the [general usage docs for date & time components](#components.datetime).
 
 ```
 import { DateInput } from "@blueprintjs/datetime";

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -35,7 +35,7 @@ Styleguide components.datetime.datepicker
 JavaScript API
 
 The `DatePicker` component is available in the __@blueprintjs/datetime__ package.
-Make sure to review the [general usage docs for DateTime components](#components.datetime).
+Make sure to review the [general usage docs for date & time components](#components.datetime).
 
 Some props are managed by the Blueprint `DatePicker` component, while others are passed
 to the **react-day-picker** library. These passed props are documented in full

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -31,7 +31,7 @@ Styleguide components.datetime.daterangepicker
 JavaScript API
 
 The `DateRangePicker` component is available in the __@blueprintjs/datetime__ package.
-Make sure to review the [general usage docs for DateTime components](#components.datetime).
+Make sure to review the [general usage docs for date & time components](#components.datetime).
 
 ```
 import { DateRangePicker } from "@blueprintjs/datetime";

--- a/packages/datetime/src/_datetimepicker.scss
+++ b/packages/datetime/src/_datetimepicker.scss
@@ -30,7 +30,7 @@ Styleguide components.datetime.datetimepicker
 JavaScript API
 
 The `DateTimePicker` component is available in the __@blueprintjs/datetime__ package.
-Make sure to review the [general usage docs for DateTime components](#components.datetime).
+Make sure to review the [general usage docs for date & time components](#components.datetime).
 
 ```
 import { DateTimePicker } from "@blueprintjs/datetime";

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -95,7 +95,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     outline: 0;
     border: 0;
     border-radius: $pt-border-radius;
-    box-shadow: input-transition-shadow($input-focus-shadow-color);
+    box-shadow: input-transition-shadow($input-shadow-color-focus);
     background: transparent;
     width: $timepicker-control-width;
     height: $timepicker-input-row-inner-height;
@@ -105,7 +105,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     transition: $input-transition;
 
     &:focus {
-      box-shadow: input-transition-shadow($input-focus-shadow-color, true);
+      box-shadow: input-transition-shadow($input-shadow-color-focus, true);
     }
   }
 }

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -4,6 +4,7 @@
 // and https://github.com/palantir/blueprint/blob/master/PATENTS
 
 @import "../../core/src/common/variables";
+@import "../../core/src/components/forms/common";
 
 /*
 Time picker
@@ -30,7 +31,7 @@ Styleguide components.datetime.timepicker
 JavaScript API
 
 The `TimePicker` component is available in the __@blueprintjs/datetime__ package.
-Make sure to review the [general usage docs for DateTime components](#components.datetime).
+Make sure to review the [general usage docs for date & time components](#components.datetime).
 
 @interface ITimePickerProps
 
@@ -58,6 +59,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
   .pt-timepicker-arrow-button {
     @include pt-icon-colors();
+
     width: $timepicker-control-width;
     padding: ($pt-grid-size * 0.4) 0;
     text-align: center;
@@ -75,7 +77,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     display: inline-block;
     border-radius: $pt-border-radius;
     box-shadow: $pt-input-box-shadow;
-    background: $white;
+    background: $input-background-color;
     height: $timepicker-input-row-height;
     padding: $timepicker-row-padding;
     line-height: $timepicker-input-row-inner-height;
@@ -93,31 +95,25 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     outline: 0;
     border: 0;
     border-radius: $pt-border-radius;
+    box-shadow: input-transition-shadow($input-focus-shadow-color);
     background: transparent;
     width: $timepicker-control-width;
     height: $timepicker-input-row-inner-height;
     padding: 0;
     text-align: center;
     color: $pt-text-color;
+    transition: $input-transition;
 
     &:focus {
-      box-shadow: border-shadow(1, $blue3, 2px);
+      box-shadow: input-transition-shadow($input-focus-shadow-color, true);
     }
   }
 }
 
 .pt-dark .pt-timepicker {
-  .pt-timepicker-arrow-button {
-    color: $gray2;
-
-    &:hover {
-      color: $gray5;
-    }
-  }
-
   .pt-timepicker-input-row {
     box-shadow: $pt-dark-input-box-shadow;
-    background: rgba($black, 0.3);
+    background: $dark-input-background-color;
   }
 
   .pt-timepicker-divider-text {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -427,12 +427,12 @@ function createDefaultShortcuts() {
     const twoYearsAgo = makeDate((d) => d.setFullYear(d.getFullYear() - 2));
 
     return [
-        createShortcut("Past Week", [oneWeekAgo, today]),
-        createShortcut("Past Month", [oneMonthAgo, today]),
-        createShortcut("Past 3 Months", [threeMonthsAgo, today]),
-        createShortcut("Past 6 Months", [sixMonthsAgo, today]),
-        createShortcut("Past Year", [oneYearAgo, today]),
-        createShortcut("Past 2 Years", [twoYearsAgo, today]),
+        createShortcut("Past week", [oneWeekAgo, today]),
+        createShortcut("Past month", [oneMonthAgo, today]),
+        createShortcut("Past 3 months", [threeMonthsAgo, today]),
+        createShortcut("Past 6 months", [sixMonthsAgo, today]),
+        createShortcut("Past year", [oneYearAgo, today]),
+        createShortcut("Past 2 years", [twoYearsAgo, today]),
     ];
 }
 


### PR DESCRIPTION
Noticed that time picker still had custom shadows. Making it consistent with already available APIs.

Before:
![image](https://cloud.githubusercontent.com/assets/199754/21827157/41a4ef30-d73f-11e6-936a-525bbf743dd6.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/21827143/306ca73a-d73f-11e6-9395-d3f11a009220.png)
