### PR TITLE
run NPM gulp build task which sets NODE_ENV

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
   # so these following commands will block the build and prevent tests
   post:
     - lerna bootstrap
-    - gulp build
+    - npm run build:gulp
 test:
   override:
     - gulp check


### PR DESCRIPTION
#### Fixes #451

#### Changes proposed in this pull request:

- run NPM `build:gulp` task instead of `gulp build` because the npm task sets NODE_ENV directly
- so external contributors don't have to set the environment variable manually on circle.
- verified in #349 but pulled out here as separate PR