### PR TITLE
Fix syntax highlighting in inputGroup.tsx

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -60,7 +60,7 @@ export class InputGroup extends React.Component<HTMLInputProps & IInputGroupProp
     };
 
     public render() {
-        const { className, intent, leftIconName } = this.props;
+        const { className, intent } = this.props;
         const classes = classNames(Classes.INPUT_GROUP, Classes.intentClass(intent), {
             [Classes.DISABLED]: this.props.disabled,
         }, className);
@@ -68,7 +68,7 @@ export class InputGroup extends React.Component<HTMLInputProps & IInputGroupProp
 
         return (
             <div className={classes}>
-                {leftIconName == null ? null : <span className={`pt-icon ${Classes.iconClass(leftIconName)}`} />}
+                {this.maybeRenderLeftIcon()}
 
                 <input
                     type="text"
@@ -89,6 +89,15 @@ export class InputGroup extends React.Component<HTMLInputProps & IInputGroupProp
 
     public componentDidUpdate() {
         this.updateInputWidth();
+    }
+
+    private maybeRenderLeftIcon() {
+        const { leftIconName } = this.props;
+        if (leftIconName == null) {
+            return null;
+        }
+        const iconClass = Classes.iconClass(leftIconName);
+        return <span className={classNames("pt-icon", iconClass)} />;
     }
 
     private maybeRenderRightElement() {

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -94,7 +94,7 @@ export class InputGroup extends React.Component<HTMLInputProps & IInputGroupProp
     private maybeRenderLeftIcon() {
         const { leftIconName } = this.props;
         if (leftIconName == null) {
-            return null;
+            return undefined;
         }
         const iconClass = Classes.iconClass(leftIconName);
         return <span className={classNames("pt-icon", iconClass)} />;


### PR DESCRIPTION
(doesn't have an issue - have just noticed it for months and finally bit the bullet to fix it)

#### Changes proposed in this pull request:

**Before**
Dense line of code and broken syntax-highlighting in VS Code.
<img width="898" alt="screen shot 2017-01-26 at 11 49 30 am" src="https://cloud.githubusercontent.com/assets/443450/22347994/e2e5c8ca-e3be-11e6-97ce-ca9fec8a0bb5.png">

**After**
Icon-rendering code is more readable, and syntax highlighting is fixed.
<img width="767" alt="screen shot 2017-01-26 at 11 52 09 am" src="https://cloud.githubusercontent.com/assets/443450/22348001/e57be7ea-e3be-11e6-8f34-a525e1a4e710.png">

#### Screenshot

Left icons still render properly
![image](https://cloud.githubusercontent.com/assets/443450/22348080/2bfb0412-e3bf-11e6-9882-0eb8a1d31b45.png)
