### PR TITLE
Modify hover colors and allow pt-active class on menu-items

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -14,10 +14,10 @@ $menu-item-padding-large: ($pt-button-height-large - $pt-icon-size-large) / 2 !d
 $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray4 !default;
 
-$menu-item-color-hover: $minimal-button-background-color-hover;
-$menu-item-color-active: $minimal-button-background-color-active;
-$dark-menu-item-color-hover: $dark-minimal-button-background-color-hover;
-$dark-menu-item-color-active: $dark-minimal-button-background-color-active;
+$menu-item-color-hover: $minimal-button-background-color-hover !default;
+$menu-item-color-active: $minimal-button-background-color-active !default;
+$dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !default;
+$dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
 
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
@@ -36,33 +36,29 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active;
   color: inherit;
   user-select: none;
 
-  &#{$active-selector},
-  &#{$active-selector}#{$hover-pseudoselector} {
+  &#{$hover-pseudoselector} {
+    background: $menu-item-color-hover;
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  &#{$active-pseudoselector} {
+    background: $menu-item-color-active;
+  }
+
+  &#{$active-selector} {
     background: $pt-intent-primary;
     cursor: pointer;
     color: $white;
   }
 
-  &#{$disabled-selector},
-  &#{$disabled-selector}#{$hover-pseudoselector} {
+  &#{$disabled-selector} {
     // override global a:focus styles
     outline: none;
     background: inherit;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
-  }
-
-  &:not(#{$active-selector}):not(#{$disabled-selector}) {
-    &#{$hover-pseudoselector} {
-      background-color: $menu-item-color-hover;
-      cursor: pointer;
-      text-decoration: none;
-      color: inherit;
-    }
-
-    &#{$active-pseudoselector} {
-      background: $menu-item-color-active;
-    }
   }
 
   .pt-dark & {
@@ -83,19 +79,21 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active;
 ) {
   color: inherit;
 
-  &#{$disabled-selector} {
-    color: $pt-dark-text-color-disabled;
+  &#{$hover-pseudoselector} {
+    background: $dark-menu-item-color-hover;
+    color: inherit;
   }
 
-  &:not(#{$active-selector}):not(#{$disabled-selector}) {
-    &#{$hover-pseudoselector} {
-      background: $dark-menu-item-color-hover;
-      color: inherit;
-    }
+  &#{$active-pseudoselector} {
+    background: $dark-menu-item-color-active;
+  }
 
-    &#{$active-pseudoselector} {
-      background: $dark-menu-item-color-active;
-    }
+  &#{$active-selector} {
+    background: $pt-intent-primary;
+  }
+
+  &#{$disabled-selector} {
+    background: inherit;
   }
 }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -55,10 +55,6 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
     cursor: not-allowed;
     color: $pt-text-color-disabled;
   }
-
-  .pt-dark & {
-    @include dark-menu-item($active-selector: ".pt-active", $disabled-selector: ".pt-disabled");
-  }
 }
 
 @mixin dark-menu-item($active-selector: ".pt-active", $disabled-selector: ".pt-disabled") {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -21,12 +21,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
 
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
-@mixin menu-item(
-  $active-selector: ".pt-active",
-  $disabled-selector: ".pt-disabled",
-  $active-pseudoselector: ":active",
-  $hover-pseudoselector: ":hover"
-) {
+@mixin menu-item($active-selector: ".pt-active", $disabled-selector: ".pt-disabled") {
   @include overflow-ellipsis();
 
   display: block;
@@ -36,14 +31,14 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   color: inherit;
   user-select: none;
 
-  &#{$hover-pseudoselector} {
+  &:hover {
     background: $menu-item-color-hover;
     cursor: pointer;
     text-decoration: none;
     color: inherit;
   }
 
-  &#{$active-pseudoselector} {
+  &:active {
     background: $menu-item-color-active;
   }
 
@@ -62,29 +57,19 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   }
 
   .pt-dark & {
-    @include dark-menu-item(
-      $active-selector: ".pt-active",
-      $disabled-selector: ".pt-disabled",
-      $active-pseudoselector: ":active",
-      $hover-pseudoselector: ":hover"
-    );
+    @include dark-menu-item($active-selector: ".pt-active", $disabled-selector: ".pt-disabled");
   }
 }
 
-@mixin dark-menu-item(
-  $active-selector: ".pt-active",
-  $disabled-selector: ".pt-disabled",
-  $active-pseudoselector: ":active",
-  $hover-pseudoselector: ":hover"
-) {
+@mixin dark-menu-item($active-selector: ".pt-active", $disabled-selector: ".pt-disabled") {
   color: inherit;
 
-  &#{$hover-pseudoselector} {
+  &:hover {
     background: $dark-menu-item-color-hover;
     color: inherit;
   }
 
-  &#{$active-pseudoselector} {
+  &:active {
     background: $dark-menu-item-color-active;
   }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -14,9 +14,19 @@ $menu-item-padding-large: ($pt-button-height-large - $pt-icon-size-large) / 2 !d
 $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray4 !default;
 
+$menu-item-color-hover: $minimal-button-background-color-hover;
+$menu-item-color-active: $minimal-button-background-color-active;
+$dark-menu-item-color-hover: $dark-minimal-button-background-color-hover;
+$dark-menu-item-color-active: $dark-minimal-button-background-color-active;
+
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
-@mixin menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
+@mixin menu-item(
+  $active-selector: ".pt-active",
+  $disabled-selector: ".pt-disabled",
+  $active-pseudoselector: ":active",
+  $hover-pseudoselector: ":hover"
+) {
   @include overflow-ellipsis();
 
   display: block;
@@ -26,27 +36,66 @@ $dark-menu-background-color: $dark-gray4 !default;
   color: inherit;
   user-select: none;
 
-  &:not(#{$disabled-selector})#{$hover-selector} {
+  &#{$active-selector},
+  &#{$active-selector}#{$hover-pseudoselector} {
     background: $pt-intent-primary;
     cursor: pointer;
     color: $white;
   }
 
-  &#{$disabled-selector} {
+  &#{$disabled-selector},
+  &#{$disabled-selector}#{$hover-pseudoselector} {
+    // override global a:focus styles
+    outline: none;
+    background: inherit;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
   }
 
+  &:not(#{$active-selector}):not(#{$disabled-selector}) {
+    &#{$hover-pseudoselector} {
+      background-color: $menu-item-color-hover;
+      cursor: pointer;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    &#{$active-pseudoselector} {
+      background: $menu-item-color-active;
+    }
+  }
+
   .pt-dark & {
-    @include dark-menu-item($disabled-selector);
+    @include dark-menu-item(
+      $active-selector: ".pt-active",
+      $disabled-selector: ".pt-disabled",
+      $active-pseudoselector: ":active",
+      $hover-pseudoselector: ":hover"
+    );
   }
 }
 
-@mixin dark-menu-item($disabled-selector: ".pt-disabled") {
+@mixin dark-menu-item(
+  $active-selector: ".pt-active",
+  $disabled-selector: ".pt-disabled",
+  $active-pseudoselector: ":active",
+  $hover-pseudoselector: ":hover"
+) {
   color: inherit;
 
   &#{$disabled-selector} {
     color: $pt-dark-text-color-disabled;
+  }
+
+  &:not(#{$active-selector}):not(#{$disabled-selector}) {
+    &#{$hover-pseudoselector} {
+      background: $dark-menu-item-color-hover;
+      color: inherit;
+    }
+
+    &#{$active-pseudoselector} {
+      background: $dark-menu-item-color-active;
+    }
   }
 }
 

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -339,9 +339,10 @@ Styleguide components.menu.css.header
       color: $pt-dark-text-color-muted;
     }
 
-    &:hover {
+    &.pt-active {
       &::before,
-      &::after {
+      &::after,
+      .pt-menu-item-label {
         color: $white;
       }
     }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -229,17 +229,32 @@ Styleguide components.menu.css
     color: $pt-text-color-muted;
   }
 
-  &:not(.pt-disabled):not(.pt-active):hover {
-    // intent color only appears on hover
-    @each $intent, $color in $pt-intent-colors {
+  &:not(.pt-disabled) {
+    @each $intent, $color in $button-intents {
       &.pt-intent-#{$intent} {
-        background-color: $color;
-        color: $white;
+        &:hover {
+          background: nth(map-get($button-intents, $intent), 1);
+        }
 
-        &::before,
-        &::after,
-        .pt-menu-item-label {
+        &:active {
+          background: nth(map-get($button-intents, $intent), 2);
+        }
+
+        &.pt-active {
+          background: nth(map-get($button-intents, $intent), 1);
+        }
+
+        &:hover,
+        &:active {
           color: $white;
+
+          // hard to fix without removing the :not(.pt-disabled)
+          // stylelint-disable max-nesting-depth
+          &::before,
+          &::after,
+          .pt-menu-item-label {
+            color: $white;
+          }
         }
       }
     }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -245,8 +245,15 @@ Styleguide components.menu.css
     }
   }
 
-  &.pt-disabled,
   &.pt-active {
+    &::before,
+    &::after,
+    .pt-menu-item-label {
+      color: $white;
+    }
+  }
+
+  &.pt-disabled {
     &::before,
     &::after {
       color: $pt-icon-color-disabled;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -229,27 +229,24 @@ Styleguide components.menu.css
     color: $pt-text-color-muted;
   }
 
-  &:not(.pt-disabled):hover {
-    &::before,
-    &::after,
-    .pt-menu-item-label {
-      color: $white;
-    }
-
+  &:not(.pt-disabled):not(.pt-active):hover {
     // intent color only appears on hover
     @each $intent, $color in $pt-intent-colors {
       &.pt-intent-#{$intent} {
         background-color: $color;
+        color: $white;
+
+        &::before,
+        &::after,
+        .pt-menu-item-label {
+          color: $white;
+        }
       }
     }
   }
 
-  &.pt-disabled {
-    // override global a:focus styles
-    outline: none;
-    cursor: not-allowed;
-    color: $pt-text-color-disabled;
-
+  &.pt-disabled,
+  &.pt-active {
     &::before,
     &::after {
       color: $pt-icon-color-disabled;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -288,6 +288,10 @@ Styleguide components.menu.css
       margin-right: $menu-item-padding-large;
     }
   }
+
+  .pt-dark & {
+    @include dark-menu-item();
+  }
 }
 
 a.pt-menu-item {

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -348,6 +348,8 @@ Styleguide components.menu.css.header
     color: $pt-dark-text-color;
   }
 
+  // keep icon and label styling outside the mixin
+  // stylelint-disable no-duplicate-selectors
   .pt-menu-item {
     &::before,
     &::after {

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -11,11 +11,6 @@ $nav-item-line-height: 16px;
 $nav-item-padding: $pt-grid-size;
 $nav-item-indent: $pt-grid-size * 2;
 
-$nav-item-color-hover: $minimal-button-background-color-hover;
-$nav-item-color-active: $minimal-button-background-color-active;
-$dark-nav-item-color-hover: $dark-minimal-button-background-color-hover;
-$dark-nav-item-color-active: $dark-minimal-button-background-color-active;
-
 $navbar-box-shadow: 0 1px 0 $pt-divider-black;
 $dark-navbar-box-shadow: 0 1px 0 $pt-dark-divider-black;
 
@@ -113,32 +108,6 @@ Lefthand navigation menu
     padding-right: $nav-item-padding;
     padding-left: $nav-item-padding;
     white-space: initial;
-  }
-
-  .pt-menu-item:not(.pt-active) {
-    &:hover {
-      background-color: $nav-item-color-hover;
-      text-decoration: none;
-      color: $pt-text-color;
-    }
-
-    &:active {
-      background-color: $nav-item-color-active;
-    }
-
-    .pt-dark & {
-      color: $pt-dark-text-color;
-
-      &:hover {
-        box-shadow: none;
-        background-color: $dark-nav-item-color-hover;
-        color: $pt-dark-text-color;
-      }
-
-      &:active {
-        background-color: $dark-nav-item-color-active;
-      }
-    }
   }
 
   @each $depth in (2, 3, 4, 5) {

--- a/packages/docs/src/styles/_navigator.scss
+++ b/packages/docs/src/styles/_navigator.scss
@@ -15,12 +15,6 @@ $navigator-min-width: $pt-grid-size * 22;
   }
 }
 
-.pt-menu-item.pt-active {
-  background: $pt-intent-primary;
-  cursor: pointer;
-  color: $white;
-}
-
 .pt-menu-item.pt-active,
 .pt-menu-item:hover {
   .docs-result-path {


### PR DESCRIPTION
#### Fixes #389 

To see the changes in the preview, hover and click on item with these additional classes (with the console):

- no edits
- `pt-active`
- `pt-disabled`
- `pt-intent-*` (intent visible only on hover)
- `pt-intent-* pt-active` (takes the color of the intent)
- `pt-disabled (pt-active pt-intent-*)` (shouldn't happen but `pt-disable` takes priority)

- also transferrable to dark colors