### PR TITLE
Refactor buttons borders

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -163,12 +163,12 @@ Weight: 1
 Styleguide variables.layering
 */
 
-// Z-Indices
+// Z-indices
 $pt-z-index-base: 0 !default;
 $pt-z-index-content: $pt-z-index-base + 10 !default;
 $pt-z-index-overlay: $pt-z-index-content + 10 !default;
 
-// Shadow Opacities
+// Shadow opacities
 $pt-border-shadow-opacity: 0.1 !default;
 $pt-drop-shadow-opacity: 0.2 !default;
 $pt-dark-border-shadow-opacity: $pt-border-shadow-opacity * 2 !default;

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -65,31 +65,43 @@ Styleguide components.button-group.css
     position: relative;
     z-index: 0;
 
-    &[class*="pt-intent-"] {
+    // the ordering of these z-index CSS rules is particular
+    // because of CSS selector specificity
+    &:focus {
       z-index: 1;
     }
 
-    &:focus {
+    &:hover {
       z-index: 2;
     }
 
-    &:hover {
-      z-index: 3;
+    &[class*="pt-intent-"] {
+      z-index: 4;
+
+      &:hover {
+        z-index: 5;
+      }
+
+      &:active,
+      &.pt-active {
+        z-index: 6;
+      }
+
+      &:disabled,
+      &.pt-disabled {
+        z-index: 3;
+      }
     }
 
     &:active,
     &.pt-active {
-      z-index: 4;
+      z-index: 3;
     }
 
     &:disabled,
     &.pt-disabled {
       z-index: 0;
     }
-  }
-
-  &:not(.pt-vertical) .pt-button:not(#{$non-default-state-selectors}) {
-    border-right-color: transparent;
   }
 
   // support wrapping buttons in a Blueprint.Tooltip, which adds a wrapper element
@@ -225,10 +237,6 @@ Styleguide components.button-group.css
     .pt-button {
       // we never want that margin-right when vertical
       margin-right: 0 !important; // stylelint-disable-line declaration-no-important
-
-      &:not(#{$non-default-state-selectors}) {
-        border-bottom-color: transparent;
-      }
     }
 
     > .pt-popover-target:first-child .pt-button,
@@ -263,5 +271,21 @@ Styleguide components.button-group.css
 
   &.pt-align-left .pt-button {
     text-align: left;
+  }
+
+  .pt-dark & {
+    &:not(.pt-minimal) {
+      > .pt-popover-target:not(:last-child) .pt-button,
+      > .pt-button:not(:last-child) {
+        margin-right: $button-border-width;
+      }
+    }
+
+    &.pt-vertical {
+      > .pt-popover-target:not(:last-child) .pt-button,
+      > .pt-button:not(:last-child) {
+        margin-bottom: $button-border-width;
+      }
+    }
   }
 }

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -75,6 +75,7 @@ Styleguide components.button-group.css
       z-index: 2;
     }
 
+    // intent buttons are always above any other button state
     &[class*="pt-intent-"] {
       z-index: 4;
 
@@ -274,6 +275,8 @@ Styleguide components.button-group.css
   }
 
   .pt-dark & {
+    // support wrapping buttons in a Blueprint.Tooltip, which adds a wrapper element
+    // in dark theme, we adjust the spacing between buttons for best visual results
     &:not(.pt-minimal) {
       > .pt-popover-target:not(:last-child) .pt-button,
       > .pt-button:not(:last-child) {

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -183,6 +183,7 @@ Styleguide components.button.css
     #{$icon-classes} {
       color: inherit !important;
     }
+    // stylelint-enable declaration-no-important
   }
 
   /*

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -13,45 +13,58 @@ $button-border-width: 1px !default;
 $button-padding: 0 $pt-grid-size !default;
 $button-padding-large: 0 ($pt-grid-size * 1.5) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) / 2 !default;
-$button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) / 2 !default;
+$button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-standard) / 2 !default;
+
+$button-box-shadow:
+  inset 0 0 0 $button-border-width rgba($black, 0.2),
+  inset 0 (-$button-border-width) 0 rgba($black, 0.1) !default;
+$button-box-shadow-active:
+  inset 0 0 0 $button-border-width rgba($black, 0.2),
+  inset 0 1px 2px rgba($black, 0.2) !default;
+$button-intent-box-shadow:
+  inset 0 0 0 $button-border-width rgba($black, 0.4),
+  inset 0 (-$button-border-width) 0 rgba($black, 0.2) !default;
+$button-intent-box-shadow-active:
+  inset 0 0 0 $button-border-width rgba($black, 0.4),
+  inset 0 1px 2px rgba($black, 0.2) !default;
+$button-box-shadow-overlay:
+  0 0 0 $button-border-width rgba($black, 0.2),
+  0 1px 1px rgba($black, 0.2) !default;
+$button-box-shadow-overlay-active:
+  0 0 0 $button-border-width rgba($black, 0.2),
+  inset 0 1px 1px rgba($black, 0.1) !default;
+
+$dark-button-box-shadow:
+  0 0 0 $button-border-width rgba($black, 0.4) !default;
+$dark-button-box-shadow-active:
+  0 0 0 $button-border-width rgba($black, 0.6),
+  inset 0 1px 2px rgba($black, 0.2) !default;
+$dark-button-intent-box-shadow:
+  0 0 0 $button-border-width rgba($black, 0.4) !default;
+$dark-button-intent-box-shadow-active:
+  0 0 0 $button-border-width rgba($black, 0.4),
+  inset 0 1px 2px rgba($black, 0.2) !default;
 
 $button-color-disabled: $pt-text-color-disabled !default;
-$dark-button-color-disabled: $pt-dark-text-color-disabled !default;
-
-$button-border-color:
-  rgba($black, 0.1) rgba($black, 0.1) rgba($black, 0.17) rgba($black, 0.1) !default;
-$button-border-color-hover:
-  rgba($black, 0.2) rgba($black, 0.2) rgba($black, 0.27) rgba($black, 0.2) !default;
-$button-border-color-active:
-  rgba($black, 0.35) rgba($black, 0.25) rgba($black, 0.25) rgba($black, 0.25) !default;
-$button-box-shadow: 0 1px 1px rgba($black, 0.1) !default;
-$dark-button-border-color: rgba($black, 0.6) !default;
-$dark-button-border-color-hover: rgba($black, 0.8) !default;
-$dark-button-box-shadow: 0 1px 1px rgba($black, 0.2) !default;
-
-$button-intent-border-color:
-  rgba($black, 0.1) rgba($black, 0.1) rgba($black, 0.3) rgba($black, 0.1) !default;
-$button-intent-border-color-active:
-  rgba($black, 0.6) rgba($black, 0.2) rgba($black, 0.2) rgba($black, 0.2) !default;
-$button-intent-box-shadow: 0 1px 1px rgba($black, 0.2) !default;
-$dark-button-intent-border-color: rgba($black, 0.6) !default;
-$dark-button-intent-box-shadow: 0 1px 1px rgba($black, 0.2) !default;
-
 $button-background-color: $light-gray5 !default;
 $button-background-color-hover: $light-gray4 !default;
-$button-background-color-active: $light-gray1 !default;
+$button-background-color-active: $light-gray2 !default;
 $button-background-color-disabled: rgba($light-gray1, 0.5) !default;
-$button-background-color-active-disabled: rgba($light-gray2, 0.4) !default;
-$dark-button-background-color: none !default;
-$dark-button-background-color-hover: rgba($white, 0.1) !default;
-$dark-button-background-color-active: rgba($black, 0.1) !default;
-$dark-button-background-color-disabled: rgba($light-gray1, 0.1) !default;
-$dark-button-background-color-active-disabled: rgba($light-gray1, 0.2) !default;
+$button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
+
+$dark-button-color-disabled: $pt-dark-text-color-disabled !default;
+$dark-button-background-color: $dark-gray5 !default;
+$dark-button-background-color-hover: $dark-gray4 !default;
+$dark-button-background-color-active: $dark-gray2 !default;
+$dark-button-background-color-disabled: rgba($dark-gray5, 0.5) !default;
+$dark-button-background-color-active-disabled: rgba($dark-gray5, 0.7) !default;
 
 $minimal-button-divider-width: 1px !default;
+
 $minimal-button-background-color: none !default;
 $minimal-button-background-color-hover: rgba($gray4, 0.3) !default;
 $minimal-button-background-color-active: rgba($gray2, 0.3) !default;
+
 $dark-minimal-button-background-color: none !default;
 $dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
 $dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
@@ -64,13 +77,9 @@ $button-intents: (
   "danger": ($pt-intent-danger, $red2, $red1)
 ) !default;
 
-// matches default buttons only -- used to remove border-right in button groups and control groups
-$non-default-state-selectors:
-  ":last-child, :hover, :active, .pt-active, [class*=\"pt-intent-\"]" !default;
-
 @mixin pt-button-base() {
   display: inline-block;
-  border: $button-border-width solid;
+  border: none;
   border-radius: $pt-border-radius;
   cursor: pointer;
   padding: $button-padding;
@@ -82,15 +91,13 @@ $non-default-state-selectors:
   min-width: $height;
   min-height: $height;
   // for text centering
-  line-height: $height - $button-border-width * 2;
+  line-height: $height;
 }
 
 @mixin pt-button() {
   @include linear-gradient-with-fallback($white, $white-transparent, $button-background-color);
 
-  border-color: $button-border-color;
   box-shadow: $button-box-shadow;
-  background-clip: padding-box;
   color: $pt-text-color;
 
   &:hover {
@@ -103,9 +110,7 @@ $non-default-state-selectors:
 
   &:disabled {
     outline: none;
-    border-color: transparent;
     box-shadow: none;
-    background-clip: border-box;
     background-color: $button-background-color-disabled;
     background-image: none;
     cursor: not-allowed;
@@ -121,24 +126,24 @@ $non-default-state-selectors:
     $button-background-color-hover
   );
 
-  border-color: $button-border-color-hover;
   box-shadow: $button-box-shadow;
   background-clip: padding-box;
 }
 
 @mixin pt-button-active() {
-  border-color: $button-border-color-active;
-  box-shadow: inset $button-box-shadow;
+  box-shadow: $button-box-shadow-active;
   background-color: $button-background-color-active;
   background-image: none;
 }
 
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
-  @include linear-gradient-with-fallback(rgba($white, 0.1), $white-transparent, $default-color);
+  @include linear-gradient-with-fallback(
+    rgba($white, 0.1),
+    $white-transparent,
+    $default-color
+  );
 
-  border-color: $button-intent-border-color;
   box-shadow: $button-intent-box-shadow;
-  background-clip: border-box;
   color: $white;
 
   &:hover,
@@ -148,13 +153,17 @@ $non-default-state-selectors:
   }
 
   &:hover {
-    @include linear-gradient-with-fallback(rgba($white, 0.1), $white-transparent, $hover-color);
+    @include linear-gradient-with-fallback(
+      rgba($white, 0.1),
+      $white-transparent,
+      $hover-color
+    );
+
     box-shadow: $button-intent-box-shadow;
   }
 
   &:active {
-    border-color: $button-intent-border-color-active;
-    box-shadow: inset $button-intent-box-shadow;
+    box-shadow: $button-intent-box-shadow-active;
     background-color: $active-color;
     background-image: none;
   }
@@ -173,14 +182,12 @@ $non-default-state-selectors:
 
 @mixin pt-dark-button() {
   @include linear-gradient-with-fallback(
-    rgba($white, 0.1),
-    rgba($white, 0.06),
+    rgba($white, 0.05),
+    $white-transparent,
     $dark-button-background-color
   );
 
-  border-color: $dark-button-border-color;
   box-shadow: $dark-button-box-shadow;
-  background-clip: padding-box;
   color: $pt-dark-text-color;
 
   &:hover,
@@ -197,7 +204,6 @@ $non-default-state-selectors:
   }
 
   &:disabled {
-    border-color: $dark-button-background-color-disabled;
     box-shadow: none;
     background-color: $dark-button-background-color-disabled;
     background-image: none;
@@ -212,37 +218,32 @@ $non-default-state-selectors:
 
 @mixin pt-dark-button-hover() {
   @include linear-gradient-with-fallback(
-    rgba($black, 0.1),
-    rgba($black, 0.2),
+    rgba($white, 0.05),
+    $white-transparent,
     $dark-button-background-color-hover
   );
 
-  border-color: $dark-button-border-color-hover;
   box-shadow: $dark-button-box-shadow;
-  background-clip: padding-box;
 }
 
 @mixin pt-dark-button-active() {
-  box-shadow: inset $dark-button-box-shadow;
+  box-shadow: $dark-button-box-shadow-active;
   background-color: $dark-button-background-color-active;
   background-image: none;
 }
 
 @mixin pt-dark-button-intent() {
-  border-color: $dark-button-intent-border-color;
   box-shadow: $dark-button-intent-box-shadow;
-  background-clip: padding-box;
 
   &:hover {
     box-shadow: $dark-button-intent-box-shadow;
   }
 
   &:active {
-    box-shadow: inset $dark-button-intent-box-shadow;
+    box-shadow: $dark-button-intent-box-shadow-active;
   }
 
   &:disabled {
-    border: none;
     box-shadow: none;
     background-image: none;
     color: rgba($white, 0.3);
@@ -254,7 +255,6 @@ $non-default-state-selectors:
 }
 
 @mixin pt-button-minimal() {
-  border-color: transparent;
   box-shadow: none;
   background: $minimal-button-background-color;
 
@@ -263,7 +263,6 @@ $non-default-state-selectors:
   }
 
   &:hover {
-    border-color: transparent;
     box-shadow: none;
     background: $minimal-button-background-color-hover;
     text-decoration: none;
@@ -272,7 +271,6 @@ $non-default-state-selectors:
 
   &.pt-active,
   &:active {
-    border-color: transparent;
     background: $minimal-button-background-color-active;
     color: $pt-text-color;
   }
@@ -280,44 +278,13 @@ $non-default-state-selectors:
   &.pt-disabled,
   &:disabled,
   &:disabled:hover {
-    border-color: transparent;
     background: inherit;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
   }
 
   .pt-dark & {
-    border-color: transparent;
-    box-shadow: none;
-    background: $dark-minimal-button-background-color;
-    color: inherit;
-
-    &:hover,
-    &:active,
-    &.pt-active {
-      border-color: transparent;
-      box-shadow: none;
-      background: none;
-    }
-
-    &:hover {
-      background: $dark-minimal-button-background-color-hover;
-    }
-
-    &:active,
-    &.pt-active {
-      background: $dark-minimal-button-background-color-active;
-      color: $pt-dark-text-color;
-    }
-
-    &.pt-disabled,
-    &:disabled,
-    &:disabled:hover {
-      border-color: transparent;
-      background: inherit;
-      cursor: not-allowed;
-      color: $pt-dark-text-color-disabled;
-    }
+    @include pt-dark-button-minimal();
   }
 
   @each $intent, $colors in $button-intents {
@@ -328,6 +295,37 @@ $non-default-state-selectors:
         map-get($pt-dark-intent-text-colors, $intent)
       );
     }
+  }
+}
+
+@mixin pt-dark-button-minimal() {
+  box-shadow: none;
+  background: $dark-minimal-button-background-color;
+  color: inherit;
+
+  &:hover,
+  &:active,
+  &.pt-active {
+    box-shadow: none;
+    background: none;
+  }
+
+  &:hover {
+    background: $dark-minimal-button-background-color-hover;
+  }
+
+  &:active,
+  &.pt-active {
+    background: $dark-minimal-button-background-color-active;
+    color: $pt-dark-text-color;
+  }
+
+  &.pt-disabled,
+  &:disabled,
+  &:disabled:hover {
+    background: inherit;
+    cursor: not-allowed;
+    color: $pt-dark-text-color-disabled;
   }
 }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -13,7 +13,7 @@ $button-border-width: 1px !default;
 $button-padding: 0 $pt-grid-size !default;
 $button-padding-large: 0 ($pt-grid-size * 1.5) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) / 2 !default;
-$button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-standard) / 2 !default;
+$button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) / 2 !default;
 
 /*
 CSS `border` property issues:
@@ -36,6 +36,13 @@ $button-intent-box-shadow:
 $button-intent-box-shadow-active:
   inset 0 0 0 $button-border-width rgba($black, 0.4),
   inset 0 1px 2px rgba($black, 0.2) !default;
+
+/*
+Overlay shadows are used for default buttons
+floating on top of other elements. This way, the
+shadows blend with the colors beneath it.
+Switches and slider handles both use these variables.
+*/
 $button-box-shadow-overlay:
   0 0 0 $button-border-width rgba($black, 0.2),
   0 1px 1px rgba($black, 0.2) !default;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -15,6 +15,15 @@ $button-padding-large: 0 ($pt-grid-size * 1.5) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) / 2 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-standard) / 2 !default;
 
+/*
+CSS `border` property issues:
+- An element can only have one border.
+- Borders can't stack with shadows.
+- Borders modify the size of the element they're applied to.
+- Border positioning requires the extra `box-sizing` property.
+
+`box-shadow` doesn't have these issues, we're using it instead of `border`.
+*/
 $button-box-shadow:
   inset 0 0 0 $button-border-width rgba($black, 0.2),
   inset 0 (-$button-border-width) 0 rgba($black, 0.1) !default;

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -39,8 +39,7 @@ Markup:
         <option selected>Filter...</option>
         <option value="1">Issues</option>
         <option value="2">Requests</option>
-        <option value="3">Features</option>
-        <option value="4">Won't fixes</option>
+        <option value="3">Projects</option>
       </select>
     </div>
     <div class="pt-input-group">
@@ -84,23 +83,12 @@ Styleguide components.forms.control-group
     border-radius: inherit;
 
     &:focus {
-      z-index: 2;
+      z-index: 1;
     }
   }
 
-  &:not(.pt-vertical) {
-    > * {
-      margin-right: -$button-border-width;
-    }
-
-    .pt-button:not(#{$non-default-state-selectors}),
-    .pt-input:not(#{$non-default-state-selectors}) {
-      border-right-color: transparent;
-    }
-
-    .pt-select:not(#{$non-default-state-selectors}) select {
-      border-right-color: transparent;
-    }
+  &:not(.pt-vertical) > * {
+    margin-right: -$button-border-width;
   }
 
   > :first-child {
@@ -114,18 +102,33 @@ Styleguide components.forms.control-group
 
   .pt-button,
   .pt-select {
+    position: relative;
     z-index: 1;
+
+    &[class*="pt-intent-"] {
+      z-index: 3;
+    }
   }
 
-  .pt-input:focus {
+  .pt-input {
     position: relative;
-    border-radius: $pt-border-radius;
+    z-index: 0;
+
+    &[class*="pt-intent-"] {
+      z-index: 3;
+    }
+
+    &:not([readonly], :disabled, .pt-disabled):focus {
+      z-index: 6;
+      border-radius: $pt-border-radius;
+    }
   }
 
   // establish new stacking context so focus state covers neighbors
   .pt-button:focus,
   select:focus {
     position: relative;
+    z-index: 2;
   }
 
   // input group contents appear above input always
@@ -133,7 +136,7 @@ Styleguide components.forms.control-group
   .pt-input-group > .pt-button,
   .pt-input-group > .pt-input-action,
   .pt-select::after {
-    z-index: 3;
+    z-index: 7;
   }
 
   // bring back border radius on these buttons
@@ -171,15 +174,6 @@ Styleguide components.forms.control-group
       width: 100%;
     }
 
-    .pt-button:not(#{$non-default-state-selectors}),
-    .pt-input:not(#{$non-default-state-selectors}) {
-      border-bottom-color: transparent;
-    }
-
-    .pt-select:not(#{$non-default-state-selectors}) select {
-      border-bottom-color: transparent;
-    }
-
     > :first-child {
       margin-top: 0;
       border-radius: $pt-border-radius $pt-border-radius 0 0;
@@ -187,6 +181,12 @@ Styleguide components.forms.control-group
 
     > :last-child {
       border-radius: 0 0 $pt-border-radius $pt-border-radius;
+    }
+  }
+
+  .pt-dark & {
+    .pt-input[class*="pt-intent-"] {
+      z-index: 5;
     }
   }
 }

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -100,6 +100,8 @@ Styleguide components.forms.control-group
     border-radius: 0 $pt-border-radius $pt-border-radius 0;
   }
 
+  // similarly to button groups, elements in control groups are stacked
+  // in a very particular order for best visual results
   .pt-button,
   .pt-select {
     position: relative;
@@ -185,6 +187,7 @@ Styleguide components.forms.control-group
   }
 
   .pt-dark & {
+    // to avoid edge blurriness in dark theme, inputs go above buttons
     .pt-input[class*="pt-intent-"] {
       z-index: 5;
     }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -58,8 +58,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     top: 0;
     left: 0;
     margin: 0;
-    border: $button-border-width solid;
-    border-color: $button-border-color;
+    border: none;
     box-shadow: $button-box-shadow;
     background-clip: padding-box;
     cursor: pointer;
@@ -70,8 +69,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
     &::before {
       position: relative;
-      top: -$button-border-width;
-      left: -$button-border-width;
       content: "";
     }
   }
@@ -83,9 +80,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       $control-checked-background-color
     );
 
-    border-color: $button-intent-border-color;
     box-shadow: $button-intent-box-shadow;
-    background-clip: border-box;
     color: $white;
   }
 
@@ -96,9 +91,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         $white-transparent,
         $control-background-color-hover
       );
-
-      border-color: $button-border-color-hover;
-      background-clip: padding-box;
     }
 
     input:checked ~ .pt-control-indicator {
@@ -108,22 +100,18 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         $control-checked-background-color-hover
       );
 
-      border-color: $button-intent-border-color;
       box-shadow: $button-intent-box-shadow;
     }
   }
 
   input:not(:disabled):active {
     ~ .pt-control-indicator {
-      border-color: $button-border-color-active;
-      box-shadow: inset $button-box-shadow;
+      box-shadow: $button-box-shadow-active;
       background: $control-background-color-active;
-      background-clip: padding-box;
     }
 
     &:checked ~ .pt-control-indicator {
-      border-color: $button-intent-border-color-active;
-      box-shadow: inset $button-intent-box-shadow;
+      box-shadow: $button-intent-box-shadow-active;
       background: $control-checked-background-color-active;
     }
   }
@@ -134,14 +122,12 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
   input:disabled {
     ~ .pt-control-indicator {
-      border-color: transparent;
       box-shadow: none;
       background: $button-background-color-disabled;
       cursor: not-allowed;
     }
 
     &:checked ~ .pt-control-indicator {
-      border-color: transparent;
       box-shadow: none;
       background: rgba($control-checked-background-color, 0.5);
     }
@@ -310,7 +296,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       left: 50%;
       transform: translate(-50%, -50%);
       border-radius: 50%;
-      box-shadow: $button-intent-box-shadow;
       background: $white;
       width: 1em;
       height: 1em;
@@ -420,7 +405,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         top: $switch-indicator-margin;
         left: $switch-indicator-margin;
         border-radius: $switch-height;
-        box-shadow: $switch-indicator-border, $button-box-shadow;
+        box-shadow: $button-box-shadow-overlay;
         background: $switch-indicator-background-color;
         background-clip: padding-box;
         width: $switch-height - ($switch-indicator-margin * 2);
@@ -439,7 +424,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
       &::before {
         left: $switch-width - $switch-height + $switch-indicator-margin;
-        box-shadow: $switch-indicator-border, $button-intent-box-shadow;
+        box-shadow: $button-box-shadow-overlay;
       }
     }
 
@@ -461,6 +446,10 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
       &:checked ~ .pt-control-indicator {
         background-color: $control-checked-background-color-active;
+
+        &::before {
+          box-shadow: $button-box-shadow-overlay;
+        }
       }
     }
 
@@ -505,7 +494,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     }
 
     &.pt-checkbox input:checked ~ .pt-control-indicator::before {
-      top: 0;
+      top: 1px;
     }
 
     &.pt-radio .pt-control-indicator {
@@ -539,60 +528,54 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   .pt-dark & {
     color: $pt-dark-text-color;
 
+    &.pt-disabled {
+      color: $pt-text-color-disabled;
+    }
+
     .pt-control-indicator {
       @include linear-gradient-with-fallback(
-        rgba($white, 0.1),
-        rgba($white, 0.06),
+        rgba($white, 0.05),
+        $white-transparent,
         $dark-control-background-color
       );
 
-      border-color: $dark-button-border-color;
       box-shadow: $dark-button-box-shadow;
     }
 
     input:checked ~ .pt-control-indicator {
-      border-color: $dark-button-intent-border-color;
       box-shadow: $dark-button-intent-box-shadow;
-      background-clip: padding-box;
     }
 
     &:hover {
       .pt-control-indicator {
         @include linear-gradient-with-fallback(
-          rgba($black, 0.1),
-          rgba($black, 0.2),
+          rgba($black, 0.05),
+          $white-transparent,
           $dark-control-background-color-hover
         );
-
-        border-color: $dark-button-border-color-hover;
       }
     }
 
     input:not(:disabled):active {
       ~ .pt-control-indicator {
-        border-color: $dark-button-border-color-hover;
-        box-shadow: inset $dark-button-box-shadow;
+        box-shadow: $dark-button-box-shadow-active;
         background: $dark-control-background-color-active;
       }
 
       &:checked ~ .pt-control-indicator {
-        border-color: $dark-button-intent-border-color;
-        box-shadow: inset $dark-button-intent-box-shadow;
-        background-clip: padding-box;
+        box-shadow: $dark-button-intent-box-shadow-active;
         background-color: $control-checked-background-color-active;
       }
     }
 
     input:disabled {
       ~ .pt-control-indicator {
-        border-color: transparent;
         box-shadow: none;
         background: $dark-button-background-color-disabled;
         cursor: not-allowed;
       }
 
       &:checked ~ .pt-control-indicator {
-        border-color: transparent;
         box-shadow: none;
         background: rgba($control-checked-background-color-active, 0.5);
       }
@@ -618,7 +601,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         background: $dark-switch-background-color;
 
         &::before {
-          box-shadow: $dark-switch-indicator-border, $dark-button-box-shadow;
+          box-shadow: $dark-button-box-shadow;
           background: $dark-switch-indicator-background-color;
         }
       }
@@ -628,7 +611,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         background-color: $dark-switch-checked-background-color;
 
         &::before {
-          box-shadow: inset $dark-switch-indicator-border, $dark-button-box-shadow;
+          box-shadow: inset $dark-button-box-shadow;
         }
       }
 
@@ -646,10 +629,20 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         ~ .pt-control-indicator {
           box-shadow: none;
           background: $dark-switch-background-color-active;
+
+          // we're in too deep to quit
+          // stylelint-disable max-nesting-depth
+          &::before {
+            box-shadow: $dark-button-box-shadow;
+          }
         }
 
         &:checked ~ .pt-control-indicator {
           background: $dark-switch-checked-background-color-active;
+
+          &::before {
+            box-shadow: inset $dark-button-box-shadow;
+          }
         }
       }
 
@@ -657,12 +650,11 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         ~ .pt-control-indicator {
           background: $dark-switch-background-color-disabled;
 
-          // we're in too deep to quit
-          // stylelint-disable max-nesting-depth
           &::before {
             box-shadow: none;
             background: $dark-switch-indicator-background-color-disabled;
           }
+          // stylelint-enable max-nesting-depth
         }
 
         &:checked ~ .pt-control-indicator {

--- a/packages/core/src/components/forms/_file-upload.scss
+++ b/packages/core/src/components/forms/_file-upload.scss
@@ -64,8 +64,6 @@ Styleguide components.forms.fileupload
       right: 0;
       left: 100%;
       margin-left: -$button-border-width;
-      border-width: $button-border-width;
-      border-style: solid;
       border-radius: $pt-border-radius;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
@@ -73,12 +71,8 @@ Styleguide components.forms.fileupload
       height: $pt-input-height;
       padding: 0 $pt-grid-size;
       text-align: center;
-      line-height: $pt-button-height - $button-border-width * 2;
+      line-height: $pt-button-height;
       content: "Browse";
-    }
-
-    &:not(:hover, :active)::after {
-      border-left-color: transparent;
     }
 
     &:hover::after {

--- a/packages/core/src/components/slider/_common.scss
+++ b/packages/core/src/components/slider/_common.scss
@@ -49,9 +49,8 @@
   position: absolute;
   top: 0;
   left: 0;
-  border-width: $button-border-width;
-  border-style: solid;
   border-radius: $pt-border-radius;
+  box-shadow: $button-box-shadow-overlay;
   cursor: pointer;
   width: $handle-height;
   height: $handle-height;
@@ -63,17 +62,18 @@
     @include pt-button-hover();
 
     z-index: 2;
+    box-shadow: $button-box-shadow-overlay;
     cursor: grab;
   }
 
   &.pt-active {
     @include pt-button-active();
 
+    box-shadow: $button-box-shadow-overlay-active;
     cursor: grabbing;
   }
 
   .pt-disabled & {
-    border-color: $gray5;
     box-shadow: none;
     background: $gray5;
     // easy way to avoid lots of special cases to ignore mouse states when disabled:

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -74,8 +74,8 @@ $label-top: $handle-height + 4px !default;
   @include slider-handle($handle-height, $track-height);
 
   .pt-slider-label {
-    transform: translate(-50%, $label-top - $button-border-width);
-    margin-left: $handle-height / 2 - $button-border-width;
+    transform: translate(-50%, $label-top);
+    margin-left: $handle-height / 2;
     border-radius: $pt-border-radius;
     box-shadow: $pt-tooltip-box-shadow;
     background: $tooltip-background-color;
@@ -137,7 +137,7 @@ Styleguide components.slider.range.js
     }
 
     &:last-of-type {
-      margin-left: $handle-height / 2 - $button-border-width;
+      margin-left: $handle-height / 2;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
 


### PR DESCRIPTION
#### Fixes #233, countless of unreported button groups and control groups visual issues

#### Changes proposed in this pull request:

- Refactor buttons to use box shadows instead of borders
- Add new variable to deal with buttons on top of non-plain content: `$button-box-shadow-overlay`
- Update shadow values for buttons (done with @piotrk)

#### Reviewers should focus on:

- Play with button groups and control groups in both themes, including with `disabled` buttons/inputs, `readonly` inputs, and all kinds of weird combinations that you can think of.
- Make sure everything is aligned and that there's no blurry edge or pixels.

#### Screenshot

Example from #233.

Before:
![image](https://cloud.githubusercontent.com/assets/443450/20587883/af1dad62-b1c5-11e6-9df4-263e393600ef.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/22262949/9fcbf354-e227-11e6-9ef1-c91100568bad.png)