### PR TITLE
Handle for cases when navigator is undefined

### DIFF
--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -5,10 +5,10 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-const userAgent = navigator.userAgent;
+const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : null;
 const browser = {
-    isEdge: !!userAgent.match(/Edge/),
-    isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
+    isEdge: userAgent ? !!userAgent.match(/Edge/) : false,
+    isInternetExplorer: userAgent ? (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)) : false,
  };
 
 export const Browser = {

--- a/packages/core/src/compatibility/browser.ts
+++ b/packages/core/src/compatibility/browser.ts
@@ -5,10 +5,10 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : null;
+const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
 const browser = {
-    isEdge: userAgent ? !!userAgent.match(/Edge/) : false,
-    isInternetExplorer: userAgent ? (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)) : false,
+    isEdge: !!userAgent.match(/Edge/),
+    isInternetExplorer: (!!userAgent.match(/Trident/) || !!userAgent.match(/rv:11/)),
  };
 
 export const Browser = {


### PR DESCRIPTION
The build is currently failing because the tests throw this error:

```
ReferenceError: navigator is not defined
```

when running `EditableText` code that imports the `browser.ts` file. 