### PR TITLE
Remove unnecessary font-family declaration on inputs

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -95,7 +95,6 @@ $control-group-stack: (
   vertical-align: middle;
   line-height: $pt-input-height;
   color: $input-color;
-  font-family: $pt-font-family;
   font-size: $pt-font-size;
   font-weight: $input-font-weight;
   transition: $input-transition;


### PR DESCRIPTION
It's already declared at a higher level