### PR TITLE
Fix .kss-example overflow on Firefox

### DIFF
--- a/packages/docs/src/styles/_content.scss
+++ b/packages/docs/src/styles/_content.scss
@@ -113,6 +113,7 @@ $dark-example-background-color: $dark-content-background-color;
 
   margin-bottom: $example-padding;
   width: 100%;
+  max-width: 100%;
   vertical-align: top;
 
   > code {


### PR DESCRIPTION
#### Fixes #598

#### Changes proposed in this pull request:

Adding `max-width: 100%;` on `.kss-example` fixes overflow problem on Firefox. 
I've tested on `Ubuntu, FF47`, but I think it should work on `OSX, FF51`.

#### Screenshot

![out](https://cloud.githubusercontent.com/assets/6267231/22857918/76dd3d8c-f0b8-11e6-9d52-1d60adfe6c1e.gif)
