### PR TITLE
[Numeric Input] Fire onValueChange when min/max updated

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -139,6 +139,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
                 ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
                 : NumericInput.VALUE_EMPTY;
             this.setState({ value: sanitizedValue });
+            this.invokeOnChangeCallbacks(sanitizedValue);
         } else {
             this.setState({ value });
         }

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -138,8 +138,11 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
             const sanitizedValue = (value !== NumericInput.VALUE_EMPTY)
                 ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
                 : NumericInput.VALUE_EMPTY;
-            this.setState({ value: sanitizedValue });
-            this.invokeOnChangeCallbacks(sanitizedValue);
+
+            if (sanitizedValue !== this.state.value) {
+                this.setState({ value: sanitizedValue });
+                this.invokeOnChangeCallbacks(sanitizedValue);
+            }
         } else {
             this.setState({ value });
         }

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -415,7 +415,7 @@ describe("<NumericInput>", () => {
                 expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
             });
 
-            it("does not fire onValueChange if nextProps.min < props.min", () => {
+            it("does not fire onValueChange if nextProps.min < value", () => {
                 const onValueChangeSpy = sinon.spy();
                 const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
 
@@ -489,7 +489,7 @@ describe("<NumericInput>", () => {
                 expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
             });
 
-            it("does not fire onValueChange if nextProps.max > props.max", () => {
+            it("does not fire onValueChange if nextProps.max > value", () => {
                 const onValueChangeSpy = sinon.spy();
                 const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -393,7 +393,7 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal(MIN_VALUE.toString());
             });
 
-            it("fires onValueChange with clamped value if props.min was updated to exceed current value ", () => {
+            it("fires onValueChange with clamped value if nextProps.min > value ", () => {
                 const onValueChangeSpy = sinon.spy();
                 const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
 
@@ -403,6 +403,18 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
                 expect(onValueChangeSpy.calledOnce).to.be.true;
                 expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
+            });
+
+            it("fires onValueChange with unchanged value if nextProps.min < props.min", () => {
+                const onValueChangeSpy = sinon.spy();
+                const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
+
+                component.setProps({ min: -20 });
+
+                const newValue = component.state().value;
+                expect(newValue).to.equal("-10");
+                expect(onValueChangeSpy.calledOnce).to.be.true;
+                expect(onValueChangeSpy.firstCall.args).to.deep.equal([-10, "-10"]);
             });
         });
 
@@ -456,7 +468,7 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal(MAX_VALUE.toString());
             });
 
-            it("fires onValueChange with clamped value if props.max was updated to be less than current value ", () => {
+            it("fires onValueChange with clamped value if nextProps.max < value ", () => {
                 const onValueChangeSpy = sinon.spy();
                 const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
 
@@ -466,6 +478,18 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
                 expect(onValueChangeSpy.calledOnce).to.be.true;
                 expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
+            });
+
+            it("fires onValueChange with unchanged value if nextProps.max > props.max", () => {
+                const onValueChangeSpy = sinon.spy();
+                const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
+
+                component.setProps({ max: 20 });
+
+                const newValue = component.state().value;
+                expect(newValue).to.equal("10");
+                expect(onValueChangeSpy.calledOnce).to.be.true;
+                expect(onValueChangeSpy.firstCall.args).to.deep.equal([10, "10"]);
             });
         });
     });

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -381,6 +381,18 @@ describe("<NumericInput>", () => {
                 const newValue = component.state().value;
                 expect(newValue).to.equal(MIN_VALUE.toString());
             });
+
+            it("fires onValueChange with clamped value if props.min was updated to exceed current value ", () => {
+                const onValueChangeSpy = sinon.spy();
+                const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
+
+                component.setProps({ min: 0 });
+
+                const newValue = component.state().value;
+                expect(newValue).to.equal("0");
+                expect(onValueChangeSpy.calledOnce).to.be.true;
+                expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
+            });
         });
 
         describe("if `max` is defined", () => {
@@ -431,6 +443,18 @@ describe("<NumericInput>", () => {
 
                 const newValue = component.state().value;
                 expect(newValue).to.equal(MAX_VALUE.toString());
+            });
+
+            it("fires onValueChange with clamped value if props.max was updated to be less than current value ", () => {
+                const onValueChangeSpy = sinon.spy();
+                const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
+
+                component.setProps({ max: 0 });
+
+                const newValue = component.state().value;
+                expect(newValue).to.equal("0");
+                expect(onValueChangeSpy.calledOnce).to.be.true;
+                expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
             });
         });
     });

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -190,6 +190,16 @@ describe("<NumericInput>", () => {
             expect(input.selectionEnd).to.equal(10);
         });
 
+        it("in controlled mode, accepts successive value changes containing non-numeric characters", () => {
+            const component = mount(<NumericInput />);
+            component.setProps({ value: "1" });
+            expect(component.state().value).to.equal("1");
+            component.setProps({ value: "1 +" });
+            expect(component.state().value).to.equal("1 +");
+            component.setProps({ value: "1 + 1" });
+            expect(component.state().value).to.equal("1 + 1");
+        });
+
         it("fires onValueChange with the number value and the string value when the value changes", () => {
             const onValueChangeSpy = sinon.spy();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
@@ -405,7 +415,7 @@ describe("<NumericInput>", () => {
                 expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
             });
 
-            it("fires onValueChange with unchanged value if nextProps.min < props.min", () => {
+            it("does not fire onValueChange if nextProps.min < props.min", () => {
                 const onValueChangeSpy = sinon.spy();
                 const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
 
@@ -413,8 +423,7 @@ describe("<NumericInput>", () => {
 
                 const newValue = component.state().value;
                 expect(newValue).to.equal("-10");
-                expect(onValueChangeSpy.calledOnce).to.be.true;
-                expect(onValueChangeSpy.firstCall.args).to.deep.equal([-10, "-10"]);
+                expect(onValueChangeSpy.called).to.be.false;
             });
         });
 
@@ -480,7 +489,7 @@ describe("<NumericInput>", () => {
                 expect(onValueChangeSpy.firstCall.args).to.deep.equal([0, "0"]);
             });
 
-            it("fires onValueChange with unchanged value if nextProps.max > props.max", () => {
+            it("does not fire onValueChange if nextProps.max > props.max", () => {
                 const onValueChangeSpy = sinon.spy();
                 const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
 
@@ -488,8 +497,7 @@ describe("<NumericInput>", () => {
 
                 const newValue = component.state().value;
                 expect(newValue).to.equal("10");
-                expect(onValueChangeSpy.calledOnce).to.be.true;
-                expect(onValueChangeSpy.firstCall.args).to.deep.equal([10, "10"]);
+                expect(onValueChangeSpy.called).to.be.false;
             });
         });
     });

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -189,6 +189,17 @@ describe("<NumericInput>", () => {
             expect(input.selectionStart).to.equal(10);
             expect(input.selectionEnd).to.equal(10);
         });
+
+        it("fires onValueChange with the number value and the string value when the value changes", () => {
+            const onValueChangeSpy = sinon.spy();
+            const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
+
+            const incrementButton = component.find(Button).first();
+            incrementButton.simulate("click");
+
+            expect(onValueChangeSpy.calledOnce).to.be.true;
+            expect(onValueChangeSpy.firstCall.args).to.deep.equal([1, "1"]);
+        });
     });
 
     describe("Keyboard interactions in input field", () => {


### PR DESCRIPTION
#### (No issue filed)

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- _Bugfix:_ When `props.min` or `props.max` are updated such that the current value is now out of bounds, fire `onValueChange` with the clamped value to prevent the parent component from "remembering" the unclamped value.

#### Screenshot

_Before:_
Original value is shown if a bound changes to something else and back.

![2017-02-09 14 04 13](https://cloud.githubusercontent.com/assets/443450/22805609/3cbeacee-eed3-11e6-9981-62a76ac8ba9f.gif)

_After:_
Original value is replaced with the clamped value, such that the clamped value stays as is when the bounds change.

![2017-02-09 14 04 47](https://cloud.githubusercontent.com/assets/443450/22805640/5d283996-eed3-11e6-875d-fa2259d0c21f.gif)
