### PR TITLE
Remove PureRender and default to detect truncation

### DIFF
--- a/packages/table/examples/tableFormatsExample.tsx
+++ b/packages/table/examples/tableFormatsExample.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import BaseExample from "@blueprintjs/core/examples/common/baseExample";
 
 import { Cell, Column, JSONFormat, Table, TruncatedFormat } from "../src";
+import { TruncatedPopoverMode } from "../src/cell/formats/truncatedFormat";
 
 interface ITimezone {
     name: string;
@@ -106,5 +107,13 @@ export class TableFormatsExample extends BaseExample<{}> {
         return <Cell><TruncatedFormat>{formattedDateTime}</TruncatedFormat></Cell>;
     }
 
-    private renderJSON = (row: number) => <Cell><JSONFormat>{this.data[row]}</JSONFormat></Cell>;
+    private renderJSON = (row: number) => {
+        return (
+            <Cell>
+                <JSONFormat>
+                    {this.data[row]}
+                </JSONFormat>
+            </Cell>
+        );
+    }
 }

--- a/packages/table/examples/tableFormatsExample.tsx
+++ b/packages/table/examples/tableFormatsExample.tsx
@@ -107,13 +107,5 @@ export class TableFormatsExample extends BaseExample<{}> {
         return <Cell><TruncatedFormat>{formattedDateTime}</TruncatedFormat></Cell>;
     }
 
-    private renderJSON = (row: number) => {
-        return (
-            <Cell>
-                <JSONFormat>
-                    {this.data[row]}
-                </JSONFormat>
-            </Cell>
-        );
-    }
+    private renderJSON = (row: number) => <Cell><JSONFormat>{this.data[row]}</JSONFormat></Cell>;
 }

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { ITruncatedFormatProps, TruncatedFormat, TruncatedPopoverMode } from "./truncatedFormat";
@@ -30,12 +29,11 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     stringify?: (obj: any) => string;
 }
 
-@PureRender
 export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
     public static defaultProps: IJSONFormatProps = {
-        detectTruncation: false,
+        detectTruncation: true,
         omitQuotesOnStrings: true,
-        showPopover: TruncatedPopoverMode.ALWAYS,
+        showPopover: TruncatedPopoverMode.WHEN_TRUNCATED,
         stringify: (obj: any) => (JSON.stringify(obj, null, 2)),
     };
 
@@ -43,13 +41,13 @@ export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
         const { children, omitQuotesOnStrings, stringify } = this.props;
         let { showPopover } = this.props;
 
-        // Change style and hide popover if value is nully
+        // always hide popover if value is nully
         const isNully = children == null;
         if (isNully) {
             showPopover = TruncatedPopoverMode.NEVER;
         }
         const className = classNames(this.props.className, {
-          [Classes.TABLE_NULL]: isNully,
+            [Classes.TABLE_NULL]: isNully,
         });
 
         let displayValue = "";

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -128,21 +128,17 @@ describe("Formats", () => {
             };
             const str = JSON.stringify(obj, null, 2);
             const comp = harness.mount(<JSONFormat>{obj}</JSONFormat>);
-            expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.exist;
-            expect(comp.find(`.${Classes.TABLE_TRUNCATED_VALUE}`).text()).to.equal(str);
+            expect(comp.find(`.${Classes.TABLE_TRUNCATED_TEXT}`).text()).to.equal(str);
         });
 
         it("omits quotes on strings and null-likes", () => {
             let comp = harness.mount(<JSONFormat>{"a string"}</JSONFormat>);
-            expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.exist;
-            expect(comp.find(`.${Classes.TABLE_TRUNCATED_VALUE}`).text()).to.equal("a string");
+            expect(comp.find(`.${Classes.TABLE_TRUNCATED_TEXT}`).text()).to.equal("a string");
 
             comp = harness.mount(<JSONFormat>{null}</JSONFormat>);
-            expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.not.exist;
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_TEXT}`).text()).to.equal("null");
 
             comp = harness.mount(<JSONFormat>{undefined}</JSONFormat>);
-            expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.not.exist;
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_TEXT}`).text()).to.equal("undefined");
         });
 
@@ -150,11 +146,16 @@ describe("Formats", () => {
             let comp = harness.mount(<JSONFormat>{null}</JSONFormat>);
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.not.exist;
 
-            const str = `
-                this is a very long string that would otherwise be truncated by the
-                settings, so we just add it here to make sure the test works.
-            `;
-            comp = harness.mount(<JSONFormat>{str}</JSONFormat>);
+            const str = `this is a very long string that will be truncated by the following settings`;
+            comp = harness.mount(
+                <JSONFormat
+                    detectTruncation={false}
+                    truncateLength={10}
+                    showPopover={TruncatedPopoverMode.WHEN_TRUNCATED}
+                >
+                    {str}
+                </JSONFormat>,
+            );
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).exist;
 
             comp = harness.mount(<JSONFormat showPopover={TruncatedPopoverMode.NEVER}>{str}</JSONFormat>);


### PR DESCRIPTION
#### Fixes #760 

#### Changes proposed in this pull request:

Remove `PureRender` and change the default props to detect truncation.

#### Reviewers should focus on:

I left JSONFormat alone when first implementing the detect truncation feature because I thought people might prefer to just always show the popover to view JSON and manually truncate. Are the default props changes okay?

#### Screenshot
JSONFormat now properly detects truncation 

![screen shot 2017-03-02 at 5 26 43 pm](https://cloud.githubusercontent.com/assets/3681045/23529900/6cd9726a-ff6d-11e6-8d2d-f761710ee15f.png)
