### PR TITLE
Allow JSX elements as text

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -40,7 +40,7 @@ export interface IActionProps extends IIntentProps, IProps {
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 
     /** Action text, required for usability. */
-    text?: string;
+    text?: string | JSX.Element;
 }
 
 /** Interface for a link, with support for customizing target window. */

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -97,7 +97,7 @@ function maybeRenderSpinner(loading: boolean) {
       : undefined;
 }
 
-function maybeRenderText(text?: string) {
+function maybeRenderText(text?: string | JSX.Element) {
     return text
       ? <span>{text}</span>
       : undefined;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -20,7 +20,7 @@ import { Menu } from "./menu";
 export interface IMenuItemProps extends IActionProps, ILinkProps {
     // override from IActionProps to make it required
     /** Item text, required for usability. */
-    text: string;
+    text: string | JSX.Element;
 
     /**
      * Right-aligned label content, useful for hotkeys.

--- a/packages/core/test/collapsible-list/collapsibleListTests.tsx
+++ b/packages/core/test/collapsible-list/collapsibleListTests.tsx
@@ -82,8 +82,7 @@ describe("<CollapsibleList>", () => {
             renderCollapsibleList(7, { renderVisibleItem, visibleItemCount: 3 });
             renderVisibleItem.args.map((arg) => {
                 const props: IMenuItemProps = arg[0];
-                const absoluteIndex = +props.text.slice(5); // "Item #"
-                assert.equal(absoluteIndex, arg[1]);
+                assert.equal(props.text, `Item ${arg[1]}`);
             });
         });
 
@@ -92,8 +91,7 @@ describe("<CollapsibleList>", () => {
             renderCollapsibleList(6, { collapseFrom: CollapseFrom.END, renderVisibleItem, visibleItemCount: 3 });
             renderVisibleItem.args.map((arg) => {
                 const props: IMenuItemProps = arg[0];
-                const absoluteIndex = +props.text.slice(5); // "Item #"
-                assert.equal(absoluteIndex, arg[1]);
+                assert.equal(props.text, `Item ${arg[1]}`);
             });
         });
     });


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Allow using `JSX.Element`s as text for `MenuItem`s, `Button`s, …
