### PR TITLE
Don't fire EditableText events if value has not changed

### DIFF
--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -44,7 +44,8 @@ usage through the `value` or `defaultValue` props, respectively.
 
 The `onConfirm` and `onCancel` callbacks are invoked based on user interaction. The user presses
 <kbd class="pt-key">enter</kbd> or blurs the input to confirm the current value, or presses <kbd
-class="pt-key">esc</kbd> to cancel. Canceling resets the field to the last confirmed value.
+class="pt-key">esc</kbd> to cancel. Canceling resets the field to the last confirmed value. Neither
+callback is invoked if the value is unchanged.
 
 `EditableText` by default supports _exactly one line of text_ and will grow or shrink horizontally
 based on the length of text. See below for information on [multiline

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -207,22 +207,27 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
     }
 
     public cancelEditing = () => {
-        const { lastValue } = this.state;
-        this.setState({ isEditing: false, value: lastValue });
-        // invoke onCancel after onChange so consumers' onCancel can override their onChange
-        safeInvoke(this.props.onChange, lastValue);
-        safeInvoke(this.props.onCancel, lastValue);
+        const { lastValue, value } = this.state;
+        if (lastValue === value) {
+            this.setState({ isEditing: false });
+        } else {
+            this.setState({ isEditing: false, value: lastValue });
+            // invoke onCancel after onChange so consumers' onCancel can override their onChange
+            safeInvoke(this.props.onChange, lastValue);
+            safeInvoke(this.props.onCancel, lastValue);
+        }
     }
 
     public toggleEditing = () => {
         if (this.state.isEditing) {
-            const { value } = this.state;
-            this.setState({
-                isEditing: false,
-                lastValue: value,
-            });
-            safeInvoke(this.props.onChange, value);
-            safeInvoke(this.props.onConfirm, value);
+            const { lastValue, value } = this.state;
+            if (lastValue === value) {
+                this.setState({ isEditing: false });
+            } else {
+                this.setState({ isEditing: false, lastValue: value });
+                safeInvoke(this.props.onChange, value);
+                safeInvoke(this.props.onConfirm, value) ;
+            }
         } else if (!this.props.disabled) {
             this.setState({ isEditing: true });
         }

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -31,7 +31,7 @@ describe("<EditableText>", () => {
         assert.isFalse(editable.state("isEditing"));
     });
 
-    describe.only("when editing", () => {
+    describe("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");
             assert.lengthOf(input, 1);

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -31,7 +31,7 @@ describe("<EditableText>", () => {
         assert.isFalse(editable.state("isEditing"));
     });
 
-    describe("when editing", () => {
+    describe.only("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");
             assert.lengthOf(input, 1);
@@ -60,8 +60,9 @@ describe("<EditableText>", () => {
 
         it("calls onCancel when escape key pressed", () => {
             const cancelSpy = sinon.spy();
-            shallow(<EditableText isEditing={true} onCancel={cancelSpy} placeholder="Edit..." value="alphabet" />)
-                .find("input")
+            shallow(
+                <EditableText isEditing={true} onCancel={cancelSpy} placeholder="Edit..." defaultValue="alphabet" />,
+                ).find("input")
                 .simulate("change", { target: { value: "hello" } })
                 .simulate("keydown", { which: Keys.ESCAPE });
             assert.isTrue(cancelSpy.calledOnce, "onCancel not called once");
@@ -76,6 +77,22 @@ describe("<EditableText>", () => {
                 .simulate("keydown", { which: Keys.ENTER });
             assert.isTrue(confirmSpy.calledOnce, "onConfirm not called once");
             assert.isTrue(confirmSpy.calledWith("hello"), `unexpected argument "${confirmSpy.args[0][0]}"`);
+        });
+
+        it("does not call onCancel when value not changed and escape key pressed", () => {
+            const confirmSpy = sinon.spy();
+            shallow(<EditableText isEditing={true} onConfirm={confirmSpy} defaultValue="alphabet" />)
+                .find("input")
+                .simulate("keydown", { which: Keys.ESCAPE });
+            assert.isTrue(confirmSpy.notCalled);
+        });
+
+        it("does not call onConfirm when value not changed and enter key pressed", () => {
+            const confirmSpy = sinon.spy();
+            shallow(<EditableText isEditing={true} onConfirm={confirmSpy} defaultValue="alphabet" />)
+                .find("input")
+                .simulate("keydown", { which: Keys.ENTER });
+            assert.isTrue(confirmSpy.notCalled);
         });
 
         it("calls onEdit when entering edit mode", () => {

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -62,7 +62,7 @@ describe("<EditableText>", () => {
             const cancelSpy = sinon.spy();
             shallow(
                 <EditableText isEditing={true} onCancel={cancelSpy} placeholder="Edit..." defaultValue="alphabet" />,
-                ).find("input")
+            ).find("input")
                 .simulate("change", { target: { value: "hello" } })
                 .simulate("keydown", { which: Keys.ESCAPE });
             assert.isTrue(cancelSpy.calledOnce, "onCancel not called once");


### PR DESCRIPTION
#### Fixes #483 

#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Do not call `onChange` nor `onConfirm` on blur / enter if value not changed
- Do not call `onChange` nor `onCancel` on escape if value not changed
