### PR TITLE
improved Less variables test checks type

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -110,7 +110,9 @@ module.exports = (gulp, plugins, blueprint) => {
             .pipe(plugins.replace(/\$/g, "@"))
             .pipe(plugins.rename("variables.less"))
             .pipe(blueprint.dest(mainProject))
-            // run it through less compiler (after writing files) to ensure we converted correctly
+            // run it through less compiler (after writing files) to ensure we converted correctly.
+            // this line will throw an 'invalid type' error if grid size is not a single px value.
+            .pipe(plugins.insert.append(".unit-test { width: @pt-grid-size * 2; }"))
             .pipe(plugins.less());
     });
 


### PR DESCRIPTION
#### Fixes #346 

#### Changes proposed in this pull request:

- if `@pt-grid-size` is not a simple `#px` value then the Less compiler will error with "invalid type"

#### Reviewers should focus on:

- can anyone think of more good simple tests? the regression we encountered was `!default` statements causing variables to be interpreted as strings instead of units or colors, which this test handles simply. not sure what else we can do?