### PR TITLE
[Date Range Input] - Part 5: Show selected values in input fields

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -110,6 +110,10 @@ export function getDateTime(date: Date, time: Date) {
     }
 }
 
+export function isMomentNull(momentDate: moment.Moment) {
+    return momentDate.parsingFlags().nullInput;
+}
+
 export function isMomentValidAndInRange(momentDate: moment.Moment, minDate: Date, maxDate: Date) {
     return momentDate.isValid() && isMomentInRange(momentDate, minDate, maxDate);
 }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -25,6 +25,7 @@ import {
     fromDateToMoment,
     fromMomentToDate,
     isMomentInRange,
+    isMomentNull,
     isMomentValidAndInRange,
 } from "./common/dateUtils";
 import { DatePicker } from "./datePicker";
@@ -164,7 +165,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         );
 
         const inputClasses = classNames({
-            "pt-intent-danger": !(this.isMomentValidAndInRange(date) || this.isNull(date) || dateString === ""),
+            "pt-intent-danger": !(this.isMomentValidAndInRange(date) || isMomentNull(date) || dateString === ""),
         });
 
         const calendarIcon = (
@@ -214,7 +215,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private getDateString = (value: moment.Moment) => {
-        if (this.isNull(value)) {
+        if (isMomentNull(value)) {
             return "";
         }
         if (value.isValid()) {
@@ -235,17 +236,13 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         return isMomentInRange(value, this.props.minDate, this.props.maxDate);
     }
 
-    private isNull(value: moment.Moment) {
-        return value.parsingFlags().nullInput;
-    }
-
     private handleClosePopover = () => {
         this.setState({ isOpen: false });
     }
 
     private handleDateChange = (date: Date, hasUserManuallySelectedDate: boolean) => {
         const momentDate = fromDateToMoment(date);
-        const hasMonthChanged = date !== null && !this.isNull(this.state.value) && this.state.value.isValid() &&
+        const hasMonthChanged = date !== null && !isMomentNull(this.state.value) && this.state.value.isValid() &&
             momentDate.month() !== this.state.value.month();
         const isOpen = !(this.props.closeOnSelection && hasUserManuallySelectedDate && !hasMonthChanged);
         if (this.props.value === undefined) {
@@ -271,7 +268,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private handleInputFocus = () => {
-        const valueString = this.isNull(this.state.value) ? "" : this.state.value.format(this.props.format);
+        const valueString = isMomentNull(this.state.value) ? "" : this.state.value.format(this.props.format);
 
         if (this.props.openOnFocus) {
             this.setState({ isInputFocused: true, isOpen: true, valueString });

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -51,7 +51,7 @@ export interface IDateRangeInputState {
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
         endInputProps: {},
-        format: "MM/DD/YYYY",
+        format: "YYYY-MM-DD",
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         startInputProps: {},

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -23,6 +23,7 @@ import {
     DateRange,
     fromDateToMoment,
     fromMomentToDate,
+    isMomentNull,
     isMomentValidAndInRange,
 } from "./common/dateUtils";
 import {
@@ -36,6 +37,7 @@ import {
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     endInputProps?: IInputGroupProps;
+    format?: string;
     onChange?: (selectedRange: DateRange) => void;
     startInputProps?: IInputGroupProps;
 }
@@ -49,6 +51,7 @@ export interface IDateRangeInputState {
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
         endInputProps: {},
+        format: "MM/DD/YYYY",
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         startInputProps: {},
@@ -79,6 +82,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     public render() {
+        const startInputString = this.getFormattedDateString(this.state.selectedStart);
+        const endInputString = this.getFormattedDateString(this.state.selectedEnd);
+
         const popoverContent = (
             <DateRangePicker
                 onChange={this.handleDateRangePickerChange}
@@ -107,6 +113,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         inputRef={this.refHandlers.startInputRef}
                         onClick={this.handleInputClick}
                         onFocus={this.handleInputFocus}
+                        value={startInputString}
                     />
                     <InputGroup
                         placeholder="End date"
@@ -114,6 +121,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         inputRef={this.refHandlers.endInputRef}
                         onClick={this.handleInputClick}
                         onFocus={this.handleInputFocus}
+                        value={endInputString}
                     />
                 </div>
             </Popover>
@@ -146,5 +154,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 ? undefined
                 : fromMomentToDate(selectedBound);
         }) as DateRange;
+    }
+
+    private getFormattedDateString = (momentDate: moment.Moment) => {
+        if (isMomentNull(momentDate)) {
+            return "";
+        } else {
+            return momentDate.format(this.props.format);
+        }
     }
 }

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -6,7 +6,7 @@
  */
 
 import { expect } from "chai";
-import { mount } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
 import { InputGroup } from "@blueprintjs/core";
@@ -47,8 +47,47 @@ describe("<DateRangeInput>", () => {
         getDayElement(22).simulate("click");
         getDayElement(24).simulate("click");
 
+        // TODO: Make these checks more rigorous once controlled mode is supported,
+        // when we'll be able to enforce which initial month is shown.
         expect(onChange.callCount).to.deep.equal(4);
     });
+
+    it("shows empty fields when no date range is selected", () => {
+        const onChange = sinon.spy();
+        const { root } = wrap(<DateRangeInput onChange={onChange} />);
+
+        expect(getStartInputText(root)).to.be.empty;
+        expect(getEndInputText(root)).to.be.empty;
+    });
+
+    it("shows formatted dates in fields when date range is selected", () => {
+        const onChange = sinon.spy();
+        const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} />);
+        root.setState({ isOpen: true });
+
+        getDayElement(22).simulate("click");
+        getDayElement(24).simulate("click");
+
+        // TODO: Make these checks more rigorous once controlled mode is supported.
+        expect(getStartInputText(root)).to.be.not.empty;
+        expect(getEndInputText(root)).to.be.not.empty;
+    });
+
+    function getStartInput(root: ReactWrapper<any, {}>) {
+        return root.find(InputGroup).first();
+    }
+
+    function getEndInput(root: ReactWrapper<any, {}>) {
+        return root.find(InputGroup).last();
+    }
+
+    function getStartInputText(root: ReactWrapper<any, {}>) {
+        return getStartInput(root).props().value;
+    }
+
+    function getEndInputText(root: ReactWrapper<any, {}>) {
+        return getEndInput(root).props().value;
+    }
 
     function wrap(dateRangeInput: JSX.Element) {
         const wrapper = mount(dateRangeInput);


### PR DESCRIPTION
> Second attempt at #680, which got in a bad state.

#### Related to #249, builds on #653 

#### Checklist

- [x] Include tests (will make them more rigorous once controlled mode is supported)

#### Changes proposed in this pull request:

- _New feature_: Show the selected date range in the input fields
- _Refactor_: Add `isMomentNull(momentDate: moment.Moment): boolean` utility function, and use it in `dateInput.tsx` instead of `this.isNull`.

#### Reviewers should focus on:

- This does _not_ support typing into the input fields yet; you can modify the date range only by clicking in the date picker.
- This does _not_ care about which input field was focused before the click; that'll come later.

#### Screenshot

![2017-02-13 13 28 19](https://cloud.githubusercontent.com/assets/443450/22904203/5ab0ddf6-f1f0-11e6-90e2-aeb20c5fc02a.gif)
