### PR TITLE
remove active prop from <button> to fix react warning

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -80,6 +80,7 @@ export interface IOptionProps extends IProps {
 
 /** A collection of curated prop keys used across our Components which are not valid HTMLElement props. */
 const INVALID_PROPS = [
+    "active",
     "containerRef",
     "defaultIndeterminate",
     "elementRef",


### PR DESCRIPTION
Fixes warning from react

```
Warning: Unknown prop `active` on <button> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in button (created by Blueprint.Button)
    in Blueprint.Button (at Applications.js:102)
    in span (created by Popover)
    in Popover (created by Tooltip)
    in Tooltip (at Applications.js:100)
    in div (at Applications.js:99)
    in div (at Applications.js:98)
    in div (at Applications.js:96)
    in Applications (created by Connect(Applications))
    in Connect(Applications) (created by RouterContext)
    in div (at App.js:14)
    in div (at App.js:11)
    in App (created by Connect(App))
    in Connect(App) (created by RouterContext)
    in RouterContext (created by Router)
    in Router (at index.js:34)
    in Provider (at index.js:33)
```