### PR TITLE
Speed up tooltips by default

### DIFF
--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -117,7 +117,7 @@ Styleguide components.tooltip.js.svg
   @include react-transition(
     "pt-popover",
     (transform: scale(0.8) scale(1)),
-    $duration: $pt-transition-duration * 2,
+    $duration: $pt-transition-duration,
     $after: "> &"
   );
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -46,7 +46,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
      * The amount of time in milliseconds the tooltip should wait before opening after the
      * user hovers over the trigger. The timer is canceled if the user mouses away from the
      * target before it expires.
-     * @default 150
+     * @default 0
      */
     hoverOpenDelay?: number;
 
@@ -129,7 +129,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
         className: "",
         content: "",
         hoverCloseDelay: 0,
-        hoverOpenDelay: 150,
+        hoverOpenDelay: 0,
         isDisabled: false,
         position: Position.TOP,
         rootElementTag: "span",

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -46,7 +46,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
      * The amount of time in milliseconds the tooltip should wait before opening after the
      * user hovers over the trigger. The timer is canceled if the user mouses away from the
      * target before it expires.
-     * @default 0
+     * @default 100
      */
     hoverOpenDelay?: number;
 
@@ -129,7 +129,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
         className: "",
         content: "",
         hoverCloseDelay: 0,
-        hoverOpenDelay: 0,
+        hoverOpenDelay: 100,
         isDisabled: false,
         position: Position.TOP,
         rootElementTag: "span",
@@ -142,7 +142,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
     public displayName = "Blueprint.Tooltip";
 
     public render(): JSX.Element {
-        const { children, intent, tooltipClassName } = this.props;
+        const { children, intent, tooltipClassName, transitionDuration } = this.props;
         const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
 
         return (
@@ -155,7 +155,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}
                 popoverClassName={classes}
-                transitionDuration={200}
+                transitionDuration={transitionDuration}
             >
                 {children}
             </Popover>

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -142,7 +142,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
     public displayName = "Blueprint.Tooltip";
 
     public render(): JSX.Element {
-        const { children, intent, tooltipClassName, transitionDuration } = this.props;
+        const { children, intent, tooltipClassName } = this.props;
         const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
 
         return (
@@ -155,7 +155,6 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}
                 popoverClassName={classes}
-                transitionDuration={transitionDuration}
             >
                 {children}
             </Popover>


### PR DESCRIPTION
- Sets `hoverOpenDelay` to `0`
- Keep transition duration at 100ms

Thoughts? cc @adidahiya @pkwi @thisisalessandro 