### PR TITLE
[Date Range Input] - Part 3: inputRef unit tests

### DIFF
--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -17,4 +17,20 @@ describe("<DateRangeInput>", () => {
         const component = mount(<DateRangeInput />);
         expect(component.find(InputGroup).length).to.equal(2);
     });
+
+    it("startInputProps.inputRef receives reference to HTML input element", () => {
+        const inputRef = sinon.spy();
+        // full DOM rendering here so the ref handler is invoked
+        mount(<DateRangeInput startInputProps={{ inputRef }} />);
+        expect(inputRef.calledOnce).to.be.true;
+        expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
+    });
+
+    it("endInputProps.inputRef receives reference to HTML input element", () => {
+        const inputRef = sinon.spy();
+        // full DOM rendering here so the ref handler is invoked
+        mount(<DateRangeInput endInputProps={{ inputRef }} />);
+        expect(inputRef.calledOnce).to.be.true;
+        expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
+    });
 });


### PR DESCRIPTION
#### Builds on #614, related to #249  

#### Changes proposed in this pull request:

Add unit tests for `inputRef` handling (should have done this in the previous part, so making it a separate followup PR).

#### Reviewers should focus on:

Nothing in particular. Should be quick.
