### PR TITLE
Adding onClick, onMouseEnter, onMouseLeave event handlers for Cell

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -91,6 +91,7 @@ ReactDOM.render(
     document.getElementById("table-0"),
 );
 
+// tslint:disable:no-console jsx-no-lambda
 class FormatsTable extends React.Component<{}, {}> {
     private static ROWS = 1000;
 
@@ -121,12 +122,12 @@ class FormatsTable extends React.Component<{}, {}> {
             </Table>
         );
     }
-
-    private renderDefaultCell = (row: number) => <Cell>{this.strings[row]}</Cell>;
+    private renderDefaultCell = (row: number) => <Cell onClick={() => {console.log("clicked")}} onMouseEnter={()=>{console.log("mouse entered")}} onMouseLeave={()=>{console.log("mouse left")}}>{this.strings[row]}</Cell>;
     private renderJSONCell = (row: number) => <Cell><JSONFormat>{this.objects[row]}</JSONFormat></Cell>;
     private renderJSONWrappedCell = (row: number) =>
         <Cell><JSONFormat preformatted={false}>{this.objects[row]}</JSONFormat></Cell>;
 }
+// tslint:enable:no-console jsx-no-lambda
 
 ReactDOM.render(
     <FormatsTable />,

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -43,6 +43,15 @@ export interface ICellProps extends IIntentProps, IProps {
      * @default true
      */
     truncated?: boolean;
+
+    /** Callback invoked when user clicks the cell. */
+    onClick?: () => void;
+
+    /** Callback invoked when mouse enters cell. */
+    onMouseEnter?: () => void;
+
+    /** Callback invoked when mouse leaves cell. */
+    onMouseLeave?: () => void;
 }
 
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
@@ -59,7 +68,7 @@ export class Cell extends React.Component<ICellProps, {}> {
     };
 
     public render() {
-        const { style, intent, interactive, loading, tooltip, truncated, className } = this.props;
+        const { style, intent, interactive, loading, tooltip, truncated, className, onClick, onMouseEnter, onMouseLeave } = this.props;
 
         const classes = classNames(
             CELL_CLASSNAME,
@@ -75,7 +84,7 @@ export class Cell extends React.Component<ICellProps, {}> {
             <div className="bp-table-truncated-text">{this.props.children}</div> : this.props.children;
 
         return (
-            <div className={classes} style={style} title={tooltip}>
+            <div className={classes} style={style} title={tooltip} onClick={onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                 <LoadableContent loading={loading} variableLength={true}>
                     {content}
                 </LoadableContent>


### PR DESCRIPTION
**Fixes #508** 

- [ ] [Enable  #CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Update documentation

#### Changes proposed in this pull request:
Adding onClick, onMouseEnter, onMouseLeave event handlers for Cell in Table(React)

#### Screenshot
![screen shot 2017-02-07 at 7 22 25 pm](https://cloud.githubusercontent.com/assets/9435853/22694280/9099023c-ed6c-11e6-8c09-ec51be7295c0.png)

