### PR TITLE
Render ghost cells properly when there is no content

### DIFF
--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -147,14 +147,14 @@ export class Grid {
      * Returns the total width of the entire grid
      */
     public getWidth() {
-        return this.cumulativeColumnWidths[this.numCols - 1];
+        return this.numCols === 0 ? 0 : this.cumulativeColumnWidths[this.numCols - 1];
     }
 
     /**
      * Returns the total width of the entire grid
      */
     public getHeight() {
-        return this.cumulativeRowHeights[this.numRows - 1];
+        return this.numRows === 0 ? 0 : this.cumulativeRowHeights[this.numRows - 1];
     }
 
     /**

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -47,6 +47,12 @@ describe("Grid", () => {
         expect(rowIndexEnd).to.equal(5);
     });
 
+    it("width and height are zero when there are no rows and columns", () => {
+        const grid = new Grid([], [], 0);
+        expect(grid.getHeight()).to.equal(0);
+        expect(grid.getWidth()).to.equal(0);
+    });
+
     it("locates column indices of overlapping rect", () => {
         const grid = new Grid(test7s, test13s, 0);
         const rect = new Rect(15, 0, 30, 0);


### PR DESCRIPTION
Fixes a bug in `grid#getWidth` and `grid#getHeight` when there are 0 columns and rows. This would prevent styles from being properly set on the table body, leading to ghost cells rendering on top of each other.

Before:
![screen shot 2017-02-02 at 12 54 24 pm](https://cloud.githubusercontent.com/assets/3681045/22561590/dcfce83e-e946-11e6-9c6b-213363bb99b1.png)

After:
![screen shot 2017-02-02 at 12 56 25 pm](https://cloud.githubusercontent.com/assets/3681045/22561636/089ee37a-e947-11e6-8db5-3fdd6dc475ad.png)
