### PR TITLE
Hide background color on dark minimal disabled intent button hover

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -393,6 +393,7 @@ $button-intents: (
 
     &:disabled,
     &.pt-disabled {
+      background: none;
       color: rgba($dark-text-color, 0.5);
     }
   }


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/199754/23042885/4388da50-f44f-11e6-8418-875708ab7543.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/23042894/4a0056b0-f44f-11e6-9b0a-fff4207ab4fe.png)
