### PR TITLE
Consistent space and enter keystrokes between buttons and anchor buttons

### DIFF
--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -77,6 +77,17 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                 />
             </div>
             <div className="docs-react-example-column">
+                <code>AnchorButton without href</code><br/><br/>
+                <AnchorButton
+                    {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS, true)}
+                    className={classes}
+                    iconName="duplicate"
+                    intent={this.state.intent}
+                    onClick={this.beginWiggling}
+                    text="wiggle other button"
+                />
+            </div>
+            <div className="docs-react-example-column">
                 <code>AnchorButton</code><br/><br/>
                 <AnchorButton
                     {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS, true)}

--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -19,9 +19,10 @@ export interface IButtonsExampleState {
     large?: boolean;
     minimal?: boolean;
     wiggling?: boolean;
+    wigglingAnchor?: boolean;
 }
 
-const INVALID_HTML_PROPS = ["large", "minimal", "wiggling"];
+const INVALID_HTML_PROPS = ["large", "minimal", "wiggling", "wigglingAnchor"];
 
 export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     public state: IButtonsExampleState = {
@@ -29,6 +30,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         large: false,
         minimal: false,
         wiggling: false,
+        wigglingAnchor: false,
     };
 
     private handleDisabledChange = handleBooleanChange((disabled) => this.setState({ disabled }));
@@ -37,6 +39,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     private handleIntentChange = handleNumberChange((intent: Intent) => this.setState({ intent }));
 
     private timeoutId: number;
+    private timeoutIdAnchor: number;
 
     protected renderExample() {
         const classes = classNames({
@@ -58,6 +61,17 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
             </div>
             <div className="docs-react-example-column">
                 <code>AnchorButton</code><br/><br/>
+                <AnchorButton
+                    {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS)}
+                    className={classNames(classes, { "docs-wiggle": this.state.wigglingAnchor })}
+                    iconName="refresh"
+                    intent={this.state.intent}
+                    onClick={this.beginWigglingAnchor}
+                    text="Click to wiggle"
+                />
+            </div>
+            <div className="docs-react-example-column">
+                <code>AnchorButton with href</code><br/><br/>
                 <AnchorButton
                     {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS)}
                     className={classes}
@@ -104,5 +118,11 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         clearTimeout(this.timeoutId);
         this.setState({ wiggling: true });
         this.timeoutId = setTimeout(() => this.setState({ wiggling: false }), 300);
+    }
+
+    private beginWigglingAnchor = () => {
+        clearTimeout(this.timeoutIdAnchor);
+        this.setState({ wigglingAnchor: true });
+        this.timeoutIdAnchor = setTimeout(() => this.setState({ wigglingAnchor: false }), 300);
     }
 }

--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -77,17 +77,6 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                 />
             </div>
             <div className="docs-react-example-column">
-                <code>AnchorButton without href</code><br/><br/>
-                <AnchorButton
-                    {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS, true)}
-                    className={classes}
-                    iconName="duplicate"
-                    intent={this.state.intent}
-                    onClick={this.beginWiggling}
-                    text="wiggle other button"
-                />
-            </div>
-            <div className="docs-react-example-column">
                 <code>AnchorButton</code><br/><br/>
                 <AnchorButton
                     {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS, true)}

--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -19,10 +19,9 @@ export interface IButtonsExampleState {
     large?: boolean;
     minimal?: boolean;
     wiggling?: boolean;
-    wigglingAnchor?: boolean;
 }
 
-const INVALID_HTML_PROPS = ["large", "minimal", "wiggling", "wigglingAnchor"];
+const INVALID_HTML_PROPS = ["large", "minimal", "wiggling"];
 
 export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     public state: IButtonsExampleState = {
@@ -30,7 +29,6 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         large: false,
         minimal: false,
         wiggling: false,
-        wigglingAnchor: false,
     };
 
     private handleDisabledChange = handleBooleanChange((disabled) => this.setState({ disabled }));
@@ -61,17 +59,6 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
             </div>
             <div className="docs-react-example-column">
                 <code>AnchorButton</code><br/><br/>
-                <AnchorButton
-                    {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS)}
-                    className={classNames(classes, { "docs-wiggle": this.state.wigglingAnchor })}
-                    iconName="refresh"
-                    intent={this.state.intent}
-                    onClick={this.beginWigglingAnchor}
-                    text="Click to wiggle"
-                />
-            </div>
-            <div className="docs-react-example-column">
-                <code>AnchorButton with href</code><br/><br/>
                 <AnchorButton
                     {...removeNonHTMLProps(this.state, INVALID_HTML_PROPS)}
                     className={classes}
@@ -118,11 +105,5 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         clearTimeout(this.timeoutId);
         this.setState({ wiggling: true });
         this.timeoutId = setTimeout(() => this.setState({ wiggling: false }), 300);
-    }
-
-    private beginWigglingAnchor = () => {
-        clearTimeout(this.timeoutIdAnchor);
-        this.setState({ wigglingAnchor: true });
-        this.timeoutIdAnchor = setTimeout(() => this.setState({ wigglingAnchor: false }), 300);
     }
 }

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import * as Keys from "../../common/keys";
+import { IActionProps } from "../../common/props";
+import { safeInvoke } from "../../common/utils";
+
+export interface IButtonProps extends IActionProps {
+    /** A ref handler that receives the native HTML element backing this component. */
+    elementRef?: (ref: HTMLElement) => any;
+
+    /** Name of icon (the part after `pt-icon-`) to add to button. */
+    rightIconName?: string;
+
+    /**
+     * If set to true, the button will display a centered loading spinner instead of its contents.
+     * The width of the button is not affected by the value of this prop.
+     * @default false
+     */
+    loading?: boolean;
+}
+
+export interface IButtonState {
+    isActive: boolean;
+}
+
+export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<T> & IButtonProps, IButtonState> {
+    public state = {
+        isActive: false,
+    };
+
+    protected buttonRef: HTMLElement;
+    protected refHandlers = {
+        button: (ref: HTMLElement) => {
+            this.buttonRef = ref;
+            safeInvoke(this.props.elementRef, ref);
+        },
+    };
+
+    public abstract render(): JSX.Element;
+
+    protected onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+        switch (e.which) {
+            case Keys.SPACE:
+                e.preventDefault();
+                this.setState({ isActive: true });
+                break;
+            case Keys.ENTER:
+                this.buttonRef.click();
+                break;
+            default:
+                break;
+        }
+    }
+
+    protected onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
+        if (e.which === Keys.SPACE) {
+            this.setState({ isActive: false });
+            this.buttonRef.click();
+        }
+    }
+}

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -57,7 +57,8 @@ export class Button extends React.Component<React.HTMLProps<HTMLButtonElement> &
 
 export const ButtonFactory = React.createFactory(Button);
 
-export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElement> & IButtonProps, { isActive: boolean }> {
+export class AnchorButton extends
+        React.Component<React.HTMLProps<HTMLAnchorElement> & IButtonProps, { isActive: boolean }> {
     public static displayName = "Blueprint.AnchorButton";
 
     public state = {
@@ -88,6 +89,7 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
         );
     }
 
+    // Provide consistent keyboard interactions across both <Button /> and <AnchorButton /> (#430)
     private onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
         const { href, onClick, target } = this.props;
         if (e.which === Keys.SPACE) {

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -46,8 +46,12 @@ export class Button extends React.Component<React.HTMLProps<HTMLButtonElement> &
 
 export const ButtonFactory = React.createFactory(Button);
 
-export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElement> & IButtonProps, {}> {
+export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElement> & IButtonProps, { isActive: boolean }> {
     public static displayName = "Blueprint.AnchorButton";
+
+    public state = {
+        isActive: false,
+    };
 
     public render() {
         const { children, disabled, elementRef, href, onClick, rightIconName, tabIndex = 0, text } = this.props;
@@ -55,7 +59,7 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
             <a
                 role="button"
                 {...removeNonHTMLProps(this.props)}
-                className={getButtonClasses(this.props)}
+                className={getButtonClasses(this.props, this.state.isActive)}
                 href={disabled ? undefined : href}
                 onClick={disabled ? undefined : onClick}
                 onKeyDown={this.onKeyDown}
@@ -75,6 +79,8 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
         if (e.which === Keys.SPACE) {
             e.preventDefault();
 
+            this.setState({isActive: true});
+
             if (href) {
                 if (target === undefined || target === "_self") {
                     window.open(href);
@@ -90,18 +96,25 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
     }
 
     private onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
-        if (e.which === Keys.SPACE && this.props.onClick) {
-            this.props.onClick(e as any);
+        if (e.which === Keys.SPACE) {
+            this.setState({isActive: false});
+
+            if (this.props.onClick) {
+                this.props.onClick(e as any);
+            }
         }
     }
 }
 
 export const AnchorButtonFactory = React.createFactory(AnchorButton);
 
-function getButtonClasses(props: IButtonProps) {
+function getButtonClasses(props: IButtonProps, isActive: boolean = false ) {
     return classNames(
         Classes.BUTTON,
-        { [Classes.DISABLED]: props.disabled },
+        {
+            [Classes.DISABLED]: props.disabled,
+            [Classes.ACTIVE]: isActive,
+        },
         Classes.iconClass(props.iconName),
         Classes.intentClass(props.intent),
         props.className,

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -12,6 +12,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
+import * as Keys from "../../common/keys";
 import { IActionProps, removeNonHTMLProps } from "../../common/props";
 
 export interface IButtonProps extends IActionProps {
@@ -49,7 +50,7 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
     public static displayName = "Blueprint.AnchorButton";
 
     public render() {
-        const { children, disabled, href, onClick, rightIconName, tabIndex = 0, text } = this.props;
+        const { children, disabled, elementRef, href, onClick, rightIconName, tabIndex = 0, text } = this.props;
         return (
             <a
                 role="button"
@@ -57,7 +58,9 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
                 className={getButtonClasses(this.props)}
                 href={disabled ? undefined : href}
                 onClick={disabled ? undefined : onClick}
-                ref={this.props.elementRef}
+                onKeyDown={this.onKeyDown}
+                onKeyUp={this.onKeyUp}
+                ref={elementRef}
                 tabIndex={disabled ? undefined : tabIndex}
             >
                 {text}
@@ -65,6 +68,31 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
                 {maybeRenderRightIcon(rightIconName)}
             </a>
         );
+    }
+
+    private onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+        const { href, onClick, target } = this.props;
+        if (e.which === Keys.SPACE) {
+            e.preventDefault();
+
+            if (href) {
+                if (target === undefined || target === "_self") {
+                    window.open(href);
+                } else if (target === "_blank") {
+                    window.open(href, "_newtab");
+                }
+            }
+        }
+
+        if (e.which === Keys.ENTER && this.props.onClick) {
+            onClick(e as any);
+        }
+    }
+
+    private onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
+        if (e.which === Keys.SPACE && this.props.onClick) {
+            this.props.onClick(e as any);
+        }
     }
 }
 

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -12,68 +12,11 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import * as Keys from "../../common/keys";
-import { IActionProps, removeNonHTMLProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
+import { removeNonHTMLProps } from "../../common/props";
 import { Spinner } from "../spinner/spinner";
+import { AbstractButton, IButtonProps } from "./abstractButton";
 
-export interface IButtonProps extends IActionProps {
-    /** A ref handler that receives the native HTML element backing this component. */
-    elementRef?: (ref: HTMLElement) => any;
-
-    /** Name of icon (the part after `pt-icon-`) to add to button. */
-    rightIconName?: string;
-
-    /**
-     * If set to true, the button will display a centered loading spinner instead of its contents.
-     * The width of the button is not affected by the value of this prop.
-     * @default false
-     */
-    loading?: boolean;
-}
-
-export interface IButtonState {
-    isActive: boolean;
-}
-
-export abstract class BaseButton<T> extends React.Component<React.HTMLProps<T> & IButtonProps, IButtonState> {
-    public state = {
-        isActive: false,
-    };
-
-    protected buttonRef: HTMLElement;
-    protected refHandlers = {
-        button: (ref: HTMLElement) => {
-            this.buttonRef = ref;
-            safeInvoke(this.props.elementRef, ref);
-        },
-    };
-
-    public abstract render(): JSX.Element;
-
-    protected onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-        switch (e.which) {
-            case Keys.SPACE:
-                e.preventDefault();
-                this.setState({ isActive: true });
-                break;
-            case Keys.ENTER:
-                this.buttonRef.click();
-                break;
-            default:
-                break;
-        }
-    }
-
-    protected onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
-        if (e.which === Keys.SPACE) {
-            this.setState({ isActive: false });
-            this.buttonRef.click();
-        }
-    }
-}
-
-export class Button extends BaseButton<HTMLButtonElement> {
+export class Button extends AbstractButton<HTMLButtonElement> {
     public static displayName = "Blueprint.Button";
 
     public render() {
@@ -101,7 +44,7 @@ export class Button extends BaseButton<HTMLButtonElement> {
 
 export const ButtonFactory = React.createFactory(Button);
 
-export class AnchorButton extends BaseButton<HTMLButtonElement> {
+export class AnchorButton extends AbstractButton<HTMLButtonElement> {
     public static displayName = "Blueprint.AnchorButton";
 
     public render() {
@@ -131,7 +74,7 @@ export class AnchorButton extends BaseButton<HTMLButtonElement> {
 
 export const AnchorButtonFactory = React.createFactory(AnchorButton);
 
-function getButtonClasses(props: IButtonProps, isActive: boolean = false) {
+function getButtonClasses(props: IButtonProps, isActive = false) {
     return classNames(
         Classes.BUTTON, {
             [Classes.ACTIVE]: isActive,

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -79,14 +79,14 @@ export class AnchorButton extends React.Component<React.HTMLProps<HTMLAnchorElem
         if (e.which === Keys.SPACE) {
             e.preventDefault();
 
-            this.setState({isActive: true});
-
             if (href) {
                 if (target === undefined || target === "_self") {
                     window.open(href);
                 } else if (target === "_blank") {
                     window.open(href, "_newtab");
                 }
+            } else {
+                this.setState({isActive: true});
             }
         }
 

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -9,51 +9,69 @@ import { assert } from "chai";
 import { mount, shallow } from "enzyme";
 import * as React from "react";
 
+import * as Keys from "../../src/common/keys";
 import { AnchorButton, Button, Classes, IButtonProps } from "../../src/index";
 
 describe("Buttons:", () => {
     buttonTestSuite(Button, "button");
-    buttonTestSuite(AnchorButton, "a");
+    buttonTestSuite(AnchorButton, "a", () => {
+        it("calls onClick when enter key pressed", () => {
+            const onClick = sinon.spy();
+            button(AnchorButton, { onClick }).simulate("keydown", { which: Keys.ENTER });
+            assert.equal(onClick.callCount, 1);
+        });
+
+        it("calls onClick when space key released", () => {
+            const onClick = sinon.spy();
+            button(AnchorButton, { onClick })
+                .simulate("keyup", { which: Keys.SPACE });;
+            assert.equal(onClick.callCount, 1);
+        });
+    });
 });
 
-function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) {
+function buttonTestSuite(component: React.ComponentClass<any>, tagName: string, moreTests?: () => void) {
     describe(`<${component.displayName.split(".")[1]}>`, () => {
         it("renders its contents", () => {
-            const wrapper = button({ className: "foo" });
+            const wrapper = button(component, { className: "foo" });
             assert.isTrue(wrapper.is(tagName));
             assert.isTrue(wrapper.hasClass(Classes.BUTTON));
             assert.isTrue(wrapper.hasClass("foo"));
         });
 
         it("iconName=\"style\" gets icon class", () => {
-            const wrapper = button({ iconName: "style" });
+            const wrapper = button(component, { iconName: "style" });
             assert.isTrue(wrapper.hasClass(Classes.iconClass("style")));
         });
 
         it("clicking button triggers onClick prop", () => {
             const onClick = sinon.spy();
-            button({ onClick }).simulate("click");
+            button(component, { onClick }).simulate("click");
             assert.equal(onClick.callCount, 1);
         });
 
         it("clicking disabled button does not trigger onClick prop", () => {
             const onClick = sinon.spy();
             // full DOM mount so `button` element will ignore click
-            button({ disabled: true, onClick }, true).simulate("click");
+            button(component, { disabled: true, onClick }, true).simulate("click");
             assert.equal(onClick.callCount, 0);
         });
 
         it("elementRef receives reference to HTML element", () => {
             const elementRef = sinon.spy();
             // full DOM rendering here so the ref handler is invoked
-            button({ elementRef }, true);
+            button(component, { elementRef }, true);
             assert.isTrue(elementRef.calledOnce);
             assert.instanceOf(elementRef.args[0][0], HTMLElement);
         });
 
-        function button(props: IButtonProps, useMount = false) {
-            const element = React.createElement(component, props);
-            return useMount ? mount(element) : shallow(element);
+        if (moreTests != null) {
+            moreTests();
         }
     });
+}
+
+function button(component: React.ComponentClass<any>, props: IButtonProps, useMount = false) {
+    const element = React.createElement(component, props);
+    return useMount ? mount(element) : shallow(element);
 }

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -14,78 +14,75 @@ import { AnchorButton, Button, Classes, IButtonProps, Spinner } from "../../src/
 
 describe("Buttons:", () => {
     buttonTestSuite(Button, "button");
-    buttonTestSuite(AnchorButton, "a", () => {
-        it("calls onClick when enter key pressed", () => {
-            const onClick = sinon.spy();
-            button(AnchorButton, { onClick }).simulate("keydown", { which: Keys.ENTER });
-            assert.equal(onClick.callCount, 1);
-        });
-
-        it("calls onClick when space key released", () => {
-            const onClick = sinon.spy();
-            button(AnchorButton, { onClick }).simulate("keyup", { which: Keys.SPACE });
-            assert.equal(onClick.callCount, 1);
-        });
-    });
+    buttonTestSuite(AnchorButton, "a");
 });
 
-function buttonTestSuite(component: React.ComponentClass<any>, tagName: string, moreTests?: () => void) {
+function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) {
     describe(`<${component.displayName.split(".")[1]}>`, () => {
         it("renders its contents", () => {
-            const wrapper = button(component, { className: "foo" });
+            const wrapper = button({ className: "foo" });
             assert.isTrue(wrapper.is(tagName));
             assert.isTrue(wrapper.hasClass(Classes.BUTTON));
             assert.isTrue(wrapper.hasClass("foo"));
         });
 
         it("iconName=\"style\" gets icon class", () => {
-            const wrapper = button(component, { iconName: "style" });
+            const wrapper = button({ iconName: "style" });
             assert.isTrue(wrapper.hasClass(Classes.iconClass("style")));
         });
 
         it("renders the button text prop", () => {
-            const wrapper = button(component, { text: "some text" }, true);
+            const wrapper = button({ text: "some text" }, true);
             assert.equal(wrapper.text(), "some text");
         });
 
         it("renders a loading spinner when the loading prop is true", () => {
-            const wrapper = button(component, { loading: true });
+            const wrapper = button({ loading: true });
             assert.lengthOf(wrapper.find(Spinner), 1);
         });
 
         it("button is disabled when the loading prop is true", () => {
-            const wrapper = button(component, { loading: true });
+            const wrapper = button({ loading: true });
             assert.isTrue(wrapper.hasClass(Classes.DISABLED));
         });
 
         it("clicking button triggers onClick prop", () => {
             const onClick = sinon.spy();
-            button(component, { onClick }).simulate("click");
+            button({ onClick }).simulate("click");
             assert.equal(onClick.callCount, 1);
         });
 
         it("clicking disabled button does not trigger onClick prop", () => {
             const onClick = sinon.spy();
             // full DOM mount so `button` element will ignore click
-            button(component, { disabled: true, onClick }, true).simulate("click");
+            button({ disabled: true, onClick }, true).simulate("click");
             assert.equal(onClick.callCount, 0);
+        });
+
+        it("calls onClick when enter key pressed", () => {
+            const onClick = sinon.spy();
+            button({ onClick }, true).simulate("keydown", { which: Keys.ENTER });
+            // wait for the whole lifecycle to run
+            setTimeout(() => assert.equal(onClick.callCount, 1), 0);
+        });
+
+        it("calls onClick when space key released", () => {
+            const onClick = sinon.spy();
+            button({ onClick }, true).simulate("keyup", { which: Keys.SPACE });
+            setTimeout(() => assert.equal(onClick.callCount, 1), 0);
         });
 
         it("elementRef receives reference to HTML element", () => {
             const elementRef = sinon.spy();
             // full DOM rendering here so the ref handler is invoked
-            button(component, { elementRef }, true);
+            button({ elementRef }, true);
             assert.isTrue(elementRef.calledOnce);
             assert.instanceOf(elementRef.args[0][0], HTMLElement);
         });
 
-        if (moreTests != null) {
-            moreTests();
+        function button(props: IButtonProps, useMount = false) {
+            const element = React.createElement(component, props);
+            return useMount ? mount(element) : shallow(element);
         }
     });
-}
-
-function button(component: React.ComponentClass<any>, props: IButtonProps, useMount = false) {
-    const element = React.createElement(component, props);
-    return useMount ? mount(element) : shallow(element);
 }

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -23,8 +23,7 @@ describe("Buttons:", () => {
 
         it("calls onClick when space key released", () => {
             const onClick = sinon.spy();
-            button(AnchorButton, { onClick })
-                .simulate("keyup", { which: Keys.SPACE });;
+            button(AnchorButton, { onClick }).simulate("keyup", { which: Keys.SPACE });
             assert.equal(onClick.callCount, 1);
         });
     });


### PR DESCRIPTION
#### Fixes #430 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Provide consistency in `SPACE` and `ENTER` keyboard Interactions between `<Button />` and `<AnchorButton />` with a base `AbstractButton`
- Manually tested across Chrome v55.0, Firefox v50.1, Safari 10.0, IE11, Edge
- NB. Interactions were already standardized across all browsers for `<button/>`

![wiggle2](https://cloud.githubusercontent.com/assets/6375593/21904609/234862ee-d8b9-11e6-9f5e-061518122866.gif)

#### Reviewers should focus on:

- Any edge cases I'm missing here?
- Leaving out splitting `buttons.tsx` into two files and moving helper functions into `AbstractButton` for another PR
