### PR TITLE
Add maxLength props to EditableText

### DIFF
--- a/packages/core/examples/editableTextExample.tsx
+++ b/packages/core/examples/editableTextExample.tsx
@@ -7,7 +7,7 @@
 
 import * as React from "react";
 
-import { Classes, EditableText, InputGroup, Intent, Switch } from "@blueprintjs/core";
+import { Classes, EditableText, Intent, Switch } from "@blueprintjs/core";
 import BaseExample, { handleBooleanChange, handleNumberChange, handleStringChange } from "./common/baseExample";
 import { IntentSelect } from "./common/intentSelect";
 
@@ -23,7 +23,6 @@ export interface IEditableTextExampleState {
 export class EditableTextExample extends BaseExample<IEditableTextExampleState> {
     public state: IEditableTextExampleState = {
         confirmOnEnterKey: false,
-        maxLength: undefined,
         report: "",
         selectAllOnFocus: false,
         title: "",
@@ -81,7 +80,8 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                 <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
                 <label className={Classes.LABEL} key="maxlength">
                     Max Length
-                    <InputGroup
+                    <input
+                        className={Classes.INPUT}
                         placeholder="Unlimited"
                         onChange={this.handleMaxLengthChange}
                         value={this.state.maxLength !== undefined ? this.state.maxLength.toString() : ""}

--- a/packages/core/examples/editableTextExample.tsx
+++ b/packages/core/examples/editableTextExample.tsx
@@ -7,27 +7,44 @@
 
 import * as React from "react";
 
-import { EditableText, Intent, Switch } from "@blueprintjs/core";
-import BaseExample, { handleBooleanChange, handleNumberChange } from "./common/baseExample";
+import { Classes, EditableText, InputGroup, Intent, Switch } from "@blueprintjs/core";
+import BaseExample, { handleBooleanChange, handleNumberChange, handleStringChange } from "./common/baseExample";
 import { IntentSelect } from "./common/intentSelect";
 
 export interface IEditableTextExampleState {
+    confirmOnEnterKey?: boolean;
     intent?: Intent;
+    maxLength?: number;
     report?: string;
     selectAllOnFocus?: boolean;
-    confirmOnEnterKey?: boolean;
     title?: string;
 }
 
 export class EditableTextExample extends BaseExample<IEditableTextExampleState> {
     public state: IEditableTextExampleState = {
         confirmOnEnterKey: false,
+        maxLength: undefined,
         report: "",
         selectAllOnFocus: false,
         title: "",
     };
 
     private handleIntentChange = handleNumberChange((intent: Intent) => this.setState({ intent }));
+    private handleMaxLengthChange = handleStringChange((maxLengthInput: string) => {
+        const invalidMaxLength = (+maxLengthInput === 0 || isNaN(+maxLengthInput)) && (maxLengthInput.length !== 0);
+        if (invalidMaxLength) {
+            return;
+        }
+
+        if (maxLengthInput.length === 0) {
+            this.setState({ maxLength: undefined });
+        } else {
+            const maxLength = +maxLengthInput;
+            const report = this.state.report.slice(0, maxLength);
+            const title = this.state.title.slice(0, maxLength);
+            this.setState({ maxLength, report, title });
+        }
+    });
     private toggleSelectAll = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
     private toggleSwap = handleBooleanChange((confirmOnEnterKey) => this.setState({ confirmOnEnterKey }));
 
@@ -36,6 +53,7 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
             <h1>
                 <EditableText
                     intent={this.state.intent}
+                    maxLength={this.state.maxLength}
                     placeholder="Edit title..."
                     selectAllOnFocus={this.state.selectAllOnFocus}
                     value={this.state.title}
@@ -44,6 +62,7 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
             </h1>
             <EditableText
                 intent={this.state.intent}
+                maxLength={this.state.maxLength}
                 maxLines={12}
                 minLines={3}
                 multiline
@@ -60,6 +79,14 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
         return [
             [
                 <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
+                <label className={Classes.LABEL} key="maxlength">
+                    Max Length
+                    <InputGroup
+                        placeholder="Unlimited"
+                        onChange={this.handleMaxLengthChange}
+                        value={this.state.maxLength !== undefined ? this.state.maxLength.toString() : ""}
+                    />
+                </label>,
                 <Switch
                     checked={this.state.selectAllOnFocus}
                     label="Select all on focus"

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -36,6 +36,9 @@ export interface IEditableTextProps extends IIntentProps, IProps {
     /** Whether the component is currently being edited. */
     isEditing?: boolean;
 
+    /** Maximum number of characters allowed. Unlimited by default. */
+    maxLength?: number;
+
     /** Minimum width in pixels of the input, when not `multiline`. */
     minWidth?: number;
 
@@ -275,12 +278,13 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
     }
 
     private maybeRenderInput(value: string) {
-        const { multiline } = this.props;
+        const { maxLength, multiline } = this.props;
         if (!this.state.isEditing) {
             return undefined;
         }
         const props: React.HTMLProps<HTMLInputElement | HTMLTextAreaElement> = {
             className: "pt-editable-input",
+            maxLength,
             onBlur: this.toggleEditing,
             onChange: this.handleTextChange,
             onKeyDown: this.handleKeyEvent,


### PR DESCRIPTION
#### Fixes #557 

#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

Allow `maxLength` prop to input and textarea element in `<EditableText />`
