### PR TITLE
Add styling to support full-width NumericInput

### DIFF
--- a/packages/core/examples/numericInputBasicExample.tsx
+++ b/packages/core/examples/numericInputBasicExample.tsx
@@ -3,6 +3,7 @@
  * Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import * as classNames from "classnames";
 import * as React from "react";
 
 import {
@@ -32,6 +33,7 @@ export interface INumericInputBasicExampleState {
     selectAllOnFocus?: boolean;
     selectAllOnIncrement?: boolean;
     showDisabled?: boolean;
+    showFullWidth?: boolean;
     showLargeSize?: boolean;
     showLeftIcon?: boolean;
     showReadOnly?: boolean;
@@ -95,6 +97,7 @@ export class NumericInputBasicExample extends BaseExample<INumericInputBasicExam
         selectAllOnFocus: false,
         selectAllOnIncrement: false,
         showDisabled: false,
+        showFullWidth: false,
         showLeftIcon: false,
         showReadOnly: false,
 
@@ -114,6 +117,7 @@ export class NumericInputBasicExample extends BaseExample<INumericInputBasicExam
     private toggleDisabled = handleBooleanChange((showDisabled) => this.setState({ showDisabled }));
     private toggleLeftIcon = handleBooleanChange((showLeftIcon) => this.setState({ showLeftIcon }));
     private toggleReadOnly = handleBooleanChange((showReadOnly) => this.setState({ showReadOnly }));
+    private toggleFullWidth = handleBooleanChange((showFullWidth) => this.setState({ showFullWidth }));
     private toggleNumericCharsOnly = handleBooleanChange((numericCharsOnly) => this.setState({ numericCharsOnly }));
     private toggleSelectAllOnFocus = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
     private toggleSelectAllOnIncrement = handleBooleanChange((selectAllOnIncrement) => {
@@ -130,19 +134,13 @@ export class NumericInputBasicExample extends BaseExample<INumericInputBasicExam
             selectAllOnFocus,
             selectAllOnIncrement,
             showDisabled,
+            showFullWidth,
             showReadOnly,
             showLeftIcon,
         } = this.state;
 
         return [
             [
-                this.renderSelectMenu("Minimum value", minValueIndex, MIN_VALUES, this.handleMinValueChange),
-                this.renderSelectMenu("Maximum value", maxValueIndex, MAX_VALUES, this.handleMaxValueChange),
-            ], [
-                this.renderSelectMenu(
-                    "Button position", buttonPositionIndex, BUTTON_POSITIONS, this.handleButtonPositionChange),
-                <IntentSelect intent={intent} key="intent" onChange={this.handleIntentChange} />,
-            ], [
                 <label className={Classes.LABEL} key="modifierslabel">Modifiers</label>,
                 this.renderSwitch("Numeric characters only", numericCharsOnly, this.toggleNumericCharsOnly),
                 this.renderSwitch("Select all on focus", selectAllOnFocus, this.toggleSelectAllOnFocus),
@@ -150,16 +148,25 @@ export class NumericInputBasicExample extends BaseExample<INumericInputBasicExam
                 this.renderSwitch("Disabled", showDisabled, this.toggleDisabled),
                 this.renderSwitch("Read-only", showReadOnly, this.toggleReadOnly),
                 this.renderSwitch("Left icon", showLeftIcon, this.toggleLeftIcon),
+                this.renderSwitch("Full width", showFullWidth, this.toggleFullWidth),
+            ], [
+                this.renderSelectMenu("Minimum value", minValueIndex, MIN_VALUES, this.handleMinValueChange),
+                this.renderSelectMenu("Maximum value", maxValueIndex, MAX_VALUES, this.handleMaxValueChange),
+            ], [
+                this.renderSelectMenu(
+                    "Button position", buttonPositionIndex, BUTTON_POSITIONS, this.handleButtonPositionChange),
+                <IntentSelect intent={intent} key="intent" onChange={this.handleIntentChange} />,
             ],
         ];
     }
 
     protected renderExample() {
         return (
-            <div>
+            <div className="docs-react-numeric-input-example">
                 <NumericInput
                     allowNumericCharactersOnly={this.state.numericCharsOnly}
                     buttonPosition={BUTTON_POSITIONS[this.state.buttonPositionIndex].value}
+                    className={classNames({ [Classes.FILL]: this.state.showFullWidth })}
                     intent={this.state.intent}
 
                     min={MIN_VALUES[this.state.minValueIndex].value}

--- a/packages/core/src/components/forms/_numeric-input.scss
+++ b/packages/core/src/components/forms/_numeric-input.scss
@@ -95,6 +95,17 @@ Styleguide components.forms.numeric-input.js
 */
 
 /*
+Responsive numeric inputs
+
+`NumericInput` can be styled with the same set of CSS classes that modify
+regular [control groups](#components.forms.input-group). The most appropriate
+such modifier for `NumericInput` is `pt-fill`, which when passed as a
+`className` will make the component expand to fill all available width.
+
+Styleguide components.forms.numeric-input.js.fill
+*/
+
+/*
 Uncontrolled mode
 
 By default, this component will function in uncontrolled mode, managing all of

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -234,7 +234,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
                 NumericInput.DECREMENT_KEY, NumericInput.DECREMENT_ICON_NAME, this.handleDecrementButtonClick);
 
             const buttonGroup = (
-                <div key="button-group" className={classNames(Classes.BUTTON_GROUP, Classes.VERTICAL)}>
+                <div key="button-group" className={classNames(Classes.BUTTON_GROUP, Classes.VERTICAL, Classes.FIXED)}>
                     {incrementButton}
                     {decrementButton}
                 </div>

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -190,6 +190,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
         const inputGroupHtmlProps = removeNonHTMLProps(this.props, [
             "allowNumericCharactersOnly",
             "buttonPosition",
+            "className",
             "majorStepSize",
             "minorStepSize",
             "onValueChange",

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -180,6 +180,14 @@
   }
 }
 
+#{section-id("components.forms.numeric-input")} {
+  // .pt-fill doesn't work out-of-the-box within .docs-react-example,
+  // because the latter is styled with display: flex.
+  .docs-react-example .docs-react-numeric-input-example {
+    width: 100%;
+  }
+}
+
 #{section-id("components.forms.numeric-input.extended-example")} {
   .docs-react-example input {
     width: $pt-grid-size * 23;


### PR DESCRIPTION
#### Fixes #618

#### Checklist

- [ ] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Add `pt-fixed` to the `pt-button-group` within `NumericInput`. This ensures only the `pt-input-group` will stretch when the `NumericInput` is styled as full-width via a `pt-fill` class.

#### Reviewers should focus on:

- Is there a good way to test this?
- **DONE** ~Do we want to add a note mentioning you can style `NumericInput` with `pt-fill`?~

#### Screenshot

![2017-03-06 13 04 14](https://cloud.githubusercontent.com/assets/443450/23629744/76d06b9a-026d-11e7-9a60-9520fcfbc90d.gif)
