### PR TITLE
Update text area docs

### DIFF
--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -85,7 +85,7 @@ Styleguide components.forms.input.search
 /*
 Text areas
 
-Text areas are similar to text inputs, but they are resizable.
+Text areas are similar to text inputs, but they are resizable and support multiline editing.
 
 You should also specify `dir="auto"` on text areas
 [to better support RTL languages](http://www.w3.org/International/questions/qa-html-dir#dirauto)


### PR DESCRIPTION
Per Andrew Colombi's feedback:
I noticed this line in the docs, "Text areas are similar to text inputs, but they are resizable" in the Text areas section of the "Form controls" page. My understanding is that the big difference between Text area and Text input is that Text area can be used for multiline editing. So that's what I would put there instead.