### PR TITLE
Props tables hygiene

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -32,7 +32,7 @@ export interface IActionProps extends IIntentProps, IProps {
     /** Whether this action is non-interactive. */
     disabled?: boolean;
 
-    /** Name of icon (the part after `pt-icon-`) to add to button. */
+    /** Name of the icon (the part after `pt-icon-`) to add to the button. */
     iconName?: string;
 
     /** Click event handler. */
@@ -47,7 +47,7 @@ export interface ILinkProps {
     /** Link URL. */
     href?: string;
 
-    /** Link target attribute. Use "_blank" to open in a new window. */
+    /** Link target attribute. Use "`_blank`" to open in a new window. */
     target?: string;
 }
 
@@ -74,7 +74,7 @@ export interface IOptionProps extends IProps {
     /** Label text for this option. */
     label: string;
 
-    /** Value of this option */
+    /** Value of this option. */
     value: string;
 }
 

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -47,7 +47,7 @@ export interface ILinkProps {
     /** Link URL. */
     href?: string;
 
-    /** Link target attribute. Use "`_blank`" to open in a new window. */
+    /** Link target attribute. Use `"_blank"` to open in a new window. */
     target?: string;
 }
 

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -21,11 +21,11 @@ export interface IAlertProps extends IProps {
 
     /**
      * The text for the confirm (right-most) button.
-     * @default "Ok"
+     * @default "OK"
      */
     confirmButtonText?: string;
 
-    /** Name of optional icon to display next to alert message. */
+    /** Name of the icon (the part after `pt-icon-`) to add next to the alert message */
     iconName?: string;
 
     /**
@@ -40,7 +40,7 @@ export interface IAlertProps extends IProps {
     isOpen: boolean;
 
     /**
-     * CSS Styles to apply to the .pt-alert element.
+     * CSS styles to apply to the alert.
      */
     style?: React.CSSProperties;
 

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -57,7 +57,7 @@ export interface IAlertProps extends IProps {
 
 export class Alert extends AbstractComponent<IAlertProps, {}> {
     public static defaultProps: IAlertProps = {
-        confirmButtonText: "Ok",
+        confirmButtonText: "OK",
         isOpen: false,
         onConfirm: null,
     };

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -53,7 +53,7 @@ Make sure to review the [general usage docs for JS components](#components.usage
 
 The component renders an `a.pt-breadcrumb`.
 You are responsible for constructing the `ul.pt-breadcrumbs` list.
-The [CollapsibleList component](#components.collapsiblelist) works nicely with this component
+[`CollapsibleList`](#components.collapsiblelist) works nicely with this component
 because its props are a subset of `IMenuItemProps`.
 
 @interface IBreadcrumbProps

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -18,11 +18,11 @@ export interface IButtonProps extends IActionProps {
     /** A ref handler that receives the native HTML element backing this component. */
     elementRef?: (ref: HTMLElement) => any;
 
-    /** Name of icon (the part after `pt-icon-`) to add to button. */
+    /** Name of the icon (the part after `pt-icon-`) to add to the button. */
     rightIconName?: string;
 
     /**
-     * If set to true, the button will display a centered loading spinner instead of its contents.
+     * If set to `true`, the button will display a centered loading spinner instead of its contents.
      * The width of the button is not affected by the value of this prop.
      * @default false
      */

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -15,7 +15,7 @@ import { IProps } from "../../common/props";
 export interface ICollapseProps extends IProps {
     /**
      * Component to render as the root element.
-     * Useful when rendering a Collapse inside a `<table>`, for instance.
+     * Useful when rendering a `Collapse` inside a `<table>`, for instance.
      * @default "div"
      */
     component?: React.ReactType;
@@ -27,7 +27,7 @@ export interface ICollapseProps extends IProps {
     isOpen?: boolean;
 
     /**
-     * The length of time the transition takes, in ms. This must match the duration of the animation in CSS.
+     * The length of time the transition takes, in milliseconds. This must match the duration of the animation in CSS.
      * Only set this prop if you override Blueprint's default transitions with new transitions of a different length.
      * @default 200
      */

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -30,7 +30,7 @@ export interface ICollapsibleListProps extends IProps {
     dropdownTarget: JSX.Element;
 
     /**
-     * Props to pass to the dropdown popover.
+     * Props to pass to the dropdown.
      */
     dropdownProps?: IPopoverProps;
 

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -28,29 +28,28 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
     hasBackdrop?: boolean;
 
     /**
-     * Name of icon (the part after `pt-icon-`) to appear in the dialog's header.
+     * Name of the icon (the part after `pt-icon-`) to appear in the dialog's header.
      * Note that the header will only be rendered if `title` is provided.
      */
     iconName?: string;
 
     /**
-     * Whether to show the close "X" button in the dialog's header.
+     * Whether to show the close button in the dialog's header.
      * Note that the header will only be rendered if `title` is provided.
      * @default true
      */
     isCloseButtonShown?: boolean;
 
     /**
-     * CSS Styles to apply to the .pt-dialog element.
+     * CSS styles to apply to the dialog.
      * @default {}
      */
     style?: React.CSSProperties;
 
     /**
-     * Title of dialog.
+     * Title of the dialog.
      * If provided, a `.pt-dialog-header` element will be rendered inside the dialog
      * before any children elements.
-     * In the next major version, this prop will be required.
      */
     title?: string | JSX.Element;
 }

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -50,6 +50,7 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
      * Title of the dialog.
      * If provided, a `.pt-dialog-header` element will be rendered inside the dialog
      * before any children elements.
+     * In the next major version, this prop will be required.
      */
     title?: string | JSX.Element;
 }

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -43,9 +43,8 @@ element](https://facebook.github.io/react/docs/forms.html) and supports controll
 usage through the `value` or `defaultValue` props, respectively.
 
 The `onConfirm` and `onCancel` callbacks are invoked based on user interaction. The user presses
-<kbd class="pt-key">enter</kbd> or blurs the input to confirm the current value, or presses <kbd
-class="pt-key">esc</kbd> to cancel. Canceling resets the field to the last confirmed value. Neither
-callback is invoked if the value is unchanged.
+<code>enter</code> or blurs the input to confirm the current value, or presses <code>esc</code> to cancel.
+Canceling resets the field to the last confirmed value. Neither callback is invoked if the value is unchanged.
 
 `EditableText` by default supports _exactly one line of text_ and will grow or shrink horizontally
 based on the length of text. See below for information on [multiline
@@ -66,11 +65,9 @@ Multiline mode
 Provide the `multiline` prop to create an `EditableText` field that spans multiple lines. Multiline
 mode uses a `<textarea>` instead of an `<input type="text">` to support multiple lines of text.
 
-Users confirm text in multiline mode by pressing <kbd class="pt-key">ctrl</kbd> <kbd
-class="pt-key">enter</kbd> or
-<kbd class="pt-key">cmd</kbd> <kbd class="pt-key">enter</kbd> rather than simply <kbd
-class="pt-key">enter</kbd>. (Pressing the <kbd class="pt-key">enter</kbd> key by itself moves the
-cursor to the next line.)
+Users confirm text in multiline mode by pressing <code>ctrl</code> <code>enter</code> or
+<code>cmd</code> <code>enter</code> rather than simply <code>enter</code>. (Pressing the
+<code>enter</code> key by itself moves the cursor to the next line.)
 
 Additionally, in multiline mode the component's width is fixed at 100%. It grows or shrinks
 _vertically_ instead, based on the number of lines of text. You can use the `minLines` and

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -43,8 +43,8 @@ element](https://facebook.github.io/react/docs/forms.html) and supports controll
 usage through the `value` or `defaultValue` props, respectively.
 
 The `onConfirm` and `onCancel` callbacks are invoked based on user interaction. The user presses
-<code>enter</code> or blurs the input to confirm the current value, or presses <code>esc</code> to cancel.
-Canceling resets the field to the last confirmed value. Neither callback is invoked if the value is unchanged.
+`enter` or blurs the input to confirm the current value, or presses `esc` to cancel. Canceling resets
+the field to the last confirmed value. Neither callback is invoked if the value is unchanged.
 
 `EditableText` by default supports _exactly one line of text_ and will grow or shrink horizontally
 based on the length of text. See below for information on [multiline
@@ -65,9 +65,8 @@ Multiline mode
 Provide the `multiline` prop to create an `EditableText` field that spans multiple lines. Multiline
 mode uses a `<textarea>` instead of an `<input type="text">` to support multiple lines of text.
 
-Users confirm text in multiline mode by pressing <code>ctrl</code> <code>enter</code> or
-<code>cmd</code> <code>enter</code> rather than simply <code>enter</code>. (Pressing the
-<code>enter</code> key by itself moves the cursor to the next line.)
+Users confirm text in multiline mode by pressing `ctrl` `enter` or `cmd` `enter` rather than
+simply `enter`. (Pressing the `enter` key by itself moves the cursor to the next line.)
 
 Additionally, in multiline mode the component's width is fixed at 100%. It grows or shrinks
 _vertically_ instead, based on the number of lines of text. You can use the `minLines` and

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -69,7 +69,7 @@ export interface IEditableTextProps extends IIntentProps, IProps {
 
     /**
      * Whether the entire text field should be selected on focus.
-     * If false, the cursor is placed at the end of the text.
+     * If `false`, the cursor is placed at the end of the text.
      * @default false
      */
     selectAllOnFocus?: boolean;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -19,7 +19,7 @@ export interface IControlProps extends IProps {
     /** Whether the control is checked. */
     checked?: boolean;
 
-    /** Whether the control is initially checked (uncontrolled) */
+    /** Whether the control is initially checked (uncontrolled mode). */
     defaultChecked?: boolean;
 
     /** Whether the control is non-interactive. */
@@ -28,10 +28,10 @@ export interface IControlProps extends IProps {
     /** Ref handler that receives HTML `<input>` element backing this component. */
     inputRef?: (ref: HTMLInputElement) => any;
 
-    /** Text label for control. */
+    /** Text label for the control. */
     label?: string;
 
-    /** Event handler invoked when input value is changed */
+    /** Event handler invoked when input value is changed. */
     onChange?: React.FormEventHandler<HTMLInputElement>;
 }
 
@@ -62,10 +62,10 @@ export class Control<P extends IControlProps> extends React.Component<React.HTML
 }
 
 export interface ICheckboxProps extends IControlProps {
-    /** Whether this checkbox is initially indeterminate (uncontrolled) */
+    /** Whether this checkbox is initially indeterminate (uncontrolled mode). */
     defaultIndeterminate?: boolean;
 
-    /** Whether this checkbox is indeterminate */
+    /** Whether this checkbox is indeterminate. */
     indeterminate?: boolean;
 }
 

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -23,7 +23,7 @@ export interface IInputGroupProps extends IControlledProps, IIntentProps, IProps
     /** Ref handler that receives HTML `<input>` element backing this component. */
     inputRef?: (ref: HTMLInputElement) => any;
 
-    /** Name of icon (the part after `pt-icon-`) to render on left side of input. */
+    /** Name of the icon (the part after `pt-icon-`) to render on left side of input. */
     leftIconName?: string;
 
     /** Placeholder text in the absence of any value. */

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -34,12 +34,15 @@ export interface INumericInputProps extends IIntentProps, IProps {
     buttonPosition?: Position.LEFT | Position.RIGHT | "none";
 
     /**
-     * Whether the input is in a non-interactive state.
+     * Whether the input is non-interactive.
      * @default false
      */
     disabled?: boolean;
 
-    /** The name of icon (the part after `pt-icon-`) to render on left side of input. */
+    /**
+     * Name of the icon (the part after `pt-icon-`) to render
+     * on the left side of input.
+     */
     leftIconName?: string;
 
     /** The placeholder text in the absence of any value. */

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -18,7 +18,7 @@ export interface IHotkeyProps {
     combo: string;
 
     /**
-     * Human-friendly label for this hotkey.
+     * Human-friendly label for the hotkey.
      */
     label: string;
 
@@ -38,12 +38,12 @@ export interface IHotkeyProps {
     group?: string;
 
     /**
-     * `keydown` event handler
+     * `keydown` event handler.
      */
     onKeyDown?(e: KeyboardEvent): any;
 
     /**
-     * `keyup` event handler
+     * `keyup` event handler.
      */
     onKeyUp?(e: KeyboardEvent): any;
 }

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -24,7 +24,7 @@ export interface IHotkeysProps extends IProps {
      * to the hotkey target, which makes it focusable. By default, we use `0`,
      * but you can override this value to change the tab navigation behavior
      * of the component. You may even set this value to `null`, which will omit
-     * the tabIndex from the component decorated by `HotkeysTarget`.
+     * the `tabIndex` from the component decorated by `HotkeysTarget`.
      */
     tabIndex?: number;
 }

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -12,7 +12,7 @@ import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
 export interface IMenuDividerProps extends IProps {
-    /** Optional header title */
+    /** Optional header title. */
     title?: string;
 }
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -23,7 +23,7 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
     text: string;
 
     /**
-     * Right-aligned label content, useful for hotkeys.
+     * Right-aligned label content, useful for displaying hotkeys.
      */
     label?: string | JSX.Element;
 
@@ -41,9 +41,9 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
     submenu?: IMenuItemProps[];
 
     /**
-     * Width of "margin" from left or right edge of viewport. Submenus will
+     * Width of `margin` from left or right edge of viewport. Submenus will
      * flip to the other side if they come within this distance of that edge.
-     * This has no effect if omitted or if `useSmartPositioning={false}`.
+     * This has no effect if omitted or if `useSmartPositioning` is set to `false`.
      * Note that these values are not CSS properties; they are used in
      * internal math to determine when to flip sides.
      */

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -14,22 +14,22 @@ import { IProps } from "../../common/props";
 
 export interface INonIdealStateProps extends IProps {
     /*
-     * An action the user can take to correct the non-ideal state.
+     * An action that's attached to the non-ideal state.
      */
     action?: JSX.Element;
 
     /**
-     * A longer description of the current non-ideal state.
+     * A longer description of the non-ideal state.
      */
     description?: string | JSX.Element;
 
     /**
-     * The title of the current non-ideal state.
+     * The title of the non-ideal state.
      */
     title?: string;
 
     /**
-     * A name of a Blueprint icon to display or a JSX Element (such as `<Spinner/>`).
+     * The name of a Blueprint icon to display or a JSX Element (such as `<Spinner/>`).
      */
     visual?: string | JSX.Element;
 }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -42,7 +42,7 @@ export interface IOverlayableProps {
      * Whether the overlay should be rendered inline or into a new element on `document.body`.
      * This prop essentially determines which element is covered by the backdrop: if `true`,
      * then only its parent is covered; otherwise, the entire application is covered.
-     * Set this prop to true when this component is used inside an `Overlay` (such as
+     * Set this prop to `true` when this component is used inside an `Overlay` (such as
      * `Dialog` or `Popover`) to ensure that this component is rendered above its parent.
      * @default false
      */

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -24,7 +24,7 @@ export interface IToastProps extends IProps, IIntentProps {
      */
     action?: IActionProps & ILinkProps;
 
-    /** Name of icon to appear before message. Specify only the part of the name after `pt-icon-`. */
+    /** Name of the icon (the part after `pt-icon-`) to appear before the message. */
     iconName?: string;
 
     /** Message to display in the body of the toast. */
@@ -38,7 +38,7 @@ export interface IToastProps extends IProps, IIntentProps {
 
     /**
      * Milliseconds to wait before automatically dismissing toast.
-     * Providing a value <= 0 will disable the timeout (this is discouraged).
+     * Providing a value less than or equal to 0 will disable the timeout (this is discouraged).
      * @default 5000
      */
     timeout?: number;

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -24,7 +24,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
 
     /**
      * Constraints for the underlying Tether instance.
-     * @see http://github.hubspot.com/tether/#constraints
+     * See http://github.hubspot.com/tether/#constraints
      */
     constraints?: ITetherConstraint[];
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -78,7 +78,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
 
     /**
      * Space-delimited string of class names applied to the
-     * portal which holds the tooltip if `inline = false`.
+     * portal which holds the tooltip if `inline` is set to `false`.
      */
     portalClassName?: string;
 
@@ -110,7 +110,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
 
     /**
      * Whether the arrow's offset should be computed such that it always points at the center
-     * of the target. If false, arrow position is hardcoded via CSS, which expects a 30px target.
+     * of the target. If `false`, arrow position is hardcoded via CSS, which expects a 30px target.
      * @default true
      */
     useSmartArrowPositioning?: boolean;

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -31,7 +31,7 @@ import {
 export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
-     * Passed to `DatePicker` component
+     * Passed to `DatePicker` component.
      * @default true
      */
     canClearSelection?: boolean;
@@ -43,7 +43,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     closeOnSelection?: boolean;
 
     /**
-     * Whether the component should be enabled or disabled.
+     * Whether the date input is non-interactive.
      * @default false
      */
     disabled?: boolean;
@@ -54,14 +54,13 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     defaultValue?: Date;
 
     /**
-     * The format of the date. See options
-     * here: http://momentjs.com/docs/#/displaying/format/
+     * The format of the date. See http://momentjs.com/docs/#/displaying/format/.
      * @default "YYYY-MM-DD"
      */
     format?: string;
 
     /**
-     * The error message to display when the date selected invalid.
+     * The error message to display when the date selected is invalid.
      * @default "Invalid date"
      */
     invalidDateMessage?: string;
@@ -75,19 +74,19 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     /**
      * Called when the user finishes typing in a new date and the date causes an error state.
      * If the date is invalid, `new Date(undefined)` will be returned. If the date is out of range,
-     * the out of range date will be returned (`onChange` is not called in this case).
+     * the out-of-range date will be returned (`onChange` is not called in this case).
      */
     onError?: (errorDate: Date) => void;
 
     /**
-     * If true, the Popover will open when the user clicks on the input. If false, the Popover will only
+     * If `true`, the popover will open when the user clicks on the input. If `false`, the popover will only
      * open when the calendar icon is clicked.
      * @default true
      */
     openOnFocus?: boolean;
 
     /**
-     * The error message to display when the date selected is out of range.
+     * The error message to display when the date selected is out-of-range.
      * @default "Out of range"
      */
     outOfRangeMessage?: string;
@@ -99,7 +98,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverPosition?: Position;
 
     /**
-     * The currently selected day. If this prop is present, the component acts in a controlled manner.
+     * The currently selected day. If this prop is provided, the component acts in a controlled manner.
      * To display no date in the input field, pass `null` to the value prop. To display an invalid date error
      * in the input field, pass `new Date(undefined)` to the value prop.
      */

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -74,7 +74,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     /**
      * Called when the user finishes typing in a new date and the date causes an error state.
      * If the date is invalid, `new Date(undefined)` will be returned. If the date is out of range,
-     * the out-of-range date will be returned (`onChange` is not called in this case).
+     * the out of range date will be returned (`onChange` is not called in this case).
      */
     onError?: (errorDate: Date) => void;
 
@@ -86,7 +86,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     openOnFocus?: boolean;
 
     /**
-     * The error message to display when the date selected is out-of-range.
+     * The error message to display when the date selected is out of range.
      * @default "Out of range"
      */
     outOfRangeMessage?: string;

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -45,13 +45,13 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
 
    /**
-    * Whether the bottom bar displaying 'Today' and 'Clear' buttons should be shown.
+    * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
     * @default false
     */
     showActionsBar?: boolean;
 
    /**
-    * The currently selected day. If this prop is present, the component acts in a controlled manner.
+    * The currently selected day. If this prop is provided, the component acts in a controlled manner.
     */
     value?: Date;
 }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -42,7 +42,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     allowSingleDayRange?: boolean;
 
     /**
-     * Initial DateRange the calendar will display as selected.
+     * Initial `DateRange` the calendar will display as selected.
      * This should not be set if `value` is set.
      */
     defaultValue?: DateRange;
@@ -59,14 +59,14 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * Whether shortcuts to quickly select a range of dates are displayed or not.
      * If `true`, preset shortcuts will be displayed.
      * If `false`, no shortcuts will be displayed.
-     * If an array, the custom shortcuts provided will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
      * @default true
      */
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
-     * The currently selected DateRange.
-     * If this prop is present, the component acts in a controlled manner.
+     * The currently selected `DateRange`.
+     * If this prop is provided, the component acts in a controlled manner.
      */
     value?: DateRange;
 }

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -41,7 +41,7 @@ export interface IDateTimePickerProps extends IProps {
     timePickerProps?: ITimePickerProps;
 
     /**
-     * The currently set date and time. If this prop is present, the component acts in a controlled manner.
+     * The currently set date and time. If this prop is provided, the component acts in a controlled manner.
      */
     value?: Date;
 }

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -51,7 +51,7 @@ export interface ITimePickerProps extends IProps {
 
    /**
     * The currently set time.
-    * If this prop is present, the component acts in a controlled manner.
+    * If this prop is provided, the component acts in a controlled manner.
     */
     value?: Date;
 }

--- a/packages/docs/src/styles/_props.scss
+++ b/packages/docs/src/styles/_props.scss
@@ -36,7 +36,6 @@
     background: none;
     padding: 0;
     color: inherit;
-    font-size: $pt-font-size;
     font-weight: 600;
   }
 

--- a/packages/docs/src/styles/_props.scss
+++ b/packages/docs/src/styles/_props.scss
@@ -36,6 +36,7 @@
     background: none;
     padding: 0;
     color: inherit;
+    font-size: $pt-font-size;
     font-weight: 600;
   }
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -19,15 +19,15 @@ export interface ICellProps extends IIntentProps, IProps {
     style?: React.CSSProperties;
 
     /**
-     * If true, the cell will be rendered above overlay layers to enable mouse
+     * If `true`, the cell will be rendered above overlay layers to enable mouse
      * interactions within the cell.
      * @default false
      */
     interactive?: boolean;
 
     /**
-     * An optional native tooltip that is displayed on hover
-     * If true, content will be replaced with a fixed-height skeleton.
+     * An optional native tooltip that is displayed on hover.
+     * If `true`, content will be replaced with a fixed-height skeleton.
      * @default false
      */
     loading?: boolean;
@@ -38,7 +38,7 @@ export interface ICellProps extends IIntentProps, IProps {
     tooltip?: string;
 
     /**
-     * If true, the cell contents will be wrapped in a div with
+     * If `true`, the cell contents will be wrapped in a `div` with
      * styling that will prevent the content from overflowing the cell.
      * @default true
      */

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -23,7 +23,7 @@ export interface IEditableCellProps extends ICellProps {
 
     /**
      * A listener that is triggered if the user cancels the edit. This is
-     * important to listen to if you are doing anything with onChange events,
+     * important to listen to if you are doing anything with `onChange` events,
      * since you'll likely want to revert whatever changes you made.
      */
     onCancel?: (value: string) => void;
@@ -36,8 +36,7 @@ export interface IEditableCellProps extends ICellProps {
 
     /**
      * A listener that is triggered once the editing is confirmed. This is
-     * usually due to the <kbd class="pt-key">return</kbd> (or
-     * <kbd class="pt-key">enter</kbd>) key press.
+     * usually due to the <code>return</code> (or <code>enter</code>) key press.
      */
     onConfirm?: (value: string) => void;
 }

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -15,16 +15,16 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     children?: any;
 
     /**
-     * By default we omit stringifying native javascript strings since
+     * By default, we omit stringifying native JavaScript strings since
      * `JSON.stringify` awkwardly adds double-quotes to the display value.
-     * This behavior can be turned off by setting this boolean to false.
+     * This behavior can be turned off by setting this boolean to `false`.
      * @default true
      */
     omitQuotesOnStrings?: boolean;
 
     /**
      * Optionally specify the stringify method. Default is `JSON.stringify`
-     * with 2 space indentation.
+     * with 2-space indentation.
      */
     stringify?: (obj: any) => string;
 }

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -30,9 +30,9 @@ export interface ITruncatedFormatProps extends IProps {
      * Configures when the popover is shown with the `TruncatedPopoverMode` enum.
      *
      * The enum values are:
-     * - `ALWAYS` - show the popover (default).
-     * - `NEVER` - don't show the popover.
-     * - `WHEN_TRUNCATED` - show the popover only when the text is truncated.
+     * - `ALWAYS`: show the popover (default).
+     * - `NEVER`: don't show the popover.
+     * - `WHEN_TRUNCATED`: show the popover only when the text is truncated.
      */
     showPopover?: TruncatedPopoverMode;
 

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -26,7 +26,7 @@ export interface IColumnProps extends IColumnNameProps, IProps {
     /**
      * Set this prop to specify whether to render the loading state of the
      * column header and cells in this column. Column-level `loadingOptions`
-     * override Table-level `loadingOptions`. For example, if you set
+     * override table-level `loadingOptions`. For example, if you set
      * `loadingOptions=[ TableLoadingOption.CELLS ]` on `Table` and
      * `loadingOptions=[ ColumnLoadingOption.HEADER ]` on a `Column`, the cells
      * in that column will _not_ show their loading state.
@@ -35,13 +35,13 @@ export interface IColumnProps extends IColumnNameProps, IProps {
 
     /**
      * An instance of `ICellRenderer`, a function that takes a row and column
-     * index, and returns a `Cell` React element
+     * index, and returns a `Cell` React element.
      */
     renderCell?: ICellRenderer;
 
     /**
      * An instance of `IColumnHeaderRenderer`, a function that takes a column
-     * index and returns a `ColumnHeaderCell` React element
+     * index and returns a `ColumnHeaderCell` React element.
      */
     renderColumnHeader?: IColumnHeaderRenderer;
 }

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -26,7 +26,7 @@ export interface IColumnProps extends IColumnNameProps, IProps {
     /**
      * Set this prop to specify whether to render the loading state of the
      * column header and cells in this column. Column-level `loadingOptions`
-     * override table-level `loadingOptions`. For example, if you set
+     * override `Table`-level `loadingOptions`. For example, if you set
      * `loadingOptions=[ TableLoadingOption.CELLS ]` on `Table` and
      * `loadingOptions=[ ColumnLoadingOption.HEADER ]` on a `Column`, the cells
      * in that column will _not_ show their loading state.

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -32,12 +32,12 @@ export interface IColumnNameProps {
      * `EditableName` component for editing column names.
      *
      * If you define this callback, we recommend you also set
-     * `useInteractionBar` to true, to avoid issues with menus or selection.
+     * `useInteractionBar` to `true`, to avoid issues with menus or selection.
      */
     renderName?: (name: string) => React.ReactElement<IProps>;
 
     /**
-     * If true, adds an interaction bar on top of the column header cell and
+     * If `true`, adds an interaction bar on top of the column header cell and
      * moves the menu and selection interactions to it.
      *
      * This allows you to override the rendering of column name without worry
@@ -50,7 +50,7 @@ export interface IColumnNameProps {
 
 export interface IColumnHeaderCellProps extends IColumnNameProps, IProps {
     /**
-     * If true, will apply the active class to the header to indicate it is
+     * If `true`, will apply the active class to the header to indicate it is
      * part of an external operation.
      *
      * @default false
@@ -63,9 +63,9 @@ export interface IColumnHeaderCellProps extends IColumnNameProps, IProps {
     isColumnSelected?: boolean;
 
     /**
-     * If true, the column `name` will be replaced with a fixed-height skeleton and the
+     * If `true`, the column `name` will be replaced with a fixed-height skeleton and the
      * `resizeHandle` will not be rendered. If passing in additional children to this component, you
-     * will also want to conditionally apply the `.pt-skeleton` class where appropriate.
+     * will also want to conditionally apply the `pt-skeleton` class where appropriate.
      * @default false
      */
     loading?: boolean;
@@ -84,7 +84,7 @@ export interface IColumnHeaderCellProps extends IColumnNameProps, IProps {
     menuIconName?: string;
 
     /**
-     * CSS styles for the top level element
+     * CSS styles for the top level element.
      */
     style?: React.CSSProperties;
 
@@ -120,9 +120,9 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
     };
 
     /**
-     * This method determines if a MouseEvent was triggered on a target that
+     * This method determines if a `MouseEvent` was triggered on a target that
      * should be used as the header click/drag target. This enables users of
-     * this component to render full interactive components in their header
+     * this component to render fully interactive components in their header
      * cells without worry of selection or resize operations from capturing
      * their mouse events.
      */

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -31,7 +31,7 @@ export interface IEditableNameProps extends IIntentProps, IProps {
 
     /**
      * A listener that is triggered once the editing is confirmed. This is
-     * usually due to the <code>return</code> (or <code>enter</code>) key press.
+     * usually due to the `return` (or `enter`) key press.
      */
     onConfirm?: (value: string) => void;
 }

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -18,7 +18,7 @@ export interface IEditableNameProps extends IIntentProps, IProps {
 
     /**
      * A listener that is triggered if the user cancels the edit. This is
-     * important to listen to if you are doing anything with onChange events,
+     * important to listen to if you are doing anything with `onChange` events,
      * since you'll likely want to revert whatever changes you made.
      */
     onCancel?: (value: string) => void;
@@ -31,8 +31,7 @@ export interface IEditableNameProps extends IIntentProps, IProps {
 
     /**
      * A listener that is triggered once the editing is confirmed. This is
-     * usually due to the <kbd class="pt-key">return</kbd> (or
-     * <kbd class="pt-key">enter</kbd>) key press.
+     * usually due to the <code>return</code> (or <code>enter</code>) key press.
      */
     onConfirm?: (value: string) => void;
 }

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -15,7 +15,7 @@ import { ResizeHandle } from "../interactions/resizeHandle";
 
 export interface IRowHeaderCellProps extends IProps {
     /**
-     * If true, will apply the active class to the header to indicate it is
+     * If `true`, will apply the active class to the header to indicate it is
      * part of an external operation.
      */
     isActive?: boolean;
@@ -31,7 +31,7 @@ export interface IRowHeaderCellProps extends IProps {
     name?: string;
 
     /**
-     * If true, the row `name` will be replaced with a fixed-height skeleton and the `resizeHandle`
+     * If `true`, the row `name` will be replaced with a fixed-height skeleton and the `resizeHandle`
      * will not be rendered. If passing in additional children to this component, you will also want
      * to conditionally apply the `.pt-skeleton` class where appropriate.
      * @default false

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -16,15 +16,15 @@ export type ISelectedRegionTransform = (region: IRegion, event: MouseEvent, coor
 export interface ISelectableProps {
     /**
      * If `false`, only a single region of a single column/row/cell may be
-     * selected at one time. Using <kbd class="pt-key">ctrl</kbd> or
-     * <kbd class="pt-key">meta</kbd> key will have no effect,
-     * and a mouse drag will select the current column/row/cell only.
+     * selected at one time. Using <code>ctrl</code> or <code>meta</code>
+     * key will have no effect, and a mouse drag will select the current
+     * column/row/cell only.
      */
     allowMultipleSelection: boolean;
 
     /**
      * When the user selects something, this callback is called with a new
-     * array of Regions. This array should be considered the new selection
+     * array of `Region`s. This array should be considered the new selection
      * state for the entire table.
      */
     onSelection: (regions: IRegion[]) => void;

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -16,9 +16,8 @@ export type ISelectedRegionTransform = (region: IRegion, event: MouseEvent, coor
 export interface ISelectableProps {
     /**
      * If `false`, only a single region of a single column/row/cell may be
-     * selected at one time. Using <code>ctrl</code> or <code>meta</code>
-     * key will have no effect, and a mouse drag will select the current
-     * column/row/cell only.
+     * selected at one time. Using `ctrl` or `meta` key will have no effect,
+     * and a mouse drag will select the current column/row/cell only.
      */
     allowMultipleSelection: boolean;
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -41,9 +41,8 @@ import { TableBody } from "./tableBody";
 export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     /**
      * If `false`, only a single region of a single column/row/cell may be
-     * selected at one time. Using <code>ctrl</code> or <code>meta</code>
-     * key will have no effect, and a mouse drag will select the current
-     * column/row/cell only.
+     * selected at one time. Using `ctrl` or `meta` key will have no effect,
+     * and a mouse drag will select the current column/row/cell only.
      * @default true
      */
     allowMultipleSelection?: boolean;
@@ -62,10 +61,10 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     fillBodyWithGhostCells?: boolean;
 
     /**
-     * Used for hotkey copy, via (mod+c), as long as this property exists.
-     * If exists, a callback that returns the data for a specific cell. This need not
-     * match the value displayed in the `<Cell>` component. The value will be
-     * invisibly added as `textContent` into the DOM before copying.
+     * Used for hotkey copy, via `mod+c`, as long as this property exists. If it
+     * exists, a callback that returns the data for a specific cell. This need
+     * not match the value displayed in the `<Cell>` component. The value will
+     * be invisibly added as `textContent` into the DOM before copying.
      */
     getCellClipboardData?: (row: number, col: number) => any;
 
@@ -185,11 +184,19 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * equivalently provide an array of `RegionCardinality` enum values for
      * precise configuration.
      *
-     * The `SelectionModes` enum values are: `ALL`, `NONE`, `COLUMNS_AND_CELLS`,
-     * `COLUMNS_ONLY`, `ROWS_AND_CELLS`, `ROWS_ONLY`.
+     * The `SelectionModes` enum values are:
+     * - `ALL`
+     * - `NONE`
+     * - `COLUMNS_AND_CELLS`
+     * - `COLUMNS_ONLY`
+     * - `ROWS_AND_CELLS`
+     * - `ROWS_ONLY`
      *
-     * The `RegionCardinality` enum values are: `FULL_COLUMNS`, `FULL_ROWS`,
-     * `FULL_TABLE`, `CELLS`.
+     * The `RegionCardinality` enum values are:
+     * - `FULL_COLUMNS`
+     * - `FULL_ROWS`
+     * - `FULL_TABLE`
+     * - `CELLS`
      *
      * @default SelectionModes.ALL
      */

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -61,10 +61,11 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     fillBodyWithGhostCells?: boolean;
 
     /**
-     * Used for hotkey copy, via `mod+c`, as long as this property exists. If it
-     * exists, a callback that returns the data for a specific cell. This need
-     * not match the value displayed in the `<Cell>` component. The value will
-     * be invisibly added as `textContent` into the DOM before copying.
+     * If defined, this callback will be invoked for each cell when the user
+     * attempts to copy a selection via `mod+c`. The returned data will be copied
+     * to the clipboard and need not match the display value of the `<Cell>`.
+     * The data will be invisibly added as `textContent` into the DOM before
+     * copying. If not defined, keyboard copying via `mod+c` will be disabled.
      */
     getCellClipboardData?: (row: number, col: number) => any;
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -41,9 +41,9 @@ import { TableBody } from "./tableBody";
 export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     /**
      * If `false`, only a single region of a single column/row/cell may be
-     * selected at one time. Using <kbd class="pt-key">ctrl</kbd> or
-     * <kbd class="pt-key">meta</kbd> key will have no effect,
-     * and a mouse drag will select the current column/row/cell only.
+     * selected at one time. Using <code>ctrl</code> or <code>meta</code>
+     * key will have no effect, and a mouse drag will select the current
+     * column/row/cell only.
      * @default true
      */
     allowMultipleSelection?: boolean;
@@ -55,22 +55,22 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     children?: React.ReactElement<IColumnProps>;
 
     /**
-     * If true, empty space in the table container will be filled with empty
+     * If `true`, empty space in the table container will be filled with empty
      * cells instead of a blank background.
      * @default false
      */
     fillBodyWithGhostCells?: boolean;
 
     /**
-     * Used for hotkey copy, via (mod+c), as long as this property exists. 
+     * Used for hotkey copy, via (mod+c), as long as this property exists.
      * If exists, a callback that returns the data for a specific cell. This need not
      * match the value displayed in the `<Cell>` component. The value will be
-     * invisibly added as `textContent` into the DOM before copying. 
+     * invisibly added as `textContent` into the DOM before copying.
      */
     getCellClipboardData?: (row: number, col: number) => any;
 
     /**
-     * If false, disables resizing of columns.
+     * If `false`, disables resizing of columns.
      * @default true
      */
     isColumnResizable?: boolean;
@@ -97,7 +97,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     columnWidths?: number[];
 
     /**
-     * If false, disables resizing of rows.
+     * If `false`, disables resizing of rows.
      * @default false
      */
     isRowResizable?: boolean;
@@ -117,7 +117,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     rowHeights?: number[];
 
     /**
-     * If false, hides the row headers and settings menu.
+     * If `false`, hides the row headers and settings menu.
      * @default true
      */
     isRowHeaderShown?: boolean;
@@ -139,7 +139,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     onCopy?: (success: boolean) => void;
 
     /**
-     * Render each row's header cell
+     * Render each row's header cell.
      */
     renderRowHeader?: IRowHeaderRenderer;
 
@@ -159,7 +159,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
 
     /**
      * If defined, will set the selected regions in the cells. If defined, this
-     * changes table selection to "controlled" mode, meaning you in charge of
+     * changes table selection to controlled mode, meaning you in charge of
      * setting the selections in response to events in the `onSelection`
      * callback.
      *
@@ -185,16 +185,8 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * equivalently provide an array of `RegionCardinality` enum values for
      * precise configuration.
      *
-     * ```
-     * SelectionModes enum values:
-     * ALL
-     * NONE
-     * COLUMNS_AND_CELLS
-     * COLUMNS_ONLY
-     * ROWS_AND_CELLS
-     * ROWS_ONLY
-     * ```
-     *
+     * The `SelectionModes` enum values are: `ALL`, `NONE`, `COLUMNS_AND_CELLS`,
+     * `COLUMNS_ONLY`, `ROWS_AND_CELLS`, `ROWS_ONLY`.
      * ```
      * RegionCardinality enum values:
      * FULL_COLUMNS
@@ -202,6 +194,8 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * FULL_TABLE
      * CELLS
      * ```
+     * The `SelectionModes` enum values are: `FULL_COLUMNS`, `FULL_ROWS`,
+     * `FULL_TABLE`, `CELLS`.
      *
      * @default SelectionModes.ALL
      */
@@ -209,7 +203,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
 
     /**
      * Styled region groups are rendered as overlays above the table and are
-     * marked with their own className for custom styling.
+     * marked with their own `className` for custom styling.
      */
     styledRegionGroups?: IStyledRegionGroup[];
 }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -187,14 +187,8 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      *
      * The `SelectionModes` enum values are: `ALL`, `NONE`, `COLUMNS_AND_CELLS`,
      * `COLUMNS_ONLY`, `ROWS_AND_CELLS`, `ROWS_ONLY`.
-     * ```
-     * RegionCardinality enum values:
-     * FULL_COLUMNS
-     * FULL_ROWS
-     * FULL_TABLE
-     * CELLS
-     * ```
-     * The `SelectionModes` enum values are: `FULL_COLUMNS`, `FULL_ROWS`,
+     *
+     * The `RegionCardinality` enum values are: `FULL_COLUMNS`, `FULL_ROWS`,
      * `FULL_TABLE`, `CELLS`.
      *
      * @default SelectionModes.ALL


### PR DESCRIPTION
- Consistent wording for similar props descriptions
- Add backticks and periods where missing
- Increases the size of `<code>` inside props table for better readability