### PR TITLE
[Numeric Input] Use onValueChange in docs example code

### DIFF
--- a/packages/core/src/components/forms/_numeric-input.scss
+++ b/packages/core/src/components/forms/_numeric-input.scss
@@ -129,15 +129,14 @@ string }> {
     public render() {
         return (
             <NumericInput
-                onKeyDown={this.handleKeyDown}
+                onValueChange={this.handleValueChange}
                 value={this.state.value}
             />
         );
     }
 
-    private handleKeyDown = (e: React.FormEvent<HTMLInputElement>) {
-        const value = e.target.value;
-        const result = SomeLibrary.evaluateMathExpression(value);
+    private handleValueChange = (_valueAsNumber: number, valueAsString: string) {
+        const result = SomeLibrary.evaluateMathExpression(valueAsString);
         this.setState({ value: result });
     }
 }


### PR DESCRIPTION
#### (no issue filed)

#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

- Use the more proper `onValueChange` callback instead of `onKeyDown` in `NumericInput` docs sample code