### PR TITLE
Remove color rule from icon classes

### DIFF
--- a/packages/core/examples/dialogExample.tsx
+++ b/packages/core/examples/dialogExample.tsx
@@ -19,7 +19,7 @@ export class DialogExample extends OverlayExample {
                     className={this.props.getTheme()}
                     iconName="inbox"
                     onClose={this.handleClose}
-                    title="Dialog Header"
+                    title="Dialog header"
                     {...this.state}
                 >
                     <div className={Classes.DIALOG_BODY}>

--- a/packages/core/examples/nonIdealStateExample.tsx
+++ b/packages/core/examples/nonIdealStateExample.tsx
@@ -16,7 +16,7 @@ export class NonIdealStateExample extends BaseExample<{}> {
         return (
             <NonIdealState
                 visual="search"
-                title="No Search Results"
+                title="No search results"
                 description={description}
                 action={<InputGroup className="pt-round" leftIconName="search" placeholder="Search..." />}
             />

--- a/packages/core/src/_icons.scss
+++ b/packages/core/src/_icons.scss
@@ -44,11 +44,6 @@ Styleguide icons.ui
 
 #{$icon-classes} {
   display: inline-block;
-  color: $pt-icon-color;
-
-  .pt-dark & {
-    color: $pt-dark-icon-color;
-  }
 }
 
 span.pt-icon-standard {

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -57,7 +57,7 @@ class DialogExample extends React.Component<{}, IDialogExampleState> {
                     iconName="inbox"
                     isOpen={this.state.isOpen}
                     onClose={this.toggleDialog}
-                    title="Dialog Header"
+                    title="Dialog header"
                 >
                     <div className="pt-dialog-body">
                         Some content
@@ -222,7 +222,7 @@ Markup:
 <div class="pt-dialog">
   <div class="pt-dialog-header">
     <span class="pt-icon-large pt-icon-inbox"></span>
-    <h5>Dialog Header</h5>
+    <h5>Dialog header</h5>
     <button aria-label="Close" class="pt-dialog-close-button pt-icon-small-cross"></button>
   </div>
   <div class="pt-dialog-body">

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -99,6 +99,7 @@ $input-button-height-large: $pt-button-height !default;
 
     margin: 0 ($pt-input-height - $pt-icon-size-standard) / 2;
     line-height: $pt-input-height;
+    color: $pt-icon-color;
   }
 
   .pt-tag {
@@ -167,6 +168,10 @@ $input-button-height-large: $pt-button-height !default;
   }
 
   .pt-dark & {
+    .pt-icon {
+      color: $pt-dark-icon-color;
+    }
+
     &.pt-disabled .pt-icon {
       color: $pt-dark-icon-color-disabled;
     }

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -36,7 +36,7 @@ Markup:
   <div class="pt-non-ideal-state-visual pt-non-ideal-state-icon">
     <span class="pt-icon pt-icon-folder-open"></span>
   </div>
-  <h4 class="pt-non-ideal-state-title">This Folder Is Empty</h4>
+  <h4 class="pt-non-ideal-state-title">This folder is empty</h4>
   <div class="pt-non-ideal-state-description">
     Create a new file to populate the folder.
   </div>

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -138,6 +138,7 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
 
 .pt-tree-node-caret {
   @include pt-icon-colors();
+
   cursor: pointer;
   text-align: center;
 
@@ -200,6 +201,10 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
 .pt-dark {
   .pt-tree-node-content:hover {
     background-color: rgba($gray1, 0.3);
+  }
+
+  .pt-tree-node-icon {
+    color: $pt-dark-icon-color;
   }
 
   .pt-tree-node.pt-tree-node-selected > .pt-tree-node-content {

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -109,7 +109,7 @@ describe("<Dialog>", () => {
         return [
             <div className={Classes.DIALOG_HEADER} key={0}>
                 <span className="pt-icon-large pt-icon-inbox"/>
-                <h4>Dialog Header</h4>
+                <h4>Dialog header</h4>
             </div>,
             <div className={Classes.DIALOG_BODY} key={1}>
                 <p>


### PR DESCRIPTION
#### Fixes #437 

#### Changes proposed in this pull request:

- Remove `color` rule from icon classes
- Adjust icon colors in input groups and dark tree items

This way, folks using a custom element with a custom `color` won't have issues with icons showing up gray.