### PR TITLE
Update Button docs to add a switch demonstrating the new active prop

### DIFF
--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -13,8 +13,8 @@ import BaseExample, { handleBooleanChange, handleNumberChange } from "./common/b
 import { IntentSelect } from "./common/intentSelect";
 
 export interface IButtonsExampleState {
-    disabled?: boolean;
     active?: boolean;
+    disabled?: boolean;
     intent?: Intent;
     loading?: boolean;
     large?: boolean;
@@ -24,16 +24,16 @@ export interface IButtonsExampleState {
 
 export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     public state: IButtonsExampleState = {
-        disabled: false,
         active: false,
+        disabled: false,
         large: false,
         loading: false,
         minimal: false,
         wiggling: false,
     };
 
-    private handleDisabledChange = handleBooleanChange((disabled) => this.setState({ disabled }));
     private handleActiveChange = handleBooleanChange((active) => this.setState({ active }));
+    private handleDisabledChange = handleBooleanChange((disabled) => this.setState({ disabled }));
     private handleLargeChange = handleBooleanChange((large) => this.setState({ large }));
     private handleLoadingChange = handleBooleanChange((loading) => this.setState({ loading }));
     private handleMinimalChange = handleBooleanChange((minimal) => this.setState({ minimal }));
@@ -88,16 +88,16 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
             [
                 <label className={Classes.LABEL} key="label">Modifiers</label>,
                 <Switch
-                    checked={this.state.disabled}
-                    key="disabled"
-                    label="Disabled"
-                    onChange={this.handleDisabledChange}
-                />,
-                <Switch
                     checked={this.state.active}
                     key="active"
                     label="Active"
                     onChange={this.handleActiveChange}
+                />,
+                <Switch
+                    checked={this.state.disabled}
+                    key="disabled"
+                    label="Disabled"
+                    onChange={this.handleDisabledChange}
                 />,
                 <Switch
                     checked={this.state.large}

--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -14,6 +14,7 @@ import { IntentSelect } from "./common/intentSelect";
 
 export interface IButtonsExampleState {
     disabled?: boolean;
+    active?: boolean;
     intent?: Intent;
     loading?: boolean;
     large?: boolean;
@@ -24,6 +25,7 @@ export interface IButtonsExampleState {
 export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     public state: IButtonsExampleState = {
         disabled: false,
+        active: false,
         large: false,
         loading: false,
         minimal: false,
@@ -31,6 +33,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     };
 
     private handleDisabledChange = handleBooleanChange((disabled) => this.setState({ disabled }));
+    private handleActiveChange = handleBooleanChange((active) => this.setState({ active }));
     private handleLargeChange = handleBooleanChange((large) => this.setState({ large }));
     private handleLoadingChange = handleBooleanChange((loading) => this.setState({ loading }));
     private handleMinimalChange = handleBooleanChange((minimal) => this.setState({ minimal }));
@@ -54,6 +57,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                 <Button
                     className={classNames(classes, { "docs-wiggle": this.state.wiggling })}
                     disabled={this.state.disabled}
+                    active={this.state.active}
                     iconName="refresh"
                     intent={this.state.intent}
                     loading={this.state.loading}
@@ -66,6 +70,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                 <AnchorButton
                     className={classes}
                     disabled={this.state.disabled}
+                    active={this.state.active}
                     href="./"
                     iconName="duplicate"
                     intent={this.state.intent}
@@ -87,6 +92,12 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                     key="disabled"
                     label="Disabled"
                     onChange={this.handleDisabledChange}
+                />,
+                <Switch
+                    checked={this.state.active}
+                    key="active"
+                    label="Active"
+                    onChange={this.handleActiveChange}
                 />,
                 <Switch
                     checked={this.state.large}


### PR DESCRIPTION
Hey Blueprint team,

I was excited my new `Button active` prop made it in 1.10 and it cleaned up my code significantly! 😄 

I noticed the docs were missing a `Switch` showing off the new prop in the docs. Here's a PR. Lmk if anything is missing.

Drew