### PR TITLE
Toast action can be a link

### DIFF
--- a/packages/core/examples/toastExample.tsx
+++ b/packages/core/examples/toastExample.tsx
@@ -32,11 +32,13 @@ export class ToastExample extends BaseExample<IToasterProps> {
 
     private TOAST_BUILDERS: IToastDemo[] = [{
         action: {
+            href: "https://www.google.com/search?q=toast&source=lnms&tbm=isch",
+            target: "_blank",
             text: "Yum",
         },
         button: "Procure toast",
         intent: Intent.PRIMARY,
-        message: <span>One toast created. <a href="javascript:void(0)">Hello world!</a></span>,
+        message: <span>One toast created. <em>Toasty.</em></span>,
     }, {
         action: {
             onClick: () => this.addToast({

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -11,18 +11,18 @@ import * as React from "react";
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
-import { IActionProps, IIntentProps, IProps } from "../../common/props";
+import { IActionProps, IIntentProps, ILinkProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
-import { Button } from "../button/buttons";
+import { AnchorButton, Button } from "../button/buttons";
 
 export interface IToastProps extends IProps, IIntentProps {
     /**
-     * Action to display in a minimal button. The toast is dismissed automatically when the
+     * Action rendered as a minimal `AnchorButton`. The toast is dismissed automatically when the
      * user clicks the action button. Note that the `intent` prop is ignored (the action button
      * cannot have its own intent color that might conflict with the toast's intent). Omit this
      * prop to omit the action button.
      */
-    action?: IActionProps;
+    action?: IActionProps & ILinkProps;
 
     /** Name of icon to appear before message. Specify only the part of the name after `pt-icon-`. */
     iconName?: string;
@@ -93,7 +93,11 @@ export class Toast extends AbstractComponent<IToastProps, {}> {
 
     private maybeRenderActionButton() {
         const { action } = this.props;
-        return action == null ? undefined : <Button {...action} intent={null} onClick={this.handleActionClick} />;
+        if (action == null) {
+            return undefined;
+        } else {
+            return <AnchorButton {...action} intent={undefined} onClick={this.handleActionClick} />;
+        }
     }
 
     private maybeRenderIcon() {
@@ -105,7 +109,7 @@ export class Toast extends AbstractComponent<IToastProps, {}> {
         }
     }
 
-    private handleActionClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    private handleActionClick = (e: React.MouseEvent<HTMLElement>) => {
         safeInvoke(this.props.action.onClick, e);
         this.triggerDismiss(false);
     }

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -55,7 +55,7 @@ describe.only("<Toast>", () => {
             action: root.find(AnchorButton),
             dismiss: root.find(Button),
             root,
-        }
+        };
     }
 
     describe("timeout", () => {

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -9,11 +9,11 @@ import { assert } from "chai";
 import { mount, shallow } from "enzyme";
 import * as React from "react";
 
-import { Button, Toast } from "../../src/index";
+import { AnchorButton, Toast } from "../../src/index";
 
 describe("<Toast>", () => {
     it("renders only dismiss button by default", () => {
-        const button = shallow(<Toast message="Hello World" />).find(Button);
+        const button = shallow(<Toast message="Hello World" />).find(AnchorButton);
         assert.lengthOf(button, 1);
         assert.strictEqual(button.prop("iconName"), "cross");
     });
@@ -21,14 +21,14 @@ describe("<Toast>", () => {
     it("clicking dismiss button triggers onDismiss callback with `false`", () => {
         const handleDismiss = sinon.spy();
         shallow(<Toast message="Hello" onDismiss={handleDismiss} />)
-            .find(Button).simulate("click");
+            .find(AnchorButton).simulate("click");
         assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
         assert.isTrue(handleDismiss.calledWith(false), "onDismiss not called with false");
     });
 
     it("renders action button when action string prop provided", () => {
         // pluralize cuz now there are two buttons
-        const buttons = shallow(<Toast action={{ text: "Undo" }} message="hello world" />).find(Button);
+        const buttons = shallow(<Toast action={{ text: "Undo" }} message="hello world" />).find(AnchorButton);
         assert.lengthOf(buttons, 2);
         assert.equal(buttons.first().prop("text"), "Undo");
     });
@@ -36,14 +36,14 @@ describe("<Toast>", () => {
     it("clicking action button triggers onClick callback", () => {
         const onClick = sinon.spy();
         shallow(<Toast action={{ onClick, text: "Undo" }} message="Hello" />)
-            .find(Button).first().simulate("click");
+            .find(AnchorButton).first().simulate("click");
         assert.isTrue(onClick.calledOnce, "action onClick not called once");
     });
 
     it("clicking action button also triggers onDismiss callback with `false`", () => {
         const handleDismiss = sinon.spy();
         shallow(<Toast message="Hello" onDismiss={handleDismiss} />)
-            .find(Button).first().simulate("click");
+            .find(AnchorButton).first().simulate("click");
         assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
         assert.isTrue(handleDismiss.calledWith(false), "onDismiss not called with false");
     });

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -11,7 +11,7 @@ import * as React from "react";
 
 import { AnchorButton, Button, Toast } from "../../src/index";
 
-describe.only("<Toast>", () => {
+describe("<Toast>", () => {
     it("renders only dismiss button by default", () => {
         const { action, dismiss } = wrap(<Toast message="Hello World" />);
         assert.lengthOf(action, 0);

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -9,44 +9,54 @@ import { assert } from "chai";
 import { mount, shallow } from "enzyme";
 import * as React from "react";
 
-import { AnchorButton, Toast } from "../../src/index";
+import { AnchorButton, Button, Toast } from "../../src/index";
 
-describe("<Toast>", () => {
+describe.only("<Toast>", () => {
     it("renders only dismiss button by default", () => {
-        const button = shallow(<Toast message="Hello World" />).find(AnchorButton);
-        assert.lengthOf(button, 1);
-        assert.strictEqual(button.prop("iconName"), "cross");
+        const { action, dismiss } = wrap(<Toast message="Hello World" />);
+        assert.lengthOf(action, 0);
+        assert.lengthOf(dismiss, 1);
+        assert.strictEqual(dismiss.prop("iconName"), "cross");
     });
 
     it("clicking dismiss button triggers onDismiss callback with `false`", () => {
         const handleDismiss = sinon.spy();
-        shallow(<Toast message="Hello" onDismiss={handleDismiss} />)
-            .find(AnchorButton).simulate("click");
+        wrap(<Toast message="Hello" onDismiss={handleDismiss} />)
+            .dismiss.simulate("click");
         assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
         assert.isTrue(handleDismiss.calledWith(false), "onDismiss not called with false");
     });
 
     it("renders action button when action string prop provided", () => {
         // pluralize cuz now there are two buttons
-        const buttons = shallow(<Toast action={{ text: "Undo" }} message="hello world" />).find(AnchorButton);
-        assert.lengthOf(buttons, 2);
-        assert.equal(buttons.first().prop("text"), "Undo");
+        const { action } = wrap(<Toast action={{ text: "Undo" }} message="hello world" />);
+        assert.lengthOf(action, 1);
+        assert.equal(action.prop("text"), "Undo");
     });
 
     it("clicking action button triggers onClick callback", () => {
         const onClick = sinon.spy();
-        shallow(<Toast action={{ onClick, text: "Undo" }} message="Hello" />)
-            .find(AnchorButton).first().simulate("click");
+        wrap(<Toast action={{ onClick, text: "Undo" }} message="Hello" />)
+            .action.simulate("click");
         assert.isTrue(onClick.calledOnce, "action onClick not called once");
     });
 
     it("clicking action button also triggers onDismiss callback with `false`", () => {
         const handleDismiss = sinon.spy();
-        shallow(<Toast message="Hello" onDismiss={handleDismiss} />)
-            .find(AnchorButton).first().simulate("click");
+        wrap(<Toast action={{ text: "Undo" }} message="Hello" onDismiss={handleDismiss} />)
+            .action.simulate("click");
         assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
         assert.isTrue(handleDismiss.calledWith(false), "onDismiss not called with false");
     });
+
+    function wrap(toast: JSX.Element) {
+        const root = shallow(toast);
+        return {
+            action: root.find(AnchorButton),
+            dismiss: root.find(Button),
+            root,
+        }
+    }
 
     describe("timeout", () => {
         let handleDismiss: Sinon.SinonSpy;

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,11 @@
 {
   "extends": ["tslint:latest", "tslint-react"],
   "rules": {
-    "ban": [true, ["Object", "assign", "use TS2.1 object spread { ...a, ...b }"]],
+    "ban": [true,
+      ["Object", "assign", "use TS2.1 object spread { ...a, ...b }"],
+      ["describe", "only"],
+      ["it", "only"]
+    ],
     "linebreak-style": [true, "LF"],
     "no-invalid-this": [true, "check-function-in-method"],
     "variable-name": [


### PR DESCRIPTION
#### Changes proposed in this pull request:

- toast `action` accepts `ILinkProps` (href and target), uses `AnchorButton`
- refactor toast tests to use a little wrapper function that find the action and dismiss buttons. this puts the queries in one place, if we need to change them in the future.
- ban `describe.only` and `it.only` in TSLint for the same reason as console.log: useful in local development but problematic in real environments.