### PR TITLE
Read target client width/height when useSmartArrowPositioning=true

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -363,10 +363,12 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     private componentDOMChange() {
-        this.setState({
-            targetHeight: this.targetElement.clientHeight,
-            targetWidth: this.targetElement.clientWidth,
-        });
+        if (this.props.useSmartArrowPositioning) {
+            this.setState({
+                targetHeight: this.targetElement.clientHeight,
+                targetWidth: this.targetElement.clientWidth,
+            });
+        }
         if (!this.props.inline) {
             this.hasDarkParent = this.targetElement.closest(`.${Classes.DARK}`) != null;
             this.updateTether();

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -401,20 +401,20 @@ describe("<Popover>", () => {
         root.detach();
     });
 
-    it('componentDOMChange updates targetHeight and targetWidth state when useSmartArrowPositioning=true', () => {
-        const wrapper = renderPopover({
-            useSmartArrowPositioning: true
-        })
-        assert.notEqual(0, wrapper.state().targetWidth, 'targetWidth should not equal 0')
-        assert.notEqual(0, wrapper.state().targetHeight, 'targetHeight should not equal 0')
+    it("componentDOMChange updates targetHeight/targetWidth state when useSmartArrowPositioning=true", () => {
+        const root = renderPopover({
+            useSmartArrowPositioning: true,
+        });
+        assert.notEqual(0, root.state().targetWidth, "targetWidth should not equal 0");
+        assert.notEqual(0, root.state().targetHeight, "targetHeight should not equal 0");
     });
 
-    it('componentDOMChange does not update targetHeight and targetWidth state when useSmartArrowPositioning=false', () => {
-        const wrapper = renderPopover({
-            useSmartArrowPositioning: false
-        })
-        assert.equal(0, wrapper.state().targetWidth, 'targetWidth should equal 0')
-        assert.equal(0, wrapper.state().targetHeight, 'targetHeight should equal 0')
+    it("componentDOMChange does not update targetHeight/targetWidth state when useSmartArrowPositioning=false", () => {
+        const root = renderPopover({
+            useSmartArrowPositioning: false,
+        });
+        assert.equal(0, root.state().targetWidth, "targetWidth should equal 0");
+        assert.equal(0, root.state().targetHeight, "targetHeight should equal 0");
     });
 
     interface IPopoverWrapper extends ReactWrapper<any, any> {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -401,6 +401,22 @@ describe("<Popover>", () => {
         root.detach();
     });
 
+    it('componentDOMChange updates targetHeight and targetWidth state when useSmartArrowPositioning=true', () => {
+        const wrapper = renderPopover({
+            useSmartArrowPositioning: true
+        })
+        assert.notEqual(0, wrapper.state().targetWidth, 'targetWidth should not equal 0')
+        assert.notEqual(0, wrapper.state().targetHeight, 'targetHeight should not equal 0')
+    });
+
+    it('componentDOMChange does not update targetHeight and targetWidth state when useSmartArrowPositioning=false', () => {
+        const wrapper = renderPopover({
+            useSmartArrowPositioning: false
+        })
+        assert.equal(0, wrapper.state().targetWidth, 'targetWidth should equal 0')
+        assert.equal(0, wrapper.state().targetHeight, 'targetHeight should equal 0')
+    });
+
     interface IPopoverWrapper extends ReactWrapper<any, any> {
         simulateTarget(eventName: string): this;
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;


### PR DESCRIPTION
#### Fixes #626

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- N/A Update documentation

#### Changes proposed in this pull request:
Read `targetElement.clientWidth/Height` only when `useSmartArrowPositioning` is true.