### PR TITLE
Add support for copying table cells with cmd+c hotkey

### DIFF
--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -10,7 +10,6 @@ const browser = {
     isEdge: !!userAgent.match(/Edge/),
     isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
     isWebkit: !!userAgent.match(/AppleWebKit/),
-    // isWebkit: Object.prototype.toString.call((window as any).HTMLElement).indexOf("Constructor") > 0,
  };
 
 export const Browser = {

--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -9,9 +9,11 @@ const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
 const browser = {
     isEdge: !!userAgent.match(/Edge/),
     isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
+    isWebkit: Object.prototype.toString.call((window as any).HTMLElement).indexOf("Constructor") > 0,
  };
 
 export const Browser = {
     isEdge: () => browser.isEdge,
     isInternetExplorer: () => browser.isInternetExplorer,
+    isWebkit: () => browser.isWebkit,
 };

--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -9,7 +9,8 @@ const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
 const browser = {
     isEdge: !!userAgent.match(/Edge/),
     isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
-    isWebkit: Object.prototype.toString.call((window as any).HTMLElement).indexOf("Constructor") > 0,
+    isWebkit: !!userAgent.match(/AppleWebKit/),
+    // isWebkit: Object.prototype.toString.call((window as any).HTMLElement).indexOf("Constructor") > 0,
  };
 
 export const Browser = {

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -44,7 +44,11 @@ ReactDOM.render(<Nav selected="index" />, document.getElementById("nav"));
 
 function getTableComponent(numCols: number, numRows: number, columnProps?: any, tableProps?: any) {
     // combine table overrides
-    const tablePropsWithDefaults = { numRows, ...tableProps };
+    const getCellData = (row: number, col: number) => {
+        return Utils.toBase26Alpha(col) + (row + 1);
+    };
+
+    const tablePropsWithDefaults = Object.assign({numRows, getCellData}, ...tableProps);
 
     // combine column overrides
     const columnPropsWithDefaults = {
@@ -271,6 +275,7 @@ class RowSelectableTable extends React.Component<{}, {}> {
     public render() {
         return (<div>
             <Table
+                renderBodyContextMenu={renderBodyContextMenu}
                 numRows={7}
                 isRowHeaderShown={false}
                 onSelection={this.handleSelection}

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -48,11 +48,7 @@ function getTableComponent(numCols: number, numRows: number, columnProps?: any, 
         return Utils.toBase26Alpha(col) + (row + 1);
     };
 
-    const onCopy = () => {
-        console.log("did copy");
-    }
-
-    const tablePropsWithDefaults = {numRows, getCellClipboardData, onCopy, ...tableProps};
+    const tablePropsWithDefaults = {numRows, getCellClipboardData, ...tableProps};
 
     // combine column overrides
     const columnPropsWithDefaults = {

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -44,7 +44,7 @@ ReactDOM.render(<Nav selected="index" />, document.getElementById("nav"));
 
 function getTableComponent(numCols: number, numRows: number, columnProps?: any, tableProps?: any) {
     // combine table overrides
-    const getCellData = (row: number, col: number) => {
+    const getCellClipboardData = (row: number, col: number) => {
         return Utils.toBase26Alpha(col) + (row + 1);
     };
 
@@ -52,7 +52,7 @@ function getTableComponent(numCols: number, numRows: number, columnProps?: any, 
         console.log("did copy");
     }
 
-    const tablePropsWithDefaults = {numRows, getCellData, onCopy, ...tableProps};
+    const tablePropsWithDefaults = {numRows, getCellClipboardData, onCopy, ...tableProps};
 
     // combine column overrides
     const columnPropsWithDefaults = {

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -48,7 +48,11 @@ function getTableComponent(numCols: number, numRows: number, columnProps?: any, 
         return Utils.toBase26Alpha(col) + (row + 1);
     };
 
-    const tablePropsWithDefaults = Object.assign({numRows, getCellData}, ...tableProps);
+    const onCopy = () => {
+        console.log("did copy");
+    }
+
+    const tablePropsWithDefaults = {numRows, getCellData, onCopy, ...tableProps};
 
     // combine column overrides
     const columnPropsWithDefaults = {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -6,12 +6,14 @@
  */
 
 import { AbstractComponent, IProps } from "@blueprintjs/core";
+import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { ICellProps } from "./cell/cell";
 import { Column, IColumnProps } from "./column";
+import { Clipboard } from "./common/clipboard";
 import { Grid } from "./common/grid";
 import { Rect } from "./common/rect";
 import { Utils } from "./common/utils";
@@ -58,6 +60,14 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * @default false
      */
     fillBodyWithGhostCells?: boolean;
+
+    /**
+     * If exists, a callback that returns the data for a specific cell. This need not
+     * match the value displayed in the `<Cell>` component. The value will be
+     * invisibly added as `textContent` into the DOM before copying. If not exists,
+     * copy via hotkeys (mod+c) will not work
+     */
+    getCellData?: (row: number, col: number) => any;
 
     /**
      * If false, disables resizing of columns.
@@ -245,6 +255,7 @@ export interface ITableState {
 }
 
 @PureRender
+@HotkeysTarget
 export class Table extends AbstractComponent<ITableProps, ITableState> {
     public static defaultProps: ITableProps = {
         allowMultipleSelection: true,
@@ -364,6 +375,30 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 </div>
             </div>
         );
+    }
+
+    public renderHotkeys() {
+        const doCopy = (e: KeyboardEvent) => {
+            const { grid } = this;
+            const { getCellData } = this.props;
+            const { selectedRegions} = this.state;
+
+            if (getCellData == null) {
+                return;
+            }
+
+            // prevent "real" copy from being called
+            e.preventDefault();
+            e.stopPropagation();
+
+            const cells = Regions.enumerateUniqueCells(selectedRegions, grid.numRows, grid.numCols);
+            const sparse = Regions.sparseMapCells(cells, getCellData);
+            Clipboard.copyCells(sparse);
+        };
+
+        return <Hotkeys>
+            <Hotkey label="copy selected table cells" group="table" combo="mod+c" onKeyDown={doCopy} />
+        </Hotkeys>;
     }
 
     /**

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -13,11 +13,22 @@ import * as ReactDOM from "react-dom";
 export type MouseEventType = "click" | "mousedown" | "mouseup" | "mousemove" | "mouseenter" | "mouseleave" ;
 export type KeyboardEventType = "keypress" | "keydown" |  "keyup" ;
 
-function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: string, metaKey = false) {
+function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: string, modKey = false) {
     const event = document.createEvent("KeyboardEvent");
     const keyCode = key.charCodeAt(0);
 
-    (event as any).initKeyboardEvent(eventType, true, true, window, key, 0, false, false, false, metaKey);
+    let ctrlKey = false;
+    let metaKey = false;
+
+    if (modKey) {
+        if ((typeof navigator !== "undefined") && /Mac|iPod|iPhone|iPad/.test(navigator.platform)) {
+            metaKey = true;
+        } else {
+            ctrlKey = true;
+        }
+    }
+
+    (event as any).initKeyboardEvent(eventType, true, true, window, key, 0, ctrlKey, false, false, metaKey);
 
     // Hack around these readonly properties in WebKit and Chrome
     if (detectBrowser() === Browser.WEBKIT) {
@@ -75,7 +86,6 @@ function detectBrowser() {
 
     return Browser.UNKNOWN;
 }
-
 
 // TODO: Share with blueprint-components #27
 
@@ -139,9 +149,9 @@ export class ElementHarness {
         return this;
     }
 
-    public keyboard(eventType: KeyboardEventType = "keypress", key = "", metaKey = false) {
+    public keyboard(eventType: KeyboardEventType = "keypress", key = "", modKey = false) {
 
-        dispatchTestKeyboardEvent(this.element, eventType, key, metaKey);
+        dispatchTestKeyboardEvent(this.element, eventType, key, modKey);
         return this;
     }
 

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -7,6 +7,7 @@
 
 // tslint:disable max-classes-per-file
 
+import { Browser } from "@blueprintjs/core/dist/compatibility";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
@@ -31,7 +32,7 @@ function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: 
     (event as any).initKeyboardEvent(eventType, true, true, window, key, 0, ctrlKey, false, false, metaKey);
 
     // Hack around these readonly properties in WebKit and Chrome
-    if (detectBrowser() === Browser.WEBKIT) {
+    if (Browser.isWebkit()) {
         (event as any).key = key;
         (event as any).which = keyCode;
     } else {
@@ -40,51 +41,6 @@ function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: 
     }
 
     target.dispatchEvent(event);
-}
-
-/**
- * Enum of possible browsers
- */
-enum Browser {
-    CHROME,
-    EDGE,
-    FIREFOX,
-    IE,
-    UNKNOWN,
-    WEBKIT,
-}
-
-/**
- * Use feature detection to determine current browser.
- * http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
- */
-function detectBrowser() {
-    // Firefox 1.0+
-    if (navigator.userAgent.toLowerCase().indexOf("firefox") > -1) {
-        return Browser.FIREFOX;
-    }
-
-    // Safari <= 9 "[object HTMLElementConstructor]"
-    if (Object.prototype.toString.call((window as any).HTMLElement).indexOf("Constructor") > 0) {
-        return Browser.WEBKIT;
-    }
-
-    // Internet Explorer 6-11
-    if (/*@cc_on!@*/false || !!(document as any).documentMode) {
-        return Browser.IE;
-    }
-
-    // Edge 20+
-    if (!!(window as any).StyleMedia) {
-        return Browser.EDGE;
-    }
-
-    // Chrome 1+
-    if (!!(window as any).chrome && !!(window as any).chrome.webstore) {
-        return Browser.CHROME;
-    }
-
-    return Browser.UNKNOWN;
 }
 
 // TODO: Share with blueprint-components #27

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -39,11 +39,11 @@ describe("Selection", () => {
 
     it("Copies selected cells when keys are pressed", () => {
         const onCopy = sinon.spy();
-        const getCellData = (row: number, col: number) => {
+        const getCellClipboardData = (row: number, col: number) => {
             return Utils.toBase26Alpha(col) + (row + 1);
         };
         const copyCellsStub = sinon.stub(Clipboard, "copyCells").returns(true);
-        const table = harness.mount(createTableOfSize(3, 7, {}, {getCellData, onCopy}));
+        const table = harness.mount(createTableOfSize(3, 7, {}, {getCellClipboardData, onCopy}));
 
         table.find(TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         table.find(TH_SELECTOR).focus();

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -7,6 +7,8 @@
 
 import { expect } from "chai";
 import "es6-shim";
+import { Clipboard } from "../src/common/clipboard";
+import { Utils } from "../src/common/utils";
 import { RegionCardinality, Regions, SelectionModes } from "../src/index";
 import { ReactHarness } from "./harness";
 import { createTableOfSize } from "./mocks/table";
@@ -33,6 +35,21 @@ describe("Selection", () => {
 
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
+    });
+
+    it("Copies selected cells when keys are pressed", () => {
+        const onCopy = sinon.spy();
+        const getCellData = (row: number, col: number) => {
+            return Utils.toBase26Alpha(col) + (row + 1);
+        };
+        const copyCellsStub = sinon.stub(Clipboard, "copyCells").returns(true);
+        const table = harness.mount(createTableOfSize(3, 7, {}, {getCellData, onCopy}));
+
+        table.find(TH_SELECTOR).mouse("mousedown").mouse("mouseup");
+        table.find(TH_SELECTOR).focus();
+        table.find(TH_SELECTOR).keyboard("keydown", "C", true);
+        expect(copyCellsStub.lastCall.args).to.deep.equal([[["A1"], ["A2"], ["A3"], ["A4"], ["A5"], ["A6"], ["A7"]]]);
+        expect(onCopy.lastCall.args).to.deep.equal([true]);
     });
 
     it("De-selects on table body click", () => {


### PR DESCRIPTION
Part of #298 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

You can specify a getCellData in the props and then
cmd+c will copy selected cells.

#### Reviewers should focus on:

What I'm doing here is sane, the shortcut only works when it's supposed to, etc.
