### PR TITLE
Show ghost cells when 0 rows or cols

### DIFF
--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -367,7 +367,9 @@ export class Grid {
     }
 
     public getCumulativeWidthAt = (index: number) => {
-        if (index >= this.numCols) {
+        if (this.numCols === 0) {
+            return this.ghostWidth * index;
+        } else if (index >= this.numCols) {
             return this.cumulativeColumnWidths[this.numCols - 1] + this.ghostWidth * (index - this.numCols + 1);
         } else {
             return this.cumulativeColumnWidths[index];
@@ -375,7 +377,9 @@ export class Grid {
     }
 
     public getCumulativeHeightAt = (index: number) => {
-        if (index >= this.numRows) {
+        if (this.numRows === 0) {
+            return this.ghostHeight * index;
+        } else if (index >= this.numRows) {
             return this.cumulativeRowHeights[this.numRows - 1] + this.ghostHeight * (index - this.numRows + 1);
         } else {
             return this.cumulativeRowHeights[index];

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -29,6 +29,24 @@ describe("Grid", () => {
         expect(rect.width).to.equal(13);
     });
 
+    it("calculates ghost indices correctly when there are no columns or rows", () => {
+        const grid = new Grid([], [], 0);
+        const rect = new Rect(
+            Grid.DEFAULT_GHOST_WIDTH,
+            0,
+            Grid.DEFAULT_GHOST_WIDTH * 4,
+            Grid.DEFAULT_GHOST_HEIGHT * 5,
+        );
+
+        const { columnIndexStart, columnIndexEnd } = grid.getColumnIndicesInRect(rect, true);
+        expect(columnIndexStart).to.equal(2);
+        expect(columnIndexEnd).to.equal(5);
+
+        const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect, true);
+        expect(rowIndexStart).to.equal(1);
+        expect(rowIndexEnd).to.equal(5);
+    });
+
     it("locates column indices of overlapping rect", () => {
         const grid = new Grid(test7s, test13s, 0);
         const rect = new Rect(15, 0, 30, 0);


### PR DESCRIPTION
Add checks to prevent index out of bounds exception when calculating
number of ghost rows and cols to add.