### PR TITLE
eliminate innerHTML

### DIFF
--- a/packages/datetime/src/common/utils.ts
+++ b/packages/datetime/src/common/utils.ts
@@ -12,7 +12,7 @@
 export function measureTextWidth(text: string, className = "", containerElement = document.body) {
     const span = document.createElement("span");
     span.classList.add(className);
-    span.innerHTML = text;
+    span.textContent = text;
 
     containerElement.appendChild(span);
     const spanWidth = span.offsetWidth;


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Changing `innerHTML` to `textContent` provides stronger protections against XSS as what's being inserted here is supposed to be text and not html.

#### Reviewers should focus on:

- The intention of the span's content being text vs html.