### PR TITLE
Fix loading Button children

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -27,6 +27,13 @@ export interface IButtonProps extends IActionProps {
      * @default false
      */
     loading?: boolean;
+
+    /**
+     * HTML `type` attribute of button. Common values are `"button"` and `"submit"`.
+     * Note that this prop has no effect on `AnchorButton`; it only affects `Button`.
+     * @default "button"
+     */
+    type?: string;
 }
 
 export interface IButtonState {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -101,8 +101,17 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
     }
 
     protected renderChildren(): React.ReactNode {
-        const { children, loading, rightIconName, text } = this.props;
+        const { loading, rightIconName, text } = this.props;
         const iconClasses = classNames(Classes.ICON_STANDARD, Classes.iconClass(rightIconName), Classes.ALIGN_RIGHT);
+
+        const children = React.Children.map(this.props.children, (child, index) => {
+            // must wrap string children in spans so loading prop can hide them
+            if (typeof child === "string") {
+                return <span key={`text-${index}`}>{child}</span>;
+            }
+            return child;
+        });
+
         return [
             loading ? <Spinner className="pt-small pt-button-spinner" key="spinner" /> : undefined,
             text != null ? <span key="text">{text}</span> : undefined,

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -36,6 +36,13 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             assert.equal(wrapper.text(), "some text");
         });
 
+        it("wraps string children in spans", () => {
+            // so text can be hidden when loading
+            const wrapper = button({}, true, "raw string", <em>not a string</em>);
+            assert.equal(wrapper.find("span").length, 1, "span not found");
+            assert.equal(wrapper.find("em").length, 1, "em not found");
+        });
+
         it("renders a loading spinner when the loading prop is true", () => {
             const wrapper = button({ loading: true });
             assert.lengthOf(wrapper.find(Spinner), 1);
@@ -80,8 +87,8 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             assert.instanceOf(elementRef.args[0][0], HTMLElement);
         });
 
-        function button(props: IButtonProps, useMount = false) {
-            const element = React.createElement(component, props);
+        function button(props: IButtonProps, useMount = false, ...children: React.ReactNode[]) {
+            const element = React.createElement(component, props, ...children);
             return useMount ? mount(element) : shallow(element);
         }
     });


### PR DESCRIPTION
#### Fixes #571, Fixes #572 

#### Changes proposed in this pull request:

- add docs for `Button` `type` prop
- wrap string children in span so `loading` can hide them

cc @greglo