### PR TITLE
Proper docs icon colors and sentence casing

### DIFF
--- a/packages/core/examples/collapsibleListExample.tsx
+++ b/packages/core/examples/collapsibleListExample.tsx
@@ -45,11 +45,11 @@ export class CollapsibleListExample extends BaseExample<ICollapsibleListExampleS
                 dropdownTarget={<span className={Classes.BREADCRUMBS_COLLAPSED} />}
                 renderVisibleItem={this.renderBreadcrumb}
             >
-                <MenuItem iconName="folder-close" text="All Files" href="#" />
+                <MenuItem iconName="folder-close" text="All files" href="#" />
                 <MenuItem iconName="folder-close" text="Users" href="#" />
                 <MenuItem iconName="folder-close" text="Jane Person" href="#" />
-                <MenuItem iconName="folder-close" text="My Documents" href="#" />
-                <MenuItem iconName="folder-close" text="Classy Dayjob" href="#" />
+                <MenuItem iconName="folder-close" text="My documents" href="#" />
+                <MenuItem iconName="folder-close" text="Classy dayjob" href="#" />
                 <MenuItem iconName="document" text="How to crush it" />
             </CollapsibleList>
         );

--- a/packages/core/examples/overlayExample.tsx
+++ b/packages/core/examples/overlayExample.tsx
@@ -70,7 +70,7 @@ export class OverlayExample extends BaseExample<IOverlayExampleState> {
                             easily custom transitions can be implemented.
                         </p>
                         <p>
-                            Click the right button below to transfer focus to the "Show Overlay" trigger
+                            Click the right button below to transfer focus to the "Show overlay" trigger
                             button outside of this overlay. If persistent focus is enabled, focus will
                             be constrained to the overlay. Use the <code>tab</code> key to move to the
                             next focusable element to illustrate this effect.

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -135,7 +135,7 @@ Grid system
 Blueprint doesn't provide a grid system. In general, you should try to use the `$pt-grid-size`
 variable to generate layout & sizing style rules in your CSS codebase.
 
-In lieu of a full grid system, you should try to use the __CSS3 Flexible Box layout model__ (a.k.a.
+In lieu of a full grid system, you should try to use the __CSS flexible box layout model__ (a.k.a.
 "flexbox"). It's quite powerful on its own and allows you to build robust, responsive layouts
 without writing much CSS. Here are some resources for learning flexbox:
    - [MDN guide](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes)

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -40,7 +40,7 @@ dependencies:
   npm install --save react react-dom react-addons-css-transition-group
   ```
 
-1. After installation, you'll be able to import the React JS components in your application:
+1. After installation, you'll be able to import the React components in your application:
 
   ```
   // extract specific components
@@ -132,9 +132,9 @@ Styleguide components.usage.typescript
 /*
 Vanilla JS APIs
 
-JS Components are built using React, but that does not limit their usage to just React applications.
+JS components are built using React, but that does not limit their usage to just React applications.
 You can render any component in any JavaScript application with `ReactDOM.render`. Think of it like
-using a JQuery plugin.
+using a jQuery plugin.
 
 ```
 const myContainerElement = document.querySelector(".my-container");

--- a/packages/core/src/components/context-menu/_context-menu.scss
+++ b/packages/core/src/components/context-menu/_context-menu.scss
@@ -11,7 +11,7 @@ Context menus present the user with a custom list of actions upon right-click.
 You can create context menus in either of the following ways:
 
 - by adding the `@ContextMenuTarget` [decorator](#components.context-menu.decorator) to a React
-  Component that implements `renderContextMenu(): JSX.Element`.
+  component that implements `renderContextMenu(): JSX.Element`.
 - via the [imperative](#components.context-menu.js) `ContextMenu.show` and `ContextMenu.hide` API
   methods, ideal for non-React-based applications.
 

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -85,7 +85,7 @@ export class MyComponent extends React.Component<{}, {}> {
                 onKeyDown={() => console.log("Awesome!")}
             />
             <Hotkey
-                group="Fancy Shortcuts"
+                group="Fancy shortcuts"
                 combo="shift + f"
                 label="Be fancy only when focused"
                 onKeyDown={() => console.log("So Fancy!")}

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -24,16 +24,16 @@ JavaScript API
 The `Menu`, `MenuItem`, and `MenuDivider` components are available in the __@blueprintjs/core__
 package. Make sure to review the [general usage docs for JS components](#components.usage).
 
-The Menu API includes three stateless React components:
+The menu API includes three stateless React components:
 
 - [`Menu`](#components.menu.js.menu)
 - [`MenuItem`](#components.menu.js.menu-item)
 - [`MenuDivider`](#components.menu.js.menu-divider)
 
-### Sample Usage
+### Sample usage
 
 ```
-const { Menu, MenuItem, MenuDivider } = BlueprintComponents;
+import { Menu, MenuItem, MenuDivider } from "@blueprintjs/core";
 
 class MenuExample extends React.Component<{}, {}> {
     public render() {

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -24,7 +24,7 @@ JavaScript API
 The `Menu`, `MenuItem`, and `MenuDivider` components are available in the __@blueprintjs/core__
 package. Make sure to review the [general usage docs for JS components](#components.usage).
 
-The menu API includes three stateless React components:
+The `Menu` API includes three stateless React components:
 
 - [`Menu`](#components.menu.js.menu)
 - [`MenuItem`](#components.menu.js.menu-item)

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -37,7 +37,7 @@ JavaScript API
 The `DatePicker` component is available in the __@blueprintjs/datetime__ package.
 Make sure to review the [general usage docs for date & time components](#components.datetime).
 
-Some props are managed by the Blueprint `DatePicker` component, while others are passed
+Some props are managed by the `DatePicker` component, while others are passed
 to the **react-day-picker** library. These passed props are documented in full
 in the [**react-day-picker** documentation](http://www.gpbl.org/react-day-picker/index.html).
 
@@ -73,7 +73,7 @@ export class DatePickerExample extends React.Component<{}, { selectedDate: Date 
         // name of modifier function, 'isSunday' is the suffix for the CSS class above
         const modifiers = { isSunday };
         return (
-            <BlueprintComponents.DatePicker
+            <DatePicker
                 modifiers={modifiers}
                 onChange={(newDate) => this.handleChange(newDate)}
                 value={this.state.selectedDate} />

--- a/packages/docs/src/styleguide.md
+++ b/packages/docs/src/styleguide.md
@@ -19,7 +19,7 @@ npm install --save @blueprintjs/core react react-dom react-addons-css-transition
 Import components from the `@blueprintjs/core` module into your project.
 Don't forget to include the main CSS stylesheet too!
 
-[See **Components usage** for more complete installation instructions.](#components.usage)
+**Review the [general usage docs](#components.usage) for more complete installation instructions.**
 
 ### Beyond core styles
 

--- a/packages/docs/src/styleguide.md
+++ b/packages/docs/src/styleguide.md
@@ -19,7 +19,7 @@ npm install --save @blueprintjs/core react react-dom react-addons-css-transition
 Import components from the `@blueprintjs/core` module into your project.
 Don't forget to include the main CSS stylesheet too!
 
-**[See Components Usage for more complete installation instructions.](#components.usage)**
+[See **Components usage** for more complete installation instructions.](#components.usage)
 
 ### Beyond core styles
 

--- a/packages/docs/src/styles/_icons.scss
+++ b/packages/docs/src/styles/_icons.scss
@@ -61,6 +61,10 @@ $icons-per-row: 5;
     position: relative;
   }
 
+  .pt-icon-large {
+    color: $pt-icon-color;
+  }
+
   .pt-dark & {
     &::before {
       background-color: $dark-gray3;
@@ -68,6 +72,10 @@ $icons-per-row: 5;
 
     &:active::before {
       background-color: $dark-gray2;
+    }
+
+    .pt-icon-large {
+      color: $pt-dark-icon-color;
     }
   }
 }

--- a/packages/table/src/_docs.scss
+++ b/packages/table/src/_docs.scss
@@ -126,7 +126,7 @@ Styleguide components.table-js.example-editable
 /*
 Loading states
 
-When fetching or updating data, it may be desirable to show a loading state. The Table components
+When fetching or updating data, it may be desirable to show a loading state. The table components
 provide fine-grain loading control of loading row headers, column headers, or individual cells.
 Several table components expose a `loading` or `loadingOptions` prop, but loading-related rendering
 is computed with components lower in the hierarchy taking priority. For example, a cell with
@@ -181,7 +181,7 @@ Styleguide components.table-js.loading.cell
 /*
 Formatted content
 
-To display long strings or native javascript objects, we provide
+To display long strings or native JavaScript objects, we provide
 `<TruncatedFormat>` and `<JSONFormat>` components, which are designed to be used
 within a `<Cell>`.
 
@@ -210,8 +210,8 @@ Styleguide components.table-js.api
 /*
 Table
 
-The top-level component of the Blueprint Table is `Table`. You must at least
-define the number of rows (`numRows` prop) as well as a set of `Column` children.
+The top-level component of the table is `Table`. You must at least define the
+number of rows (`numRows` prop) as well as a set of `Column` children.
 
 @interface ITableProps
 
@@ -316,7 +316,7 @@ Styleguide components.table-js.api.truncated-format
 /*
 JSONFormat
 
-Wrap your javascript object cell contents with a `JSONFormat` component like so:
+Wrap your JavaScript object cell contents with a `JSONFormat` component like so:
 
 ```tsx
 const content = { any: "javascript variable", even: [null, "is", "okay", "too"] };


### PR DESCRIPTION
- Icons page icons are now using `$pt-icon-color` following #497 
- Various sentence casing type of things