### PR TITLE
Use same color for colored icon and text in menus, callouts

### DIFF
--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -76,10 +76,7 @@ Styleguide components.callout.css
     &.pt-intent-#{$intent} {
       background-color: rgba($color, 0.15);
 
-      &[class*="pt-icon-"]::before {
-        color: $color;
-      }
-
+      &[class*="pt-icon-"]::before,
       h5 {
         color: map-get($pt-intent-text-colors, $intent);
       }
@@ -87,6 +84,7 @@ Styleguide components.callout.css
       .pt-dark & {
         background-color: rgba($color, 0.25);
 
+        &[class*="pt-icon-"]::before,
         h5 {
           color: map-get($pt-dark-intent-text-colors, $intent);
         }

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -197,7 +197,11 @@ $input-button-height-large: $pt-button-height !default;
       }
 
       .pt-icon {
-        color: $color;
+        color: map-get($pt-intent-text-colors, $intent);
+      }
+
+      .pt-dark & .pt-icon {
+        color: map-get($pt-dark-intent-text-colors, $intent);
       }
     }
   }

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -198,10 +198,10 @@ $input-button-height-large: $pt-button-height !default;
 
       .pt-icon {
         color: map-get($pt-intent-text-colors, $intent);
-      }
 
-      .pt-dark & .pt-icon {
-        color: map-get($pt-dark-intent-text-colors, $intent);
+        .pt-dark & {
+          color: map-get($pt-dark-intent-text-colors, $intent);
+        }
       }
     }
   }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -69,7 +69,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
       &::before,
       &::after,
       .pt-menu-item-label {
-        color: map-get($pt-intent-colors, $intent);
+        color: $color;
       }
 
       &:hover,


### PR DESCRIPTION
With this PR, colored icons get the same color value than the text next to it, in menus, callouts... Somehow, this was already the case for minimal buttons, so nothing to change there.

Before:
![image](https://cloud.githubusercontent.com/assets/199754/23043276/985663b2-f450-11e6-8b88-fc3efebd55d2.png)
![image](https://cloud.githubusercontent.com/assets/199754/23043324/ba378c5e-f450-11e6-97fe-3c834da60834.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/23043292/a7f09ac2-f450-11e6-9606-042c9c26869f.png)
![image](https://cloud.githubusercontent.com/assets/199754/23043341/c5babb0a-f450-11e6-9e1f-b738dcd80331.png)

cc @pkwi 