### PR TITLE
Add onNodeContextMenu prop to Tree

### DIFF
--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -32,6 +32,11 @@ export interface ITreeProps extends IProps {
    onNodeCollapse?: TreeEventHandler;
 
    /**
+    * Invoked when a node is right-clicked or the context menu button is pressed on a focused node.
+    */
+   onNodeContextMenu?: TreeEventHandler;
+
+   /**
     * Invoked when a node is double-clicked. Be careful when using this in combination with
     * an `onNodeClick` (single-click) handler, as the way this behaves can vary between browsers.
     * See http://stackoverflow.com/q/5497073/3124288
@@ -74,6 +79,7 @@ export class Tree extends React.Component<ITreeProps, {}> {
                     key={node.id}
                     depth={elementPath.length - 1}
                     onClick={this.handleNodeClick}
+                    onContextMenu={this.handleNodeContextMenu}
                     onCollapse={this.handleNodeCollapse}
                     onDoubleClick={this.handleNodeDoubleClick}
                     onExpand={this.handleNodeExpand}
@@ -97,6 +103,10 @@ export class Tree extends React.Component<ITreeProps, {}> {
 
     private handleNodeClick = (node: TreeNode, e: React.MouseEvent<HTMLElement>) => {
         this.handlerHelper(this.props.onNodeClick, node, e);
+    }
+
+    private handleNodeContextMenu = (node: TreeNode, e: React.MouseEvent<HTMLElement>) => {
+        this.handlerHelper(this.props.onNodeContextMenu, node, e);
     }
 
     private handleNodeDoubleClick = (node: TreeNode, e: React.MouseEvent<HTMLElement>) => {

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -68,6 +68,7 @@ export interface ITreeNodeProps extends ITreeNode {
     key?: string | number;
     onClick?: (node: TreeNode, e: React.MouseEvent<HTMLDivElement>) => void;
     onCollapse?: (node: TreeNode, e: React.MouseEvent<HTMLSpanElement>) => void;
+    onContextMenu?: (node: TreeNode, e: React.MouseEvent<HTMLDivElement>) => void;
     onDoubleClick?: (node: TreeNode, e: React.MouseEvent<HTMLDivElement>) => void;
     onExpand?: (node: TreeNode, e: React.MouseEvent<HTMLSpanElement>) => void;
     path: number[];
@@ -96,6 +97,7 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
                 <div
                     className={contentClasses}
                     onClick={this.handleClick}
+                    onContextMenu={this.handleContextMenu}
                     onDoubleClick={this.handleDoubleClick}
                 >
                     <span className={caretClasses} onClick={showCaret ? this.handleCaretClick : null}/>
@@ -136,6 +138,10 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
 
     private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
         safeInvoke(this.props.onClick, this, e);
+    }
+
+    private handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+        safeInvoke(this.props.onContextMenu, this, e);
     }
 
     private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -84,13 +84,14 @@ describe("<Tree>", () => {
     it("event callbacks are fired correctly", () => {
         const onNodeClick = sinon.spy();
         const onNodeCollapse = sinon.spy();
+        const onNodeContextMenu = sinon.spy();
         const onNodeDoubleClick = sinon.spy();
         const onNodeExpand = sinon.spy();
 
         const contents = createDefaultContents();
         contents[3].isExpanded = true;
 
-        renderTree({contents, onNodeClick, onNodeCollapse, onNodeDoubleClick, onNodeExpand});
+        renderTree({contents, onNodeClick, onNodeCollapse, onNodeContextMenu, onNodeDoubleClick, onNodeExpand});
 
         TestUtils.Simulate.click(document.query(`.c0 > .${Classes.TREE_NODE_CONTENT}`));
         assert.isTrue(onNodeClick.calledOnce);
@@ -109,6 +110,14 @@ describe("<Tree>", () => {
         TestUtils.Simulate.click(document.query(`.c3 > .${Classes.TREE_NODE_CONTENT} .${Classes.TREE_NODE_CARET}`));
         assert.isTrue(onNodeCollapse.calledOnce);
         assert.deepEqual(onNodeCollapse.args[0][1], [3]);
+
+        assert.isTrue(onNodeContextMenu.notCalled);
+        // TestUtils.Simulate.contextMenu is a function, just not included in the typings
+        // nonetheless, the below line causes React to throw an error for some reason
+        // (TestUtils.Simulate as any).contextMenu(document.query(`.c0 > .${Classes.TREE_NODE_CONTENT}`));
+
+        // assert.isTrue(onNodeContextMenu.calledOnce);
+        // assert.deepEqual(onNodeContextMenu.args[0][1], [0]);
     });
 
     it("icons are rendered correctly if present", () => {

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -111,13 +111,10 @@ describe("<Tree>", () => {
         assert.isTrue(onNodeCollapse.calledOnce);
         assert.deepEqual(onNodeCollapse.args[0][1], [3]);
 
-        assert.isTrue(onNodeContextMenu.notCalled);
         // TestUtils.Simulate.contextMenu is a function, just not included in the typings
-        // nonetheless, the below line causes React to throw an error for some reason
-        // (TestUtils.Simulate as any).contextMenu(document.query(`.c0 > .${Classes.TREE_NODE_CONTENT}`));
-
-        // assert.isTrue(onNodeContextMenu.calledOnce);
-        // assert.deepEqual(onNodeContextMenu.args[0][1], [0]);
+        (TestUtils.Simulate as any).contextMenu(document.query(`.c0 > .${Classes.TREE_NODE_CONTENT}`));
+        assert.isTrue(onNodeContextMenu.calledOnce);
+        assert.deepEqual(onNodeContextMenu.args[0][1], [0]);
     });
 
     it("icons are rendered correctly if present", () => {


### PR DESCRIPTION
Fixes #637

#### Changes proposed in this pull request:

Added an `onNodeContextMenu` callback prop to `Tree`

#### Reviewers should focus on:

* Can we get the tests working?
* Do we need the example in the docs changed at all?
