### PR TITLE
[Date Range Input] - Part 9: Obey and control the focused field

### DIFF
--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -12,3 +12,4 @@ export const ARROW_UP = 38;
 export const ENTER = 13;
 export const ESCAPE = 27;
 export const SPACE = 32;
+export const TAB = 9;

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -10,6 +10,11 @@ import * as moment from "moment";
 export type DateRange = [Date | undefined, Date | undefined];
 export type MomentDateRange = [moment.Moment, moment.Moment];
 
+export enum DateRangeBoundary {
+    START,
+    END,
+};
+
 export function areEqual(date1: Date, date2: Date) {
     if (date1 == null && date2 == null) {
         return true;

--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -22,3 +22,5 @@ export const DATERANGEPICKER_INITIAL_MONTH_INVALID =
     DATEPICKER_INITIAL_MONTH_INVALID.replace("DatePicker", "DateRangePicker");
 export const DATERANGEPICKER_MAX_DATE_INVALID = DATEPICKER_MAX_DATE_INVALID.replace("DatePicker", "DateRangePicker");
 export const DATERANGEPICKER_VALUE_INVALID = DATEPICKER_VALUE_INVALID.replace("DatePicker", "DateRangePicker");
+export const DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID =
+    "<DateRangePicker> preferredBoundaryToModify must be a valid DateRangeBoundary if defined";

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -664,7 +664,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const { values } = this.getStateKeysAndValuesForBoundary(boundary);
         const { isInputFocused, inputString, selectedValue, hoverString } = values;
 
-        if (hoverString != null) {
+        if (hoverString != null && !this.isControlled()) {
+            // we don't want to overwrite the inputStrings in controlled mode
             return hoverString;
         } else if (isInputFocused) {
             return (inputString == null) ? "" : inputString;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -187,9 +187,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     public componentDidUpdate() {
-        if (this.state.isStartInputFocused && document.activeElement !== this.startInputRef) {
+        if (this.shouldFocusInputRef(this.state.isStartInputFocused, this.startInputRef)) {
             this.startInputRef.focus();
-        } else if (this.state.isEndInputFocused && document.activeElement !== this.endInputRef) {
+        } else if (this.shouldFocusInputRef(this.state.isEndInputFocused, this.endInputRef)) {
             this.endInputRef.focus();
         }
     }
@@ -628,6 +628,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     // Helpers
     // =======
+
+    private shouldFocusInputRef(isFocused: boolean, inputRef: HTMLInputElement) {
+        return isFocused && inputRef !== undefined && document.activeElement !== inputRef;
+    }
 
     private dateStringToMoment = (dateString: string) => {
         if (this.isInputEmpty(dateString)) {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -177,6 +177,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         };
     }
 
+    public componentDidUpdate() {
+        if (this.state.isStartInputFocused && document.activeElement !== this.startInputRef) {
+            this.startInputRef.focus();
+        } else if (this.state.isEndInputFocused && document.activeElement !== this.endInputRef) {
+            this.endInputRef.focus();
+        }
+    }
+
     public render() {
         const { startInputProps, endInputProps } = this.props;
 
@@ -254,7 +262,27 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
         if (this.props.value === undefined) {
             const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
-            this.setState({ selectedStart, selectedEnd });
+
+            let isStartInputFocused: boolean;
+            let isEndInputFocused: boolean;
+
+            if (isMomentNull(selectedStart)) {
+                // focus the start field by default or if only an end date is specified
+                isStartInputFocused = true;
+                isEndInputFocused = false;
+            } else if (isMomentNull(selectedEnd)) {
+                // focus the end field if a start date is specified
+                isStartInputFocused = false;
+                isEndInputFocused = true;
+            } else if (this.state.preferredBoundaryToModify === DateRangeBoundary.START) {
+                // keep the start field focused
+                isStartInputFocused = true;
+            } else {
+                // keep the end field focused
+                isEndInputFocused = true;
+            }
+
+            this.setState({ selectedEnd, selectedStart, isEndInputFocused, isStartInputFocused });
         }
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -112,6 +112,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
 export interface IDateRangeInputState {
     isOpen?: boolean;
+    preferredBoundaryToModify?: DateRangeBoundary;
 
     isStartInputFocused?: boolean;
     isEndInputFocused?: boolean;
@@ -187,6 +188,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 onChange={this.handleDateRangePickerChange}
                 maxDate={this.props.maxDate}
                 minDate={this.props.minDate}
+                preferredBoundaryToModify={this.state.preferredBoundaryToModify}
                 value={this.getSelectedRange()}
             />
         );
@@ -284,6 +286,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
         this.setState({
             isOpen: true,
+            preferredBoundaryToModify: boundary,
             [keys.inputString]: inputString,
             [keys.isInputFocused]: true,
         });

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -22,6 +22,7 @@ import {
 
 import {
     DateRange,
+    DateRangeBoundary,
     fromDateRangeToMomentDateRange,
     fromMomentToDate,
     isMomentInRange,
@@ -134,11 +135,6 @@ interface IStateKeysAndValuesObject {
         isInputFocused?: boolean;
         selectedValue?: moment.Moment;
     };
-};
-
-export enum DateRangeBoundary {
-    START,
-    END,
 };
 
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -388,7 +388,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     // Callbacks - Input
     // =================
 
-    // Key down
+    // Key events
 
     // add a keydown listener to persistently change focus when tabbing:
     // - if focused in start field, Tab moves focus to end field
@@ -430,7 +430,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         e.preventDefault();
     }
 
-    // Mouse down
+    // Mouse events
 
     private handleInputMouseDown = () => {
         // clicking in the field constitutes an explicit focus change. we update
@@ -438,8 +438,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         // set before onFocus is called ("click" triggers after "focus").
         this.setState({ wasLastFocusChangeDueToHover: false });
     }
-
-    // Click
 
     private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
         // unless we stop propagation on this event, a click within an input

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -296,11 +296,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 isEndInputFocused = true;
 
                 endHoverString = null;
-            } else if (this.state.preferredBoundaryToModify === DateRangeBoundary.START) {
+            } else if (this.state.mostRecentlyFocusedField === DateRangeBoundary.START) {
                 // keep the start field focused
                 isStartInputFocused = true;
+                isEndInputFocused = false;
             } else {
                 // keep the end field focused
+                isStartInputFocused = false;
                 isEndInputFocused = true;
             }
 
@@ -311,6 +313,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 isStartInputFocused,
                 startHoverString,
                 endHoverString,
+                endInputString: this.getFormattedDateString(selectedEnd),
+                startInputString: this.getFormattedDateString(selectedStart),
                 wasLastFocusChangeDueToHover: false,
             });
         }
@@ -333,8 +337,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const isEndNull = isMomentNull(selectedEnd);
         const isExactlyOneBoundaryDateSpecified = isStartNull !== isEndNull;
 
-        let isStartInputFocused: boolean;
-        let isEndInputFocused: boolean;
+        let { isStartInputFocused, isEndInputFocused } = this.state;
 
         if (isExactlyOneBoundaryDateSpecified) {
             if (isEndNull) {
@@ -381,6 +384,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             endHoverString,
             isStartInputFocused,
             isEndInputFocused,
+            mostRecentlyFocusedField: (isStartInputFocused) ? DateRangeBoundary.START : DateRangeBoundary.END,
             wasLastFocusChangeDueToHover: true,
         });
     }
@@ -388,7 +392,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     // Callbacks - Input
     // =================
 
-    // Key events
+    // Key down
 
     // add a keydown listener to persistently change focus when tabbing:
     // - if focused in start field, Tab moves focus to end field
@@ -430,7 +434,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         e.preventDefault();
     }
 
-    // Mouse events
+    // Mouse down
 
     private handleInputMouseDown = () => {
         // clicking in the field constitutes an explicit focus change. we update
@@ -438,6 +442,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         // set before onFocus is called ("click" triggers after "focus").
         this.setState({ wasLastFocusChangeDueToHover: false });
     }
+
+    // Click
 
     private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
         // unless we stop propagation on this event, a click within an input

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -64,6 +64,15 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     onHoverChange?: (hoveredDates: DateRange) => void;
 
     /**
+     * The date-range boundary that the next click should modify.
+     * This will be honored unless the next click would overlap an existing date selection for the other boundary.
+     * In that case, the next click will auto-swap the two boundary dates to keep the date range boundaries in
+     * chronological order, effectively changing the other boundary's selected date.
+     * If `null`, the picker will revert to its default selection behavior.
+     */
+    preferredBoundaryToModify?: DateRangeBoundary;
+
+    /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
      * If `true`, preset shortcuts will be displayed.
      * If `false`, no shortcuts will be displayed.

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -233,7 +233,14 @@ export class DateRangePicker
     }
 
     protected validateProps(props: IDateRangePickerProps) {
-        const { defaultValue, initialMonth, maxDate, minDate, value } = props;
+        const {
+            defaultValue,
+            initialMonth,
+            maxDate,
+            minDate,
+            preferredBoundaryToModify,
+            value,
+        } = props;
         const dateRange: DateRange = [minDate, maxDate];
 
         if (defaultValue != null && !DateUtils.isDayRangeInRange(defaultValue, dateRange)) {
@@ -253,6 +260,12 @@ export class DateRangePicker
 
         if (value != null && !DateUtils.isDayRangeInRange(value, dateRange)) {
             throw new Error(Errors.DATERANGEPICKER_VALUE_INVALID);
+        }
+
+        if (preferredBoundaryToModify != null
+            && preferredBoundaryToModify !== DateRangeBoundary.START
+            && preferredBoundaryToModify !== DateRangeBoundary.END) {
+            throw new Error(Errors.DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID)
         }
     }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -43,6 +43,14 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     allowSingleDayRange?: boolean;
 
     /**
+     * The date-range boundary that the next click should modify.
+     * This will be honored unless the next click would overlap the other boundary date.
+     * In that case, the two boundary dates will be auto-swapped to keep them in chronological order.
+     * If `undefined`, the picker will revert to its default selection behavior.
+     */
+    boundaryToModify?: DateRangeBoundary;
+
+    /**
      * Initial DateRange the calendar will display as selected.
      * This should not be set if `value` is set.
      */
@@ -62,15 +70,6 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * When triggered from mouseleave, it will pass `undefined`.
      */
     onHoverChange?: (hoveredDates: DateRange) => void;
-
-    /**
-     * The date-range boundary that the next click should modify.
-     * This will be honored unless the next click would overlap an existing date selection for the other boundary.
-     * In that case, the next click will auto-swap the two boundary dates to keep the date range boundaries in
-     * chronological order, effectively changing the other boundary's selected date.
-     * If `null`, the picker will revert to its default selection behavior.
-     */
-    preferredBoundaryToModify?: DateRangeBoundary;
 
     /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
@@ -238,7 +237,7 @@ export class DateRangePicker
             initialMonth,
             maxDate,
             minDate,
-            preferredBoundaryToModify,
+            boundaryToModify,
             value,
         } = props;
         const dateRange: DateRange = [minDate, maxDate];
@@ -262,9 +261,9 @@ export class DateRangePicker
             throw new Error(Errors.DATERANGEPICKER_VALUE_INVALID);
         }
 
-        if (preferredBoundaryToModify != null
-            && preferredBoundaryToModify !== DateRangeBoundary.START
-            && preferredBoundaryToModify !== DateRangeBoundary.END) {
+        if (boundaryToModify != null
+            && boundaryToModify !== DateRangeBoundary.START
+            && boundaryToModify !== DateRangeBoundary.END) {
             throw new Error(Errors.DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID);
         }
     }
@@ -349,7 +348,7 @@ export class DateRangePicker
         const { allowSingleDayRange } = this.props;
 
         // rename for conciseness
-        const boundary = this.props.preferredBoundaryToModify;
+        const boundary = this.props.boundaryToModify;
 
         if (boundary != null) {
             const boundaryDate = (boundary === DateRangeBoundary.START) ? start : end;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -265,7 +265,7 @@ export class DateRangePicker
         if (preferredBoundaryToModify != null
             && preferredBoundaryToModify !== DateRangeBoundary.START
             && preferredBoundaryToModify !== DateRangeBoundary.END) {
-            throw new Error(Errors.DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID)
+            throw new Error(Errors.DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID);
         }
     }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -12,7 +12,7 @@ import * as DayPicker from "react-day-picker";
 
 import * as DateClasses from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
-import { DateRange } from "./common/dateUtils";
+import { DateRange, DateRangeBoundary } from "./common/dateUtils";
 import * as Errors from "./common/errors";
 import { Months } from "./common/months";
 

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -9,12 +9,12 @@ import * as classes from "./common/classes";
 
 export const Classes = classes;
 
-export { DateRange } from "./common/dateUtils";
+export { DateRange, DateRangeBoundary } from "./common/dateUtils";
 export { Months } from "./common/months";
 export { DateInput, IDateInputProps } from "./dateInput";
 export { DatePicker, DatePickerFactory, IDatePickerProps } from "./datePicker";
 export { IDatePickerLocaleUtils, IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
-export { DateRangeBoundary, DateRangeInput } from "./dateRangeInput";
+export { DateRangeInput } from "./dateRangeInput";
 export { DateRangePicker, DateRangePickerFactory, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
 export { ITimePickerProps, TimePicker, TimePickerFactory, TimePickerPrecision } from "./timePicker";

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -1859,19 +1859,12 @@ describe.only("<DateRangeInput>", () => {
         it("Clicking a date invokes onChange with the new date range, but doesn't change the UI", () => {
             const onChange = sinon.spy();
             const { root, getDayElement } = wrap(<DateRangeInput value={DATE_RANGE} onChange={onChange} />);
-            root.setState({ isOpen: true });
 
-            // click start date
+            getStartInput(root).simulate("focus"); // to open popover
             getDayElement(START_DAY).simulate("click");
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
             assertInputTextsEqual(root, START_STR, END_STR);
-
-            // click end date
-            getDayElement(END_DAY).simulate("click");
-            assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, null]);
-            assertInputTextsEqual(root, START_STR, END_STR);
-
-            expect(onChange.callCount).to.equal(2);
+            expect(onChange.callCount).to.equal(1);
         });
 
         it("Typing a valid start or end date invokes onChange with the new date range but doesn't change UI", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2148,7 +2148,7 @@ describe("<DateRangeInput>", () => {
     }
 
     function assertEndInputFocused(root: WrappedComponentRoot) {
-        expect(isEndInputFocused(root)).to.be.true
+        expect(isEndInputFocused(root)).to.be.true;
     }
 
     function assertInputTextsEqual(root: WrappedComponentRoot, startInputText: string, endInputText: string) {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -16,6 +16,7 @@ import * as DateTestUtils from "./common/dateTestUtils";
 
 type WrappedComponentRoot = ReactWrapper<any, {}>;
 type WrappedComponentInput = ReactWrapper<React.HTMLAttributes<{}>, any>;
+type WrappedComponentDayElement = ReactWrapper<React.HTMLAttributes<{}>, any>;
 
 type OutOfRangeTestFunction = (input: WrappedComponentInput,
                                inputString: string,
@@ -25,7 +26,7 @@ type InvalidDateTestFunction = (input: WrappedComponentInput,
                                 boundary: DateRangeBoundary,
                                 otherInput: WrappedComponentInput) => void;
 
-describe("<DateRangeInput>", () => {
+describe.only("<DateRangeInput>", () => {
 
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
@@ -493,187 +494,1293 @@ describe("<DateRangeInput>", () => {
             // TODO: rename all date constants in this file to use a similar
             // scheme, then get rid of these extra constants
 
-            const HOVER_TEST_DATE_1 = START_DATE_2;
-            const HOVER_TEST_DATE_2 = START_DATE;
-            const HOVER_TEST_DATE_3 = new Date(2017, Months.JANUARY, 23);
-            const HOVER_TEST_DATE_4 = END_DATE;
-            const HOVER_TEST_DATE_5 = END_DATE_2;
+            const HOVER_TEST_DAY_1 = 5;
+            const HOVER_TEST_DAY_2 = 10;
+            const HOVER_TEST_DAY_3 = 15;
+            const HOVER_TEST_DAY_4 = 20;
+            const HOVER_TEST_DAY_5 = 25;
 
-            const HOVER_TEST_STR_1 = START_STR_2;
-            const HOVER_TEST_STR_2 = START_STR;
+            const HOVER_TEST_DATE_1 = new Date(2017, Months.JANUARY, HOVER_TEST_DAY_1);
+            const HOVER_TEST_DATE_2 = new Date(2017, Months.JANUARY, HOVER_TEST_DAY_2);
+            const HOVER_TEST_DATE_3 = new Date(2017, Months.JANUARY, HOVER_TEST_DAY_3);
+            const HOVER_TEST_DATE_4 = new Date(2017, Months.JANUARY, HOVER_TEST_DAY_4);
+            const HOVER_TEST_DATE_5 = new Date(2017, Months.JANUARY, HOVER_TEST_DAY_5);
+
+            const HOVER_TEST_STR_1 = DateTestUtils.toHyphenatedDateString(HOVER_TEST_DATE_1);
+            const HOVER_TEST_STR_2 = DateTestUtils.toHyphenatedDateString(HOVER_TEST_DATE_2);
             const HOVER_TEST_STR_3 = DateTestUtils.toHyphenatedDateString(HOVER_TEST_DATE_3);
-            const HOVER_TEST_STR_4 = END_STR;
-            const HOVER_TEST_STR_5 = END_STR_2;
+            const HOVER_TEST_STR_4 = DateTestUtils.toHyphenatedDateString(HOVER_TEST_DATE_4);
+            const HOVER_TEST_STR_5 = DateTestUtils.toHyphenatedDateString(HOVER_TEST_DATE_5);
+
+            const HOVER_TEST_DATE_CONFIG_1 = { day: HOVER_TEST_DAY_1, date: HOVER_TEST_DATE_1, str: HOVER_TEST_STR_1 };
+            const HOVER_TEST_DATE_CONFIG_2 = { day: HOVER_TEST_DAY_2, date: HOVER_TEST_DATE_2, str: HOVER_TEST_STR_2 };
+            const HOVER_TEST_DATE_CONFIG_3 = { day: HOVER_TEST_DAY_3, date: HOVER_TEST_DATE_3, str: HOVER_TEST_STR_3 };
+            const HOVER_TEST_DATE_CONFIG_4 = { day: HOVER_TEST_DAY_4, date: HOVER_TEST_DATE_4, str: HOVER_TEST_STR_4 };
+            const HOVER_TEST_DATE_CONFIG_5 = { day: HOVER_TEST_DAY_5, date: HOVER_TEST_DATE_5, str: HOVER_TEST_STR_5 };
+
+            type HoverTextDateConfig = {
+                day: number;
+                date: Date;
+                str: string;
+            };
+
+            let root: WrappedComponentRoot;
+            let startInput: WrappedComponentInput;
+            let endInput: WrappedComponentInput;
+            let getDayElement: (dayNumber?: number, fromLeftMonth?: boolean) => WrappedComponentDayElement;
+            let dayElement: WrappedComponentDayElement;
+
+            beforeEach(() => {
+                const result = wrap(<DateRangeInput defaultValue={[HOVER_TEST_DATE_2, HOVER_TEST_DATE_4]} />);
+
+                root = result.root;
+                getDayElement = result.getDayElement;
+                startInput = getStartInput(root);
+                endInput = getEndInput(root);
+
+                // clear the inputs to start from a fresh state, but do so
+                // *after* opening the popover so that the calendar doesn't
+                // move away from the view we expect for these tests.
+                root.setState({ isOpen: true });
+                changeInputText(startInput, "");
+                changeInputText(endInput, "");
+            });
+
+            function setSelectedRangeForHoverTest(selectedDateConfigs: HoverTextDateConfig[]) {
+                const [startConfig, endConfig] = selectedDateConfigs;
+                changeInputText(startInput, (startConfig == null) ? "" : startConfig.str);
+                changeInputText(endInput, (endConfig == null) ? "" : endConfig.str);
+            }
 
             describe("when selected date range is [null, null]", () => {
 
+                const SELECTED_RANGE = [null, null];
+                const HOVER_TEST_DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                    dayElement = getDayElement(HOVER_TEST_DATE_CONFIG.day);
+                });
+
                 describe("if start field is focused...", () => {
-                    it("shows [<hoveredDate>, null] in input fields", fail);
-                    it("keeps focus on start field", fail);
-                    it("sets selection to [<hoveredDate>, null] on click", fail);
+
+                    beforeEach(() => {
+                        startInput.simulate("focus");
+                        dayElement.simulate("mouseenter");
+                    });
+
+                    it("shows [<hoveredDate>, null] in input fields", () => {
+                        assertInputTextsEqual(root, HOVER_TEST_DATE_CONFIG.str, "");
+                    });
+
+                    it("keeps focus on start field", () => {
+                        assertStartInputFocused(root);
+                    });
+
+                    describe("on click", () => {
+
+                        beforeEach(() => {
+                            dayElement.simulate("click");
+                        });
+
+                        it("sets selection to [<hoveredDate>, null]", () => {
+                            assertInputTextsEqual(root, HOVER_TEST_DATE_CONFIG.str, "");
+                        });
+
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
+                        });
+                    });
 
                     describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [null, null] in input fields", fail);
-                        it("keeps focus on start field", fail);
+
+                        beforeEach(() => {
+                            dayElement.simulate("mouseleave");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputTextsEqual(root, "", "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
                     });
                 });
 
                 describe("if end field is focused...", () => {
-                    it("shows [null, <hoveredDate>] in input fields", fail);
-                    it("keeps focus on end field", fail);
-                    it("sets selection to [null, <hoveredDate>] on click", fail);
+
+                    beforeEach(() => {
+                        endInput.simulate("focus");
+                        dayElement.simulate("mouseenter");
+                    });
+
+                    it("shows [null, <hoveredDate>] in input fields", () => {
+                        assertInputTextsEqual(root, "", HOVER_TEST_DATE_CONFIG.str);
+                    });
+
+                    it("keeps focus on end field", () => {
+                        assertEndInputFocused(root);
+                    });
+
+                    it("sets selection to [null, <hoveredDate>] on click", () => {
+                        dayElement.simulate("click");
+                        assertInputTextsEqual(root, "", HOVER_TEST_DATE_CONFIG.str);
+                    });
+
+                    describe("on click", () => {
+
+                        beforeEach(() => {
+                            dayElement.simulate("click");
+                        });
+
+                        it("sets selection to [null, <hoveredDate>]", () => {
+                            assertInputTextsEqual(root, "", HOVER_TEST_DATE_CONFIG.str);
+                        });
+
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
+                        });
+                    });
 
                     describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [null, null] in input fields", fail);
-                        it("keeps focus on end field", fail);
+
+                        beforeEach(() => {
+                            dayElement.simulate("mouseleave");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputTextsEqual(root, "", "");
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
                     });
                 });
             });
 
             describe("when selected date range is [<startDate>, null]", () => {
 
-                describe("if start field is focused...", () => {
-                    it("shows [<hoveredDate>, null] in input fields", fail);
-                    it("keeps focus on start field", fail);
-                    it("sets selection to [<hoveredDate>, null] on click", fail);
+                const SELECTED_RANGE = [HOVER_TEST_DATE_CONFIG_2, null];
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [<startDate>, null] in input fields", fail);
-                        it("keeps focus on start field", fail);
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
+                describe("if start field is focused...", () => {
+
+                    beforeEach(() => {
+                        startInput.simulate("focus");
+                    });
+
+                    describe("if <startDate> < <hoveredDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> < <startDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputTextsEqual(root, "", "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, null]", () => {
+                                assertInputTextsEqual(root, "", "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
                 });
 
                 describe("if end field is focused...", () => {
 
+                    beforeEach(() => {
+                        endInput.simulate("focus");
+                    });
+
                     describe("if <startDate> < <hoveredDate>...", () => {
-                        it("shows [<startDate>, <hoveredDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
-                        it("sets selection to [<startDate>, <hoveredDate>] on click", fail);
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, SELECTED_RANGE[0].str, DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, <hoveredDate>]", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <hoveredDate> < <startDate>...", () => {
-                        it("shows [<hoveredDate>, <startDate>] in input fields", fail);
-                        it("moves focus to start field", fail);
-                        it("sets selection to [<hoveredDate>, <startDate>] on click", fail);
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <startDate>] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[0].str);
+                        });
+
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <startDate>]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[0].str);
+                            });
+
+                            it("leaves focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-                        it("shows [null, <hoveredDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
-                        it("sets selection to [null, <hoveredDate>] on click", fail);
-                    });
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [<startDate>, null] in input fields", fail);
-                        it("keeps focus on end field", fail);
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>] on click", () => {
+                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("leaves focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
                 });
-
             });
 
             describe("when selected date range is [null, <endDate>]", () => {
 
+                const SELECTED_RANGE = [null, HOVER_TEST_DATE_CONFIG_4];
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
                 describe("if start field is focused...", () => {
 
+                    beforeEach(() => {
+                        startInput.simulate("focus");
+                    });
+
                     describe("if <hoveredDate> < <endDate>...", () => {
-                        it("shows [<hoveredDate>, <endDate>] in input fields", fail);
-                        it("keeps focus on start field", fail);
-                        it("sets selection to [<hoveredDate>, <endDate>] on click", fail);
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <endDate>] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1].str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <endDate>]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <endDate> < <hoveredDate>...", () => {
-                        it("shows [<endDate>, <hoveredDate>] in input fields", fail);
-                        it("moves focus to end field", fail);
-                        it("sets selection to [<endDate>, <hoveredDate>] on click", fail);
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<endDate>, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, SELECTED_RANGE[1].str, DATE_CONFIG.str);
+                        });
+
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<endDate>, <hoveredDate>] on click", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[1].str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("moves focus back to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <hoveredDate> == <endDate>", () => {
-                        it("shows [<hoveredDate>, null] in input fields", fail);
-                        it("keeps focus on start field", fail);
-                        it("sets selection to [<hoveredDate>, null] on click", fail);
-                    });
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [null, <endDate>] in input fields", fail);
-                        it("keeps focus on start field", fail);
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null] on click", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
                 });
 
                 describe("if end field is focused...", () => {
-                    it("shows [null, <hoveredDate>] in input fields", fail);
-                    it("keeps focus on end field", fail);
-                    it("sets selection to [null, <hoveredDate>] on click", fail);
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [null, <endDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
+                    beforeEach(() => {
+                        endInput.simulate("focus");
+                    });
+
+                    describe("if <hoveredDate> < <endDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>]", () => {
+                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <endDate> < <hoveredDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>] on click", () => {
+                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputTextsEqual(root, "", "");
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, null] on click", () => {
+                                assertInputTextsEqual(root, "", "");
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
                 });
             });
 
             describe("when selected date range is [<startDate>, <endDate>]", () => {
 
+                const SELECTED_RANGE = [HOVER_TEST_DATE_CONFIG_2, HOVER_TEST_DATE_CONFIG_4];
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
                 describe("if start field is focused...", () => {
 
-                    describe("if <hoveredDate> < <endDate>...", () => {
-                        it("shows [<hoveredDate>, <endDate>] in input fields", fail);
-                        it("keeps focus on start field", fail);
-                        it("sets selection to [<hoveredDate>, <endDate>] on click", fail);
+                    beforeEach(() => {
+                        startInput.simulate("focus");
+                    });
+
+                    describe("if <hoveredDate> < <startDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <endDate>] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1].str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <endDate>]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <startDate> < <hoveredDate> < <endDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <endDate>] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1].str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <endDate>]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <endDate> < <hoveredDate>...", () => {
-                        it("shows [<hoveredDate>, null] in input fields", fail);
-                        it("keeps focus on start field", fail);
-                        it("sets selection to [<hoveredDate>, null] on click", fail);
-                    });
 
-                    describe("if <hoveredDate> == <endDate>", () => {
-                        it("shows [<hoveredDate>, null] in input fields", fail);
-                        it("keeps focus on start field", fail);
-                        it("sets selection to [<hoveredDate>, null] on click", fail);
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-                        it("shows [null, <endDate>] in input fields", fail);
-                        it("keeps focus on start field", fail);
-                        it("sets selection to [null, <endDate>] on click", fail);
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, <endDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, <endDate>]", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
+                            });
+
+                            it("keep focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [<startDate>, <endDate>] in input fields", fail);
-                        it("keeps focus on start field", fail);
+                    describe("if <hoveredDate> == <endDate>", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
                     });
                 });
 
                 describe("if end field is focused...", () => {
 
-                    describe("if <startDate> < <hoveredDate>", () => {
-                        it("shows [<startDate>, <hoveredDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
-                        it("sets selection to [<startDate>, <hoveredDate>] on click", fail);
+                    beforeEach(() => {
+                        endInput.simulate("focus");
                     });
 
-                    describe("if <hoveredDate> < <startDate>", () => {
-                        it("shows [null, <hoveredDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
-                        it("sets selection to [null, <hoveredDate>] on click", fail);
+                    describe("if <hoveredDate> < <startDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>]", () => {
+                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <startDate> < <hoveredDate> < <endDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, SELECTED_RANGE[0].str, DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, <hoveredDate>]", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <endDate> < <hoveredDate>...", () => {
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, SELECTED_RANGE[0].str, DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, <hoveredDate>]", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-                        it("shows [null, <hoveredDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
-                        it("sets selection to [null, <hoveredDate>] on click", fail);
+
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>]", () => {
+                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
 
                     describe("if <hoveredDate> == <endDate>", () => {
-                        it("shows [<startDate>, null] in input fields", fail);
-                        it("keeps focus on end field", fail);
-                        it("sets selection to [<startDate>, null] on click", fail);
-                    });
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-                        it("shows [<startDate>, <endDate>] in input fields", fail);
-                        it("keeps focus on end field", fail);
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            dayElement = getDayElement(DATE_CONFIG.day);
+                            dayElement.simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, null]", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day...", () => {
+
+                            beforeEach(() => {
+                                dayElement.simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
                     });
                 });
             });
@@ -1021,6 +2128,16 @@ describe("<DateRangeInput>", () => {
         return input.props().value;
     }
 
+    function isStartInputFocused(root: WrappedComponentRoot) {
+        // TODO: find a more elegant way to do this; reaching into component state is gross.
+        return root.state("isStartInputFocused");
+    }
+
+    function isEndInputFocused(root: WrappedComponentRoot) {
+        // TODO: find a more elegant way to do this; reaching into component state is gross.
+        return root.state("isEndInputFocused");
+    }
+
     function changeStartInputText(root: WrappedComponentRoot, value: string) {
         changeInputText(getStartInput(root), value);
     }
@@ -1031,6 +2148,14 @@ describe("<DateRangeInput>", () => {
 
     function changeInputText(input: WrappedComponentInput, value: string) {
         input.simulate("change", { target: { value }});
+    }
+
+    function assertStartInputFocused(root: WrappedComponentRoot) {
+        expect(isStartInputFocused(root)).to.be.true;
+    }
+
+    function assertEndInputFocused(root: WrappedComponentRoot) {
+        expect(isEndInputFocused(root)).to.be.true
     }
 
     function assertInputTextsEqual(root: WrappedComponentRoot, startInputText: string, endInputText: string) {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -487,6 +487,198 @@ describe("<DateRangeInput>", () => {
             });
         });
 
+        describe.only("Hovering over dates...", () => {
+
+            // define new constants to clarify chronological ordering of dates
+            // TODO: rename all date constants in this file to use a similar
+            // scheme, then get rid of these extra constants
+
+            const HOVER_TEST_DATE_1 = START_DATE_2;
+            const HOVER_TEST_DATE_2 = START_DATE;
+            const HOVER_TEST_DATE_3 = new Date(2017, Months.JANUARY, 23);
+            const HOVER_TEST_DATE_4 = END_DATE;
+            const HOVER_TEST_DATE_5 = END_DATE_2;
+
+            const HOVER_TEST_STR_1 = START_STR_2;
+            const HOVER_TEST_STR_2 = START_STR;
+            const HOVER_TEST_STR_3 = DateTestUtils.toHyphenatedDateString(HOVER_TEST_DATE_3);
+            const HOVER_TEST_STR_4 = END_STR;
+            const HOVER_TEST_STR_5 = END_STR_2;
+
+            describe("when selected date range is [null, null]", () => {
+
+                describe("if start field is focused...", () => {
+                    it("shows [<hoveredDate>, null] in input fields", fail);
+                    it("keeps focus on start field", fail);
+                    it("sets selection to [<hoveredDate>, null] on click", fail);
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [null, null] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                    });
+                });
+
+                describe("if end field is focused...", () => {
+                    it("shows [null, <hoveredDate>] in input fields", fail);
+                    it("keeps focus on end field", fail);
+                    it("sets selection to [null, <hoveredDate>] on click", fail);
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [null, null] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                    });
+                });
+            });
+
+            describe("when selected date range is [<startDate>, null]", () => {
+
+                describe("if start field is focused...", () => {
+                    it("shows [<hoveredDate>, null] in input fields", fail);
+                    it("keeps focus on start field", fail);
+                    it("sets selection to [<hoveredDate>, null] on click", fail);
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [<startDate>, null] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                    });
+                });
+
+                describe("if end field is focused...", () => {
+
+                    describe("if <startDate> < <hoveredDate>...", () => {
+                        it("shows [<startDate>, <hoveredDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                        it("sets selection to [<startDate>, <hoveredDate>] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> < <startDate>...", () => {
+                        it("shows [<hoveredDate>, <startDate>] in input fields", fail);
+                        it("moves focus to start field", fail);
+                        it("sets selection to [<hoveredDate>, <startDate>] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        it("shows [null, <hoveredDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                        it("sets selection to [null, <hoveredDate>] on click", fail);
+                    });
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [<startDate>, null] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                    });
+                });
+
+            });
+
+            describe("when selected date range is [null, <endDate>]", () => {
+
+                describe("if start field is focused...", () => {
+
+                    describe("if <hoveredDate> < <endDate>...", () => {
+                        it("shows [<hoveredDate>, <endDate>] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                        it("sets selection to [<hoveredDate>, <endDate>] on click", fail);
+                    });
+
+                    describe("if <endDate> < <hoveredDate>...", () => {
+                        it("shows [<endDate>, <hoveredDate>] in input fields", fail);
+                        it("moves focus to end field", fail);
+                        it("sets selection to [<endDate>, <hoveredDate>] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        it("shows [<hoveredDate>, null] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                        it("sets selection to [<hoveredDate>, null] on click", fail);
+                    });
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [null, <endDate>] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                    });
+                });
+
+                describe("if end field is focused...", () => {
+                    it("shows [null, <hoveredDate>] in input fields", fail);
+                    it("keeps focus on end field", fail);
+                    it("sets selection to [null, <hoveredDate>] on click", fail);
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [null, <endDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                    });
+                });
+            });
+
+            describe("when selected date range is [<startDate>, <endDate>]", () => {
+
+                describe("if start field is focused...", () => {
+
+                    describe("if <hoveredDate> < <endDate>...", () => {
+                        it("shows [<hoveredDate>, <endDate>] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                        it("sets selection to [<hoveredDate>, <endDate>] on click", fail);
+                    });
+
+                    describe("if <endDate> < <hoveredDate>...", () => {
+                        it("shows [<hoveredDate>, null] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                        it("sets selection to [<hoveredDate>, null] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        it("shows [<hoveredDate>, null] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                        it("sets selection to [<hoveredDate>, null] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        it("shows [null, <endDate>] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                        it("sets selection to [null, <endDate>] on click", fail);
+                    });
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [<startDate>, <endDate>] in input fields", fail);
+                        it("keeps focus on start field", fail);
+                    });
+                });
+
+                describe("if end field is focused...", () => {
+
+                    describe("if <startDate> < <hoveredDate>", () => {
+                        it("shows [<startDate>, <hoveredDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                        it("sets selection to [<startDate>, <hoveredDate>] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> < <startDate>", () => {
+                        it("shows [null, <hoveredDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                        it("sets selection to [null, <hoveredDate>] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        it("shows [null, <hoveredDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                        it("sets selection to [null, <hoveredDate>] on click", fail);
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        it("shows [<startDate>, null] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                        it("sets selection to [<startDate>, null] on click", fail);
+                    });
+
+                    describe("if mouse moves to no longer be over a calendar day...", () => {
+                        it("shows [<startDate>, <endDate>] in input fields", fail);
+                        it("keeps focus on end field", fail);
+                    });
+                });
+            });
+        });
+
         it("Clearing the date range in the picker invokes onChange with [null, null] and clears the inputs", () => {
             const onChange = sinon.spy();
             const defaultValue = [START_DATE, null] as DateRange;
@@ -878,5 +1070,9 @@ describe("<DateRangeInput>", () => {
             },
             root: wrapper,
         };
+    }
+
+    function fail() {
+        expect(true).to.be.false;
     }
 });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -27,7 +27,6 @@ type InvalidDateTestFunction = (input: WrappedComponentInput,
                                 otherInput: WrappedComponentInput) => void;
 
 describe("<DateRangeInput>", () => {
-
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
     const START_STR = DateTestUtils.toHyphenatedDateString(START_DATE);
@@ -168,8 +167,7 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR_2, END_STR_2);
         });
 
-        describe("Typing an out-of-range date...", () => {
-
+        describe("Typing an out-of-range date", () => {
             // we run the same four tests for each of several cases. putting
             // setup logic in beforeEach lets us express our it(...) tests as
             // nice one-liners further down this block, and it also gives
@@ -263,8 +261,7 @@ describe("<DateRangeInput>", () => {
             }
         });
 
-        describe("Typing an invalid date...", () => {
-
+        describe("Typing an invalid date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
@@ -376,8 +373,7 @@ describe("<DateRangeInput>", () => {
 
         // this test sub-suite is structured a little differently because of the
         // different semantics of this error case in each field
-        describe("Typing an overlapping date...", () => {
-
+        describe("Typing an overlapping date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
@@ -400,8 +396,7 @@ describe("<DateRangeInput>", () => {
                 endInput = getEndInput(root);
             });
 
-            describe("in the start field...", () => {
-
+            describe("in the start field", () => {
                 it("shows an error message in the end field right away", () => {
                     startInput.simulate("focus");
                     changeInputText(startInput, OVERLAPPING_START_STR);
@@ -441,8 +436,7 @@ describe("<DateRangeInput>", () => {
                 });
             });
 
-            describe("in the end field...", () => {
-
+            describe("in the end field", () => {
                 it("shows an error message in the end field on blur", () => {
                     endInput.simulate("focus");
                     changeInputText(endInput, OVERLAPPING_END_STR);
@@ -488,8 +482,7 @@ describe("<DateRangeInput>", () => {
             });
         });
 
-        describe("Hovering over dates...", () => {
-
+        describe("Hovering over dates", () => {
             // define new constants to clarify chronological ordering of dates
             // TODO: rename all date constants in this file to use a similar
             // scheme, then get rid of these extra constants
@@ -553,7 +546,6 @@ describe("<DateRangeInput>", () => {
             }
 
             describe("when selected date range is [null, null]", () => {
-
                 const SELECTED_RANGE = [null, null];
                 const HOVER_TEST_DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
 
@@ -562,8 +554,7 @@ describe("<DateRangeInput>", () => {
                     dayElement = getDayElement(HOVER_TEST_DATE_CONFIG.day);
                 });
 
-                describe("if start field is focused...", () => {
-
+                describe("if start field is focused", () => {
                     beforeEach(() => {
                         startInput.simulate("focus");
                         dayElement.simulate("mouseenter");
@@ -578,7 +569,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("on click", () => {
-
                         beforeEach(() => {
                             dayElement.simulate("click");
                         });
@@ -592,8 +582,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                    describe("if mouse moves to no longer be over a calendar day", () => {
                         beforeEach(() => {
                             dayElement.simulate("mouseleave");
                         });
@@ -608,8 +597,7 @@ describe("<DateRangeInput>", () => {
                     });
                 });
 
-                describe("if end field is focused...", () => {
-
+                describe("if end field is focused", () => {
                     beforeEach(() => {
                         endInput.simulate("focus");
                         dayElement.simulate("mouseenter");
@@ -629,7 +617,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("on click", () => {
-
                         beforeEach(() => {
                             dayElement.simulate("click");
                         });
@@ -643,8 +630,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                    describe("if mouse moves to no longer be over a calendar day", () => {
                         beforeEach(() => {
                             dayElement.simulate("mouseleave");
                         });
@@ -661,21 +647,18 @@ describe("<DateRangeInput>", () => {
             });
 
             describe("when selected date range is [<startDate>, null]", () => {
-
                 const SELECTED_RANGE = [HOVER_TEST_DATE_CONFIG_2, null];
 
                 beforeEach(() => {
                     setSelectedRangeForHoverTest(SELECTED_RANGE);
                 });
 
-                describe("if start field is focused...", () => {
-
+                describe("if start field is focused", () => {
                     beforeEach(() => {
                         startInput.simulate("focus");
                     });
 
-                    describe("if <startDate> < <hoveredDate>...", () => {
-
+                    describe("if <startDate> < <hoveredDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
 
                         beforeEach(() => {
@@ -692,7 +675,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -706,8 +688,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -722,8 +703,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <hoveredDate> < <startDate>...", () => {
-
+                    describe("if <hoveredDate> < <startDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
 
                         beforeEach(() => {
@@ -740,7 +720,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -754,8 +733,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -771,7 +749,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
 
                         beforeEach(() => {
@@ -788,7 +765,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -802,8 +778,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -819,14 +794,12 @@ describe("<DateRangeInput>", () => {
                     });
                 });
 
-                describe("if end field is focused...", () => {
-
+                describe("if end field is focused", () => {
                     beforeEach(() => {
                         endInput.simulate("focus");
                     });
 
-                    describe("if <startDate> < <hoveredDate>...", () => {
-
+                    describe("if <startDate> < <hoveredDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
 
                         beforeEach(() => {
@@ -843,7 +816,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -857,8 +829,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -873,8 +844,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <hoveredDate> < <startDate>...", () => {
-
+                    describe("if <hoveredDate> < <startDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
 
                         beforeEach(() => {
@@ -891,7 +861,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -905,8 +874,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -922,7 +890,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
 
                         beforeEach(() => {
@@ -939,7 +906,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -953,8 +919,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -972,21 +937,18 @@ describe("<DateRangeInput>", () => {
             });
 
             describe("when selected date range is [null, <endDate>]", () => {
-
                 const SELECTED_RANGE = [null, HOVER_TEST_DATE_CONFIG_4];
 
                 beforeEach(() => {
                     setSelectedRangeForHoverTest(SELECTED_RANGE);
                 });
 
-                describe("if start field is focused...", () => {
-
+                describe("if start field is focused", () => {
                     beforeEach(() => {
                         startInput.simulate("focus");
                     });
 
-                    describe("if <hoveredDate> < <endDate>...", () => {
-
+                    describe("if <hoveredDate> < <endDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
 
                         beforeEach(() => {
@@ -1003,7 +965,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1017,8 +978,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1033,8 +993,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <endDate> < <hoveredDate>...", () => {
-
+                    describe("if <endDate> < <hoveredDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
 
                         beforeEach(() => {
@@ -1051,7 +1010,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1065,8 +1023,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1082,7 +1039,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <endDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
 
                         beforeEach(() => {
@@ -1099,7 +1055,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1113,8 +1068,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1130,14 +1084,12 @@ describe("<DateRangeInput>", () => {
                     });
                 });
 
-                describe("if end field is focused...", () => {
-
+                describe("if end field is focused", () => {
                     beforeEach(() => {
                         endInput.simulate("focus");
                     });
 
-                    describe("if <hoveredDate> < <endDate>...", () => {
-
+                    describe("if <hoveredDate> < <endDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
 
                         beforeEach(() => {
@@ -1154,7 +1106,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1168,8 +1119,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1184,8 +1134,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <endDate> < <hoveredDate>...", () => {
-
+                    describe("if <endDate> < <hoveredDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
 
                         beforeEach(() => {
@@ -1202,7 +1151,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1216,8 +1164,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1233,7 +1180,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <endDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
 
                         beforeEach(() => {
@@ -1250,7 +1196,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1264,8 +1209,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1283,21 +1227,18 @@ describe("<DateRangeInput>", () => {
             });
 
             describe("when selected date range is [<startDate>, <endDate>]", () => {
-
                 const SELECTED_RANGE = [HOVER_TEST_DATE_CONFIG_2, HOVER_TEST_DATE_CONFIG_4];
 
                 beforeEach(() => {
                     setSelectedRangeForHoverTest(SELECTED_RANGE);
                 });
 
-                describe("if start field is focused...", () => {
-
+                describe("if start field is focused", () => {
                     beforeEach(() => {
                         startInput.simulate("focus");
                     });
 
-                    describe("if <hoveredDate> < <startDate>...", () => {
-
+                    describe("if <hoveredDate> < <startDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
 
                         beforeEach(() => {
@@ -1314,7 +1255,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1328,8 +1268,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1344,8 +1283,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <startDate> < <hoveredDate> < <endDate>...", () => {
-
+                    describe("if <startDate> < <hoveredDate> < <endDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
 
                         beforeEach(() => {
@@ -1362,7 +1300,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1376,8 +1313,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1392,8 +1328,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <endDate> < <hoveredDate>...", () => {
-
+                    describe("if <endDate> < <hoveredDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
 
                         beforeEach(() => {
@@ -1410,7 +1345,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1424,8 +1358,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1441,7 +1374,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
 
                         beforeEach(() => {
@@ -1458,7 +1390,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1472,8 +1403,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1489,7 +1419,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <endDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
 
                         beforeEach(() => {
@@ -1506,7 +1435,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1520,8 +1448,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1537,14 +1464,12 @@ describe("<DateRangeInput>", () => {
                     });
                 });
 
-                describe("if end field is focused...", () => {
-
+                describe("if end field is focused", () => {
                     beforeEach(() => {
                         endInput.simulate("focus");
                     });
 
-                    describe("if <hoveredDate> < <startDate>...", () => {
-
+                    describe("if <hoveredDate> < <startDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
 
                         beforeEach(() => {
@@ -1561,7 +1486,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1575,8 +1499,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1591,8 +1514,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <startDate> < <hoveredDate> < <endDate>...", () => {
-
+                    describe("if <startDate> < <hoveredDate> < <endDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
 
                         beforeEach(() => {
@@ -1609,7 +1531,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1623,8 +1544,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1639,8 +1559,7 @@ describe("<DateRangeInput>", () => {
                         });
                     });
 
-                    describe("if <endDate> < <hoveredDate>...", () => {
-
+                    describe("if <endDate> < <hoveredDate>", () => {
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
 
                         beforeEach(() => {
@@ -1657,7 +1576,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1671,8 +1589,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1688,7 +1605,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <startDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
 
                         beforeEach(() => {
@@ -1705,7 +1621,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1719,8 +1634,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1736,7 +1650,6 @@ describe("<DateRangeInput>", () => {
                     });
 
                     describe("if <hoveredDate> == <endDate>", () => {
-
                         const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
 
                         beforeEach(() => {
@@ -1753,7 +1666,6 @@ describe("<DateRangeInput>", () => {
                         });
 
                         describe("on click", () => {
-
                             beforeEach(() => {
                                 dayElement.simulate("click");
                             });
@@ -1767,8 +1679,7 @@ describe("<DateRangeInput>", () => {
                             });
                         });
 
-                        describe("if mouse moves to no longer be over a calendar day...", () => {
-
+                        describe("if mouse moves to no longer be over a calendar day", () => {
                             beforeEach(() => {
                                 dayElement.simulate("mouseleave");
                             });
@@ -1883,8 +1794,7 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, END_STR);
         });
 
-        describe("Typing an out-of-range date...", () => {
-
+        describe("Typing an out-of-range date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
@@ -1937,8 +1847,7 @@ describe("<DateRangeInput>", () => {
             }
         });
 
-        describe("Typing an invalid date...", () => {
-
+        describe("Typing an invalid date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
@@ -1989,8 +1898,7 @@ describe("<DateRangeInput>", () => {
             }
         });
 
-        describe("Typing an overlapping date...", () => {
-
+        describe("Typing an overlapping date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;
             let root: WrappedComponentRoot;
@@ -2014,7 +1922,6 @@ describe("<DateRangeInput>", () => {
             });
 
             describe("in the start field", () => {
-
                 it("calls onError with [<overlappingDate>, <endDate] on blur", () => {
                     startInput.simulate("focus");
                     changeInputText(startInput, OVERLAPPING_START_STR);
@@ -2034,7 +1941,6 @@ describe("<DateRangeInput>", () => {
             });
 
             describe("in the end field", () => {
-
                 it("calls onError with [<startDate>, <overlappingDate>] on blur", () => {
                     endInput.simulate("focus");
                     changeInputText(endInput, OVERLAPPING_END_STR);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -26,7 +26,7 @@ type InvalidDateTestFunction = (input: WrappedComponentInput,
                                 boundary: DateRangeBoundary,
                                 otherInput: WrappedComponentInput) => void;
 
-describe.only("<DateRangeInput>", () => {
+describe("<DateRangeInput>", () => {
 
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
@@ -488,7 +488,7 @@ describe.only("<DateRangeInput>", () => {
             });
         });
 
-        describe.only("Hovering over dates...", () => {
+        describe("Hovering over dates...", () => {
 
             // define new constants to clarify chronological ordering of dates
             // TODO: rename all date constants in this file to use a similar

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2189,8 +2189,4 @@ describe("<DateRangeInput>", () => {
             root: wrapper,
         };
     }
-
-    function fail() {
-        expect(true).to.be.false;
-    }
 });


### PR DESCRIPTION
#### Related to #249, Builds on #726 

#### Checklist

- [x] Include tests (sooooo many tests)
- [ ] ~Update documentation~ (last thing I need to do before merging, coming in a separate PR)

#### Changes proposed in this pull request:

I tried to find some lower bar of completeness so that we can release this thing ASAP, but I really couldn't find a tradeoff that made sense. **A usable `DateRangeInput` that supports both typing and click-selection really needs to obey—and control—the focused input field.** This PR makes that happen to (I think) glorious effect, and I've tested the heck out of it to make sure every little edge case works as expected.

#### Reviewers should focus on:

- [ ] The best way to explain the functionality is to let you play with it. **Test-drive the component at the preview link below, and let me know how it feels.** Pay close attention to how hovered ranges and selected ranges interact, and also pay attention to which field is in focus throughout.
- [ ] There are tests for literally every little case I could think of regarding hover ranges with respect to selected ranges. The only domain I didn't want to think about yet is how to handle invalid/out-of-range/overlapping inputs that might currently be in the field. As of this PR, the behavior there is not rigorously defined; I think clicking will just wipe invalid inputs and start from scratch. I'm personally okay with that for now. We can revisit later if we want.
- [ ] There's a _lot_ of test code. It's simple and easy to read through, but it's also fairly repetitive. I'm confident there's a way to build a parameterized suite of tests that would _dramatically_ reduce the amount of test code without reducing the footprint of the tests. LMK if you want me to spend time figuring that out before merging. I'd prefer not to for this PR in the interest of time.
- [ ] I haven't yet thought about controlled mode or adding an `onHoverChange` prop for hovering. Didn't feel necessary for the initial release of the `DateRangeInput` component. Can revisit later.
- [ ] I added a good amount of new code in `dateRangePicker.tsx`, but the merge with Ben's code in `master` (from #575) should still be easy.

#### Screenshot

(See preview for now, will add a GIF tomorrow)
