### PR TITLE
Set independent months in DateRangePicker through props, and add tests

### DIFF
--- a/packages/datetime/examples/dateRangePickerExample.tsx
+++ b/packages/datetime/examples/dateRangePickerExample.tsx
@@ -14,20 +14,20 @@ import { Moment } from "./datePickerExample";
 
 export interface IDateRangePickerExampleState {
     allowSingleDayRange?: boolean;
-    contigiousCalendarMonths?: boolean;
+    contiguousCalendarMonths?: boolean;
     dateRange?: DateRange;
 }
 
 export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
-        contigiousCalendarMonths: true,
+        contiguousCalendarMonths: true,
         dateRange: [null, null],
     };
 
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
-    private toggleContigiousCalendarMonths = handleBooleanChange((contigiousCalendarMonths) => {
-        this.setState({ contigiousCalendarMonths });
+    private toggleContiguousCalendarMonths = handleBooleanChange((contiguousCalendarMonths) => {
+        this.setState({ contiguousCalendarMonths });
     });
 
     protected renderExample() {
@@ -35,7 +35,7 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
         return <div className="docs-datetime-example">
             <DateRangePicker
                 allowSingleDayRange={this.state.allowSingleDayRange}
-                contigiousCalendarMonths={this.state.contigiousCalendarMonths}
+                contiguousCalendarMonths={this.state.contiguousCalendarMonths}
                 className={Classes.ELEVATION_1}
                 onChange={this.handleDateChange}
             />
@@ -57,10 +57,10 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
                     onChange={this.toggleSingleDay}
                 />,
                 <Switch
-                    checked={this.state.contigiousCalendarMonths}
-                    key="Sequential"
+                    checked={this.state.contiguousCalendarMonths}
+                    key="Contiguous"
                     label="Contrain to sequentual months"
-                    onChange={this.toggleContigiousCalendarMonths}
+                    onChange={this.toggleContiguousCalendarMonths}
                 />,
             ],
         ];

--- a/packages/datetime/examples/dateRangePickerExample.tsx
+++ b/packages/datetime/examples/dateRangePickerExample.tsx
@@ -15,21 +15,25 @@ import { Moment } from "./datePickerExample";
 export interface IDateRangePickerExampleState {
     allowSingleDayRange?: boolean;
     dateRange?: DateRange;
+    isSequential?: boolean;
 }
 
 export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
         dateRange: [null, null],
+        isSequential: true,
     };
 
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
+    private toggleSequential = handleBooleanChange((isSequential) => this.setState({ isSequential }));
 
     protected renderExample() {
         const [start, end] = this.state.dateRange;
         return <div className="docs-datetime-example">
             <DateRangePicker
                 allowSingleDayRange={this.state.allowSingleDayRange}
+                isSequential={this.state.isSequential}
                 className={Classes.ELEVATION_1}
                 onChange={this.handleDateChange}
             />
@@ -42,13 +46,22 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
     }
 
     protected renderOptions() {
-        return (
-            <Switch
-                checked={this.state.allowSingleDayRange}
-                label="Allow single day range"
-                onChange={this.toggleSingleDay}
-            />
-        );
+        return [
+            [
+                <Switch
+                    checked={this.state.allowSingleDayRange}
+                    key="SingleDay"
+                    label="Allow single day range"
+                    onChange={this.toggleSingleDay}
+                />,
+                <Switch
+                    checked={this.state.isSequential}
+                    key="Sequential"
+                    label="Contrain to sequentual months"
+                    onChange={this.toggleSequential}
+                />,
+            ],
+        ];
     }
 
     private handleDateChange = (dateRange: DateRange) => this.setState({ dateRange });

--- a/packages/datetime/examples/dateRangePickerExample.tsx
+++ b/packages/datetime/examples/dateRangePickerExample.tsx
@@ -14,26 +14,28 @@ import { Moment } from "./datePickerExample";
 
 export interface IDateRangePickerExampleState {
     allowSingleDayRange?: boolean;
+    contigiousCalendarMonths?: boolean;
     dateRange?: DateRange;
-    isSequential?: boolean;
 }
 
 export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
+        contigiousCalendarMonths: true,
         dateRange: [null, null],
-        isSequential: true,
     };
 
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
-    private toggleSequential = handleBooleanChange((isSequential) => this.setState({ isSequential }));
+    private toggleContigiousCalendarMonths = handleBooleanChange((contigiousCalendarMonths) => {
+        this.setState({ contigiousCalendarMonths });
+    });
 
     protected renderExample() {
         const [start, end] = this.state.dateRange;
         return <div className="docs-datetime-example">
             <DateRangePicker
                 allowSingleDayRange={this.state.allowSingleDayRange}
-                isSequential={this.state.isSequential}
+                contigiousCalendarMonths={this.state.contigiousCalendarMonths}
                 className={Classes.ELEVATION_1}
                 onChange={this.handleDateChange}
             />
@@ -55,10 +57,10 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
                     onChange={this.toggleSingleDay}
                 />,
                 <Switch
-                    checked={this.state.isSequential}
+                    checked={this.state.contigiousCalendarMonths}
                     key="Sequential"
                     label="Contrain to sequentual months"
-                    onChange={this.toggleSequential}
+                    onChange={this.toggleContigiousCalendarMonths}
                 />,
             ],
         ];

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -8,7 +8,7 @@
 /*
 Date range picker
 
-A `DateRangePicker` shows two sequential month calendars and lets the user select a single range of
+A `DateRangePicker` shows two month calendars and lets the user select a single range of
 days.
 
 Use the `onChange` prop to listen for changes to the set date range. You can control the selected

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -55,6 +55,21 @@ Styleguide components.datetime.daterangepicker.js
 .pt-daterangepicker {
   white-space: nowrap;
 
+  &.pt-daterangepicker-sequential {
+    .DayPicker {
+      min-width: $pt-grid-size * 43;
+    }
+
+    .DayPicker-Month:not(:last-child) {
+      margin-right: $pt-grid-size;
+    }
+
+    ~ .DayPicker {
+      border-left: 1px solid $pt-divider-black;
+      min-width: $pt-grid-size * 44;
+    }
+  }
+
   .DayPicker {
     min-width: $pt-grid-size * 21;
   }
@@ -100,7 +115,7 @@ Styleguide components.datetime.daterangepicker.js
   padding-left: 0;
 
   ~ .DayPicker {
-    padding-left: $pt-grid-size - 1px;
+    padding-left: $pt-grid-size;
 
     &:not(:last-child) {
       margin-right: 0;
@@ -112,6 +127,12 @@ Styleguide components.datetime.daterangepicker.js
   }
 
   .pt-dark & {
+    &.pt-daterangepicker-sequential {
+      ~ .DayPicker {
+        border-left: 1px solid $pt-dark-divider-black;
+      }
+    }
+
     + .DayPicker {
       border-left: 1px solid $pt-dark-divider-black;
     }

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -18,6 +18,7 @@ export const DATEPICKER_MONTH_SELECT = "pt-datepicker-month-select";
 export const DATEPICKER_YEAR_SELECT = "pt-datepicker-year-select";
 
 export const DATERANGEPICKER = "pt-daterangepicker";
+export const DATERANGEPICKER_SEQUENTIAL = "pt-daterangepicker-sequential";
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = "DayPicker-Day--selected-range";
 export const DATERANGEPICKER_SHORTCUTS = "pt-daterangepicker-shortcuts";
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -168,9 +168,12 @@ export class DateRangePicker
         const { disabledDays, selectedDays } = this.states;
 
         if (isSequential || isShowingOneMonth) {
-            // use the left DayPicker when we only show one
+            // use the left DayPicker when we only need one
+            const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
+                [DateClasses.DATERANGEPICKER_SEQUENTIAL]: !isShowingOneMonth,
+            });
             return (
-                <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
+                <div className={classes}>
                     {this.maybeRenderShortcuts()}
                     <DayPicker
                         captionElement={this.renderSingleDayPickerCaption()}

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -48,10 +48,11 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     defaultValue?: DateRange;
 
     /**
-     * Constrains months to be sequential
+     * Whether displayed months in the calendar are contiguous.
+     * If false, each side of the calendar can move independently to non-contiguous months.
      * @default true
      */
-    isSequential?: boolean;
+    contigiousCalendarMonths?: boolean;
 
     /**
      * Called when the user selects a day.
@@ -89,7 +90,7 @@ export class DateRangePicker
 
     public static defaultProps: IDateRangePickerProps = {
         allowSingleDayRange: false,
-        isSequential: true,
+        contigiousCalendarMonths: true,
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         shortcuts: true,
@@ -162,12 +163,12 @@ export class DateRangePicker
 
     public render() {
         const modifiers = combineModifiers(this.modifiers, this.props.modifiers);
-        const { className, isSequential, locale, localeUtils, maxDate, minDate } = this.props;
+        const { className, contigiousCalendarMonths, locale, localeUtils, maxDate, minDate } = this.props;
         const isShowingOneMonth = DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
         const { leftView, rightView } = this.state;
         const { disabledDays, selectedDays } = this.states;
 
-        if (isSequential || isShowingOneMonth) {
+        if (contigiousCalendarMonths || isShowingOneMonth) {
             // use the left DayPicker when we only need one
             const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
                 [DateClasses.DATERANGEPICKER_SEQUENTIAL]: !isShowingOneMonth,
@@ -176,7 +177,7 @@ export class DateRangePicker
                 <div className={classes}>
                     {this.maybeRenderShortcuts()}
                     <DayPicker
-                        captionElement={this.renderSingleDayPickerCaption()}
+                        captionElement={this.renderSingleCaption()}
                         disabledDays={disabledDays}
                         fromMonth={minDate}
                         initialMonth={leftView.getFullDate()}
@@ -287,7 +288,7 @@ export class DateRangePicker
         );
     }
 
-    private renderSingleDayPickerCaption() {
+    private renderSingleCaption() {
         const { maxDate, minDate } = this.props;
         return (
             <DatePickerCaption
@@ -401,7 +402,7 @@ export class DateRangePicker
 
     private updateLeftView(leftView: MonthAndYear) {
         let rightView = this.state.rightView.clone();
-        if (rightView.isBefore(leftView) || rightView.isSame(leftView)) {
+        if (!leftView.isBefore(rightView)) {
             rightView = leftView.getNextMonth();
         }
         this.setViews(leftView, rightView);
@@ -409,7 +410,7 @@ export class DateRangePicker
 
     private updateRightView(rightView: MonthAndYear) {
         let leftView = this.state.leftView.clone();
-        if (leftView.isAfter(rightView) || leftView.isSame(rightView)) {
+        if (!rightView.isBefore(rightView)) {
             leftView = rightView.getPreviousMonth();
         }
         this.setViews(leftView, rightView);

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -389,16 +389,16 @@ export class DateRangePicker
 
     private updateLeftView(leftView: MonthAndYear) {
         let rightView = this.state.rightView.clone();
-        if (rightView.isBefore(leftView)) {
-            rightView = rightView.getNextMonth();
+        if (rightView.isBefore(leftView) || rightView.isSame(leftView)) {
+            rightView = leftView.getNextMonth();
         }
         this.setViews(leftView, rightView);
     }
 
     private updateRightView(rightView: MonthAndYear) {
         let leftView = this.state.leftView.clone();
-        if (leftView.isAfter(rightView)) {
-            leftView = leftView.getPreviousMonth();
+        if (leftView.isAfter(rightView) || leftView.isSame(rightView)) {
+            leftView = rightView.getPreviousMonth();
         }
         this.setViews(leftView, rightView);
     }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -48,6 +48,12 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     defaultValue?: DateRange;
 
     /**
+     * Constrains months to be sequential
+     * @default true
+     */
+    isSequential?: boolean;
+
+    /**
      * Called when the user selects a day.
      * If no days are selected, it will pass `[null, null]`.
      * If a start date is selected but not an end date, it will pass `[selectedDate, null]`.
@@ -83,6 +89,7 @@ export class DateRangePicker
 
     public static defaultProps: IDateRangePickerProps = {
         allowSingleDayRange: false,
+        isSequential: true,
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         shortcuts: true,
@@ -155,25 +162,27 @@ export class DateRangePicker
 
     public render() {
         const modifiers = combineModifiers(this.modifiers, this.props.modifiers);
-        const { className, locale, localeUtils, maxDate, minDate } = this.props;
+        const { className, isSequential, locale, localeUtils, maxDate, minDate } = this.props;
         const isShowingOneMonth = DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
         const { leftView, rightView } = this.state;
         const { disabledDays, selectedDays } = this.states;
 
-        if (isShowingOneMonth) {
+        if (isSequential || isShowingOneMonth) {
             // use the left DayPicker when we only show one
             return (
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
                     {this.maybeRenderShortcuts()}
                     <DayPicker
-                        captionElement={this.renderOneMonthCaption()}
+                        captionElement={this.renderSingleDayPickerCaption()}
                         disabledDays={disabledDays}
                         fromMonth={minDate}
                         initialMonth={leftView.getFullDate()}
                         locale={locale}
                         localeUtils={localeUtils}
                         modifiers={modifiers}
+                        numberOfMonths={isShowingOneMonth ? 1 : 2}
                         onDayClick={this.handleDayClick}
+                        onMonthChange={this.handleLeftMonthChange}
                         selectedDays={selectedDays}
                         toMonth={maxDate}
                     />
@@ -275,7 +284,7 @@ export class DateRangePicker
         );
     }
 
-    private renderOneMonthCaption() {
+    private renderSingleDayPickerCaption() {
         const { maxDate, minDate } = this.props;
         return (
             <DatePickerCaption

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -52,7 +52,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * If false, each side of the calendar can move independently to non-contiguous months.
      * @default true
      */
-    contigiousCalendarMonths?: boolean;
+    contiguousCalendarMonths?: boolean;
 
     /**
      * Called when the user selects a day.
@@ -90,7 +90,7 @@ export class DateRangePicker
 
     public static defaultProps: IDateRangePickerProps = {
         allowSingleDayRange: false,
-        contigiousCalendarMonths: true,
+        contiguousCalendarMonths: true,
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         shortcuts: true,
@@ -163,12 +163,12 @@ export class DateRangePicker
 
     public render() {
         const modifiers = combineModifiers(this.modifiers, this.props.modifiers);
-        const { className, contigiousCalendarMonths, locale, localeUtils, maxDate, minDate } = this.props;
+        const { className, contiguousCalendarMonths, locale, localeUtils, maxDate, minDate } = this.props;
         const isShowingOneMonth = DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
         const { leftView, rightView } = this.state;
         const { disabledDays, selectedDays } = this.states;
 
-        if (contigiousCalendarMonths || isShowingOneMonth) {
+        if (contiguousCalendarMonths || isShowingOneMonth) {
             // use the left DayPicker when we only need one
             const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
                 [DateClasses.DATERANGEPICKER_SEQUENTIAL]: !isShowingOneMonth,

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -135,44 +135,44 @@ describe("<DateRangePicker>", () => {
     });
 
     describe("left/right calendar when not sequential", () => {
-        it("only shows one calendar when minDate and maxDate are the same month", () => {
-            const isSequential = false;
+        it("only shows one calendar when minDate and maxDate are in the same month", () => {
+            const contigiousCalendarMonths = false;
             const minDate = new Date(2015, Months.DECEMBER, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ isSequential, maxDate, minDate });
+            renderDateRangePicker({ contigiousCalendarMonths, maxDate, minDate });
             assert.lengthOf(document.getElementsByClassName("DayPicker"), 1);
             assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--prev"), 0);
             assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--next"), 0);
         });
 
-        it("left calendar bound between minDate and (maxDate - 1 month)", () => {
-            const isSequential = false;
+        it("left calendar is bound between minDate and (maxDate - 1 month)", () => {
+            const contigiousCalendarMonths = false;
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ isSequential, maxDate, minDate });
+            renderDateRangePicker({ contigiousCalendarMonths, maxDate, minDate });
             const monthSelects = getMonthSelect().children;
             assert.equal(monthSelects[0].getAttribute("value"), Months.JANUARY);
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.NOVEMBER);
         });
 
-        it("right calendar bound between (minDate + 1 month) and maxDate", () => {
-            const isSequential = false;
+        it("right calendar is bound between (minDate + 1 month) and maxDate", () => {
+            const contigiousCalendarMonths = false;
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ isSequential, maxDate, minDate });
+            renderDateRangePicker({ contigiousCalendarMonths, maxDate, minDate });
             const monthSelects = getMonthSelect(false).children;
             assert.equal(monthSelects[0].getAttribute("value"), Months.FEBRUARY);
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.DECEMBER);
         });
 
-        it("left calendar can altered independent of right calendar", () => {
-            const isSequential = false;
+        it("left calendar can be altered independent of right calendar", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
@@ -183,11 +183,11 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
         });
 
-        it("right calendar can altered independent of left calendar", () => {
-            const isSequential = false;
+        it("right calendar can be altered independent of left calendar", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
@@ -198,11 +198,11 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
         });
 
-        it("right calendar is shifted if left calendar is equal or past right calendar with month dropdown", () => {
-            const isSequential = false;
+        it("changing left calendar with month dropdown to be equal or after right calendar, shifts the right", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             TestUtils.Simulate.change(getMonthSelect(), { target: { value: Months.AUGUST } } as any);
@@ -210,11 +210,11 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.SEPTEMBER);
         });
 
-        it("left calendar is shifted if right calendar is equal or past right calendar with month dropdown", () => {
-            const isSequential = false;
+        it("changing right calendar with month dropdown to be equal or before left calendar, shifts the left", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             TestUtils.Simulate.change(getMonthSelect(false), { target: { value: Months.APRIL } } as any);
@@ -222,12 +222,12 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.APRIL);
         });
 
-        it("right calendar is shifted if left calendar is equal or past right calendar with year dropdown", () => {
-            const isSequential = false;
+        it("changing left calendar with year dropdown to be equal or after right calendar, shifts the right", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2013, Months.MAY, 5);
             const NEW_YEAR = 2014;
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             TestUtils.Simulate.change(getYearSelect(), { target: { value: NEW_YEAR } } as any);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
@@ -235,12 +235,12 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getYear(), NEW_YEAR);
         });
 
-        it("left calendar is shifted if right calendar is equal or past right calendar with year dropdown", () => {
-            const isSequential = false;
+        it("changing right calendar with year dropdown to be equal or before left calendar, shifts the left", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2013, Months.MAY, 5);
             const NEW_YEAR = 2012;
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             TestUtils.Simulate.change(getYearSelect(false), { target: { value: NEW_YEAR } } as any);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
@@ -248,11 +248,11 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getYear(), NEW_YEAR);
         });
 
-        it("right calendar is shifted if left calendar is equal or past right calendar with navButton", () => {
-            const isSequential = false;
+        it("changing left calendar with navButton to equal right calendar, shifts right calendar", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
 
             TestUtils.Simulate.click(nextBtn[0]);
@@ -260,11 +260,11 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JULY);
         });
 
-        it("left calendar is shifted if right calendar is equal or past right calendar with navButton", () => {
-            const isSequential = false;
+        it("changing right calendar with navButton to equal left calendar, shifts left calendar", () => {
+            const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, isSequential });
+            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
 
             TestUtils.Simulate.click(prevBtn[1]);

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -134,41 +134,45 @@ describe("<DateRangePicker>", () => {
         });
     });
 
-    describe("left/right calendar", () => {
+    describe("left/right calendar when not sequential", () => {
         it("only shows one calendar when minDate and maxDate are the same month", () => {
+            const isSequential = false;
             const minDate = new Date(2015, Months.DECEMBER, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ maxDate, minDate });
+            renderDateRangePicker({ isSequential, maxDate, minDate });
             assert.lengthOf(document.getElementsByClassName("DayPicker"), 1);
             assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--prev"), 0);
             assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--next"), 0);
         });
 
         it("left calendar bound between minDate and (maxDate - 1 month)", () => {
+            const isSequential = false;
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ maxDate, minDate });
+            renderDateRangePicker({ isSequential, maxDate, minDate });
             const monthSelects = getMonthSelect().children;
             assert.equal(monthSelects[0].getAttribute("value"), Months.JANUARY);
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.NOVEMBER);
         });
 
         it("right calendar bound between (minDate + 1 month) and maxDate", () => {
+            const isSequential = false;
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ maxDate, minDate });
+            renderDateRangePicker({ isSequential, maxDate, minDate });
             const monthSelects = getMonthSelect(false).children;
             assert.equal(monthSelects[0].getAttribute("value"), Months.FEBRUARY);
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.DECEMBER);
         });
 
         it("left calendar can altered independent of right calendar", () => {
+            const isSequential = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
@@ -180,9 +184,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("right calendar can altered independent of left calendar", () => {
+            const isSequential = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
@@ -194,9 +199,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("right calendar is shifted if left calendar is equal or past right calendar with month dropdown", () => {
+            const isSequential = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             TestUtils.Simulate.change(getMonthSelect(), { target: { value: Months.AUGUST } } as any);
@@ -205,9 +211,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("left calendar is shifted if right calendar is equal or past right calendar with month dropdown", () => {
+            const isSequential = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             TestUtils.Simulate.change(getMonthSelect(false), { target: { value: Months.APRIL } } as any);
@@ -216,10 +223,11 @@ describe("<DateRangePicker>", () => {
         });
 
         it("right calendar is shifted if left calendar is equal or past right calendar with year dropdown", () => {
+            const isSequential = false;
             const initialMonth = new Date(2013, Months.MAY, 5);
             const NEW_YEAR = 2014;
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             TestUtils.Simulate.change(getYearSelect(), { target: { value: NEW_YEAR } } as any);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
@@ -228,10 +236,11 @@ describe("<DateRangePicker>", () => {
         });
 
         it("left calendar is shifted if right calendar is equal or past right calendar with year dropdown", () => {
+            const isSequential = false;
             const initialMonth = new Date(2013, Months.MAY, 5);
             const NEW_YEAR = 2012;
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             TestUtils.Simulate.change(getYearSelect(false), { target: { value: NEW_YEAR } } as any);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
@@ -240,9 +249,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("right calendar is shifted if left calendar is equal or past right calendar with navButton", () => {
+            const isSequential = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
 
             TestUtils.Simulate.click(nextBtn[0]);
@@ -251,9 +261,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("left calendar is shifted if right calendar is equal or past right calendar with navButton", () => {
+            const isSequential = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth });
+            renderDateRangePicker({ initialMonth, isSequential });
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
 
             TestUtils.Simulate.click(prevBtn[1]);
@@ -344,12 +355,12 @@ describe("<DateRangePicker>", () => {
             renderDateRangePicker({ initialMonth, minDate });
             assert.strictEqual(dateRangePicker.state.leftView.getMonth(), Months.FEBRUARY);
             let prevBtn = document.queryAll(".DayPicker-NavButton--prev");
-            assert.lengthOf(prevBtn, 2);
+            assert.lengthOf(prevBtn, 1);
 
             TestUtils.Simulate.click(prevBtn[0]);
             assert.strictEqual(dateRangePicker.state.leftView.getMonth(), Months.JANUARY);
             prevBtn = document.queryAll(".DayPicker-NavButton--prev");
-            assert.lengthOf(prevBtn, 1);
+            assert.lengthOf(prevBtn, 0);
         });
     });
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -168,7 +168,7 @@ describe("<DateRangePicker>", () => {
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.DECEMBER);
         });
 
-        it("left calendar can be altered independent of right calendar", () => {
+        it("left calendar can be altered independently of right calendar", () => {
             const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
@@ -183,7 +183,7 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
         });
 
-        it("right calendar can be altered independent of left calendar", () => {
+        it("right calendar can be altered independently of left calendar", () => {
             const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
@@ -248,7 +248,7 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getYear(), NEW_YEAR);
         });
 
-        it("changing left calendar with navButton to equal right calendar, shifts right calendar", () => {
+        it("changing left calendar with navButton to equal right calendar, shifts the right", () => {
             const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
@@ -260,7 +260,7 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JULY);
         });
 
-        it("changing right calendar with navButton to equal left calendar, shifts left calendar", () => {
+        it("changing right calendar with navButton to equal left calendar, shifts the left", () => {
             const contigiousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -136,43 +136,43 @@ describe("<DateRangePicker>", () => {
 
     describe("left/right calendar when not sequential", () => {
         it("only shows one calendar when minDate and maxDate are in the same month", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const minDate = new Date(2015, Months.DECEMBER, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ contigiousCalendarMonths, maxDate, minDate });
+            renderDateRangePicker({ contiguousCalendarMonths, maxDate, minDate });
             assert.lengthOf(document.getElementsByClassName("DayPicker"), 1);
             assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--prev"), 0);
             assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--next"), 0);
         });
 
         it("left calendar is bound between minDate and (maxDate - 1 month)", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ contigiousCalendarMonths, maxDate, minDate });
+            renderDateRangePicker({ contiguousCalendarMonths, maxDate, minDate });
             const monthSelects = getMonthSelect().children;
             assert.equal(monthSelects[0].getAttribute("value"), Months.JANUARY);
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.NOVEMBER);
         });
 
         it("right calendar is bound between (minDate + 1 month) and maxDate", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);
 
-            renderDateRangePicker({ contigiousCalendarMonths, maxDate, minDate });
+            renderDateRangePicker({ contiguousCalendarMonths, maxDate, minDate });
             const monthSelects = getMonthSelect(false).children;
             assert.equal(monthSelects[0].getAttribute("value"), Months.FEBRUARY);
             assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.DECEMBER);
         });
 
         it("left calendar can be altered independently of right calendar", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
@@ -184,10 +184,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("right calendar can be altered independently of left calendar", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
@@ -199,10 +199,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("changing left calendar with month dropdown to be equal or after right calendar, shifts the right", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             TestUtils.Simulate.change(getMonthSelect(), { target: { value: Months.AUGUST } } as any);
@@ -211,10 +211,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("changing right calendar with month dropdown to be equal or before left calendar, shifts the left", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
             TestUtils.Simulate.change(getMonthSelect(false), { target: { value: Months.APRIL } } as any);
@@ -223,11 +223,11 @@ describe("<DateRangePicker>", () => {
         });
 
         it("changing left calendar with year dropdown to be equal or after right calendar, shifts the right", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2013, Months.MAY, 5);
             const NEW_YEAR = 2014;
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             TestUtils.Simulate.change(getYearSelect(), { target: { value: NEW_YEAR } } as any);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
@@ -236,11 +236,11 @@ describe("<DateRangePicker>", () => {
         });
 
         it("changing right calendar with year dropdown to be equal or before left calendar, shifts the left", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2013, Months.MAY, 5);
             const NEW_YEAR = 2012;
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             TestUtils.Simulate.change(getYearSelect(false), { target: { value: NEW_YEAR } } as any);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
             assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
@@ -249,10 +249,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("changing left calendar with navButton to equal right calendar, shifts the right", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             const nextBtn = document.queryAll(".DayPicker-NavButton--next");
 
             TestUtils.Simulate.click(nextBtn[0]);
@@ -261,10 +261,10 @@ describe("<DateRangePicker>", () => {
         });
 
         it("changing right calendar with navButton to equal left calendar, shifts the left", () => {
-            const contigiousCalendarMonths = false;
+            const contiguousCalendarMonths = false;
             const initialMonth = new Date(2015, Months.MAY, 5);
 
-            renderDateRangePicker({ initialMonth, contigiousCalendarMonths });
+            renderDateRangePicker({ initialMonth, contiguousCalendarMonths });
             const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
 
             TestUtils.Simulate.click(prevBtn[1]);

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -134,6 +134,134 @@ describe("<DateRangePicker>", () => {
         });
     });
 
+    describe("left/right calendar", () => {
+        it("only shows one calendar when minDate and maxDate are the same month", () => {
+            const minDate = new Date(2015, Months.DECEMBER, 1);
+            const maxDate = new Date(2015, Months.DECEMBER, 15);
+
+            renderDateRangePicker({ maxDate, minDate });
+            assert.lengthOf(document.getElementsByClassName("DayPicker"), 1);
+            assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--prev"), 0);
+            assert.lengthOf(document.getElementsByClassName(".DayPicker-NavButton--next"), 0);
+        });
+
+        it("left calendar bound between minDate and (maxDate - 1 month)", () => {
+            const minDate = new Date(2015, Months.JANUARY, 1);
+            const maxDate = new Date(2015, Months.DECEMBER, 15);
+
+            renderDateRangePicker({ maxDate, minDate });
+            const monthSelects = getMonthSelect().children;
+            assert.equal(monthSelects[0].getAttribute("value"), Months.JANUARY);
+            assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.NOVEMBER);
+        });
+
+        it("right calendar bound between (minDate + 1 month) and maxDate", () => {
+            const minDate = new Date(2015, Months.JANUARY, 1);
+            const maxDate = new Date(2015, Months.DECEMBER, 15);
+
+            renderDateRangePicker({ maxDate, minDate });
+            const monthSelects = getMonthSelect(false).children;
+            assert.equal(monthSelects[0].getAttribute("value"), Months.FEBRUARY);
+            assert.equal(monthSelects[monthSelects.length - 1].getAttribute("value"), Months.DECEMBER);
+        });
+
+        it("left calendar can altered independent of right calendar", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            renderDateRangePicker({ initialMonth });
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
+            const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
+            const nextBtn = document.queryAll(".DayPicker-NavButton--next");
+
+            TestUtils.Simulate.click(prevBtn[0]);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.APRIL);
+            TestUtils.Simulate.click(nextBtn[0]);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
+        });
+
+        it("right calendar can altered independent of left calendar", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            renderDateRangePicker({ initialMonth });
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+            const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
+            const nextBtn = document.queryAll(".DayPicker-NavButton--next");
+
+            TestUtils.Simulate.click(nextBtn[1]);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JULY);
+            TestUtils.Simulate.click(prevBtn[1]);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+        });
+
+        it("right calendar is shifted if left calendar is equal or past right calendar with month dropdown", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            renderDateRangePicker({ initialMonth });
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+            TestUtils.Simulate.change(getMonthSelect(), { target: { value: Months.AUGUST } } as any);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.AUGUST);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.SEPTEMBER);
+        });
+
+        it("left calendar is shifted if right calendar is equal or past right calendar with month dropdown", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            renderDateRangePicker({ initialMonth });
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+            TestUtils.Simulate.change(getMonthSelect(false), { target: { value: Months.APRIL } } as any);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MARCH);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.APRIL);
+        });
+
+        it("right calendar is shifted if left calendar is equal or past right calendar with year dropdown", () => {
+            const initialMonth = new Date(2013, Months.MAY, 5);
+            const NEW_YEAR = 2014;
+
+            renderDateRangePicker({ initialMonth });
+            TestUtils.Simulate.change(getYearSelect(), { target: { value: NEW_YEAR } } as any);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
+            assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+            assert.equal(dateRangePicker.state.rightView.getYear(), NEW_YEAR);
+        });
+
+        it("left calendar is shifted if right calendar is equal or past right calendar with year dropdown", () => {
+            const initialMonth = new Date(2013, Months.MAY, 5);
+            const NEW_YEAR = 2012;
+
+            renderDateRangePicker({ initialMonth });
+            TestUtils.Simulate.change(getYearSelect(false), { target: { value: NEW_YEAR } } as any);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MAY);
+            assert.equal(dateRangePicker.state.leftView.getYear(), NEW_YEAR);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+            assert.equal(dateRangePicker.state.rightView.getYear(), NEW_YEAR);
+        });
+
+        it("right calendar is shifted if left calendar is equal or past right calendar with navButton", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            renderDateRangePicker({ initialMonth });
+            const nextBtn = document.queryAll(".DayPicker-NavButton--next");
+
+            TestUtils.Simulate.click(nextBtn[0]);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.JUNE);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JULY);
+        });
+
+        it("left calendar is shifted if right calendar is equal or past right calendar with navButton", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            renderDateRangePicker({ initialMonth });
+            const prevBtn = document.queryAll(".DayPicker-NavButton--prev");
+
+            TestUtils.Simulate.click(prevBtn[1]);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.APRIL);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.MAY);
+        });
+    });
+
     describe("minDate/maxDate bounds", () => {
         it("maxDate must be later than minDate", () => {
             const minDate = new Date(2000, Months.JANUARY, 10);
@@ -500,8 +628,9 @@ describe("<DateRangePicker>", () => {
         })[0];
     }
 
-    function getMonthSelect() {
-        return document.getElementsByClassName(DateClasses.DATEPICKER_MONTH_SELECT)[0] as HTMLSelectElement;
+    function getMonthSelect(fromLeftView: boolean = true) {
+        const monthSelect = document.getElementsByClassName(DateClasses.DATEPICKER_MONTH_SELECT);
+        return fromLeftView ? monthSelect[0] : monthSelect[1];
     }
 
     function getOptionsText(selectElementClass: string): string[] {
@@ -518,7 +647,8 @@ describe("<DateRangePicker>", () => {
         return document.queryAll(`.${selectedRange}:not(.${DateClasses.DATEPICKER_DAY_OUTSIDE})`);
     }
 
-    function getYearSelect() {
-        return document.getElementsByClassName(DateClasses.DATEPICKER_YEAR_SELECT)[0] as HTMLSelectElement;
+    function getYearSelect(fromLeftView: boolean = true) {
+        const yearSelect = document.getElementsByClassName(DateClasses.DATEPICKER_YEAR_SELECT);
+        return fromLeftView ? yearSelect[0] : yearSelect[1];
     }
 });


### PR DESCRIPTION
- Enable independent months feature though props
- Add independent DateRangePicker months tests
- Update docs

`isSequential` naming?