### PR TITLE
Non ideal docs

### DIFF
--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -13,7 +13,7 @@ import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
 export interface INonIdealStateProps extends IProps {
-    /*
+    /**
      * An action that's attached to the non-ideal state.
      */
     action?: JSX.Element;


### PR DESCRIPTION
It would appear that the docs for this component were
....
![8adea640-0ea2-0132-70b0-0add9426c766](https://cloud.githubusercontent.com/assets/3452559/23731786/4f5e42d6-0424-11e7-8c44-a1c9c98c6602.gif)
....
"non-ideal"