### PR TITLE
restore props defaults

### DIFF
--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -180,6 +180,7 @@ module.exports = (blueprint, gulp, plugins) => {
         const props = tsdoc.fromFiles(glob.sync("packages/*/dist/index.d.ts").concat(TYPINGS_PATH), {}, {
             excludeNames: [/Factory$/, /^I.+State$/],
             excludePaths: ["node_modules/", "core/typings"],
+            includeDefinitionFiles: true,
         }).map(markdownEntry);
 
         return text.fileStream(filenames.props, JSON.stringify(props, null, 2))

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "stylelint-config-palantir": "1.1.0",
     "stylelint-scss": "1.3.4",
     "ts-loader": "0.9.5",
-    "ts-quick-docs": "0.4.0",
+    "ts-quick-docs": "0.5.0",
     "tslint": "4.0.1",
     "tslint-react": "2.0.0",
     "typescript": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "stylelint-config-palantir": "1.1.0",
     "stylelint-scss": "1.3.4",
     "ts-loader": "0.9.5",
-    "ts-quick-docs": "0.5.0",
+    "ts-quick-docs": "0.5.1",
     "tslint": "4.0.1",
     "tslint-react": "2.0.0",
     "typescript": "2.1.5",

--- a/packages/docs/src/common/propsStore.tsx
+++ b/packages/docs/src/common/propsStore.tsx
@@ -1,4 +1,4 @@
-import { IInterfaceEntry, IPropertyEntry } from "ts-quick-docs/src/interfaces";
+import { IInterfaceEntry, IPropertyEntry } from "ts-quick-docs/dist/interfaces";
 
 export class PropsStore {
     constructor(private props: IInterfaceEntry[]) {}

--- a/packages/docs/src/common/propsStore.tsx
+++ b/packages/docs/src/common/propsStore.tsx
@@ -1,9 +1,13 @@
 import { IInterfaceEntry, IPropertyEntry } from "ts-quick-docs/dist/interfaces";
 
+export interface IInheritedPropertyEntry extends IPropertyEntry {
+    inheritedFrom?: string;
+}
+
 export class PropsStore {
     constructor(private props: IInterfaceEntry[]) {}
 
-    public getProps = (name: string): IPropertyEntry[] => {
+    public getProps = (name: string): IInheritedPropertyEntry[] => {
         const entry = this.props.filter((props) => props.name === name)[0];
         if (entry == null) {
             return [];
@@ -22,7 +26,7 @@ export class PropsStore {
     }
 
     private getInheritedProps = (name: string) => {
-        return this.getProps(name).map((p) => {
+        return this.getProps(name).map((p: IInheritedPropertyEntry) => {
             p.inheritedFrom = name;
             return p;
         });

--- a/packages/docs/src/components/propsTable.tsx
+++ b/packages/docs/src/components/propsTable.tsx
@@ -8,7 +8,7 @@
 import { Classes, Intent, Tag } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
-import { IPropertyEntry } from "ts-quick-docs/dist/interfaces";
+import { IInheritedPropertyEntry } from "../common/propsStore";
 
 // HACKHACK support `code` blocks until we get real markdown parsing in ts-quick-docs
 function dirtyMarkdown(text: string) {
@@ -26,7 +26,7 @@ function propsTag(intent: Intent, title: string, ...children: React.ReactNode[])
     );
 }
 
-const renderPropRow = (prop: IPropertyEntry) => {
+const renderPropRow = (prop: IInheritedPropertyEntry) => {
     const { documentation, inheritedFrom, name, optional } = prop;
     const { default: defaultValue, deprecated, internal } = prop.tags;
 
@@ -69,7 +69,7 @@ const renderPropRow = (prop: IPropertyEntry) => {
     );
 };
 
-export const PropsTable: React.SFC<{ name: string, props: IPropertyEntry[] }> = ({ name, props }) => (
+export const PropsTable: React.SFC<{ name: string, props: IInheritedPropertyEntry[] }> = ({ name, props }) => (
     <div className="kss-modifiers">
         <div className="docs-interface-name">{name}</div>
         <table className="pt-table">

--- a/packages/docs/src/components/propsTable.tsx
+++ b/packages/docs/src/components/propsTable.tsx
@@ -8,7 +8,7 @@
 import { Classes, Intent, Tag } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
-import { IPropertyEntry } from "ts-quick-docs/src/interfaces";
+import { IPropertyEntry } from "ts-quick-docs/dist/interfaces";
 
 // HACKHACK support `code` blocks until we get real markdown parsing in ts-quick-docs
 function dirtyMarkdown(text: string) {
@@ -18,7 +18,8 @@ function dirtyMarkdown(text: string) {
 }
 
 const renderPropRow = (prop: IPropertyEntry) => {
-    const { deprecated, documentation, inheritedFrom, internal, name, optional } = prop;
+    const { documentation, inheritedFrom, name, optional } = prop;
+    const { default: defaultValue, deprecated, internal, since } = prop.tags;
 
     if (internal) {
         return undefined;
@@ -49,6 +50,13 @@ const renderPropRow = (prop: IPropertyEntry) => {
             </p>,
         );
     }
+    if (since) {
+        tags.push(
+            <p key="since">
+                <Tag className={Classes.MINIMAL}>Since {since}</Tag>
+            </p>,
+        );
+    }
 
     const formattedType = prop.type.replace("__React", "React").replace(/\b(JSX\.)?Element\b/, "JSX.Element");
 
@@ -57,7 +65,7 @@ const renderPropRow = (prop: IPropertyEntry) => {
             <td className={classes}><code>{name}</code></td>
             <td>
                 <span className="docs-prop-type pt-monospace-text">{formattedType}</span>
-                <span className="docs-prop-default pt-monospace-text">{prop.default}</span>
+                <span className="docs-prop-default pt-monospace-text">{defaultValue}</span>
                 <div className="docs-prop-description" dangerouslySetInnerHTML={{ __html: documentation }} />
                 {tags}
             </td>

--- a/packages/docs/src/components/propsTable.tsx
+++ b/packages/docs/src/components/propsTable.tsx
@@ -17,9 +17,18 @@ function dirtyMarkdown(text: string) {
         .replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`) };
 }
 
+function propsTag(intent: Intent, title: string, ...children: React.ReactNode[]) {
+    return (
+        <Tag key={title} className={Classes.MINIMAL} intent={intent}>
+            <strong>{title}</strong>
+            {children}
+        </Tag>
+    );
+}
+
 const renderPropRow = (prop: IPropertyEntry) => {
     const { documentation, inheritedFrom, name, optional } = prop;
-    const { default: defaultValue, deprecated, internal, since } = prop.tags;
+    const { default: defaultValue, deprecated, internal } = prop.tags;
 
     if (internal) {
         return undefined;
@@ -33,29 +42,16 @@ const renderPropRow = (prop: IPropertyEntry) => {
 
     const tags: JSX.Element[] = [];
     if (!optional) {
-        tags.push(
-            <p key="required"><Tag className={Classes.MINIMAL} intent={Intent.SUCCESS}>Required</Tag></p>,
-        );
+        tags.push(propsTag(Intent.SUCCESS, "Required"));
     }
     if (inheritedFrom != null) {
-        tags.push(
-            <p key="inherited"><Tag className={Classes.MINIMAL}>Inherited</Tag> from <code>{inheritedFrom}</code></p>,
-        );
+        tags.push(propsTag(Intent.NONE, "Inherited", " from ", <code>{inheritedFrom}</code>));
     }
     if (deprecated) {
-        tags.push(
-            <p key="deprecated">
-                <Tag className={Classes.MINIMAL} intent={Intent.DANGER}>Deprecated</Tag>
-                <span dangerouslySetInnerHTML={dirtyMarkdown("" + deprecated)} />
-            </p>,
-        );
-    }
-    if (since) {
-        tags.push(
-            <p key="since">
-                <Tag className={Classes.MINIMAL}>Since {since}</Tag>
-            </p>,
-        );
+        const maybeMessage = typeof deprecated === "string"
+            ? <span dangerouslySetInnerHTML={dirtyMarkdown(": " + deprecated)} />
+            : undefined;
+        tags.push(propsTag(Intent.DANGER, "Deprecated", maybeMessage));
     }
 
     const formattedType = prop.type.replace("__React", "React").replace(/\b(JSX\.)?Element\b/, "JSX.Element");
@@ -65,9 +61,9 @@ const renderPropRow = (prop: IPropertyEntry) => {
             <td className={classes}><code>{name}</code></td>
             <td>
                 <span className="docs-prop-type pt-monospace-text">{formattedType}</span>
-                <span className="docs-prop-default pt-monospace-text">{defaultValue}</span>
+                <span className="docs-prop-default pt-text-muted pt-monospace-text">{defaultValue}</span>
                 <div className="docs-prop-description" dangerouslySetInnerHTML={{ __html: documentation }} />
-                {tags}
+                <p>{tags}</p>
             </td>
         </tr>
     );

--- a/packages/docs/src/components/propsTable.tsx
+++ b/packages/docs/src/components/propsTable.tsx
@@ -17,7 +17,7 @@ function dirtyMarkdown(text: string) {
         .replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`) };
 }
 
-function propsTag(intent: Intent, title: string, ...children: React.ReactNode[]) {
+function propTag(intent: Intent, title: string, ...children: React.ReactNode[]) {
     return (
         <Tag key={title} className={Classes.MINIMAL} intent={intent}>
             <strong>{title}</strong>
@@ -42,16 +42,16 @@ const renderPropRow = (prop: IInheritedPropertyEntry) => {
 
     const tags: JSX.Element[] = [];
     if (!optional) {
-        tags.push(propsTag(Intent.SUCCESS, "Required"));
+        tags.push(propTag(Intent.SUCCESS, "Required"));
     }
     if (deprecated) {
         const maybeMessage = typeof deprecated === "string"
             ? <span dangerouslySetInnerHTML={dirtyMarkdown(": " + deprecated)} />
             : undefined;
-        tags.push(propsTag(Intent.DANGER, "Deprecated", maybeMessage));
+        tags.push(propTag(Intent.DANGER, "Deprecated", maybeMessage));
     }
     if (inheritedFrom != null) {
-        tags.push(propsTag(Intent.NONE, "Inherited", " from ", <code>{inheritedFrom}</code>));
+        tags.push(propTag(Intent.NONE, "Inherited", " from ", <code>{inheritedFrom}</code>));
     }
 
     const formattedType = prop.type.replace("__React", "React").replace(/\b(JSX\.)?Element\b/, "JSX.Element");

--- a/packages/docs/src/components/propsTable.tsx
+++ b/packages/docs/src/components/propsTable.tsx
@@ -44,14 +44,14 @@ const renderPropRow = (prop: IPropertyEntry) => {
     if (!optional) {
         tags.push(propsTag(Intent.SUCCESS, "Required"));
     }
-    if (inheritedFrom != null) {
-        tags.push(propsTag(Intent.NONE, "Inherited", " from ", <code>{inheritedFrom}</code>));
-    }
     if (deprecated) {
         const maybeMessage = typeof deprecated === "string"
             ? <span dangerouslySetInnerHTML={dirtyMarkdown(": " + deprecated)} />
             : undefined;
         tags.push(propsTag(Intent.DANGER, "Deprecated", maybeMessage));
+    }
+    if (inheritedFrom != null) {
+        tags.push(propsTag(Intent.NONE, "Inherited", " from ", <code>{inheritedFrom}</code>));
     }
 
     const formattedType = prop.type.replace("__React", "React").replace(/\b(JSX\.)?Element\b/, "JSX.Element");
@@ -63,7 +63,7 @@ const renderPropRow = (prop: IPropertyEntry) => {
                 <span className="docs-prop-type pt-monospace-text">{formattedType}</span>
                 <span className="docs-prop-default pt-text-muted pt-monospace-text">{defaultValue}</span>
                 <div className="docs-prop-description" dangerouslySetInnerHTML={{ __html: documentation }} />
-                <p>{tags}</p>
+                <p className="docs-prop-tags">{tags}</p>
             </td>
         </tr>
     );

--- a/packages/docs/src/components/propsTable.tsx
+++ b/packages/docs/src/components/propsTable.tsx
@@ -20,7 +20,7 @@ function dirtyMarkdown(text: string) {
 function propTag(intent: Intent, title: string, ...children: React.ReactNode[]) {
     return (
         <Tag key={title} className={Classes.MINIMAL} intent={intent}>
-            <strong>{title}</strong>
+            {title}
             {children}
         </Tag>
     );
@@ -60,8 +60,8 @@ const renderPropRow = (prop: IInheritedPropertyEntry) => {
         <tr key={name}>
             <td className={classes}><code>{name}</code></td>
             <td>
-                <span className="docs-prop-type pt-monospace-text">{formattedType}</span>
-                <span className="docs-prop-default pt-text-muted pt-monospace-text">{defaultValue}</span>
+                <strong className="docs-prop-type pt-monospace-text">{formattedType}</strong>
+                <em className="docs-prop-default pt-text-muted pt-monospace-text">{defaultValue}</em>
                 <div className="docs-prop-description" dangerouslySetInnerHTML={{ __html: documentation }} />
                 <p className="docs-prop-tags">{tags}</p>
             </td>

--- a/packages/docs/src/components/section.tsx
+++ b/packages/docs/src/components/section.tsx
@@ -9,7 +9,7 @@ import { IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
-import { IPropertyEntry } from "ts-quick-docs/src/interfaces";
+import { IPropertyEntry } from "ts-quick-docs/dist/interfaces";
 
 import { ExampleComponentClass } from "../common/resolveExample";
 import { getTheme } from "../common/theme";

--- a/packages/docs/src/components/styleguide.tsx
+++ b/packages/docs/src/components/styleguide.tsx
@@ -8,7 +8,7 @@
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
-import { IPropertyEntry } from "ts-quick-docs/src/interfaces";
+import { IPropertyEntry } from "ts-quick-docs/dist/interfaces";
 
 import { Hotkey, Hotkeys, HotkeysTarget, IHotkeysDialogProps, setHotkeysDialogProps } from "@blueprintjs/core";
 
@@ -20,7 +20,7 @@ import { NavMenu } from "./navMenu";
 import { Section } from "./section";
 
 // these interfaces are essential to the docs app, so it's helpful to re-export here
-export { IInterfaceEntry, IPropertyEntry } from "ts-quick-docs/src/interfaces";
+export { IInterfaceEntry, IPropertyEntry } from "ts-quick-docs/dist/interfaces";
 
 const DARK_THEME = "pt-dark";
 const LIGHT_THEME = "";

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -10,7 +10,7 @@ import "dom4";
 import { FocusStyleManager } from "@blueprintjs/core";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { IInterfaceEntry } from "ts-quick-docs/src/interfaces";
+import { IInterfaceEntry } from "ts-quick-docs/dist/interfaces";
 
 import { PropsStore } from "./common/propsStore";
 import { resolveDocs } from "./common/resolveDocs";

--- a/packages/docs/src/styles/_props.scss
+++ b/packages/docs/src/styles/_props.scss
@@ -12,7 +12,6 @@
 }
 
 .docs-prop-default {
-  color: $gray3;
   font-style: italic;
 
   &:empty { display: none; }

--- a/packages/docs/src/styles/_props.scss
+++ b/packages/docs/src/styles/_props.scss
@@ -52,6 +52,12 @@
   line-height: smaller;
 }
 
+.docs-prop-tags {
+  .pt-tag + .pt-tag {
+    margin-left: $pt-grid-size;
+  }
+}
+
 .docs-prop-is-deprecated code {
   color: $red3;
 

--- a/packages/docs/src/styles/_props.scss
+++ b/packages/docs/src/styles/_props.scss
@@ -1,19 +1,17 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
-.docs-prop-type,
-.docs-prop-default {
-  display: inline-block;
-  // align text with <code> blocks for prop name
-  padding-top: 2px;
+.docs-prop-description,
+.docs-prop-tags {
+  code {
+    box-shadow: none;
+    background: none;
+    padding: 0;
+    color: inherit;
+    font-weight: 600;
+  }
 }
 
-.docs-prop-type {
-  font-weight: 600;
-}
-
 .docs-prop-default {
-  font-style: italic;
-
   &:empty { display: none; }
 
   &::before {
@@ -29,20 +27,6 @@
   p:last-child {
     margin: 0;
   }
-
-  code {
-    box-shadow: none;
-    background: none;
-    padding: 0;
-    color: inherit;
-    font-weight: 600;
-  }
-
-  // tags following description
-  ~ p {
-    margin-top: $pt-grid-size;
-    margin-bottom: 0;
-  }
 }
 
 .docs-prop-name code::after {
@@ -53,6 +37,10 @@
 }
 
 .docs-prop-tags {
+  margin: $pt-grid-size 0 0;
+
+  &:empty { display: none; }
+
   .pt-tag + .pt-tag {
     margin-left: $pt-grid-size;
   }


### PR DESCRIPTION
#### Fixes #579 

#### Changes proposed in this pull request:

- update to [ts-quick-docs@0.5.1](https://github.com/giladgray/ts-quick-docs/releases) to bring back default values
- refactor props table Tags: bold title, inline-block, reorder

we now have support for arbitrary `@tags` in doc comments, but we only know how to render the three shown in the screenshot (required, deprecated, inherited). a cool future task would be adding some new tags like `@since <version>` and `@warning <usage note/caveat>` (this could render a small callout!).

#### Screenshot

contrived example to demonstrate some of the new features:

![props-tables-refactor](https://cloud.githubusercontent.com/assets/464822/22719638/43a1d4ec-ed5b-11e6-99d2-d5e2f115a85a.png)
