### PR TITLE
Fix z-index stack for .pt-button-group and .pt-control-group elements

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -109,6 +109,10 @@ Styleguide components.forms.control-group
 
     &[class*="pt-intent-"] {
       z-index: 3;
+
+      &:focus {
+        z-index: 6;
+      }
     }
   }
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -110,6 +110,12 @@ Styleguide components.forms.control-group
     &[class*="pt-intent-"] {
       z-index: 3;
 
+      // ensure hovering over an element won't lift it above a neighboring
+      // element's focus outline
+      &:hover {
+        z-index: 5;
+      }
+
       &:focus {
         z-index: 6;
       }
@@ -130,11 +136,29 @@ Styleguide components.forms.control-group
     }
   }
 
-  // establish new stacking context so focus state covers neighbors
-  .pt-button:focus,
-  select:focus {
-    position: relative;
-    z-index: 2;
+  .pt-button,
+  select {
+
+    // prevent hovered elements from stacking themselves above focused neighbors
+    &:hover:not(:focus) {
+      z-index: 1;
+    }
+
+    // establish new stacking context so focus state covers neighbors
+    &:focus {
+      position: relative;
+      z-index: 4;
+
+      // need to rearticulate this rule in the new stacking context, otherwise
+      // the focused element on hover will appear below its neighbors!
+      &:hover {
+        z-index: 3;
+
+        &[class*="pt-intent-"] {
+          z-index: 4;
+        }
+      }
+    }
   }
 
   // input group contents appear above input always


### PR DESCRIPTION
(Sweeping up a couple final issues from #537, specifically from [these changes](https://github.com/palantir/blueprint/pull/537/files#diff-9f4ffc04872ae8416007b7851351b176) to `_control-group.scss`.)

## Changes proposed in this pull request:

### Before

(Note: I discovered these issues while working on the `NumericInput` component in #189.)

- If a control group has multiple consecutive buttons with an intent styling, the focus outlines will be improperly layered behind neighboring buttons. See here:

<img width="440" alt="screen shot 2017-01-26 at 6 52 35 pm" src="https://cloud.githubusercontent.com/assets/443450/22359156/94d2a91a-e3f9-11e6-8d3b-12a04aeaba3b.png">

- For buttons in a `.pt-control-group > .pt-button-group` with _no_ intent, a hovered neighbor would appear above a focused neighbor's outline:

![image](https://cloud.githubusercontent.com/assets/443450/22360962/14f70798-e40a-11e6-9f50-216832aa54a3.png)

Here's a GIF of the issues in action:

_Case 1: The buttons are **not** nested in a `.pt-button-group`:_
![2017-01-26 21 16 17](https://cloud.githubusercontent.com/assets/443450/22361266/d9131f3e-e40c-11e6-95c0-0bb527e35b95.gif)

_Case 2: The buttons **are** nested in a `.pt-button-group`:_
![2017-01-26 21 14 09](https://cloud.githubusercontent.com/assets/443450/22361273/df7f7796-e40c-11e6-9218-a5f76d736445.gif)

 
## After:
After some z-index massaging, everything behaves as expected:

_Case 1: The buttons are **not** nested in a `.pt-button-group`:_
![2017-01-26 21 10 31](https://cloud.githubusercontent.com/assets/443450/22361310/35e9ee40-e40d-11e6-83db-929dee411d3e.gif)

_Case 2: The buttons **are** nested in a `.pt-button-group`:_
![2017-01-26 21 07 32](https://cloud.githubusercontent.com/assets/443450/22361312/3ad82a02-e40d-11e6-8bdb-74a2a80e5621.gif)

### Dark Theme

Looks good as well.

_Case 1: The buttons are **not** nested in a `.pt-button-group`:_
![2017-01-26 21 27 04](https://cloud.githubusercontent.com/assets/443450/22361416/4154bebc-e40e-11e6-88ef-41137a96f022.gif)

_Case 2: The buttons **are** nested in a `.pt-button-group`:_
![2017-01-26 21 25 55](https://cloud.githubusercontent.com/assets/443450/22361407/243aa576-e40e-11e6-8c03-2e8cb6ff2876.gif)

#### Reviewers should focus on:

- Does this handle all the cases?
- Should we write unit tests for CSS edge cases like this?
- Should we start using variables for z-indexes within `_control-group.scss`? (I think so)
