### PR TITLE
Fix appearance of custom minimal buttons in focus states

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -386,6 +386,7 @@ $button-intents: (
   &:hover,
   &:focus {
     background: rgba($intent-color, 0.15);
+    color: $text-color;
   }
 
   &:active,
@@ -407,7 +408,8 @@ $button-intents: (
   .pt-dark & {
     color: $dark-text-color;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: rgba($intent-color, 0.2);
       color: $dark-text-color;
     }


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/199754/23323934/ce49560a-fa9f-11e6-9539-419d01a5b443.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/23323936/d45da9ce-fa9f-11e6-8084-53502178cee0.png)
