### PR TITLE
fix bad index comparison in Overlay stack

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -252,9 +252,9 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
         document.body.classList.remove(Classes.OVERLAY_OPEN);
 
         const { openStack } = Overlay;
-        const idx = openStack.indexOf(this);
-        if (idx >= 0) {
-            openStack.splice(idx, 1);
+        const stackIndex = openStack.indexOf(this);
+        if (stackIndex !== -1) {
+            openStack.splice(stackIndex, 1);
             const lastOpenedOverlay = Overlay.getLastOpened();
             if (openStack.length > 0 && lastOpenedOverlay.props.enforceFocus) {
                 document.addEventListener("focus", lastOpenedOverlay.handleDocumentFocus, /* useCapture */ true);

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -253,7 +253,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
 
         const { openStack } = Overlay;
         const idx = openStack.indexOf(this);
-        if (idx > 0) {
+        if (idx >= 0) {
             openStack.splice(idx, 1);
             const lastOpenedOverlay = Overlay.getLastOpened();
             if (openStack.length > 0 && lastOpenedOverlay.props.enforceFocus) {


### PR DESCRIPTION
#### Fixes #406 

#### Changes proposed in this pull request:

literally a single character fixes the Overlay `openStack` so it removes overlays when they're at index `0`.

