### PR TITLE
center NonIdealState contents vertically

### DIFF
--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -70,6 +70,7 @@ Styleguide components.nonidealstate.js
   margin: 0 auto;
   width: 100%;
   max-width: $pt-grid-size * 40;
+  height: 100%;
 }
 
 .pt-non-ideal-state-visual {


### PR DESCRIPTION
#### Fixes #651 

#### Changes proposed in this pull request:

add `height: 100%` to NonIdealState so it fills its container and centers its contents. we already set `width: 100%` so this is just consistent.

try setting an explicit height on the parent `div` of the example and you'll see how the `.pt-non-ideal-state` grows to fill the space and keeps its content centered.
