### PR TITLE
Only add buffer widths in EditableText for IE and Edge

### DIFF
--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -6,8 +6,12 @@
  */
 
 const userAgent = navigator.userAgent;
-
-export const Browser = {
+const browser = {
     isEdge: !!userAgent.match(/Edge/),
     isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
+ };
+
+export const Browser = {
+    isEdge: () => browser.isEdge,
+    isInternetExplorer: () => browser.isInternetExplorer,
 };

--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -6,12 +6,8 @@
  */
 
 const userAgent = navigator.userAgent;
-const browser = {
-    isEdge: !!userAgent.match(/Edge/),
-    isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
-};
 
 export const Browser = {
-    isEdge: () => browser.isEdge,
-    isInternetExplorer: () => browser.isInternetExplorer,
+    isEdge: !!userAgent.match(/Edge/),
+    isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
 };

--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+const userAgent = navigator.userAgent;
+const browser = {
+    isEdge: !!userAgent.match(/Edge/),
+    isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
+};
+
+export const Browser = {
+    isEdge: () => browser.isEdge,
+    isInternetExplorer: () => browser.isInternetExplorer,
+};

--- a/packages/core/src/compatibility/index.ts
+++ b/packages/core/src/compatibility/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+export * from "./browser";

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -315,8 +315,11 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
             // The computed scrollHeight must also account for a larger inherited line-height from the parent.
             scrollHeight = Math.max(scrollHeight, getFontSize(this.valueElement) + 1, getLineHeight(parentElement));
             // IE11 & Edge needs a small buffer so text does not shift prior to resizing
-            scrollWidth = Browser.isEdge() ? scrollWidth + BUFFER_WIDTH_EDGE : scrollWidth;
-            scrollWidth = Browser.isInternetExplorer() ? scrollWidth + BUFFER_WIDTH_IE : scrollWidth;
+            if (Browser.isEdge) {
+                scrollWidth += BUFFER_WIDTH_EDGE;
+            } else if (Browser.isInternetExplorer) {
+                scrollWidth += BUFFER_WIDTH_IE;
+            }
             this.setState({
                 inputHeight: scrollHeight,
                 inputWidth: Math.max(scrollWidth, minWidth),

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -14,6 +14,7 @@ import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IIntentProps, IProps } from "../../common/props";
 import { clamp, safeInvoke } from "../../common/utils";
+import { Browser } from "../../compatibility";
 
 export interface IEditableTextProps extends IIntentProps, IProps {
     /**
@@ -99,7 +100,8 @@ export interface IEditableTextState {
     value?: string;
 }
 
-const BUFFER_WIDTH = 30;
+const BUFFER_WIDTH_EDGE = 5;
+const BUFFER_WIDTH_IE = 30;
 
 @PureRender
 export class EditableText extends AbstractComponent<IEditableTextProps, IEditableTextState> {
@@ -312,10 +314,12 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
             // Chrome's input caret height misaligns text so the line-height must be larger than font-size.
             // The computed scrollHeight must also account for a larger inherited line-height from the parent.
             scrollHeight = Math.max(scrollHeight, getFontSize(this.valueElement) + 1, getLineHeight(parentElement));
-            // IE11 needs a small buffer so text does not shift prior to resizing
+            // IE11 & Edge needs a small buffer so text does not shift prior to resizing
+            scrollWidth = Browser.isEdge() ? scrollWidth + BUFFER_WIDTH_EDGE : scrollWidth;
+            scrollWidth = Browser.isInternetExplorer() ? scrollWidth + BUFFER_WIDTH_IE : scrollWidth;
             this.setState({
                 inputHeight: scrollHeight,
-                inputWidth: Math.max(scrollWidth + BUFFER_WIDTH, minWidth),
+                inputWidth: Math.max(scrollWidth, minWidth),
             });
             // synchronizes the ::before pseudo-element's height while editing for Chrome 53
             if (multiline && this.state.isEditing) {

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -315,9 +315,9 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
             // The computed scrollHeight must also account for a larger inherited line-height from the parent.
             scrollHeight = Math.max(scrollHeight, getFontSize(this.valueElement) + 1, getLineHeight(parentElement));
             // IE11 & Edge needs a small buffer so text does not shift prior to resizing
-            if (Browser.isEdge) {
+            if (Browser.isEdge()) {
                 scrollWidth += BUFFER_WIDTH_EDGE;
-            } else if (Browser.isInternetExplorer) {
+            } else if (Browser.isInternetExplorer()) {
                 scrollWidth += BUFFER_WIDTH_IE;
             }
             this.setState({


### PR DESCRIPTION
#### Fixes #482 

#### Checklist

- [x] Chrome v55.0 (no shift)
- [x] Firefox v51.0 (no shift)
- [x] IE 11.0 (shift 30px)
- [x] Edge 13.0 (shift 5px)
