### PR TITLE
Fix z-index stack for .pt-button-group and .pt-control-group elements

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -126,18 +126,8 @@ Styleguide components.button-group.css
 //
 //   (highest z-index)
 
-$-button-group-z-index-stack:
-  "button-disabled",
-  "button-default",
-  "button-focus",
-  "button-hover",
-  "button-active",
-
-  "intent-button-disabled",
-  "intent-button-default",
-  "intent-button-focus",
-  "intent-button-hover",
-  "intent-button-active";
+// boost all states of intent buttons above all states of default buttons
+$button-group-intent-boost: length($button-state-stack);
 
 .pt-button-group {
   display: inline-flex;
@@ -146,7 +136,7 @@ $-button-group-z-index-stack:
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: index($button-group-z-index-stack, "button-default");
+    z-index: index($button-state-stack, "default");
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -154,42 +144,42 @@ $-button-group-z-index-stack:
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: index($button-group-z-index-stack, "button-focus");
+      z-index: index($button-state-stack, "focus");
     }
 
     &:hover {
-      z-index: index($button-group-z-index-stack, "button-hover");
+      z-index: index($button-state-stack, "hover");
     }
 
     &:active,
     &.pt-active {
-      z-index: index($button-group-z-index-stack, "button-active");
+      z-index: index($button-state-stack, "active");
     }
 
     &:disabled,
     &.pt-disabled {
-      z-index: index($button-group-z-index-stack, "button-disabled");
+      z-index: index($button-state-stack, "disabled");
     }
 
     &[class*="pt-intent-"] {
-      z-index: index($button-group-z-index-stack, "intent-button-default");
+      z-index: index($button-state-stack, "default") + $button-group-intent-boost;
 
       &:focus {
-        z-index: index($button-group-z-index-stack, "intent-button-focus");
+        z-index: index($button-state-stack, "focus") + $button-group-intent-boost;
       }
 
       &:hover {
-        z-index: index($button-group-z-index-stack, "intent-button-hover");
+        z-index: index($button-state-stack, "hover") + $button-group-intent-boost;
       }
 
       &:active,
       &.pt-active {
-        z-index: index($button-group-z-index-stack, "intent-button-active");
+        z-index: index($button-state-stack, "active") + $button-group-intent-boost;
       }
 
       &:disabled,
       &.pt-disabled {
-        z-index: index($button-group-z-index-stack, "intent-button-disabled");
+        z-index: index($button-state-stack, "disabled") + $button-group-intent-boost;
       }
     }
   }

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -126,17 +126,18 @@ Styleguide components.button-group.css
 //
 //   (highest z-index)
 
-$button-group-z-index-button-disabled: 1;
-$button-group-z-index-button-default: 2;
-$button-group-z-index-button-focus: 3;
-$button-group-z-index-button-hover: 4;
-$button-group-z-index-button-active: 5;
+$-button-group-z-index-stack:
+  "button-disabled",
+  "button-default",
+  "button-focus",
+  "button-hover",
+  "button-active",
 
-$button-group-z-index-intent-button-disabled: 6;
-$button-group-z-index-intent-button-default: 7;
-$button-group-z-index-intent-button-focus: 8;
-$button-group-z-index-intent-button-hover: 9;
-$button-group-z-index-intent-button-active: 10;
+  "intent-button-disabled",
+  "intent-button-default",
+  "intent-button-focus",
+  "intent-button-hover",
+  "intent-button-active";
 
 .pt-button-group {
   display: inline-flex;
@@ -145,7 +146,7 @@ $button-group-z-index-intent-button-active: 10;
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: $button-group-z-index-button-default;
+    z-index: index($button-group-z-index-stack, "button-default");
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -153,42 +154,42 @@ $button-group-z-index-intent-button-active: 10;
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: $button-group-z-index-button-focus;
+      z-index: index($button-group-z-index-stack, "button-focus");
     }
 
     &:hover {
-      z-index: $button-group-z-index-button-hover;
+      z-index: index($button-group-z-index-stack, "button-hover");
     }
 
     &:active,
     &.pt-active {
-      z-index: $button-group-z-index-button-active;
+      z-index: index($button-group-z-index-stack, "button-active");
     }
 
     &:disabled,
     &.pt-disabled {
-      z-index: $button-group-z-index-button-disabled;
+      z-index: index($button-group-z-index-stack, "button-disabled");
     }
 
     &[class*="pt-intent-"] {
-      z-index: $button-group-z-index-intent-button-default;
+      z-index: index($button-group-z-index-stack, "intent-button-default");
 
       &:focus {
-        z-index: $button-group-z-index-intent-button-focus;
+        z-index: index($button-group-z-index-stack, "intent-button-focus");
       }
 
       &:hover {
-        z-index: $button-group-z-index-intent-button-hover;
+        z-index: index($button-group-z-index-stack, "intent-button-hover");
       }
 
       &:active,
       &.pt-active {
-        z-index: $button-group-z-index-intent-button-active;
+        z-index: index($button-group-z-index-stack, "intent-button-active");
       }
 
       &:disabled,
       &.pt-disabled {
-        z-index: $button-group-z-index-intent-button-disabled;
+        z-index: index($button-group-z-index-stack, "intent-button-disabled");
       }
     }
   }

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -56,6 +56,40 @@ Markup:
 Styleguide components.button-group.css
 */
 
+//
+// for best visual results, button group elements should be stacked in the
+// following order to ensure sharp edges in all cases and states:
+//
+//   (lowest z-index)
+//
+//   default buttons
+//     :disabled, .pt-disabled
+//     normal
+//     :focus
+//     :hover
+//     :active, .pt-active
+//
+//   intent buttons
+//     :disabled, .pt-disabled
+//     normal
+//     :focus
+//     :hover
+//     :active, .pt-active
+//
+//   (highest z-index)
+
+$button-group-z-index-button-disabled: 1;
+$button-group-z-index-button-default: 2;
+$button-group-z-index-button-focus: 3;
+$button-group-z-index-button-hover: 4;
+$button-group-z-index-button-active: 5;
+
+$button-group-z-index-intent-button-disabled: 6;
+$button-group-z-index-intent-button-default: 7;
+$button-group-z-index-intent-button-focus: 8;
+$button-group-z-index-intent-button-hover: 9;
+$button-group-z-index-intent-button-active: 10;
+
 .pt-button-group {
   display: inline-flex;
 
@@ -63,45 +97,51 @@ Styleguide components.button-group.css
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: 0;
+    z-index: $button-group-z-index-button-default;
 
-    // the ordering of these z-index CSS rules is particular
-    // because of CSS selector specificity
+    // the ordering of these z-index CSS rules is particular because of CSS
+    // selector specificity. specifically, disabled styles should have
+    // precedence over hover and active styles to prevent mouse interactions on
+    // disabled buttons from reordering elements in the stack.
+
     &:focus {
-      z-index: 1;
+      z-index: $button-group-z-index-button-focus;
     }
 
     &:hover {
-      z-index: 2;
-    }
-
-    // intent buttons are always above any other button state
-    &[class*="pt-intent-"] {
-      z-index: 4;
-
-      &:hover {
-        z-index: 5;
-      }
-
-      &:active,
-      &.pt-active {
-        z-index: 6;
-      }
-
-      &:disabled,
-      &.pt-disabled {
-        z-index: 3;
-      }
+      z-index: $button-group-z-index-button-hover;
     }
 
     &:active,
     &.pt-active {
-      z-index: 3;
+      z-index: $button-group-z-index-button-active;
     }
 
     &:disabled,
     &.pt-disabled {
-      z-index: 0;
+      z-index: $button-group-z-index-button-disabled;
+    }
+
+    &[class*="pt-intent-"] {
+      z-index: $button-group-z-index-intent-button-default;
+
+      &:focus {
+        z-index: $button-group-z-index-intent-button-focus;
+      }
+
+      &:hover {
+        z-index: $button-group-z-index-intent-button-hover;
+      }
+
+      &:active,
+      &.pt-active {
+        z-index: $button-group-z-index-intent-button-active;
+      }
+
+      &:disabled,
+      &.pt-disabled {
+        z-index: $button-group-z-index-intent-button-disabled;
+      }
     }
   }
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -54,54 +54,6 @@ Markup:
 .pt-minimal - Use minimal buttons. Note that these minimal buttons will not automatically
               truncate text in an ellipsis because of the divider line added in CSS.
 
-<div class="docs-button-group-example-set">
-  <h4>Regular</h4>
-  <div class="pt-button-group">
-    <button tabindex="0" class="pt-button" disabled>:disabled</button>
-    <a tabindex="0" class="pt-button" role="button">Normal</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button pt-disabled" role="button">.pt-disabled</a>
-    <a tabindex="0" class="pt-button" role="button">Normal</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button" role="button">Normal</a>
-    <a tabindex="0" class="pt-button" role="button">Normal</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button" role="button">Normal</a>
-    <a tabindex="0" class="pt-button pt-active" role="button">.pt-active</a>
-  </div>
-</div>
-
-<div class="docs-button-group-example-set">
-  <h4>Intent</h4>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button" role="button">Normal</a>
-    <a tabindex="0" class="pt-button pt-intent-success" role="button">Intent Normal</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button pt-active" role="button">.pt-active</a>
-    <button tabindex="0" class="pt-button pt-intent-success" disabled>Intent Disabled</button>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button pt-active" role="button">.pt-active</a>
-    <a tabindex="0" class="pt-button pt-intent-success pt-disabled" role="button">Intent .pt-disabled</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button pt-intent-warning pt-disabled" role="button">Intent .pt-disabled</a>
-    <a tabindex="0" class="pt-button pt-intent-danger" role="button">Intent Normal</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button pt-intent-warning" role="button">Intent Normal</a>
-    <a tabindex="0" class="pt-button pt-intent-danger" role="button">Intent Normal</a>
-  </div>
-  <div class="pt-button-group">
-    <a tabindex="0" class="pt-button pt-intent-warning" role="button">Intent Normal</a>
-    <a tabindex="0" class="pt-button pt-intent-danger pt-active" role="button">Intent .pt-active</a>
-  </div>
-</div>
-
 Styleguide components.button-group.css
 */
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -53,6 +53,54 @@ Markup:
 .pt-minimal - Use minimal buttons. Note that these minimal buttons will not automatically
               truncate text in an ellipsis because of the divider line added in CSS.
 
+<div class="docs-button-group-example-set">
+  <h4>Regular</h4>
+  <div class="pt-button-group">
+    <button tabindex="0" class="pt-button" disabled>:disabled</button>
+    <a tabindex="0" class="pt-button" role="button">Normal</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button pt-disabled" role="button">.pt-disabled</a>
+    <a tabindex="0" class="pt-button" role="button">Normal</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button" role="button">Normal</a>
+    <a tabindex="0" class="pt-button" role="button">Normal</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button" role="button">Normal</a>
+    <a tabindex="0" class="pt-button pt-active" role="button">.pt-active</a>
+  </div>
+</div>
+
+<div class="docs-button-group-example-set">
+  <h4>Intent</h4>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button" role="button">Normal</a>
+    <a tabindex="0" class="pt-button pt-intent-success" role="button">Intent Normal</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button pt-active" role="button">.pt-active</a>
+    <button tabindex="0" class="pt-button pt-intent-success" disabled>Intent Disabled</button>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button pt-active" role="button">.pt-active</a>
+    <a tabindex="0" class="pt-button pt-intent-success pt-disabled" role="button">Intent .pt-disabled</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button pt-intent-warning pt-disabled" role="button">Intent .pt-disabled</a>
+    <a tabindex="0" class="pt-button pt-intent-danger" role="button">Intent Normal</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button pt-intent-warning" role="button">Intent Normal</a>
+    <a tabindex="0" class="pt-button pt-intent-danger" role="button">Intent Normal</a>
+  </div>
+  <div class="pt-button-group">
+    <a tabindex="0" class="pt-button pt-intent-warning" role="button">Intent Normal</a>
+    <a tabindex="0" class="pt-button pt-intent-danger pt-active" role="button">Intent .pt-active</a>
+  </div>
+</div>
+
 Styleguide components.button-group.css
 */
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -5,6 +5,7 @@
 
 @import "~bourbon/app/assets/stylesheets/bourbon";
 @import "../../common/variables";
+@import "../forms/common";
 @import "./common";
 
 /*
@@ -104,31 +105,6 @@ Markup:
 Styleguide components.button-group.css
 */
 
-//
-// for best visual results, button group elements should be stacked in the
-// following order to ensure sharp edges in all cases and states:
-//
-//   (lowest z-index)
-//
-//   default buttons
-//     :disabled, .pt-disabled
-//     normal
-//     :focus
-//     :hover
-//     :active, .pt-active
-//
-//   intent buttons
-//     :disabled, .pt-disabled
-//     normal
-//     :focus
-//     :hover
-//     :active, .pt-active
-//
-//   (highest z-index)
-
-// boost all states of intent buttons above all states of default buttons
-$button-group-intent-boost: length($button-state-stack);
-
 .pt-button-group {
   display: inline-flex;
 
@@ -136,7 +112,7 @@ $button-group-intent-boost: length($button-state-stack);
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: index($button-state-stack, "default");
+    z-index: index($control-group-stack, "button-default");
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -144,42 +120,42 @@ $button-group-intent-boost: length($button-state-stack);
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: index($button-state-stack, "focus");
+      z-index: index($control-group-stack, "button-focus");
     }
 
     &:hover {
-      z-index: index($button-state-stack, "hover");
+      z-index: index($control-group-stack, "button-hover");
     }
 
     &:active,
     &.pt-active {
-      z-index: index($button-state-stack, "active");
+      z-index: index($control-group-stack, "button-active");
     }
 
     &:disabled,
     &.pt-disabled {
-      z-index: index($button-state-stack, "disabled");
+      z-index: index($control-group-stack, "button-disabled");
     }
 
     &[class*="pt-intent-"] {
-      z-index: index($button-state-stack, "default") + $button-group-intent-boost;
+      z-index: index($control-group-stack, "intent-button-default");
 
       &:focus {
-        z-index: index($button-state-stack, "focus") + $button-group-intent-boost;
+        z-index: index($control-group-stack, "intent-button-focus");
       }
 
       &:hover {
-        z-index: index($button-state-stack, "hover") + $button-group-intent-boost;
+        z-index: index($control-group-stack, "intent-button-hover");
       }
 
       &:active,
       &.pt-active {
-        z-index: index($button-state-stack, "active") + $button-group-intent-boost;
+        z-index: index($control-group-stack, "intent-button-active");
       }
 
       &:disabled,
       &.pt-disabled {
-        z-index: index($button-state-stack, "disabled") + $button-group-intent-boost;
+        z-index: index($control-group-stack, "intent-button-disabled");
       }
     }
   }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -93,6 +93,9 @@ $button-intents: (
   "danger": ($pt-intent-danger, $red2, $red1)
 ) !default;
 
+// z-index ordering of button states
+$button-state-stack: "disabled", "default", "focus", "hover", "active";
+
 @mixin pt-button-base() {
   display: inline-block;
   border: none;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -93,9 +93,6 @@ $button-intents: (
   "danger": ($pt-intent-danger, $red2, $red1)
 ) !default;
 
-// z-index ordering of button states
-$button-state-stack: "disabled", "default", "focus", "hover", "active";
-
 @mixin pt-button-base() {
   display: inline-block;
   border: none;

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -49,7 +49,8 @@ $control-group-stack: (
   "intent-input-default",
   "input-focus",
   "intent-input-focus",
-  "input-group-children"
+  "input-group-children",
+  "select-caret"
 );
 
 // animating shadows requires the same number of shadows in different states

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -26,6 +26,33 @@ $dark-input-shadow-color-focus: $pt-intent-primary !default;
 // second box-shadow of $pt-input-box-shadow
 $input-box-shadow-focus: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
 
+// for best visual results, button group and control group elements should be
+// stacked in the following order to ensure sharp edges in all cases and states:
+
+$control-group-stack:
+  // lowest z-index
+  "input-disabled",
+  "input-default",
+
+  "button-disabled",
+  "button-default",
+  "button-focus",
+  "button-hover",
+  "button-active",
+
+  "intent-button-disabled",
+  "intent-button-default",
+  "intent-button-focus",
+  "intent-button-hover",
+  "intent-button-active",
+
+  "intent-input-default",
+  "input-focus",
+  "intent-input-focus",
+  "input-group-children",
+
+  "select-caret";
+
 // animating shadows requires the same number of shadows in different states
 @function input-transition-shadow($color: $input-shadow-color-focus, $focus: false) {
   @if $focus {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -29,7 +29,7 @@ $input-box-shadow-focus: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !
 // for best visual results, button group and control group elements should be
 // stacked in the following order to ensure sharp edges in all cases and states:
 
-$control-group-stack:
+$control-group-stack: (
   // lowest z-index
   "input-disabled",
   "input-default",
@@ -49,7 +49,8 @@ $control-group-stack:
   "intent-input-default",
   "input-focus",
   "intent-input-focus",
-  "input-group-children";
+  "input-group-children"
+);
 
 // animating shadows requires the same number of shadows in different states
 @function input-transition-shadow($color: $input-shadow-color-focus, $focus: false) {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -49,9 +49,7 @@ $control-group-stack:
   "intent-input-default",
   "input-focus",
   "intent-input-focus",
-  "input-group-children",
-
-  "select-caret";
+  "input-group-children";
 
 // animating shadows requires the same number of shadows in different states
 @function input-transition-shadow($color: $input-shadow-color-focus, $focus: false) {

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -5,6 +5,7 @@
 
 @import "../../common/variables";
 @import "../button/common";
+@import "./common";
 
 /*
 Control groups
@@ -102,66 +103,6 @@ Weight: 4
 Styleguide components.forms.control-group
 */
 
-// for best visual results, button group elements should be stacked in the
-// following order to ensure sharp edges in all cases and states:
-//
-//   (lowest z-index)
-//
-//   input fields
-//      :disabled
-//      default
-//
-//   regular buttons / pt-select > select
-//     :disabled, .pt-disabled
-//     default
-//     :focus
-//     :hover
-//     :active, .pt-active
-//
-//   pt-input intent
-//
-//   intent buttons (selects can't be intented yet, but if they could be, they'd be here too)
-//     :disabled, .pt-disabled
-//     default
-//     :focus
-//     :hover
-//     :active, .pt-active
-//
-//   input fields (NOT readonly, disabled, pt-disabled)
-//      :focus
-//
-//   intent input fields (NOT readonly, disabled, pt-disabled)
-//      :focus
-//
-//   input-group children
-//
-//   .pt-select::after (the caret)
-//
-//   (highest z-index)
-
-$control-group-z-index-stack:
-  "input-disabled",
-  "input-default",
-
-  "button-disabled",
-  "button-default",
-  "button-focus",
-  "button-hover",
-  "button-active",
-
-  "intent-button-disabled",
-  "intent-button-default",
-  "intent-button-focus",
-  "intent-button-hover",
-  "intent-button-active",
-
-  "intent-input-default",
-  "input-focus",
-  "intent-input-focus",
-  "input-group-children",
-
-  "select-caret";
-
 .pt-control-group {
   display: flex;
   align-items: flex-start;
@@ -186,76 +127,76 @@ $control-group-z-index-stack:
   }
 
   .pt-input {
-    z-index: index($control-group-z-index-stack, "input-default");
+    z-index: index($control-group-stack, "input-default");
     // inherit radius since it's most likely to be zero
     border-radius: inherit;
 
     &:focus {
-      z-index: index($control-group-z-index-stack, "input-focus");
+      z-index: index($control-group-stack, "input-focus");
       border-radius: $pt-border-radius;
     }
 
     [readonly],
     :disabled,
     .pt-disabled {
-      z-index: index($control-group-z-index-stack, "input-disabled");
+      z-index: index($control-group-stack, "input-disabled");
       border-radius: 0;
     }
 
     &[class*="pt-intent"] {
-      z-index: index($control-group-z-index-stack, "intent-input-default");
+      z-index: index($control-group-stack, "intent-input-default");
 
       &:focus {
-        z-index: index($control-group-z-index-stack, "intent-input-focus");
+        z-index: index($control-group-stack, "intent-input-focus");
       }
     }
   }
 
   .pt-button,
   .pt-select select {
-    z-index: index($control-group-z-index-stack, "button-default");
+    z-index: index($control-group-stack, "button-default");
     // inherit radius since it's most likely to be zero
     border-radius: inherit;
 
     &:focus {
       // establish new stacking context so focus state covers neighbors
       position: relative;
-      z-index: index($control-group-z-index-stack, "button-focus");
+      z-index: index($control-group-stack, "button-focus");
     }
 
     &:hover {
-      z-index: index($control-group-z-index-stack, "button-hover");
+      z-index: index($control-group-stack, "button-hover");
     }
 
     &:active {
-      z-index: index($control-group-z-index-stack, "button-active");
+      z-index: index($control-group-stack, "button-active");
     }
 
     &[readonly],
     &:disabled,
     &.pt-disabled {
-      z-index: index($control-group-z-index-stack, "button-disabled");
+      z-index: index($control-group-stack, "button-disabled");
     }
 
     &[class*="pt-intent"] {
-      z-index: index($control-group-z-index-stack, "intent-button-default");
+      z-index: index($control-group-stack, "intent-button-default");
 
       &:focus {
-        z-index: index($control-group-z-index-stack, "intent-button-focus");
+        z-index: index($control-group-stack, "intent-button-focus");
       }
 
       &:hover {
-        z-index: index($control-group-z-index-stack, "intent-button-hover");
+        z-index: index($control-group-stack, "intent-button-hover");
       }
 
       &:active {
-        z-index: index($control-group-z-index-stack, "intent-button-active");
+        z-index: index($control-group-stack, "intent-button-active");
       }
 
       &[readonly],
       &:disabled,
       &.pt-disabled {
-        z-index: index($control-group-z-index-stack, "intent-button-disabled");
+        z-index: index($control-group-stack, "intent-button-disabled");
       }
     }
   }
@@ -264,12 +205,12 @@ $control-group-z-index-stack:
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
   .pt-input-group > .pt-input-action {
-    z-index: index($control-group-z-index-stack, "input-group-children");
+    z-index: index($control-group-stack, "input-group-children");
   }
 
   // keep the select-menu carets on top of everything always
   .pt-select::after {
-    z-index: index($control-group-z-index-stack, "select-caret");
+    z-index: index($control-group-stack, "select-caret");
   }
 
   // have consecutive elements share a border

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -149,18 +149,17 @@ $control-group-z-index-stack:
   "button-hover",
   "button-active",
 
-  "intent-input-default",
   "intent-button-disabled",
   "intent-button-default",
   "intent-button-focus",
   "intent-button-hover",
   "intent-button-active",
 
+  "intent-input-default",
   "input-focus",
-  "dark-theme-intent-input-default",
   "intent-input-focus",
-
   "input-group-children",
+
   "select-caret";
 
 .pt-control-group {
@@ -205,10 +204,6 @@ $control-group-z-index-stack:
 
     &[class*="pt-intent"] {
       z-index: index($control-group-z-index-stack, "intent-input-default");
-
-      .pt-dark & {
-        z-index: index($control-group-z-index-stack, "dark-theme-intent-input-default");
-      }
 
       &:focus {
         z-index: index($control-group-z-index-stack, "intent-input-focus");

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -172,6 +172,12 @@ Styleguide components.forms.control-group
     z-index: index($control-group-stack, "input-group-children");
   }
 
+  // keep the select-menu carets on top of everything always (particularly when
+  // .pt-selects are focused).
+  .pt-select::after {
+    z-index: index($control-group-stack, "select-caret");
+  }
+
   // have consecutive elements share a border
   &:not(.pt-vertical) {
     > * {

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -208,11 +208,6 @@ Styleguide components.forms.control-group
     z-index: index($control-group-stack, "input-group-children");
   }
 
-  // keep the select-menu carets on top of everything always
-  .pt-select::after {
-    z-index: index($control-group-stack, "select-caret");
-  }
-
   // have consecutive elements share a border
   &:not(.pt-vertical) {
     > * {
@@ -224,9 +219,9 @@ Styleguide components.forms.control-group
         margin-right: 0;
       }
 
-      // conseuctive buttons within a button group look okay out of the box, but
+      // consecutive buttons within a button group look okay out of the box, but
       // we need need to make a small correction for non-grouped buttons. this
-      // replicates what's already done in dark-theme button groups.
+      // replicates what's already done in dark theme button groups.
       > .pt-button + .pt-button {
         margin-left: $button-border-width;
       }

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -176,13 +176,22 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
     flex: 0 0 auto;
   }
 
-  // define the z-index stack separately
+  // similarly to button groups, elements in control groups are stacked
+  // in a very particular order for best visual results
+  .pt-button,
+  .pt-input,
+  .pt-select {
+    position: relative;
+  }
 
   .pt-input {
     z-index: $control-group-z-index-input-default;
+    // inherit radius since it's most likely to be zero
+    border-radius: inherit;
 
     &:focus {
       z-index: $control-group-z-index-input-focus;
+      border-radius: $pt-border-radius;
     }
 
     // define disabled styles last so that they override all others.
@@ -190,6 +199,7 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
     :disabled,
     .pt-disabled {
       z-index: $control-group-z-index-input-disabled;
+      border-radius: 0;
     }
 
     &[class*="pt-intent"] {
@@ -208,8 +218,12 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
   .pt-button,
   .pt-select select {
     z-index: $control-group-z-index-button-default;
+    // inherit radius since it's most likely to be zero
+    border-radius: inherit;
 
     &:focus {
+      // establish new stacking context so focus state covers neighbors
+      position: relative;
       z-index: $control-group-z-index-button-focus;
     }
 
@@ -252,6 +266,7 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
     }
   }
 
+  // input group contents appear above input always
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
   .pt-input-group > .pt-input-action {
@@ -260,19 +275,6 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
 
   .pt-select::after {
     z-index: $control-group-z-index-select-caret;
-  }
-
-  // now define other styles
-
-  .pt-button,
-  .pt-input,
-  .pt-select select {
-    // inherit radius since it's most likely to be zero
-    border-radius: inherit;
-
-    // &:focus {
-    //   z-index: 1;
-    // }
   }
 
   &:not(.pt-vertical) > * {
@@ -286,54 +288,6 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
   > :last-child {
     margin-right: 0;
     border-radius: 0 $pt-border-radius $pt-border-radius 0;
-  }
-
-  // similarly to button groups, elements in control groups are stacked
-  // in a very particular order for best visual results
-  .pt-button,
-  .pt-select {
-    position: relative;
-    // z-index: 1;
-
-    &[class*="pt-intent-"] {
-      // z-index: 3;
-    }
-  }
-
-  .pt-input {
-    position: relative;
-    // z-index: $control-group-z-index-input-default;
-
-    // &[class*="pt-intent-"] {
-    //   z-index: 3;
-    // }
-
-    &:focus {
-      // z-index: 6;
-      border-radius: $pt-border-radius;
-    }
-
-    [readonly],
-    :disabled,
-    .pt-disabled {
-      // z-index: $control-group-z-index-input-disabled;
-      border-radius: 0;
-    }
-  }
-
-  // establish new stacking context so focus state covers neighbors
-  .pt-button:focus,
-  select:focus {
-    position: relative;
-    // z-index: 2;
-  }
-
-  // input group contents appear above input always
-  .pt-input-group > .pt-icon,
-  .pt-input-group > .pt-button,
-  .pt-input-group > .pt-input-action,
-  .pt-select::after {
-    // z-index: 7;
   }
 
   // bring back border radius on these buttons
@@ -380,11 +334,4 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
       border-radius: 0 0 $pt-border-radius $pt-border-radius;
     }
   }
-
-  // .pt-dark & {
-  //   // to avoid edge blurriness in dark theme, inputs go above buttons
-  //   .pt-input[class*="pt-intent-"] {
-  //     z-index: 5;
-  //   }
-  // }
 }

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -31,70 +31,34 @@ child must be marked individually as `.pt-large` for uniform large appearance.
 Markup:
 <div class="pt-control-group-example">
   <div class="pt-control-group">
-    <input type="text" class="pt-input" placeholder="I am a text input..." disabled />
-    <input type="text" class="pt-input" placeholder="I am a text input..." />
+    <button class="pt-button pt-icon-filter">Filter</button>
+    <input type="text" class="pt-input" placeholder="Find filters..." />
   </div>
   <div class="pt-control-group">
-    <input type="text" class="pt-input" placeholder="I am a text input..." />
-    <button class="pt-button" disabled>Button</button>
-  </div>
-  <div class="pt-control-group">
-    <button class="pt-button" disabled>Button</button>
-    <button class="pt-button">Button</button>
-  </div>
-  <div class="pt-control-group">
-    <button class="pt-button">Button</button>
-    <button class="pt-button">Button</button>
-  </div>
-  <div class="pt-control-group">
-    <button class="pt-button">Button</button>
-    <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." />
-  </div>
-  <div class="pt-control-group">
-    <input type="text" class="pt-input pt-intent-warning" placeholder="I am a text input..." />
-    <button class="pt-button pt-intent-success" disabled>Button</button>
-  </div>
-  <div class="pt-control-group">
-    <button class="pt-button pt-intent-warning" disabled>Button</button>
-    <button class="pt-button pt-intent-success">Button</button>
-  </div>
-  <div class="pt-control-group">
-    <button class="pt-button pt-intent-warning">Button</button>
-    <button class="pt-button pt-intent-success">Button</button>
-  </div>
-  <div class="pt-control-group">
-    <button class="pt-button pt-intent-warning">Button</button>
-    <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." />
+    <div class="pt-select">
+      <select>
+        <option selected>Filter...</option>
+        <option value="1">Issues</option>
+        <option value="2">Requests</option>
+        <option value="3">Projects</option>
+      </select>
+    </div>
+    <div class="pt-input-group">
+      <span class="pt-icon pt-icon-search"></span>
+      <input type="text" class="pt-input" value="from:ggray to:allorca" />
+    </div>
   </div>
   <div class="pt-control-group">
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." style="padding-right:94px" />
+      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
       <div class="pt-input-action">
         <button class="pt-button pt-minimal pt-intent-primary">
           can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
         </button>
       </div>
     </div>
-    <button class="pt-button pt-intent-warning">Button</button>
-    <button class="pt-button pt-intent-success">Button</button>
-    <button class="pt-button">Button</button>
-  </div>
-  <div class="pt-control-group">
-    <div class="pt-input-group">
-      <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." style="padding-right:94px" />
-      <div class="pt-input-action">
-        <button class="pt-button pt-minimal pt-intent-primary">
-          can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
-        </button>
-      </div>
-    </div>
-    <div class="pt-button-group">
-      <button class="pt-button pt-intent-warning">Button</button>
-      <button class="pt-button pt-intent-success">Button</button>
-      <button class="pt-button">Button</button>
-    </div>
+    <button class="pt-button pt-intent-primary">Add</button>
   </div>
 </div>
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -30,34 +30,70 @@ child must be marked individually as `.pt-large` for uniform large appearance.
 Markup:
 <div class="pt-control-group-example">
   <div class="pt-control-group">
-    <button class="pt-button pt-icon-filter">Filter</button>
-    <input type="text" class="pt-input" placeholder="Find filters..." />
+    <input type="text" class="pt-input" placeholder="I am a text input..." disabled />
+    <input type="text" class="pt-input" placeholder="I am a text input..." />
   </div>
   <div class="pt-control-group">
-    <div class="pt-select">
-      <select>
-        <option selected>Filter...</option>
-        <option value="1">Issues</option>
-        <option value="2">Requests</option>
-        <option value="3">Projects</option>
-      </select>
-    </div>
-    <div class="pt-input-group">
-      <span class="pt-icon pt-icon-search"></span>
-      <input type="text" class="pt-input" value="from:ggray to:allorca" />
-    </div>
+    <input type="text" class="pt-input" placeholder="I am a text input..." />
+    <button class="pt-button" disabled>Button</button>
+  </div>
+  <div class="pt-control-group">
+    <button class="pt-button" disabled>Button</button>
+    <button class="pt-button">Button</button>
+  </div>
+  <div class="pt-control-group">
+    <button class="pt-button">Button</button>
+    <button class="pt-button">Button</button>
+  </div>
+  <div class="pt-control-group">
+    <button class="pt-button">Button</button>
+    <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." />
+  </div>
+  <div class="pt-control-group">
+    <input type="text" class="pt-input pt-intent-warning" placeholder="I am a text input..." />
+    <button class="pt-button pt-intent-success" disabled>Button</button>
+  </div>
+  <div class="pt-control-group">
+    <button class="pt-button pt-intent-warning" disabled>Button</button>
+    <button class="pt-button pt-intent-success">Button</button>
+  </div>
+  <div class="pt-control-group">
+    <button class="pt-button pt-intent-warning">Button</button>
+    <button class="pt-button pt-intent-success">Button</button>
+  </div>
+  <div class="pt-control-group">
+    <button class="pt-button pt-intent-warning">Button</button>
+    <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." />
   </div>
   <div class="pt-control-group">
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
+      <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." style="padding-right:94px" />
       <div class="pt-input-action">
         <button class="pt-button pt-minimal pt-intent-primary">
           can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
         </button>
       </div>
     </div>
-    <button class="pt-button pt-intent-primary">Add</button>
+    <button class="pt-button pt-intent-warning">Button</button>
+    <button class="pt-button pt-intent-success">Button</button>
+    <button class="pt-button">Button</button>
+  </div>
+  <div class="pt-control-group">
+    <div class="pt-input-group">
+      <span class="pt-icon pt-icon-people"></span>
+      <input type="text" class="pt-input pt-intent-success" placeholder="I am a text input..." style="padding-right:94px" />
+      <div class="pt-input-action">
+        <button class="pt-button pt-minimal pt-intent-primary">
+          can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
+        </button>
+      </div>
+    </div>
+    <div class="pt-button-group">
+      <button class="pt-button pt-intent-warning">Button</button>
+      <button class="pt-button pt-intent-success">Button</button>
+      <button class="pt-button">Button</button>
+    </div>
   </div>
 </div>
 
@@ -66,6 +102,70 @@ Weight: 4
 Styleguide components.forms.control-group
 */
 
+//
+// for best visual results, button group elements should be stacked in the
+// following order to ensure sharp edges in all cases and states:
+//
+//   (lowest z-index)
+//
+//   input fields
+//      :disabled
+//      normal
+//
+//   regular buttons / pt-select > select
+//     :disabled, .pt-disabled
+//     normal
+//     :focus
+//     :hover
+//     :active, .pt-active
+//
+//   pt-input intent
+//
+//   intent buttons (selects can't be intented yet, but if they could be, they'd be here too)
+//     :disabled, .pt-disabled
+//     normal
+//     :focus
+//     :hover
+//     :active, .pt-active
+//
+//   input fields (NOT readonly, disabled, pt-disabled)
+//      :focus
+//
+//   intent input fields (NOT readonly, disabled, pt-disabled)
+//      :focus
+//
+//   input-group children
+//
+//   .pt-select::after (the caret)
+//
+//   (highest z-index)
+
+$control-group-z-index-input-disabled: 1;
+$control-group-z-index-input-default: 2;
+
+$control-group-z-index-button-disabled: 3;
+$control-group-z-index-button-default: 4;
+$control-group-z-index-button-focus: 5;
+$control-group-z-index-button-hover: 6;
+$control-group-z-index-button-active: 7;
+
+$control-group-z-index-intent-input-default: 8;
+
+$control-group-z-index-intent-button-disabled: 9;
+$control-group-z-index-intent-button-default: 10;
+$control-group-z-index-intent-button-focus: 11;
+$control-group-z-index-intent-button-hover: 12;
+$control-group-z-index-intent-button-active: 13;
+
+$control-group-z-index-input-focus: 14;
+$control-group-z-index-dark-theme-intent-input-default: 14;
+$control-group-z-index-intent-input-focus: 15;
+
+$control-group-z-index-input-group-children: 16;
+$control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
+
+// it's easier to understand the z-index rules if we define them separately above.
+// stylelint-disable no-duplicate-selectors
 .pt-control-group {
   display: flex;
   align-items: flex-start;
@@ -76,15 +176,103 @@ Styleguide components.forms.control-group
     flex: 0 0 auto;
   }
 
+  // define the z-index stack separately
+
+  .pt-input {
+    z-index: $control-group-z-index-input-default;
+
+    &:focus {
+      z-index: $control-group-z-index-input-focus;
+    }
+
+    // define disabled styles last so that they override all others.
+    [readonly],
+    :disabled,
+    .pt-disabled {
+      z-index: $control-group-z-index-input-disabled;
+    }
+
+    &[class*="pt-intent"] {
+      z-index: $control-group-z-index-intent-input-default;
+
+      .pt-dark & {
+        z-index: $control-group-z-index-dark-theme-intent-input-default;
+      }
+
+      &:focus {
+        z-index: $control-group-z-index-intent-input-focus;
+      }
+    }
+  }
+
+  .pt-button,
+  .pt-select select {
+    z-index: $control-group-z-index-button-default;
+
+    &:focus {
+      z-index: $control-group-z-index-button-focus;
+    }
+
+    &:hover {
+      z-index: $control-group-z-index-button-hover;
+    }
+
+    &:active {
+      z-index: $control-group-z-index-button-active;
+    }
+
+    // define disabled styles last so that they override all others.
+    &[readonly],
+    &:disabled,
+    &.pt-disabled {
+      z-index: $control-group-z-index-button-disabled;
+    }
+
+    &[class*="pt-intent"] {
+      z-index: $control-group-z-index-intent-button-default;
+
+      &:focus {
+        z-index: $control-group-z-index-intent-button-focus;
+      }
+
+      &:hover {
+        z-index: $control-group-z-index-intent-button-hover;
+      }
+
+      &:active {
+        z-index: $control-group-z-index-intent-button-active;
+      }
+
+      // define disabled styles last so that they override all others.
+      &[readonly],
+      &:disabled,
+      &.pt-disabled {
+        z-index: $control-group-z-index-intent-button-disabled;
+      }
+    }
+  }
+
+  .pt-input-group > .pt-icon,
+  .pt-input-group > .pt-button,
+  .pt-input-group > .pt-input-action {
+    z-index: $control-group-z-index-input-group-children;
+  }
+
+  .pt-select::after {
+    z-index: $control-group-z-index-select-caret;
+  }
+
+  // now define other styles
+
   .pt-button,
   .pt-input,
   .pt-select select {
     // inherit radius since it's most likely to be zero
     border-radius: inherit;
 
-    &:focus {
-      z-index: 1;
-    }
+    // &:focus {
+    //   z-index: 1;
+    // }
   }
 
   &:not(.pt-vertical) > * {
@@ -105,24 +293,31 @@ Styleguide components.forms.control-group
   .pt-button,
   .pt-select {
     position: relative;
-    z-index: 1;
+    // z-index: 1;
 
     &[class*="pt-intent-"] {
-      z-index: 3;
+      // z-index: 3;
     }
   }
 
   .pt-input {
     position: relative;
-    z-index: 0;
+    // z-index: $control-group-z-index-input-default;
 
-    &[class*="pt-intent-"] {
-      z-index: 3;
+    // &[class*="pt-intent-"] {
+    //   z-index: 3;
+    // }
+
+    &:focus {
+      // z-index: 6;
+      border-radius: $pt-border-radius;
     }
 
-    &:not([readonly], :disabled, .pt-disabled):focus {
-      z-index: 6;
-      border-radius: $pt-border-radius;
+    [readonly],
+    :disabled,
+    .pt-disabled {
+      // z-index: $control-group-z-index-input-disabled;
+      border-radius: 0;
     }
   }
 
@@ -130,7 +325,7 @@ Styleguide components.forms.control-group
   .pt-button:focus,
   select:focus {
     position: relative;
-    z-index: 2;
+    // z-index: 2;
   }
 
   // input group contents appear above input always
@@ -138,7 +333,7 @@ Styleguide components.forms.control-group
   .pt-input-group > .pt-button,
   .pt-input-group > .pt-input-action,
   .pt-select::after {
-    z-index: 7;
+    // z-index: 7;
   }
 
   // bring back border radius on these buttons
@@ -186,10 +381,10 @@ Styleguide components.forms.control-group
     }
   }
 
-  .pt-dark & {
-    // to avoid edge blurriness in dark theme, inputs go above buttons
-    .pt-input[class*="pt-intent-"] {
-      z-index: 5;
-    }
-  }
+  // .pt-dark & {
+  //   // to avoid edge blurriness in dark theme, inputs go above buttons
+  //   .pt-input[class*="pt-intent-"] {
+  //     z-index: 5;
+  //   }
+  // }
 }

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -110,11 +110,11 @@ Styleguide components.forms.control-group
 //
 //   input fields
 //      :disabled
-//      normal
+//      default
 //
 //   regular buttons / pt-select > select
 //     :disabled, .pt-disabled
-//     normal
+//     default
 //     :focus
 //     :hover
 //     :active, .pt-active
@@ -123,7 +123,7 @@ Styleguide components.forms.control-group
 //
 //   intent buttons (selects can't be intented yet, but if they could be, they'd be here too)
 //     :disabled, .pt-disabled
-//     normal
+//     default
 //     :focus
 //     :hover
 //     :active, .pt-active
@@ -162,10 +162,8 @@ $control-group-z-index-dark-theme-intent-input-default: 14;
 $control-group-z-index-intent-input-focus: 15;
 
 $control-group-z-index-input-group-children: 16;
-$control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
+$control-group-z-index-select-caret: 17;
 
-// it's easier to understand the z-index rules if we define them separately above.
-// stylelint-disable no-duplicate-selectors
 .pt-control-group {
   display: flex;
   align-items: flex-start;
@@ -176,11 +174,16 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
     flex: 0 0 auto;
   }
 
-  // similarly to button groups, elements in control groups are stacked
-  // in a very particular order for best visual results
+  // similarly to button groups, elements in control groups are stacked in a
+  // very particular order for best visual results. in each level of selector
+  // specificity, we define disabled styles last so that they override all other
+  // equally-specific styles (e.g. we don't want mouse interactions or focus
+  // changes to change the z-index of a disabled element).
+
   .pt-button,
   .pt-input,
   .pt-select {
+    // create a new stacking context
     position: relative;
   }
 
@@ -194,7 +197,8 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
       border-radius: $pt-border-radius;
     }
 
-    // define disabled styles last so that they override all others.
+    // define disabled styles last so that they override all other
+    // equally-specific styles.
     [readonly],
     :disabled,
     .pt-disabled {
@@ -235,7 +239,6 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
       z-index: $control-group-z-index-button-active;
     }
 
-    // define disabled styles last so that they override all others.
     &[readonly],
     &:disabled,
     &.pt-disabled {
@@ -257,7 +260,6 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
         z-index: $control-group-z-index-intent-button-active;
       }
 
-      // define disabled styles last so that they override all others.
       &[readonly],
       &:disabled,
       &.pt-disabled {
@@ -273,18 +275,22 @@ $control-group-z-index-select-caret: 17; // TODO: Make this 17 as well?
     z-index: $control-group-z-index-input-group-children;
   }
 
+  // keep the select-menu carets on top of everything always
   .pt-select::after {
     z-index: $control-group-z-index-select-caret;
   }
 
+  // have consecutive elements share a border
   &:not(.pt-vertical) > * {
     margin-right: -$button-border-width;
   }
 
+  // round the left corners of the left-most element
   > :first-child {
     border-radius: $pt-border-radius 0 0 $pt-border-radius;
   }
 
+  // round the right corners of the right-most element
   > :last-child {
     margin-right: 0;
     border-radius: 0 $pt-border-radius $pt-border-radius 0;

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -102,7 +102,6 @@ Weight: 4
 Styleguide components.forms.control-group
 */
 
-//
 // for best visual results, button group elements should be stacked in the
 // following order to ensure sharp edges in all cases and states:
 //
@@ -140,29 +139,29 @@ Styleguide components.forms.control-group
 //
 //   (highest z-index)
 
-$control-group-z-index-input-disabled: 1;
-$control-group-z-index-input-default: 2;
+$control-group-z-index-stack:
+  "input-disabled",
+  "input-default",
 
-$control-group-z-index-button-disabled: 3;
-$control-group-z-index-button-default: 4;
-$control-group-z-index-button-focus: 5;
-$control-group-z-index-button-hover: 6;
-$control-group-z-index-button-active: 7;
+  "button-disabled",
+  "button-default",
+  "button-focus",
+  "button-hover",
+  "button-active",
 
-$control-group-z-index-intent-input-default: 8;
+  "intent-input-default",
+  "intent-button-disabled",
+  "intent-button-default",
+  "intent-button-focus",
+  "intent-button-hover",
+  "intent-button-active",
 
-$control-group-z-index-intent-button-disabled: 9;
-$control-group-z-index-intent-button-default: 10;
-$control-group-z-index-intent-button-focus: 11;
-$control-group-z-index-intent-button-hover: 12;
-$control-group-z-index-intent-button-active: 13;
+  "input-focus",
+  "dark-theme-intent-input-default",
+  "intent-input-focus",
 
-$control-group-z-index-input-focus: 14;
-$control-group-z-index-dark-theme-intent-input-default: 14;
-$control-group-z-index-intent-input-focus: 15;
-
-$control-group-z-index-input-group-children: 16;
-$control-group-z-index-select-caret: 17;
+  "input-group-children",
+  "select-caret";
 
 .pt-control-group {
   display: flex;
@@ -188,82 +187,80 @@ $control-group-z-index-select-caret: 17;
   }
 
   .pt-input {
-    z-index: $control-group-z-index-input-default;
+    z-index: index($control-group-z-index-stack, "input-default");
     // inherit radius since it's most likely to be zero
     border-radius: inherit;
 
     &:focus {
-      z-index: $control-group-z-index-input-focus;
+      z-index: index($control-group-z-index-stack, "input-focus");
       border-radius: $pt-border-radius;
     }
 
-    // define disabled styles last so that they override all other
-    // equally-specific styles.
     [readonly],
     :disabled,
     .pt-disabled {
-      z-index: $control-group-z-index-input-disabled;
+      z-index: index($control-group-z-index-stack, "input-disabled");
       border-radius: 0;
     }
 
     &[class*="pt-intent"] {
-      z-index: $control-group-z-index-intent-input-default;
+      z-index: index($control-group-z-index-stack, "intent-input-default");
 
       .pt-dark & {
-        z-index: $control-group-z-index-dark-theme-intent-input-default;
+        z-index: index($control-group-z-index-stack, "dark-theme-intent-input-default");
       }
 
       &:focus {
-        z-index: $control-group-z-index-intent-input-focus;
+        z-index: index($control-group-z-index-stack, "intent-input-focus");
       }
     }
   }
 
   .pt-button,
   .pt-select select {
-    z-index: $control-group-z-index-button-default;
+    z-index: index($control-group-z-index-stack, "button-default");
     // inherit radius since it's most likely to be zero
     border-radius: inherit;
 
     &:focus {
       // establish new stacking context so focus state covers neighbors
       position: relative;
-      z-index: $control-group-z-index-button-focus;
+      z-index: index($control-group-z-index-stack, "button-focus");
     }
 
     &:hover {
-      z-index: $control-group-z-index-button-hover;
+      z-index: index($control-group-z-index-stack, "button-hover");
     }
 
     &:active {
-      z-index: $control-group-z-index-button-active;
+      z-index: index($control-group-z-index-stack, "button-active");
     }
 
     &[readonly],
     &:disabled,
     &.pt-disabled {
-      z-index: $control-group-z-index-button-disabled;
+      z-index: index($control-group-z-index-stack, "button-disabled");
     }
 
     &[class*="pt-intent"] {
-      z-index: $control-group-z-index-intent-button-default;
+      z-index: index($control-group-z-index-stack, "intent-button-default");
 
       &:focus {
-        z-index: $control-group-z-index-intent-button-focus;
+        z-index: index($control-group-z-index-stack, "intent-button-focus");
       }
 
       &:hover {
-        z-index: $control-group-z-index-intent-button-hover;
+        z-index: index($control-group-z-index-stack, "intent-button-hover");
       }
 
       &:active {
-        z-index: $control-group-z-index-intent-button-active;
+        z-index: index($control-group-z-index-stack, "intent-button-active");
       }
 
       &[readonly],
       &:disabled,
       &.pt-disabled {
-        z-index: $control-group-z-index-intent-button-disabled;
+        z-index: index($control-group-z-index-stack, "intent-button-disabled");
       }
     }
   }
@@ -272,17 +269,32 @@ $control-group-z-index-select-caret: 17;
   .pt-input-group > .pt-icon,
   .pt-input-group > .pt-button,
   .pt-input-group > .pt-input-action {
-    z-index: $control-group-z-index-input-group-children;
+    z-index: index($control-group-z-index-stack, "input-group-children");
   }
 
   // keep the select-menu carets on top of everything always
   .pt-select::after {
-    z-index: $control-group-z-index-select-caret;
+    z-index: index($control-group-z-index-stack, "select-caret");
   }
 
   // have consecutive elements share a border
-  &:not(.pt-vertical) > * {
-    margin-right: -$button-border-width;
+  &:not(.pt-vertical) {
+    > * {
+      margin-right: -$button-border-width;
+    }
+
+    .pt-dark & {
+      > * {
+        margin-right: 0;
+      }
+
+      // conseuctive buttons within a button group look okay out of the box, but
+      // we need need to make a small correction for non-grouped buttons. this
+      // replicates what's already done in dark-theme button groups.
+      > .pt-button + .pt-button {
+        margin-left: $button-border-width;
+      }
+    }
   }
 
   // round the left corners of the left-most element

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -38,6 +38,13 @@
 
 // Section-Specific Styles
 
+#{section-id("components.button-group")} {
+  .docs-button-group-example-set .pt-button-group {
+    margin-top: 20px;
+    margin-left: 20px;
+  }
+}
+
 #{section-id("components.forms.checkbox")},
 #{section-id("components.forms.radio")},
 #{section-id("components.forms.switch")} {
@@ -54,7 +61,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: $pt-grid-size * 13;
+  height: $pt-grid-size * 50;
 }
 
 #{section-name("Inline controls")} {

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -40,8 +40,8 @@
 
 #{section-id("components.button-group")} {
   .docs-button-group-example-set .pt-button-group {
-    margin-top: 20px;
-    margin-left: 20px;
+    margin-top: $pt-grid-size * 2;
+    margin-left: $pt-grid-size * 2;
   }
 }
 
@@ -61,7 +61,10 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: $pt-grid-size * 50;
+
+  > .pt-control-group:not(:last-child) {
+    margin-bottom: $pt-grid-size * 2;
+  }
 }
 
 #{section-name("Inline controls")} {


### PR DESCRIPTION
#### No official issue filed, but originally discovered problems here while working on #249 and #189 

#### Checklist

- [ ] Include tests (it would be awesome to add unit tests to verify the z-index stacking order, but we'd need [`chai-enzyme`](https://github.com/producthunt/chai-enzyme) to access computed styles for mounted React components - should we add it as a dependency?).
- [ ] Update documentation (@llorca - can you edit examples to your liking?)

#### Changes proposed in this pull request:

- Clearly specify the z-index stack of all possible `.pt-button-group` elements to ensure sharp edges in all cases and states:

```
  (lowest z-index)

  default buttons
    :disabled, .pt-disabled
    normal
    :focus
    :hover
    :active, .pt-active

  intent buttons
    :disabled, .pt-disabled
    normal
    :focus
    :hover
    :active, .pt-active

  (highest z-index)
```

- Clearly specify the z-index stack of all possible `.pt-control-group` elements to ensure sharp edges in all cases and states:

```
  (lowest z-index)

  input fields
     :disabled, .pt-disabled
     normal

  regular buttons / pt-select > select
    :disabled, .pt-disabled
    normal
    :focus
    :hover
    :active, .pt-active

  pt-input intent

  intent buttons (selects can't be intented yet, but if they could be, they'd be here too)
    :disabled, .pt-disabled
    normal
    :focus
    :hover
    :active, .pt-active

  input fields (NOT readonly, :disabled, .pt-disabled)
     :focus

  intent input fields (NOT readonly, :disabled, .pt-disabled)
     :focus

  input-group children

  .pt-select::after (i.e. the caret)

  (highest z-index)
```

#### Reviewers should focus on:

_Definitely look at the diff in "Split" mode, not "Unified" mode._

- How does the new z-index stack feel?
- Is it implemented correctly?
- Are we good with the z-index variable names? Thought about combining them, but the two group types had different enough stacking semantics that it was clearer to spell everything out separately. 
- Are there any weird edge cases with certain combinations of grouped elements?
- Are there any regressions?

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
