### PR TITLE
[Date Range Input] - Part 4: Basic DateRangePicker popover

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -110,12 +110,12 @@ export function getDateTime(date: Date, time: Date) {
     }
 }
 
-export function isMomentValidAndInRange(value: moment.Moment, minDate: Date, maxDate: Date) {
-    return value.isValid() && isMomentInRange(value, minDate, maxDate);
+export function isMomentValidAndInRange(momentDate: moment.Moment, minDate: Date, maxDate: Date) {
+    return momentDate.isValid() && isMomentInRange(momentDate, minDate, maxDate);
 }
 
-export function isMomentInRange(value: moment.Moment, minDate: Date, maxDate: Date) {
-    return value.isBetween(minDate, maxDate, "day", "[]");
+export function isMomentInRange(momentDate: moment.Moment, minDate: Date, maxDate: Date) {
+    return momentDate.isBetween(minDate, maxDate, "day", "[]");
 }
 
 /**

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -5,6 +5,8 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as moment from "moment";
+
 export type DateRange = [Date | undefined, Date | undefined];
 
 export function areEqual(date1: Date, date2: Date) {
@@ -105,5 +107,53 @@ export function getDateTime(date: Date, time: Date) {
     } else {
         return new Date(date.getFullYear(), date.getMonth(), date.getDate(),
             time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
+    }
+}
+
+export function isMomentValidAndInRange(value: moment.Moment, minDate: Date, maxDate: Date) {
+    return value.isValid() && isMomentInRange(value, minDate, maxDate);
+}
+
+export function isMomentInRange(value: moment.Moment, minDate: Date, maxDate: Date) {
+    return value.isBetween(minDate, maxDate, "day", "[]");
+}
+
+/**
+ * Translate a Date object into a moment, adjusting the local timezone into the moment one.
+ * This is a no-op unless moment-timezone's setDefault has been called.
+ */
+export function fromDateToMoment(date: Date) {
+    if (date == null || typeof date === "string") {
+        return moment(date);
+    } else {
+        return moment([
+            date.getFullYear(),
+            date.getMonth(),
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes(),
+            date.getSeconds(),
+            date.getMilliseconds(),
+        ]);
+    }
+}
+
+/**
+ * Translate a moment into a Date object, adjusting the moment timezone into the local one.
+ * This is a no-op unless moment-timezone's setDefault has been called.
+ */
+export function fromMomentToDate(momentDate: moment.Moment) {
+    if (momentDate == null) {
+        return undefined;
+    } else {
+        return new Date(
+            momentDate.year(),
+            momentDate.month(),
+            momentDate.date(),
+            momentDate.hours(),
+            momentDate.minutes(),
+            momentDate.seconds(),
+            momentDate.milliseconds(),
+        );
     }
 }

--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -20,7 +20,5 @@ export const DATERANGEPICKER_DEFAULT_VALUE_INVALID =
     DATEPICKER_DEFAULT_VALUE_INVALID.replace("DatePicker", "DateRangePicker");
 export const DATERANGEPICKER_INITIAL_MONTH_INVALID =
     DATEPICKER_INITIAL_MONTH_INVALID.replace("DatePicker", "DateRangePicker");
-export const DATERANGEPICKER_INVALID_DATE_RANGE =
-    `${ns} <DateRangePicker> value and defaultValue props cannot have a null start date and a non-null end date.`;
 export const DATERANGEPICKER_MAX_DATE_INVALID = DATEPICKER_MAX_DATE_INVALID.replace("DatePicker", "DateRangePicker");
 export const DATERANGEPICKER_VALUE_INVALID = DATEPICKER_VALUE_INVALID.replace("DatePicker", "DateRangePicker");

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -21,6 +21,12 @@ import {
     Utils,
 } from "@blueprintjs/core";
 
+import {
+    fromDateToMoment,
+    fromMomentToDate,
+    isMomentInRange,
+    isMomentValidAndInRange,
+} from "./common/dateUtils";
 import { DatePicker } from "./datePicker";
 import {
     getDefaultMaxDate,
@@ -133,12 +139,12 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     public constructor(props?: IDateInputProps, context?: any) {
         super(props, context);
 
-        const defaultValue = this.props.defaultValue ? this.fromDateToMoment(this.props.defaultValue) : moment(null);
+        const defaultValue = this.props.defaultValue ? fromDateToMoment(this.props.defaultValue) : moment(null);
 
         this.state = {
             isInputFocused: false,
             isOpen: false,
-            value: this.props.value !== undefined ? this.fromDateToMoment(this.props.value) : defaultValue,
+            value: this.props.value !== undefined ? fromDateToMoment(this.props.value) : defaultValue,
             valueString: null,
         };
     }
@@ -153,12 +159,12 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 canClearSelection={this.props.canClearSelection}
                 defaultValue={null}
                 onChange={this.handleDateChange}
-                value={this.validAndInRange(this.state.value) ? this.fromMomentToDate(this.state.value) : null}
+                value={this.isMomentValidAndInRange(this.state.value) ? fromMomentToDate(this.state.value) : null}
             />
         );
 
         const inputClasses = classNames({
-            "pt-intent-danger": !(this.validAndInRange(date) || this.isNull(date) || dateString === ""),
+            "pt-intent-danger": !(this.isMomentValidAndInRange(date) || this.isNull(date) || dateString === ""),
         });
 
         const calendarIcon = (
@@ -201,7 +207,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     public componentWillReceiveProps(nextProps: IDateInputProps) {
         if (nextProps.value !== this.props.value) {
-            this.setState({ value: this.fromDateToMoment(nextProps.value) });
+            this.setState({ value: fromDateToMoment(nextProps.value) });
         }
 
         super.componentWillReceiveProps(nextProps);
@@ -212,7 +218,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             return "";
         }
         if (value.isValid()) {
-            if (this.dateIsInRange(value)) {
+            if (this.isMomentInRange(value)) {
                 return value.format(this.props.format);
             } else {
                 return this.props.outOfRangeMessage;
@@ -221,16 +227,16 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         return this.props.invalidDateMessage;
     }
 
-    private validAndInRange(value: moment.Moment) {
-        return value.isValid() && this.dateIsInRange(value);
+    private isMomentValidAndInRange(value: moment.Moment) {
+        return isMomentValidAndInRange(value, this.props.minDate, this.props.maxDate);
+    }
+
+    private isMomentInRange(value: moment.Moment) {
+        return isMomentInRange(value, this.props.minDate, this.props.maxDate);
     }
 
     private isNull(value: moment.Moment) {
         return value.parsingFlags().nullInput;
-    }
-
-    private dateIsInRange(value: moment.Moment) {
-        return value.isBetween(this.props.minDate, this.props.maxDate, "day", "[]");
     }
 
     private handleClosePopover = () => {
@@ -238,7 +244,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private handleDateChange = (date: Date, hasUserManuallySelectedDate: boolean) => {
-        const momentDate = this.fromDateToMoment(date);
+        const momentDate = fromDateToMoment(date);
         const hasMonthChanged = date !== null && !this.isNull(this.state.value) && this.state.value.isValid() &&
             momentDate.month() !== this.state.value.month();
         const isOpen = !(this.props.closeOnSelection && hasUserManuallySelectedDate && !hasMonthChanged);
@@ -247,7 +253,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         } else {
             this.setState({ isInputFocused: false, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, date === null ? null : this.fromMomentToDate(momentDate));
+        Utils.safeInvoke(this.props.onChange, date === null ? null : fromMomentToDate(momentDate));
     }
 
     private handleIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
@@ -284,13 +290,13 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         const valueString = (e.target as HTMLInputElement).value;
         const value = moment(valueString, this.props.format);
 
-        if (value.isValid() && this.dateIsInRange(value)) {
+        if (value.isValid() && this.isMomentInRange(value)) {
             if (this.props.value === undefined) {
                 this.setState({ value, valueString });
             } else {
                 this.setState({ valueString });
             }
-            Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(value));
+            Utils.safeInvoke(this.props.onChange, fromMomentToDate(value));
         } else {
             if (valueString.length === 0) {
                 Utils.safeInvoke(this.props.onChange, null);
@@ -304,7 +310,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         let value = moment(valueString, this.props.format);
         if (valueString.length > 0
             && valueString !== this.getDateString(this.state.value)
-            && (!value.isValid() || !this.dateIsInRange(value))) {
+            && (!value.isValid() || !this.isMomentInRange(value))) {
 
             if (this.props.value === undefined) {
                 this.setState({ isInputFocused: false, value, valueString: null });
@@ -314,10 +320,10 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
             if (!value.isValid()) {
                 Utils.safeInvoke(this.props.onError, new Date(undefined));
-            } else if (!this.dateIsInRange(value)) {
-                Utils.safeInvoke(this.props.onError, this.fromMomentToDate(value));
+            } else if (!this.isMomentInRange(value)) {
+                Utils.safeInvoke(this.props.onError, fromMomentToDate(value));
             } else {
-                Utils.safeInvoke(this.props.onChange, this.fromMomentToDate(value));
+                Utils.safeInvoke(this.props.onChange, fromMomentToDate(value));
             }
         } else {
             if (valueString.length === 0) {
@@ -330,45 +336,5 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     private setInputRef = (el: HTMLElement) => {
         this.inputRef = el;
-    }
-
-    /**
-     * Translate a moment into a Date object, adjusting the moment timezone into the local one.
-     * This is a no-op unless moment-timezone's setDefault has been called.
-     */
-    private fromMomentToDate = (momentDate: moment.Moment) => {
-        if (momentDate == null) {
-            return undefined;
-        } else {
-            return new Date(
-                momentDate.year(),
-                momentDate.month(),
-                momentDate.date(),
-                momentDate.hours(),
-                momentDate.minutes(),
-                momentDate.seconds(),
-                momentDate.milliseconds(),
-            );
-        }
-    }
-
-    /**
-     * Translate a Date object into a moment, adjusting the local timezone into the moment one.
-     * This is a no-op unless moment-timezone's setDefault has been called.
-     */
-    private fromDateToMoment = (date: Date) => {
-        if (date == null || typeof date === "string") {
-            return moment(date);
-        } else {
-            return moment([
-                date.getFullYear(),
-                date.getMonth(),
-                date.getDate(),
-                date.getHours(),
-                date.getMinutes(),
-                date.getSeconds(),
-                date.getMilliseconds(),
-            ]);
-        }
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -35,8 +35,9 @@ import {
 } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
-    startInputProps?: IInputGroupProps;
     endInputProps?: IInputGroupProps;
+    onChange?: (selectedRange: DateRange) => void;
+    startInputProps?: IInputGroupProps;
 }
 
 export interface IDateRangeInputState {
@@ -123,6 +124,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
         const [selectedStart, selectedEnd] = selectedRange.map(fromDateToMoment);
         this.setState({ selectedStart, selectedEnd });
+        Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
     private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -21,6 +21,9 @@ import {
 
 import {
     DateRange,
+    fromDateToMoment,
+    fromMomentToDate,
+    isMomentValidAndInRange,
 } from "./common/dateUtils";
 import {
     getDefaultMaxDate,
@@ -118,7 +121,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
-        const [selectedStart, selectedEnd] = selectedRange.map(this.fromDateToMoment);
+        const [selectedStart, selectedEnd] = selectedRange.map(fromDateToMoment);
         this.setState({ selectedStart, selectedEnd });
     }
 
@@ -138,57 +141,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private getSelectedRange = () => {
         return [this.state.selectedStart, this.state.selectedEnd].map((selectedBound?: moment.Moment) => {
-            return (!this.isDateValidAndInRange(selectedBound))
+            return (!isMomentValidAndInRange(selectedBound, this.props.minDate, this.props.maxDate))
                 ? undefined
-                : this.fromMomentToDate(selectedBound);
+                : fromMomentToDate(selectedBound);
         }) as DateRange;
-    }
-
-    private isDateValidAndInRange(value: moment.Moment) {
-        return value.isValid() && this.dateIsInRange(value);
-    }
-
-    private dateIsInRange(value: moment.Moment) {
-        return value.isBetween(this.props.minDate, this.props.maxDate, "day", "[]");
-    }
-
-    /**
-     * Translate a Date object into a moment, adjusting the local timezone into the moment one.
-     * This is a no-op unless moment-timezone's setDefault has been called.
-     */
-    private fromDateToMoment = (date: Date) => {
-        if (date == null || typeof date === "string") {
-            return moment(date);
-        } else {
-            return moment([
-                date.getFullYear(),
-                date.getMonth(),
-                date.getDate(),
-                date.getHours(),
-                date.getMinutes(),
-                date.getSeconds(),
-                date.getMilliseconds(),
-            ]);
-        }
-    }
-
-    /**
-     * Translate a moment into a Date object, adjusting the moment timezone into the local one.
-     * This is a no-op unless moment-timezone's setDefault has been called.
-     */
-    private fromMomentToDate = (momentDate: moment.Moment) => {
-        if (momentDate == null) {
-            return undefined;
-        } else {
-            return new Date(
-                momentDate.year(),
-                momentDate.month(),
-                momentDate.date(),
-                momentDate.hours(),
-                momentDate.minutes(),
-                momentDate.seconds(),
-                momentDate.milliseconds(),
-            );
-        }
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -5,6 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as moment from "moment";
 import * as React from "react";
 
 import {
@@ -25,7 +26,12 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     endInputProps?: IInputGroupProps;
 }
 
-export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> {
+export interface IDateRangeInputState {
+    selectedEnd?: moment.Moment;
+    selectedStart?: moment.Moment;
+};
+
+export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
         endInputProps: {},
         startInputProps: {},
@@ -45,6 +51,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, {}> 
             Utils.safeInvoke(this.props.startInputProps.inputRef, ref);
         },
     };
+
+    public constructor(props: IDateRangeInputProps, context?: any) {
+        super(props, context);
+        this.state = {
+            selectedEnd: null,
+            selectedStart: null,
+        };
+    }
 
     public render() {
         // allow custom props for each input group, but pass them in an order

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -99,7 +99,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 isOpen={this.state.isOpen}
                 onClose={this.handlePopoverClose}
                 position={Position.TOP_LEFT}
-                useSmartArrowPositioning={false}
             >
                 <div className={Classes.CONTROL_GROUP}>
                     <InputGroup

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -14,12 +14,19 @@ import {
     IInputGroupProps,
     InputGroup,
     IProps,
+    Popover,
+    Position,
     Utils,
 } from "@blueprintjs/core";
 
 import {
+    getDefaultMaxDate,
+    getDefaultMinDate,
     IDatePickerBaseProps,
 } from "./datePickerCore";
+import {
+    DateRangePicker,
+} from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     startInputProps?: IInputGroupProps;
@@ -27,6 +34,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 }
 
 export interface IDateRangeInputState {
+    isOpen?: boolean,
     selectedEnd?: moment.Moment;
     selectedStart?: moment.Moment;
 };
@@ -34,6 +42,8 @@ export interface IDateRangeInputState {
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
         endInputProps: {},
+        maxDate: getDefaultMaxDate(),
+        minDate: getDefaultMinDate(),
         startInputProps: {},
     };
 
@@ -55,6 +65,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     public constructor(props: IDateRangeInputProps, context?: any) {
         super(props, context);
         this.state = {
+            isOpen: false,
             selectedEnd: null,
             selectedStart: null,
         };
@@ -64,18 +75,47 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         // allow custom props for each input group, but pass them in an order
         // that guarantees only some props are overridable.
         return (
-            <div className={Classes.CONTROL_GROUP}>
-                <InputGroup
-                    placeholder="Start date"
-                    {...this.props.startInputProps}
-                    inputRef={this.refHandlers.startInputRef}
-                />
-                <InputGroup
-                    placeholder="End date"
-                    {...this.props.endInputProps}
-                    inputRef={this.refHandlers.endInputRef}
-                />
-            </div>
+            <Popover
+                autoFocus={false}
+                content={<DateRangePicker maxDate={this.props.maxDate} minDate={this.props.minDate} />}
+                enforceFocus={false}
+                inline={true}
+                isOpen={this.state.isOpen}
+                onClose={this.handlePopoverClose}
+                position={Position.TOP_LEFT}
+                useSmartArrowPositioning={false}
+            >
+                <div className={Classes.CONTROL_GROUP}>
+                    <InputGroup
+                        placeholder="Start date"
+                        {...this.props.startInputProps}
+                        inputRef={this.refHandlers.startInputRef}
+                        onClick={this.handleInputClick}
+                        onFocus={this.handleInputFocus}
+                    />
+                    <InputGroup
+                        placeholder="End date"
+                        {...this.props.endInputProps}
+                        inputRef={this.refHandlers.endInputRef}
+                        onClick={this.handleInputClick}
+                        onFocus={this.handleInputFocus}
+                    />
+                </div>
+            </Popover>
         );
+    }
+
+    private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+        // unless we stop propagation on this event, a click within an input
+        // will close the popover almost as soon as it opens.
+        e.stopPropagation();
+    }
+
+    private handleInputFocus = () => {
+        this.setState({ isOpen: true });
+    }
+
+    private handlePopoverClose = () => {
+        this.setState({ isOpen: false });
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -34,7 +34,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 }
 
 export interface IDateRangeInputState {
-    isOpen?: boolean,
+    isOpen?: boolean;
     selectedEnd?: moment.Moment;
     selectedStart?: moment.Moment;
 };

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -235,11 +235,6 @@ export class DateRangePicker
             throw new Error(Errors.DATERANGEPICKER_INITIAL_MONTH_INVALID);
         }
 
-        if (defaultValue != null && defaultValue[0] == null && defaultValue[1] != null
-            || value != null && value[0] == null && value[1] != null) {
-            throw new Error(Errors.DATERANGEPICKER_INVALID_DATE_RANGE);
-        }
-
         if (maxDate != null
                 && minDate != null
                 && maxDate < minDate

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -10,7 +10,7 @@ import { mount } from "enzyme";
 import * as React from "react";
 
 import { InputGroup } from "@blueprintjs/core";
-import { DateRangeInput } from "../src/index";
+import { Classes as DateClasses, DateRangeInput } from "../src/index";
 
 describe("<DateRangeInput>", () => {
     it("renders with two InputGroup children", () => {
@@ -33,4 +33,35 @@ describe("<DateRangeInput>", () => {
         expect(inputRef.calledOnce).to.be.true;
         expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
     });
+
+    it("invokes onChange when a day is selected or deselected in the picker", () => {
+        const onChange = sinon.spy();
+        const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} />);
+        root.setState({ isOpen: true });
+
+        // select days
+        getDayElement(22).simulate("click");
+        getDayElement(24).simulate("click");
+
+        // deselect days
+        getDayElement(22).simulate("click");
+        getDayElement(24).simulate("click");
+
+        expect(onChange.callCount).to.deep.equal(4);
+    });
+
+    function wrap(dateRangeInput: JSX.Element) {
+        const wrapper = mount(dateRangeInput);
+        return {
+            getDayElement: (dayNumber = 1, fromLeftMonth = true) => {
+                const monthElement = wrapper.find(".DayPicker-Month").at(fromLeftMonth ? 0 : 1);
+                const dayElements = monthElement.find(`.${DateClasses.DATEPICKER_DAY}`);
+                return dayElements.filterWhere((d) => {
+                    return d.text() === dayNumber.toString()
+                        && !d.hasClass(DateClasses.DATEPICKER_DAY_OUTSIDE);
+                });
+            },
+            root: wrapper,
+        };
+    }
 });

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -400,11 +400,6 @@ describe("<DateRangePicker>", () => {
             assert.equal(selectedDays[0].textContent, value[0].getDate());
         });
 
-        it("throws if a value without a start date but with an end date is provided", () => {
-            assert.throws(() => renderDateRangePicker({value: [null, new Date()]}),
-                Errors.DATERANGEPICKER_INVALID_DATE_RANGE);
-        });
-
         it("onChange fired when a day is clicked", () => {
             renderDateRangePicker({ value: [null, null] });
             assert.isTrue(onDateRangePickerChangeSpy.notCalled);
@@ -478,11 +473,6 @@ describe("<DateRangePicker>", () => {
             const selectedDays = getSelectedDayElements();
             assert.lengthOf(selectedDays, 1);
             assert.equal(selectedDays[0].textContent, today.getDate());
-        });
-
-        it("throws if a defaultValue without a start date but with an end date is provided", () => {
-            assert.throws(() => renderDateRangePicker({defaultValue: [null, new Date()]}),
-                Errors.DATERANGEPICKER_INVALID_DATE_RANGE);
         });
 
         it("onChange fired when a day is clicked", () => {

--- a/packages/docs/src/styles/_examples.scss
+++ b/packages/docs/src/styles/_examples.scss
@@ -65,7 +65,7 @@ $options-margin: $pt-grid-size * 3;
     margin-bottom: $options-margin;
   }
 
-  :not(.pt-control-group) .pt-input-group + .pt-input-group {
+  :not(.pt-control-group) > .pt-input-group + .pt-input-group {
     margin-top: $pt-grid-size * 2;
   }
 }


### PR DESCRIPTION
> Follow the commits to see the bite-sized progression of this work.

#### Builds on #643, related to #249

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- *New Feature:* Show a basic `DateRangePicker` popover on focus in either input field.
- *New Feature:* Save the selected date range in the `DateRangeInput`'s state.
- *New Feature:* Trigger `onChange` when the selected date range changes.
- *Refactor:* Pull utility functions shared between `DateRangeInput` and `DateInput`, into `dateUtils`. 
- *Bugfix:* Tweak the docs style for immediate-sibling `pt-input-group`s to fix a style bug.

#### Reviewers should focus on:

- [ ] Do the `moment`-related utility functions belong in `dateUtils`? Makes sense to me, but it introduced a new dependency (the Moment.js library) to that file.
- [ ] Do we want to explicitly trigger `this.props.{startInputProps,endInputProps}.{onFocus,onClick}` within `handleInputFocus` and `handleInputClick`? Currently we're overriding those, but I `DateInput` doesn't trigger either of those either as far as I can tell. 
- [ ] Does the unit test for `onChange` look sufficient? Or too verbose? Or not thorough enough?
- [ ] After implementing the prototype of `DateRangeInput` last month, I found it clearer to deviate from `DateInput`'s nomenclature and name my state variables `selectedStart` and `selectedEnd` rather than something to do with the word `value` (e.g. `startValue`, `endValue`), particularly when hover-related variables came into the picture. LMK if this sounds okay.

#### Screenshot

![2017-02-09 11 16 34](https://cloud.githubusercontent.com/assets/443450/22799087/5118c158-eeb9-11e6-8ccd-f5d01d232251.gif)
