### PR TITLE
Add 'selectAllOnIncrement' to removeNonHTMLProps

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -194,6 +194,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
             "minorStepSize",
             "onValueChange",
             "selectAllOnFocus",
+            "selectAllOnIncrement",
             "stepSize",
         ], true);
 


### PR DESCRIPTION
#### Fixes #736 

#### Changes proposed in this pull request:

- Add `selectAllOnIncrement` to `removeNonHTMLProps` to get rid of the React warning.