### PR TITLE
Menu item hover / active states (including with pt-intent-*)

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -15,9 +15,7 @@ $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray4 !default;
 
 $menu-item-color-hover: $minimal-button-background-color-hover !default;
-// $menu-item-color-active: $minimal-button-background-color-active !default;
 $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !default;
-// $dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
 
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
@@ -51,10 +49,52 @@ $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !defaul
 
   &:not(#{$disabled-selector})#{$hover-selector} {
     background: $dark-menu-item-color-hover;
+    color: inherit;
   }
 
   &#{$disabled-selector} {
     color: $pt-dark-text-color-disabled;
+  }
+}
+
+@mixin menu-item-intents($text-color: $pt-intent-text-colors) {
+  @each $intent, $color in $text-color {
+    &.pt-intent-#{$intent} {
+      color: $color;
+
+      &::before,
+      &::after,
+      .pt-menu-item-label {
+        color: $color;
+      }
+    }
+  }
+
+  @each $intent, $color in $button-intents {
+    &.pt-intent-#{$intent} {
+      &:hover {
+        background: nth(map-get($button-intents, $intent), 1);
+      }
+
+      &:active,
+      &.pt-active {
+        background: nth(map-get($button-intents, $intent), 2);
+      }
+
+      // blargh
+      // stylelint-disable max-nesting-depth
+      &:hover,
+      &:active,
+      &.pt-active {
+        color: $white;
+
+        &::before,
+        &::after,
+        .pt-menu-item-label {
+          color: $white;
+        }
+      }
+    }
   }
 }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -72,12 +72,12 @@ $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !defaul
 
   @each $intent, $color in $button-intents {
     &.pt-intent-#{$intent} {
-      &:hover {
+      &:hover,
+      &.pt-active {
         background: nth(map-get($button-intents, $intent), 1);
       }
 
-      &:active,
-      &.pt-active {
+      &:active {
         background: nth(map-get($button-intents, $intent), 2);
       }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -14,6 +14,11 @@ $menu-item-padding-large: ($pt-button-height-large - $pt-icon-size-large) / 2 !d
 $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray4 !default;
 
+$menu-item-color-hover: $minimal-button-background-color-hover !default;
+// $menu-item-color-active: $minimal-button-background-color-active !default;
+$dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !default;
+// $dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
+
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
 @mixin menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
@@ -27,9 +32,8 @@ $dark-menu-background-color: $dark-gray4 !default;
   user-select: none;
 
   &:not(#{$disabled-selector})#{$hover-selector} {
-    background: $pt-intent-primary;
+    background: $menu-item-color-hover;
     cursor: pointer;
-    color: $white;
   }
 
   &#{$disabled-selector} {
@@ -38,12 +42,16 @@ $dark-menu-background-color: $dark-gray4 !default;
   }
 
   .pt-dark & {
-    @include dark-menu-item($disabled-selector);
+    @include dark-menu-item($disabled-selector, $hover-selector);
   }
 }
 
-@mixin dark-menu-item($disabled-selector: ".pt-disabled") {
+@mixin dark-menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
   color: inherit;
+
+  &:not(#{$disabled-selector})#{$hover-selector} {
+    background: $dark-menu-item-color-hover;
+  }
 
   &#{$disabled-selector} {
     color: $pt-dark-text-color-disabled;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -57,7 +57,7 @@ $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !defaul
   }
 }
 
-@mixin menu-item-intents($text-color: $pt-intent-text-colors) {
+@mixin menu-item-intent($text-color: $pt-intent-text-colors) {
   @each $intent, $color in $text-color {
     &.pt-intent-#{$intent} {
       color: $color;
@@ -81,8 +81,6 @@ $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !defaul
         background: nth(map-get($button-intents, $intent), 2);
       }
 
-      // blargh
-      // stylelint-disable max-nesting-depth
       &:hover,
       &:active,
       &.pt-active {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -65,7 +65,7 @@ $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !defaul
       &::before,
       &::after,
       .pt-menu-item-label {
-        color: $color;
+        color: map-get($pt-intent-colors, $intent);
       }
     }
   }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -31,12 +31,13 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   color: inherit;
   user-select: none;
 
-  &:not(#{$disabled-selector})#{$hover-selector} {
-    background: $menu-item-color-hover;
+  &#{$hover-selector} {
+    background-color: $menu-item-color-hover;
     cursor: pointer;
   }
 
   &#{$disabled-selector} {
+    background-color: inherit;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
   }
@@ -49,17 +50,22 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
 @mixin dark-menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
   color: inherit;
 
-  &:not(#{$disabled-selector})#{$hover-selector} {
-    background: $dark-menu-item-color-hover;
+  &#{$hover-selector} {
+    background-color: $dark-menu-item-color-hover;
     color: inherit;
   }
 
   &#{$disabled-selector} {
+    background-color: inherit;
     color: $pt-dark-text-color-disabled;
   }
 }
 
-@mixin menu-item-intent($text-color: $pt-intent-text-colors) {
+@mixin menu-item-intent(
+  $text-color: $pt-intent-text-colors,
+  $text-color-disabled: $pt-text-color-disabled,
+  $icon-color-disabled: $pt-icon-color-disabled
+) {
   @each $intent, $color in $text-color {
     &.pt-intent-#{$intent} {
       color: $color;
@@ -69,18 +75,14 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
       .pt-menu-item-label {
         color: map-get($pt-intent-colors, $intent);
       }
-    }
-  }
 
-  @each $intent, $color in $button-intents {
-    &.pt-intent-#{$intent} {
       &:hover,
       &.pt-active {
-        background: nth(map-get($button-intents, $intent), 1);
+        background-color: nth(map-get($button-intents, $intent), 1);
       }
 
       &:active {
-        background: nth(map-get($button-intents, $intent), 2);
+        background-color: nth(map-get($button-intents, $intent), 2);
       }
 
       &:hover,
@@ -91,6 +93,20 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
         &::after,
         .pt-menu-item-label {
           color: $white;
+        }
+      }
+
+      &.pt-disabled {
+        background-color: inherit;
+
+        &,
+        &::before,
+        &::after {
+          color: $icon-color-disabled;
+        }
+
+        .pt-menu-item-label {
+          color: $text-color-disabled;
         }
       }
     }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -61,8 +61,8 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   }
 }
 
-@mixin menu-item-intent($text-color: $pt-intent-text-colors) {
-  @each $intent, $color in $text-color {
+@mixin menu-item-intent($text-colors: $pt-intent-text-colors) {
+  @each $intent, $color in $text-colors {
     &.pt-intent-#{$intent} {
       color: $color;
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -15,7 +15,9 @@ $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray4 !default;
 
 $menu-item-color-hover: $minimal-button-background-color-hover !default;
+$menu-item-color-active: $minimal-button-background-color-active !default;
 $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !default;
+$dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
 
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
@@ -84,8 +86,7 @@ $dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !defaul
       &:hover,
       &:active,
       &.pt-active {
-        color: $white;
-
+        &,
         &::before,
         &::after,
         .pt-menu-item-label {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -61,11 +61,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   }
 }
 
-@mixin menu-item-intent(
-  $text-color: $pt-intent-text-colors,
-  $text-color-disabled: $pt-text-color-disabled,
-  $icon-color-disabled: $pt-icon-color-disabled
-) {
+@mixin menu-item-intent($text-color: $pt-intent-text-colors) {
   @each $intent, $color in $text-color {
     &.pt-intent-#{$intent} {
       color: $color;
@@ -93,20 +89,6 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
         &::after,
         .pt-menu-item-label {
           color: $white;
-        }
-      }
-
-      &.pt-disabled {
-        background-color: inherit;
-
-        &,
-        &::before,
-        &::after {
-          color: $icon-color-disabled;
-        }
-
-        .pt-menu-item-label {
-          color: $text-color-disabled;
         }
       }
     }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -284,23 +284,6 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
       margin-right: $menu-item-padding-large;
     }
   }
-
-  .pt-dark & {
-    &:not(.pt-disabled) {
-      &:not(.pt-selected) {
-        @include menu-item-intents($pt-dark-intent-text-colors);
-      }
-
-      &.pt-active,
-      &:active {
-        background-color: $dark-menu-item-color-active;
-      }
-
-      &.pt-selected {
-        background-color: $pt-intent-primary;
-      }
-    }
-  }
 }
 
 a.pt-menu-item {
@@ -371,6 +354,21 @@ Styleguide components.menu.css.header
       &::before,
       &::after {
         color: $white;
+      }
+    }
+
+    &:not(.pt-disabled) {
+      &:not(.pt-selected) {
+        @include menu-item-intents($pt-dark-intent-text-colors);
+      }
+
+      &.pt-active,
+      &:active {
+        background-color: $dark-menu-item-color-active;
+      }
+
+      &.pt-selected {
+        background-color: $pt-intent-primary;
       }
     }
 

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -241,22 +241,25 @@ Styleguide components.menu.css
     background-color: $menu-item-color-active;
   }
 
+  // pt-disable always overrides over styles
+  // stylelint-disable declaration-no-important
   &.pt-disabled {
     // override global a:focus styles
-    outline: none;
-    background-color: inherit;
-    cursor: not-allowed;
-    color: $pt-text-color-disabled;
+    outline: none !important;
+    background-color: inherit !important;
+    cursor: not-allowed !important;
+    color: $pt-text-color-disabled !important;
 
     &::before,
     &::after {
-      color: $pt-icon-color-disabled;
+      color: $pt-icon-color-disabled !important;
     }
 
     .pt-menu-item-label {
-      color: $pt-text-color-disabled;
+      color: $pt-text-color-disabled !important;
     }
   }
+  // stylelint-enable declaration-no-important
 
   .pt-large & {
     @include menu-item-large();
@@ -324,7 +327,7 @@ Styleguide components.menu.css.header
   }
 
   .pt-menu-item {
-    @include menu-item-intent($pt-dark-intent-text-colors, $pt-dark-text-color-disabled, $pt-dark-icon-color-disabled);
+    @include menu-item-intent($pt-dark-intent-text-colors);
 
     &::before,
     &::after {
@@ -347,19 +350,21 @@ Styleguide components.menu.css.header
       background-color: $dark-menu-item-color-active;
     }
 
+    // pt-disable always overrides over styles
+    // stylelint-disable declaration-no-important
     &.pt-disabled {
-      background-color: inherit;
-      color: $pt-dark-text-color-disabled;
+      color: $pt-dark-text-color-disabled !important;
 
       &::before,
       &::after {
-        color: $pt-dark-icon-color-disabled;
+        color: $pt-dark-icon-color-disabled !important;
       }
 
       .pt-menu-item-label {
-        color: $pt-dark-icon-color-disabled;
+        color: $pt-dark-icon-color-disabled !important;
       }
     }
+    // stylelint-enable declaration-no-important
   }
 
   .pt-menu-divider,

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -348,6 +348,7 @@ Styleguide components.menu.css.header
     }
 
     &.pt-disabled {
+      background-color: inherit;
       color: $pt-dark-text-color-disabled;
 
       &::before,

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -251,12 +251,9 @@ Styleguide components.menu.css
     color: $pt-text-color-disabled !important;
 
     &::before,
-    &::after {
-      color: $pt-icon-color-disabled !important;
-    }
-
+    &::after,
     .pt-menu-item-label {
-      color: $pt-text-color-disabled !important;
+      color: $pt-icon-color-disabled !important;
     }
   }
   // stylelint-enable declaration-no-important
@@ -356,10 +353,7 @@ Styleguide components.menu.css.header
       color: $pt-dark-text-color-disabled !important;
 
       &::before,
-      &::after {
-        color: $pt-dark-icon-color-disabled !important;
-      }
-
+      &::after,
       .pt-menu-item-label {
         color: $pt-dark-icon-color-disabled !important;
       }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -214,6 +214,7 @@ Styleguide components.menu.css
 
 .pt-menu-item {
   @include menu-item();
+  @include menu-item-intent();
 
   &::before {
     // support pt-icon-* classes directly on this element
@@ -227,21 +228,17 @@ Styleguide components.menu.css
     color: $pt-icon-color;
   }
 
-  &:hover {
-    color: inherit;
-  }
-
   .pt-menu-item-label {
     color: $pt-text-color-muted;
   }
 
-  &:not(.pt-disabled) {
-    @include menu-item-intent();
+  &:hover {
+    color: inherit;
+  }
 
-    &.pt-active,
-    &:active {
-      background-color: $menu-item-color-active;
-    }
+  &.pt-active,
+  &:active {
+    background-color: $menu-item-color-active;
   }
 
   &.pt-disabled {
@@ -327,6 +324,8 @@ Styleguide components.menu.css.header
   }
 
   .pt-menu-item {
+    @include menu-item-intent($pt-dark-intent-text-colors, $pt-dark-text-color-disabled, $pt-dark-icon-color-disabled);
+
     &::before,
     &::after {
       color: $pt-dark-icon-color;
@@ -343,17 +342,12 @@ Styleguide components.menu.css.header
       }
     }
 
-    &:not(.pt-disabled) {
-      @include menu-item-intent($pt-dark-intent-text-colors);
-
-      &.pt-active,
-      &:active {
-        background-color: $dark-menu-item-color-active;
-      }
+    &.pt-active,
+    &:active {
+      background-color: $dark-menu-item-color-active;
     }
 
-    &.pt-disabled,
-    &.pt-disabled:hover {
+    &.pt-disabled {
       color: $pt-dark-text-color-disabled;
 
       &::before,

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -197,9 +197,6 @@ Markup:
 Styleguide components.menu.css
 */
 
-$menu-item-color-active: $minimal-button-background-color-active !default;
-$dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
-
 .pt-menu {
   margin: 0;
   border-radius: $pt-border-radius;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -237,24 +237,11 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   }
 
   &:not(.pt-disabled) {
-    &:not(.pt-selected) {
-      @include menu-item-intents();
-    }
+    @include menu-item-intent();
 
     &.pt-active,
     &:active {
       background-color: $menu-item-color-active;
-    }
-
-    &.pt-selected {
-      background-color: $pt-intent-primary;
-      color: $white;
-
-      &::before,
-      &::after,
-      .pt-menu-item-label {
-        color: $white;
-      }
     }
   }
 
@@ -358,17 +345,11 @@ Styleguide components.menu.css.header
     }
 
     &:not(.pt-disabled) {
-      &:not(.pt-selected) {
-        @include menu-item-intents($pt-dark-intent-text-colors);
-      }
+      @include menu-item-intent($pt-dark-intent-text-colors);
 
       &.pt-active,
       &:active {
         background-color: $dark-menu-item-color-active;
-      }
-
-      &.pt-selected {
-        background-color: $pt-intent-primary;
       }
     }
 

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -237,64 +237,24 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   }
 
   &:not(.pt-disabled) {
-    @each $intent, $color in $pt-intent-text-colors {
-      &.pt-intent-#{$intent} {
-        color: $color;
-
-        &::before,
-        &::after,
-        .pt-menu-item-label {
-          color: $color;
-        }
-      }
+    &:not(.pt-selected) {
+      @include menu-item-intents();
     }
 
-    @each $intent, $color in $button-intents {
-      &.pt-intent-#{$intent} {
-        &:hover {
-          background: nth(map-get($button-intents, $intent), 1);
-        }
-
-        &:active,
-        &.pt-active {
-          background: nth(map-get($button-intents, $intent), 2);
-        }
-
-        &.pt-selected {
-          background: nth(map-get($button-intents, $intent), 1);
-        }
-
-        // blargh
-        // stylelint-disable max-nesting-depth
-        &:hover,
-        &:active,
-        &.pt-active,
-        &.pt-selected {
-          color: $white;
-
-          &::before,
-          &::after,
-          .pt-menu-item-label {
-            color: $white;
-          }
-        }
-      }
+    &.pt-active,
+    &:active {
+      background-color: $menu-item-color-active;
     }
-  }
 
-  &:not(.pt-disabled).pt-active,
-  &:not(.pt-disabled):active, {
-    background-color: $menu-item-color-active;
-  }
-
-  &:not(.pt-disabled).pt-selected {
-    background-color: $pt-intent-primary;
-    color: $white;
-
-    &::before,
-    &::after,
-    .pt-menu-item-label {
+    &.pt-selected {
+      background-color: $pt-intent-primary;
       color: $white;
+
+      &::before,
+      &::after,
+      .pt-menu-item-label {
+        color: $white;
+      }
     }
   }
 
@@ -322,6 +282,23 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
       @include pt-icon($pt-icon-size-large);
 
       margin-right: $menu-item-padding-large;
+    }
+  }
+
+  .pt-dark & {
+    &:not(.pt-disabled) {
+      &:not(.pt-selected) {
+        @include menu-item-intents($pt-dark-intent-text-colors);
+      }
+
+      &.pt-active,
+      &:active {
+        background-color: $dark-menu-item-color-active;
+      }
+
+      &.pt-selected {
+        background-color: $pt-intent-primary;
+      }
     }
   }
 }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -195,6 +195,9 @@ Markup:
 Styleguide components.menu.css
 */
 
+$menu-item-color-active: $minimal-button-background-color-active !default;
+$dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
+
 .pt-menu {
   margin: 0;
   border-radius: $pt-border-radius;
@@ -225,28 +228,80 @@ Styleguide components.menu.css
     color: $pt-icon-color;
   }
 
+  &:hover {
+    color: inherit;
+  }
+
   .pt-menu-item-label {
     color: $pt-text-color-muted;
   }
 
-  &:not(.pt-disabled):hover {
+  &:not(.pt-disabled) {
+    @each $intent, $color in $pt-intent-text-colors {
+      &.pt-intent-#{$intent} {
+        color: $color;
+
+        &::before,
+        &::after,
+        .pt-menu-item-label {
+          color: $color;
+        }
+      }
+    }
+
+    @each $intent, $color in $button-intents {
+      &.pt-intent-#{$intent} {
+        &:hover {
+          background: nth(map-get($button-intents, $intent), 1);
+        }
+
+        &:active,
+        &.pt-active {
+          background: nth(map-get($button-intents, $intent), 2);
+        }
+
+        &.pt-selected {
+          background: nth(map-get($button-intents, $intent), 1);
+        }
+
+        // blargh
+        // stylelint-disable max-nesting-depth
+        &:hover,
+        &:active,
+        &.pt-active,
+        &.pt-selected {
+          color: $white;
+
+          &::before,
+          &::after,
+          .pt-menu-item-label {
+            color: $white;
+          }
+        }
+      }
+    }
+  }
+
+  &:not(.pt-disabled).pt-active,
+  &:not(.pt-disabled):active, {
+    background-color: $menu-item-color-active;
+  }
+
+  &:not(.pt-disabled).pt-selected {
+    background-color: $pt-intent-primary;
+    color: $white;
+
     &::before,
     &::after,
     .pt-menu-item-label {
       color: $white;
-    }
-
-    // intent color only appears on hover
-    @each $intent, $color in $pt-intent-colors {
-      &.pt-intent-#{$intent} {
-        background-color: $color;
-      }
     }
   }
 
   &.pt-disabled {
     // override global a:focus styles
     outline: none;
+    background-color: inherit;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
 

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -151,6 +151,8 @@ abstract away the tedious parts of implementing a menu.
 - Add icons to menu items the same way you would to buttons: simply add the appropriate
 `pt-icon-<name>` class*.
 
+- Make menu items active with the class `pt-active` (along with `pt-intent-*` if suitable).
+
 - Make menu items non-interactive with the class `pt-disabled`.
 
 - Wrap menu item text in a `<span>` element for proper alignment. (Note that React automatically

--- a/packages/docs/src/components/navMenu.tsx
+++ b/packages/docs/src/components/navMenu.tsx
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Classes, IProps } from "@blueprintjs/core";
+import { Classes, Intent, IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 
@@ -24,7 +24,10 @@ export interface INavMenuItemProps extends IStyleguideSection, IProps {
 
 export const NavMenuItem: React.SFC<INavMenuItemProps> = (props: INavMenuItemProps & { children: React.ReactNode }) => {
     const classes = classNames("docs-menu-item", `depth-${props.depth}`, props.className);
-    const itemClasses = classNames(Classes.MENU_ITEM, { [Classes.ACTIVE]: props.isActive });
+    const itemClasses = classNames(Classes.MENU_ITEM, {
+        [Classes.ACTIVE]: props.isActive,
+        [Classes.intentClass(Intent.PRIMARY)]: props.isActive,
+    });
     const handleClick = () => props.onClick(props);
     return (
         <li className={classes}>

--- a/packages/docs/src/components/navMenu.tsx
+++ b/packages/docs/src/components/navMenu.tsx
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Classes, Intent, IProps } from "@blueprintjs/core";
+import { Classes, IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 
@@ -26,7 +26,7 @@ export const NavMenuItem: React.SFC<INavMenuItemProps> = (props: INavMenuItemPro
     const classes = classNames("docs-menu-item", `depth-${props.depth}`, props.className);
     const itemClasses = classNames(Classes.MENU_ITEM, {
         [Classes.ACTIVE]: props.isActive,
-        [Classes.intentClass(Intent.PRIMARY)]: props.isActive,
+        [Classes.INTENT_PRIMARY]: props.isActive,
     });
     const handleClick = () => props.onClick(props);
     return (

--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -12,6 +12,7 @@ import {
     HotkeysTarget,
     IconContents,
     InputGroup,
+    Intent,
     Keys,
     Menu,
     Popover,
@@ -125,8 +126,10 @@ export class Navigator extends React.Component<INavigatorProps, INavigatorState>
         const matches = this.getMatches();
         const selectedIndex = Math.min(matches.length, this.state.selectedIndex);
         let items = matches.map((section, index) => {
+            const isSelected = index === selectedIndex;
             const classes = classNames(Classes.MENU_ITEM, Classes.POPOVER_DISMISS, {
-                [Classes.ACTIVE]: index === selectedIndex,
+                [Classes.ACTIVE]: isSelected,
+                [Classes.intentClass(Intent.PRIMARY)]: isSelected,
             });
             const headerHtml = { __html: section.header };
             // add $icons16-family to font stack to support mixing icons with regular text!

--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -12,7 +12,6 @@ import {
     HotkeysTarget,
     IconContents,
     InputGroup,
-    Intent,
     Keys,
     Menu,
     Popover,
@@ -129,7 +128,7 @@ export class Navigator extends React.Component<INavigatorProps, INavigatorState>
             const isSelected = index === selectedIndex;
             const classes = classNames(Classes.MENU_ITEM, Classes.POPOVER_DISMISS, {
                 [Classes.ACTIVE]: isSelected,
-                [Classes.intentClass(Intent.PRIMARY)]: isSelected,
+                [Classes.INTENT_PRIMARY]: isSelected,
             });
             const headerHtml = { __html: section.header };
             // add $icons16-family to font stack to support mixing icons with regular text!

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -115,32 +115,6 @@ Lefthand navigation menu
     white-space: initial;
   }
 
-  .pt-menu-item:not(.pt-active) {
-    &:hover {
-      background-color: $nav-item-color-hover;
-      text-decoration: none;
-      color: $pt-text-color;
-    }
-
-    &:active {
-      background-color: $nav-item-color-active;
-    }
-
-    .pt-dark & {
-      color: $pt-dark-text-color;
-
-      &:hover {
-        box-shadow: none;
-        background-color: $dark-nav-item-color-hover;
-        color: $pt-dark-text-color;
-      }
-
-      &:active {
-        background-color: $dark-nav-item-color-active;
-      }
-    }
-  }
-
   @each $depth in (2, 3, 4, 5) {
     &.depth-#{$depth} > .pt-menu-item {
       padding-left: $nav-item-padding + $nav-item-indent * ($depth - 1);

--- a/packages/docs/src/styles/_navigator.scss
+++ b/packages/docs/src/styles/_navigator.scss
@@ -13,10 +13,13 @@ $navigator-min-width: $pt-grid-size * 22;
     max-height: $navigator-height;
     overflow: auto;
   }
+
+  .pt-menu-item:not(.pt-active) {
+    background: inherit;
+  }
 }
 
-.pt-menu-item.pt-active,
-.pt-menu-item:hover {
+.pt-menu-item.pt-active {
   .docs-result-path {
     color: $white;
   }

--- a/packages/docs/src/styles/_navigator.scss
+++ b/packages/docs/src/styles/_navigator.scss
@@ -15,12 +15,6 @@ $navigator-min-width: $pt-grid-size * 22;
   }
 }
 
-.pt-menu-item.pt-active {
-  background: $pt-intent-primary;
-  cursor: pointer;
-  color: $white;
-}
-
 .pt-menu-item.pt-active,
 .pt-menu-item:hover {
   .docs-result-path {

--- a/packages/docs/src/styles/_navigator.scss
+++ b/packages/docs/src/styles/_navigator.scss
@@ -19,8 +19,6 @@ $navigator-min-width: $pt-grid-size * 22;
   }
 }
 
-.pt-menu-item.pt-active {
-  .docs-result-path {
-    color: $white;
-  }
+.pt-menu-item.pt-active .docs-result-path {
+  color: $white;
 }


### PR DESCRIPTION
#### Fixes #389 

#### Changes proposed in this pull request:

As per the previous discussion thread on #513.

- Default hover and active states are grey
- `.pt-active` === `:active` (background is dependent on `.pt-intent-*`)
- `.pt-disabled` > `.pt-active` / `pt-intent-*`

- [x] Update documentation
- [x] Update docs site