### PR TITLE
Add bundle tasks for distribution

### DIFF
--- a/gulp/aliases.js
+++ b/gulp/aliases.js
@@ -19,7 +19,7 @@ module.exports = (gulp) => {
     gulp.task("docs", ["docs-interfaces", "docs-kss", "docs-versions", "docs-releases"]);
 
     // perform a full build of the code and then finish
-    gulp.task("build", (done) => rs("clean", "compile", "webpack-compile-docs", done));
+    gulp.task("build", (done) => rs("clean", "compile", "typescript-bundle", "webpack-compile-docs", done));
 
     // build code, run unit tests, terminate
     gulp.task("test", ["test-dist", "karma"]);

--- a/gulp/aliases.js
+++ b/gulp/aliases.js
@@ -19,7 +19,7 @@ module.exports = (gulp) => {
     gulp.task("docs", ["docs-interfaces", "docs-kss", "docs-versions", "docs-releases"]);
 
     // perform a full build of the code and then finish
-    gulp.task("build", (done) => rs("clean", "compile", "typescript-bundle", "webpack-compile-docs", done));
+    gulp.task("build", (done) => rs("clean", "compile", "bundle", "webpack-compile-docs", done));
 
     // build code, run unit tests, terminate
     gulp.task("test", ["test-dist", "karma"]);

--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -7,6 +7,21 @@ module.exports = (gulp, plugins, blueprint) => {
     const fs = require("fs");
     const path = require("path");
     const mergeStream = require("merge-stream");
+    const webpack = require("webpack");
+    const webpackConfig = require("./util/webpack-config");
+
+    const bundleTaskNames = blueprint.projectsWithBlock("typescript").map((project) => {
+        const taskName = `bundle-${project.id}`;
+        gulp.task(taskName, (done) => {
+            webpack(
+                webpackConfig.generateWebpackBundleConfig(project),
+                webpackConfig.webpackDone(done)
+            );
+        });
+        return taskName;
+    });
+
+    gulp.task("bundle", bundleTaskNames);
 
     [
         "major",

--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -6,8 +6,6 @@
 module.exports = (gulp, plugins, blueprint) => {
     const mergeStream = require("merge-stream");
     const path = require("path");
-    const webpack = require("webpack");
-    const webpackConfig = require("./util/webpack-config");
 
     function createTypescriptProject(tsConfigPath) {
         return plugins.typescript.createProject(tsConfigPath, {

--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -6,6 +6,8 @@
 module.exports = (gulp, plugins, blueprint) => {
     const mergeStream = require("merge-stream");
     const path = require("path");
+    const webpack = require("webpack");
+    const webpackConfig = require("./util/webpack-config");
 
     function createTypescriptProject(tsConfigPath) {
         return plugins.typescript.createProject(tsConfigPath, {
@@ -53,4 +55,17 @@ module.exports = (gulp, plugins, blueprint) => {
             tsResult.dts,
         ]).pipe(blueprint.dest(project));
     });
+
+    const bundleTaskNames = blueprint.projectsWithBlock("typescript").map((project) => {
+        const taskName = `typescript-bundle-${project.id}`;
+        gulp.task(taskName, (done) => {
+            webpack(
+                webpackConfig.generateWebpackBundleConfig(project),
+                webpackConfig.webpackDone(done),
+            );
+        });
+        return taskName;
+    });
+
+    gulp.task("typescript-bundle", bundleTaskNames);
 };

--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -61,7 +61,7 @@ module.exports = (gulp, plugins, blueprint) => {
         gulp.task(taskName, (done) => {
             webpack(
                 webpackConfig.generateWebpackBundleConfig(project),
-                webpackConfig.webpackDone(done),
+                webpackConfig.webpackDone(done)
             );
         });
         return taskName;

--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -55,17 +55,4 @@ module.exports = (gulp, plugins, blueprint) => {
             tsResult.dts,
         ]).pipe(blueprint.dest(project));
     });
-
-    const bundleTaskNames = blueprint.projectsWithBlock("typescript").map((project) => {
-        const taskName = `typescript-bundle-${project.id}`;
-        gulp.task(taskName, (done) => {
-            webpack(
-                webpackConfig.generateWebpackBundleConfig(project),
-                webpackConfig.webpackDone(done)
-            );
-        });
-        return taskName;
-    });
-
-    gulp.task("typescript-bundle", bundleTaskNames);
 };

--- a/gulp/util/webpack-config.js
+++ b/gulp/util/webpack-config.js
@@ -50,12 +50,15 @@ const EXTERNALS = {
     "@blueprintjs/core": "Blueprint",
     "classnames": "classNames",
     "dom4": "window",
+    "es6-shim": "window",
     "jquery": "$",
+    "moment": "moment",
     "react": "React",
     "react-addons-css-transition-group": "React.addons.CSSTransitionGroup",
     "react-day-picker": "DayPicker",
     "react-dom": "ReactDOM",
     "tether": "Tether",
+    "tslib": "tslib"
 };
 
 const ASSIGN_SIG = "var __assign = (this && this.__assign) || Object.assign || function(t) {";
@@ -84,13 +87,13 @@ module.exports = {
 
         const returnVal = Object.assign({
             entry: {
-                [project.id]: `./${project.cwd}/dist/index.js`,
+                [project.id]: path.resolve(project.cwd, "dist", "index.js"),
             },
             externals: EXTERNALS,
             output: {
-                filename: `${project.id}.js`,
+                filename: `${project.id}.bundle.js`,
                 library: globalName(project.id),
-                path: `${project.cwd}/dist`,
+                path: path.join(project.cwd, "dist"),
             },
         }, DEFAULT_CONFIG);
 


### PR DESCRIPTION
#### Fixes #303 

#### Changes proposed in this pull request:

new `typescript-bundle` task group webpacks each package's compiled js files and spits out `dist/[name].bundle.js`.

#### Reviewers should focus on:

- is there a convention for specifying a bundled file in package.json? a la main/typings/style? i couldn't find anything relevant after much googling.
