### PR TITLE
Add Tree#getNodeContentElement

### DIFF
--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -31,7 +31,6 @@ example, `[2, 0]` represents the first child (`0`) of the third top-level node (
 
 @interface ITreeProps
 
-
 @react-example TreeExample
 
 Styleguide components.tree.js

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -31,9 +31,23 @@ example, `[2, 0]` represents the first child (`0`) of the third top-level node (
 
 @interface ITreeProps
 
+
 @react-example TreeExample
 
 Styleguide components.tree.js
+*/
+
+/*
+Instance methods
+
+<div class="docs-interface-name">Tree</div>
+
+- `getNodeContentElement(nodeId: string | number): HTMLElement | undefined` &ndash;
+   Returns the underlying HTML element of the `Tree` node with an id of `nodeId`.
+   This element does not contain the children of the node, only its label and controls.
+   If the node is not currently mounted, `undefined` is returned.
+
+Styleguide components.tree.js.instance
 */
 
 /*

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -58,7 +58,7 @@ export class Tree extends React.Component<ITreeProps, {}> {
         }
     }
 
-    private nodeRefs: {[nodeId: string]: HTMLElement} = {};
+    private nodeRefs: { [nodeId: string]: HTMLElement } = {};
 
     public render() {
         return (

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -68,6 +68,11 @@ export class Tree extends React.Component<ITreeProps, {}> {
         );
     }
 
+    /**
+     * Returns the underlying HTML element of the `Tree` node with an id of `nodeId`.
+     * This element does not contain the children of the node, only its label and controls.
+     * If the node is not currently mounted, `undefined` is returned.
+     */
     public getNodeContentElement(nodeId: string | number): HTMLElement | undefined {
         return this.nodeRefs[nodeId];
     }

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -117,10 +117,10 @@ export class Tree extends React.Component<ITreeProps, {}> {
         this.handlerHelper(this.props.onNodeClick, node, e);
     }
 
-    private handleContentRef = (node: TreeNode, ele: HTMLElement | null) => {
+    private handleContentRef = (node: TreeNode, element: HTMLElement | null) => {
         const nodeData = Tree.nodeFromPath(node.props.path, this.props.contents);
-        if (ele != null) {
-            this.nodeRefs[nodeData.id] = ele;
+        if (element != null) {
+            this.nodeRefs[nodeData.id] = element;
         } else {
             // don't want our object to get bloated with old keys
             delete this.nodeRefs[nodeData.id];

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -126,6 +126,7 @@ export class Tree extends React.Component<ITreeProps, {}> {
             delete this.nodeRefs[nodeData.id];
         }
     }
+
     private handleNodeContextMenu = (node: TreeNode, e: React.MouseEvent<HTMLElement>) => {
         this.handlerHelper(this.props.onNodeContextMenu, node, e);
     }

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -58,12 +58,18 @@ export class Tree extends React.Component<ITreeProps, {}> {
         }
     }
 
+    private nodeRefs: {[nodeId: string]: HTMLElement} = {};
+
     public render() {
         return (
             <div className={classNames(Classes.TREE, this.props.className)}>
                 {this.renderNodes(this.props.contents, [], Classes.TREE_ROOT)}
             </div>
         );
+    }
+
+    public getNodeContentElement(nodeId: string | number): HTMLElement | undefined {
+        return this.nodeRefs[nodeId];
     }
 
     private renderNodes(treeNodes: ITreeNode[], currentPath?: number[], className?: string): JSX.Element {
@@ -77,6 +83,7 @@ export class Tree extends React.Component<ITreeProps, {}> {
                 <TreeNode
                     {...node}
                     key={node.id}
+                    contentRef={this.handleContentRef}
                     depth={elementPath.length - 1}
                     onClick={this.handleNodeClick}
                     onContextMenu={this.handleNodeContextMenu}
@@ -105,6 +112,15 @@ export class Tree extends React.Component<ITreeProps, {}> {
         this.handlerHelper(this.props.onNodeClick, node, e);
     }
 
+    private handleContentRef = (node: TreeNode, ele: HTMLElement | null) => {
+        const nodeData = Tree.nodeFromPath(node.props.path, this.props.contents);
+        if (ele != null) {
+            this.nodeRefs[nodeData.id] = ele;
+        } else {
+            // don't want our object to get bloated with old keys
+            delete this.nodeRefs[nodeData.id];
+        }
+    }
     private handleNodeContextMenu = (node: TreeNode, e: React.MouseEvent<HTMLElement>) => {
         this.handlerHelper(this.props.onNodeContextMenu, node, e);
     }

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -64,6 +64,7 @@ export interface ITreeNode {
 
 export interface ITreeNodeProps extends ITreeNode {
     children?: React.ReactNode;
+    contentRef?: (node: TreeNode, ele: HTMLDivElement | null) => void;
     depth: number;
     key?: string | number;
     onClick?: (node: TreeNode, e: React.MouseEvent<HTMLDivElement>) => void;
@@ -99,6 +100,7 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
                     onClick={this.handleClick}
                     onContextMenu={this.handleContextMenu}
                     onDoubleClick={this.handleDoubleClick}
+                    ref={this.handleContentRef}
                 >
                     <span className={caretClasses} onClick={showCaret ? this.handleCaretClick : null}/>
                     {this.maybeRenderIcon()}
@@ -138,6 +140,10 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
 
     private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
         safeInvoke(this.props.onClick, this, e);
+    }
+
+    private handleContentRef = (ele: HTMLDivElement | null) => {
+        safeInvoke(this.props.contentRef, this, ele);
     }
 
     private handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -142,8 +142,8 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
         safeInvoke(this.props.onClick, this, e);
     }
 
-    private handleContentRef = (ele: HTMLDivElement | null) => {
-        safeInvoke(this.props.contentRef, this, ele);
+    private handleContentRef = (element: HTMLDivElement | null) => {
+        safeInvoke(this.props.contentRef, this, element);
     }
 
     private handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -64,7 +64,7 @@ export interface ITreeNode {
 
 export interface ITreeNodeProps extends ITreeNode {
     children?: React.ReactNode;
-    contentRef?: (node: TreeNode, ele: HTMLDivElement | null) => void;
+    contentRef?: (node: TreeNode, element: HTMLDivElement | null) => void;
     depth: number;
     key?: string | number;
     onClick?: (node: TreeNode, e: React.MouseEvent<HTMLDivElement>) => void;

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -173,6 +173,23 @@ describe("<Tree>", () => {
         assert.strictEqual(label.innerText, "Paragraph");
     });
 
+    it("getNodeContentElement returns references to underlying node elements", (done) => {
+        const contents = createDefaultContents();
+        contents[1].isExpanded = true;
+        renderTree({contents});
+
+        assert.strictEqual(tree.getNodeContentElement(5), document.query(`.c5 > .${Classes.TREE_NODE_CONTENT}`));
+        assert.isUndefined(tree.getNodeContentElement(100));
+
+        contents[1].isExpanded = false;
+        renderTree({contents});
+        // wait for animation to finish
+        setTimeout(() => {
+            assert.isUndefined(tree.getNodeContentElement(5));
+            done();
+        }, 300);
+    });
+
     function renderTree(props?: Partial<ITreeProps>) {
         tree = ReactDOM.render(
             <Tree contents={createDefaultContents()} {...props}/>,


### PR DESCRIPTION
Fixes #644

#### Changes proposed in this pull request:

Add a `Tree#getNodeContentElement` method in order to get the underlying HTMLElement of tree nodes.

#### Reviewers should focus on:

* We probably should add docs. Do we have any examples of other components with public methods?
* Naming for the new method
* Make sure implementation logic looks right