### PR TITLE
Same styles for minimal button hover & focus

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -274,11 +274,8 @@ $button-intents: (
   box-shadow: none;
   background: $minimal-button-background-color;
 
+  &:hover,
   &:focus {
-    box-shadow: none;
-  }
-
-  &:hover {
     box-shadow: none;
     background: $minimal-button-background-color-hover;
     text-decoration: none;
@@ -357,7 +354,8 @@ $button-intents: (
     color: $text-color;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: rgba($intent-color, 0.15);
   }
 


### PR DESCRIPTION
Before (colored text only):
![image](https://cloud.githubusercontent.com/assets/199754/23140324/c91875cc-f765-11e6-81fe-c959cf504305.png)

After (adds background shape):
![image](https://cloud.githubusercontent.com/assets/199754/23140331/d1b755d6-f765-11e6-832d-f79acdf88e7e.png)
