### PR TITLE
Prepare Release Table 1.4.1

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@blueprintjs/core": "^1.7.0",
     "@blueprintjs/datetime": "^1.6.0",
-    "@blueprintjs/table": "^1.4.0",
+    "@blueprintjs/table": "^1.4.1",
     "chroma-js": "1.1.1",
     "classnames": "2.2.5",
     "dom4": "1.8.3",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## @blueprintjs/table `1.4.1`
- __Fixed__ misplaced main files so the package can be imported correctly #566 