### PR TITLE
Fix datetimepicker clear date selection

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -98,6 +98,12 @@ export function getDateBetween(dateRange: DateRange) {
 }
 
 export function getDateTime(date: Date, time: Date) {
-    return new Date(date.getFullYear(), date.getMonth(), date.getDate(),
+    if (date === null) {
+        return null;
+    } else if (time === null) {
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+    } else {
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate(),
            time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
+    }
 }

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -104,6 +104,6 @@ export function getDateTime(date: Date, time: Date) {
         return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
     } else {
         return new Date(date.getFullYear(), date.getMonth(), date.getDate(),
-           time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
+            time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
     }
 }

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -46,8 +46,10 @@ export interface IDateTimePickerProps extends IProps {
     value?: Date;
 }
 
+// Handle Date and Time separately because changing the date doesn't reset the time.
 export interface IDateTimePickerState {
-    value?: Date;
+    dateValue?: Date;
+    timeValue?: Date;
 }
 
 export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDateTimePickerState> {
@@ -60,23 +62,26 @@ export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDat
     public constructor(props?: IDateTimePickerProps, context?: any) {
         super(props, context);
 
+        const initialValue = (this.props.value != null) ? this.props.value : this.props.defaultValue;
         this.state = {
-            value: (this.props.value != null) ? this.props.value : this.props.defaultValue,
+            dateValue: initialValue,
+            timeValue: initialValue,
         };
     }
 
     public render() {
+        const value = DateUtils.getDateTime(this.state.dateValue, this.state.timeValue);
         return (
             <div className={classNames(Classes.DATETIMEPICKER, this.props.className)}>
                 <DatePicker
                     {...this.props.datePickerProps}
                     onChange={this.handleDateChange}
-                    value={this.state.value}
+                    value={value}
                 />
                 <TimePicker
                     {...this.props.timePickerProps}
                     onChange={this.handleTimeChange}
-                    value={this.state.value}
+                    value={value}
                 />
             </div>
         );
@@ -84,22 +89,25 @@ export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDat
 
     public componentWillReceiveProps(nextProps: IDatePickerProps) {
         if (nextProps.value != null) {
-            this.setState({ value: nextProps.value });
+            this.setState({
+                dateValue: nextProps.value,
+                timeValue: nextProps.value,
+            });
         }
     }
 
     public handleDateChange = (date: Date, isUserChange: boolean) => {
-        const value = DateUtils.getDateTime(date, this.state.value);
+        const value = DateUtils.getDateTime(date, this.state.timeValue);
         if (this.props.value === undefined) {
-            this.setState({ value });
+            this.setState({ dateValue: value });
         }
         Utils.safeInvoke(this.props.onChange, value, isUserChange);
     }
 
     public handleTimeChange = (time: Date) => {
-        const value = DateUtils.getDateTime(this.state.value, time);
+        const value = DateUtils.getDateTime(this.state.dateValue, time);
         if (this.props.value === undefined) {
-            this.setState({ value });
+            this.setState({ timeValue: value });
         }
         Utils.safeInvoke(this.props.onChange, value, true);
     }

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -46,7 +46,7 @@ export interface IDateTimePickerProps extends IProps {
     value?: Date;
 }
 
-// Handle Date and Time separately because changing the date doesn't reset the time.
+// Handle date and time separately because changing the date shouldn't reset the time.
 export interface IDateTimePickerState {
     dateValue?: Date;
     timeValue?: Date;
@@ -96,19 +96,19 @@ export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDat
         }
     }
 
-    public handleDateChange = (date: Date, isUserChange: boolean) => {
-        const value = DateUtils.getDateTime(date, this.state.timeValue);
+    public handleDateChange = (dateValue: Date, isUserChange: boolean) => {
         if (this.props.value === undefined) {
-            this.setState({ dateValue: value });
+            this.setState({ dateValue });
         }
+        const value = DateUtils.getDateTime(dateValue, this.state.timeValue);
         Utils.safeInvoke(this.props.onChange, value, isUserChange);
     }
 
-    public handleTimeChange = (time: Date) => {
-        const value = DateUtils.getDateTime(this.state.dateValue, time);
+    public handleTimeChange = (timeValue: Date) => {
         if (this.props.value === undefined) {
-            this.setState({ timeValue: value });
+            this.setState({ timeValue });
         }
+        const value = DateUtils.getDateTime(this.state.dateValue, timeValue);
         Utils.safeInvoke(this.props.onChange, value, true);
     }
 }

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -23,13 +23,15 @@ describe("<DateTimePicker>", () => {
         const defaultValue = new Date(2010, 1, 2, 5, 2, 10);
         const value = new Date(2010, 0, 1, 11, 2, 30);
         const { root } = wrap(<DateTimePicker defaultValue={defaultValue} value={value} />);
-        assert.strictEqual(root.state("value"), value);
+        assert.strictEqual(root.state("dateValue"), value);
+        assert.strictEqual(root.state("timeValue"), value);
     });
 
     it("defaultValue initially selects a date/time", () => {
         const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
         const { root } = wrap(<DateTimePicker defaultValue={defaultValue} />);
-        assert.strictEqual(root.state("value"), defaultValue);
+        assert.strictEqual(root.state("dateValue"), defaultValue);
+        assert.strictEqual(root.state("timeValue"), defaultValue);
     });
 
     it("onChange fired when a day is clicked", () => {
@@ -56,6 +58,18 @@ describe("<DateTimePicker>", () => {
         root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
         assert.isTrue(onChangeSpy.calledOnce);
         assert.deepEqual(onChangeSpy.firstCall.args[0], new Date(2012, 2, 5, 7, 5, 40));
+    });
+
+    it("clearing a date and selecting another does not change the time", () => {
+        const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
+        const onChangeSpy = sinon.spy();
+        const { getDay, root } = wrap(<DateTimePicker defaultValue={defaultValue} onChange={onChangeSpy} />);
+        getDay(5).simulate("click");
+        getDay(15).simulate("click");
+        assert.equal(root.state("timeValue").getHours(), defaultValue.getHours());
+        assert.equal(root.state("timeValue").getMinutes(), defaultValue.getMinutes());
+        assert.equal(root.state("timeValue").getSeconds(), defaultValue.getSeconds());
+        assert.equal(root.state("timeValue").getMilliseconds(), defaultValue.getMilliseconds());
     });
 
     function wrap(dtp: JSX.Element) {

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -71,6 +71,23 @@ describe("<DateTimePicker>", () => {
         assert.equal(root.state("timeValue").getMilliseconds(), defaultValue.getMilliseconds());
     });
 
+    it("changing the time before selecting a date works as expected", () => {
+        const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
+        const { getDay, root } = wrap(
+            <DateTimePicker
+                defaultValue={defaultValue}
+                timePickerProps={{ showArrowButtons: true }}
+            />,
+        );
+        getDay(5).simulate("click");
+        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
+        getDay(15).simulate("click");
+        assert.equal(root.state("timeValue").getHours(), defaultValue.getHours() + 1);
+        assert.equal(root.state("timeValue").getMinutes(), defaultValue.getMinutes());
+        assert.equal(root.state("timeValue").getSeconds(), defaultValue.getSeconds());
+        assert.equal(root.state("timeValue").getMilliseconds(), defaultValue.getMilliseconds());
+    });
+
     function wrap(dtp: JSX.Element) {
         const root = mount(dtp);
         return {

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -62,8 +62,7 @@ describe("<DateTimePicker>", () => {
 
     it("clearing a date and selecting another does not change the time", () => {
         const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
-        const onChangeSpy = sinon.spy();
-        const { getDay, root } = wrap(<DateTimePicker defaultValue={defaultValue} onChange={onChangeSpy} />);
+        const { getDay, root } = wrap(<DateTimePicker defaultValue={defaultValue} />);
         getDay(5).simulate("click");
         getDay(15).simulate("click");
         assert.equal(root.state("timeValue").getHours(), defaultValue.getHours());


### PR DESCRIPTION
#### Fixes #466 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Split up the internal state in `DateTimePicker` to let the date and time be manipulated separately.

#### Reviewers should focus on:

I considered keeping `value` in the state in addition to `dateValue` and `timeValue` to quickly access the combination of the two. Would this be more confusing than it is useful?
