### PR TITLE
[Bugfix] Fix NumericInput auto-selection in controlled mode

### DIFF
--- a/packages/core/examples/numericInputExample.tsx
+++ b/packages/core/examples/numericInputExample.tsx
@@ -171,6 +171,7 @@ export class NumericInputExample extends BaseExample<INumericInputExampleState> 
 
                     onBlur={this.handleBlur}
                     onKeyDown={this.handleKeyDown}
+                    onValueChange={this.handleValueChange}
                     value={value}
                 />
             </div>
@@ -220,6 +221,10 @@ export class NumericInputExample extends BaseExample<INumericInputExampleState> 
         if (e.keyCode === Keys.ENTER) {
             this.handleConfirm((e.target as HTMLInputElement).value);
         }
+    }
+
+    private handleValueChange = (_valueAsNumber: number, valueAsString: string) => {
+        this.setState({ value: valueAsString });
     }
 
     private handleConfirm = (value: string) => {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -138,9 +138,9 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
             const sanitizedValue = (value !== NumericInput.VALUE_EMPTY)
                 ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
                 : NumericInput.VALUE_EMPTY;
-            this.setState({ value: sanitizedValue, shouldSelectAfterUpdate: true });
+            this.setState({ value: sanitizedValue });
         } else {
-            this.setState({ value, shouldSelectAfterUpdate: true });
+            this.setState({ value });
         }
     }
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -537,7 +537,6 @@ describe("<NumericInput>", () => {
         it("shows placeholder text if provided", () => {
             const component = mount(<NumericInput placeholder={"Enter a number..."} />);
 
-            const inputGroup = component.find(InputGroup);
             const inputField = component.find("input");
             const placeholderText = inputField.props().placeholder;
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -171,6 +171,24 @@ describe("<NumericInput>", () => {
             const value = component.state().value;
             expect(value).to.equal("10");
         });
+
+        it("places the cursor at the end of the input field on focus", () => {
+            const attachTo = document.createElement("div");
+            mount(<NumericInput value="12345678" />, { attachTo });
+            const input = attachTo.query("input") as HTMLInputElement;
+            expect(input.selectionStart).to.equal(8);
+            expect(input.selectionEnd).to.equal(8);
+        });
+
+        it("in controlled mode, keeps the cursor at the end of the input after additional characters are typed", () => {
+            const attachTo = document.createElement("div");
+            const component = mount(<NumericInput value="12345678" />, { attachTo });
+            component.setProps({ value: "1234567890" });
+
+            const input = attachTo.query("input") as HTMLInputElement;
+            expect(input.selectionStart).to.equal(10);
+            expect(input.selectionEnd).to.equal(10);
+        });
     });
 
     describe("Keyboard interactions in input field", () => {


### PR DESCRIPTION
#### Fixes #647 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- _Bugfix:_ Stop auto-selecting the entire contents of the in the input field whenever props change
- _Nit:_ Deleted an errant unused variable in `numericInputTests.tsx`
- Updated `NumericInput` example to be fully controlled, so we can verify the error doesn't pop up again.