### PR TITLE
Support pt-fill in control groups

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -112,7 +112,7 @@ Styleguide components.button-group.css
     }
   }
 
-  // support wrapping buttons in a Blueprint.Tooltip, which adds a wrapper element
+  // support wrapping buttons in a tooltip, which adds a wrapper element
   &:not(.pt-minimal) {
     > .pt-popover-target:not(:first-child) .pt-button,
     > .pt-button:not(:first-child) {

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -51,7 +51,7 @@ Markup:
   <div class="pt-control-group">
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
+      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right: 105px" />
       <div class="pt-input-action">
         <button class="pt-button pt-minimal pt-intent-primary">
           can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
@@ -212,6 +212,35 @@ Styleguide components.forms.control-group
   // bring back border radius on these buttons
   .pt-input-group .pt-button {
     border-radius: $pt-border-radius;
+  }
+
+  /*
+  Responsive control groups
+
+  Add the class `pt-fill` to a control group to make all controls expand equally to fill the
+  available space. Then add the class `pt-fixed` to individual controls to revert them to their
+  original default sizes.
+
+  You can adjust the specific size of a control with the `flex-basis` CSS property.
+
+  Markup:
+  <div class="pt-control-group pt-fill">
+    <div class="pt-input-group">
+      <span class="pt-icon pt-icon-people"></span>
+      <input type="text" class="pt-input" placeholder="Find collaborators..." />
+    </div>
+    <button class="pt-button pt-intent-primary pt-fixed">Add</button>
+  </div>
+
+  Styleguide components.forms.control-group.fill
+  */
+
+  &.pt-fill {
+    display: flex;
+  }
+
+  &.pt-fill > *:not(.pt-fixed) {
+    flex: 1 1 auto;
   }
 
   /*

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -217,11 +217,14 @@ Styleguide components.forms.control-group
   /*
   Responsive control groups
 
-  Add the class `pt-fill` to a control group to make all controls expand equally to fill the
-  available space. Then add the class `pt-fixed` to individual controls to revert them to their
+  Add the class `pt-fill` to a control group to make all elements expand equally to fill the
+  available space. Then add the class `pt-fixed` to individual elements to revert them to their
   original default sizes.
 
-  You can adjust the specific size of a control with the `flex-basis` CSS property.
+  Alternatively, add the class `pt-fill` to an individual element (instead of to the container)
+  to expand it to fill the available space while other elements retain their original sizes.
+
+  You can adjust the specific size of an element with the `flex-basis` CSS property.
 
   Markup:
   <div class="pt-control-group-example">

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -51,7 +51,7 @@ Markup:
   <div class="pt-control-group">
     <div class="pt-input-group">
       <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right: 105px" />
+      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
       <div class="pt-input-action">
         <button class="pt-button pt-minimal pt-intent-primary">
           can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
@@ -224,19 +224,26 @@ Styleguide components.forms.control-group
   You can adjust the specific size of a control with the `flex-basis` CSS property.
 
   Markup:
-  <div class="pt-control-group pt-fill">
-    <div class="pt-input-group">
-      <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input" placeholder="Find collaborators..." />
+  <div class="pt-control-group-example">
+    <div class="pt-control-group">
+      <div class="pt-input-group pt-fill">
+        <span class="pt-icon pt-icon-people"></span>
+        <input type="text" class="pt-input" placeholder="Find collaborators..." />
+      </div>
+      <button class="pt-button pt-intent-primary">Add</button>
     </div>
-    <button class="pt-button pt-intent-primary pt-fixed">Add</button>
+    <div class="pt-control-group pt-fill">
+      <button class="pt-button pt-icon-minus pt-fixed"></button>
+      <input type="text" class="pt-input" placeholder="Enter a value..." />
+      <button class="pt-button pt-icon-plus pt-fixed"></button>
+    </div>
   </div>
 
   Styleguide components.forms.control-group.fill
   */
 
-  &.pt-fill {
-    display: flex;
+  > .pt-fill {
+    flex: 1 1 auto;
   }
 
   &.pt-fill > *:not(.pt-fixed) {


### PR DESCRIPTION
#### Fixes #620 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Update documentation

#### Changes proposed in this pull request:

Add support for the generic `pt-fill` class modifier to control groups.

#### Reviewers should focus on:

The CSS that enables that. It's very similar to button groups.
