### PR TITLE
Fix click callback called twice when pressing ENTER key on Button

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -45,6 +45,7 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
                 this.setState({ isActive: true });
                 break;
             case Keys.ENTER:
+                e.preventDefault();
                 this.buttonRef.click();
                 break;
             default:

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -43,15 +43,10 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
     protected onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
         switch (e.which) {
             case Keys.SPACE:
-                e.preventDefault();
-                if (e.which !== this.currentKeyDown) {
-                    this.setState({ isActive: true });
-                }
-                break;
             case Keys.ENTER:
                 e.preventDefault();
                 if (e.which !== this.currentKeyDown) {
-                    this.buttonRef.click();
+                    this.setState({ isActive: true });
                 }
                 break;
             default:
@@ -61,9 +56,14 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
     }
 
     protected onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
-        if (e.which === Keys.SPACE) {
-            this.setState({ isActive: false });
-            this.buttonRef.click();
+        switch (e.which) {
+            case Keys.SPACE:
+            case Keys.ENTER:
+                this.setState({ isActive: false });
+                this.buttonRef.click();
+                break;
+            default:
+                break;
         }
         this.currentKeyDown = null;
     }

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -36,21 +36,28 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
         },
     };
 
+    private currentKeyDown: number = null;
+
     public abstract render(): JSX.Element;
 
     protected onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
         switch (e.which) {
             case Keys.SPACE:
                 e.preventDefault();
-                this.setState({ isActive: true });
+                if (e.which !== this.currentKeyDown) {
+                    this.setState({ isActive: true });
+                }
                 break;
             case Keys.ENTER:
                 e.preventDefault();
-                this.buttonRef.click();
+                if (e.which !== this.currentKeyDown) {
+                    this.buttonRef.click();
+                }
                 break;
             default:
                 break;
         }
+        this.currentKeyDown = e.which;
     }
 
     protected onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -58,5 +65,6 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
             this.setState({ isActive: false });
             this.buttonRef.click();
         }
+        this.currentKeyDown = null;
     }
 }


### PR DESCRIPTION
#### Fixes #518 

- Two toasts appear when pressing `ENTER` on the button in an alert

note: Holding down on `ENTER` will show multiple alerts. This was also an issue < v1.6. I'm not sure if we want to throttle the call (the default browser behaviour that we're mimicking doesn't).