### PR TITLE
[Date Range Input] - Part 7: Typing dates into input fields

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -164,9 +164,9 @@ export function fromMomentToDate(momentDate: moment.Moment) {
 }
 
 /**
- * Translate a DateRange into a two-element array of moments, adjusting the
- * local timezone into the moment one (a no-op unless moment-timezone's
- * setDefault has been called).
+ * Translate a DateRange into a MomentDateRange, adjusting the local timezone
+ * into the moment one (a no-op unless moment-timezone's setDefault has been
+ * called).
  */
 export function fromDateRangeToMomentDateRange(dateRange: DateRange) {
     if (dateRange == null) {
@@ -176,4 +176,19 @@ export function fromDateRangeToMomentDateRange(dateRange: DateRange) {
         fromDateToMoment(dateRange[0]),
         fromDateToMoment(dateRange[1]),
     ] as MomentDateRange;
+}
+
+/**
+ * Translate a MomentDateRange into a DateRange, adjusting the moment timezone
+ * into the local one. This is a no-op unless moment-timezone's setDefault has
+ * been called.
+ */
+export function fromMomentDateRangeToDateRange(momentDateRange: MomentDateRange) {
+    if (momentDateRange == null) {
+        return undefined;
+    }
+    return [
+        fromMomentToDate(momentDateRange[0]),
+        fromMomentToDate(momentDateRange[1]),
+    ] as DateRange;
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -409,7 +409,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 values: {
                     controlledValue: (controlledRange != null) ? controlledRange[0] : undefined,
                     inputString: this.state.startInputString,
-                    isFocused: this.state.isStartInputFocused,
+                    isInputFocused: this.state.isStartInputFocused,
                     selectedValue: this.state.selectedStart,
                 },
             } as IStateKeysAndValuesObject;
@@ -423,7 +423,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 values: {
                     controlledValue: (controlledRange != null) ? controlledRange[1] : undefined,
                     inputString: this.state.endInputString,
-                    isFocused: this.state.isEndInputFocused,
+                    isInputFocused: this.state.isEndInputFocused,
                     selectedValue: this.state.selectedEnd,
                 },
             } as IStateKeysAndValuesObject;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -171,6 +171,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="Start date"
                         {...this.props.startInputProps}
                         inputRef={this.refHandlers.startInputRef}
+                        onChange={this.handleInputChange}
                         onClick={this.handleInputClick}
                         onFocus={this.handleInputFocus}
                         value={startInputString}
@@ -179,6 +180,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="End date"
                         {...this.props.endInputProps}
                         inputRef={this.refHandlers.endInputRef}
+                        onChange={this.handleInputChange}
                         onClick={this.handleInputClick}
                         onFocus={this.handleInputFocus}
                         value={endInputString}
@@ -214,6 +216,25 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         this.setState({ isOpen: true });
     }
 
+    private handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+        const inputElement = e.target as HTMLInputElement;
+        const inputString = inputElement.value;
+
+        const nextValue = this.dateStringToMoment(inputString);
+        const { keys } = this.getStateKeysAndValuesForInput(e.target as HTMLInputElement);
+
+        if (inputString.length === 0) {
+            // this case will be relevant when we start showing the hovered
+            // range in the input fields. goal is to show an empty field for
+            // clarity until the mouse moves over a different date.
+            this.setState({ [keys.inputString]: "", [keys.selectedValue]: moment(null) });
+        } else if (this.props.value === undefined && this.isMomentValidAndInRange(nextValue)) {
+            this.setState({ [keys.inputString]: inputString, [keys.selectedValue]: nextValue });
+        } else {
+            this.setState({ [keys.inputString]: inputString });
+        }
+    }
+
     private handlePopoverClose = () => {
         this.setState({ isOpen: false });
     }
@@ -245,7 +266,44 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
+    private dateStringToMoment = (dateString: String) => {
+        return moment(dateString, this.props.format);
+    }
+
     private isMomentValidAndInRange = (momentDate: moment.Moment) => {
         return isMomentValidAndInRange(momentDate, this.props.minDate, this.props.maxDate);
+    }
+
+    private getStateKeysAndValuesForInput = (inputElement: HTMLInputElement): IStateKeysAndValuesObject => {
+        if (inputElement === this.startInputRef) {
+            return {
+                keys: {
+                    inputString: "startInputString",
+                    isInputFocused: "isStartInputFocused",
+                    selectedValue: "selectedStart",
+                },
+                values: {
+                    inputString: this.state.startInputString,
+                    isFocused: this.state.isStartInputFocused,
+                    selectedValue: this.state.selectedStart,
+                },
+            } as IStateKeysAndValuesObject;
+        } else if (inputElement === this.endInputRef) {
+            return {
+                keys: {
+                    inputString: "endInputString",
+                    isInputFocused: "isEndInputFocused",
+                    selectedValue: "selectedEnd",
+                },
+                values: {
+                    inputString: this.state.endInputString,
+                    isFocused: this.state.isEndInputFocused,
+                    selectedValue: this.state.selectedEnd,
+                },
+            } as IStateKeysAndValuesObject;
+        } else {
+            // return an object to help downstream code stay less verbose.
+            return {} as IStateKeysAndValuesObject;
+        }
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -211,9 +211,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private getSelectedRange = () => {
         return [this.state.selectedStart, this.state.selectedEnd].map((selectedBound?: moment.Moment) => {
-            return (!isMomentValidAndInRange(selectedBound, this.props.minDate, this.props.maxDate))
-                ? undefined
-                : fromMomentToDate(selectedBound);
+            return this.isMomentValidAndInRange(selectedBound)
+                ? fromMomentToDate(selectedBound)
+                : undefined;
         }) as DateRange;
     }
 
@@ -223,5 +223,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         } else {
             return momentDate.format(this.props.format);
         }
+    }
+
+    private isMomentValidAndInRange = (momentDate: moment.Moment) => {
+        return isMomentValidAndInRange(momentDate, this.props.minDate, this.props.maxDate);
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -177,20 +177,20 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="Start date"
                         {...this.props.startInputProps}
                         inputRef={this.refHandlers.startInputRef}
-                        onBlur={this.handleInputBlur}
+                        onBlur={this.handleStartInputBlur}
                         onChange={this.handleStartInputChange}
                         onClick={this.handleInputClick}
-                        onFocus={this.handleInputFocus}
+                        onFocus={this.handleStartInputFocus}
                         value={startInputString}
                     />
                     <InputGroup
                         placeholder="End date"
                         {...this.props.endInputProps}
                         inputRef={this.refHandlers.endInputRef}
-                        onBlur={this.handleInputBlur}
+                        onBlur={this.handleEndInputBlur}
                         onChange={this.handleEndInputChange}
                         onClick={this.handleInputClick}
-                        onFocus={this.handleInputFocus}
+                        onFocus={this.handleEndInputFocus}
                         value={endInputString}
                     />
                 </div>
@@ -220,9 +220,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         e.stopPropagation();
     }
 
-    private handleInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
-        const inputElement = e.target as HTMLInputElement;
-        const { keys, values } = this.getStateKeysAndValuesForInput(inputElement);
+    private handleStartInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
+        this.handleInputFocus(e, DateRangeBoundary.START);
+    }
+
+    private handleEndInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
+        this.handleInputFocus(e, DateRangeBoundary.END);
+    }
+
+    private handleInputFocus = (_e: React.FormEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {
+        const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
         const inputString = this.getFormattedDateString(values.selectedValue);
 
         this.setState({
@@ -232,9 +239,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         });
     }
 
-    private handleInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
-        const inputElement = e.target as HTMLInputElement;
-        const { keys, values } = this.getStateKeysAndValuesForInput(inputElement);
+    private handleStartInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
+        this.handleInputBlur(e, DateRangeBoundary.START);
+    }
+
+    private handleEndInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
+        this.handleInputBlur(e, DateRangeBoundary.END);
+    }
+
+    private handleInputBlur = (_e: React.FormEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {
+        const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
 
         const maybeNextValue = this.dateStringToMoment(values.inputString);
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -214,8 +214,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         e.stopPropagation();
     }
 
-    private handleInputFocus = () => {
-        this.setState({ isOpen: true });
+    private handleInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
+        const inputElement = e.target as HTMLInputElement;
+        const { keys, values } = this.getStateKeysAndValuesForInput(inputElement);
+        const inputString = this.getFormattedDateString(values.selectedValue);
+
+        this.setState({
+            isOpen: true,
+            [keys.inputString]: inputString,
+            [keys.isInputFocused]: true,
+        });
     }
 
     private handleInputBlur = (e: React.FormEvent<HTMLInputElement>) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -95,9 +95,9 @@ export interface IDateRangeInputState {
 
 interface IStateKeysAndValuesObject {
     keys: {
-        inputString: string;
-        isInputFocused: string;
-        selectedValue: string;
+        inputString: "startInputString" | "endInputString";
+        isInputFocused: "isStartInputFocused" | "isEndInputFocused";
+        selectedValue: "selectedStart" | "selectedEnd";
     };
     values: {
         controlledValue?: moment.Moment,
@@ -207,6 +207,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
+    // Callbacks - DateRangePicker
+    // ===========================
+
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
         if (this.props.value === undefined) {
             const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
@@ -215,11 +218,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
+    // Callbacks - Input
+    // =================
+
+    // Click
+
     private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
         // unless we stop propagation on this event, a click within an input
         // will close the popover almost as soon as it opens.
         e.stopPropagation();
     }
+
+    // Focus
 
     private handleStartInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputFocus(e, DateRangeBoundary.START);
@@ -240,6 +250,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         });
     }
 
+    // Blur
+
     private handleStartInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputBlur(e, DateRangeBoundary.START);
     }
@@ -252,7 +264,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
 
         const maybeNextValue = this.dateStringToMoment(values.inputString);
-        const isValueControlled = this.props.value !== undefined;
+        const isValueControlled = this.isControlled();
 
         if (values.inputString == null || values.inputString.length === 0) {
             if (isValueControlled) {
@@ -288,6 +300,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
+    // Change
+
     private handleStartInputChange = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputChange(e, DateRangeBoundary.START);
     }
@@ -301,8 +315,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
         const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
         const maybeNextValue = this.dateStringToMoment(inputString);
-
-        const isValueControlled = this.props.value !== undefined;
+        const isValueControlled = this.isControlled();
 
         if (inputString.length === 0) {
             // this case will be relevant when we start showing the hovered
@@ -331,8 +344,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
+    // Callbacks - Popover
+    // ===================
+
     private handlePopoverClose = () => {
         this.setState({ isOpen: false });
+    }
+
+    // Helpers
+    // =======
+
+    private dateStringToMoment = (dateString: String) => {
+        return moment(dateString, this.props.format);
     }
 
     private getInitialRange = (props = this.props) => {
@@ -374,14 +397,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
-    private dateStringToMoment = (dateString: String) => {
-        return moment(dateString, this.props.format);
-    }
-
-    private isMomentValidAndInRange = (momentDate: moment.Moment) => {
-        return isMomentValidAndInRange(momentDate, this.props.minDate, this.props.maxDate);
-    }
-
     private getStateKeysAndValuesForBoundary = (boundary: DateRangeBoundary): IStateKeysAndValuesObject => {
         const controlledValue = fromDateRangeToMomentDateRange(this.props.value);
 
@@ -417,5 +432,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             // return an object to help downstream code stay less verbose.
             return {} as IStateKeysAndValuesObject;
         }
+    }
+
+    private isControlled = () => {
+        return this.props.value !== undefined;
+    }
+
+    private isMomentValidAndInRange = (momentDate: moment.Moment) => {
+        return isMomentValidAndInRange(momentDate, this.props.minDate, this.props.maxDate);
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -171,6 +171,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="Start date"
                         {...this.props.startInputProps}
                         inputRef={this.refHandlers.startInputRef}
+                        onBlur={this.handleInputBlur}
                         onChange={this.handleInputChange}
                         onClick={this.handleInputClick}
                         onFocus={this.handleInputFocus}
@@ -180,6 +181,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="End date"
                         {...this.props.endInputProps}
                         inputRef={this.refHandlers.endInputRef}
+                        onBlur={this.handleInputBlur}
                         onChange={this.handleInputChange}
                         onClick={this.handleInputClick}
                         onFocus={this.handleInputFocus}
@@ -214,6 +216,41 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleInputFocus = () => {
         this.setState({ isOpen: true });
+    }
+
+    private handleInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
+        const inputElement = e.target as HTMLInputElement;
+        const { keys, values } = this.getStateKeysAndValuesForInput(inputElement);
+
+        const maybeNextValue = this.dateStringToMoment(values.inputString);
+
+        if (values.inputString == null || values.inputString.length === 0) {
+            this.setState({
+                [keys.isInputFocused]: false,
+                [keys.selectedValue]: moment(null),
+                [keys.inputString]: null,
+            });
+        } else if (!this.isMomentValidAndInRange(maybeNextValue)) {
+            if (this.props.value === undefined) {
+                // uncontrolled mode
+                this.setState({
+                    [keys.isInputFocused]: false,
+                    [keys.inputString]: null,
+                    [keys.selectedValue]: maybeNextValue,
+                });
+            } else {
+                // controlled mode
+                this.setState({ [keys.isInputFocused]: false });
+            }
+
+            // TODO:
+            // - if date invalid, invoke onError with...?
+            // - if date out of range, invoke onError with...?
+            // - if end date invalid, invoke onError with...?
+            // - else, invoke onChange with...?
+        } else {
+            this.setState({ [keys.isInputFocused]: false });
+        }
     }
 
     private handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -81,8 +81,28 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
 export interface IDateRangeInputState {
     isOpen?: boolean;
+
+    isStartInputFocused?: boolean;
+    isEndInputFocused?: boolean;
+
+    startInputString?: string;
+    endInputString?: string;
+
     selectedEnd?: moment.Moment;
     selectedStart?: moment.Moment;
+};
+
+interface IStateKeysAndValuesObject {
+    keys: {
+        inputString: string;
+        isInputFocused: string;
+        selectedValue: string;
+    };
+    values: {
+        inputString?: string;
+        isInputFocused?: string;
+        selectedValue?: moment.Moment;
+    };
 };
 
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -397,9 +397,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
-    private getStateKeysAndValuesForBoundary = (boundary: DateRangeBoundary): IStateKeysAndValuesObject => {
-        const controlledValue = fromDateRangeToMomentDateRange(this.props.value);
-
+    private getStateKeysAndValuesForBoundary = (boundary: DateRangeBoundary) => {
+        const controlledRange = fromDateRangeToMomentDateRange(this.props.value);
         if (boundary === DateRangeBoundary.START) {
             return {
                 keys: {
@@ -408,13 +407,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     selectedValue: "selectedStart",
                 },
                 values: {
-                    controlledValue: (controlledValue != null) ? controlledValue[0] : undefined,
+                    controlledValue: (controlledRange != null) ? controlledRange[0] : undefined,
                     inputString: this.state.startInputString,
                     isFocused: this.state.isStartInputFocused,
                     selectedValue: this.state.selectedStart,
                 },
             } as IStateKeysAndValuesObject;
-        } else if (boundary === DateRangeBoundary.END) {
+        } else {
             return {
                 keys: {
                     inputString: "endInputString",
@@ -422,15 +421,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     selectedValue: "selectedEnd",
                 },
                 values: {
-                    controlledValue: (controlledValue != null) ? controlledValue[1] : undefined,
+                    controlledValue: (controlledRange != null) ? controlledRange[1] : undefined,
                     inputString: this.state.endInputString,
                     isFocused: this.state.isEndInputFocused,
                     selectedValue: this.state.selectedEnd,
                 },
             } as IStateKeysAndValuesObject;
-        } else {
-            // return an object to help downstream code stay less verbose.
-            return {} as IStateKeysAndValuesObject;
         }
     }
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -142,8 +142,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     public render() {
-        const startInputString = this.getFormattedDateString(this.state.selectedStart);
-        const endInputString = this.getFormattedDateString(this.state.selectedEnd);
+        const startInputString = this.getStartInputDisplayString();
+        const endInputString = this.getEndInputDisplayString();
 
         const popoverContent = (
             <DateRangePicker
@@ -301,6 +301,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 ? fromMomentToDate(selectedBound)
                 : undefined;
         }) as DateRange;
+    }
+
+    private getStartInputDisplayString = () => {
+        return this.state.isStartInputFocused
+            ? this.state.startInputString
+            : this.getFormattedDateString(this.state.selectedStart);
+    }
+
+    private getEndInputDisplayString = () => {
+        return this.state.isEndInputFocused
+            ? this.state.endInputString
+            : this.getFormattedDateString(this.state.selectedEnd);
     }
 
     private getFormattedDateString = (momentDate: moment.Moment) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -102,7 +102,7 @@ interface IStateKeysAndValuesObject {
     values: {
         controlledValue?: moment.Moment,
         inputString?: string;
-        isInputFocused?: string;
+        isInputFocused?: boolean;
         selectedValue?: moment.Moment;
     };
 };

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -87,9 +87,7 @@ describe("<DateRangeInput>", () => {
             root.setState({ isOpen: true });
 
             getDayElement(START_DAY).simulate("click");
-
-            expect(getStartInputText(root)).to.be.empty;
-            expect(getEndInputText(root)).to.be.empty;
+            assertInputTextsEqual(root, "", "");
             expect(onChange.calledWith([null, null])).to.be.true;
         });
 
@@ -132,14 +130,12 @@ describe("<DateRangeInput>", () => {
             // click start date
             getDayElement(START_DAY).simulate("click");
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
-            expect(getStartInputText(root)).to.equal(START_STR);
-            expect(getEndInputText(root)).to.equal(END_STR);
+            assertInputTextsEqual(root, START_STR, END_STR);
 
             // click end date
             getDayElement(END_DAY).simulate("click");
             assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, null]);
-            expect(getStartInputText(root)).to.equal(START_STR);
-            expect(getEndInputText(root)).to.equal(END_STR);
+            assertInputTextsEqual(root, START_STR, END_STR);
 
             expect(onChange.callCount).to.equal(2);
         });
@@ -154,20 +150,17 @@ describe("<DateRangeInput>", () => {
             getDayElement(START_DAY).simulate("click");
 
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
-            expect(getStartInputText(root)).to.equal(START_STR);
-            expect(getEndInputText(root)).to.be.empty;
+            assertInputTextsEqual(root, START_STR, "");
         });
 
         it("Updating value updates the text boxes", () => {
             const { root } = wrap(<DateRangeInput value={DATE_RANGE} />);
             root.setState({ isOpen: true });
 
-            expect(getStartInputText(root)).to.equal(START_STR);
-            expect(getEndInputText(root)).to.equal(END_STR);
+            assertInputTextsEqual(root, START_STR, END_STR);
 
             root.setProps({ value: DATE_RANGE_2 });
-            expect(getStartInputText(root)).to.equal(START_STR_2);
-            expect(getEndInputText(root)).to.equal(END_STR_2);
+            assertInputTextsEqual(root, START_STR_2, END_STR_2);
         });
 
         it("Typing in a date runs the onChange callback", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -92,6 +92,22 @@ describe("<DateRangeInput>", () => {
             expect(getEndInputText(root)).to.be.empty;
             expect(onChange.calledWith([null, null])).to.be.true;
         });
+
+        it("Clearing the date in the input clears the selection and invokes onChange with null", () => {
+            expect(true).to.be.false;
+        });
+
+        it("Typing in a valid date runs the onChange callback", () => {
+            expect(true).to.be.false;
+        });
+
+        it("Typing in a date out of range displays the error message and calls onError with invalid date", () => {
+            expect(true).to.be.false;
+        });
+
+        it("Typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {
+            expect(true).to.be.false;
+        });
     });
 
     describe("when controlled", () => {
@@ -152,6 +168,14 @@ describe("<DateRangeInput>", () => {
             root.setProps({ value: DATE_RANGE_2 });
             expect(getStartInputText(root)).to.equal(START_STR_2);
             expect(getEndInputText(root)).to.equal(END_STR_2);
+        });
+
+        it("Typing in a date runs the onChange callback", () => {
+            expect(true).to.be.false;
+        });
+
+        it("Clearing the date in the input invokes onChange with null", () => {
+            expect(true).to.be.false;
         });
     });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -14,6 +14,9 @@ import { Months } from "../src/common/months";
 import { Classes as DateClasses, DateRange, DateRangeInput } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
 
+type WrappedComponentRoot = ReactWrapper<any, {}>;
+type WrappedComponentInput = ReactWrapper<React.HTMLAttributes<{}>, any>;
+
 describe("<DateRangeInput>", () => {
 
     const START_DAY = 22;
@@ -57,29 +60,77 @@ describe("<DateRangeInput>", () => {
     });
 
     describe("when uncontrolled", () => {
-        it("Clicking a date puts the selected date range in the input boxes", () => {
-            const defaultValue = [START_DATE, null] as DateRange;
-
-            const { root, getDayElement } = wrap(<DateRangeInput defaultValue={defaultValue} />);
-            root.setState({ isOpen: true });
-
-            // verify the default value
-            assertInputTextsEqual(root, START_STR, "");
-
-            getDayElement(END_DAY).simulate("click");
-            assertInputTextsEqual(root, START_STR, END_STR);
-
-            getDayElement(START_DAY).simulate("click");
-            assertInputTextsEqual(root, "", END_STR);
-
-            getDayElement(END_DAY).simulate("click");
+        it("Shows empty fields when defaultValue is [null, null]", () => {
+            const { root } = wrap(<DateRangeInput defaultValue={[null, null]} />);
             assertInputTextsEqual(root, "", "");
+        });
 
-            getDayElement(START_DAY).simulate("click");
+        it("Shows empty start field and formatted date in end field when defaultValue is [null, <date>]", () => {
+            const { root } = wrap(<DateRangeInput defaultValue={[null, END_DATE]} />);
+            assertInputTextsEqual(root, "", END_STR);
+        });
+
+        it("Shows empty end field and formatted date in start field when defaultValue is [<date>, null]", () => {
+            const { root } = wrap(<DateRangeInput defaultValue={[START_DATE, null]} />);
             assertInputTextsEqual(root, START_STR, "");
         });
 
-        it("Clicking to clear the date range clears the inputs and invokes onChange with [null, null]", () => {
+        it("Shows formatted dates in both fields when defaultValue is [<date1>, <date2>]", () => {
+            const { root } = wrap(<DateRangeInput defaultValue={[START_DATE, END_DATE]} />);
+            assertInputTextsEqual(root, START_STR, END_STR);
+        });
+
+        it("Clicking a date invokes onChange with the new date range and updates the input fields", () => {
+            const defaultValue = [START_DATE, null] as DateRange;
+
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(<DateRangeInput defaultValue={defaultValue} onChange={onChange} />);
+            root.setState({ isOpen: true });
+
+            getDayElement(END_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, END_STR]);
+            assertInputTextsEqual(root, START_STR, END_STR);
+
+            getDayElement(START_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(1).args[0], [null, END_STR]);
+            assertInputTextsEqual(root, "", END_STR);
+
+            getDayElement(END_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(2).args[0], [null, null]);
+            assertInputTextsEqual(root, "", "");
+
+            getDayElement(START_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(3).args[0], [START_STR, null]);
+            assertInputTextsEqual(root, START_STR, "");
+
+            expect(onChange.callCount).to.equal(4);
+        });
+
+        it(`Typing a valid start or end date invokes onChange with the new date range and updates the
+            input fields`, () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput onChange={onChange} defaultValue={DATE_RANGE} />);
+
+            changeStartInputText(root, START_STR_2);
+            expect(onChange.callCount).to.equal(1);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR_2, END_STR]);
+            assertInputTextsEqual(root, START_STR_2, END_STR);
+
+            changeEndInputText(root, END_STR_2);
+            expect(onChange.callCount).to.equal(2);
+            assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR_2, END_STR_2]);
+            assertInputTextsEqual(root, START_STR_2, END_STR_2);
+        });
+
+        it.skip("Typing a date out of range displays the error message and calls onError with invalid date", () => {
+            expect(true).to.be.false;
+        });
+
+        it.skip("Typing an invalid date displays the error message and calls onError with Date(undefined)", () => {
+            expect(true).to.be.false;
+        });
+
+        it("Clearing the date range in the picker invokes onChange with [null, null] and clears the inputs", () => {
             const onChange = sinon.spy();
             const defaultValue = [START_DATE, null] as DateRange;
 
@@ -88,23 +139,19 @@ describe("<DateRangeInput>", () => {
 
             getDayElement(START_DAY).simulate("click");
             assertInputTextsEqual(root, "", "");
+            expect(onChange.called).to.be.true;
             expect(onChange.calledWith([null, null])).to.be.true;
         });
 
-        it("Clearing the date in the input clears the selection and invokes onChange with null", () => {
-            expect(true).to.be.false;
-        });
+        it(`Clearing the date range in the inputs invokes onChange with [null, null] and leaves the
+            inputs empty`, () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput onChange={onChange} value={[START_DATE, null]} />);
 
-        it("Typing in a valid date runs the onChange callback", () => {
-            expect(true).to.be.false;
-        });
-
-        it("Typing in a date out of range displays the error message and calls onError with invalid date", () => {
-            expect(true).to.be.false;
-        });
-
-        it("Typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {
-            expect(true).to.be.false;
+            changeStartInputText(root, "");
+            expect(onChange.called).to.be.true;
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
+            assertInputTextsEqual(root, "", "");
         });
     });
 
@@ -120,6 +167,28 @@ describe("<DateRangeInput>", () => {
         it("Setting value to [null, null] shows empty fields", () => {
             const { root } = wrap(<DateRangeInput value={[null, null]} />);
             assertInputTextsEqual(root, "", "");
+        });
+
+        it("Shows empty start field and formatted date in end field when value is [null, <date>]", () => {
+            const { root } = wrap(<DateRangeInput value={[null, END_DATE]} />);
+            assertInputTextsEqual(root, "", END_STR);
+        });
+
+        it("Shows empty end field and formatted date in start field when value is [<date>, null]", () => {
+            const { root } = wrap(<DateRangeInput value={[START_DATE, null]} />);
+            assertInputTextsEqual(root, START_STR, "");
+        });
+
+        it("Shows formatted dates in both fields when value is [<date1>, <date2>]", () => {
+            const { root } = wrap(<DateRangeInput value={[START_DATE, END_DATE]} />);
+            assertInputTextsEqual(root, START_STR, END_STR);
+        });
+
+        it("Updating value changes the text accordingly in both fields", () => {
+            const { root } = wrap(<DateRangeInput value={DATE_RANGE} />);
+            root.setState({ isOpen: true });
+            root.setProps({ value: DATE_RANGE_2 });
+            assertInputTextsEqual(root, START_STR_2, END_STR_2);
         });
 
         it("Clicking a date invokes onChange with the new date range, but doesn't change the UI", () => {
@@ -140,7 +209,31 @@ describe("<DateRangeInput>", () => {
             expect(onChange.callCount).to.equal(2);
         });
 
-        it("Clearing the date invokes onChange with [null, null], but doesn't change the UI", () => {
+        it("Typing a valid start or end date invokes onChange with the new date range but doesn't change UI", () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput onChange={onChange} value={DATE_RANGE} />);
+
+            changeStartInputText(root, START_STR_2);
+            expect(onChange.callCount).to.equal(1);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR_2, END_STR]);
+            assertInputTextsEqual(root, START_STR, END_STR);
+
+            // since the component is controlled, value changes don't persist across onChanges
+            changeEndInputText(root, END_STR_2);
+            expect(onChange.callCount).to.equal(2);
+            assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, END_STR_2]);
+            assertInputTextsEqual(root, START_STR, END_STR);
+        });
+
+        it.skip("Typing a date out of range displays the error message and calls onError with invalid date", () => {
+            expect(true).to.be.false;
+        });
+
+        it.skip("Typing an invalid date displays the error message and calls onError with Date(undefined)", () => {
+            expect(true).to.be.false;
+        });
+
+        it("Clearing the dates in the picker invokes onChange with [null, null], but doesn't change the UI", () => {
             const onChange = sinon.spy();
             const value = [START_DATE, null] as DateRange;
 
@@ -153,42 +246,51 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, "");
         });
 
-        it("Updating value updates the text boxes", () => {
-            const { root } = wrap(<DateRangeInput value={DATE_RANGE} />);
-            root.setState({ isOpen: true });
+        it(`[INCORRECT BEHAVIOR?] Clearing the date range in the inputs invokes
+            onChange with [null, null], leaves the fields empty, and clears the selected date range`, () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput onChange={onChange} value={[START_DATE, null]} />);
 
-            assertInputTextsEqual(root, START_STR, END_STR);
-
-            root.setProps({ value: DATE_RANGE_2 });
-            assertInputTextsEqual(root, START_STR_2, END_STR_2);
-        });
-
-        it("Typing in a date runs the onChange callback", () => {
-            expect(true).to.be.false;
-        });
-
-        it("Clearing the date in the input invokes onChange with null", () => {
-            expect(true).to.be.false;
+            changeStartInputText(root, "");
+            expect(onChange.callCount).to.equal(1);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
+            assertInputTextsEqual(root, "", "");
         });
     });
 
-    function getStartInput(root: ReactWrapper<any, {}>) {
-        return root.find(InputGroup).first();
+    function getStartInput(root: WrappedComponentRoot): WrappedComponentInput {
+        return root.find(InputGroup).first().find("input");
     }
 
-    function getEndInput(root: ReactWrapper<any, {}>) {
-        return root.find(InputGroup).last();
+    function getEndInput(root: WrappedComponentRoot): WrappedComponentInput {
+        return root.find(InputGroup).last().find("input");
     }
 
-    function getStartInputText(root: ReactWrapper<any, {}>) {
-        return getStartInput(root).props().value;
+    function getStartInputText(root: WrappedComponentRoot) {
+        return getInputText(getStartInput(root));
     }
 
-    function getEndInputText(root: ReactWrapper<any, {}>) {
-        return getEndInput(root).props().value;
+    function getEndInputText(root: WrappedComponentRoot) {
+        return getInputText(getEndInput(root));
     }
 
-    function assertInputTextsEqual(root: ReactWrapper<any, {}>, startInputText: string, endInputText: string) {
+    function getInputText(input: WrappedComponentInput) {
+        return input.props().value;
+    }
+
+    function changeStartInputText(root: WrappedComponentRoot, value: string) {
+        changeInputText(getStartInput(root), value);
+    }
+
+    function changeEndInputText(root: WrappedComponentRoot, value: string) {
+        changeInputText(getEndInput(root), value);
+    }
+
+    function changeInputText(input: WrappedComponentInput, value: string) {
+        input.simulate("change", { target: { value }});
+    }
+
+    function assertInputTextsEqual(root: WrappedComponentRoot, startInputText: string, endInputText: string) {
         expect(getStartInputText(root)).to.equal(startInputText);
         expect(getEndInputText(root)).to.equal(endInputText);
     }

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -146,7 +146,7 @@ describe("<DateRangeInput>", () => {
         it(`Clearing the date range in the inputs invokes onChange with [null, null] and leaves the
             inputs empty`, () => {
             const onChange = sinon.spy();
-            const { root } = wrap(<DateRangeInput onChange={onChange} value={[START_DATE, null]} />);
+            const { root } = wrap(<DateRangeInput onChange={onChange} defaultValue={[START_DATE, null]} />);
 
             changeStartInputText(root, "");
             expect(onChange.called).to.be.true;
@@ -246,15 +246,29 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, "");
         });
 
-        it(`[INCORRECT BEHAVIOR?] Clearing the date range in the inputs invokes
-            onChange with [null, null], leaves the fields empty, and clears the selected date range`, () => {
+        it(`Clearing the inputs invokes onChange with [null, null], doesn't clear the selected dates, and\
+            repopulates the controlled values in the inputs on blur`, () => {
             const onChange = sinon.spy();
-            const { root } = wrap(<DateRangeInput onChange={onChange} value={[START_DATE, null]} />);
+            const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} value={[START_DATE, null]} />);
 
-            changeStartInputText(root, "");
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+            changeInputText(startInput, "");
+
+            // emit the new date range
             expect(onChange.callCount).to.equal(1);
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
+
+            // update the fields per the user's typing
             assertInputTextsEqual(root, "", "");
+
+            // start day should still be selected in the calendar, ignoring user's typing
+            const startDayElement = getDayElement(START_DAY);
+            expect(startDayElement.hasClass(DateClasses.DATEPICKER_DAY_SELECTED)).to.be.true;
+
+            // blurring should put the controlled start date back in the start input, overriding user's typing
+            startInput.simulate("blur");
+            assertInputTextsEqual(root, START_STR, "");
         });
     });
 


### PR DESCRIPTION
#### Related to #249, builds on #686

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- _New feature:_ Can now type dates into the input fields, and the picker selection will update (if uncontrolled).
- _Bugfix:_ Fix parallel issue I noticed in `DateInput` where editing the input field in controlled mode overwrote a controlled value. Now, if the user changes the text in an input field in controlled mode, (1) the calendar selection will not change, and (2) the controlled value will be repopulated in the field on blur. (And to be clear, I fixed this just for `DateRangeInput`, not for `DateInput` too).

_Changes NOT included:_
- **I didn't implement input validation yet**. It's perfectly possible to input backward or otherwise invalid date ranges. The next PR will deal with input validation.
- **I didn't implement focus-handling yet.** The focused field has no bearing on which end of the date range will be specified by the next click. A near-future PR will deal with focus handling. 

#### Reviewers should focus on:

- What's the best way to support generic `onBlur`, `onFocus`, and `onChange` handlers for the two input fields, given that each field needs to process the same logic with different pieces of `state`?

    In my prototype from a couple weeks ago, I passed boundary-specific `state` keys (e.g. `"isStartInputFocused"`, `"selectedEnd"`) as separate string parameters from `handleStartInputBlur` (e.g.) into `handleGenericInputBlur` (e.g.).

    The `IStateKeysAndValuesObject` here looks a little smelly at a glance, but it feels nicer than my previous approach.

    Or maybe it's better to pull the logic out into a couple child components (called `DateRangeInputField`?) Not sure how much mileage that'll get us, but happy to take a look if we're not okay with the current implementation.

- How does the controlled-mode _Bugfix_ sound?

#### Screenshot

_Uncontrolled Mode_

![2017-02-20 16 10 17](https://cloud.githubusercontent.com/assets/443450/23145956/60b4eff2-f787-11e6-8575-b54bbd5666a9.gif)

_Controlled Mode_

![2017-02-20 16 15 56](https://cloud.githubusercontent.com/assets/443450/23146024/eccff388-f787-11e6-95e4-fff5a3848996.gif)