### PR TITLE
Use Cell's className instead of TableBody

### DIFF
--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -157,7 +157,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
                 [CELL_LEDGER_ODD_CLASS]: (rowIndex % 2) === 1,
                 [CELL_LEDGER_EVEN_CLASS]: (rowIndex % 2) === 0,
             },
-            this.props.className,
+            baseCell.props.className,
         );
         const key = TableBody.cellReactKey(rowIndex, columnIndex);
         const rect = isGhost ? grid.getGhostCellRect(rowIndex, columnIndex) : grid.getCellRect(rowIndex, columnIndex);


### PR DESCRIPTION
Fixes an issue where the className on `Cell` is not being passed correctly via the `renderCell`

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Use `baseCell.props.className` instead of `this.props.className`

