### PR TITLE
Add type attribute to tag remove button

### DIFF
--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -31,11 +31,13 @@ export class Tag extends React.Component<ITagProps, {}> {
         const tagClasses = classNames(Classes.TAG, Classes.intentClass(intent), {
             [Classes.TAG_REMOVABLE]: onRemove != null,
         }, className);
+        const button =
+          isFunction(onRemove) ? <button type="button" className={Classes.TAG_REMOVE} onClick={onRemove} /> : undefined;
 
         return (
             <span {...removeNonHTMLProps(this.props)} className={tagClasses}>
                 {this.props.children}
-                {isFunction(onRemove) ? <button className={Classes.TAG_REMOVE} onClick={onRemove} /> : null}
+                {button}
             </span>
         );
     }


### PR DESCRIPTION
#### Fixes #550

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
#### Changes proposed in this pull request:

Add `type` attribute to remove buttons on Tag components, since not having type="button" submits forms that contain the element on some browsers.

