### PR TITLE
Tweak IActionProps docs

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -38,7 +38,7 @@ export interface IActionProps extends IIntentProps, IProps {
     /** Click event handler. */
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 
-    /** Action text, required for usability. */
+    /** Action text. */
     text?: string;
 }
 


### PR DESCRIPTION
The `text` prop isn't required so the docs should reflect that