### PR TITLE
add deprecation warning to Tabs constructor

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -54,6 +54,8 @@ export const RANGESLIDER_NULL_VALUE = `${ns} <RangeSlider> value prop must be an
 
 export const TABS_FIRST_CHILD = `${ns} First child of <Tabs> component should be a <TabList>`;
 export const TABS_MISMATCH = `${ns} Number of <Tab> components should equal number of <TabPanel> components`;
+export const TABS_DEPRECATED = `${ns} <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>.`
+    + " https://blueprintjs.com/#components.tabs.js";
 
 export const TOASTER_INLINE_WARNING = `${ns} Toaster.create() ignores inline prop as it always creates a new element`;
 

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -5,6 +5,14 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+// only accessible within this file, so use `Utils.isNodeEnv` from the outside.
+declare var process: { env: any };
+
+/** Returns whether `process.env.NODE_ENV` exists and equals `env`. */
+export function isNodeEnv(env: string) {
+    return typeof process !== "undefined" && process.env && process.env.NODE_ENV === env;
+}
+
 /** Returns whether the value is a function. Acts as a type guard. */
 export function isFunction(value: any): value is Function {
     return typeof value === "function";

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -45,6 +45,12 @@ Styleguide components.tabs.css
 /*
 JavaScript API
 
+<div class="pt-callout pt-intent-danger pt-icon-error">
+  <h5>Deprecated in v1.11.0</h5>
+  This `Tabs` API has been deprecated in v1.11.0 favor of the simpler and more flexible
+  `Tabs2` API [described above](#components.tabs.js).
+</div>
+
 The `Tabs`, `TabList`, `Tab`, and `TabPanel` components are available in the __@blueprintjs/core__
 package. Make sure to review the [general usage docs for JS components](#components.usage).
 
@@ -57,6 +63,8 @@ because of how the library manages the virtual DOM for you.
 ### Sample Usage
 
 ```
+import { Tab, TabList, TabPanel, Tabs } from "@blueprintjs/core";
+
 <Tabs>
     <TabList>
         <Tab>First tab</Tab>

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -75,6 +75,10 @@ export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
     constructor(props?: ITabsProps, context?: any) {
         super(props, context);
         this.state = this.getStateFromProps(this.props);
+
+        if (!Utils.isNodeEnv("production")) {
+            console.warn(Errors.TABS_DEPRECATED);
+        }
     }
 
     public render() {


### PR DESCRIPTION
#### Changes proposed in this pull request:

- `Utils.isNodeEnv` helper function checks value of `process.env.NODE_ENV`.
