### PR TITLE
Ignore mouse events in DateRangeInput popover when animating closed

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -290,6 +290,11 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     // ===========================
 
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
+        // ignore mouse events in the date-range picker if the popover is animating closed.
+        if (!this.state.isOpen) {
+            return;
+        }
+
         if (this.props.value === undefined) {
             const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
 
@@ -345,6 +350,11 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private handleDateRangePickerHoverChange = (hoveredRange: DateRange) => {
+        // ignore mouse events in the date-range picker if the popover is animating closed.
+        if (!this.state.isOpen) {
+            return;
+        }
+
         if (hoveredRange == null) {
             // undo whatever focus changes we made while hovering
             // over various calendar dates


### PR DESCRIPTION
#### Fixes #771 

#### Checklist

- [ ] Include tests

#### Changes proposed in this pull request:

**Before:** If you moved your mouse within the calendar while the `DateRangeInput` popover was closing, then `handleDateRangePickerHoverChange` was invoked, which had the unfortunate side effect of refocusing an input and consequently reopening the popover on focus.

**After:** If `isOpen` is false, then we know the popover is either closed or animating closed. Adding a check for that case in `handleDateRangePickerChange` and `handleDateRangePickerHoverChange` fixes the re-opening popover issue.

#### Reviewers should focus on:

Do we want to add unit tests for this? Would require a hard assumption on a transition duration specified in a SCSS file, which feels...meh.
