### PR TITLE
Fix docs compilation unused var errors

### DIFF
--- a/packages/table/examples/cellLoadingExample.tsx
+++ b/packages/table/examples/cellLoadingExample.tsx
@@ -56,10 +56,9 @@ export class CellLoadingExample extends BaseExample<ICellLoadingExampleState> {
         if (configuration === CellsLoadingConfiguration.RANDOM) {
             // calculate random numbers just once instead of inside renderCell which is called during table scrolling
             const randomNumbers: number[] = [];
-            for (let bigSpaceRock of bigSpaceRocks) {
-                for (let property of Object.getOwnPropertyNames(bigSpaceRocks[0])) {
-                    randomNumbers.push(Math.random());
-                }
+            const numberOfCells = bigSpaceRocks.length * Object.getOwnPropertyNames(bigSpaceRocks[0]).length;
+            for (let i = 0; i < numberOfCells; i++) {
+                randomNumbers.push(Math.random());
             }
             this.setState({ randomNumbers });
         }

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -95,7 +95,6 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
     public render() {
         const {
             allowMultipleSelection,
-            cellRenderer,
             columnIndexEnd,
             columnIndexStart,
             grid,


### PR DESCRIPTION
The docs build is reporting unused variable errors. This PR addresses those issue. A followup PR (https://github.com/palantir/blueprint/pull/471) will update the tsconfig settings across the packages to make these errors visible when compiling the packages.