### PR TITLE
EditableText `props.lastValue` reflects last `props.value`

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -194,6 +194,9 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
         if (nextProps.disabled || (nextProps.disabled == null && this.props.disabled)) {
             state.isEditing = false;
         }
+        if (nextProps.value !== this.props.value) {
+            state.lastValue = state.value;
+        }
         this.setState(state);
     }
 
@@ -210,7 +213,6 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
             const { value } = this.state;
             this.setState({
                 isEditing: false,
-                lastValue: value,
             });
             safeInvoke(this.props.onChange, value);
             safeInvoke(this.props.onConfirm, value);


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests

#### Changes proposed in this pull request:

- Since `EditableText` is a controlled component, `lastValue` should be updated in response to a new `value`.
- This fixes a bug where the controller sets a new `value` independently of the component, and `onCancel` subsequently fails.
