### PR TITLE
gulp defineTaskGroup withTasks

### DIFF
--- a/gulp/aliases.js
+++ b/gulp/aliases.js
@@ -9,7 +9,7 @@ module.exports = (blueprint, gulp) => {
     // lint all the things!
     // this will fail the CI build but will not block starting the server.
     // your editor is expected to handle this in realtime during development.
-    gulp.task("check", ["tslint", "tslint-gulp", "stylelint"]);
+    gulp.task("check", ["tslint", "stylelint"]);
 
     // compile all the project source codes EXCEPT for docs webpack
     // (so we can run it in watch mode during development)

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -52,11 +52,11 @@ module.exports = (gulp, config) => {
          * The task name is of the format `[name]-[project.id]`.
          * Finally, a "group task" is defined with the base name that runs all the project tasks.
          * This group task can be configured to run in parallel or in sequence.
-         * @param {{block: string, name?: string, parallel?: boolean}} options
+         * @param {{block: string, name?: string, parallel?: boolean, withTasks?: string[]}} options
          * @param {Function} taskFn called for each project containing block with `(project, taskName, depTaskNames)`
          */
         defineTaskGroup(options, taskFn) {
-            const { block, name = block, parallel = true } = options;
+            const { block, name = block, parallel = true, withTasks = [] } = options;
 
             const projects = (block === "all") ? blueprint.projects : blueprint.projectsWithBlock(block);
 
@@ -67,7 +67,7 @@ module.exports = (gulp, config) => {
                 const depNames = dependencies.map((dep) => [name, dep].join("-"));
                 taskFn(project, taskName, depNames);
                 return taskName;
-            });
+            }).concat(withTasks);
 
             // can run tasks in series when it's preferable to keep output separate
             gulp.task(name, parallel ? taskNames : (done) => rs(...taskNames, done));

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -70,7 +70,14 @@ module.exports = (gulp, config) => {
             }).concat(withTasks);
 
             // can run tasks in series when it's preferable to keep output separate
-            gulp.task(name, parallel ? taskNames : (done) => rs(...taskNames, done));
+            gulp.task(name, (done) => {
+                // using rs in both cases so the parent task timing will capture all its children :)
+                if (parallel) {
+                    rs(taskNames, done);
+                } else {
+                    rs(...taskNames, done);
+                }
+            });
         },
     }, config);
 

--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -10,6 +10,7 @@ module.exports = (blueprint, gulp, plugins) => {
     blueprint.defineTaskGroup({
         block: "all",
         name: "tslint",
+        withTasks: ["tslint-gulp"],
     }, (project, taskName) => {
         gulp.task(taskName, () => (
             gulp.src([


### PR DESCRIPTION
- add `withTasks` option to `defineTaskGroup` to include tasks that can't be defined in the group, such as `tslint-gulp`.
- always use `run-sequence` so parent task timing includes children:
```
[13:46:39] Using gulpfile ~/palantir/blueprint-public/Gulpfile.js
[13:46:39] Starting 'tsc'...                    <-- parent task starts first
[13:46:39] Starting 'icons'...
[13:46:39] Finished 'icons' after 102 ms
[13:46:39] Starting 'tsc-core'...
[13:46:39] core: compiling 68 typescript files
[13:46:44] Finished 'tsc-core' after 5.02 s
[13:46:44] Starting 'tsc-datetime'...
[13:46:44] Starting 'tsc-table'...
[13:46:44] datetime: compiling 13 typescript files
[13:46:46] table: compiling 35 typescript files
[13:46:49] Finished 'tsc-datetime' after 5.26 s
[13:46:49] Finished 'tsc-table' after 5.3 s
[13:46:49] Finished 'tsc' after 10 s            <-- timing includes all children
```