### PR TITLE
test existence of dist files

### DIFF
--- a/gulp/aliases.js
+++ b/gulp/aliases.js
@@ -22,7 +22,7 @@ module.exports = (gulp) => {
     gulp.task("build", (done) => rs("clean", "compile", "webpack-compile-docs", done));
 
     // build code, run unit tests, terminate
-    gulp.task("test", ["karma"]);
+    gulp.task("test", ["test-dist", "karma"]);
 
     // compile code and start watching for development
     gulp.task("default", (done) => rs("clean", "compile", "docs", "watch", done));

--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -34,7 +34,7 @@ module.exports = (gulp, plugins, blueprint) => {
         const promises = ["main", "style", "typings"]
             .filter((field) => pkgJson[field] !== undefined)
             .map((field) => {
-                const filePath = path.resolve(project.cwd, pkgJson[field])
+                const filePath = path.resolve(project.cwd, pkgJson[field]);
                 return new Promise((resolve, reject) => {
                     // non-existent file will callback with err; we don't care about actual contents
                     fs.readFile(filePath, (err) => {
@@ -53,7 +53,7 @@ module.exports = (gulp, plugins, blueprint) => {
         const name = `test-dist-${project.id}`;
         gulp.task(name, () => testDist(project));
         return name;
-    })
+    });
 
     gulp.task("test-dist", testDistTasks);
 };

--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -4,6 +4,7 @@
 "use strict";
 
 module.exports = (gulp, plugins, blueprint) => {
+    const fs = require("fs");
     const path = require("path");
     const mergeStream = require("merge-stream");
 
@@ -26,4 +27,33 @@ module.exports = (gulp, plugins, blueprint) => {
             return mergeStream(streams);
         });
     });
+
+    // asserts that all main fields in package.json reference existing files
+    function testDist(project) {
+        const pkgJson = require(path.resolve(project.cwd, "package.json"));
+        const promises = ["main", "style", "typings"]
+            .filter((field) => pkgJson[field] !== undefined)
+            .map((field) => {
+                const filePath = path.resolve(project.cwd, pkgJson[field])
+                return new Promise((resolve, reject) => {
+                    // non-existent file will callback with err; we don't care about actual contents
+                    fs.readFile(filePath, (err) => {
+                        if (err) {
+                            reject(`${pkgJson.name}: "${field}" not found (${pkgJson[field]})`);
+                        } else {
+                            resolve();
+                        }
+                    });
+                });
+            });
+        return Promise.all(promises);
+    }
+
+    const testDistTasks = blueprint.projects.map((project) => {
+        const name = `test-dist-${project.id}`;
+        gulp.task(name, () => testDist(project));
+        return name;
+    })
+
+    gulp.task("test-dist", testDistTasks);
 };

--- a/packages/table/preview/tsconfig.json
+++ b/packages/table/preview/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig",
+    "include": [
+        "*.*"
+    ],
+    "exclude": [
+        "dist"
+    ]
+}

--- a/packages/table/tsconfig.json
+++ b/packages/table/tsconfig.json
@@ -22,7 +22,7 @@
     "target": "es5"
   },
   "include": [
-    "preview/*",
+    "preview/*.d.ts",
     "src/**/*"
   ],
   "exclude": [


### PR DESCRIPTION
#### Fixes #566

#### Changes proposed in this pull request:

- new gulp `test-dist` task asserts that main files exist for each package.json
- revert table tsconfig change
- add tsconfig.json to table/preview that extends its parent so those files can be compiled (hooray TS 2.1)
