### PR TITLE
Add :disabled support for pt-file-upload

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -110,15 +110,6 @@ $button-intents: (
   line-height: $height;
 }
 
-@mixin pt-button-disabled() {
-  outline: none;
-  box-shadow: none;
-  background-color: $button-background-color-disabled;
-  background-image: none;
-  cursor: not-allowed;
-  color: $button-color-disabled;
-}
-
 @mixin pt-button() {
   @include linear-gradient-with-fallback($white, $white-transparent, $button-background-color);
 
@@ -138,7 +129,6 @@ $button-intents: (
   }
 }
 
-
 @mixin pt-button-hover() {
   @include linear-gradient-with-fallback(
     rgba($white, 0.5),
@@ -156,12 +146,13 @@ $button-intents: (
   background-image: none;
 }
 
-@mixin pt-button-intent-disabled($default-color) {
-  border-color: transparent;
+@mixin pt-button-disabled() {
+  outline: none;
   box-shadow: none;
-  background-color: rgba($default-color, 0.5);
+  background-color: $button-background-color-disabled;
   background-image: none;
-  color: $white;
+  cursor: not-allowed;
+  color: $button-color-disabled;
 }
 
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
@@ -204,11 +195,12 @@ $button-intents: (
   }
 }
 
-@mixin pt-dark-button-disabled() {
+@mixin pt-button-intent-disabled($default-color) {
+  border-color: transparent;
   box-shadow: none;
-  background-color: $dark-button-background-color-disabled;
+  background-color: rgba($default-color, 0.5);
   background-image: none;
-  color: $dark-button-color-disabled;
+  color: $white;
 }
 
 @mixin pt-dark-button() {
@@ -260,10 +252,11 @@ $button-intents: (
   background-image: none;
 }
 
-@mixin pt-dark-button-intent-disabled() {
+@mixin pt-dark-button-disabled() {
   box-shadow: none;
+  background-color: $dark-button-background-color-disabled;
   background-image: none;
-  color: rgba($white, 0.3);
+  color: $dark-button-color-disabled;
 }
 
 @mixin pt-dark-button-intent() {
@@ -284,6 +277,12 @@ $button-intents: (
   .pt-button-spinner .pt-spinner-head {
     stroke: $dark-progress-head-color;
   }
+}
+
+@mixin pt-dark-button-intent-disabled() {
+  box-shadow: none;
+  background-image: none;
+  color: rgba($white, 0.3);
 }
 
 @mixin pt-button-minimal() {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -110,6 +110,15 @@ $button-intents: (
   line-height: $height;
 }
 
+@mixin pt-button-disabled() {
+  outline: none;
+  box-shadow: none;
+  background-color: $button-background-color-disabled;
+  background-image: none;
+  cursor: not-allowed;
+  color: $button-color-disabled;
+}
+
 @mixin pt-button() {
   @include linear-gradient-with-fallback($white, $white-transparent, $button-background-color);
 
@@ -125,12 +134,7 @@ $button-intents: (
   }
 
   &:disabled {
-    outline: none;
-    box-shadow: none;
-    background-color: $button-background-color-disabled;
-    background-image: none;
-    cursor: not-allowed;
-    color: $button-color-disabled;
+    @include pt-button-disabled();
   }
 }
 
@@ -152,6 +156,14 @@ $button-intents: (
   background-image: none;
 }
 
+@mixin pt-button-intent-disabled($default-color) {
+  border-color: transparent;
+  box-shadow: none;
+  background-color: rgba($default-color, 0.5);
+  background-image: none;
+  color: $white;
+}
+
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
   @include linear-gradient-with-fallback(
     rgba($white, 0.1),
@@ -163,8 +175,7 @@ $button-intents: (
   color: $white;
 
   &:hover,
-  &:active,
-  &:disabled {
+  &:active {
     color: $white;
   }
 
@@ -185,15 +196,19 @@ $button-intents: (
   }
 
   &:disabled {
-    border-color: transparent;
-    box-shadow: none;
-    background-color: rgba($default-color, 0.5);
-    background-image: none;
+    @include pt-button-intent-disabled($default-color);
   }
 
   .pt-button-spinner .pt-spinner-head {
     stroke: $white;
   }
+}
+
+@mixin pt-dark-button-disabled() {
+  box-shadow: none;
+  background-color: $dark-button-background-color-disabled;
+  background-image: none;
+  color: $dark-button-color-disabled;
 }
 
 @mixin pt-dark-button() {
@@ -220,10 +235,7 @@ $button-intents: (
   }
 
   &:disabled {
-    box-shadow: none;
-    background-color: $dark-button-background-color-disabled;
-    background-image: none;
-    color: $dark-button-color-disabled;
+    @include pt-dark-button-disabled();
   }
 
   .pt-button-spinner .pt-spinner-head {
@@ -248,6 +260,12 @@ $button-intents: (
   background-image: none;
 }
 
+@mixin pt-dark-button-intent-disabled() {
+  box-shadow: none;
+  background-image: none;
+  color: rgba($white, 0.3);
+}
+
 @mixin pt-dark-button-intent() {
   box-shadow: $dark-button-intent-box-shadow;
 
@@ -260,9 +278,7 @@ $button-intents: (
   }
 
   &:disabled {
-    box-shadow: none;
-    background-image: none;
-    color: rgba($white, 0.3);
+    @include pt-dark-button-intent-disabled();
   }
 
   .pt-button-spinner .pt-spinner-head {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -84,6 +84,14 @@ $control-group-stack: (
   }
 }
 
+@mixin pt-input-disabled() {
+  box-shadow: none;
+  background: $input-background-color-disabled;
+  cursor: not-allowed;
+  color: $input-color-disabled;
+  resize: none;
+}
+
 @mixin pt-input() {
   outline: none;
   border: none;
@@ -123,11 +131,7 @@ $control-group-stack: (
 
   &:disabled,
   &.pt-disabled {
-    box-shadow: none;
-    background: $input-background-color-disabled;
-    cursor: not-allowed;
-    color: $input-color-disabled;
-    resize: none;
+    @include pt-input-disabled();
   }
 }
 
@@ -140,6 +144,12 @@ $control-group-stack: (
   &.pt-round {
     padding: 0 $input-padding-horizontal * 1.5;
   }
+}
+
+@mixin pt-dark-input-disabled() {
+  box-shadow: none;
+  background: $dark-input-background-color-disabled;
+  color: $dark-input-color-disabled;
 }
 
 @mixin pt-dark-input() {
@@ -163,9 +173,7 @@ $control-group-stack: (
 
   &:disabled,
   &.pt-disabled {
-    box-shadow: none;
-    background: $dark-input-background-color-disabled;
-    color: $dark-input-color-disabled;
+    @include pt-dark-input-disabled();
   }
 }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -84,14 +84,6 @@ $control-group-stack: (
   }
 }
 
-@mixin pt-input-disabled() {
-  box-shadow: none;
-  background: $input-background-color-disabled;
-  cursor: not-allowed;
-  color: $input-color-disabled;
-  resize: none;
-}
-
 @mixin pt-input() {
   outline: none;
   border: none;
@@ -133,6 +125,14 @@ $control-group-stack: (
   &.pt-disabled {
     @include pt-input-disabled();
   }
+}
+
+@mixin pt-input-disabled() {
+  box-shadow: none;
+  background: $input-background-color-disabled;
+  cursor: not-allowed;
+  color: $input-color-disabled;
+  resize: none;
 }
 
 @mixin pt-input-large() {

--- a/packages/core/src/components/forms/_file-upload.scss
+++ b/packages/core/src/components/forms/_file-upload.scss
@@ -20,9 +20,11 @@ Wrap that all in a `label` with class `pt-file-upload`.
 
 Markup:
 <label class="pt-file-upload">
-  <input type="file" />
+  <input type="file" {{:modifier}}/>
   <span class="pt-file-upload-input">Choose file...</span>
 </label>
+
+:disabled - Disabled
 
 Weight: 10
 

--- a/packages/core/src/components/forms/_file-upload.scss
+++ b/packages/core/src/components/forms/_file-upload.scss
@@ -39,6 +39,27 @@ Styleguide components.forms.fileupload
     opacity: 0;
     margin: 0;
     min-width: $pt-grid-size * 20;
+
+    // unlike other form controls that directly style native elements,
+    // pt-file-upload wraps and hides the native element for better control over
+    // visual styles. to disable, we need to disable the hidden child input, not
+    // the surrounding wrapper. see #689 for gory details.
+    &:disabled + .pt-file-upload-input,
+    &.pt-disabled + .pt-file-upload-input {
+      @include pt-input-disabled();
+
+      &::after {
+        @include pt-button-disabled();
+      }
+
+      .pt-dark & {
+        @include pt-dark-input-disabled();
+
+        &::after {
+          @include pt-dark-button-disabled();
+        }
+      }
+    }
   }
 
   .pt-file-upload-input {


### PR DESCRIPTION
#### Fixes #689

#### Checklist

- [ ] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- _New feature:_ Add support for `:disabled` on `pt-file-upload`
- _Refactor:_ Pull common `pt-button`/`pt-input` disabled styles into reusable mixins
- _Documentation:_ Add Modifier example in docs to showcase the new `:disabled` state.

#### Reviewers should focus on:

- See #689 for the full discussion. Does this approach make sense? And does my execution look good on each of the three points above?
- I can add a unit test if we want.

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/443450/23229859/b1cc87fe-f8f6-11e6-859c-24a19520af50.png)

![image](https://cloud.githubusercontent.com/assets/443450/23229910/e5178a0a-f8f6-11e6-8e0e-22a10128007a.png)

Also, buttons are visually unchanged:

![image](https://cloud.githubusercontent.com/assets/443450/23232900/cd7dff5e-f901-11e6-8b90-aed91a621e5c.png)

![image](https://cloud.githubusercontent.com/assets/443450/23232929/eb78de8e-f901-11e6-8507-e9570daa2c46.png)

And inputs are visually unchanged:

![image](https://cloud.githubusercontent.com/assets/443450/23232914/d8bd0e78-f901-11e6-83fe-0c10ee0ef842.png)

![image](https://cloud.githubusercontent.com/assets/443450/23232921/e40ae688-f901-11e6-92c2-cce75c201ece.png)
