### PR TITLE
Fix Tabs onChange handler called twice when controlled

### DIFF
--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -92,10 +92,6 @@ export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
 
     public componentWillReceiveProps(newProps: ITabsProps) {
         const newState = this.getStateFromProps(newProps);
-        const newIndex = newState.selectedTabIndex;
-        if (newIndex !== this.state.selectedTabIndex) {
-            this.setSelectedTabIndex(newIndex);
-        }
         this.setState(newState);
     }
 

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -210,6 +210,7 @@ describe("<Tabs>", () => {
 
         it("does switch tabs if the user hooks up onChange() to do so", () => {
             const TAB_INDEX_TO_SELECT = 1;
+            const onChangeSpy = sinon.spy();
             class TestComponent extends React.Component<{}, any> {
                 public state = {
                     mySelectedTab: 0,
@@ -224,6 +225,7 @@ describe("<Tabs>", () => {
                 }
 
                 private handleChange = (selectedTabIndex: number) => {
+                    onChangeSpy();
                     this.setState({ mySelectedTab: selectedTabIndex });
                 }
             }
@@ -231,6 +233,8 @@ describe("<Tabs>", () => {
             const wrapper = mount(<TestComponent />);
             wrapper.find(Tab).at(TAB_INDEX_TO_SELECT).simulate("click");
             assert.strictEqual(wrapper.find(TabPanel).text(), "second panel");
+            // ensure only called once (#502)
+            assert.isTrue(onChangeSpy.calledOnce);
         });
 
         it("indicator moves correctly if tabs switch externally via the selectedTabIndex prop", (done) => {


### PR DESCRIPTION
#### Fixes #502 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Remove the `if` block in componentWillReceiveProps which leads to `setState` being called twice.
- Although specific, adding a test because of the complexity in the component.

#### Reviewers should focus on:

Tried looking at #48 to see why that bit of code was introduced but can't quite figure it out, @cyu06 does anything ring a bell? Unless I'm missing something, the interactions look fine.