### PR TITLE
[Date Range Input] - Part 10v0: Docs, final little props, etc.

### DIFF
--- a/packages/datetime/examples/common/formatSelect.tsx
+++ b/packages/datetime/examples/common/formatSelect.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { Radio, RadioGroup } from  "@blueprintjs/core";
+import * as React from "react";
+
+export interface IFormatSelectProps {
+    /**
+     * The format-string option to display as selected.
+     */
+    selectedValue: string;
+
+    /**
+     * The callback to fire when the selected value changes.
+     */
+    onChange: (event: React.FormEvent<HTMLElement>) => void;
+}
+
+export const FormatSelect: React.SFC<IFormatSelectProps> = (props) => (
+    <RadioGroup
+        label="Date format"
+        onChange={props.onChange}
+        selectedValue={props.selectedValue}
+    >
+        <Radio label="DD/MM/YYYY" value="DD/MM/YYYY" />
+        <Radio label="MM-DD-YYYY" value="MM-DD-YYYY" />
+        <Radio label="YYYY-MM-DD" value="YYYY-MM-DD" />
+    </RadioGroup>
+);

--- a/packages/datetime/examples/common/formatSelect.tsx
+++ b/packages/datetime/examples/common/formatSelect.tsx
@@ -20,14 +20,18 @@ export interface IFormatSelectProps {
     onChange: (event: React.FormEvent<HTMLElement>) => void;
 }
 
+export const FORMATS = [
+    "DD/MM/YYYY",
+    "MM-DD-YYYY",
+    "YYYY-MM-DD",
+];
+
 export const FormatSelect: React.SFC<IFormatSelectProps> = (props) => (
     <RadioGroup
         label="Date format"
         onChange={props.onChange}
         selectedValue={props.selectedValue}
     >
-        <Radio label="DD/MM/YYYY" value="DD/MM/YYYY" />
-        <Radio label="MM-DD-YYYY" value="MM-DD-YYYY" />
-        <Radio label="YYYY-MM-DD" value="YYYY-MM-DD" />
+        {FORMATS.map((value) => <Radio key={value} label={value} value={value} />)}
     </RadioGroup>
 );

--- a/packages/datetime/examples/dateInputExample.tsx
+++ b/packages/datetime/examples/dateInputExample.tsx
@@ -5,11 +5,12 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import { Switch } from "@blueprintjs/core";
 import BaseExample, { handleBooleanChange, handleStringChange } from "@blueprintjs/core/examples/common/baseExample";
 import * as React from "react";
 
 import { DateInput } from "../src";
+import { FormatSelect } from "./common/formatSelect";
 
 export interface IDateInputExampleState {
     closeOnSelection?: boolean;
@@ -59,16 +60,11 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     onChange={this.toggleDisabled}
                 />,
             ], [
-                <RadioGroup
+                <FormatSelect
                     key="Format"
-                    label="Date format"
                     onChange={this.toggleFormat}
                     selectedValue={this.state.format}
-                >
-                    <Radio label="DD/MM/YYYY" value="DD/MM/YYYY" />
-                    <Radio label="MM-DD-YYYY" value="MM-DD-YYYY" />
-                    <Radio label="YYYY-MM-DD" value="YYYY-MM-DD" />
-                </RadioGroup>,
+                />,
             ],
         ];
     }

--- a/packages/datetime/examples/dateInputExample.tsx
+++ b/packages/datetime/examples/dateInputExample.tsx
@@ -10,7 +10,7 @@ import BaseExample, { handleBooleanChange, handleStringChange } from "@blueprint
 import * as React from "react";
 
 import { DateInput } from "../src";
-import { FormatSelect } from "./common/formatSelect";
+import { FORMATS, FormatSelect } from "./common/formatSelect";
 
 export interface IDateInputExampleState {
     closeOnSelection?: boolean;
@@ -23,7 +23,7 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
     public state: IDateInputExampleState = {
         closeOnSelection: true,
         disabled: false,
-        format: "DD/MM/YYYY",
+        format: FORMATS[0],
         openOnFocus: true,
     };
 

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -5,11 +5,12 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import { Switch } from "@blueprintjs/core";
 import BaseExample, { handleBooleanChange, handleStringChange } from "@blueprintjs/core/examples/common/baseExample";
 import * as React from "react";
 
 import { DateRangeInput } from "../src";
+import { FormatSelect } from "./common/formatSelect";
 
 export interface IDateRangeInputExampleState {
     closeOnSelection?: boolean;
@@ -48,16 +49,11 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     onChange={this.toggleDisabled}
                 />,
             ], [
-                <RadioGroup
+                <FormatSelect
                     key="Format"
-                    label="Date format"
                     onChange={this.toggleFormat}
                     selectedValue={this.state.format}
-                >
-                    <Radio label="DD/MM/YYYY" value="DD/MM/YYYY" />
-                    <Radio label="MM-DD-YYYY" value="MM-DD-YYYY" />
-                    <Radio label="YYYY-MM-DD" value="YYYY-MM-DD" />
-                </RadioGroup>,
+                />,
             ],
         ];
     }

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -5,13 +5,41 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import BaseExample from "@blueprintjs/core/examples/common/baseExample";
+import { Radio, RadioGroup } from "@blueprintjs/core";
+import BaseExample, { handleStringChange } from "@blueprintjs/core/examples/common/baseExample";
 import * as React from "react";
 
 import { DateRangeInput } from "../src";
 
-export class DateRangeInputExample extends BaseExample<{}> {
+export interface IDateRangeInputExampleState {
+    format?: string;
+}
+
+export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
+    public state: IDateRangeInputExampleState = {
+        format: "DD/MM/YYYY",
+    };
+
+    private toggleFormat = handleStringChange((format) => this.setState({ format }));
+
     protected renderExample() {
-        return <DateRangeInput />;
+        return <DateRangeInput {...this.state} />;
+    }
+
+    protected renderOptions() {
+        return [
+            [
+                <RadioGroup
+                    key="Format"
+                    label="Date format"
+                    onChange={this.toggleFormat}
+                    selectedValue={this.state.format}
+                >
+                    <Radio label="DD/MM/YYYY" value="DD/MM/YYYY" />
+                    <Radio label="MM-DD-YYYY" value="MM-DD-YYYY" />
+                    <Radio label="YYYY-MM-DD" value="YYYY-MM-DD" />
+                </RadioGroup>,
+            ],
+        ];
     }
 }

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -10,7 +10,7 @@ import BaseExample, { handleBooleanChange, handleStringChange } from "@blueprint
 import * as React from "react";
 
 import { DateRangeInput } from "../src";
-import { FormatSelect } from "./common/formatSelect";
+import { FORMATS, FormatSelect } from "./common/formatSelect";
 
 export interface IDateRangeInputExampleState {
     closeOnSelection?: boolean;
@@ -22,7 +22,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     public state: IDateRangeInputExampleState = {
         closeOnSelection: false,
         disabled: false,
-        format: "DD/MM/YYYY",
+        format: FORMATS[0],
     };
 
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -5,21 +5,24 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Radio, RadioGroup } from "@blueprintjs/core";
-import BaseExample, { handleStringChange } from "@blueprintjs/core/examples/common/baseExample";
+import { Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import BaseExample, { handleBooleanChange, handleStringChange } from "@blueprintjs/core/examples/common/baseExample";
 import * as React from "react";
 
 import { DateRangeInput } from "../src";
 
 export interface IDateRangeInputExampleState {
+    disabled?: boolean;
     format?: string;
 }
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
     public state: IDateRangeInputExampleState = {
+        disabled: false,
         format: "DD/MM/YYYY",
     };
 
+    private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
 
     protected renderExample() {
@@ -29,6 +32,13 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     protected renderOptions() {
         return [
             [
+                <Switch
+                    checked={this.state.disabled}
+                    label="Disabled"
+                    key="Disabled"
+                    onChange={this.toggleDisabled}
+                />,
+            ], [
                 <RadioGroup
                     key="Format"
                     label="Date format"

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -12,18 +12,21 @@ import * as React from "react";
 import { DateRangeInput } from "../src";
 
 export interface IDateRangeInputExampleState {
+    closeOnSelection?: boolean;
     disabled?: boolean;
     format?: string;
 }
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
     public state: IDateRangeInputExampleState = {
+        closeOnSelection: false,
         disabled: false,
         format: "DD/MM/YYYY",
     };
 
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
+    private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
 
     protected renderExample() {
         return <DateRangeInput {...this.state} />;
@@ -32,6 +35,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     protected renderOptions() {
         return [
             [
+                <Switch
+                    checked={this.state.closeOnSelection}
+                    label="Close on selection"
+                    key="Selection"
+                    onChange={this.toggleSelection}
+                />,
                 <Switch
                     checked={this.state.disabled}
                     label="Disabled"

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -12,12 +12,6 @@ The `DateRangeInput` component is a [control group](#components.forms.control-gr
 [input groups](#components.forms.input-group). It shows a
 [`DateRangePicker`](#components.datetime.daterangepicker) in a [`Popover`](#components.popover) on focus.
 
-Use the `onChange` function to listen for changes to the selected date. Use `onError` to listen for
-invalid entered dates or date ranges.
-
-You can control the selected date by setting the `value` prop, or use the component in uncontrolled
-mode and specify an initial date by setting `defaultValue`.
-
 Use this component in forms where the user must enter a date range.
 
 @react-example DateRangeInputExample
@@ -32,6 +26,12 @@ JavaScript API
 
 The `DateRangeInput` component is available in the __@blueprintjs/datetime__ package.
 Make sure to review the [general usage docs for date & time components](#components.datetime).
+
+Use the `onChange` function to listen for changes to the selected date. Use `onError` to listen for
+invalid entered dates or date ranges.
+
+You can control the selected date by setting the `value` prop, or use the component in uncontrolled
+mode and specify an initial date by setting `defaultValue`.
 
 ```
 import { DateRangeInput } from "@blueprintjs/datetime";

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -8,6 +8,18 @@
 /*
 Date range input
 
+The `DateRangeInput` component is a [control group](#components.forms.control-group) composed of two
+[input groups](#components.forms.input-group). It shows a
+[`DateRangePicker`](#components.datetime.daterangepicker) in a [`Popover`](#components.popover) on focus.
+
+Use the `onChange` function to listen for changes to the selected date. Use `onError` to listen for
+invalid entered dates or date ranges.
+
+You can control the selected date by setting the `value` prop, or use the component in uncontrolled
+mode and specify an initial date by setting `defaultValue`.
+
+Use this component in forms where the user must enter a date range.
+
 @react-example DateRangeInputExample
 
 Weight: 3

--- a/packages/datetime/src/_daterangeinput.scss
+++ b/packages/datetime/src/_daterangeinput.scss
@@ -14,3 +14,20 @@ Weight: 3
 
 Styleguide components.datetime.daterangeinput
 */
+
+/*
+JavaScript API
+
+The `DateRangeInput` component is available in the __@blueprintjs/datetime__ package.
+Make sure to review the [general usage docs for date & time components](#components.datetime).
+
+```
+import { DateRangeInput } from "@blueprintjs/datetime";
+
+<DateRangeInput value={[this.state.startDate, this.state.endDate]} onChange={this.handleChange} />
+```
+
+@interface IDateRangeInputProps
+
+Styleguide components.datetime.daterangeinput.js
+*/

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -228,7 +228,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 inline={true}
                 isOpen={this.state.isOpen}
                 onClose={this.handlePopoverClose}
-                position={Position.TOP_LEFT}
+                position={Position.BOTTOM_LEFT}
             >
                 <div className={Classes.CONTROL_GROUP}>
                     <InputGroup

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -55,7 +55,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     defaultValue?: DateRange;
 
     /**
-     * Whether the component should be enabled or disabled.
+     * Whether the text inputs are non-interactive.
      * @default false
      */
     disabled?: boolean;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -49,6 +49,12 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     defaultValue?: DateRange;
 
     /**
+     * Whether the component should be enabled or disabled.
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
      * Props to pass to the end-date input.
      */
     endInputProps?: IInputGroupProps;
@@ -149,6 +155,7 @@ interface IStateKeysAndValuesObject {
 
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
+        disabled: false,
         endInputProps: {},
         format: "YYYY-MM-DD",
         invalidDateMessage: "Invalid date",
@@ -235,6 +242,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="Start date"
                         {...startInputProps}
                         className={startInputClasses}
+                        disabled={this.props.disabled}
                         inputRef={this.refHandlers.startInputRef}
                         onBlur={this.handleStartInputBlur}
                         onChange={this.handleStartInputChange}
@@ -248,6 +256,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         placeholder="End date"
                         {...endInputProps}
                         className={endInputClasses}
+                        disabled={this.props.disabled}
                         inputRef={this.refHandlers.endInputRef}
                         onBlur={this.handleEndInputBlur}
                         onChange={this.handleEndInputChange}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -43,6 +43,12 @@ import {
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
+     * Whether the calendar popover should close when a date range is fully selected.
+     * @default true
+     */
+    closeOnSelection?: boolean;
+
+    /**
      * The default date range to be used in the component when uncontrolled.
      * This will be ignored if `value` is set.
      */
@@ -155,6 +161,7 @@ interface IStateKeysAndValuesObject {
 
 export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
+        closeOnSelection: true,
         disabled: false,
         endInputProps: {},
         format: "YYYY-MM-DD",
@@ -286,6 +293,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         if (this.props.value === undefined) {
             const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
 
+            let isOpen = true;
+
             let isStartInputFocused: boolean;
             let isEndInputFocused: boolean;
 
@@ -305,6 +314,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 isEndInputFocused = true;
 
                 endHoverString = null;
+            } else if (this.props.closeOnSelection) {
+                isOpen = false;
+                isStartInputFocused = false;
+                isEndInputFocused = false;
             } else if (this.state.lastFocusedField === DateRangeBoundary.START) {
                 // keep the start field focused
                 isStartInputFocused = true;
@@ -316,6 +329,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             }
 
             this.setState({
+                isOpen,
                 selectedEnd,
                 selectedStart,
                 isEndInputFocused,

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -113,6 +113,22 @@ describe("<DateRangeInput>", () => {
         expect(getEndInput(root).prop("disabled")).to.be.true;
     });
 
+    it("if closeOnSelection=false, popover stays open when full date range is selected", () => {
+        const { root, getDayElement } = wrap(<DateRangeInput closeOnSelection={false} />);
+        root.setState({ isOpen: true });
+        getDayElement(1).simulate("click");
+        getDayElement(10).simulate("click");
+        expect(root.state("isOpen")).to.be.true;
+    });
+
+    it("if closeOnSelection=true, popover closes when full date range is selected", () => {
+        const { root, getDayElement } = wrap(<DateRangeInput />);
+        root.setState({ isOpen: true });
+        getDayElement(1).simulate("click");
+        getDayElement(10).simulate("click");
+        expect(root.state("isOpen")).to.be.false;
+    });
+
     describe("when uncontrolled", () => {
         it("Shows empty fields when defaultValue is [null, null]", () => {
             const { root } = wrap(<DateRangeInput defaultValue={[null, null]} />);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -9,7 +9,7 @@ import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
-import { InputGroup } from "@blueprintjs/core";
+import { InputGroup, Popover } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes as DateClasses, DateRange, DateRangeBoundary, DateRangeInput } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -102,6 +102,15 @@ describe("<DateRangeInput>", () => {
     it("shows empty fields when no date range is selected", () => {
         const { root } = wrap(<DateRangeInput />);
         assertInputTextsEqual(root, "", "");
+    });
+
+    it("inputs disable and popover doesn't open if disabled=true", () => {
+        const { root } = wrap(<DateRangeInput disabled={true} />);
+        const startInput = getStartInput(root);
+        startInput.simulate("click");
+        expect(root.find(Popover).prop("isOpen")).to.be.false;
+        expect(startInput.prop("disabled")).to.be.true;
+        expect(getEndInput(root).prop("disabled")).to.be.true;
     });
 
     describe("when uncontrolled", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -154,7 +154,11 @@ describe("<DateRangeInput>", () => {
             const defaultValue = [START_DATE, null] as DateRange;
 
             const onChange = sinon.spy();
-            const { root, getDayElement } = wrap(<DateRangeInput defaultValue={defaultValue} onChange={onChange} />);
+            const { root, getDayElement } = wrap(<DateRangeInput
+                closeOnSelection={false}
+                defaultValue={defaultValue}
+                onChange={onChange}
+            />);
             root.setState({ isOpen: true });
 
             getDayElement(END_DAY).simulate("click");
@@ -549,7 +553,10 @@ describe("<DateRangeInput>", () => {
             let dayElement: WrappedComponentDayElement;
 
             beforeEach(() => {
-                const result = wrap(<DateRangeInput defaultValue={[HOVER_TEST_DATE_2, HOVER_TEST_DATE_4]} />);
+                const result = wrap(<DateRangeInput
+                    closeOnSelection={false}
+                    defaultValue={[HOVER_TEST_DATE_2, HOVER_TEST_DATE_4]}
+                />);
 
                 root = result.root;
                 getDayElement = result.getDayElement;
@@ -571,7 +578,7 @@ describe("<DateRangeInput>", () => {
             }
 
             describe("when selected date range is [null, null]", () => {
-                const SELECTED_RANGE = [null, null];
+                const SELECTED_RANGE = [null, null] as HoverTextDateConfig[];
                 const HOVER_TEST_DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
 
                 beforeEach(() => {


### PR DESCRIPTION
# ⚠️ For content review only, don't merge this PR (see explanation below)

#### Related to #249, Builds on #757

#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Change popover position back to `BOTTOM_LEFT`
- Add documentation for `DateRangeInput` (pretty closely mimicking documentation for `DateInput`).
- Add `disabled` prop, add a control for it to the example, and add tests
- Add `closeOnSelection` prop, add a control for it to the example, and add tests
- Add a `format` control to the example (and create a new, reusable `FormatSelect` component)

#### Reviewers should focus on:

This is the full—and final!—set of changes I'd like to merge into `feature/date-range-input`. I'm opening this PR so that you can review its content while I'm in apartment tours this morning. Assuming this looks good and that Part 9 (#757) squash+merges before I return to my computer at ~2pm, I'll close this Part 10 v0 PR (it'll be in a bad state due to the squashing of its Part 9 ancestor commits), cherry pick the same Part 10 commits over to a new branch based off of the latest `feature/date-range-input` branch, open that PR, and merge.

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/443450/23564328/e17073c6-fffe-11e6-9cb3-106d4c0ee163.png)
