### PR TITLE
Emit onChange with null when DateInput is empty

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -246,7 +246,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         } else {
             this.setState({ isInputFocused: false, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(momentDate));
+        Utils.safeInvoke(this.props.onChange, date === null ? null : this.fromMomentToDate(momentDate));
     }
 
     private handleIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
@@ -291,6 +291,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             }
             Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(value));
         } else {
+            if (valueString.length === 0) {
+                Utils.safeInvoke(this.props.onChange, null);
+            }
             this.setState({ valueString });
         }
     }

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -166,7 +166,7 @@ describe("<DateInput>", () => {
         it("Clicking a date invokes onChange callback with that date", () => {
             const onChange = sinon.spy();
             const { getDay, root } = wrap(<DateInput onChange={onChange} value={DATE} />);
-            root.setState({ isOpen: true })
+            root.setState({ isOpen: true });
             getDay(27).simulate("click");
 
             assert.isTrue(onChange.calledOnce);


### PR DESCRIPTION
#### Fixes #504 

#### Changes proposed in this pull request:

- Return `null` as the date argument in DateInput's `onChange` handler
