### PR TITLE
[Date Range Input] - Part 6: Controlled Mode

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -161,3 +161,18 @@ export function fromMomentToDate(momentDate: moment.Moment) {
         );
     }
 }
+
+/**
+ * Translate a DateRange into a two-element array of moments, adjusting the
+ * local timezone into the moment one (a no-op unless moment-timezone's
+ * setDefault has been called).
+ */
+export function fromDateRangeToMomentArray(dateRange: DateRange) {
+    if (dateRange == null) {
+        return undefined;
+    }
+    return [
+        fromDateToMoment(dateRange[0]),
+        fromDateToMoment(dateRange[1]),
+    ];
+}

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -8,6 +8,7 @@
 import * as moment from "moment";
 
 export type DateRange = [Date | undefined, Date | undefined];
+export type MomentDateRange = [moment.Moment, moment.Moment];
 
 export function areEqual(date1: Date, date2: Date) {
     if (date1 == null && date2 == null) {
@@ -167,12 +168,12 @@ export function fromMomentToDate(momentDate: moment.Moment) {
  * local timezone into the moment one (a no-op unless moment-timezone's
  * setDefault has been called).
  */
-export function fromDateRangeToMomentArray(dateRange: DateRange) {
+export function fromDateRangeToMomentDateRange(dateRange: DateRange) {
     if (dateRange == null) {
         return undefined;
     }
     return [
         fromDateToMoment(dateRange[0]),
         fromDateToMoment(dateRange[1]),
-    ];
+    ] as MomentDateRange;
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -37,6 +37,7 @@ import {
 } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
+    defaultValue?: DateRange;
     endInputProps?: IInputGroupProps;
     format?: string;
     onChange?: (selectedRange: DateRange) => void;
@@ -77,9 +78,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     public constructor(props: IDateRangeInputProps, context?: any) {
         super(props, context);
 
-        const [selectedStart, selectedEnd] = (this.props.value != null)
-            ? fromDateRangeToMomentArray(this.props.value)
-            : [moment(null), moment(null)];
+        const [selectedStart, selectedEnd] = this.getInitialRange();
 
         this.state = {
             isOpen: false,
@@ -153,6 +152,23 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handlePopoverClose = () => {
         this.setState({ isOpen: false });
+    }
+
+    private getInitialRange = (): moment.Moment[] => {
+        const { defaultValue, value } = this.props;
+
+        let initialStart: moment.Moment;
+        let initialEnd: moment.Moment;
+
+        if (value != null) {
+            [initialStart, initialEnd] = fromDateRangeToMomentArray(value);
+        } else if (defaultValue != null) {
+            [initialStart, initialEnd] = fromDateRangeToMomentArray(defaultValue);
+        } else {
+            [initialStart, initialEnd] = [moment(null), moment(null)];
+        }
+
+        return [initialStart, initialEnd];
     }
 
     private getSelectedRange = () => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -21,6 +21,7 @@ import {
 
 import {
     DateRange,
+    fromDateRangeToMomentArray,
     fromDateToMoment,
     fromMomentToDate,
     isMomentNull,
@@ -40,6 +41,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     format?: string;
     onChange?: (selectedRange: DateRange) => void;
     startInputProps?: IInputGroupProps;
+    value?: DateRange;
 }
 
 export interface IDateRangeInputState {
@@ -74,10 +76,15 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     public constructor(props: IDateRangeInputProps, context?: any) {
         super(props, context);
+
+        const [selectedStart, selectedEnd] = (this.props.value != null)
+            ? fromDateRangeToMomentArray(this.props.value)
+            : [moment(null), moment(null)];
+
         this.state = {
             isOpen: false,
-            selectedEnd: moment(null),
-            selectedStart: moment(null),
+            selectedEnd,
+            selectedStart,
         };
     }
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -52,7 +52,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     /**
      * The format of each date in the date range. See options
      * here: http://momentjs.com/docs/#/displaying/format/
-     * @default "MM/DD/YYYY"
+     * @default "YYYY-MM-DD"
      */
     format?: string;
 
@@ -176,7 +176,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
         if (this.props.value === undefined) {
-            const [selectedStart, selectedEnd] = selectedRange.map(fromDateToMoment);
+            const [selectedStart, selectedEnd] = fromDateRangeToMomentArray(selectedRange);
             this.setState({ selectedStart, selectedEnd });
         }
         Utils.safeInvoke(this.props.onChange, selectedRange);
@@ -198,19 +198,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private getInitialRange = (props = this.props): moment.Moment[] => {
         const { defaultValue, value } = props;
-
-        let initialStart: moment.Moment;
-        let initialEnd: moment.Moment;
-
         if (value != null) {
-            [initialStart, initialEnd] = fromDateRangeToMomentArray(value);
+            return fromDateRangeToMomentArray(value);
         } else if (defaultValue != null) {
-            [initialStart, initialEnd] = fromDateRangeToMomentArray(defaultValue);
+            return fromDateRangeToMomentArray(defaultValue);
         } else {
-            [initialStart, initialEnd] = [moment(null), moment(null)];
+            return [moment(null), moment(null)];
         }
-
-        return [initialStart, initialEnd];
     }
 
     private getSelectedRange = () => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -22,7 +22,6 @@ import {
 import {
     DateRange,
     fromDateRangeToMomentArray,
-    fromDateToMoment,
     fromMomentToDate,
     isMomentNull,
     isMomentValidAndInRange,

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -166,9 +166,19 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         );
     }
 
+    public componentWillReceiveProps(nextProps: IDateRangeInputProps) {
+        if (nextProps.value !== this.props.value) {
+            const [selectedStart, selectedEnd] = this.getInitialRange(nextProps);
+            this.setState({ selectedStart, selectedEnd });
+        }
+        super.componentWillReceiveProps(nextProps);
+    }
+
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
-        const [selectedStart, selectedEnd] = selectedRange.map(fromDateToMoment);
-        this.setState({ selectedStart, selectedEnd });
+        if (this.props.value === undefined) {
+            const [selectedStart, selectedEnd] = selectedRange.map(fromDateToMoment);
+            this.setState({ selectedStart, selectedEnd });
+        }
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
@@ -186,8 +196,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         this.setState({ isOpen: false });
     }
 
-    private getInitialRange = (): moment.Moment[] => {
-        const { defaultValue, value } = this.props;
+    private getInitialRange = (props = this.props): moment.Moment[] => {
+        const { defaultValue, value } = props;
 
         let initialStart: moment.Moment;
         let initialEnd: moment.Moment;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -21,10 +21,11 @@ import {
 
 import {
     DateRange,
-    fromDateRangeToMomentArray,
+    fromDateRangeToMomentDateRange,
     fromMomentToDate,
     isMomentNull,
     isMomentValidAndInRange,
+    MomentDateRange,
 } from "./common/dateUtils";
 import {
     getDefaultMaxDate,
@@ -39,7 +40,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * The default date range to be used in the component when uncontrolled.
-     * This should not be set if `value` is set.
+     * This will be ignored if `value` is set.
      */
     defaultValue?: DateRange;
 
@@ -69,9 +70,11 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     startInputProps?: IInputGroupProps;
 
     /**
-     * The currently selected date range. If this prop is present, the component acts in a controlled manner.
-     * To display no date range in the input fields, pass `null` to the value prop. To display an invalid date error
-     * in either input field, pass `new Date(undefined)` for the appropriate date in the value prop.
+     * The currently selected date range.
+     * If this prop is present, the component acts in a controlled manner.
+     * To display no date range in the input fields, pass `[null, null]` to the value prop.
+     * To display an invalid date error in either input field, pass `new Date(undefined)`
+     * for the appropriate date in the value prop.
      */
     value?: DateRange;
 }
@@ -166,16 +169,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     public componentWillReceiveProps(nextProps: IDateRangeInputProps) {
+        super.componentWillReceiveProps(nextProps);
         if (nextProps.value !== this.props.value) {
             const [selectedStart, selectedEnd] = this.getInitialRange(nextProps);
             this.setState({ selectedStart, selectedEnd });
         }
-        super.componentWillReceiveProps(nextProps);
     }
 
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
         if (this.props.value === undefined) {
-            const [selectedStart, selectedEnd] = fromDateRangeToMomentArray(selectedRange);
+            const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
             this.setState({ selectedStart, selectedEnd });
         }
         Utils.safeInvoke(this.props.onChange, selectedRange);
@@ -195,14 +198,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         this.setState({ isOpen: false });
     }
 
-    private getInitialRange = (props = this.props): moment.Moment[] => {
+    private getInitialRange = (props = this.props) => {
         const { defaultValue, value } = props;
         if (value != null) {
-            return fromDateRangeToMomentArray(value);
+            return fromDateRangeToMomentDateRange(value);
         } else if (defaultValue != null) {
-            return fromDateRangeToMomentArray(defaultValue);
+            return fromDateRangeToMomentDateRange(defaultValue);
         } else {
-            return [moment(null), moment(null)];
+            return [moment(null), moment(null)] as MomentDateRange;
         }
     }
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -37,11 +37,43 @@ import {
 } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
+
+    /**
+     * The default date range to be used in the component when uncontrolled.
+     * This should not be set if `value` is set.
+     */
     defaultValue?: DateRange;
+
+    /**
+     * Props to pass to the end-date input.
+     */
     endInputProps?: IInputGroupProps;
+
+    /**
+     * The format of each date in the date range. See options
+     * here: http://momentjs.com/docs/#/displaying/format/
+     * @default "MM/DD/YYYY"
+     */
     format?: string;
+
+    /**
+     * Called when the user selects a day.
+     * If no days are selected, it will pass `[null, null]`.
+     * If a start date is selected but not an end date, it will pass `[selectedDate, null]`.
+     * If both a start and end date are selected, it will pass `[startDate, endDate]`.
+     */
     onChange?: (selectedRange: DateRange) => void;
+
+    /**
+     * Props to pass to the start-date input.
+     */
     startInputProps?: IInputGroupProps;
+
+    /**
+     * The currently selected date range. If this prop is present, the component acts in a controlled manner.
+     * To display no date range in the input fields, pass `null` to the value prop. To display an invalid date error
+     * in either input field, pass `new Date(undefined)` for the appropriate date in the value prop.
+     */
     value?: DateRange;
 }
 

--- a/packages/datetime/test/common/dateTestUtils.ts
+++ b/packages/datetime/test/common/dateTestUtils.ts
@@ -1,0 +1,16 @@
+
+import { padWithZeroes } from "../../src/common/utils";
+
+/**
+ * Converts a date to a "YYYY-MM-DD" string without relying on moment.js.
+ */
+export function toHyphenatedDateString(date: Date) {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1; // 0-indexed => 1-indexed
+    const day = date.getDate();
+    return [
+        year.toString(),
+        padWithZeroes(month.toString(), 2),
+        padWithZeroes(day.toString(), 2),
+    ].join("-");
+}

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -11,8 +11,8 @@ import * as React from "react";
 
 import { Button, InputGroup, Popover } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
-import { padWithZeroes } from "../src/common/utils";
 import { Classes, DateInput } from "../src/index";
+import * as DateTestUtils from "./common/dateTestUtils";
 
 describe("<DateInput>", () => {
     it("handles null inputs without crashing", () => {
@@ -211,11 +211,7 @@ describe("<DateInput>", () => {
 
     /* Assert Date equals YYYY-MM-DD string. */
     function assertDateEquals(actual: Date, expected: string) {
-        const actualString = [
-            actual.getFullYear(),
-            padWithZeroes((actual.getMonth() + 1) + "", 2),
-            padWithZeroes(actual.getDate() + "", 2),
-        ].join("-");
+        const actualString = DateTestUtils.toHyphenatedDateString(actual);
         assert.strictEqual(actualString, expected);
     }
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -14,7 +14,7 @@ import { Months } from "../src/common/months";
 import { padWithZeroes } from "../src/common/utils";
 import { Classes as DateClasses, DateRange, DateRangeInput } from "../src/index";
 
-describe.only("<DateRangeInput>", () => {
+describe("<DateRangeInput>", () => {
     it("renders with two InputGroup children", () => {
         const component = mount(<DateRangeInput />);
         expect(component.find(InputGroup).length).to.equal(2);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -36,28 +36,6 @@ describe.only("<DateRangeInput>", () => {
         expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
     });
 
-    it("invokes onChange when a day is selected or deselected in the picker", () => {
-        const onChange = sinon.spy();
-        const defaultValue = [new Date(2017, Months.JANUARY, 22), new Date(2017, Months.JANUARY, 24)] as DateRange;
-
-        const { root, getDayElement } = wrap(<DateRangeInput defaultValue={defaultValue} onChange={onChange} />);
-        root.setState({ isOpen: true });
-
-        // deselect days
-        getDayElement(22).simulate("click");
-        getDayElement(24).simulate("click");
-
-        // select days
-        getDayElement(22).simulate("click");
-        getDayElement(24).simulate("click");
-
-        expect(onChange.callCount).to.equal(4);
-        assertDateRangesEqual(onChange.getCall(0).args[0], [null, "2017-01-24"]);
-        assertDateRangesEqual(onChange.getCall(1).args[0], [null, null]);
-        assertDateRangesEqual(onChange.getCall(2).args[0], ["2017-01-22", null]);
-        assertDateRangesEqual(onChange.getCall(3).args[0], ["2017-01-22", "2017-01-24"]);
-    });
-
     it("shows empty fields when no date range is selected", () => {
         const onChange = sinon.spy();
         const { root } = wrap(<DateRangeInput onChange={onChange} />);
@@ -75,6 +53,30 @@ describe.only("<DateRangeInput>", () => {
 
         expect(getStartInputText(root)).to.equal("2017-01-22");
         expect(getEndInputText(root)).to.equal("2017-01-24");
+    });
+
+    describe("when controlled", () => {
+        it("invokes onChange with the selected date range when a date is clicked", () => {
+            const onChange = sinon.spy();
+            const value = [new Date(2017, Months.JANUARY, 22), new Date(2017, Months.JANUARY, 24)] as DateRange;
+
+            const { root, getDayElement } = wrap(<DateRangeInput value={value} onChange={onChange} />);
+            root.setState({ isOpen: true });
+
+            // deselect days
+            getDayElement(22).simulate("click");
+            getDayElement(24).simulate("click");
+
+            // select days
+            getDayElement(22).simulate("click");
+            getDayElement(24).simulate("click");
+
+            expect(onChange.callCount).to.equal(4);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, "2017-01-24"]);
+            assertDateRangesEqual(onChange.getCall(1).args[0], [null, null]);
+            assertDateRangesEqual(onChange.getCall(2).args[0], ["2017-01-22", null]);
+            assertDateRangesEqual(onChange.getCall(3).args[0], ["2017-01-22", "2017-01-24"]);
+        });
     });
 
     function getStartInput(root: ReactWrapper<any, {}>) {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -84,38 +84,38 @@ describe.only("<DateRangeInput>", () => {
         const END_STR_2 = "2017-01-31";
         const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
 
-        it("Clicking a date invokes onChange with the selected date range", () => {
+        it("Clicking a date invokes onChange with the selected date range but doesn't change UI", () => {
             const onChange = sinon.spy();
             const { root, getDayElement } = wrap(<DateRangeInput value={DATE_RANGE} onChange={onChange} />);
             root.setState({ isOpen: true });
 
-            // deselect days
+            // click start date
             getDayElement(22).simulate("click");
-            getDayElement(24).simulate("click");
-
-            // select days
-            getDayElement(22).simulate("click");
-            getDayElement(24).simulate("click");
-
-            expect(onChange.callCount).to.equal(4);
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
-            assertDateRangesEqual(onChange.getCall(1).args[0], [null, null]);
-            assertDateRangesEqual(onChange.getCall(2).args[0], [START_STR, null]);
-            assertDateRangesEqual(onChange.getCall(3).args[0], [START_STR, END_STR]);
+            expect(getStartInputText(root)).to.equal(START_STR);
+            expect(getEndInputText(root)).to.equal(END_STR);
+
+            // click end date
+            getDayElement(24).simulate("click");
+            assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, null]);
+            expect(getStartInputText(root)).to.equal(START_STR);
+            expect(getEndInputText(root)).to.equal(END_STR);
+
+            expect(onChange.callCount).to.equal(2);
         });
 
         it("Clearing the date in the DatePicker invokes onChange with [null, null] but doesn't change UI", () => {
             const onChange = sinon.spy();
+            const value = [START_DATE, null] as DateRange;
 
-            const { root, getDayElement } = wrap(<DateRangeInput value={DATE_RANGE} onChange={onChange} />);
+            const { root, getDayElement } = wrap(<DateRangeInput value={value} onChange={onChange} />);
             root.setState({ isOpen: true });
 
             getDayElement(22).simulate("click");
-            getDayElement(24).simulate("click");
 
-            assertDateRangesEqual(onChange.getCall(1).args[0], [null, null]);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
             expect(getStartInputText(root)).to.equal(START_STR);
-            expect(getEndInputText(root)).to.equal(END_STR);
+            expect(getEndInputText(root)).to.be.empty;
         });
 
         it("Updating value updates the text boxes", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -79,7 +79,7 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, "");
         });
 
-        it("Clearing the date range clears the inputs, and invokes onChange with [null, null]", () => {
+        it("Clicking to clear the date range clears the inputs and invokes onChange with [null, null]", () => {
             const onChange = sinon.spy();
             const defaultValue = [START_DATE, null] as DateRange;
 
@@ -95,7 +95,7 @@ describe("<DateRangeInput>", () => {
     });
 
     describe("when controlled", () => {
-        it("Ignores defaultValue if it is also set", () => {
+        it("Setting value causes defaultValue to be ignored", () => {
             const { root } = wrap(<DateRangeInput
                 defaultValue={DATE_RANGE_2}
                 value={DATE_RANGE}
@@ -103,12 +103,12 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, END_STR);
         });
 
-        it("shows empty fields when value is [null, null]", () => {
+        it("Setting value to [null, null] shows empty fields", () => {
             const { root } = wrap(<DateRangeInput value={[null, null]} />);
             assertInputTextsEqual(root, "", "");
         });
 
-        it("Clicking a date invokes onChange with the selected date range but doesn't change UI", () => {
+        it("Clicking a date invokes onChange with the new date range, but doesn't change the UI", () => {
             const onChange = sinon.spy();
             const { root, getDayElement } = wrap(<DateRangeInput value={DATE_RANGE} onChange={onChange} />);
             root.setState({ isOpen: true });
@@ -128,7 +128,7 @@ describe("<DateRangeInput>", () => {
             expect(onChange.callCount).to.equal(2);
         });
 
-        it("Clearing the date in the DatePicker invokes onChange with [null, null] but doesn't change UI", () => {
+        it("Clearing the date invokes onChange with [null, null], but doesn't change the UI", () => {
             const onChange = sinon.spy();
             const value = [START_DATE, null] as DateRange;
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -18,16 +18,16 @@ describe("<DateRangeInput>", () => {
 
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
-    const START_STR = "2017-01-22";
+    const START_STR = DateTestUtils.toHyphenatedDateString(START_DATE);
     const END_DAY = 24;
     const END_DATE = new Date(2017, Months.JANUARY, END_DAY);
-    const END_STR = "2017-01-24";
+    const END_STR = DateTestUtils.toHyphenatedDateString(END_DATE);
     const DATE_RANGE = [START_DATE, END_DATE] as DateRange;
 
     const START_DATE_2 = new Date(2017, Months.JANUARY, 1);
-    const START_STR_2 = "2017-01-01";
+    const START_STR_2 = DateTestUtils.toHyphenatedDateString(START_DATE_2);
     const END_DATE_2 = new Date(2017, Months.JANUARY, 31);
-    const END_STR_2 = "2017-01-31";
+    const END_STR_2 = DateTestUtils.toHyphenatedDateString(END_DATE_2);
     const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
 
     it("renders with two InputGroup children", () => {
@@ -95,6 +95,19 @@ describe("<DateRangeInput>", () => {
     });
 
     describe("when controlled", () => {
+        it("Ignores defaultValue if it is also set", () => {
+            const { root } = wrap(<DateRangeInput
+                defaultValue={DATE_RANGE_2}
+                value={DATE_RANGE}
+            />);
+            assertInputTextsEqual(root, START_STR, END_STR);
+        });
+
+        it("shows empty fields when value is [null, null]", () => {
+            const { root } = wrap(<DateRangeInput value={[null, null]} />);
+            assertInputTextsEqual(root, "", "");
+        });
+
         it("Clicking a date invokes onChange with the selected date range but doesn't change UI", () => {
             const onChange = sinon.spy();
             const { root, getDayElement } = wrap(<DateRangeInput value={DATE_RANGE} onChange={onChange} />);


### PR DESCRIPTION
> Second attempt at #683. The squashing is getting in the way of my rebasing behavior as I proceed to successive Parts. I'll stop opening multiple PRs at once.

#### Related to #249, builds on #682 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Implemented controlled mode.

- _New feature_: Introduce a `value` prop.
- _New feature_: Introduce a `defaultValue` prop.
- Add prop descriptions for all existing props. 
- Add unit tests (and some reorganize existing ones into `when controlled` and `when uncontrolled` blocks).
- Harden existing unit tests (now that we can control the initial display month via `defaultValue` or `value`).

#### Reviewers should focus on:

- [x] Polishing copy in prop descriptions