### PR TITLE
Fix input group action static color

### DIFF
--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -120,7 +120,12 @@ $input-button-height-large: $pt-button-height !default;
   .pt-input:not(:focus) + .pt-button,
   .pt-input:not(:focus) + .pt-input-action .pt-button {
     &.pt-minimal:not(:hover):not(:focus) {
-      color: $pt-icon-color;
+      color: $pt-text-color-muted;
+
+      // same goes for dark
+      // stylelint-disable selector-max-compound-selectors
+      .pt-dark & { color: $pt-dark-text-color-muted; }
+      // stylelint-enable selector-max-compound-selectors
 
       #{$icon-classes} {
         color: $pt-icon-color;

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -123,9 +123,10 @@ $input-button-height-large: $pt-button-height !default;
       color: $pt-text-color-muted;
 
       // same goes for dark
-      // stylelint-disable selector-max-compound-selectors
-      .pt-dark & { color: $pt-dark-text-color-muted; }
-      // stylelint-enable selector-max-compound-selectors
+      // stylelint-disable-next-line selector-max-compound-selectors
+      .pt-dark & {
+        color: $pt-dark-text-color-muted;
+      }
 
       #{$icon-classes} {
         color: $pt-icon-color;


### PR DESCRIPTION
Before (lighter than placeholder, bad):
![image](https://cloud.githubusercontent.com/assets/199754/23140378/125aedb4-f766-11e6-9d1c-2769ca8c26e2.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/23140387/1a18b842-f766-11e6-84ec-55a50c21329f.png)
