### PR TITLE
Pass along column props to cell renderer

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -610,7 +610,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             ? cellLoading
             : this.hasLoadingOption(columnProps.loadingOptions, ColumnLoadingOption.CELLS);
 
-        return React.cloneElement(cell, { loading } as ICellProps);
+        return React.cloneElement(cell, { ...columnProps, loading } as ICellProps);
     }
 
     private renderBody() {


### PR DESCRIPTION
#### Fixes #690

#### Changes proposed in this pull request:
Fix behavior so that className (and everything else) from the parent column, as it worked before. 
