### PR TITLE
Fix toast autofocus

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -161,7 +161,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
 
         // add a special class to each child that will automatically set the appropriate
         // CSS position mode under the hood. also, make the container focusable so we can
-        // trap focus inside it (via `persistentFocus()`).
+        // trap focus inside it (via `enforceFocus`).
         const decoratedChildren = React.Children.map(children, (child: React.ReactElement<any>) => {
             return React.cloneElement(child, {
                 className: classNames(child.props.className, Classes.OVERLAY_CONTENT),

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -63,6 +63,7 @@ export class Toast extends AbstractComponent<IToastProps, {}> {
                 onFocus={this.clearTimeouts}
                 onMouseEnter={this.clearTimeouts}
                 onMouseLeave={this.startTimeout}
+                tabIndex={0}
             >
                 {this.maybeRenderIcon()}
                 <span className={Classes.TOAST_MESSAGE}>{message}</span>

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -129,11 +129,6 @@ describe("Toaster", () => {
             toaster = Toaster.create({autoFocus: true}, testsContainerElement);
         });
 
-        after(() => {
-            toaster.clear();
-            ReactDOM.unmountComponentAtNode(testsContainerElement);
-        });
-
         it("focuses on new toast if autoFocus is set to true", () => {
             toaster.show({ message: "focus on me" });
             assert.equal(testsContainerElement.querySelector(".pt-toast"), document.activeElement);

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -121,4 +121,22 @@ describe("Toaster", () => {
             "mutation side effect!",
         );
     });
+
+    describe("with autoFocus set to true", () => {
+        before(() => {
+            testsContainerElement = document.createElement("div");
+            document.documentElement.appendChild(testsContainerElement);
+            toaster = Toaster.create({autoFocus: true}, testsContainerElement);
+        });
+
+        after(() => {
+            toaster.clear();
+            ReactDOM.unmountComponentAtNode(testsContainerElement);
+        });
+
+        it("focuses on new toast if autoFocus is set to true", () => {
+            toaster.show({ message: "focus on me" });
+            assert.equal(testsContainerElement.querySelector(".pt-toast"), document.activeElement);
+        });
+    });
 });

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -129,7 +129,7 @@ describe("Toaster", () => {
             toaster = Toaster.create({autoFocus: true}, testsContainerElement);
         });
 
-        it("focuses on new toast if autoFocus is set to true", () => {
+        it("focuses on newly created toast", () => {
             toaster.show({ message: "focus on me" });
             assert.equal(testsContainerElement.querySelector(".pt-toast"), document.activeElement);
         });


### PR DESCRIPTION
#### Fixes #469 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add `tabIndex` to toast wrappers - necessary from the changes in #276, which is looking for an explicit `tabIndex`.
- Another solution is that we could set the `tabIndex` on the first toast if `autoFocus` is set to true, but I don't want to expose that in the Toast props...
