### PR TITLE
fix bourbon deprecations warnings

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^15.0.1 || ^0.14"
   },
   "devDependencies": {
-    "bourbon": "4.2.6",
+    "bourbon": "4.3.2",
     "react": "15.4.0",
     "react-addons-css-transition-group": "15.4.0",
     "react-addons-test-utils": "15.4.0",

--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -3,6 +3,9 @@
 // of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
 // and https://github.com/palantir/blueprint/blob/master/PATENTS */
 
+// This line can be removed when we upgrade to Bourbon 5.0
+$output-bourbon-deprecation-warnings: false;
+
 // Import files in the same order that they are documented in the docs
 @import "common/resets";
 @import "common/font-imports";

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -29,14 +29,17 @@ $pt-dark-intent-text-colors: (
 @mixin linear-gradient-with-fallback($start-color, $end-color, $fallback-color: $start-color) {
   $gradient: linear-gradient(to bottom, $start-color, $end-color);
 
-  // explicit `none` argument disables second gradient
+  // fallback is a solid color (for very old browsers)
+  // stylelint-disable declaration-block-no-duplicate-properties
   @if ($fallback-color == none) {
     background: $start-color;
-    @include background($gradient left no-repeat);
+    // explicit `none` argument disables second gradient
+    background: $gradient left no-repeat;
   } @else {
     background: $fallback-color;
-    @include background($gradient left no-repeat, center no-repeat $fallback-color);
+    background: $gradient left no-repeat, center no-repeat $fallback-color;
   }
+  // stylelint-enable declaration-block-no-duplicate-properties
 }
 
 @mixin base-typography() {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -99,7 +99,7 @@ $control-group-stack: (
   font-weight: $input-font-weight;
   transition: $input-transition;
 
-  @include placeholder {
+  &::placeholder {
     // normalize.css sets an opacity less than 1, we don't want this
     opacity: 1;
     color: $input-placeholder-color;
@@ -148,7 +148,7 @@ $control-group-stack: (
   background: $dark-input-background-color;
   color: $dark-input-color;
 
-  @include placeholder {
+  &::placeholder {
     color: $dark-input-placeholder-color;
   }
 

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -79,7 +79,17 @@ $progress-bar-height: round($pt-grid-size * 0.8) !default;
 $progress-bar-stripes-size: $pt-grid-size * 3 !default;
 $progress-bar-border-radius: $pt-grid-size * 4 !default;
 
-@include keyframes(linear-progress-bar-stripes) {
+$progress-bar-gradient: linear-gradient(
+  -45deg,
+  $progress-bar-stripes-color 25%,
+  transparent 25%,
+  transparent 50%,
+  $progress-bar-stripes-color 50%,
+  $progress-bar-stripes-color 75%,
+  transparent 75%
+) !default;
+
+@keyframes linear-progress-bar-stripes {
   from {
     background-position: 0 0;
   }
@@ -99,19 +109,11 @@ $progress-bar-border-radius: $pt-grid-size * 4 !default;
   overflow: hidden;
 
   .pt-progress-meter {
-    @include linear-gradient(
-      -45deg,
-      $progress-bar-stripes-color 25%,
-      transparent 25%,
-      transparent 50%,
-      $progress-bar-stripes-color 50%,
-      $progress-bar-stripes-color 75%,
-      transparent 75%
-    );
 
     display: inline-block;
     position: absolute;
     border-radius: $progress-bar-border-radius;
+    background: $progress-bar-gradient;
     background-color: $progress-head-color;
     background-size: $progress-bar-stripes-size $progress-bar-stripes-size;
     // initial state is a full bar, a la "indeterminate"
@@ -121,9 +123,7 @@ $progress-bar-border-radius: $pt-grid-size * 4 !default;
   }
 
   &:not(.pt-no-animation):not(.pt-no-stripes) .pt-progress-meter {
-    @include animation(
-      linear-progress-bar-stripes ($pt-transition-duration * 3) linear infinite reverse
-    );
+    animation: linear-progress-bar-stripes ($pt-transition-duration * 3) linear infinite reverse;
   }
 
   &.pt-no-stripes .pt-progress-meter {


### PR DESCRIPTION
#### Fixes #674

#### Changes proposed in this pull request:

- bump bourbon to latest 4.x
- stop using bourbon prefixer mixins. Bourbon has deprecated _all_ of them in favor of a tool like Autoprefixer. we already use Autoprefixer so this was easy.
- manually disable logging of bourbon deprecations warnings via handy Sass variable!
  - the only remaining warning is about `strip-units` being renamed, but nothing we can do as we're not on 5.0 yet.

cc @bsr203
