### PR TITLE
Use overflow: auto for table popovers rather than scroll

### DIFF
--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -53,7 +53,7 @@
   min-width: 20 * $pt-grid-size;
   max-width: 60 * $pt-grid-size;
   max-height: 30 * $pt-grid-size;
-  overflow: scroll;
+  overflow: auto;
   padding: $pt-grid-size $pt-grid-size;
   font-family: $pt-font-family-monospace;
 }


### PR DESCRIPTION
#### Fixes #720 

#### Changes proposed in this pull request:

Change overflow: scroll to auto

#### Screenshot

Looks so much better now: 
<img width="410" alt="screen shot 2017-03-03 at 3 00 28 pm" src="https://cloud.githubusercontent.com/assets/2463526/23566964/27f0c292-0022-11e7-8b55-d93189b46e48.png">
<img width="424" alt="screen shot 2017-03-03 at 3 00 54 pm" src="https://cloud.githubusercontent.com/assets/2463526/23566986/397f0848-0022-11e7-932e-8cce334a6801.png">

