### PR TITLE
Overwrite dialog z-index in docs css api section

### DIFF
--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -260,6 +260,7 @@
   .pt-dialog {
     top: $content-padding;
     transform: translateX(50%);
+    z-index: inherit;
   }
 }
 

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -260,7 +260,7 @@
   .pt-dialog {
     top: $content-padding;
     transform: translateX(50%);
-    z-index: inherit;
+    z-index: $pt-z-index-base;
   }
 }
 


### PR DESCRIPTION
#### Fixes #450 

#### Reviewers should focus on:

Dialog in the CSS API section of the docs doesn't go above the top nav bar anymore when scrolling.