### PR TITLE
Add tetherOptions prop to Popover

### DIFF
--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -44,8 +44,8 @@ export function createTetherOptions(element: Element,
                                     target: Node,
                                     position: Position,
                                     useSmartPositioning: boolean,
-                                    tetherOptions: Partial<Tether.ITetherOptions>) {
-    if (tetherOptions == null && (tetherOptions.constraints == null && useSmartPositioning)) {
+                                    tetherOptions: Partial<Tether.ITetherOptions> = {}) {
+    if (tetherOptions.constraints == null && useSmartPositioning) {
         tetherOptions.constraints = [DEFAULT_CONSTRAINTS];
     }
 

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -44,16 +44,16 @@ export function createTetherOptions(element: Element,
                                     target: Node,
                                     position: Position,
                                     useSmartPositioning: boolean,
-                                    constraints: ITetherConstraint[]) {
-    if (constraints == null && useSmartPositioning) {
-        constraints = [DEFAULT_CONSTRAINTS];
+                                    tetherOptions: Partial<Tether.ITetherOptions>) {
+    if (tetherOptions == null && (tetherOptions.constraints == null && useSmartPositioning)) {
+        tetherOptions.constraints = [DEFAULT_CONSTRAINTS];
     }
 
     const options: Tether.ITetherOptions = {
+        ...tetherOptions,
         attachment: getPopoverAttachment(position),
         bodyElement: fakeHtmlElement,
         classPrefix: "pt-tether",
-        constraints,
         element,
         target,
         targetAttachment: getTargetAttachment(position),

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -7,7 +7,6 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import * as Tether from 'tether';
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
@@ -27,7 +26,7 @@ interface IContextMenuState {
     onClose?: () => void;
 }
 
-const TETHER_OPTIONS:Tether.ITetherOptions = {constraints: [{ attachment: "together", pin: true, to: "window" }]};
+const CONSTRAINTS = [ { attachment: "together", pin: true, to: "window" } ];
 const TRANSITION_DURATION = 100;
 
 class ContextMenu extends AbstractComponent<{}, IContextMenuState> {
@@ -41,7 +40,7 @@ class ContextMenu extends AbstractComponent<{}, IContextMenuState> {
         return (
             <Popover
                 backdropProps={{ onContextMenu: this.handleBackdropContextMenu }}
-                tetherOptions={TETHER_OPTIONS}
+                constraints={CONSTRAINTS}
                 content={content}
                 enforceFocus={false}
                 isModal={true}

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -7,6 +7,7 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import * as Tether from 'tether';
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
@@ -26,7 +27,7 @@ interface IContextMenuState {
     onClose?: () => void;
 }
 
-const CONSTRAINTS = [ { attachment: "together", pin: true, to: "window" } ];
+const TETHER_OPTIONS:Tether.ITetherOptions = {constraints: [{ attachment: "together", pin: true, to: "window" }]};
 const TRANSITION_DURATION = 100;
 
 class ContextMenu extends AbstractComponent<{}, IContextMenuState> {
@@ -40,7 +41,7 @@ class ContextMenu extends AbstractComponent<{}, IContextMenuState> {
         return (
             <Popover
                 backdropProps={{ onContextMenu: this.handleBackdropContextMenu }}
-                constraints={CONSTRAINTS}
+                tetherOptions={TETHER_OPTIONS}
                 content={content}
                 enforceFocus={false}
                 isModal={true}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -180,7 +180,7 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
      * Options for the underlying Tether instance.
      * See http://tether.io/#options
      */
-    tetherOptions?: Partial<Tether.ITetherOptions>
+    tetherOptions?: Partial<Tether.ITetherOptions>;
 }
 
 export interface IPopoverState {
@@ -523,7 +523,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
             const target = findDOMNode(this).childNodes[0];
             let tetherUtilOptions = this.props.tetherOptions || {};
 
-            //This is for backwards compatibility. this.props.constraints is always leading
+            // This is for backwards compatibility. this.props.constraints is always leading
             if (this.props.constraints != null) {
                 tetherUtilOptions.constraints = this.props.constraints;
             }

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -207,10 +207,10 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
         popoverClassName: "",
         position: PosUtils.Position.RIGHT,
         rootElementTag: "span",
+        tetherOptions: {},
         transitionDuration: 300,
         useSmartArrowPositioning: true,
         useSmartPositioning: false,
-        tetherOptions: {},
     };
 
     public displayName = "Blueprint.Popover";

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -52,6 +52,13 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     arrowSize?: number;
 
     /**
+     * Constraints for the underlying Tether instance.
+     * See http://tether.io/#constraints.
+     * @deprecated
+     */
+    constraints?: TetherUtils.ITetherConstraint[];
+
+    /**
      * Initial opened state when uncontrolled.
      * @default false
      */
@@ -514,9 +521,16 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
             // so instead, we'll position tether based off of its first child.
             // NOTE: use findDOMNode(this) directly because this.targetElement may not exist yet
             const target = findDOMNode(this).childNodes[0];
+            let tetherUtilOptions = this.props.tetherOptions || {};
+
+            //This is for backwards compatibility. this.props.constraints is always leading
+            if (this.props.constraints != null) {
+                tetherUtilOptions.constraints = this.props.constraints;
+            }
+
             const tetherOptions = TetherUtils.createTetherOptions(
                 this.popoverElement, target, this.props.position,
-                this.props.useSmartPositioning, this.props.tetherOptions,
+                this.props.useSmartPositioning, tetherUtilOptions,
             );
             if (this.tether == null) {
                 this.tether = new Tether(tetherOptions);

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -52,12 +52,6 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     arrowSize?: number;
 
     /**
-     * Constraints for the underlying Tether instance.
-     * See http://tether.io/#constraints.
-     */
-    constraints?: TetherUtils.ITetherConstraint[];
-
-    /**
      * Initial opened state when uncontrolled.
      * @default false
      */
@@ -174,6 +168,12 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
      * @default false
      */
     useSmartPositioning?: boolean;
+
+    /**
+     * Options for the underlying Tether instance.
+     * See http://tether.io/#options
+     */
+    tetherOptions?: Partial<Tether.ITetherOptions>
 }
 
 export interface IPopoverState {
@@ -516,7 +516,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
             const target = findDOMNode(this).childNodes[0];
             const tetherOptions = TetherUtils.createTetherOptions(
                 this.popoverElement, target, this.props.position,
-                this.props.useSmartPositioning, this.props.constraints,
+                this.props.useSmartPositioning, this.props.tetherOptions,
             );
             if (this.tether == null) {
                 this.tether = new Tether(tetherOptions);

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -210,6 +210,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
         transitionDuration: 300,
         useSmartArrowPositioning: true,
         useSmartPositioning: false,
+        tetherOptions: {},
     };
 
     public displayName = "Blueprint.Popover";
@@ -521,16 +522,15 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
             // so instead, we'll position tether based off of its first child.
             // NOTE: use findDOMNode(this) directly because this.targetElement may not exist yet
             const target = findDOMNode(this).childNodes[0];
-            let tetherUtilOptions = this.props.tetherOptions || {};
 
             // This is for backwards compatibility. this.props.constraints is always leading
             if (this.props.constraints != null) {
-                tetherUtilOptions.constraints = this.props.constraints;
+                this.props.tetherOptions.constraints = this.props.constraints;
             }
 
             const tetherOptions = TetherUtils.createTetherOptions(
                 this.popoverElement, target, this.props.position,
-                this.props.useSmartPositioning, tetherUtilOptions,
+                this.props.useSmartPositioning, this.props.tetherOptions,
             );
             if (this.tether == null) {
                 this.tether = new Tether(tetherOptions);

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -95,11 +95,15 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             );
             const popoverContent = <div className={popoverClasses}>{children}</div>;
             const className = classNames(this.props.className, Classes.TABLE_TRUNCATED_FORMAT);
-            const constraints = [{
-                attachment: "together",
-                pin: true,
-                to: "window",
-            }];
+            const tetherOptions: Tether.ITetherOptions = {
+                constraints: [
+                    {
+                        attachment: "together",
+                        pin: true,
+                        to: "window",
+                    }
+                ]
+            };
 
             const iconClasses = classNames(
                 CoreClasses.ICON_STANDARD,
@@ -111,7 +115,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
                     <div className={Classes.TABLE_TRUNCATED_VALUE} ref={this.handleContentDivRef}>{cellContent}</div>
                     <Popover
                         className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
-                        constraints={constraints}
+                        tetherOptions={tetherOptions}
                         content={popoverContent}
                         position={Position.BOTTOM}
                         useSmartArrowPositioning

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -111,8 +111,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
                     <div className={Classes.TABLE_TRUNCATED_VALUE} ref={this.handleContentDivRef}>{cellContent}</div>
                     <Popover
                         className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
-                        constraints={constraints}
-                        tetherOptions={{constraints}}
+                        tetherOptions={{ constraints }}
                         content={popoverContent}
                         position={Position.BOTTOM}
                         useSmartArrowPositioning

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -95,15 +95,11 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             );
             const popoverContent = <div className={popoverClasses}>{children}</div>;
             const className = classNames(this.props.className, Classes.TABLE_TRUNCATED_FORMAT);
-            const tetherOptions: Tether.ITetherOptions = {
-                constraints: [
-                    {
-                        attachment: "together",
-                        pin: true,
-                        to: "window",
-                    }
-                ]
-            };
+            const constraints = [{
+                attachment: "together",
+                pin: true,
+                to: "window",
+            }];
 
             const iconClasses = classNames(
                 CoreClasses.ICON_STANDARD,
@@ -115,7 +111,8 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
                     <div className={Classes.TABLE_TRUNCATED_VALUE} ref={this.handleContentDivRef}>{cellContent}</div>
                     <Popover
                         className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
-                        tetherOptions={tetherOptions}
+                        constraints={constraints}
+                        tetherOptions={{constraints}}
                         content={popoverContent}
                         position={Position.BOTTOM}
                         useSmartArrowPositioning

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -204,19 +204,16 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
             CoreClasses.iconClass(menuIconName),
         );
 
-        const tetherOptions: Tether.ITetherOptions = {
-            constraints: [
-                {
-                    attachment: "together",
-                    pin: true,
-                    to: "window",
-                }
-            ]
-        };
+        const constraints = [{
+            attachment: "together",
+            pin: true,
+            to: "window",
+        }];
 
         return (
             <Popover
-                tetherOptions={tetherOptions}
+                constraints={constraints}
+                tetherOptions={{constraints}}
                 content={menu}
                 position={Position.BOTTOM}
                 className={Classes.TABLE_TH_MENU}

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -203,15 +203,20 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
             CoreClasses.ICON_STANDARD,
             CoreClasses.iconClass(menuIconName),
         );
-        const constraints = [{
-            attachment: "together",
-            pin: true,
-            to: "window",
-        }];
+
+        const tetherOptions: Tether.ITetherOptions = {
+            constraints: [
+                {
+                    attachment: "together",
+                    pin: true,
+                    to: "window",
+                }
+            ]
+        };
 
         return (
             <Popover
-                constraints={constraints}
+                tetherOptions={tetherOptions}
                 content={menu}
                 position={Position.BOTTOM}
                 className={Classes.TABLE_TH_MENU}

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -212,8 +212,7 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
 
         return (
             <Popover
-                constraints={constraints}
-                tetherOptions={{constraints}}
+                tetherOptions={{ constraints }}
                 content={menu}
                 position={Position.BOTTOM}
                 className={Classes.TABLE_TH_MENU}


### PR DESCRIPTION
#### ~~Fixes~~ partially addresses #394 - Blurry text in popover when zoomed

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [X] [Enable CircleCI for your fork](https://circleci.com/add-projects)

#### Changes proposed in this pull request:
- Set the constraints prop on Popover to deprecated
- Introduced the tetherOptions prop on Popover, where it is possible to overwrite the settings of Tether