### PR TITLE
[Date Range Input] - Part 2: Basic HTML/CSS, example, and unit test

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -12,8 +12,6 @@ import { DateRangeInput } from "../src";
 
 export class DateRangeInputExample extends BaseExample<{}> {
     protected renderExample() {
-        return (
-            <DateRangeInput />
-        );
+        return <DateRangeInput />;
     }
 }

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import BaseExample from "@blueprintjs/core/examples/common/baseExample";
+import * as React from "react";
+
+import { DateRangeInput } from "../src";
+
+export class DateRangeInputExample extends BaseExample<{}> {
+    protected renderExample() {
+        return (
+            <DateRangeInput />
+        );
+    }
+}

--- a/packages/datetime/examples/index.ts
+++ b/packages/datetime/examples/index.ts
@@ -7,6 +7,7 @@
 
 export * from "./dateInputExample";
 export * from "./datePickerExample";
+export * from "./dateRangeInputExample";
 export * from "./dateRangePickerExample";
 export * from "./dateTimePickerExample";
 export * from "./timePickerExample";

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -1,0 +1,46 @@
+// Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+// of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+// and https://github.com/palantir/blueprint/blob/master/PATENTS
+
+@import "../../core/src/common/variables";
+
+/*
+Date range input
+
+@react-example DateRangeInputExample
+
+Styleguide components.datetime.daterangeinput
+*/
+
+.pt-daterangeinput {
+  position: relative;
+}
+
+.pt-daterangeinput-icon-wrapper {
+
+  // .pt-input-group already styles immediate-children .pt-buttons with
+  // these position styles. however, the .pt-button is a grandchild of the
+  // .pt-input-group in this case, so we need to restate the styles here.
+  .pt-button {
+    position: absolute;
+    top: 0;
+
+    // .pt-control-group styles .pt-button with position: relative when the
+    // button gains focus. that causes the button to move down on click in this
+    // case, so we disable that behavior.
+    &:focus {
+      position: absolute;
+    }
+  }
+
+  // we're applying the .pt-input class to a div here, not a proper <input>. the
+  // .pt-button above is the only child and is absolutely positioned, so we need
+  // to explicitly specify the size of the .pt-input to be a square. we also
+  // need to clear its padding, as that's not needed here.
+  .pt-input {
+    width: $pt-input-height;
+    height: $pt-input-height;
+    padding: 0;
+  }
+}

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -12,7 +12,3 @@ Date range input
 
 Styleguide components.datetime.daterangeinput
 */
-
-.pt-daterangeinput {
-  position: relative;
-}

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -16,31 +16,3 @@ Styleguide components.datetime.daterangeinput
 .pt-daterangeinput {
   position: relative;
 }
-
-.pt-daterangeinput-icon-wrapper {
-
-  // .pt-input-group already styles immediate-children .pt-buttons with
-  // these position styles. however, the .pt-button is a grandchild of the
-  // .pt-input-group in this case, so we need to restate the styles here.
-  .pt-button {
-    position: absolute;
-    top: 0;
-
-    // .pt-control-group styles .pt-button with position: relative when the
-    // button gains focus. that causes the button to move down on click in this
-    // case, so we disable that behavior.
-    &:focus {
-      position: absolute;
-    }
-  }
-
-  // we're applying the .pt-input class to a div here, not a proper <input>. the
-  // .pt-button above is the only child and is absolutely positioned, so we need
-  // to explicitly specify the size of the .pt-input to be a square. we also
-  // need to clear its padding, as that's not needed here.
-  .pt-input {
-    width: $pt-input-height;
-    height: $pt-input-height;
-    padding: 0;
-  }
-}

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -10,5 +10,7 @@ Date range input
 
 @react-example DateRangeInputExample
 
+Weight: 3
+
 Styleguide components.datetime.daterangeinput
 */

--- a/packages/datetime/src/blueprint-datetime.scss
+++ b/packages/datetime/src/blueprint-datetime.scss
@@ -42,6 +42,7 @@ Styleguide components.datetime
 */
 
 @import "datepicker";
+@import "daterangeinput";
 @import "daterangepicker";
 @import "timepicker";
 @import "datetimepicker";

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -18,7 +18,6 @@ export const DATEPICKER_MONTH_SELECT = "pt-datepicker-month-select";
 export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 
 export const DATERANGEINPUT = "pt-daterangeinput";
-export const DATERANGEINPUT_FIELD = "pt-daterangeinput-field";
 export const DATERANGEINPUT_ICON_WRAPPER = "pt-daterangeinput-icon-wrapper";
 
 export const DATERANGEPICKER = "pt-daterangepicker";

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -18,7 +18,6 @@ export const DATEPICKER_MONTH_SELECT = "pt-datepicker-month-select";
 export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 
 export const DATERANGEINPUT = "pt-daterangeinput";
-export const DATERANGEINPUT_ICON_WRAPPER = "pt-daterangeinput-icon-wrapper";
 
 export const DATERANGEPICKER = "pt-daterangepicker";
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = "DayPicker-Day--selected-range";

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -17,6 +17,10 @@ export const DATEPICKER_FOOTER = "pt-datepicker-footer";
 export const DATEPICKER_MONTH_SELECT = "pt-datepicker-month-select";
 export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 
+export const DATERANGEINPUT = "pt-daterangeinput";
+export const DATERANGEINPUT_FIELD = "pt-daterangeinput-field";
+export const DATERANGEINPUT_ICON_WRAPPER = "pt-daterangeinput-icon-wrapper";
+
 export const DATERANGEPICKER = "pt-daterangepicker";
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = "DayPicker-Day--selected-range";
 export const DATERANGEPICKER_DAY_HOVERED_RANGE = "DayPicker-Day--hovered-range";

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -17,8 +17,6 @@ export const DATEPICKER_FOOTER = "pt-datepicker-footer";
 export const DATEPICKER_MONTH_SELECT = "pt-datepicker-month-select";
 export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 
-export const DATERANGEINPUT = "pt-daterangeinput";
-
 export const DATERANGEPICKER = "pt-daterangepicker";
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = "DayPicker-Day--selected-range";
 export const DATERANGEPICKER_DAY_HOVERED_RANGE = "DayPicker-Day--hovered-range";

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -51,14 +51,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> 
                     {...this.props.endInputProps}
                     inputRef={this.setEndDateInputRef}
                 />
-                <div className={classNames(DateClasses.DATERANGEINPUT_ICON_WRAPPER, Classes.INPUT_GROUP)}>
-                    <div className={Classes.INPUT}>
-                        <Button
-                            className={classNames(Classes.MINIMAL, Classes.iconClass("calendar"))}
-                            intent={Intent.PRIMARY}
-                        />
-                    </div>
-                </div>
             </div>
         );
     }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import * as classNames from "classnames";
+import * as React from "react";
+
+import {
+    AbstractComponent,
+    Button,
+    Classes,
+    IInputGroupProps,
+    InputGroup,
+    Intent,
+    IProps,
+} from "@blueprintjs/core";
+
+import * as DateClasses from "./common/classes";
+import {
+    IDatePickerBaseProps,
+} from "./datePickerCore";
+
+export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
+    startInputProps?: IInputGroupProps;
+    endInputProps?: IInputGroupProps;
+}
+
+export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> {
+    public static defaultProps: IDateRangeInputProps = {};
+
+    public displayName = "Blueprint.DateRangeInput";
+
+    private startDateInputRef: HTMLInputElement = null;
+    private endDateInputRef: HTMLInputElement = null;
+
+    public render() {
+        return (
+            <div className={Classes.CONTROL_GROUP}>
+                <InputGroup
+                    className={DateClasses.DATERANGEINPUT_FIELD}
+                    inputRef={this.setStartDateInputRef}
+                    placeholder="Start date"
+                    type="text"
+                    {...this.props.startInputProps}
+                />
+                <InputGroup
+                    className={DateClasses.DATERANGEINPUT_FIELD}
+                    inputRef={this.setEndDateInputRef}
+                    placeholder="End date"
+                    type="text"
+                    {...this.props.endInputProps}
+                />
+                <div className={classNames(DateClasses.DATERANGEINPUT_ICON_WRAPPER, Classes.INPUT_GROUP)}>
+                    <div className={Classes.INPUT}>
+                        <Button
+                            className={classNames(Classes.MINIMAL, "pt-icon-calendar")}
+                            intent={Intent.PRIMARY}
+                        />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    private setStartDateInputRef = (el: HTMLInputElement) => {
+        this.startDateInputRef = el;
+    }
+
+    private setEndDateInputRef = (el: HTMLInputElement) => {
+        this.endDateInputRef = el;
+    }
+}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -13,6 +13,7 @@ import {
     IInputGroupProps,
     InputGroup,
     IProps,
+    Utils,
 } from "@blueprintjs/core";
 
 import {
@@ -25,12 +26,25 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 }
 
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> {
-    public static defaultProps: IDateRangeInputProps = {};
+    public static defaultProps: IDateRangeInputProps = {
+        endInputProps: {},
+        startInputProps: {},
+    };
 
     public displayName = "Blueprint.DateRangeInput";
 
-    private startDateInputRef: HTMLInputElement = null;
-    private endDateInputRef: HTMLInputElement = null;
+    private startInputRef: HTMLInputElement;
+    private endInputRef: HTMLInputElement;
+    private refHandlers = {
+        endInputRef: (ref: HTMLInputElement) => {
+            this.endInputRef = ref;
+            Utils.safeInvoke(this.props.endInputProps.inputRef, ref);
+        },
+        startInputRef: (ref: HTMLInputElement) => {
+            this.startInputRef = ref;
+            Utils.safeInvoke(this.props.startInputProps.inputRef, ref);
+        },
+    };
 
     public render() {
         // allow custom props for each input group, but pass them in an order
@@ -40,22 +54,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> 
                 <InputGroup
                     placeholder="Start date"
                     {...this.props.startInputProps}
-                    inputRef={this.setStartDateInputRef}
+                    inputRef={this.refHandlers.startInputRef}
                 />
                 <InputGroup
                     placeholder="End date"
                     {...this.props.endInputProps}
-                    inputRef={this.setEndDateInputRef}
+                    inputRef={this.refHandlers.endInputRef}
                 />
             </div>
         );
-    }
-
-    private setStartDateInputRef = (el: HTMLInputElement) => {
-        this.startDateInputRef = el;
-    }
-
-    private setEndDateInputRef = (el: HTMLInputElement) => {
-        this.endDateInputRef = el;
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -56,7 +56,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> 
                 <div className={classNames(DateClasses.DATERANGEINPUT_ICON_WRAPPER, Classes.INPUT_GROUP)}>
                     <div className={Classes.INPUT}>
                         <Button
-                            className={classNames(Classes.MINIMAL, "pt-icon-calendar")}
+                            className={classNames(Classes.MINIMAL, Classes.iconClass("calendar"))}
                             intent={Intent.PRIMARY}
                         />
                     </div>

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -37,21 +37,19 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> 
     private endDateInputRef: HTMLInputElement = null;
 
     public render() {
+        // allow custom props for each input group, but pass them in an order
+        // that guarantees only some props are overridable.
         return (
             <div className={Classes.CONTROL_GROUP}>
                 <InputGroup
-                    className={DateClasses.DATERANGEINPUT_FIELD}
-                    inputRef={this.setStartDateInputRef}
                     placeholder="Start date"
-                    type="text"
                     {...this.props.startInputProps}
+                    inputRef={this.setStartDateInputRef}
                 />
                 <InputGroup
-                    className={DateClasses.DATERANGEINPUT_FIELD}
-                    inputRef={this.setEndDateInputRef}
                     placeholder="End date"
-                    type="text"
                     {...this.props.endInputProps}
+                    inputRef={this.setEndDateInputRef}
                 />
                 <div className={classNames(DateClasses.DATERANGEINPUT_ICON_WRAPPER, Classes.INPUT_GROUP)}>
                     <div className={Classes.INPUT}>

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -5,20 +5,16 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import * as classNames from "classnames";
 import * as React from "react";
 
 import {
     AbstractComponent,
-    Button,
     Classes,
     IInputGroupProps,
     InputGroup,
-    Intent,
     IProps,
 } from "@blueprintjs/core";
 
-import * as DateClasses from "./common/classes";
 import {
     IDatePickerBaseProps,
 } from "./datePickerCore";

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -15,5 +15,6 @@ export { DateInput, IDateInputProps } from "./dateInput";
 export { DatePicker, DatePickerFactory, IDatePickerProps } from "./datePicker";
 export { IDatePickerLocaleUtils, IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
+export { DateRangeInput } from "./dateRangeInput";
 export { DateRangePicker, DateRangePickerFactory, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
 export { ITimePickerProps, TimePicker, TimePickerFactory, TimePickerPrecision } from "./timePicker";

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { expect } from "chai";
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { InputGroup } from "@blueprintjs/core";
+import { DateRangeInput } from "../src/index";
+
+describe("<DateRangeInput>", () => {
+    it("renders with three children, the first two of which are input groups", () => {
+        const component = mount(<DateRangeInput />);
+        expect(component.childAt(0).type()).to.equal(InputGroup);
+        expect(component.childAt(1).type()).to.equal(InputGroup);
+        expect(component.children().length).to.equal(3);
+    });
+});

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -13,10 +13,10 @@ import { InputGroup } from "@blueprintjs/core";
 import { DateRangeInput } from "../src/index";
 
 describe("<DateRangeInput>", () => {
-    it("renders with three children, the first two of which are input groups", () => {
+    it("renders with two InputGroup children", () => {
         const component = mount(<DateRangeInput />);
         expect(component.childAt(0).type()).to.equal(InputGroup);
         expect(component.childAt(1).type()).to.equal(InputGroup);
-        expect(component.children().length).to.equal(3);
+        expect(component.children().length).to.equal(2);
     });
 });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -15,8 +15,6 @@ import { DateRangeInput } from "../src/index";
 describe("<DateRangeInput>", () => {
     it("renders with two InputGroup children", () => {
         const component = mount(<DateRangeInput />);
-        expect(component.childAt(0).type()).to.equal(InputGroup);
-        expect(component.childAt(1).type()).to.equal(InputGroup);
-        expect(component.children().length).to.equal(2);
+        expect(component.find(InputGroup).length).to.equal(2);
     });
 });

--- a/packages/datetime/test/index.ts
+++ b/packages/datetime/test/index.ts
@@ -7,6 +7,7 @@ import "../src";
 import "./dateInputTests";
 import "./datePickerCaptionTests";
 import "./datePickerTests";
+import "./dateRangeInputTests";
 import "./dateRangePickerTests";
 import "./dateTimePickerTests";
 import "./timePickerTests";

--- a/packages/docs/src/styles/_examples.scss
+++ b/packages/docs/src/styles/_examples.scss
@@ -65,7 +65,7 @@ $options-margin: $pt-grid-size * 3;
     margin-bottom: $options-margin;
   }
 
-  .pt-input-group + .pt-input-group {
+  :not(.pt-control-group) .pt-input-group + .pt-input-group {
     margin-top: $pt-grid-size * 2;
   }
 }


### PR DESCRIPTION
> Second attempt at PR #609, which got in a bad state

#### Related to #249, builds on #586

#### Changes proposed in this pull request:

Implemented the basic HTML and CSS for the `DateRangeInput` (without the popover), plus an example and a unit test.

#### Reviewers should focus on:

- The unit test here is just a placeholder; it's present to ensure this PR meets the minimum coverage threshold.
- @llorca and I decided to nix (read: not implement) the calendar icon for now in preparation for nixing the `openOnFocus` prop eventually. That prop doesn't really make sense on this component, since this input wouldn't be particularly usable sans popover.

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/443450/22711608/acd5033c-ed36-11e6-816a-8f55900e3b0f.png)

![image](https://cloud.githubusercontent.com/assets/443450/22711963/ebd85696-ed37-11e6-9496-13557ac960e2.png)
