### PR TITLE
onCloseContextMenu implemention added in contextMenuTarget

### DIFF
--- a/packages/core/examples/contextMenuExample.tsx
+++ b/packages/core/examples/contextMenuExample.tsx
@@ -62,10 +62,6 @@ export class ContextMenuExample extends BaseExample<{}> {
         );
     }
 
-    public onCloseContextMenu() {
-        console.log("Context menu was closed.");
-    }
-
     public renderContextMenu(e: React.MouseEvent<HTMLElement>) {
         return <Menu>
             <MenuItem iconName="select" text="Select all" />

--- a/packages/core/examples/contextMenuExample.tsx
+++ b/packages/core/examples/contextMenuExample.tsx
@@ -62,6 +62,10 @@ export class ContextMenuExample extends BaseExample<{}> {
         );
     }
 
+    public onCloseContextMenu() {
+        console.log("Context menu was closed.");
+    }
+
     public renderContextMenu(e: React.MouseEvent<HTMLElement>) {
         return <Menu>
             <MenuItem iconName="select" text="Select all" />

--- a/packages/core/src/components/context-menu/_context-menu.scss
+++ b/packages/core/src/components/context-menu/_context-menu.scss
@@ -41,6 +41,9 @@ When the user triggers the `"contextmenu"` event on the decorated class, `render
 called. If `renderContextMenu()` returns an element, the browser's native [context menu][wiki-cm] is
 blocked and the returned element is displayed instead in a `Popover` at the cursor's location.
 
+If the instance has a `onContextMenuClose` method, the decorator will call this function when
+the context menu is closed.
+
 ```
 import { ContextMenuTarget, Menu, MenuItem } from "@blueprintjs/core";
 
@@ -59,6 +62,10 @@ class RightClickMe extends React.Component<{}, {}> {
                 <MenuItem onClick={this.handleDelete} text="Delete" />
             </Menu>
         );
+    }
+
+    public onContextMenuClose() {
+        // Optional method called once the context menu is closed.
     }
 }
 ```

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -12,11 +12,11 @@ import * as ContextMenu from "./contextMenu";
 
 export interface IContextMenuTarget extends React.Component<any, any> {
     renderContextMenu(e: React.MouseEvent<HTMLElement>): JSX.Element ;
-    onCloseContextMenu?(): void;
+    onContextMenuClose?(): void;
 }
 
 export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(constructor: T) {
-    const { render, renderContextMenu, onCloseContextMenu } = constructor.prototype;
+    const { render, renderContextMenu, onContextMenuClose } = constructor.prototype;
 
     if (!isFunction(renderContextMenu)) {
         throw new Error(`@ContextMenuTarget-decorated class must implement \`renderContextMenu\`. ${constructor}`);
@@ -43,11 +43,7 @@ export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(c
             const menu = this.renderContextMenu(e);
             if (menu != null) {
                 e.preventDefault();
-                ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, () => {
-                    if (isFunction(onCloseContextMenu)) {
-                        onCloseContextMenu.call(this);
-                    }
-                });
+                ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, onContextMenuClose);
             }
 
             safeInvoke(oldOnContextMenu, e);

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -12,6 +12,7 @@ import * as ContextMenu from "./contextMenu";
 
 export interface IContextMenuTarget extends React.Component<any, any> {
     renderContextMenu(e: React.MouseEvent<HTMLElement>): JSX.Element ;
+    onCloseContextMenu?(): void;
 }
 
 export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(constructor: T) {

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -15,7 +15,7 @@ export interface IContextMenuTarget extends React.Component<any, any> {
 }
 
 export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(constructor: T) {
-    const { render, renderContextMenu } = constructor.prototype;
+    const { render, renderContextMenu, onCloseContextMenu } = constructor.prototype;
 
     if (!isFunction(renderContextMenu)) {
         throw new Error(`@ContextMenuTarget-decorated class must implement \`renderContextMenu\`. ${constructor}`);
@@ -42,7 +42,11 @@ export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(c
             const menu = this.renderContextMenu(e);
             if (menu != null) {
                 e.preventDefault();
-                ContextMenu.show(menu, { left: e.clientX, top: e.clientY });
+                ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, () => {
+                    if (isFunction(onCloseContextMenu)) {
+                        onCloseContextMenu.call(this);
+                    }
+                });
             }
 
             safeInvoke(oldOnContextMenu, e);


### PR DESCRIPTION
#### Fixes #591

#### Changes proposed in this pull request:

ContextMenuTarget class decorator has no onClose callback
