### PR TITLE
[WIP] Date range input

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import BaseExample from "@blueprintjs/core/examples/common/baseExample";
+import * as React from "react";
+
+import { DateRangeInput } from "../src";
+
+export class DateRangeInputExample extends BaseExample<{}> {
+    protected renderExample() {
+        return (
+            <DateRangeInput />
+        );
+    }
+}

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -13,7 +13,7 @@ import { DateRangeInput } from "../src";
 export class DateRangeInputExample extends BaseExample<{}> {
     protected renderExample() {
         return (
-            <DateRangeInput />
+            <DateRangeInput format={"MM/DD/YYYY"} />
         );
     }
 }

--- a/packages/datetime/examples/index.ts
+++ b/packages/datetime/examples/index.ts
@@ -7,6 +7,7 @@
 
 export * from "./dateInputExample";
 export * from "./datePickerExample";
+export * from "./dateRangeInputExample";
 export * from "./dateRangePickerExample";
 export * from "./dateTimePickerExample";
 export * from "./timePickerExample";

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -1,0 +1,18 @@
+// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+// of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+// and https://github.com/palantir/blueprint/blob/master/PATENTS
+
+@import "../../core/src/common/variables";
+
+/*
+Date range input
+
+@react-example DateRangeInputExample
+
+Styleguide components.datetime.daterangeinput
+*/
+
+.pt-daterangeinput {
+  width: 22 * $pt-grid-size;
+}

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -13,6 +13,10 @@ Date range input
 Styleguide components.datetime.daterangeinput
 */
 
+.pt-daterangeinput-popover {
+  padding: 0;
+}
+
 .pt-daterangeinput {
   width: 22 * $pt-grid-size;
 }

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -18,5 +18,5 @@ Styleguide components.datetime.daterangeinput
 }
 
 .pt-daterangeinput {
-  width: 22 * $pt-grid-size;
+  width: 25 * $pt-grid-size;
 }

--- a/packages/datetime/src/blueprint-datetime.scss
+++ b/packages/datetime/src/blueprint-datetime.scss
@@ -46,3 +46,4 @@ Styleguide components.datetime
 @import "timepicker";
 @import "datetimepicker";
 @import "dateinput";
+@import "daterangeinput";

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -25,7 +25,7 @@ import {
     getDefaultMinDate,
     IDatePickerBaseProps,
 } from "./datePickerCore";
-import { DateRangePicker } from "./dateRangePicker";
+import { DateRangePicker, IDateRangeShortcut } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     /**
@@ -102,7 +102,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
      * If an array, the custom shortcuts provided will be displayed.
      * @default true
      */
-    // shortcuts?: boolean | IDateRangeShortcut[];
+    shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
      * The currently selected DateRange.
@@ -157,6 +157,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             <DateRangePicker
                 allowSingleDayRange={this.props.allowSingleDayRange}
                 onChange={this.handleDateRangeChange}
+                shortcuts={this.props.shortcuts}
                 value={this.state.value}
             />
         );

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -5,6 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as moment from "moment";
 import * as React from "react";
 
 import {
@@ -111,10 +112,10 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 }
 
 export interface IDateRangeInputState {
-    value?: DateRange;
-    valueString?: string;
     isInputFocused?: boolean;
     isOpen?: boolean;
+    value?: DateRange;
+    valueString?: string;
 }
 
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
@@ -132,9 +133,25 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     public displayName = "Blueprint.DateRangeInput";
 
+    public constructor(props: IDateRangeInputProps, context?: any) {
+        super(props, context);
+
+        this.state = {
+            isInputFocused: false,
+            isOpen: false,
+            value: null,
+            valueString: null,
+        };
+    }
+
     public render() {
+        const { format } = this.props;
+        const dateRangeString = this.getDateRangeString(this.state.value);
+
         const popoverContent = (
-            <DateRangePicker />
+            <DateRangePicker
+                onChange={this.handleDateRangeChange}
+            />
         );
 
         const calendarIcon = (
@@ -161,12 +178,49 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     disabled={this.props.disabled}
                     type="text"
                     onChange={this.onChange}
-                    placeholder={this.props.format}
+                    placeholder={`${format} - ${format}`}
                     rightElement={calendarIcon}
-                    value={"01/17/2017 to 02/04/2017"}
+                    value={dateRangeString}
                 />
             </Popover>
         );
+    }
+
+    private getDateRangeString = (value: DateRange) => {
+        if (value == null) {
+            return "";
+        }
+
+        const startDate = value[0];
+        const endDate = value[1];
+
+        const startDateFormatted = this.formatDate(startDate);
+        const endDateFormatted = this.formatDate(endDate);
+
+        let dateRangeString: string;
+
+        if (startDate != null && endDate != null) {
+            dateRangeString = `${startDateFormatted} - ${endDateFormatted}`;
+        } else if (startDate != null) {
+            dateRangeString = `${startDateFormatted} - `;
+        } else if (endDate != null) {
+            dateRangeString = ` - ${endDateFormatted}`;
+        } else {
+            dateRangeString = "";
+        }
+
+        return dateRangeString;
+    }
+
+    private formatDate = (date: Date) => {
+        if (date == null) {
+            return "";
+        }
+        return moment(date).format(this.props.format);
+    }
+
+    private handleDateRangeChange = (dateRange: DateRange) => {
+        this.setState({ value: dateRange });
     }
 
     private handleClosePopover = () => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -14,6 +14,7 @@ import {
     InputGroup,
     Intent,
     IProps,
+    Popover,
     Position,
 } from "@blueprintjs/core";
 
@@ -23,6 +24,7 @@ import {
     getDefaultMinDate,
     IDatePickerBaseProps,
 } from "./datePickerCore";
+import { DateRangePicker } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     /**
@@ -125,12 +127,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         minDate: getDefaultMinDate(),
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
-        popoverPosition: Position.BOTTOM,
+        popoverPosition: Position.BOTTOM_LEFT,
     };
 
     public displayName = "Blueprint.DateRangeInput";
 
     public render() {
+        const popoverContent = (
+            <DateRangePicker />
+        );
+
         const calendarIcon = (
             <Button
                 className={Classes.MINIMAL}
@@ -141,16 +147,30 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         );
 
         return (
-            <InputGroup
-                className={"pt-daterangeinput"}
-                disabled={this.props.disabled}
-                type="text"
-                onChange={this.onChange}
-                placeholder={this.props.format}
-                rightElement={calendarIcon}
-                value={"01/17/2017 to 02/04/2017"}
-            />
+            <Popover
+                autoFocus={false}
+                content={popoverContent}
+                enforceFocus={false}
+                inline={true}
+                onClose={this.handleClosePopover}
+                popoverClassName="pt-daterangeinput-popover"
+                position={this.props.popoverPosition}
+            >
+                <InputGroup
+                    className={"pt-daterangeinput"}
+                    disabled={this.props.disabled}
+                    type="text"
+                    onChange={this.onChange}
+                    placeholder={this.props.format}
+                    rightElement={calendarIcon}
+                    value={"01/17/2017 to 02/04/2017"}
+                />
+            </Popover>
         );
+    }
+
+    private handleClosePopover = () => {
+        return;
     }
 
     private onChange = () => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import * as React from "react";
+
+import {
+    AbstractComponent,
+    Button,
+    Classes,
+    InputGroup,
+    Intent,
+    IProps,
+    Position,
+} from "@blueprintjs/core";
+
+import { DateRange } from "./common/dateUtils";
+import {
+    getDefaultMaxDate,
+    getDefaultMinDate,
+    IDatePickerBaseProps,
+} from "./datePickerCore";
+
+export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
+    /**
+     * Whether the start and end dates of the range can be the same day.
+     * If `true`, clicking a selected date will create a one-day range.
+     * If `false`, clicking a selected date will clear the selection.
+     * @default false
+     */
+    allowSingleDayRange?: boolean;
+
+    /**
+     * Whether the component should be enabled or disabled.
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * Initial DateRange the calendar will display as selected.
+     * This should not be set if `value` is set.
+     */
+    defaultValue?: DateRange;
+
+    /**
+     * The format of the date. See options
+     * here: http://momentjs.com/docs/#/displaying/format/
+     * @default "YYYY-MM-DD"
+     */
+    format?: string;
+
+    /**
+     * The error message to display when the date selected invalid.
+     * @default "Invalid date"
+     */
+    invalidDateRangeMessage?: string;
+
+    /**
+     * Called when the user selects a day.
+     * If no days are selected, it will pass `[null, null]`.
+     * If a start date is selected but not an end date, it will pass `[selectedDate, null]`.
+     * If both a start and end date are selected, it will pass `[startDate, endDate]`.
+     */
+    onChange?: (selectedDates: DateRange) => void;
+
+    /**
+     * Called when the user finishes typing in a new date and the date causes an error state.
+     * If the date is invalid, `new Date(undefined)` will be returned. If the date is out of range,
+     * the out of range date will be returned (`onChange` is not called in this case).
+     */
+    onError?: (errorDate: Date) => void;
+
+    /**
+     * If true, the Popover will open when the user clicks on the input. If false, the Popover will only
+     * open when the calendar icon is clicked.
+     * @default true
+     */
+    openOnFocus?: boolean;
+
+    /**
+     * The error message to display when the date selected is out of range.
+     * @default "Out of range"
+     */
+    outOfRangeMessage?: string;
+
+    /**
+     * The position the date popover should appear in relative to the input box.
+     * @default Position.BOTTOM
+     */
+    popoverPosition?: Position;
+
+    /**
+     * Whether shortcuts to quickly select a range of dates are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array, the custom shortcuts provided will be displayed.
+     * @default true
+     */
+    // shortcuts?: boolean | IDateRangeShortcut[];
+
+    /**
+     * The currently selected DateRange.
+     * If this prop is present, the component acts in a controlled manner.
+     */
+    value?: DateRange;
+}
+
+export interface IDateRangeInputState {
+    value?: DateRange;
+    valueString?: string;
+    isInputFocused?: boolean;
+    isOpen?: boolean;
+}
+
+export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
+    public static defaultProps: IDateRangeInputProps = {
+        allowSingleDayRange: false,
+        disabled: false,
+        format: "YYYY-MM-DD",
+        invalidDateRangeMessage: "Invalid date range",
+        maxDate: getDefaultMaxDate(),
+        minDate: getDefaultMinDate(),
+        openOnFocus: true,
+        outOfRangeMessage: "Out of range",
+        popoverPosition: Position.BOTTOM,
+    };
+
+    public displayName = "Blueprint.DateRangeInput";
+
+    public render() {
+        const calendarIcon = (
+            <Button
+                className={Classes.MINIMAL}
+                disabled={this.props.disabled}
+                iconName="calendar"
+                intent={Intent.PRIMARY}
+            />
+        );
+
+        return (
+            <InputGroup
+                className={"pt-daterangeinput"}
+                disabled={this.props.disabled}
+                type="text"
+                onChange={this.onChange}
+                placeholder={this.props.format}
+                rightElement={calendarIcon}
+                value={"01/17/2017 to 02/04/2017"}
+            />
+        );
+    }
+
+    private onChange = () => {
+        return;
+    }
+}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -199,8 +199,11 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         );
     }
 
-    private setInputRef = (el: HTMLElement) => {
-        this.inputRef = el;
+    // Helper functions
+    // ================
+
+    private dateIsInRange(value: moment.Moment) {
+        return value.isBetween(this.props.minDate, this.props.maxDate, "day", "[]");
     }
 
     private getDateRangeString = (value: DateRange) => {
@@ -236,17 +239,40 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         return moment(date).format(this.props.format);
     }
 
+    private setInputRef = (el: HTMLElement) => {
+        this.inputRef = el;
+    }
+
     private validAndInRange(value: moment.Moment) {
         return value.isValid() && this.dateIsInRange(value);
     }
+
+    private valueStringToDateRangeTokens(valueString: string) {
+        return valueString.split("-") // TODO: make separator(s) parameterizable
+            .map((token) => token.trim())
+            .map((token) => (token.length > 0) ? token : null);
+    }
+
+    private dateRangeTokenToDateOrNull(token: string) {
+        return (token != null) ? moment(token, this.props.format) : null;
+    }
+
+    // Callbacks - DateRangePicker
+    // ===========================
 
     private handleDateRangeChange = (dateRange: DateRange) => {
         this.setState({ value: dateRange });
     }
 
+    // Callbacks - Popover
+    // ===================
+
     private handleClosePopover = () => {
         this.setState({ isOpen: false });
     }
+
+    // Callbacks - Button
+    // ==================
 
     private handleIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
         if (this.state.isOpen) {
@@ -262,6 +288,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
+    // Callbacks - InputGroup
+    // ======================
+
     private handleInputBlur = () => {
         this.setState({ isInputFocused: false });
     }
@@ -269,15 +298,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     private handleInputChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
         const valueString = (e.target as HTMLInputElement).value;
 
-        const tokensOrNulls = valueString.split("-") // TODO: make separator(s) parameterizable
-            .map((token) => token.trim())
-            .map((token) => (token.length > 0) ? token : null);
+        const dateRangeTokens = this.valueStringToDateRangeTokens(valueString);
 
-        const startDateToken = tokensOrNulls[0];
-        const endDateToken = tokensOrNulls[1];
-
-        const startDate = (startDateToken != null) ? moment(startDateToken, this.props.format) : null;
-        const endDate = (endDateToken != null) ? moment(endDateToken, this.props.format) : null;
+        const startDate = this.dateRangeTokenToDateOrNull(dateRangeTokens[0]);
+        const endDate = this.dateRangeTokenToDateOrNull(dateRangeTokens[1]);
 
         if (startDate == null) {
             this.setState({ valueString });
@@ -307,9 +331,5 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         } else {
             this.setState({ isInputFocused: true });
         }
-    }
-
-    private dateIsInRange(value: moment.Moment) {
-        return value.isBetween(this.props.minDate, this.props.maxDate, "day", "[]");
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -133,6 +133,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     public displayName = "Blueprint.DateRangeInput";
 
+    private inputRef: HTMLElement = null;
+
     public constructor(props: IDateRangeInputProps, context?: any) {
         super(props, context);
 
@@ -160,6 +162,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 disabled={this.props.disabled}
                 iconName="calendar"
                 intent={Intent.PRIMARY}
+                onClick={this.handleIconClick}
             />
         );
 
@@ -169,6 +172,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 content={popoverContent}
                 enforceFocus={false}
                 inline={true}
+                isOpen={this.state.isOpen}
                 onClose={this.handleClosePopover}
                 popoverClassName="pt-daterangeinput-popover"
                 position={this.props.popoverPosition}
@@ -176,14 +180,22 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 <InputGroup
                     className={"pt-daterangeinput"}
                     disabled={this.props.disabled}
+                    inputRef={this.setInputRef}
                     type="text"
+                    onBlur={this.handleInputBlur}
                     onChange={this.onChange}
+                    onClick={this.handleInputClick}
+                    onFocus={this.handleInputFocus}
                     placeholder={`${format} - ${format}`}
                     rightElement={calendarIcon}
                     value={dateRangeString}
                 />
             </Popover>
         );
+    }
+
+    private setInputRef = (el: HTMLElement) => {
+        this.inputRef = el;
     }
 
     private getDateRangeString = (value: DateRange) => {
@@ -224,7 +236,39 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private handleClosePopover = () => {
-        return;
+        this.setState({ isOpen: false });
+    }
+
+    private handleIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
+        if (this.state.isOpen) {
+            if (this.inputRef != null) {
+                this.inputRef.blur();
+            }
+        } else {
+            this.setState({ isOpen: true });
+            e.stopPropagation();
+            if (this.inputRef != null) {
+                this.inputRef.focus();
+            }
+        }
+    }
+
+    private handleInputBlur = () => {
+        this.setState({ isInputFocused: false });
+    }
+
+    private handleInputClick = (e: React.SyntheticEvent<HTMLInputElement>) => {
+        if (this.props.openOnFocus) {
+            e.stopPropagation();
+        }
+    }
+
+    private handleInputFocus = () => {
+        if (this.props.openOnFocus) {
+            this.setState({ isInputFocused: true, isOpen: true });
+        } else {
+            this.setState({ isInputFocused: true });
+        }
     }
 
     private onChange = () => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -148,11 +148,15 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     public render() {
         const { format } = this.props;
-        const dateRangeString = this.getDateRangeString(this.state.value);
+
+        const dateRangeString = this.state.isInputFocused
+             ? this.state.valueString
+             : this.getDateRangeString(this.state.value);
 
         const popoverContent = (
             <DateRangePicker
                 onChange={this.handleDateRangeChange}
+                value={this.state.value}
             />
         );
 
@@ -183,7 +187,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     inputRef={this.setInputRef}
                     type="text"
                     onBlur={this.handleInputBlur}
-                    onChange={this.onChange}
+                    onChange={this.handleInputChange}
                     onClick={this.handleInputClick}
                     onFocus={this.handleInputFocus}
                     placeholder={`${format} - ${format}`}
@@ -257,6 +261,33 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         this.setState({ isInputFocused: false });
     }
 
+    private handleInputChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+        const valueString = (e.target as HTMLInputElement).value;
+        const tokens = valueString.split("-").map((token) => token.trim());
+
+        const startDate = moment(tokens[0], this.props.format);
+        const endDate = (tokens.length > 1) ? moment(tokens[1], this.props.format) : null;
+
+        if (valueString.length > 0) {
+            let dateRange: Date[] = [null, null];
+
+            if (startDate.isValid() && this.dateIsInRange(startDate)) {
+                dateRange[0] = startDate.toDate();
+            }
+            if (endDate != null && endDate.isValid() && this.dateIsInRange(endDate)) {
+                dateRange[1] = endDate.toDate();
+            }
+
+            if (this.props.value === undefined) {
+                this.setState({ value: dateRange as DateRange, valueString });
+            } else {
+                this.setState({ valueString });
+            }
+        } else {
+            this.setState({ valueString });
+        }
+    }
+
     private handleInputClick = (e: React.SyntheticEvent<HTMLInputElement>) => {
         if (this.props.openOnFocus) {
             e.stopPropagation();
@@ -271,7 +302,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
-    private onChange = () => {
-        return;
+    private dateIsInRange(value: moment.Moment) {
+        return value.isBetween(this.props.minDate, this.props.maxDate, "day", "[]");
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -173,7 +173,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
         const dateRangeString = this.state.isInputFocused
              ? this.state.valueString
-             : this.getDateRangeString(this.state.value);
+             : this.getDateRangeString(this.state.value, true);
 
         const dateRange = this.state.value;
         const isStartDateValid =
@@ -239,7 +239,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         return value.isBetween(this.props.minDate, this.props.maxDate, "day", "[]");
     }
 
-    private getDateRangeString = (value: DateRange) => {
+    private getDateRangeString = (value: DateRange, validateDates = false) => {
         if (value == null) {
             return "";
         }
@@ -250,18 +250,20 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const momentStartDate = moment(startDate);
         const momentEndDate = moment(endDate);
 
-        // check if dates are in bounds
-        const isStartDateOutOfRange = startDate != null && !this.dateIsInRange(momentStartDate);
-        const isEndDateOutOfRange = endDate != null && !this.dateIsInRange(momentEndDate);
-        if (isStartDateOutOfRange || isEndDateOutOfRange) {
-            return this.props.outOfRangeMessage;
-        }
+        if (validateDates) {
+            // check if dates are in bounds
+            const isStartDateOutOfRange = startDate != null && !this.dateIsInRange(momentStartDate);
+            const isEndDateOutOfRange = endDate != null && !this.dateIsInRange(momentEndDate);
+            if (isStartDateOutOfRange || isEndDateOutOfRange) {
+                return this.props.outOfRangeMessage;
+            }
 
-        // check if dates are valid
-        const isStartDateInvalid = startDate != null && !momentStartDate.isValid();
-        const isEndDateInvalid = endDate != null && !momentEndDate.isValid();
-        if (isStartDateInvalid || isEndDateInvalid) {
-            return this.props.invalidDateRangeMessage;
+            // check if dates are valid
+            const isStartDateInvalid = startDate != null && !momentStartDate.isValid();
+            const isEndDateInvalid = endDate != null && !momentEndDate.isValid();
+            if (isStartDateInvalid || isEndDateInvalid) {
+                return this.props.invalidDateRangeMessage;
+            }
         }
 
         const startDateFormatted = this.formatDate(startDate);
@@ -363,7 +365,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const [startDate, endDate] = dateRange;
 
         if (valueString.length > 0
-            && valueString !== this.getDateRangeString(this.state.value)
+            && valueString !== this.getDateRangeString(this.state.value, true)
             && (!this.validAndInRange(startDate) || !this.validAndInRange(endDate))) {
 
             if (this.props.value === undefined) {
@@ -377,9 +379,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             }
 
             // TODO: Trigger onError and onChange callbacks
+        } else {
+            this.setState({ isInputFocused: false });
         }
-
-        this.setState({ isInputFocused: false });
     }
 
     private handleInputChange = (e: React.SyntheticEvent<HTMLInputElement>) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -261,6 +261,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         ] as DateRange;
     }
 
+    private dateRangeToString(dateRange: DateRange) {
+        const startDateFormatted = this.formatDate(dateRange[0]);
+        const endDateFormatted = this.formatDate(dateRange[1]);
+        return `${startDateFormatted} - ${endDateFormatted}`; // TODO: Use parameterizable separator
+    }
+
     // Callbacks - DateRangePicker
     // ===========================
 
@@ -349,10 +355,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private handleInputFocus = () => {
+        const valueString = (this.state.value == null)
+            ? ""
+            : this.dateRangeToString(this.state.value);
+
         if (this.props.openOnFocus) {
-            this.setState({ isInputFocused: true, isOpen: true });
+            this.setState({ isInputFocused: true, isOpen: true, valueString });
         } else {
-            this.setState({ isInputFocused: true });
+            this.setState({ isInputFocused: true, valueString });
         }
     }
 }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -186,7 +186,7 @@ export class DateRangePicker
     }
 
     protected validateProps(props: IDateRangePickerProps) {
-        const { defaultValue, initialMonth, maxDate, minDate, value } = props;
+        const { defaultValue, initialMonth, maxDate, minDate/*, value */ } = props;
         const dateRange: DateRange = [minDate, maxDate];
 
         if (defaultValue != null && !DateUtils.isDayRangeInRange(defaultValue, dateRange)) {
@@ -197,10 +197,10 @@ export class DateRangePicker
             throw new Error(Errors.DATERANGEPICKER_INITIAL_MONTH_INVALID);
         }
 
-        if (defaultValue != null && defaultValue[0] == null && defaultValue[1] != null
-            || value != null && value[0] == null && value[1] != null) {
-            throw new Error(Errors.DATERANGEPICKER_INVALID_DATE_RANGE);
-        }
+        // if (defaultValue != null && defaultValue[0] == null && defaultValue[1] != null
+        //     || value != null && value[0] == null && value[1] != null) {
+        //     throw new Error(Errors.DATERANGEPICKER_INVALID_DATE_RANGE);
+        // }
 
         if (maxDate != null
                 && minDate != null
@@ -209,9 +209,9 @@ export class DateRangePicker
             throw new Error(Errors.DATERANGEPICKER_MAX_DATE_INVALID);
         }
 
-        if (value != null && !DateUtils.isDayRangeInRange(value, dateRange)) {
-            throw new Error(Errors.DATERANGEPICKER_VALUE_INVALID);
-        }
+        // if (value != null && !DateUtils.isDayRangeInRange(value, dateRange)) {
+        //     throw new Error(Errors.DATERANGEPICKER_VALUE_INVALID);
+        // }
     }
 
     private maybeRenderShortcuts() {

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -15,5 +15,6 @@ export { DateInput } from "./dateInput";
 export { DatePicker, DatePickerFactory, IDatePickerProps } from "./datePicker";
 export { IDatePickerLocaleUtils, IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
+export { DateRangeInput } from "./dateRangeInput";
 export { DateRangePicker, DateRangePickerFactory, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
 export { ITimePickerProps, TimePicker, TimePickerFactory, TimePickerPrecision } from "./timePicker";


### PR DESCRIPTION
# [!] This is just a proof of concept to play around with. Don't merge.

#### Fixes #249

@llorca @giladgray

Figured it would be easier to open a temporary PR and share a preview link (EDIT: ugh, still have to write tests to enable that) than to ask you guys to pull and run the branch yourselves. What do you think of the UX here? Also curious about the props API around separators - it'd be nice if the component could parse different separators (e.g. "-" and "to") but render only one kind of separator when displaying the formatted date range (in this case, "to"). These are configurable here via `separators` and `displaySeparator`, which seems...meh.

Overall, not sure I'm loving this single-field date range input. Feels like it isn't on rails enough, plus the behavior when you nullify the start or end date is particularly weird. There's also a lot of code that's not-quiiiite-identical to code in DateInput, but close enough. I'm sure we could pull some common functionality out into a dateInputCore.tsx file; I just didn't put any effort into that yet.

There's still some incorrect functionality around invalid dates. But I'm mostly curious about UX for the moment.

Here's a screen capture (ignore the weirdness at the end when refocusing after inputting an invalid date):

![date-range-input](https://cloud.githubusercontent.com/assets/443450/21901254/cdf96642-d8ab-11e6-8e01-bb127d9ba599.gif)

LMK what you think. Also LMK if you'd prefer a different forum for this discussion. 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

- <!-- fill this out -->
- <!-- fill this out -->
- <!-- fill this out -->

#### Reviewers should focus on:

- <!-- fill this out -->
- <!-- fill this out -->
- <!-- fill this out -->
