### PR TITLE
[Date Range Input] - Part 1: Show a selection preview on hover

### DIFF
--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -94,34 +94,16 @@ Styleguide components.datetime.daterangepicker.js
   // very long selectors ahead!
   // stylelint-disable max-line-length
 
-  .DayPicker-Day--hover-range:not(.DayPicker-Day--hover-range-end) {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  .DayPicker-Day--hover-range:not(.DayPicker-Day--hover-range-start) {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-  }
-
   .DayPicker-Day--selected-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end):not(.DayPicker-Day--hovered-range-end),
-  .DayPicker-Day--hovered-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end):not(.DayPicker-Day--hovered-range-end) {
+  .DayPicker-Day--hovered-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--hovered-range-end) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-
-    &.DayPicker-Day--hovered-range {
-      border-radius: 0;
-    }
   }
 
-  .DayPicker-Day--selected-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-start),
+  .DayPicker-Day--selected-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-start):not(.DayPicker-Day--hovered-range-start),
   .DayPicker-Day--hovered-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--hovered-range-start) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-
-    &.DayPicker-Day--hovered-range {
-      border-radius: 0;
-    }
   }
 
   // stylelint-enable max-line-length

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -63,22 +63,65 @@ Styleguide components.datetime.daterangepicker.js
     margin-right: $pt-grid-size;
   }
 
+  .DayPicker-Day--hovered-range:not(.DayPicker-Day--outside) {
+    border-radius: 0;
+
+    // need to disable hover-styles for all variants of selected dates
+    // stylelint-disable max-line-length
+    &:not(.DayPicker-Day--selected):not(.DayPicker-Day--selected-range):not(.DayPicker-Day--selected-range-start):not(.DayPicker-Day--selected-range-end) {
+      background-color: $light-gray4;
+
+      &:hover {
+        background-color: $light-gray1;
+      }
+    }
+    // stylelint-enable max-line-length
+  }
+
   .DayPicker-Day--selected-range:not(.DayPicker-Day--outside) {
     border-radius: 0;
     background-color: $light-gray4;
+
+    &:hover {
+      background-color: $light-gray1;
+    }
+  }
+
+  .DayPicker-Day--outside {
+    visibility: hidden;
   }
 
   // very long selectors ahead!
   // stylelint-disable max-line-length
 
-  .DayPicker-Day--selected-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end) {
+  .DayPicker-Day--hover-range:not(.DayPicker-Day--hover-range-end) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
 
-  .DayPicker-Day--selected-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-start) {
+  .DayPicker-Day--hover-range:not(.DayPicker-Day--hover-range-start) {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .DayPicker-Day--selected-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end):not(.DayPicker-Day--hovered-range-end),
+  .DayPicker-Day--hovered-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--hovered-range-end) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    &.DayPicker-Day--hovered-range {
+      border-radius: 0;
+    }
+  }
+
+  .DayPicker-Day--selected-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-start):not(.DayPicker-Day--hovered-range-start),
+  .DayPicker-Day--hovered-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--hovered-range-start) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+
+    &.DayPicker-Day--hovered-range {
+      border-radius: 0;
+    }
   }
 
   // stylelint-enable max-line-length

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -105,7 +105,7 @@ Styleguide components.datetime.daterangepicker.js
   }
 
   .DayPicker-Day--selected-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end):not(.DayPicker-Day--hovered-range-end),
-  .DayPicker-Day--hovered-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--hovered-range-end) {
+  .DayPicker-Day--hovered-range-start:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-end):not(.DayPicker-Day--hovered-range-end) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 
@@ -114,7 +114,7 @@ Styleguide components.datetime.daterangepicker.js
     }
   }
 
-  .DayPicker-Day--selected-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-start):not(.DayPicker-Day--hovered-range-start),
+  .DayPicker-Day--selected-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--selected-range-start),
   .DayPicker-Day--hovered-range-end:not(.DayPicker-Day--outside):not(.DayPicker-Day--hovered-range-start) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -20,8 +20,6 @@ export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 export const DATERANGEPICKER = "pt-daterangepicker";
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = "DayPicker-Day--selected-range";
 export const DATERANGEPICKER_DAY_HOVERED_RANGE = "DayPicker-Day--hovered-range";
-export const DATERANGEPICKER_DAY_HOVERED_RANGE_START = "DayPicker-Day--hovered-range-start";
-export const DATERANGEPICKER_DAY_HOVERED_RANGE_END = "DayPicker-Day--hovered-range-end";
 export const DATERANGEPICKER_SHORTCUTS = "pt-daterangepicker-shortcuts";
 
 export const DATETIMEPICKER = "pt-datetimepicker";

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -19,6 +19,9 @@ export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 
 export const DATERANGEPICKER = "pt-daterangepicker";
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = "DayPicker-Day--selected-range";
+export const DATERANGEPICKER_DAY_HOVERED_RANGE = "DayPicker-Day--hovered-range";
+export const DATERANGEPICKER_DAY_HOVERED_RANGE_START = "DayPicker-Day--hovered-range-start";
+export const DATERANGEPICKER_DAY_HOVERED_RANGE_END = "DayPicker-Day--hovered-range-end";
 export const DATERANGEPICKER_SHORTCUTS = "pt-daterangepicker-shortcuts";
 
 export const DATETIMEPICKER = "pt-datetimepicker";

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -63,11 +63,18 @@ export interface IDatePickerBaseProps {
 }
 
 export const DISABLED_MODIFIER = "disabled";
+export const HOVERED_RANGE_MODIFIER = "hovered-range";
 export const OUTSIDE_MODIFIER = "outside";
 export const SELECTED_MODIFIER = "selected";
 export const SELECTED_RANGE_MODIFIER = "selected-range";
 // modifiers the user can't set because they are used by Blueprint or react-day-picker
-export const DISALLOWED_MODIFIERS = [DISABLED_MODIFIER, OUTSIDE_MODIFIER, SELECTED_MODIFIER, SELECTED_RANGE_MODIFIER];
+export const DISALLOWED_MODIFIERS = [
+    DISABLED_MODIFIER,
+    HOVERED_RANGE_MODIFIER,
+    OUTSIDE_MODIFIER,
+    SELECTED_MODIFIER,
+    SELECTED_RANGE_MODIFIER,
+];
 
 export function getDefaultMaxDate() {
     const date = new Date();

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -299,7 +299,7 @@ export class DateRangePicker
     }
 
     private handleDayMouseLeave =
-        (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
+        (_e: React.SyntheticEvent<HTMLElement>, _day: Date, modifiers: IDatePickerDayModifiers) => {
 
         if (modifiers.disabled) {
             return;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -281,45 +281,31 @@ export class DateRangePicker
     }
 
     private handleDayMouseEnter = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
-        const [start, end] = this.state.value;
-        const { allowSingleDayRange } = this.props;
-
-        let hoverValue: DateRange;
-
-        if (start == null && end == null) {
-            hoverValue = [day, null];
-        } else if (start != null && end == null) {
-            if (!allowSingleDayRange && DateUtils.areSameDay(start, day)) {
-                hoverValue = [null, null];
-            } else {
-                hoverValue = this.createRange(start, day);
-            }
-        } else if (start == null && end != null) {
-            if (!allowSingleDayRange && DateUtils.areSameDay(day, end)) {
-                hoverValue = [null, null];
-            } else {
-                hoverValue = this.createRange(day, end);
-            }
-        } else {
-            // default behavior is to start a new date-range selection
-            hoverValue = [day, null];
-        }
-
-        this.setState({ hoverValue });
+        this.setState({ hoverValue: this.getNextValue(this.state.value, day) });
     }
 
     private handleDayMouseLeave = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
         this.setState({ hoverValue: [null, null] });
     }
 
-    private handleDayClick = (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
+    private handleDayClick = (e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
         if (modifiers.disabled) {
             // rerender base component to get around bug where you can navigate past bounds by clicking days
             this.forceUpdate();
             return;
         }
 
-        const [start, end] = this.state.value;
+        const nextValue = this.getNextValue(this.state.value, day);
+
+        // update the hovered date range after click to show the newly selected
+        // state, at leasts until the mouse moves again
+        this.handleDayMouseEnter(e, day);
+
+        this.handleNextState(nextValue);
+    }
+
+    private getNextValue(currentRange: DateRange, day: Date) {
+        const [start, end] = currentRange;
         let nextValue: DateRange;
 
         if (start == null && end == null) {
@@ -342,7 +328,7 @@ export class DateRangePicker
             }
         }
 
-        this.handleNextState(nextValue);
+        return nextValue;
     }
 
     private createRange(a: Date, b: Date): DateRange {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -315,13 +315,13 @@ export class DateRangePicker
             hoverValue = [day, null];
         } else if (start != null && end == null) {
             if (!allowSingleDayRange && DateUtils.areSameDay(start, day)) {
-                hoverValue = [null, day];
+                hoverValue = [null, null];
             } else {
                 hoverValue = this.createRange(start, day);
             }
         } else if (start == null && end != null) {
             if (!allowSingleDayRange && DateUtils.areSameDay(day, end)) {
-                hoverValue = [day, null];
+                hoverValue = [null, null];
             } else {
                 hoverValue = this.createRange(day, end);
             }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -58,8 +58,8 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Called when the user changes the hovered date range, either from mouseenter or mouseleave.
-     * If no dates are hovered, it will pass `[null, null]`.
-     * Otherwise, it will pass `[startDate, endDate]`.
+     * When triggered from mouseenter, it will pass the date range that would result from next click.
+     * When triggered from mouseleave, it will pass `[null, null]`.
      */
     onHoverChange?: (hoveredDates: DateRange) => void;
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -106,22 +106,24 @@ export class DateRangePicker
             if (selectedStart == null && selectedEnd == null) {
                 return false;
             }
-            if (hoverValue == null || hoverValue[0] == null || hoverValue[1] == null) {
+            if (hoverValue[0] == null || hoverValue[1] == null) {
                 return false;
             }
             return DateUtils.isDayInRange(day, hoverValue, true);
         },
         [`${HOVERED_RANGE_MODIFIER}-start`]: (day: Date) => {
-            if (this.state.hoverValue == null || this.state.hoverValue[0] == null) {
+            const hoveredStart = this.state.hoverValue[0];
+            if (hoveredStart == null) {
                 return false;
             }
-            return DateUtils.areSameDay(this.state.hoverValue[0], day);
+            return DateUtils.areSameDay(hoveredStart, day);
         },
         [`${HOVERED_RANGE_MODIFIER}-end`]: (day: Date) => {
-            if (this.state.hoverValue == null || this.state.hoverValue[1] == null) {
+            const hoveredEnd = this.state.hoverValue[1];
+            if (hoveredEnd == null) {
                 return false;
             }
-            return DateUtils.areSameDay(this.state.hoverValue[1], day);
+            return DateUtils.areSameDay(hoveredEnd, day);
         },
     };
 
@@ -170,6 +172,7 @@ export class DateRangePicker
         this.state = {
             displayMonth: initialMonth.getMonth(),
             displayYear: initialMonth.getFullYear(),
+            hoverValue: [null, null],
             value,
         };
     }
@@ -281,7 +284,7 @@ export class DateRangePicker
         const [start, end] = this.state.value;
         const { allowSingleDayRange } = this.props;
 
-        let hoverValue: DateRange = null;
+        let hoverValue: DateRange;
 
         if (start == null && end == null) {
             hoverValue = [day, null];
@@ -297,7 +300,7 @@ export class DateRangePicker
             } else {
                 hoverValue = this.createRange(day, end);
             }
-        } else if (start != null && end != null) {
+        } else {
             // default behavior is to start a new date-range selection
             hoverValue = [day, null];
         }
@@ -306,7 +309,7 @@ export class DateRangePicker
     }
 
     private handleDayMouseLeave = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
-        this.setState({ hoverValue: null });
+        this.setState({ hoverValue: [null, null] });
     }
 
     private handleDayClick = (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -59,7 +59,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     /**
      * Called when the user changes the hovered date range, either from mouseenter or mouseleave.
      * When triggered from mouseenter, it will pass the date range that would result from next click.
-     * When triggered from mouseleave, it will pass `[null, null]`.
+     * When triggered from mouseleave, it will pass `undefined`.
      */
     onHoverChange?: (hoveredDates: DateRange) => void;
 
@@ -113,24 +113,24 @@ export class DateRangePicker
             if (selectedStart == null && selectedEnd == null) {
                 return false;
             }
-            if (hoverValue[0] == null || hoverValue[1] == null) {
+            if (hoverValue == null || hoverValue[0] == null || hoverValue[1] == null) {
                 return false;
             }
             return DateUtils.isDayInRange(day, hoverValue, true);
         },
         [`${HOVERED_RANGE_MODIFIER}-start`]: (day: Date) => {
-            const hoveredStart = this.state.hoverValue[0];
-            if (hoveredStart == null) {
+            const { hoverValue } = this.state;
+            if (hoverValue == null ||  hoverValue[0] == null) {
                 return false;
             }
-            return DateUtils.areSameDay(hoveredStart, day);
+            return DateUtils.areSameDay(hoverValue[0], day);
         },
         [`${HOVERED_RANGE_MODIFIER}-end`]: (day: Date) => {
-            const hoveredEnd = this.state.hoverValue[1];
-            if (hoveredEnd == null) {
+            const { hoverValue } = this.state;
+            if (hoverValue == null || hoverValue[1] == null) {
                 return false;
             }
-            return DateUtils.areSameDay(hoveredEnd, day);
+            return DateUtils.areSameDay(hoverValue[1], day);
         },
     };
 
@@ -304,7 +304,7 @@ export class DateRangePicker
         if (modifiers.disabled) {
             return;
         }
-        const nextHoverValue = [null, null] as DateRange;
+        const nextHoverValue = undefined as DateRange;
         this.setState({ hoverValue: nextHoverValue });
         Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
     }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -227,18 +227,8 @@ export class DateRangePicker
         super.componentWillReceiveProps(nextProps);
 
         const { displayMonth, displayYear } = this.state;
-
-        // this method is called a lot when hover values change in the parent,
-        // but no provided props change. this is a quick and dirty way to check
-        // deep object equality in a way that assumes identical property order
-        // (which is not an *insane* assumption). some more efficient method for
-        // efficient deep-object comparison would be wonderful here.
-        const didValueChange = JSON.stringify(this.props) !== JSON.stringify(nextProps);
-
-        if (didValueChange) {
-            const nextState = getStateChange(this.props.value, nextProps.value, displayMonth, displayYear);
-            this.setState(nextState);
-        }
+        const nextState = getStateChange(this.props.value, nextProps.value, displayMonth, displayYear);
+        this.setState(nextState);
     }
 
     protected validateProps(props: IDateRangePickerProps) {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -57,6 +57,13 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     onChange?: (selectedDates: DateRange) => void;
 
     /**
+     * Called when the user changes the hovered date range, either from mouseenter or mouseleave.
+     * If no dates are hovered, it will pass `[null, null]`.
+     * Otherwise, it will pass `[startDate, endDate]`.
+     */
+    onHoverChange?: (hoveredDates: DateRange) => void;
+
+    /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
      * If `true`, preset shortcuts will be displayed.
      * If `false`, no shortcuts will be displayed.
@@ -281,11 +288,15 @@ export class DateRangePicker
     }
 
     private handleDayMouseEnter = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
-        this.setState({ hoverValue: this.getNextValue(this.state.value, day) });
+        const nextHoverValue = this.getNextValue(this.state.value, day);
+        this.setState({ hoverValue: nextHoverValue });
+        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
     }
 
-    private handleDayMouseLeave = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
-        this.setState({ hoverValue: [null, null] });
+    private handleDayMouseLeave = () => {
+        const nextHoverValue = [null, null] as DateRange;
+        this.setState({ hoverValue: nextHoverValue });
+        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
     }
 
     private handleDayClick = (e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -57,24 +57,6 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     onChange?: (selectedDates: DateRange) => void;
 
     /**
-     * Called when the user changes the hovered date range
-     * (on both mouseenter and mouseleave for each hovered date).
-     * If no dates are hovered, it will pass `[null, null]`.
-     * Otherwise, it will pass `[startDate, endDate]`.
-     */
-    onHoverChange?: (hoveredDates: DateRange) => void;
-
-    /**
-     * Called when the mouse enters a date in the calendar.
-     */
-    onDayMouseEnter?: (date: Date) => void;
-
-    /**
-     * Called when the mouse leaves a date in the calendar.
-     */
-    onDayMouseLeave?: (date: Date) => void;
-
-    /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
      * If `true`, preset shortcuts will be displayed.
      * If `false`, no shortcuts will be displayed.
@@ -321,15 +303,10 @@ export class DateRangePicker
         }
 
         this.setState({ hoverValue });
-
-        Utils.safeInvoke(this.props.onHoverChange, hoverValue);
-        Utils.safeInvoke(this.props.onDayMouseEnter, day);
     }
 
     private handleDayMouseLeave = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
         this.setState({ hoverValue: null });
-        Utils.safeInvoke(this.props.onHoverChange, null);
-        Utils.safeInvoke(this.props.onDayMouseLeave, day);
     }
 
     private handleDayClick = (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -287,13 +287,23 @@ export class DateRangePicker
         );
     }
 
-    private handleDayMouseEnter = (_e: React.SyntheticEvent<HTMLElement>, day: Date) => {
+    private handleDayMouseEnter =
+        (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
+
+        if (modifiers.disabled) {
+            return;
+        }
         const nextHoverValue = this.getNextValue(this.state.value, day);
         this.setState({ hoverValue: nextHoverValue });
         Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
     }
 
-    private handleDayMouseLeave = () => {
+    private handleDayMouseLeave =
+        (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
+
+        if (modifiers.disabled) {
+            return;
+        }
         const nextHoverValue = [null, null] as DateRange;
         this.setState({ hoverValue: nextHoverValue });
         Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
@@ -310,7 +320,7 @@ export class DateRangePicker
 
         // update the hovered date range after click to show the newly selected
         // state, at leasts until the mouse moves again
-        this.handleDayMouseEnter(e, day);
+        this.handleDayMouseEnter(e, day, modifiers);
 
         this.handleNextState(nextValue);
     }

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -223,6 +223,34 @@ describe("<DateRangePicker>", () => {
         });
     });
 
+    describe.skip("hover interactions", () => {
+
+        describe("when neither start nor end date is defined", () => {
+            it("should show a hovered range of [day, null]");
+        });
+
+        describe("when only start date is defined", () => {
+            it("should show a hovered range of [start, day] if day > start");
+            it("should show a hovered range of [null, null] if day === start");
+            it("should show a hovered range of [day, start] if day < start");
+        });
+
+        describe("when only end date is defined", () => {
+            it("should show a hovered range of [end, day] if day > end");
+            it("should show a hovered range of [null, null] if day === end");
+            it("should show a hovered range of [day, end] if day < end");
+        });
+
+        describe("when both start and end date are defined", () => {
+            it("should show a hovered range of [null, end] if day === start");
+            it("should show a hovered range of [start, null] if day === end");
+            it("should show a hovered range of [day, null] if start < day < end");
+            it("should show a hovered range of [day, null] if day < start");
+            it("should show a hovered range of [day, null] if day > end");
+            it("should show a hovered range of [null, null] if start === day === end");
+        });
+    });
+
     describe("when controlled", () => {
         it("value initially selects a day", () => {
             const defaultValue = [new Date(2010, Months.FEBRUARY, 2), null] as DateRange;

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -266,6 +266,19 @@ describe("<DateRangePicker>", () => {
                 assert.equal(getHoveredRangeStartDayElement().textContent, "10");
                 assert.equal(getHoveredRangeEndDayElement().textContent, "14");
             });
+
+            it("should not show a hovered range when mousing over a disabled date", () => {
+                renderDateRangePicker({
+                    maxDate: new Date(2017, Months.FEBRUARY, 1),
+                    minDate: new Date(2017, Months.JANUARY, 1),
+                });
+                clickDay(14); // Jan 14th
+                mouseEnterDay(5, false); // Feb 5th
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "14");
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
         });
 
         describe("when only end date is defined", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -234,29 +234,146 @@ describe("<DateRangePicker>", () => {
                 mouseEnterDay(14);
                 assert.lengthOf(getHoveredRangeDayElements(), 0);
                 assert.equal(getHoveredRangeStartDayElement().textContent, "14");
-                assert.equal(getHoveredRangeEndDayElement(), null);
+                assert.isNull(getHoveredRangeEndDayElement());
             });
         });
 
         describe("when only start date is defined", () => {
-            it("should show a hovered range of [start, day] if day > start");
-            it("should show a hovered range of [null, null] if day === start");
-            it("should show a hovered range of [day, start] if day < start");
+
+            it("should show a hovered range of [start, day] if day > start", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                mouseEnterDay(18);
+                assert.lengthOf(getHoveredRangeDayElements(), 3);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "14");
+                assert.equal(getHoveredRangeEndDayElement().textContent, "18");
+            });
+
+            it("should show a hovered range of [null, null] if day === start", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                mouseEnterDay(14);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.isNull(getHoveredRangeStartDayElement());
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
+            it("should show a hovered range of [day, start] if day < start", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                mouseEnterDay(10);
+                assert.lengthOf(getHoveredRangeDayElements(), 3);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "10");
+                assert.equal(getHoveredRangeEndDayElement().textContent, "14");
+            });
         });
 
         describe("when only end date is defined", () => {
-            it("should show a hovered range of [end, day] if day > end");
-            it("should show a hovered range of [null, null] if day === end");
-            it("should show a hovered range of [day, end] if day < end");
+
+            it("should show a hovered range of [end, day] if day > end", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+                clickDay(14); // deselect start date
+
+                mouseEnterDay(22);
+                assert.lengthOf(getHoveredRangeDayElements(), 3);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "18");
+                assert.equal(getHoveredRangeEndDayElement().textContent, "22");
+            });
+
+            it("should show a hovered range of [null, null] if day === end", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+                clickDay(14);
+
+                mouseEnterDay(18);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.isNull(getHoveredRangeStartDayElement());
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
+            it("should show a hovered range of [day, end] if day < end", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+                clickDay(14);
+
+                mouseEnterDay(14);
+                assert.lengthOf(getHoveredRangeDayElements(), 3);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "14");
+                assert.equal(getHoveredRangeEndDayElement().textContent, "18");
+            });
         });
 
         describe("when both start and end date are defined", () => {
-            it("should show a hovered range of [null, end] if day === start");
-            it("should show a hovered range of [start, null] if day === end");
-            it("should show a hovered range of [day, null] if start < day < end");
-            it("should show a hovered range of [day, null] if day < start");
-            it("should show a hovered range of [day, null] if day > end");
-            it("should show a hovered range of [null, null] if start === day === end");
+
+            it("should show a hovered range of [null, end] if day === start", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+
+                mouseEnterDay(14);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.isNull(getHoveredRangeStartDayElement());
+                assert.equal(getHoveredRangeEndDayElement().textContent, "18");
+            });
+
+            it("should show a hovered range of [start, null] if day === end", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+
+                mouseEnterDay(18);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "14");
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
+            it("should show a hovered range of [day, null] if start < day < end", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+
+                mouseEnterDay(16);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "16");
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
+            it("should show a hovered range of [day, null] if day < start", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+
+                mouseEnterDay(10);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "10");
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
+            it("should show a hovered range of [day, null] if day > end", () => {
+                renderDateRangePicker();
+                clickDay(14);
+                clickDay(18);
+
+                mouseEnterDay(22);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "22");
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
+
+            it("should show a hovered range of [null, null] if start === day === end", () => {
+                renderDateRangePicker({ allowSingleDayRange: true });
+                clickDay(14);
+                clickDay(14);
+
+                mouseEnterDay(14);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.isNull(getHoveredRangeStartDayElement());
+                assert.isNull(getHoveredRangeEndDayElement());
+            });
         });
     });
 
@@ -280,6 +397,20 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(onDateRangePickerChangeSpy.notCalled);
             clickDay();
             assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
+        });
+
+        it("onHoverChange fired on mouseenter within a day", () => {
+            renderDateRangePicker({ value: [null, null] });
+            assert.isTrue(onDateRangePickerHoverChangeSpy.notCalled);
+            mouseEnterDay();
+            assert.isTrue(onDateRangePickerHoverChangeSpy.calledOnce);
+        });
+
+        it("onHoverChange fired on mouseleave within a day", () => {
+            renderDateRangePicker({ value: [null, null] });
+            assert.isTrue(onDateRangePickerHoverChangeSpy.notCalled);
+            mouseLeaveDay();
+            assert.isTrue(onDateRangePickerHoverChangeSpy.calledOnce);
         });
 
         it("selected day updates are not automatic", () => {
@@ -346,6 +477,37 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(onDateRangePickerChangeSpy.notCalled);
             clickDay();
             assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
+        });
+
+        it("onHoverChange fired with correct values when a day is clicked", () => {
+            const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)] as DateRange;
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
+            assert.isTrue(onDateRangePickerHoverChangeSpy.notCalled);
+            clickDay(1);
+            assert.isTrue(onDateRangePickerHoverChangeSpy.calledOnce);
+            assert.isTrue(DateUtils.areSameDay(dateRange[0], onDateRangePickerHoverChangeSpy.args[0][0][0]));
+            assert.isNull(onDateRangePickerHoverChangeSpy.args[0][0][1]);
+        });
+
+        it("onHoverChange fired with correct values on mouseenter within a day", () => {
+            const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)] as DateRange;
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
+            assert.isTrue(onDateRangePickerHoverChangeSpy.notCalled);
+            clickDay(1);
+            mouseEnterDay(5);
+            assert.isTrue(onDateRangePickerHoverChangeSpy.calledTwice);
+            assert.isTrue(DateUtils.areSameDay(dateRange[0], onDateRangePickerHoverChangeSpy.args[1][0][0]));
+            assert.isTrue(DateUtils.areSameDay(dateRange[1], onDateRangePickerHoverChangeSpy.args[1][0][1]));
+        });
+
+        it("onHoverChange fired with [null, null] on mouseleave within a day", () => {
+            renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
+            assert.isTrue(onDateRangePickerHoverChangeSpy.notCalled);
+            clickDay(1);
+            mouseLeaveDay(5);
+            assert.isTrue(onDateRangePickerHoverChangeSpy.calledTwice);
+            assert.isNull(onDateRangePickerHoverChangeSpy.args[1][0][0]);
+            assert.isNull(onDateRangePickerHoverChangeSpy.args[1][0][1]);
         });
 
         it("selected day updates are automatic", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -753,7 +753,6 @@ describe("<DateRangePicker>", () => {
     }
 
     function getHoveredRangeStartDayElement() {
-        // use .query to return just the first element
         return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE_START}`);
     }
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -513,14 +513,13 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(dateRange[1], onDateRangePickerHoverChangeSpy.args[1][0][1]));
         });
 
-        it("onHoverChange fired with [null, null] on mouseleave within a day", () => {
+        it("onHoverChange fired with `undefined` on mouseleave within a day", () => {
             renderDateRangePicker({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             assert.isTrue(onDateRangePickerHoverChangeSpy.notCalled);
             clickDay(1);
             mouseLeaveDay(5);
             assert.isTrue(onDateRangePickerHoverChangeSpy.calledTwice);
-            assert.isNull(onDateRangePickerHoverChangeSpy.args[1][0][0]);
-            assert.isNull(onDateRangePickerHoverChangeSpy.args[1][0][1]);
+            assert.isUndefined(onDateRangePickerHoverChangeSpy.args[1][0]);
         });
 
         it("selected day updates are automatic", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -20,6 +20,7 @@ describe("<DateRangePicker>", () => {
     let testsContainerElement: Element;
     let dateRangePicker: DateRangePicker;
     let onDateRangePickerChangeSpy: Sinon.SinonSpy;
+    let onDateRangePickerHoverChangeSpy: Sinon.SinonSpy;
 
     before(() => {
         // this is essentially what TestUtils.renderIntoDocument does
@@ -223,10 +224,18 @@ describe("<DateRangePicker>", () => {
         });
     });
 
-    describe.skip("hover interactions", () => {
+    describe("hover interactions", () => {
 
         describe("when neither start nor end date is defined", () => {
-            it("should show a hovered range of [day, null]");
+
+            it("should show a hovered range of [day, null]", () => {
+                renderDateRangePicker();
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                mouseEnterDay(14);
+                assert.lengthOf(getHoveredRangeDayElements(), 0);
+                assert.equal(getHoveredRangeStartDayElement().textContent, "14");
+                assert.equal(getHoveredRangeEndDayElement(), null);
+            });
         });
 
         describe("when only start date is defined", () => {
@@ -501,14 +510,27 @@ describe("<DateRangePicker>", () => {
 
     function renderDateRangePicker(props?: IDateRangePickerProps) {
         onDateRangePickerChangeSpy = sinon.spy();
+        onDateRangePickerHoverChangeSpy = sinon.spy();
         dateRangePicker = ReactDOM.render(
-            <DateRangePicker onChange={onDateRangePickerChangeSpy} {...props}/>,
+            <DateRangePicker
+                onChange={onDateRangePickerChangeSpy}
+                onHoverChange={onDateRangePickerHoverChangeSpy}
+                {...props}
+            />,
             testsContainerElement,
         ) as DateRangePicker;
     }
 
     function clickDay(dayNumber = 1, fromLeftMonth = true) {
         TestUtils.Simulate.click(getDayElement(dayNumber, fromLeftMonth));
+    }
+
+    function mouseEnterDay(dayNumber = 1, fromLeftMonth = true) {
+        TestUtils.Simulate.mouseEnter(getDayElement(dayNumber, fromLeftMonth));
+    }
+
+    function mouseLeaveDay(dayNumber = 1, fromLeftMonth = true) {
+        TestUtils.Simulate.mouseLeave(getDayElement(dayNumber, fromLeftMonth));
     }
 
     function clickFirstShortcut() {
@@ -539,9 +561,29 @@ describe("<DateRangePicker>", () => {
         return document.queryAll(`.${DateClasses.DATEPICKER_DAY_SELECTED}:not(.${DateClasses.DATEPICKER_DAY_OUTSIDE})`);
     }
 
+    /**
+     * Returns the selected range excluding endpoints.
+     */
     function getSelectedRangeDayElements() {
         const selectedRange = DateClasses.DATERANGEPICKER_DAY_SELECTED_RANGE;
         return document.queryAll(`.${selectedRange}:not(.${DateClasses.DATEPICKER_DAY_OUTSIDE})`);
+    }
+
+    /**
+     * Returns the hovered range excluding endpoints.
+     */
+    function getHoveredRangeDayElements() {
+        const selectedRange = DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE;
+        return document.queryAll(`.${selectedRange}:not(.${DateClasses.DATEPICKER_DAY_OUTSIDE})`);
+    }
+
+    function getHoveredRangeStartDayElement() {
+        // use .query to return just the first element
+        return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE_START}`);
+    }
+
+    function getHoveredRangeEndDayElement() {
+        return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE_END}`);
     }
 
     function getYearSelect() {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -753,11 +753,11 @@ describe("<DateRangePicker>", () => {
     }
 
     function getHoveredRangeStartDayElement() {
-        return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE_START}`);
+        return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE}-start`);
     }
 
     function getHoveredRangeEndDayElement() {
-        return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE_END}`);
+        return document.query(`.${DateClasses.DATERANGEPICKER_DAY_HOVERED_RANGE}-end`);
     }
 
     function getYearSelect() {


### PR DESCRIPTION
#### Related to #249  

#### Checklist

- [x] Include tests
- [x] Update documentation (should update automatically to show `onHoverChange` in the props list)

#### Changes proposed in this pull request:

##### What
On hover in the `DateRangePicker`, show a visual preview of the range you're about to select. Additionally, hide "outside" dates, because they introduce too much weirdness in hover interactions.

##### Why?
The upcoming `DateRangeInput` implementation will need to display the hovered range in its input fields so that the user remains fully aware what the effect of the next mouse click will be (e.g. the component will need to show the hovered dates in the input fields and move focus between the fields based on the hovered date vs. the selected date/range). This PR just gets the visual hover preview working.

#### Reviewers should focus on:

- Are the CSS styles sane and minimal?
- Are there any weird bugs with hovered ranges vis-a-vis selected dates/ranges?
- Are there any bugs with `allowSingleDayRange`?
- Is it reasonable to call `handleDayMouseEnter` from `handleDayClick`? Another option may be to update `hoverValue` within `getStateChange`, but my `hoverValue` was emerging as `undefined` in my `modifiers` when I tried to update it through that code path. I'm also not sure how 1:1 the update logic will be between hover and selection in more complex strategies.

#### Screenshot

![2017-01-31 17 06 43](https://cloud.githubusercontent.com/assets/443450/22491368/d3a8a31a-e7d7-11e6-832f-189932f50893.gif)
![2017-02-02 00 01 25](https://cloud.githubusercontent.com/assets/443450/22541393/ce60831a-e8da-11e6-85d3-80efef15fa7c.gif)
