### PR TITLE
[Date Range Input] - Part 8: Input Validation

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -328,7 +328,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     [keys.selectedValue]: maybeNextValue,
                 });
 
-                // TODO: if end date invalid, invoke onError with...?
                 if (this.isMomentValidAndInRange(maybeNextValue)) {
                     // TODO: invoke onChange with...?
                 } else {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -305,7 +305,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const maybeNextValue = this.dateStringToMoment(values.inputString);
         const isValueControlled = this.isControlled();
 
-        if (values.inputString == null || values.inputString.length === 0) {
+        if (this.isInputEmpty(values.inputString)) {
             if (isValueControlled) {
                 this.setState({
                     [keys.isInputFocused]: false,

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -422,7 +422,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         });
         // show only the start date if the dates overlap
         // TODO: add different handling for the === case once
-        // allowSingleDayRange is implemented
+        // allowSingleDayRange is implemented (#249)
         return [startDate, (startDate >= endDate) ? null : endDate] as DateRange;
     }
 
@@ -516,7 +516,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const otherBoundary = this.getOtherBoundary(boundary);
         const otherBoundaryDate = this.getStateKeysAndValuesForBoundary(otherBoundary).values.selectedValue;
 
-        // TODO: add handling for allowSingleDayRange
+        // TODO: add handling for allowSingleDayRange (#249)
         if (boundary === DateRangeBoundary.START) {
             return boundaryDate.isSameOrAfter(otherBoundaryDate);
         } else {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -342,16 +342,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleStartInputChange = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputChange(e, DateRangeBoundary.START);
-        if (this.props.startInputProps != null) {
-            Utils.safeInvoke(this.props.startInputProps.onChange, e);
-        }
+        Utils.safeInvoke(this.props.startInputProps.onChange, e);
     }
 
     private handleEndInputChange = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputChange(e, DateRangeBoundary.END);
-        if (this.props.endInputProps != null) {
-            Utils.safeInvoke(this.props.endInputProps.onChange, e);
-        }
+        Utils.safeInvoke(this.props.endInputProps.onChange, e);
     }
 
     private handleInputChange = (e: React.FormEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {
@@ -440,7 +436,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             return "";
         } else if (!this.isMomentInRange(selectedValue)) {
             return this.props.outOfRangeMessage;
-        } else if (this.isEndBoundaryThatOverlapsStartBoundary(selectedValue, boundary)) {
+        } else if (this.doesEndBoundaryOverlapStartBoundary(selectedValue, boundary)) {
             return this.props.overlappingDatesMessage;
         } else {
             return this.getFormattedDateString(selectedValue);
@@ -528,13 +524,15 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
     }
 
-    private isEndBoundaryThatOverlapsStartBoundary = (boundaryDate: moment.Moment, boundary: DateRangeBoundary) => {
-        // if the boundaries overlap, always consider the END boundary to be
-        // erroneous.
-        if (boundary === DateRangeBoundary.START) {
-            return false;
-        }
-        return this.doBoundaryDatesOverlap(boundaryDate, boundary);
+    /**
+     * Returns true if the provided boundary is an END boundary overlapping the
+     * selected start date. (If the boundaries overlap, we consider the END
+     * boundary to be erroneous.)
+     */
+    private doesEndBoundaryOverlapStartBoundary = (boundaryDate: moment.Moment, boundary: DateRangeBoundary) => {
+        return (boundary === DateRangeBoundary.START)
+            ? false
+            : this.doBoundaryDatesOverlap(boundaryDate, boundary);
     }
 
     private isControlled = () => {
@@ -568,7 +566,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             return true;
         }
 
-        if (this.isEndBoundaryThatOverlapsStartBoundary(boundaryValue, boundary)) {
+        if (this.doesEndBoundaryOverlapStartBoundary(boundaryValue, boundary)) {
             return true;
         }
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -342,10 +342,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleStartInputChange = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputChange(e, DateRangeBoundary.START);
+        if (this.props.startInputProps != null) {
+            Utils.safeInvoke(this.props.startInputProps.onChange, e);
+        }
     }
 
     private handleEndInputChange = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputChange(e, DateRangeBoundary.END);
+        if (this.props.endInputProps != null) {
+            Utils.safeInvoke(this.props.endInputProps.onChange, e);
+        }
     }
 
     private handleInputChange = (e: React.FormEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -118,7 +118,7 @@ interface IStateKeysAndValuesObject {
     };
 };
 
-enum DateRangeBoundary {
+export enum DateRangeBoundary {
     START,
     END,
 };

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -331,8 +331,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     [keys.inputString]: null,
                     [keys.selectedValue]: maybeNextValue,
                 });
-                Utils.safeInvoke(this.props.onError, this.getDateRangeForCallback(maybeNextValue, boundary));
             }
+            Utils.safeInvoke(this.props.onError, this.getDateRangeForCallback(maybeNextValue, boundary));
         } else {
             this.setState({ [keys.isInputFocused]: false });
         }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -60,6 +60,12 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     format?: string;
 
     /**
+     * The error message to display when the selected date is invalid.
+     * @default "Invalid date"
+     */
+    invalidDateMessage?: string;
+
+    /**
      * Called when the user selects a day.
      * If no days are selected, it will pass `[null, null]`.
      * If a start date is selected but not an end date, it will pass `[selectedDate, null]`.
@@ -75,6 +81,12 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
      * boundary of the date range (`onChange` is not called in this case).
      */
     onError?: (errorRange: DateRange) => void;
+
+    /**
+     * The error message to display when the date selected is out of range.
+     * @default "Out of range"
+     */
+    outOfRangeMessage?: string;
 
     /**
      * Props to pass to the start-date input.
@@ -127,8 +139,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     public static defaultProps: IDateRangeInputProps = {
         endInputProps: {},
         format: "YYYY-MM-DD",
+        invalidDateMessage: "Invalid date 2",
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
+        outOfRangeMessage: "Out of range",
         startInputProps: {},
     };
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -14,7 +14,6 @@ import {
     Classes,
     IInputGroupProps,
     InputGroup,
-    Intent,
     IProps,
     Popover,
     Position,
@@ -154,8 +153,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         startInputProps: {},
     };
 
-    private static ERROR_CLASS = Classes.intentClass(Intent.DANGER);
-
     public displayName = "Blueprint.DateRangeInput";
 
     private startInputRef: HTMLInputElement;
@@ -199,10 +196,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         );
 
         const startInputClasses = classNames(startInputProps.className, {
-            [DateRangeInput.ERROR_CLASS]: this.isInputInErrorState(DateRangeBoundary.START),
+            [Classes.INTENT_DANGER]: this.isInputInErrorState(DateRangeBoundary.START),
         });
         const endInputClasses = classNames(endInputProps.className, {
-            [DateRangeInput.ERROR_CLASS]: this.isInputInErrorState(DateRangeBoundary.END),
+            [Classes.INTENT_DANGER]: this.isInputInErrorState(DateRangeBoundary.END),
         });
 
         // allow custom props for each input group, but pass them in an order
@@ -428,16 +425,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
         if (isInputFocused) {
             return inputString;
+        } else if (isMomentNull(selectedValue)) {
+            return "";
+        } else if (!this.isMomentInRange(selectedValue)) {
+            return this.props.outOfRangeMessage;
+        } else if (this.isEndBoundaryThatOverlapsStartBoundary(boundary, selectedValue)) {
+            return this.props.overlappingDatesMessage;
         } else {
-            if (isMomentNull(selectedValue)) {
-                return "";
-            } else if (!this.isMomentInRange(selectedValue)) {
-                return this.props.outOfRangeMessage;
-            } else if (this.isEndBoundaryThatOverlapsStartBoundary(boundary, selectedValue)) {
-                return this.props.overlappingDatesMessage;
-            } else {
-                return this.getFormattedDateString(selectedValue);
-            }
+            return this.getFormattedDateString(selectedValue);
         }
     }
 
@@ -445,9 +440,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         if (isMomentNull(momentDate)) {
             return "";
         } else if (!momentDate.isValid()) {
-            // moment.js formats invalid dates as "Invalid date", which may or
-            // may not match the invalidDateMessage. let's just always show the
-            // custom invalidDateMessage for invalid dates, for consistency.
             return this.props.invalidDateMessage;
         } else {
             return momentDate.format(this.props.format);

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -5,6 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as classNames from "classnames";
 import * as moment from "moment";
 import * as React from "react";
 
@@ -13,6 +14,7 @@ import {
     Classes,
     IInputGroupProps,
     InputGroup,
+    Intent,
     IProps,
     Popover,
     Position,
@@ -121,6 +123,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         startInputProps: {},
     };
 
+    private static ERROR_CLASS = Classes.intentClass(Intent.DANGER);
+
     public displayName = "Blueprint.DateRangeInput";
 
     private startInputRef: HTMLInputElement;
@@ -149,6 +153,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     public render() {
+        const { startInputProps, endInputProps } = this.props;
+
         const startInputString = this.getStartInputDisplayString();
         const endInputString = this.getEndInputDisplayString();
 
@@ -160,6 +166,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 value={this.getSelectedRange()}
             />
         );
+
+        const startInputClasses = classNames(startInputProps.className, {
+            [DateRangeInput.ERROR_CLASS]: this.isStartInputInErrorState(),
+        });
+        const endInputClasses = classNames(endInputProps.className, {
+            [DateRangeInput.ERROR_CLASS]: this.isEndInputInErrorState(),
+        });
 
         // allow custom props for each input group, but pass them in an order
         // that guarantees only some props are overridable.
@@ -176,7 +189,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 <div className={Classes.CONTROL_GROUP}>
                     <InputGroup
                         placeholder="Start date"
-                        {...this.props.startInputProps}
+                        {...startInputProps}
+                        className={startInputClasses}
                         inputRef={this.refHandlers.startInputRef}
                         onBlur={this.handleStartInputBlur}
                         onChange={this.handleStartInputChange}
@@ -186,7 +200,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     />
                     <InputGroup
                         placeholder="End date"
-                        {...this.props.endInputProps}
+                        {...endInputProps}
+                        className={endInputClasses}
                         inputRef={this.refHandlers.endInputRef}
                         onBlur={this.handleEndInputBlur}
                         onChange={this.handleEndInputChange}
@@ -432,6 +447,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private isControlled = () => {
         return this.props.value !== undefined;
+    }
+
+    private isStartInputInErrorState = () => {
+        return true;
+    }
+
+    private isEndInputInErrorState = () => {
+        return true;
     }
 
     private isMomentValidAndInRange = (momentDate: moment.Moment) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -68,6 +68,15 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     onChange?: (selectedRange: DateRange) => void;
 
     /**
+     * Called when the user finishes typing in a new date and the date causes an error state.
+     * If the date is invalid, `new Date(undefined)` will be returned for the corresponding
+     * boundary of the date range.
+     * If the date is out of range, the out-of-range date will be returned for the corresponding
+     * boundary of the date range (`onChange` is not called in this case).
+     */
+    onError?: (errorRange: DateRange) => void;
+
+    /**
      * Props to pass to the start-date input.
      */
     startInputProps?: IInputGroupProps;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -428,6 +428,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         if (isMomentNull(momentDate)) {
             return "";
         } else if (!momentDate.isValid()) {
+            // moment.js formats invalid dates as "Invalid date", which may or
+            // may not match the invalidDateMessage. let's just always show the
+            // custom invalidDateMessage for invalid dates, for consistency.
             return this.props.invalidDateMessage;
         } else {
             return momentDate.format(this.props.format);

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -422,20 +422,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const { values } = this.getStateKeysAndValuesForBoundary(boundary);
         const { isInputFocused, inputString, selectedValue } = values;
 
-        const isValid = selectedValue.isValid();
-
-        // these cases are handled the same whether or not the field is focused
-        if (isMomentNull(selectedValue)) {
-            return "";
-        } else if (!isValid) {
-            return this.props.invalidDateMessage;
-        }
-
-        // break out the following if/else logic to make the code easier to grok
         if (isInputFocused) {
             return inputString;
         } else {
-            if (!this.isMomentInRange(selectedValue)) {
+            if (isMomentNull(selectedValue)) {
+                return "";
+            } else if (!this.isMomentInRange(selectedValue)) {
                 return this.props.outOfRangeMessage;
             } else {
                 return this.getFormattedDateString(selectedValue);
@@ -446,6 +438,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     private getFormattedDateString = (momentDate: moment.Moment) => {
         if (isMomentNull(momentDate)) {
             return "";
+        } else if (!momentDate.isValid()) {
+            return this.props.invalidDateMessage;
         } else {
             return momentDate.format(this.props.format);
         }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -140,7 +140,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     public static defaultProps: IDateRangeInputProps = {
         endInputProps: {},
         format: "YYYY-MM-DD",
-        invalidDateMessage: "Invalid date 2",
+        invalidDateMessage: "Invalid date",
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         outOfRangeMessage: "Out of range",

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -424,7 +424,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const { isInputFocused, inputString, selectedValue } = values;
 
         if (isInputFocused) {
-            return inputString;
+            return (inputString == null) ? "" : inputString;
         } else if (isMomentNull(selectedValue)) {
             return "";
         } else if (!this.isMomentInRange(selectedValue)) {

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -15,6 +15,6 @@ export { DateInput, IDateInputProps } from "./dateInput";
 export { DatePicker, DatePickerFactory, IDatePickerProps } from "./datePicker";
 export { IDatePickerLocaleUtils, IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
-export { DateRangeInput } from "./dateRangeInput";
+export { DateRangeBoundary, DateRangeInput } from "./dateRangeInput";
 export { DateRangePicker, DateRangePickerFactory, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
 export { ITimePickerProps, TimePicker, TimePickerFactory, TimePickerPrecision } from "./timePicker";

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -138,17 +138,20 @@ describe("<DateRangeInput>", () => {
             // we run the same four tests for each of several cases. putting
             // setup logic in beforeEach lets us express our it(...) tests as
             // nice one-liners further down this block, and it also gives
-            // certain tests easy access to onError if they need it.
+            // certain tests easy access to onError/onChange if they need it.
 
+            let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
 
             beforeEach(() => {
+                onChange = sinon.spy();
                 onError = sinon.spy();
                 const result = wrap(<DateRangeInput
                     defaultValue={DATE_RANGE}
                     minDate={OUT_OF_RANGE_TEST_MIN}
                     maxDate={OUT_OF_RANGE_TEST_MAX}
+                    onChange={onChange}
                     onError={onError}
                     outOfRangeMessage={OUT_OF_RANGE_MESSAGE}
                 />);
@@ -157,6 +160,7 @@ describe("<DateRangeInput>", () => {
             });
 
             afterEach(() => {
+                onChange = null;
                 onError = null;
                 root = null;
             });
@@ -195,6 +199,17 @@ describe("<DateRangeInput>", () => {
                 _runTestForEachScenario(_runTest);
             });
 
+            describe("does NOT call onChange before OR after blur", () => {
+                const _runTest = (input: WrappedComponentInput, inputString: string) => {
+                    input.simulate("focus");
+                    changeInputText(input, inputString);
+                    expect(onChange.called).to.be.false;
+                    input.simulate("blur");
+                    expect(onChange.called).to.be.false;
+                };
+                _runTestForEachScenario(_runTest);
+            });
+
             describe("removes error message if input is changed to an in-range date again", () => {
                 const _runTest = (input: WrappedComponentInput, inputString: string) => {
                     changeInputText(input, inputString);
@@ -224,14 +239,17 @@ describe("<DateRangeInput>", () => {
 
         describe("Typing an invalid date...", () => {
 
+            let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
 
             beforeEach(() => {
+                onChange = sinon.spy();
                 onError = sinon.spy();
                 const result = wrap(<DateRangeInput
                     defaultValue={DATE_RANGE}
                     invalidDateMessage={INVALID_MESSAGE}
+                    onChange={onChange}
                     onError={onError}
                 />);
                 root = result.root;
@@ -239,6 +257,7 @@ describe("<DateRangeInput>", () => {
             });
 
             afterEach(() => {
+                onChange = null;
                 onError = null;
                 root = null;
             });
@@ -275,6 +294,17 @@ describe("<DateRangeInput>", () => {
                     const dateRange = onError.getCall(0).args[0];
                     const dateIndex = (boundary === DateRangeBoundary.START) ? 0 : 1;
                     expect((dateRange[dateIndex] as Date).valueOf()).to.be.NaN;
+                };
+                _runTestForEachScenario(_runTest);
+            });
+
+            describe("does NOT call onChange before OR after blur", () => {
+                const _runTest = (input: WrappedComponentInput) => {
+                    input.simulate("focus");
+                    changeInputText(input, INVALID_STR);
+                    expect(onChange.called).to.be.false;
+                    input.simulate("blur");
+                    expect(onChange.called).to.be.false;
                 };
                 _runTestForEachScenario(_runTest);
             });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -42,7 +42,7 @@ describe("<DateRangeInput>", () => {
     const OUT_OF_RANGE_START_STR = DateTestUtils.toHyphenatedDateString(OUT_OF_RANGE_START_DATE);
     const OUT_OF_RANGE_END_DATE = new Date(3000, 1, 1);
     const OUT_OF_RANGE_END_STR = DateTestUtils.toHyphenatedDateString(OUT_OF_RANGE_END_DATE);
-    const OUT_OF_RANGE_MESSAGE = "Out of range";
+    const OUT_OF_RANGE_MESSAGE = "Custom out-of-range message";
 
     it("renders with two InputGroup children", () => {
         const component = mount(<DateRangeInput />);
@@ -150,6 +150,7 @@ describe("<DateRangeInput>", () => {
                     minDate={OUT_OF_RANGE_TEST_MIN}
                     maxDate={OUT_OF_RANGE_TEST_MAX}
                     onError={onError}
+                    outOfRangeMessage={OUT_OF_RANGE_MESSAGE}
                 />);
                 root = result.root;
                 return { root, onError };

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -217,8 +217,23 @@ describe("<DateRangeInput>", () => {
             }
         });
 
-        it.skip("Typing an invalid date displays the error message and calls onError with Date(undefined)", () => {
-            expect(true).to.be.false;
+        describe("Typing an invalid date...", () => {
+
+            it("shows the error message on blur", () => {
+                expect(true).to.be.false;
+            });
+
+            it("shows the error message on focus", () => {
+                expect(true).to.be.false;
+            });
+
+            it("calls onError on blur with Date(undefined) in place of the invalid date", () => {
+                expect(true).to.be.false;
+            });
+
+            it("removes error message if input is changed to an in-range date again", () => {
+                expect(true).to.be.false;
+            });
         });
 
         it("Clearing the date range in the picker invokes onChange with [null, null] and clears the inputs", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -151,15 +151,23 @@ describe("<DateRangeInput>", () => {
             beforeEach(() => {
                 onChange = sinon.spy();
                 onError = sinon.spy();
+
+                // use defaultValue to specify the calendar months in view
                 const result = wrap(<DateRangeInput
                     defaultValue={DATE_RANGE}
                     minDate={OUT_OF_RANGE_TEST_MIN}
                     maxDate={OUT_OF_RANGE_TEST_MAX}
-                    onChange={onChange}
                     onError={onError}
                     outOfRangeMessage={OUT_OF_RANGE_MESSAGE}
                 />);
                 root = result.root;
+
+                // clear the fields *before* setting up an onChange callback to
+                // keep onChange.callCount at 0 before tests run
+                changeStartInputText(root, "");
+                changeEndInputText(root, "");
+                root.setProps({ onChange });
+
                 return { root, onError };
             });
 
@@ -191,8 +199,8 @@ describe("<DateRangeInput>", () => {
             describe("calls onError with invalid date on blur", () => {
                 const _runTest = (input: WrappedComponentInput, inputString: string, boundary: DateRangeBoundary) => {
                     const expectedRange = (boundary === DateRangeBoundary.START)
-                        ? [inputString, END_STR]
-                        : [START_STR, inputString];
+                        ? [inputString, null]
+                        : [null, inputString];
                     input.simulate("focus");
                     changeInputText(input, inputString);
                     expect(onError.called).to.be.false;
@@ -250,13 +258,20 @@ describe("<DateRangeInput>", () => {
             beforeEach(() => {
                 onChange = sinon.spy();
                 onError = sinon.spy();
+
                 const result = wrap(<DateRangeInput
                     defaultValue={DATE_RANGE}
                     invalidDateMessage={INVALID_MESSAGE}
-                    onChange={onChange}
                     onError={onError}
                 />);
                 root = result.root;
+
+                // clear the fields *before* setting up an onChange callback to
+                // keep onChange.callCount at 0 before tests run
+                changeStartInputText(root, "");
+                changeEndInputText(root, "");
+                root.setProps({ onChange });
+
                 return { root, onError };
             });
 
@@ -322,7 +337,6 @@ describe("<DateRangeInput>", () => {
                     // just use START_STR for this test, because it will be
                     // valid in either field.
                     const VALID_STR = START_STR;
-
                     input.simulate("focus");
                     changeInputText(input, VALID_STR);
                     input.simulate("blur");

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -366,7 +366,7 @@ describe("<DateRangeInput>", () => {
                         : [UNDEFINED_DATE_STR, VALID_STR];
 
                     assertDateRangesEqual(actualRange, expectedRange);
-                }
+                };
                 _runTestForEachScenario(_runTest);
             });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -67,12 +67,28 @@ describe("<DateRangeInput>", () => {
         expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
     });
 
+    it("startInputProps.onChange receives change events in the start field", () => {
+        const onChange = sinon.spy();
+        const component = mount(<DateRangeInput startInputProps={{ onChange }} />);
+        changeStartInputText(component, "text");
+        expect(onChange.calledOnce).to.be.true;
+        expect((onChange.firstCall.args[0].target as HTMLInputElement).value).to.equal("text");
+    });
+
     it("endInputProps.inputRef receives reference to HTML input element", () => {
         const inputRef = sinon.spy();
         // full DOM rendering here so the ref handler is invoked
         mount(<DateRangeInput endInputProps={{ inputRef }} />);
         expect(inputRef.calledOnce).to.be.true;
         expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
+    });
+
+    it("endInputProps.onChange receives change events in the end field", () => {
+        const onChange = sinon.spy();
+        const component = mount(<DateRangeInput endInputProps={{ onChange }} />);
+        changeEndInputText(component, "text");
+        expect(onChange.calledOnce).to.be.true;
+        expect((onChange.firstCall.args[0].target as HTMLInputElement).value).to.equal("text");
     });
 
     it("shows empty fields when no date range is selected", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -355,6 +355,72 @@ describe("<DateRangeInput>", () => {
             }
         });
 
+        // this test sub-suite is structured a little differently because of the
+        // different semantics of this error case
+        describe("Typing an overlapping date...", () => {
+
+            describe("in the start field...", () => {
+
+                it("shows an error message in the end field right away", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("shows the offending date in the end field on re-focus", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("shows the offending date in the end field on re-focus", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("calls onError with [<overlappingDate>, <endDate] on blur (???)", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("does NOT call onChange before OR after blur", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("removes error message if input is changed to an in-range date again", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+            });
+
+            describe("in the end field...", () => {
+
+                it("shows an error message in the end field on blur", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("shows the offending date in the end field on re-focus", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("calls onError with [<startDate>, <overlappingDate>] on blur (???)", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("does NOT call onChange before OR after blur", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+
+                it("removes error message if input is changed to an in-range date again", () => {
+                    // TODO
+                    expect(true).to.be.false;
+                });
+            });
+        });
+
         it("Clearing the date range in the picker invokes onChange with [null, null] and clears the inputs", () => {
             const onChange = sinon.spy();
             const defaultValue = [START_DATE, null] as DateRange;

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -33,6 +33,9 @@ describe("<DateRangeInput>", () => {
     const END_STR_2 = DateTestUtils.toHyphenatedDateString(END_DATE_2);
     const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
 
+    const INVALID_STR = "<this is an invalid date string>";
+    const INVALID_MESSAGE = "Custom invalid-date message";
+
     const OUT_OF_RANGE_TEST_MIN = new Date(2000, 1, 1);
     const OUT_OF_RANGE_TEST_MAX = new Date(2020, 1, 1);
     const OUT_OF_RANGE_START_DATE = new Date(1000, 1, 1);
@@ -220,19 +223,63 @@ describe("<DateRangeInput>", () => {
         describe("Typing an invalid date...", () => {
 
             it("shows the error message on blur", () => {
-                expect(true).to.be.false;
+                const { root } = wrap(<DateRangeInput
+                    defaultValue={DATE_RANGE}
+                    invalidDateMessage={INVALID_MESSAGE}
+                />);
+                const startInput = getStartInput(root);
+                startInput.simulate("focus");
+                changeInputText(startInput, INVALID_STR);
+                startInput.simulate("blur");
+                assertInputTextEquals(startInput, INVALID_MESSAGE);
             });
 
-            it("shows the error message on focus", () => {
-                expect(true).to.be.false;
+            it("keeps showing the error message on next focus", () => {
+                const { root } = wrap(<DateRangeInput
+                    defaultValue={DATE_RANGE}
+                    invalidDateMessage={INVALID_MESSAGE}
+                />);
+                const startInput = getStartInput(root);
+                startInput.simulate("focus");
+                changeInputText(startInput, INVALID_STR);
+                startInput.simulate("blur");
+                startInput.simulate("focus");
+                assertInputTextEquals(startInput, INVALID_MESSAGE);
             });
 
             it("calls onError on blur with Date(undefined) in place of the invalid date", () => {
-                expect(true).to.be.false;
+                const onError = sinon.spy();
+                const { root } = wrap(<DateRangeInput
+                    defaultValue={DATE_RANGE}
+                    invalidDateMessage={INVALID_MESSAGE}
+                    onError={onError}
+                />);
+
+                const startInput = getStartInput(root);
+                changeInputText(startInput, INVALID_STR);
+                expect(onError.called).to.be.false;
+                startInput.simulate("blur");
+                expect(onError.calledOnce).to.be.true;
+
+                const dateRange = onError.getCall(0).args[0];
+                expect((dateRange[0] as Date).valueOf()).to.be.NaN;
             });
 
             it("removes error message if input is changed to an in-range date again", () => {
-                expect(true).to.be.false;
+                const { root } = wrap(<DateRangeInput
+                    defaultValue={DATE_RANGE}
+                    invalidDateMessage={INVALID_MESSAGE}
+                />);
+
+                const startInput = getStartInput(root);
+                changeInputText(startInput, INVALID_STR);
+                startInput.simulate("blur");
+
+                const VALID_STR = START_STR;
+                startInput.simulate("focus");
+                changeInputText(startInput, VALID_STR);
+                startInput.simulate("blur");
+                assertInputTextEquals(startInput, VALID_STR);
             });
         });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -45,7 +45,7 @@ describe("<DateRangeInput>", () => {
     const OUT_OF_RANGE_MESSAGE = "Custom out-of-range message";
 
     // a custom string representation for `new Date(undefined)` that we use in
-    // date-range equality checks
+    // date-range equality checks just in this file
     const UNDEFINED_DATE_STR = "<UNDEFINED DATE>";
 
     it("renders with two InputGroup children", () => {
@@ -355,7 +355,6 @@ describe("<DateRangeInput>", () => {
                 }
                 _runTestForEachScenario(_runTest);
             });
-
 
             type InvalidDateTestFunction = (input: WrappedComponentInput,
                                             boundary: DateRangeBoundary,

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -122,8 +122,22 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR_2, END_STR_2);
         });
 
-        it.skip("Typing a date out of range displays the error message and calls onError with invalid date", () => {
-            expect(true).to.be.false;
+        describe("Typing an out-of-range date...", () => {
+            it("shows the offending date in the field on focus", () => {
+                expect(true).to.be.false;
+            });
+
+            it("shows the error message in the field on blur", () => {
+                expect(true).to.be.false;
+            });
+
+            it("shows a danger intent on the input field on focus and blur", () => {
+                expect(true).to.be.false;
+            });
+
+            it("calls onError with invalid date on blur", () => {
+                expect(true).to.be.false;
+            });
         });
 
         it.skip("Typing an invalid date displays the error message and calls onError with Date(undefined)", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -9,7 +9,7 @@ import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
-import { Classes, InputGroup, Intent } from "@blueprintjs/core";
+import { InputGroup } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes as DateClasses, DateRange, DateRangeBoundary, DateRangeInput } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -18,8 +18,6 @@ type WrappedComponentRoot = ReactWrapper<any, {}>;
 type WrappedComponentInput = ReactWrapper<React.HTMLAttributes<{}>, any>;
 
 describe("<DateRangeInput>", () => {
-
-    const DANGER_CLASS = Classes.intentClass(Intent.DANGER);
 
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
@@ -178,16 +176,6 @@ describe("<DateRangeInput>", () => {
                 _runTestForEachScenario(_runTest);
             });
 
-            describe("shows a danger intent on the input field on focus and on blur", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string) => {
-                    changeInputText(input, inputString);
-                    expect(input.hasClass(DANGER_CLASS)).to.be.true;
-                    input.simulate("blur");
-                    expect(input.hasClass(DANGER_CLASS)).to.be.true;
-                };
-                _runTestForEachScenario(_runTest);
-            });
-
             describe("calls onError with invalid date on blur", () => {
                 const _runTest = (input: WrappedComponentInput, inputString: string, boundary: DateRangeBoundary) => {
                     const expectedRange = (boundary === DateRangeBoundary.START)
@@ -199,25 +187,6 @@ describe("<DateRangeInput>", () => {
                     input.simulate("blur");
                     expect(onError.calledOnce).to.be.true;
                     assertDateRangesEqual(onError.getCall(0).args[0], expectedRange);
-                };
-                _runTestForEachScenario(_runTest);
-            });
-
-            describe("removes danger intent on focus and blur if input is changed to an in-range date again", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string) => {
-                    // input an invalid date
-                    changeInputText(input, inputString);
-                    input.simulate("blur");
-
-                    // now fix it (START_STR is between OUT_OF_RANGE_TEST_MIN
-                    // and OUT_OF_RANGE_TEST_MAX, so it will be in range for
-                    // whichever boundary we're testing).
-                    const IN_RANGE_DATE_STR = START_STR;
-                    input.simulate("focus");
-                    changeInputText(input, IN_RANGE_DATE_STR);
-                    expect(input.hasClass(DANGER_CLASS)).to.be.false;
-                    input.simulate("blur");
-                    expect(input.hasClass(DANGER_CLASS)).to.be.false;
                 };
                 _runTestForEachScenario(_runTest);
             });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -44,6 +44,12 @@ describe("<DateRangeInput>", () => {
     const OUT_OF_RANGE_END_STR = DateTestUtils.toHyphenatedDateString(OUT_OF_RANGE_END_DATE);
     const OUT_OF_RANGE_MESSAGE = "Custom out-of-range message";
 
+    const OVERLAPPING_DATES_MESSAGE = "Custom overlapping-dates message";
+    const OVERLAPPING_START_DATE = END_DATE_2; // should be later then END_DATE
+    const OVERLAPPING_END_DATE = START_DATE_2; // should be earlier then START_DATE
+    const OVERLAPPING_START_STR = DateTestUtils.toHyphenatedDateString(OVERLAPPING_START_DATE);
+    const OVERLAPPING_END_STR = DateTestUtils.toHyphenatedDateString(OVERLAPPING_END_DATE);
+
     // a custom string representation for `new Date(undefined)` that we use in
     // date-range equality checks just in this file
     const UNDEFINED_DATE_STR = "<UNDEFINED DATE>";
@@ -167,8 +173,6 @@ describe("<DateRangeInput>", () => {
                 changeStartInputText(root, "");
                 changeEndInputText(root, "");
                 root.setProps({ onChange });
-
-                return { root, onError };
             });
 
             describe("shows the error message on blur", () => {
@@ -260,8 +264,6 @@ describe("<DateRangeInput>", () => {
                 changeStartInputText(root, "");
                 changeEndInputText(root, "");
                 root.setProps({ onChange });
-
-                return { root, onError };
             });
 
             describe("shows the error message on blur", () => {
@@ -356,67 +358,115 @@ describe("<DateRangeInput>", () => {
         });
 
         // this test sub-suite is structured a little differently because of the
-        // different semantics of this error case
+        // different semantics of this error case in each field
         describe("Typing an overlapping date...", () => {
+
+            let onChange: Sinon.SinonSpy;
+            let onError: Sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            let startInput: WrappedComponentInput;
+            let endInput: WrappedComponentInput;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(<DateRangeInput
+                    defaultValue={DATE_RANGE}
+                    overlappingDatesMessage={OVERLAPPING_DATES_MESSAGE}
+                    onChange={onChange}
+                    onError={onError}
+                />);
+                root = result.root;
+                startInput = getStartInput(root);
+                endInput = getEndInput(root);
+            });
 
             describe("in the start field...", () => {
 
                 it("shows an error message in the end field right away", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    assertInputTextEquals(endInput, OVERLAPPING_DATES_MESSAGE);
                 });
 
-                it("shows the offending date in the end field on re-focus", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                it("shows the offending date in the end field on focus in the end field", () => {
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    startInput.simulate("blur");
+                    endInput.simulate("focus");
+                    assertInputTextEquals(endInput, END_STR);
                 });
 
-                it("shows the offending date in the end field on re-focus", () => {
-                    // TODO
-                    expect(true).to.be.false;
-                });
-
-                it("calls onError with [<overlappingDate>, <endDate] on blur (???)", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                it("calls onError with [<overlappingDate>, <endDate] on blur", () => {
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    expect(onError.called).to.be.false;
+                    startInput.simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], [OVERLAPPING_START_STR, END_STR]);
                 });
 
                 it("does NOT call onChange before OR after blur", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    expect(onChange.called).to.be.false;
+                    startInput.simulate("blur");
+                    expect(onChange.called).to.be.false;
                 });
 
                 it("removes error message if input is changed to an in-range date again", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    changeInputText(startInput, START_STR);
+                    assertInputTextEquals(endInput, END_STR);
                 });
             });
 
             describe("in the end field...", () => {
 
                 it("shows an error message in the end field on blur", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    assertInputTextEquals(endInput, OVERLAPPING_END_STR);
+                    endInput.simulate("blur");
+                    assertInputTextEquals(endInput, OVERLAPPING_DATES_MESSAGE);
                 });
 
                 it("shows the offending date in the end field on re-focus", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    endInput.simulate("blur");
+                    endInput.simulate("focus");
+                    assertInputTextEquals(endInput, OVERLAPPING_END_STR);
                 });
 
-                it("calls onError with [<startDate>, <overlappingDate>] on blur (???)", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                it("calls onError with [<startDate>, <overlappingDate>] on blur", () => {
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    expect(onError.called).to.be.false;
+                    endInput.simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], [START_STR, OVERLAPPING_END_STR]);
                 });
 
                 it("does NOT call onChange before OR after blur", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    expect(onChange.called).to.be.false;
+                    endInput.simulate("blur");
+                    expect(onChange.called).to.be.false;
                 });
 
                 it("removes error message if input is changed to an in-range date again", () => {
-                    // TODO
-                    expect(true).to.be.false;
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    endInput.simulate("blur");
+                    endInput.simulate("focus");
+                    changeInputText(endInput, END_STR);
+                    endInput.simulate("blur");
+                    assertInputTextEquals(endInput, END_STR);
                 });
             });
         });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -171,33 +171,25 @@ describe("<DateRangeInput>", () => {
                 return { root, onError };
             });
 
-            afterEach(() => {
-                onChange = null;
-                onError = null;
-                root = null;
-            });
-
             describe("shows the error message on blur", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string) => {
+                runTestForEachScenario((input, inputString) => {
                     changeInputText(input, inputString);
                     input.simulate("blur");
                     assertInputTextEquals(input, OUT_OF_RANGE_MESSAGE);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("shows the offending date in the field on focus", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string) => {
+                runTestForEachScenario((input, inputString) => {
                     changeInputText(input, inputString);
                     input.simulate("blur");
                     input.simulate("focus");
                     assertInputTextEquals(input, inputString);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("calls onError with invalid date on blur", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string, boundary: DateRangeBoundary) => {
+                runTestForEachScenario((input, inputString, boundary) => {
                     const expectedRange = (boundary === DateRangeBoundary.START)
                         ? [inputString, null]
                         : [null, inputString];
@@ -207,23 +199,21 @@ describe("<DateRangeInput>", () => {
                     input.simulate("blur");
                     expect(onError.calledOnce).to.be.true;
                     assertDateRangesEqual(onError.getCall(0).args[0], expectedRange);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("does NOT call onChange before OR after blur", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string) => {
+                runTestForEachScenario((input, inputString) => {
                     input.simulate("focus");
                     changeInputText(input, inputString);
                     expect(onChange.called).to.be.false;
                     input.simulate("blur");
                     expect(onChange.called).to.be.false;
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("removes error message if input is changed to an in-range date again", () => {
-                const _runTest = (input: WrappedComponentInput, inputString: string) => {
+                runTestForEachScenario((input, inputString) => {
                     changeInputText(input, inputString);
                     input.simulate("blur");
 
@@ -232,15 +222,14 @@ describe("<DateRangeInput>", () => {
                     changeInputText(input, IN_RANGE_DATE_STR);
                     input.simulate("blur");
                     assertInputTextEquals(input, IN_RANGE_DATE_STR);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             type OutOfRangeTestFunction = (input: WrappedComponentInput,
                                            inputString: string,
                                            boundary?: DateRangeBoundary) => void;
 
-            function _runTestForEachScenario(runTestFn: OutOfRangeTestFunction) {
+            function runTestForEachScenario(runTestFn: OutOfRangeTestFunction) {
                 const { START, END } = DateRangeBoundary; // deconstruct to keep line lengths under threshold
                 it("if start < minDate", () => runTestFn(getStartInput(root), OUT_OF_RANGE_START_STR, START));
                 it("if start > maxDate", () => runTestFn(getStartInput(root), OUT_OF_RANGE_END_STR, START));
@@ -275,35 +264,27 @@ describe("<DateRangeInput>", () => {
                 return { root, onError };
             });
 
-            afterEach(() => {
-                onChange = null;
-                onError = null;
-                root = null;
-            });
-
             describe("shows the error message on blur", () => {
-                const _runTest = (input: WrappedComponentInput) => {
+                runTestForEachScenario((input) => {
                     input.simulate("focus");
                     changeInputText(input, INVALID_STR);
                     input.simulate("blur");
                     assertInputTextEquals(input, INVALID_MESSAGE);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("keeps showing the error message on next focus", () => {
-                const _runTest = (input: WrappedComponentInput) => {
+                runTestForEachScenario((input) => {
                     input.simulate("focus");
                     changeInputText(input, INVALID_STR);
                     input.simulate("blur");
                     input.simulate("focus");
                     assertInputTextEquals(input, INVALID_MESSAGE);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("calls onError on blur with Date(undefined) in place of the invalid date", () => {
-                const _runTest = (input: WrappedComponentInput, boundary: DateRangeBoundary) => {
+                runTestForEachScenario((input, boundary) => {
                     input.simulate("focus");
                     changeInputText(input, INVALID_STR);
                     expect(onError.called).to.be.false;
@@ -313,23 +294,21 @@ describe("<DateRangeInput>", () => {
                     const dateRange = onError.getCall(0).args[0];
                     const dateIndex = (boundary === DateRangeBoundary.START) ? 0 : 1;
                     expect((dateRange[dateIndex] as Date).valueOf()).to.be.NaN;
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("does NOT call onChange before OR after blur", () => {
-                const _runTest = (input: WrappedComponentInput) => {
+                runTestForEachScenario((input) => {
                     input.simulate("focus");
                     changeInputText(input, INVALID_STR);
                     expect(onChange.called).to.be.false;
                     input.simulate("blur");
                     expect(onChange.called).to.be.false;
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             describe("removes error message if input is changed to an in-range date again", () => {
-                const _runTest = (input: WrappedComponentInput) => {
+                runTestForEachScenario((input) => {
                     input.simulate("focus");
                     changeInputText(input, INVALID_STR);
                     input.simulate("blur");
@@ -341,15 +320,12 @@ describe("<DateRangeInput>", () => {
                     changeInputText(input, VALID_STR);
                     input.simulate("blur");
                     assertInputTextEquals(input, VALID_STR);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             // tslint:disable-next-line:max-line-length
             describe("calls onChange if last-edited boundary is in range and the other boundary is out of range", () => {
-                const _runTest = (input: WrappedComponentInput,
-                                  boundary: DateRangeBoundary,
-                                  otherInput: WrappedComponentInput) => {
+                runTestForEachScenario((input, boundary, otherInput) => {
                     otherInput.simulate("focus");
                     changeInputText(otherInput, INVALID_STR);
                     otherInput.simulate("blur");
@@ -366,15 +342,14 @@ describe("<DateRangeInput>", () => {
                         : [UNDEFINED_DATE_STR, VALID_STR];
 
                     assertDateRangesEqual(actualRange, expectedRange);
-                };
-                _runTestForEachScenario(_runTest);
+                });
             });
 
             type InvalidDateTestFunction = (input: WrappedComponentInput,
                                             boundary: DateRangeBoundary,
                                             otherInput: WrappedComponentInput) => void;
 
-            function _runTestForEachScenario(runTestFn: InvalidDateTestFunction) {
+            function runTestForEachScenario(runTestFn: InvalidDateTestFunction) {
                 it("in start field", () => runTestFn(getStartInput(root), DateRangeBoundary.START, getEndInput(root)));
                 it("in end field", () => runTestFn(getEndInput(root), DateRangeBoundary.END, getStartInput(root)));
             }


### PR DESCRIPTION
#### Related to #249, builds on #711

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Input validation when typing dates.

- _New feature_: Show an error message when the inputted date has an invalid date format (configurable via a new prop: `invalidDateMessage`).
- _New feature_: Show an error message when the inputted date is out of range of `[minDate, maxDate]` (configurable via a new prop: `outOfRangeMessage`).
- _New feature_: Show an error message when the inputted dates overlap (configurable via a new prop: `overlappingDatesMessage`).
- _New feature_: Trigger `this.props.{start,end}InputProps.onChange` for controlled usage.
- Add a bunch of rigorous unit tests for each of these cases, verifying behavior for all permutations of scenarios (inputting in start field or end field, inputting out-of-range dates that precede min or exceed max, etc.).
- Various other handling for input validation in controlled mode.

#### Reviewers should focus on:

Particularly:
- Are the prop names good?
- Are the default error messages good? ("Overlapping dates" is clear enough but feels inelegant)
- I'd like to support passing `null` to disable the showing of a particular error message when it would otherwise be shown. Not implemented yet, but would be quick. Thoughts?
- The tests for controlled and uncontrolled input validation scenarios are fairly repetitive (with one or two subtle differences), but the fact that `describe` runs before `beforeEach` makes it tricky to decompose into reusable chunks. For instance, to pull out `runTestForEachScenario` into a reusable function, you need to pass it a mounted `root` instance, but that isn't populated until each `it(...)` test triggers the `beforeEach` block; the result is that unit tests receive an undefined/uninitialized `root` in that approach. There may be a way to make this work, but I haven't discovered it yet.

#### Screenshot

_Invalid dates_

![2017-02-24 14 05 56](https://cloud.githubusercontent.com/assets/443450/23322785/6d41c680-fa9a-11e6-8fd3-33721c780c0f.gif)

_Out-of-range dates_

![2017-02-24 14 06 46](https://cloud.githubusercontent.com/assets/443450/23322812/93bd0f72-fa9a-11e6-8c4f-b8f4b9e8da58.gif)

_Overlapping dates_

![2017-02-24 14 07 35](https://cloud.githubusercontent.com/assets/443450/23322847/afcc6898-fa9a-11e6-8228-bbc07cff3f86.gif)