### PR TITLE
Upgrade to TS 2.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ general:
     # code coverage reports
     - packages/core/coverage
     - packages/datetime/coverage
+    - packages/table/coverage
     # preview pages
     - packages/table/preview
     # GH Pages content

--- a/gulp/karma.js
+++ b/gulp/karma.js
@@ -44,8 +44,8 @@ module.exports = (gulp, plugins, blueprint) => {
             coverageReporter: {
                 check: {
                     each: {
-                        lines: 80,
-                        statements: 80,
+                        lines: 79,
+                        statements: 79,
                     },
                 },
                 includeAllSources: true,
@@ -58,8 +58,8 @@ module.exports = (gulp, plugins, blueprint) => {
                     { type: "text" },
                 ],
                 watermarks: {
-                    lines: [80, 90],
-                    statements: [80, 90],
+                    lines: [79, 90],
+                    statements: [79, 90],
                 },
             },
             files: filesToInclude,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-strip-css-comments": "1.2.0",
     "gulp-stylelint": "3.4.0",
     "gulp-tslint": "7.0.1",
-    "gulp-typescript": "3.0.2",
+    "gulp-typescript": "3.1.4",
     "gulp-util": "3.0.7",
     "highlights": "1.4.1",
     "http-server": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ts-quick-docs": "0.4.0",
     "tslint": "4.0.1",
     "tslint-react": "2.0.0",
-    "typescript": "2.0.10",
+    "typescript": "2.1.5",
     "vinyl-source-stream": "1.1.0",
     "webpack": "1.13.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
     "dom4": "^1.8",
     "normalize.css": "4.1.1",
     "pure-render-decorator": "^1.1",
-    "tether": "^1.4"
+    "tether": "^1.4",
+    "tslib": "^1.5.0"
   },
   "peerDependencies": {
     "react": "^15.0.1 || ^0.14",

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -8,7 +8,6 @@
 import * as React from "react";
 
 import { Intent } from "./intent";
-import { shallowClone } from "./utils";
 
 export type HTMLInputProps = React.HTMLProps<HTMLInputElement>;
 
@@ -104,7 +103,12 @@ const INVALID_PROPS = [
  * @param {string[]} invalidProps If supplied, overwrites the default blacklist.
  * @param {boolean} shouldMerge If true, will merge supplied invalidProps and blacklist together.
  */
-export function removeNonHTMLProps<T extends U, U>(props: T, invalidProps = INVALID_PROPS, shouldMerge = false): U {
+export function removeNonHTMLProps(
+    props: { [key: string]: any },
+    invalidProps = INVALID_PROPS,
+    shouldMerge = false,
+): { [key: string]: any } {
+
     if (shouldMerge) {
         invalidProps = invalidProps.concat(INVALID_PROPS);
     }
@@ -114,5 +118,5 @@ export function removeNonHTMLProps<T extends U, U>(props: T, invalidProps = INVA
             delete (prev as any)[curr];
         }
         return prev;
-    }, shallowClone(props));
+    }, { ...props });
 }

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -50,17 +50,6 @@ export function clamp(val: number, min: number, max: number) {
     return Math.min(Math.max(val, min), max);
 }
 
-/** Return a new object with the same keys as the given object (values are copied, not cloned). */
-export function shallowClone<T>(object: T): T {
-    const clonedObject: any = {};
-    for (const key in object) {
-        if (object.hasOwnProperty(key)) {
-            clonedObject[key] = (<any> object)[key];
-        }
-    }
-    return clonedObject as T;
-}
-
 /**
  * Throttle an event on an EventTarget by wrapping it in `requestAnimationFrame` call.
  * Returns the event handler that was bound to given eventName so you can clean up after yourself.

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -16,6 +16,8 @@ import { removeNonHTMLProps } from "../../common/props";
 import { Spinner } from "../spinner/spinner";
 import { AbstractButton, IButtonProps } from "./abstractButton";
 
+export { IButtonProps } from "./abstractButton";
+
 export class Button extends AbstractButton<HTMLButtonElement> {
     public static displayName = "Blueprint.Button";
 

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -16,7 +16,7 @@ import { TOASTER_INLINE_WARNING } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
-import { safeInvoke, shallowClone } from "../../common/utils";
+import { safeInvoke } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { IToastProps, Toast } from "./toast";
 
@@ -178,9 +178,7 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
 
     private createToastOptions(props: IToastProps, key = `toast-${this.toastId++}`) {
         // clone the object before adding the key prop to avoid leaking the mutation
-        const options = shallowClone<IToastOptions>(props);
-        options.key = key;
-        return options;
+        return { ...props, key };
     }
 
     private getPositionClasses() {

--- a/packages/core/test/collapsible-list/collapsibleListTests.tsx
+++ b/packages/core/test/collapsible-list/collapsibleListTests.tsx
@@ -9,7 +9,15 @@ import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
-import { CollapseFrom, CollapsibleList, IMenuItemProps, MenuItem, Popover, Position } from "../../src/index";
+import {
+    CollapseFrom,
+    CollapsibleList,
+    ICollapsibleListProps,
+    IMenuItemProps,
+    MenuItem,
+    Popover,
+    Position,
+} from "../../src/index";
 
 describe("<CollapsibleList>", () => {
     it("adds className to itself", () => {
@@ -99,7 +107,7 @@ describe("<CollapsibleList>", () => {
     });
 
     function renderItem(props: IMenuItemProps, index: number) {
-        return React.createElement("label", {key: index}, props.text);
+        return React.createElement("label", { key: index }, props.text);
     }
 
     function withItems(length: number) {
@@ -110,7 +118,7 @@ describe("<CollapsibleList>", () => {
         return list;
     }
 
-    function renderCollapsibleList(broodSize: number, props?: any) {
+    function renderCollapsibleList(broodSize: number, props?: Partial<ICollapsibleListProps>) {
         return mount(
             <CollapsibleList dropdownTarget={<button />} renderVisibleItem={renderItem} {...props}>
                 {withItems(broodSize)}

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -204,7 +204,7 @@ describe("Hotkeys", () => {
 
         it("matches lowercase alphabet chars", () => {
             const alpha = 65;
-            verifyCombos(Array.apply(null, Array(26)).map((o: any, i: number) => {
+            verifyCombos(Array.apply(null, Array(26)).map((_: any, i: number) => {
                 const combo = String.fromCharCode(alpha + i).toLowerCase();
                 const event = { which: alpha + i } as KeyboardEvent;
                 return makeComboTest(combo, event);
@@ -213,7 +213,7 @@ describe("Hotkeys", () => {
 
         it("bare alphabet chars ignore case", () => {
             const alpha = 65;
-            verifyCombos(Array.apply(null, Array(26)).map((o: any, i: number) => {
+            verifyCombos(Array.apply(null, Array(26)).map((_: any, i: number) => {
                 const combo = String.fromCharCode(alpha + i).toUpperCase();
                 const event = { which: alpha + i } as KeyboardEvent;
                 return makeComboTest(combo, event);
@@ -222,7 +222,7 @@ describe("Hotkeys", () => {
 
         it("matches uppercase alphabet chars using shift", () => {
             const alpha = 65;
-            verifyCombos(Array.apply(null, Array(26)).map((o: any, i: number) => {
+            verifyCombos(Array.apply(null, Array(26)).map((_: any, i: number) => {
                 const combo = "shift + " + String.fromCharCode(alpha + i).toLowerCase();
                 const event = { shiftKey: true, which: alpha + i } as KeyboardEvent;
                 return makeComboTest(combo, event);

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -14,6 +14,7 @@ import * as Errors from "../../src/common/errors";
 import * as Keys from "../../src/common/keys";
 import {
     Classes,
+    IPopoverProps,
     Popover,
     PopoverInteractionKind,
     SVGPopover,
@@ -406,7 +407,7 @@ describe("<Popover>", () => {
         sendEscapeKey(): this;
     }
 
-    function renderPopover(props: any = {}, content?: any) {
+    function renderPopover(props: Partial<IPopoverProps> = {}, content?: any) {
         wrapper = mount(
             <Popover inline {...props} content={<p>Text {content}</p>} hoverOpenDelay={0} hoverCloseDelay={0}>
                 <button>Target</button>

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -71,8 +71,9 @@ describe("<Tabs>", () => {
             { attachTo: testsContainerElement },
         );
 
-        // tslint:disable-next-line:no-unused-variable
-        const [tab0, tab1, tab2, tab3] = testsContainerElement.queryAll(".pt-tab");
+        const tabs = testsContainerElement.queryAll(".pt-tab");
+        const tab0 = tabs[0];
+        const tab2 = tabs[2];
         (tab0 as HTMLElement).focus();
         wrapper.simulate("keydown", { target: tab0, which: Keys.ARROW_RIGHT });
         assert.equal(tab2, document.activeElement);

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { Classes, Popover, SVGTooltip, Tooltip } from "../../src/index";
+import { Classes, ITooltipProps, Popover, SVGTooltip, Tooltip } from "../../src/index";
 
 const TOOLTIP_SELECTOR = `.${Classes.TOOLTIP}`;
 
@@ -95,7 +95,7 @@ describe("<Tooltip>", () => {
         svgTooltip.unmount();
     });
 
-    function renderTooltip(props?: any) {
+    function renderTooltip(props?: Partial<ITooltipProps>) {
         return mount(
             <Tooltip {...props} content={<p>Text</p>} hoverOpenDelay={0} inline>
                 <button>Target</button>

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as TestUtils from "react-addons-test-utils";
 import * as ReactDOM from "react-dom";
 
-import { Classes, ITreeNode, Tree } from "../../src/index";
+import { Classes, ITreeNode, ITreeProps, Tree } from "../../src/index";
 
 /* tslint:disable:object-literal-sort-keys */
 describe("<Tree>", () => {
@@ -99,7 +99,7 @@ describe("<Tree>", () => {
         TestUtils.Simulate.click(document.query(`.c1 > .${Classes.TREE_NODE_CONTENT} .${Classes.TREE_NODE_CARET}`));
         assert.isTrue(onNodeExpand.calledOnce);
         assert.deepEqual(onNodeExpand.args[0][1], [1]);
-        // make sure that onNodeClick isn't fired again, only onNodeExpand should be 
+        // make sure that onNodeClick isn't fired again, only onNodeExpand should be
         assert.isTrue(onNodeClick.calledOnce);
 
         TestUtils.Simulate.doubleClick(document.query(`.c6 > .${Classes.TREE_NODE_CONTENT}`));
@@ -167,7 +167,7 @@ describe("<Tree>", () => {
         assert.strictEqual(label.innerText, "Paragraph");
     });
 
-    function renderTree(props?: any) {
+    function renderTree(props?: Partial<ITreeProps>) {
         tree = ReactDOM.render(
             <Tree contents={createDefaultContents()} {...props}/>,
             testsContainerElement,

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,22 +1,9 @@
 {
-    "version": "2.0.0",
-    "compilerOptions": {
-        "declaration": false,
-        "jsx": "react",
-        "module": "commonjs",
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "removeComments": false,
-        "sourceMap": true,
-        "target": "es5",
-        "experimentalDecorators": true
-    },
+    "extends": "../tsconfig",
     "include": [
         "../typings/tsd.d.ts",
         "../../../test/typings/tsd.d.ts",
         "**/*"
     ],
-    "exclude": [],
-    "compileOnSave": false
+    "exclude": []
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "declaration": true,
         "experimentalDecorators": true,
+        "importHelpers": true,
         "jsx": "react",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -9,7 +9,8 @@
     "@blueprintjs/core": "^1.3.0",
     "classnames": "^2.2",
     "moment": "^2.14.1",
-    "react-day-picker": "^3.1.1"
+    "react-day-picker": "^3.1.1",
+    "tslib": "^1.5.0"
   },
   "devDependencies": {
     "bourbon": "4.2.6",

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -266,9 +266,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 // no new value, this means only text has changed (from user typing)
                 // we want inputs to change, so update state with new text for the inputs
                 // but don't change actual value
-                const clonedNewState = BlueprintUtils.shallowClone(newState);
-                clonedNewState.value = DateUtils.clone(this.state.value);
-                this.setState(clonedNewState);
+                this.setState({ ...newState, value: DateUtils.clone(this.state.value) });
             }
         }
 

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { DatePickerCaption } from "../src/datePickerCaption";
+import { DatePickerCaption, IDatePickerCaptionProps } from "../src/datePickerCaption";
 import { Classes, IDatePickerLocaleUtils } from "../src/index";
 
 describe("<DatePickerCaption>", () => {
@@ -58,7 +58,7 @@ describe("<DatePickerCaption>", () => {
         assert.isTrue(options.last().prop("disabled"), "2017 is not disabled");
     });
 
-    function renderDatePickerCaption(props?: any) {
+    function renderDatePickerCaption(props?: Partial<IDatePickerCaptionProps>) {
         const wrapper = mount(
             <DatePickerCaption
                 date={new Date(2015, 0)}

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -47,7 +47,7 @@ describe("<DateTimePicker>", () => {
     it("onChange fired when the time is changed", () => {
         const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
         const onChangeSpy = sinon.spy();
-        const { getDay, root } = wrap(
+        const { root } = wrap(
             <DateTimePicker
                 defaultValue={defaultValue}
                 onChange={onChangeSpy}

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -11,7 +11,7 @@ import * as React from "react";
 import * as TestUtils from "react-addons-test-utils";
 import * as ReactDOM from "react-dom";
 
-import { Classes, TimePicker, TimePickerPrecision } from "../src/index";
+import { Classes, ITimePickerProps, TimePicker, TimePickerPrecision } from "../src/index";
 
 describe("<TimePicker>", () => {
     let testsContainerElement: Element;
@@ -360,7 +360,7 @@ describe("<TimePicker>", () => {
         return document.querySelector(`.${Classes.TIMEPICKER_INPUT}.${className}`) as HTMLInputElement;
     }
 
-    function renderTimePicker(props?: any) {
+    function renderTimePicker(props?: Partial<ITimePickerProps>) {
         timePicker = ReactDOM.render(
             <TimePicker onChange={onTimePickerChange} {...props}/>,
             testsContainerElement,

--- a/packages/datetime/test/tsconfig.json
+++ b/packages/datetime/test/tsconfig.json
@@ -1,22 +1,9 @@
 {
-    "version": "2.0.0",
-    "compilerOptions": {
-        "declaration": false,
-        "jsx": "react",
-        "module": "commonjs",
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "removeComments": false,
-        "sourceMap": true,
-        "target": "es5",
-        "experimentalDecorators": true
-    },
+    "extends": "../tsconfig",
     "include": [
         "../typings/tsd.d.ts",
         "../../../test/typings/tsd.d.ts",
         "**/*"
     ],
-    "exclude": [],
-    "compileOnSave": false
+    "exclude": []
 }

--- a/packages/datetime/tsconfig.json
+++ b/packages/datetime/tsconfig.json
@@ -4,6 +4,7 @@
         "allowSyntheticDefaultImports": true,
         "declaration": true,
         "experimentalDecorators": true,
+        "importHelpers": true,
         "jsx": "react",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -17,7 +17,8 @@
     "pure-render-decorator": "1.1.1",
     "react": "15.4.0",
     "react-addons-css-transition-group": "15.4.0",
-    "react-dom": "15.4.0"
+    "react-dom": "15.4.0",
+    "tslib": "1.5.0"
   },
   "devDependencies": {
     "@types/fuzzaldrin-plus": "0.0.1",

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -4,6 +4,7 @@
         "baseUrl": ".",
         "declaration": false,
         "experimentalDecorators": true,
+        "importHelpers": true,
         "jsx": "react",
         "module": "commonjs",
         "noFallthroughCasesInSwitch": true,

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -43,7 +43,7 @@
     "style-loader": "0.13.1",
     "svgo": "0.7.1",
     "ts-loader": "0.8.2",
-    "typescript": "2.0.10",
+    "typescript": "2.1.5",
     "webpack": "1.13.3"
   },
   "keywords": [

--- a/packages/table/examples/tableEditableExample.tsx
+++ b/packages/table/examples/tableEditableExample.tsx
@@ -113,8 +113,8 @@ export class TableEditableExample extends BaseExample<{}> {
     }
 
     private setSparseState<T>(stateKey: string, dataKey: string, value: T)  {
-        const values = Object.assign({}, (this.state as any)[stateKey]) as {[key: string]: T};
-        values[dataKey] = value;
-        this.setState({ [stateKey] : values });
+        const stateData = (this.state as any)[stateKey] as { [key: string]: T };
+        const values = { ...stateData, [dataKey]: value };
+        this.setState({ [stateKey]: values });
     }
 }

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -22,7 +22,8 @@
     "@blueprintjs/core": "^1.5.0",
     "classnames": "^2.2",
     "es6-shim": "^0.35",
-    "pure-render-decorator": "^1.1"
+    "pure-render-decorator": "^1.1",
+    "tslib": "^1.5.0"
   },
   "devDependencies": {
     "css-loader": "0.26.0",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -36,7 +36,7 @@
     "react-addons-test-utils": "15.4.0",
     "react-dom": "15.4.0",
     "style-loader": "0.13.1",
-    "typescript": "2.0.10",
+    "typescript": "2.1.5",
     "webpack": "1.13.3"
   },
   "repository": {

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -40,8 +40,6 @@ import {
     Utils,
 } from "../src/index";
 
-// tslint:disable:max-classes-per-file no-console jsx-no-lambda jsx-no-multiline-js
-
 import { Nav } from "./nav";
 ReactDOM.render(<Nav selected="index" />, document.getElementById("nav"));
 
@@ -56,10 +54,15 @@ function getTableComponent(numCols: number, numRows: number, columnProps?: any, 
         },
         ...columnProps,
     };
-    const columns = Utils.times(numCols, (index) => {
-        return <Column key={index} {...columnPropsWithDefaults} />;
-    });
-    return <Table {...tablePropsWithDefaults}>{columns}</Table>;
+    return (
+        <Table {...tablePropsWithDefaults}>
+            {
+                Utils.times(numCols, (index) => {
+                    return <Column key={index} {...columnPropsWithDefaults} />;
+                })
+            }
+        </Table>
+    );
 };
 
 const testMenu = (
@@ -67,25 +70,22 @@ const testMenu = (
         <MenuItem
             iconName="export"
             onClick={() => console.log("Beam me up!")}
-            text="Teleport"
-        />
+            text="Teleport" />
         <MenuItem
             iconName="sort-alphabetical-desc"
             onClick={() => console.log("ZA is the worst")}
-            text="Down with ZA!"
-        />
+            text="Down with ZA!" />
         <MenuDivider />
         <MenuItem
             iconName="curved-range-chart"
             onClick={() => console.log("You clicked the trident!")}
-            text="Psi"
-        />
+            text="Psi" />
     </Menu>
 );
 
 ReactDOM.render(
     getTableComponent(3, 7),
-    document.getElementById("table-0"),
+    document.getElementById("table-0")
 );
 
 class FormatsTable extends React.Component<{}, {}> {
@@ -110,25 +110,25 @@ class FormatsTable extends React.Component<{}, {}> {
 
         let obj = {} as any;
         for (let i = 0; i < 1000; i++) {
-            obj[`KEY-${(Math.random() * 10000).toFixed(2)}`] = (Math.random() * 10000).toFixed(2);
+            obj[`KEY-${(Math.random()*10000).toFixed(2)}`] = (Math.random()*10000).toFixed(2);
         }
         return obj;
     });
 
-    private strings = Utils.times(FormatsTable.ROWS, () => ("ABC " + (Math.random() * 10000)));
+    private strings = Utils.times(FormatsTable.ROWS, () => ('ABC ' + (Math.random()*10000)));
 
     public render() {
         return (<Table numRows={FormatsTable.ROWS} isRowResizable={true}>
-            <Column name="Default" renderCell={(row: number) => (<Cell>{this.strings[row]}</Cell>)} />
-            <Column name="JSON" renderCell={(row: number) => (<Cell><JSONFormat>{this.objects[row]}</JSONFormat></Cell>)} />
-            <Column name="JSON wrapped" renderCell={(row: number) => (<Cell><JSONFormat preformatted={false}>{this.objects[row]}</JSONFormat></Cell>)} />
+            <Column name="Default" renderCell={(row: number) => (<Cell>{this.strings[row]}</Cell>)}/>
+            <Column name="JSON" renderCell={(row: number) => (<Cell><JSONFormat>{this.objects[row]}</JSONFormat></Cell>)}/>
+            <Column name="JSON wrapped" renderCell={(row: number) => (<Cell><JSONFormat preformatted={false}>{this.objects[row]}</JSONFormat></Cell>)}/>
         </Table>);
     }
 }
 
 ReactDOM.render(
     <FormatsTable />,
-    document.getElementById("table-formats"),
+    document.getElementById("table-formats")
 );
 
 class EditableTable extends React.Component<{}, {}> {
@@ -137,21 +137,21 @@ class EditableTable extends React.Component<{}, {}> {
     }
 
     public state = {
-        intents: [] as Intent[],
         names: [
             "Please",
             "Rename",
             "Me",
         ] as string[],
-        sparseCellData: {} as { [key: string]: string },
-        sparseCellIntent: {} as { [key: string]: Intent },
+        intents : [] as Intent[],
+        sparseCellData : {} as {[key: string]: string},
+        sparseCellIntent : {} as {[key: string]: Intent},
     };
 
     public render() {
         return (<Table
-            numRows={7}
-            selectionModes={SelectionModes.COLUMNS_AND_CELLS}
-        >
+                numRows={7}
+                selectionModes={SelectionModes.COLUMNS_AND_CELLS}
+            >
             {this.state.names.map((name: string, index: number) => (
                 <Column key={index} renderCell={this.renderCell} renderColumnHeader={this.renderColumnHeader} />
             ))}
@@ -224,22 +224,22 @@ class EditableTable extends React.Component<{}, {}> {
         };
     }
 
-    private setArrayState<T>(key: string, index: number, value: T) {
+    private setArrayState<T>(key: string, index: number, value: T)  {
         const values = (this.state as any)[key].slice() as T[];
         values[index] = value;
-        this.setState({ [key]: values });
+        this.setState({ [key] : values });
     }
 
-    private setSparseState<T>(stateKey: string, dataKey: string, value: T) {
+    private setSparseState<T>(stateKey: string, dataKey: string, value: T)  {
         const stateData = (this.state as any)[stateKey] as { [key: string]: T };
         const values = { ...stateData, [dataKey]: value };
-        this.setState({ [stateKey]: values });
+        this.setState({ [stateKey] : values });
     }
 }
 
 ReactDOM.render(
     <EditableTable />,
-    document.getElementById("table-editable-names"),
+    document.getElementById("table-editable-names")
 );
 
 ReactDOM.render(
@@ -247,7 +247,7 @@ ReactDOM.render(
         fillBodyWithGhostCells: true,
         selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-ghost"),
+    document.getElementById("table-ghost")
 );
 
 ReactDOM.render(
@@ -255,20 +255,20 @@ ReactDOM.render(
         fillBodyWithGhostCells: true,
         selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-inline-ghost"),
+    document.getElementById("table-inline-ghost")
 );
 
 ReactDOM.render(
-    getTableComponent(200, 100 * 1000, {}, {
+    getTableComponent(200, 100 * 1000, {} , {
         fillBodyWithGhostCells: true,
         selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-big"),
+    document.getElementById("table-big")
 );
 
 class RowSelectableTable extends React.Component<{}, {}> {
     public state = {
-        selectedRegions: [Regions.row(2)],
+        selectedRegions: [ Regions.row(2) ],
     };
 
     public render() {
@@ -284,7 +284,7 @@ class RowSelectableTable extends React.Component<{}, {}> {
                 <Column name="Select" />
                 <Column name="Rows" />
             </Table>
-            <br />
+            <br/>
             <Button onClick={this.handleClear} intent={Intent.PRIMARY}>Clear Selection</Button>
         </div>);
     }
@@ -308,22 +308,22 @@ class RowSelectableTable extends React.Component<{}, {}> {
 }
 
 ReactDOM.render(
-    <RowSelectableTable />,
-    document.getElementById("table-select-rows"),
+    <RowSelectableTable/>,
+    document.getElementById("table-select-rows")
 );
 
 document.getElementById("table-ledger").classList.add("bp-table-striped");
 
 ReactDOM.render(
     getTableComponent(3, 7, {}, { className: "" }),
-    document.getElementById("table-ledger"),
+    document.getElementById("table-ledger")
 );
 
 class AdjustableColumnsTable extends React.Component<{}, {}> {
     public state = {
         columns: [
-            <Column name="First" key={0} id={0} />,
-            <Column name="Second" key={1} id={1} />,
+            <Column name="First" key={0} id={0}/>,
+            <Column name="Second" key={1} id={1}/>,
         ],
     };
 
@@ -345,7 +345,7 @@ class AdjustableColumnsTable extends React.Component<{}, {}> {
 
     private add() {
         const columns = this.state.columns.slice();
-        columns.push(<Column key={columns.length} id={columns.length} />);
+        columns.push(<Column key={columns.length} id={columns.length}/>);
         this.setState({ columns });
     }
 
@@ -369,7 +369,7 @@ class AdjustableColumnsTable extends React.Component<{}, {}> {
 
 ReactDOM.render(
     <AdjustableColumnsTable />,
-    document.getElementById("table-cols"),
+    document.getElementById("table-cols")
 );
 
 ReactDOM.render(
@@ -378,11 +378,11 @@ ReactDOM.render(
             return <Cell intent={rowIndex as Intent}>{Utils.toBase26Alpha(columnIndex) + (rowIndex + 1)}</Cell>;
         },
     }, {
-            isColumnResizable: false,
-            isRowResizable: false,
-            selectionModes: SelectionModes.NONE,
-        }),
-    document.getElementById("table-1"),
+        isColumnResizable: false,
+        isRowResizable: false,
+        selectionModes: SelectionModes.NONE,
+    }),
+    document.getElementById("table-1")
 );
 
 const renderBodyContextMenu = (context: IMenuContext) => {
@@ -404,12 +404,12 @@ const renderBodyContextMenu = (context: IMenuContext) => {
 ReactDOM.render(
     getTableComponent(3, 7, {}, {
         allowMultipleSelection: true,
-        isColumnResizable: true,
-        isRowResizable: true,
         renderBodyContextMenu,
         selectionModes: SelectionModes.ALL,
+        isColumnResizable: true,
+        isRowResizable: true,
     }),
-    document.getElementById("table-2"),
+    document.getElementById("table-2")
 );
 
 ReactDOM.render(
@@ -417,7 +417,7 @@ ReactDOM.render(
         defaultColumnWidth: 60,
         isRowHeaderShown: false,
     }),
-    document.getElementById("table-3"),
+    document.getElementById("table-3")
 );
 
 const customRowHeaders = [
@@ -435,7 +435,7 @@ ReactDOM.render(
             return <RowHeaderCell name={customRowHeaders[rowIndex]} />;
         },
     }),
-    document.getElementById("table-4"),
+    document.getElementById("table-4")
 );
 
 ReactDOM.render(
@@ -444,18 +444,18 @@ ReactDOM.render(
             return <ColumnHeaderCell name={Utils.toBase26Alpha(columnIndex)} isActive={columnIndex % 3 === 0} />;
         },
     }, {
-            styledRegionGroups: [
-                {
-                    className: "my-group",
-                    regions: [
-                        Regions.cell(0, 0),
-                        Regions.row(2),
-                        Regions.cell(1, 2, 5, 2),
-                    ],
-                },
-            ],
-        }),
-    document.getElementById("table-5"),
+        styledRegionGroups: [
+            {
+                className: "my-group",
+                regions: [
+                    Regions.cell(0, 0),
+                    Regions.row(2),
+                    Regions.cell(1, 2, 5, 2),
+                ],
+            },
+        ],
+    }),
+    document.getElementById("table-5")
 );
 
 ReactDOM.render(
@@ -470,11 +470,11 @@ ReactDOM.render(
             );
         },
     }, {
-            renderRowHeaderCell: (rowIndex: number) => {
-                return <RowHeaderCell name={`${rowIndex + 1}`} menu={testMenu} />;
-            },
-        }),
-    document.getElementById("table-6"),
+        renderRowHeaderCell : (rowIndex: number) => {
+            return <RowHeaderCell name={`${rowIndex + 1}`} menu={testMenu} />;
+        }
+    }),
+    document.getElementById("table-6")
 );
 
 class CustomHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
@@ -489,11 +489,11 @@ class CustomHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
 
 ReactDOM.render(
     getTableComponent(2, 5, {
-        renderColumnHeader: (columnIndex: number) => <CustomHeaderCell name="sup" />,
+        renderColumnHeader: (columnIndex: number) => <CustomHeaderCell name="sup"/>,
     }, {
-            allowMultipleSelection: false,
-        }),
-    document.getElementById("table-7"),
+        allowMultipleSelection: false,
+    }),
+    document.getElementById("table-7")
 );
 
 const longContentRenderCell = (rowIndex: number, columnIndex: number) => {
@@ -504,23 +504,23 @@ const longContentRenderCell = (rowIndex: number, columnIndex: number) => {
 ReactDOM.render(
     <Table numRows={4}>
         <Column name="My" />
-        <Column name="Table" renderCell={longContentRenderCell} />
+        <Column name="Table" renderCell={longContentRenderCell}/>
     </Table>,
-    document.getElementById("table-8"),
+    document.getElementById("table-8")
 );
 
 ReactDOM.render(
-    <div style={{ position: "relative" }}>
-        <div style={{ zIndex: 0 }} className="stack-fill">Z = 0</div>
-        <div style={{ zIndex: 1 }} className="stack-fill">Z = 1</div>
-        <div style={{ zIndex: 2 }} className="stack-fill"><br />Z = 2</div>
+    <div style={{position: "relative"}}>
+        <div style={{zIndex: 0}} className="stack-fill">Z = 0</div>
+        <div style={{zIndex: 1}} className="stack-fill">Z = 1</div>
+        <div style={{zIndex: 2}} className="stack-fill"><br/>Z = 2</div>
         <Table numRows={3}>
-            <Column name="A" />
-            <Column name="B" />
-            <Column name="C" />
+            <Column name="A"/>
+            <Column name="B"/>
+            <Column name="C"/>
         </Table>
-        <div className="stack-fill"><br /><br />after</div>
+        <div className="stack-fill"><br/><br/>after</div>
     </div>
     ,
-    document.getElementById("table-9"),
+    document.getElementById("table-9")
 );

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -14,8 +14,8 @@ import {
     Button,
     Intent,
     Menu,
-    MenuItem,
     MenuDivider,
+    MenuItem,
 } from "@blueprintjs/core";
 
 import {
@@ -25,10 +25,10 @@ import {
     CopyCellsMenuItem,
     EditableCell,
     EditableName,
+    HorizontalCellDivider,
     IColumnHeaderCellProps,
     IColumnProps,
     ICoordinateData,
-    HorizontalCellDivider,
     IMenuContext,
     IRegion,
     JSONFormat,
@@ -40,28 +40,26 @@ import {
     Utils,
 } from "../src/index";
 
+// tslint:disable:max-classes-per-file no-console jsx-no-lambda jsx-no-multiline-js
+
 import { Nav } from "./nav";
 ReactDOM.render(<Nav selected="index" />, document.getElementById("nav"));
 
 function getTableComponent(numCols: number, numRows: number, columnProps?: any, tableProps?: any) {
     // combine table overrides
-    const tablePropsWithDefaults = Object.assign({numRows}, tableProps);
+    const tablePropsWithDefaults = { numRows, ...tableProps };
 
     // combine column overrides
-    const columnPropsWithDefaults = Object.assign({
+    const columnPropsWithDefaults = {
         renderCell: (rowIndex: number, columnIndex: number) => {
             return <Cell>{Utils.toBase26Alpha(columnIndex) + (rowIndex + 1)}</Cell>;
         },
-    }, columnProps);
-    return (
-        <Table {...tablePropsWithDefaults}>
-            {
-                Utils.times(numCols, (index) => {
-                    return <Column key={index} {...columnPropsWithDefaults} />;
-                })
-            }
-        </Table>
-    );
+        ...columnProps,
+    };
+    const columns = Utils.times(numCols, (index) => {
+        return <Column key={index} {...columnPropsWithDefaults} />;
+    });
+    return <Table {...tablePropsWithDefaults}>{columns}</Table>;
 };
 
 const testMenu = (
@@ -69,22 +67,25 @@ const testMenu = (
         <MenuItem
             iconName="export"
             onClick={() => console.log("Beam me up!")}
-            text="Teleport" />
+            text="Teleport"
+        />
         <MenuItem
             iconName="sort-alphabetical-desc"
             onClick={() => console.log("ZA is the worst")}
-            text="Down with ZA!" />
+            text="Down with ZA!"
+        />
         <MenuDivider />
         <MenuItem
             iconName="curved-range-chart"
             onClick={() => console.log("You clicked the trident!")}
-            text="Psi" />
+            text="Psi"
+        />
     </Menu>
 );
 
 ReactDOM.render(
     getTableComponent(3, 7),
-    document.getElementById("table-0")
+    document.getElementById("table-0"),
 );
 
 class FormatsTable extends React.Component<{}, {}> {
@@ -109,25 +110,25 @@ class FormatsTable extends React.Component<{}, {}> {
 
         let obj = {} as any;
         for (let i = 0; i < 1000; i++) {
-            obj[`KEY-${(Math.random()*10000).toFixed(2)}`] = (Math.random()*10000).toFixed(2);
+            obj[`KEY-${(Math.random() * 10000).toFixed(2)}`] = (Math.random() * 10000).toFixed(2);
         }
         return obj;
     });
 
-    private strings = Utils.times(FormatsTable.ROWS, () => ('ABC ' + (Math.random()*10000)));
+    private strings = Utils.times(FormatsTable.ROWS, () => ("ABC " + (Math.random() * 10000)));
 
     public render() {
         return (<Table numRows={FormatsTable.ROWS} isRowResizable={true}>
-            <Column name="Default" renderCell={(row: number) => (<Cell>{this.strings[row]}</Cell>)}/>
-            <Column name="JSON" renderCell={(row: number) => (<Cell><JSONFormat>{this.objects[row]}</JSONFormat></Cell>)}/>
-            <Column name="JSON wrapped" renderCell={(row: number) => (<Cell><JSONFormat preformatted={false}>{this.objects[row]}</JSONFormat></Cell>)}/>
+            <Column name="Default" renderCell={(row: number) => (<Cell>{this.strings[row]}</Cell>)} />
+            <Column name="JSON" renderCell={(row: number) => (<Cell><JSONFormat>{this.objects[row]}</JSONFormat></Cell>)} />
+            <Column name="JSON wrapped" renderCell={(row: number) => (<Cell><JSONFormat preformatted={false}>{this.objects[row]}</JSONFormat></Cell>)} />
         </Table>);
     }
 }
 
 ReactDOM.render(
     <FormatsTable />,
-    document.getElementById("table-formats")
+    document.getElementById("table-formats"),
 );
 
 class EditableTable extends React.Component<{}, {}> {
@@ -136,21 +137,21 @@ class EditableTable extends React.Component<{}, {}> {
     }
 
     public state = {
+        intents: [] as Intent[],
         names: [
             "Please",
             "Rename",
             "Me",
         ] as string[],
-        intents : [] as Intent[],
-        sparseCellData : {} as {[key: string]: string},
-        sparseCellIntent : {} as {[key: string]: Intent},
+        sparseCellData: {} as { [key: string]: string },
+        sparseCellIntent: {} as { [key: string]: Intent },
     };
 
     public render() {
         return (<Table
-                numRows={7}
-                selectionModes={SelectionModes.COLUMNS_AND_CELLS}
-            >
+            numRows={7}
+            selectionModes={SelectionModes.COLUMNS_AND_CELLS}
+        >
             {this.state.names.map((name: string, index: number) => (
                 <Column key={index} renderCell={this.renderCell} renderColumnHeader={this.renderColumnHeader} />
             ))}
@@ -223,22 +224,22 @@ class EditableTable extends React.Component<{}, {}> {
         };
     }
 
-    private setArrayState<T>(key: string, index: number, value: T)  {
+    private setArrayState<T>(key: string, index: number, value: T) {
         const values = (this.state as any)[key].slice() as T[];
         values[index] = value;
-        this.setState({ [key] : values });
+        this.setState({ [key]: values });
     }
 
-    private setSparseState<T>(stateKey: string, dataKey: string, value: T)  {
-        const values = Object.assign({}, (this.state as any)[stateKey]) as {[key: string]: T};
-        values[dataKey] = value;
-        this.setState({ [stateKey] : values });
+    private setSparseState<T>(stateKey: string, dataKey: string, value: T) {
+        const stateData = (this.state as any)[stateKey] as { [key: string]: T };
+        const values = { ...stateData, [dataKey]: value };
+        this.setState({ [stateKey]: values });
     }
 }
 
 ReactDOM.render(
     <EditableTable />,
-    document.getElementById("table-editable-names")
+    document.getElementById("table-editable-names"),
 );
 
 ReactDOM.render(
@@ -246,7 +247,7 @@ ReactDOM.render(
         fillBodyWithGhostCells: true,
         selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-ghost")
+    document.getElementById("table-ghost"),
 );
 
 ReactDOM.render(
@@ -254,20 +255,20 @@ ReactDOM.render(
         fillBodyWithGhostCells: true,
         selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-inline-ghost")
+    document.getElementById("table-inline-ghost"),
 );
 
 ReactDOM.render(
-    getTableComponent(200, 100 * 1000, {} , {
+    getTableComponent(200, 100 * 1000, {}, {
         fillBodyWithGhostCells: true,
         selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-big")
+    document.getElementById("table-big"),
 );
 
 class RowSelectableTable extends React.Component<{}, {}> {
     public state = {
-        selectedRegions: [ Regions.row(2) ],
+        selectedRegions: [Regions.row(2)],
     };
 
     public render() {
@@ -283,7 +284,7 @@ class RowSelectableTable extends React.Component<{}, {}> {
                 <Column name="Select" />
                 <Column name="Rows" />
             </Table>
-            <br/>
+            <br />
             <Button onClick={this.handleClear} intent={Intent.PRIMARY}>Clear Selection</Button>
         </div>);
     }
@@ -307,22 +308,22 @@ class RowSelectableTable extends React.Component<{}, {}> {
 }
 
 ReactDOM.render(
-    <RowSelectableTable/>,
-    document.getElementById("table-select-rows")
+    <RowSelectableTable />,
+    document.getElementById("table-select-rows"),
 );
 
 document.getElementById("table-ledger").classList.add("bp-table-striped");
 
 ReactDOM.render(
     getTableComponent(3, 7, {}, { className: "" }),
-    document.getElementById("table-ledger")
+    document.getElementById("table-ledger"),
 );
 
 class AdjustableColumnsTable extends React.Component<{}, {}> {
     public state = {
         columns: [
-            <Column name="First" key={0} id={0}/>,
-            <Column name="Second" key={1} id={1}/>,
+            <Column name="First" key={0} id={0} />,
+            <Column name="Second" key={1} id={1} />,
         ],
     };
 
@@ -344,7 +345,7 @@ class AdjustableColumnsTable extends React.Component<{}, {}> {
 
     private add() {
         const columns = this.state.columns.slice();
-        columns.push(<Column key={columns.length} id={columns.length}/>);
+        columns.push(<Column key={columns.length} id={columns.length} />);
         this.setState({ columns });
     }
 
@@ -368,7 +369,7 @@ class AdjustableColumnsTable extends React.Component<{}, {}> {
 
 ReactDOM.render(
     <AdjustableColumnsTable />,
-    document.getElementById("table-cols")
+    document.getElementById("table-cols"),
 );
 
 ReactDOM.render(
@@ -377,11 +378,11 @@ ReactDOM.render(
             return <Cell intent={rowIndex as Intent}>{Utils.toBase26Alpha(columnIndex) + (rowIndex + 1)}</Cell>;
         },
     }, {
-        isColumnResizable: false,
-        isRowResizable: false,
-        selectionModes: SelectionModes.NONE,
-    }),
-    document.getElementById("table-1")
+            isColumnResizable: false,
+            isRowResizable: false,
+            selectionModes: SelectionModes.NONE,
+        }),
+    document.getElementById("table-1"),
 );
 
 const renderBodyContextMenu = (context: IMenuContext) => {
@@ -403,12 +404,12 @@ const renderBodyContextMenu = (context: IMenuContext) => {
 ReactDOM.render(
     getTableComponent(3, 7, {}, {
         allowMultipleSelection: true,
-        renderBodyContextMenu,
-        selectionModes: SelectionModes.ALL,
         isColumnResizable: true,
         isRowResizable: true,
+        renderBodyContextMenu,
+        selectionModes: SelectionModes.ALL,
     }),
-    document.getElementById("table-2")
+    document.getElementById("table-2"),
 );
 
 ReactDOM.render(
@@ -416,7 +417,7 @@ ReactDOM.render(
         defaultColumnWidth: 60,
         isRowHeaderShown: false,
     }),
-    document.getElementById("table-3")
+    document.getElementById("table-3"),
 );
 
 const customRowHeaders = [
@@ -434,7 +435,7 @@ ReactDOM.render(
             return <RowHeaderCell name={customRowHeaders[rowIndex]} />;
         },
     }),
-    document.getElementById("table-4")
+    document.getElementById("table-4"),
 );
 
 ReactDOM.render(
@@ -443,18 +444,18 @@ ReactDOM.render(
             return <ColumnHeaderCell name={Utils.toBase26Alpha(columnIndex)} isActive={columnIndex % 3 === 0} />;
         },
     }, {
-        styledRegionGroups: [
-            {
-                className: "my-group",
-                regions: [
-                    Regions.cell(0, 0),
-                    Regions.row(2),
-                    Regions.cell(1, 2, 5, 2),
-                ],
-            },
-        ],
-    }),
-    document.getElementById("table-5")
+            styledRegionGroups: [
+                {
+                    className: "my-group",
+                    regions: [
+                        Regions.cell(0, 0),
+                        Regions.row(2),
+                        Regions.cell(1, 2, 5, 2),
+                    ],
+                },
+            ],
+        }),
+    document.getElementById("table-5"),
 );
 
 ReactDOM.render(
@@ -469,11 +470,11 @@ ReactDOM.render(
             );
         },
     }, {
-        renderRowHeaderCell : (rowIndex: number) => {
-            return <RowHeaderCell name={`${rowIndex + 1}`} menu={testMenu} />;
-        }
-    }),
-    document.getElementById("table-6")
+            renderRowHeaderCell: (rowIndex: number) => {
+                return <RowHeaderCell name={`${rowIndex + 1}`} menu={testMenu} />;
+            },
+        }),
+    document.getElementById("table-6"),
 );
 
 class CustomHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
@@ -488,11 +489,11 @@ class CustomHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
 
 ReactDOM.render(
     getTableComponent(2, 5, {
-        renderColumnHeader: (columnIndex: number) => <CustomHeaderCell name="sup"/>,
+        renderColumnHeader: (columnIndex: number) => <CustomHeaderCell name="sup" />,
     }, {
-        allowMultipleSelection: false,
-    }),
-    document.getElementById("table-7")
+            allowMultipleSelection: false,
+        }),
+    document.getElementById("table-7"),
 );
 
 const longContentRenderCell = (rowIndex: number, columnIndex: number) => {
@@ -503,23 +504,23 @@ const longContentRenderCell = (rowIndex: number, columnIndex: number) => {
 ReactDOM.render(
     <Table numRows={4}>
         <Column name="My" />
-        <Column name="Table" renderCell={longContentRenderCell}/>
+        <Column name="Table" renderCell={longContentRenderCell} />
     </Table>,
-    document.getElementById("table-8")
+    document.getElementById("table-8"),
 );
 
 ReactDOM.render(
-    <div style={{position: "relative"}}>
-        <div style={{zIndex: 0}} className="stack-fill">Z = 0</div>
-        <div style={{zIndex: 1}} className="stack-fill">Z = 1</div>
-        <div style={{zIndex: 2}} className="stack-fill"><br/>Z = 2</div>
+    <div style={{ position: "relative" }}>
+        <div style={{ zIndex: 0 }} className="stack-fill">Z = 0</div>
+        <div style={{ zIndex: 1 }} className="stack-fill">Z = 1</div>
+        <div style={{ zIndex: 2 }} className="stack-fill"><br />Z = 2</div>
         <Table numRows={3}>
-            <Column name="A"/>
-            <Column name="B"/>
-            <Column name="C"/>
+            <Column name="A" />
+            <Column name="B" />
+            <Column name="C" />
         </Table>
-        <div className="stack-fill"><br/><br/>after</div>
+        <div className="stack-fill"><br /><br />after</div>
     </div>
     ,
-    document.getElementById("table-9")
+    document.getElementById("table-9"),
 );

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -320,7 +320,7 @@ export class Grid {
                 rect.left -= offsetLeft;
                 rect.width += offsetLeft;
                 rect.top -= offsetTop;
-                return Object.assign(rect.style(), { display: "block" });
+                return { ...rect.style(), display: "block" };
             }
 
             case RegionCardinality.FULL_COLUMNS: {

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -99,7 +99,7 @@ export abstract class Resizable extends React.Component<IResizableProps, IResize
 
     public render() {
         const child = React.Children.only(this.props.children);
-        const style = Object.assign({}, child.props.style, this.getStyle());
+        const style = { ...child.props.style, ...this.getStyle() };
 
         if (this.props.isResizable === false) {
             return React.cloneElement(child, { style });

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -161,7 +161,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         );
         const key = TableBody.cellReactKey(rowIndex, columnIndex);
         const rect = isGhost ? grid.getGhostCellRect(rowIndex, columnIndex) : grid.getCellRect(rowIndex, columnIndex);
-        const style = Object.assign({}, baseCell.props.style, Rect.style(rect));
+        const style = { ...baseCell.props.style, ...Rect.style(rect) };
         return React.cloneElement(baseCell, { className, style, key } as ICellProps);
     }
 

--- a/packages/table/test/mocks/table.tsx
+++ b/packages/table/test/mocks/table.tsx
@@ -25,14 +25,16 @@ export function createTableOfSize(numColumns: number, numRows: number, columnPro
 
 export function createTableWithData(columnNames: string[], data: string[][], columnProps?: any, tableProps?: any) {
     // combine column overrides
-    const columnPropsWithDefaults = Object.assign({
+    const columnPropsWithDefaults = {
         renderCell: (rowIndex: number, columnIndex: number) => <Cell>{data[rowIndex][columnIndex]}</Cell>,
-    }, columnProps) as IColumnProps;
+        ...columnProps,
+    } as IColumnProps;
 
     // combine table overrides
-    const tablePropsWithDefaults = Object.assign({
+    const tablePropsWithDefaults = {
         numRows: data.length,
-    }, tableProps) as ITableProps;
+        ...tableProps,
+     } as ITableProps;
 
     const SampleColumns = columnNames.map((name, index) => {
         return (

--- a/packages/table/test/tsconfig.json
+++ b/packages/table/test/tsconfig.json
@@ -1,23 +1,10 @@
 {
-    "version": "2.0.0",
-    "compilerOptions": {
-        "declaration": false,
-        "jsx": "react",
-        "module": "commonjs",
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "removeComments": false,
-        "sourceMap": true,
-        "target": "es5",
-        "experimentalDecorators": true
-    },
+    "extends": "../tsconfig",
     "include": [
         "../typings/tsd.d.ts",
         "../../../test/typings/tsd.d.ts",
         "**/*Tests.tsx",
         "**/*Tests.ts"
     ],
-    "exclude": [],
-    "compileOnSave": false
+    "exclude": []
 }

--- a/packages/table/tsconfig.json
+++ b/packages/table/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "jsx": "react",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
#### Fixes #376, Fixes #11 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] `tslib`
- [x] `Partial` for props in some test suites
- [x] `extends` outside of gulp-typescript 😭  https://github.com/ivogabe/gulp-typescript/issues/459

#### Changes proposed in this pull request:

- update typescript and gulp-typescript
- replace `Object.assign` and `Utils.shallowClone` with object spreads
- some lint fixes in table examples
- ⚠️  new dependency on `tslib` for `--importHelpers` flag
  - this reduces the size of each source file at the cost of one additional NPM dependency
- use `Partial<Props>` in test suites for components that have required props!
- use `extends` in tsconfig.json files that are never built with `gulp-typescript`