### PR TITLE
Upgrade react day picker

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -9,7 +9,7 @@
     "@blueprintjs/core": "^1.3.0",
     "classnames": "^2.2",
     "moment": "^2.14.1",
-    "react-day-picker": "^2.5.0"
+    "react-day-picker": "^3.1.1"
   },
   "devDependencies": {
     "bourbon": "4.2.6",


### PR DESCRIPTION
#### Fixes #465 

- We don't use anything in the breaking changes in the change log.
- NB. The typings we pull in are based on v1.2.0