### PR TITLE
Handle popover prop on JSONFormat

### DIFF
--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -33,14 +33,19 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
 export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
     public static defaultProps: IJSONFormatProps = {
         omitQuotesOnStrings: true,
+        showPopover: TruncatedPopoverMode.ALWAYS,
         stringify: (obj: any) => (JSON.stringify(obj, null, 2)),
     };
 
     public render() {
         const { children, omitQuotesOnStrings, stringify } = this.props;
+        let { showPopover } = this.props;
 
+        // Change style and hide popover if value is nully
         const isNully = children == null;
-        const showPopover = isNully ? TruncatedPopoverMode.NEVER : TruncatedPopoverMode.ALWAYS;
+        if (isNully) {
+            showPopover = TruncatedPopoverMode.NEVER;
+        }
         const className = classNames(this.props.className, {
           "bp-table-null": isNully,
         });

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -126,6 +126,21 @@ describe("Formats", () => {
             expect(comp.find(".bp-table-truncated-popover-target").element).to.not.exist;
             expect(comp.find(".bp-table-truncated-text").text()).to.equal("undefined");
         });
+
+        it("hides popover for null-likes, still passes showPopover prop", () => {
+            let comp = harness.mount(<JSONFormat>{null}</JSONFormat>);
+            expect(comp.find(".bp-table-truncated-popover-target").element).to.not.exist;
+
+            const str = `
+                this is a very long string that would otherwise be truncated by the
+                settings, so we just add it here to make sure the test works.
+            `;
+            comp = harness.mount(<JSONFormat>{str}</JSONFormat>);
+            expect(comp.find(".bp-table-truncated-popover-target").element).exist;
+
+            comp = harness.mount(<JSONFormat showPopover={TruncatedPopoverMode.NEVER}>{str}</JSONFormat>);
+            expect(comp.find(".bp-table-truncated-popover-target").element).to.not.exist;
+        });
     });
 
 });


### PR DESCRIPTION
#### Changes proposed in this pull request:

Previously, JSONFormat cells would not allow you to change the
showPopover prop because it wanted to detect nulls and override
the value.

Now, if the user actually sets the prop on JSONFormat, we will
still hide the popover for nully values, but will use their
prop as the default.
