### PR TITLE
Add linked column and linked row resizing -- resizing one does all

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -103,7 +103,7 @@ class FormatsTable extends React.Component<{}, {}> {
             case 6: return null;
             case 8: return "this is a very long string";
         }
-        const obj = {};
+        const obj: {[key: string]: string} = {};
         for (let i = 0; i < 1000; i++) {
             obj[`KEY-${(Math.random() * 10000).toFixed(2)}`] = (Math.random() * 10000).toFixed(2);
         }

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -258,6 +258,24 @@ export class Regions {
     }
 
     /**
+     * Returns true if the regions contain a region that has FULL_TABLE cardinality
+     */
+    public static hasFullTable(regions: IRegion[]) {
+        if (regions == null) {
+            return false;
+        }
+
+        for (const region of regions) {
+            const cardinality = Regions.getRegionCardinality(region);
+            if (cardinality === RegionCardinality.FULL_TABLE) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Returns true if the regions contain the query region. The query region
      * may be a subset of the `regions` parameter.
      */
@@ -308,6 +326,25 @@ export class Regions {
                     if (!seen[col]) {
                         seen[col] = true;
                         iteratee(col);
+                    }
+                }
+            }
+        });
+    }
+
+    public static eachUniqueFullRow(regions: IRegion[], iteratee: (row: number) => void) {
+        if (regions == null || regions.length === 0 || iteratee == null) {
+            return;
+        }
+
+        const seen: {[row: number]: boolean} = {};
+        regions.forEach((region: IRegion) => {
+            if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_ROWS) {
+                const [ start, end ] = region.rows;
+                for (let row = start; row <= end; row++) {
+                    if (!seen[row]) {
+                        seen[row] = true;
+                        iteratee(row);
                     }
                 }
             }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -829,8 +829,22 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private handleColumnWidthChanged = (columnIndex: number, width: number) => {
+        const selectedRegions = this.state.selectedRegions;
         const columnWidths = this.state.columnWidths.slice();
-        columnWidths[columnIndex] = width;
+
+        if (Regions.hasFullTable(selectedRegions)) {
+            for (let col = 0; col < columnWidths.length; col++) {
+                columnWidths[col] = width;
+            }
+        }
+        if (Regions.hasFullColumn(selectedRegions, columnIndex)) {
+            Regions.eachUniqueFullColumn(selectedRegions, (col: number) => {
+                columnWidths[col] = width;
+            });
+        } else {
+            columnWidths[columnIndex] = width;
+        }
+
         this.invalidateGrid();
         this.setState({ columnWidths });
 
@@ -841,8 +855,22 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private handleRowHeightChanged = (rowIndex: number, height: number) => {
+        const selectedRegions = this.state.selectedRegions;
         const rowHeights = this.state.rowHeights.slice();
-        rowHeights[rowIndex] = height;
+
+        if (Regions.hasFullTable(selectedRegions)) {
+            for (let row = 0; row < rowHeights.length; row++) {
+                rowHeights[row] = height;
+            }
+        }
+        if (Regions.hasFullRow(selectedRegions, rowIndex)) {
+            Regions.eachUniqueFullRow(selectedRegions, (row: number) => {
+                rowHeights[row] = height;
+            });
+        } else {
+            rowHeights[rowIndex] = height;
+        }
+
         this.invalidateGrid();
         this.setState({ rowHeights });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 
 import { Cell, Column, Table, TableLoadingOption } from "../src";
 import * as Classes from "../src/common/classes";
+import { Regions } from "../src/regions";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 import { ElementHarness, ReactHarness } from "./harness";
 
@@ -84,6 +85,46 @@ describe("<Table>", () => {
 
         const rowHeaders = tableHarness.element.queryAll(`.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`);
         rowHeaders.forEach((rowHeader) => expectCellLoading(rowHeader, CellType.ROW_HEADER));
+    });
+
+    it("Resizes selected rows together", () => {
+        const renderCell = () => {
+            return <Cell>gg</Cell>;
+        };
+
+        const selectedRegions = [Regions.row(0, 1), Regions.row(4, 6), Regions.row(8)];
+
+        const table = harness.mount(
+            // set the row height so small so they can all fit in the viewport and be rendered
+            <Table
+                numRows={10}
+                isRowResizable={true}
+                selectedRegions={selectedRegions}
+                defaultRowHeight={1}
+                minRowHeight={1}
+            >
+                <Column renderCell={renderCell}/>
+                <Column renderCell={renderCell}/>
+                <Column renderCell={renderCell}/>
+            </Table>,
+        );
+
+        const rows = table.find(`.${Classes.TABLE_ROW_HEADERS}`);
+        const resizeHandleTarget = rows.find(`.${Classes.TABLE_RESIZE_HANDLE_TARGET}`, 0);
+        resizeHandleTarget.mouse("mousemove")
+            .mouse("mousedown")
+            .mouse("mousemove", 0, 2)
+            .mouse("mouseup");
+
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 0).bounds().height).to.equal(3);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 1).bounds().height).to.equal(3);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 2).bounds().height).to.equal(1);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 3).bounds().height).to.equal(1);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 4).bounds().height).to.equal(3);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 5).bounds().height).to.equal(3);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 6).bounds().height).to.equal(3);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 7).bounds().height).to.equal(1);
+        expect(rows.find(`.${Classes.TABLE_HEADER}`, 8).bounds().height).to.equal(3);
     });
 
     xit("Accepts a sparse array of column widths", () => {


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Add the ability to resize multiple columns or rows together -- all selected columns/rows will resize when you resize a single one. 

#### Reviewers should focus on:

Right now I'm just calling the callback for the one row/col that was changed by user interaction -- I'm not sure if we should call it a bunch of times, or change the interface and make it a breaking change, or what. What are your thoughts here? 

#### Screenshot

![mar-07-2017 16-38-34](https://cloud.githubusercontent.com/assets/2463526/23679059/8f16a632-0354-11e7-9d4c-81d258841ab3.gif)

