### PR TITLE
[DM] KSS for CSS examples

### DIFF
--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -25,9 +25,10 @@ module.exports = (blueprint, gulp, plugins) => {
         versions: "versions.json",
     };
 
-    gulp.task("docs-json", () => {
-        const docs = new dm.Documentalist({ renderer: text.renderer });
-        const contents = docs.documentGlobs("packages/core/src/**/*");
+    gulp.task("docs-json", async () => {
+        const docs = dm.Documentalist.create({ renderer: text.renderer })
+            .use(".scss", new dm.KssPlugin());
+        const contents = await docs.documentGlobs("packages/core/src/**/*");
 
         function nestChildPage(child, parent) {
             const originalRef = child.reference;

--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -25,43 +25,44 @@ module.exports = (blueprint, gulp, plugins) => {
         versions: "versions.json",
     };
 
-    gulp.task("docs-json", async () => {
-        const docs = dm.Documentalist.create({ renderer: text.renderer })
-            .use(".scss", new dm.KssPlugin());
-        const contents = await docs.documentGlobs("packages/core/src/**/*");
+    gulp.task("docs-json", () => {
+        return dm.Documentalist.create({ renderer: text.renderer })
+            .use(".scss", new dm.KssPlugin())
+            .documentGlobs("packages/core/src/**/*")
+            .then((contents) => {
+                function nestChildPage(child, parent) {
+                    const originalRef = child.reference;
 
-        function nestChildPage(child, parent) {
-            const originalRef = child.reference;
+                    // update entry reference to include parent reference
+                    const nestedRef = dm.slugify(parent.reference, originalRef);
+                    child.reference = nestedRef;
 
-            // update entry reference to include parent reference
-            const nestedRef = dm.slugify(parent.reference, originalRef);
-            child.reference = nestedRef;
+                    if (dm.isPageNode(child)) {
+                        // rename nested pages to be <parent>.<child> and remove old <child> entry
+                        contents.docs[nestedRef] = contents.docs[originalRef];
+                        contents.docs[nestedRef].reference = nestedRef;
+                        delete contents.docs[originalRef];
+                        // recurse through page children
+                        child.children.forEach((innerchild) => nestChildPage(innerchild, child));
+                    }
+                }
 
-            if (dm.isPageNode(child)) {
-                // rename nested pages to be <parent>.<child> and remove old <child> entry
-                contents.docs[nestedRef] = contents.docs[originalRef];
-                contents.docs[nestedRef].reference = nestedRef;
-                delete contents.docs[originalRef];
-                // recurse through page children
-                child.children.forEach((innerchild) => nestChildPage(innerchild, child));
-            }
-        }
+                // navPage is used to construct the sidebar menu
+                const roots = dm.createNavigableTree(contents.docs, contents.docs[config.navPage]).children;
+                // nav page is not a real docs page so we can remove it from output
+                delete contents.docs[config.navPage];
+                roots.forEach((page) => {
+                    if (dm.isPageNode(page)) {
+                        page.children.forEach((child) => nestChildPage(child, page));
+                    }
+                });
 
-        // navPage is used to construct the sidebar menu
-        const roots = dm.createNavigableTree(contents.docs, contents.docs[config.navPage]).children;
-        // nav page is not a real docs page so we can remove it from output
-        delete contents.docs[config.navPage];
-        roots.forEach((page) => {
-            if (dm.isPageNode(page)) {
-                page.children.forEach((child) => nestChildPage(child, page));
-            }
-        });
+                // add a new field to data file with pre-processed layout tree
+                contents.layout = roots;
 
-        // add a new field to data file with pre-processed layout tree
-        contents.layout = roots;
-
-        return text.fileStream(filenames.data, JSON.stringify(contents, null, 2))
-            .pipe(gulp.dest(config.data));
+                return text.fileStream(filenames.data, JSON.stringify(contents, null, 2))
+                    .pipe(gulp.dest(config.data));
+            });
     });
 
     // create a JSON file containing latest released version of each project

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "better-handlebars": "github:wmeldon/better-handlebars",
     "chai": "3.5.0",
     "del": "2.2.2",
-    "documentalist": "0.0.2",
+    "documentalist": "0.0.3",
     "enzyme": "2.6.0",
     "gulp": "3.9.1",
     "gulp-concat": "2.6.0",

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -37,15 +37,12 @@ small {
 /*
 Fonts
 
-Blueprint does not include any fonts of its own; it will use the default sans-serif operating system
-font. We provide a class to use the default monospace font instead.
-
 Markup:
 <div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
 
 .pt-monospace-text - Use a monospace font (ideal for code)
 
-Styleguide typography.fonts
+Styleguide fonts
 */
 
 .pt-monospace-text {
@@ -63,7 +60,7 @@ Markup:
 <h5>H5 heading</h5>
 <h6>H6 heading</h6>
 
-Styleguide typography.headings
+Styleguide headings
 */
 
 $headers: (
@@ -89,18 +86,13 @@ $headers: (
 /*
 UI text
 
-The base font size for Blueprint web applications is 14px. This should be the default type size
-for most short strings of text which are not headings or titles. If you wish to reset some
-element's font size and line height to the default base styles, use the `.pt-ui-text` class.
-For longer running text, see [running text styles](#typography.running-text).
-
 Markup:
 <div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
 
 .pt-ui-text - Default UI text. This is applied to the document body as part of core styles.
 .pt-ui-text-large - Larger UI text.
 
-Styleguide typography.ui-text
+Styleguide pt-ui-text
 */
 
 .pt-ui-text {
@@ -115,33 +107,21 @@ Styleguide typography.ui-text
 /*
 Running text
 
-Large blocks of _running text_ should use `.pt-running-text` styles.
-
-Note that `<p>` elements by default don't add any styles; they just inherit the base typography.
-This is a conservative design; `<p>` elements are so ubiquitous that they're more often used for UI
-text than long form text. It's up to the user to decide which blocks of text in an application
-should get running text styles.
-
 Markup:
-<p>
-  Default paragraphs have base typography styles.
-</p>
-<p class="pt-running-text">
-  Running text is larger and more spaced out.
-  <br />
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-  labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
-  nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-  esse cillum dolore eu fugiat nulla pariatur.
-  <br />
-  <a href="#">Excepteur sint occaecat cupidatat non proident.</a>
-</p>
-<div class="pt-running-text">
-  Includes support for <strong>strong</strong>, <em>emphasized</em>, and <u>underlined</u> text.
-  <a href="#">Also links!</a>
+<div class="{{.modifier}}">
+  <p>Longform text, such as rendered Markdown documents, benefit from additional spacing and slightly
+large font size. Apply <code>.pt-running-text</code> to the parent element to adjust spacing for the following
+elements:</p>
+  <ul>
+    <li><code>&lt;p></code> tags have increased line-height and font size.</li>
+    <li><code>&lt;h*></code> tag margins are adjusted to provide clear separation between sections in a document.</li>
+    <li><code>&lt;ul></code> and <code>&lt;ol></code> tags receive [`.pt-list`](#typography.lists) styles for legibility.</li>
+  </ul>
+  <h3>New section</h3>
+  <p>And another paragraph.</p>
 </div>
 
-Styleguide typography.running-text
+Styleguide pt-running-text
 */
 
 .pt-running-text {
@@ -207,9 +187,6 @@ a {
 /*
 Preformatted text
 
-Use `<pre>` for code blocks, and `<code>` for inline code. Note that `<pre>` blocks will
-retain _all_ whitespace so you'll have to format the content accordingly.
-
 Markup:
 <code>$ npm install</code>
 <pre>
@@ -230,7 +207,7 @@ Markup:
     });
 }</code></pre>
 
-Styleguide typography.preformatted
+Styleguide preformatted
 */
 
 pre,
@@ -290,8 +267,6 @@ pre {
 /*
 Block quotes
 
-Block quotes are treated as running text.
-
 Markup:
 <blockquote>
   <p>
@@ -308,7 +283,7 @@ Markup:
   </p>
 </blockquote>
 
-Styleguide typography.blockquotes
+Styleguide blockquote
 */
 
 blockquote {
@@ -329,11 +304,6 @@ blockquote {
 /*
 Lists
 
-Blueprint provides a small amount of global styling and a few modifier classes for list elements.
-
-`<ul>` and `<ol>` elements in blocks with the `.pt-running-text` modifier class will
-automatically assume the `.pt-list` styles to promote readability.
-
 Markup:
 <ul class="{{.modifier}}">
   <li>Item the first</li>
@@ -349,7 +319,7 @@ Markup:
 .pt-list - Add a little spacing between items for readability.
 .pt-list-unstyled - Remove all list styling (including indicators) so you can add your own.
 
-Styleguide typography.lists
+Styleguide lists
 */
 
 ol,
@@ -389,9 +359,6 @@ ul {
 /*
 Text utilities
 
-Blueprint provides a small handful of class-based text utilities which can applied to any element
-that contains text.
-
 Markup:
 <div class="{{.modifier}}" style="width: 320px;">
   Blueprint components react overlay date picker. Breadcrumbs dialog progress non-ideal state.
@@ -401,7 +368,7 @@ Markup:
 .pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
   container.
 
-Styleguide typography.utilities
+Styleguide utilities
 */
 
 .pt-text-muted {
@@ -419,8 +386,6 @@ Styleguide typography.utilities
 /*
 Right-to-left text
 
-Use the utility class `.pt-rtl`.
-
 Markup:
 <h4>Arabic:</h4>
 <p class="pt-rtl">
@@ -433,7 +398,7 @@ Markup:
   מתן החלל מאמרשיחהצפה ב. הספרות אנציקלופדיה אם זכר, על שימושי שימושיים תאולוגיה עזה
 </p>
 
-Styleguide typography.intl.rtl
+Styleguide pt-rtl
 */
 
 .pt-rtl {

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -8,6 +8,8 @@
 @import "../../common/variables";
 
 /*
+Breadcrumbs
+
 Markup:
 <ul class="pt-breadcrumbs">
   <li><a class="pt-breadcrumbs-collapsed" href="#"></a></li>
@@ -16,6 +18,8 @@ Markup:
   <li><a class="pt-breadcrumb" href="#">Folder three</a></li>
   <li><span class="pt-breadcrumb pt-breadcrumb-current">File</span></li>
 </ul>
+
+Styleguide pt-breadcrumbs
 */
 
 // shaving off 1px for perfect centering (... icon is 5px high)

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -18,6 +18,8 @@ containing breadcrumbs that are collapsed due to layout constraints.
 * When adding another element (such as a [tooltip](#components.tooltip) or
 [popover](#components.popover)) to a breadcrumb, wrap it around the contents of the `li`.
 
+@css pt-breadcrumbs
+
 @## JavaScript API
 
 The `Breadcrumb` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -9,6 +9,8 @@
 @import "./common";
 
 /*
+Button groups
+
 Markup:
 <div class="pt-button-group {{.modifier}}">
   <a class="pt-button pt-icon-database" tabindex="0" role="button">Queries</a>
@@ -38,6 +40,8 @@ Markup:
 .pt-large - Use large buttons
 .pt-minimal - Use minimal buttons. Note that these minimal buttons will not automatically
               truncate text in an ellipsis because of the divider line added in CSS.
+
+Styleguide pt-button-group
 */
 
 .pt-button-group {
@@ -150,6 +154,8 @@ Markup:
   }
 
   /*
+  Responsive
+
   Markup:
   <div class="pt-button-group pt-large pt-fill">
     <a class="pt-button pt-intent-primary pt-fixed" tabindex="0" role="button">Start</a>
@@ -164,6 +170,8 @@ Markup:
     <button class="pt-button pt-fill">Middle</button>
     <button class="pt-button pt-icon-arrow-right"></button>
   </div>
+
+  Styleguide pt-button-group.pt-fill
   */
 
   &.pt-fill {
@@ -176,6 +184,8 @@ Markup:
   }
 
   /*
+  Vertical button groups
+
   Markup:
   <div class="pt-button-group pt-vertical">
     <a class="pt-button pt-icon-search-template" role="button" tabindex="0"></a>
@@ -194,6 +204,8 @@ Markup:
     <button type="button" class="pt-button pt-intent-primary pt-icon-media pt-active">Media</button>
     <button type="button" class="pt-button pt-intent-primary pt-icon-link">Sources</button>
   </div>
+
+  Styleguide pt-button-group.pt-vertical
   */
 
   &.pt-vertical {

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -8,6 +8,8 @@
 @import "./common";
 
 /*
+Button
+
 Markup:
 <a role="button" class="pt-button {{.modifier}}" {{:modifier}} tabindex="0">Anchor</a>
 <button type="button" class="pt-button pt-icon-add {{.modifier}}" {{:modifier}}>Button</button>
@@ -21,8 +23,9 @@ Markup:
 .pt-active - Active appearance
 .pt-large - Larger size
 .pt-fill - Fill parent container
-*/
 
+Styleguide pt-button
+*/
 .pt-button {
   @include pt-button-base();
   @include pt-button-height($pt-button-height);
@@ -70,13 +73,16 @@ Markup:
   }
 
   /*
+  Buttons with icons
+
   Markup:
   <button type="button" class="pt-button pt-icon-add">Default button</button>
   <button type="button" class="pt-button pt-icon-refresh"></button>
   <button type="button" class="pt-button pt-large pt-icon-add">Large button</button>
   <button type="button" class="pt-button pt-large pt-icon-refresh"></button>
-  */
 
+  Styleguide pt-button.pt-icon
+  */
   &[class*="pt-icon-"]::before {
     @include pt-icon();
 
@@ -85,6 +91,8 @@ Markup:
   }
 
   /*
+  Advanced icon usage
+
   Markup:
   <button type="button" class="pt-button pt-intent-success">
     Next step
@@ -104,6 +112,8 @@ Markup:
     upload.txt
     <span class="pt-icon-standard pt-icon-cross pt-align-right"></span>
   </button>
+
+  Styleguide pt-button.pt-icon-advanced
   */
 
   #{$icon-classes} {
@@ -154,6 +164,8 @@ Markup:
   }
 
   /*
+  Minimal buttons
+
   Markup:
   <a role="button" class="pt-button pt-minimal {{.modifier}}" {{:modifier}} tabindex="0">Anchor</a>
   <button type="button" class="pt-button pt-minimal pt-icon-add {{.modifier}}" {{:modifier}}>Button</button>
@@ -163,6 +175,8 @@ Markup:
   .pt-intent-success - Success intent
   .pt-intent-warning - Warning intent
   .pt-intent-danger - Danger intent
+
+  Styleguide pt-button.pt-minimal
   */
 
   &.pt-minimal {

--- a/packages/core/src/components/button/button-group.md
+++ b/packages/core/src/components/button/button-group.md
@@ -9,6 +9,8 @@ You can apply sizing directly on the button group container element.
 
 You should implement interactive segmented controls as button groups.
 
+@css pt-button-group
+
 @### Responsive button groups
 
 Add the class `pt-fill` to a button group to make all buttons expand equally to fill the
@@ -20,6 +22,8 @@ to expand it to fill the available space while other buttons retain their origin
 
 You can adjust the specific size of a button with the `flex-basis` CSS property.
 
+@css pt-button-group.pt-fill
+
 @### Vertical button groups
 
 Add the class `pt-vertical` to create a vertical button group. The buttons in a vertical
@@ -28,3 +32,5 @@ group all have the same size as the widest button in the group.
 Add the modifier class `pt-align-left` to left-align all button text and icons.
 
 You can also combine vertical groups with the `pt-fill` and `pt-minimal` class modifiers.
+
+@css pt-button-group.pt-vertical

--- a/packages/core/src/components/button/button.md
+++ b/packages/core/src/components/button/button.md
@@ -15,10 +15,14 @@ focusable by default.
 user from focusing them by pressing <kbd class="pt-key">tab</kbd> on the keyboard.
 - Note that `<a>` tags do not respond to the `:disabled` attribute; use `.pt-disabled` instead.
 
+@css pt-button
+
 @### Buttons with icons
 
 Add an icon before the button text with `pt-icon-*` classes.
 You _do not_ need to include an icon sizing class.
+
+@css pt-button.pt-icon
 
 @### Advanced icon layout
 
@@ -28,6 +32,8 @@ Add multiple icons to the same button, or move icons after the text.
 
 To adjust margins on right-aligned icons, add the class `pt-align-right` to the icon.
 
+@css pt-button.pt-icon-advanced
+
 @### Minimal buttons
 
 For a subtler button that appears to fade into the UI, add the `.pt-minimal` modifier
@@ -35,6 +41,8 @@ to any `.pt-button`. `pt-minimal` is compatible with all other button modifiers,
 except for `.pt-fill` (due to lack of visual affordances).
 
 Note that minimal buttons are _not supported_ in button groups at this time.
+
+@css pt-button.pt-minimal
 
 @## JavaScript API
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -7,6 +7,8 @@
 @import "../../common/variables";
 
 /*
+Callout
+
 Markup:
 <div class="pt-callout {{.modifier}}">
   <h5>Callout Heading</h5>
@@ -18,6 +20,8 @@ Markup:
 .pt-intent-warning - Warning intent
 .pt-intent-danger  - Danger intent
 .pt-icon-info-sign - With an icon
+
+Styleguide pt-callout
 */
 
 .pt-callout {

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -10,3 +10,5 @@ heading, use the `<h5>` element.
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
     Note that the `<h5>` heading is entirely optional.
 </div>
+
+@css pt-callout

--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -6,6 +6,8 @@
 @import "../../common/variables";
 
 /*
+Cards
+
 Markup:
 <div class="pt-card {{.modifier}}">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec dapibus et mauris,
@@ -17,6 +19,8 @@ Markup:
 .pt-elevation-2 - Second. An even stronger shadow, moving on up.
 .pt-elevation-3 - Third. For containers overlaying content temporarily.
 .pt-elevation-4 - Fourth. The strongest shadow, usually for overlay containers on top of backdrops.
+
+Styleguide pt-card
 */
 
 $card-padding: $pt-grid-size * 2 !default;
@@ -66,6 +70,8 @@ $dark-elevation-shadows: (
 }
 
 /*
+Interactive cards
+
 Markup:
 <div class="docs-card-example">
   <div class="pt-card pt-elevation-0 pt-interactive">
@@ -81,6 +87,8 @@ Markup:
     <p>Stats of dataset completeness and reference data join percentages.</p>
   </div>
 </div>
+
+Styleguide pt-card.pt-interactive
 */
 
 .pt-card.pt-interactive {

--- a/packages/core/src/components/card/card.md
+++ b/packages/core/src/components/card/card.md
@@ -10,6 +10,8 @@ height in the UI.
 You can also use the `.pt-elevation-*` classes by themselves to apply shadows to any arbitrary
 element.
 
+@css pt-card
+
 @### Interactive cards
 
 Add the `.pt-interactive` modifier class to make a `.pt-card` respond to user interactions. When you
@@ -17,3 +19,5 @@ hover over cards with this class applied, the mouse changes to a pointer and the
 the card increases by two levels.
 
 Users expect an interactive card to be a single clickable unit.
+
+@css pt-card.pt-interactive

--- a/packages/core/src/components/components.md
+++ b/packages/core/src/components/components.md
@@ -173,12 +173,12 @@ Check out the [React API docs](https://facebook.github.io/react/docs/react-api.h
 @page alert
 @page breadcrumbs
 @page button
+@page button-group
 @page callout
 @page card
 @page collapse
 @page collapsible-list
 @page context-menu
-<!--@page datetime-->
 @page dialog
 @page editable-text
 @page forms

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -10,6 +10,8 @@
 @import "../../common/variables";
 
 /*
+Dialog
+
 Markup:
 <div class="pt-dialog">
   <div class="pt-dialog-header">
@@ -28,6 +30,8 @@ Markup:
     </div>
   </div>
 </div>
+
+Styleguide pt-dialog
 */
 
 $dialog-border-radius: $pt-border-radius * 2 !default;

--- a/packages/core/src/components/dialog/dialog.md
+++ b/packages/core/src/components/dialog/dialog.md
@@ -76,3 +76,5 @@ However, you should use the dialog [JavaScript APIs](#components.dialog.js) when
 as they automatically generate some of this markup.
 
 More examples of dialog content are shown below.
+
+@css pt-dialog

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -8,6 +8,8 @@
 @import "./common";
 
 /*
+Control groups
+
 Markup:
 <div class="pt-control-group-example">
   <div class="pt-control-group">
@@ -41,6 +43,8 @@ Markup:
     <button class="pt-button pt-intent-primary">Add</button>
   </div>
 </div>
+
+Styleguide pt-control-group
 */
 
 .pt-control-group {
@@ -198,6 +202,8 @@ Markup:
   }
 
   /*
+  Responsive control groups
+
   Markup:
   <div class="pt-control-group-example">
     <div class="pt-control-group">
@@ -213,6 +219,8 @@ Markup:
       <button class="pt-button pt-icon-plus pt-fixed"></button>
     </div>
   </div>
+
+  Styleguide pt-control-group.pt-fill
   */
 
   > .pt-fill {
@@ -224,6 +232,8 @@ Markup:
   }
 
   /*
+  Vertical control groups
+
   Markup:
   <div class="pt-control-group pt-vertical" style="width: 300px;">
     <div class="pt-input-group pt-large">
@@ -236,6 +246,8 @@ Markup:
     </div>
     <button class="pt-button pt-large pt-intent-primary">Login</button>
   </div>
+
+  Styleguide pt-control-group.pt-vertical
   */
 
   &.pt-vertical {

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -11,37 +11,35 @@
 Control groups
 
 Markup:
-<div class="pt-control-group-example">
-  <div class="pt-control-group">
-    <button class="pt-button pt-icon-filter">Filter</button>
-    <input type="text" class="pt-input" placeholder="Find filters..." />
+<div class="pt-control-group">
+  <button class="pt-button pt-icon-filter">Filter</button>
+  <input type="text" class="pt-input" placeholder="Find filters..." />
+</div>
+<div class="pt-control-group">
+  <div class="pt-select">
+    <select>
+      <option selected>Filter...</option>
+      <option value="1">Issues</option>
+      <option value="2">Requests</option>
+      <option value="3">Projects</option>
+    </select>
   </div>
-  <div class="pt-control-group">
-    <div class="pt-select">
-      <select>
-        <option selected>Filter...</option>
-        <option value="1">Issues</option>
-        <option value="2">Requests</option>
-        <option value="3">Projects</option>
-      </select>
-    </div>
-    <div class="pt-input-group">
-      <span class="pt-icon pt-icon-search"></span>
-      <input type="text" class="pt-input" value="from:ggray to:allorca" />
+  <div class="pt-input-group">
+    <span class="pt-icon pt-icon-search"></span>
+    <input type="text" class="pt-input" value="from:ggray to:allorca" />
+  </div>
+</div>
+<div class="pt-control-group">
+  <div class="pt-input-group">
+    <span class="pt-icon pt-icon-people"></span>
+    <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
+    <div class="pt-input-action">
+      <button class="pt-button pt-minimal pt-intent-primary">
+        can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
+      </button>
     </div>
   </div>
-  <div class="pt-control-group">
-    <div class="pt-input-group">
-      <span class="pt-icon pt-icon-people"></span>
-      <input type="text" class="pt-input" placeholder="Find collaborators..." style="padding-right:94px" />
-      <div class="pt-input-action">
-        <button class="pt-button pt-minimal pt-intent-primary">
-          can view<span class="pt-icon-standard pt-icon-caret-down pt-align-right"></span>
-        </button>
-      </div>
-    </div>
-    <button class="pt-button pt-intent-primary">Add</button>
-  </div>
+  <button class="pt-button pt-intent-primary">Add</button>
 </div>
 
 Styleguide pt-control-group
@@ -205,19 +203,17 @@ Styleguide pt-control-group
   Responsive control groups
 
   Markup:
-  <div class="pt-control-group-example">
-    <div class="pt-control-group">
-      <div class="pt-input-group pt-fill">
-        <span class="pt-icon pt-icon-people"></span>
-        <input type="text" class="pt-input" placeholder="Find collaborators..." />
-      </div>
-      <button class="pt-button pt-intent-primary">Add</button>
+  <div class="pt-control-group">
+    <div class="pt-input-group pt-fill">
+      <span class="pt-icon pt-icon-people"></span>
+      <input type="text" class="pt-input" placeholder="Find collaborators..." />
     </div>
-    <div class="pt-control-group pt-fill">
-      <button class="pt-button pt-icon-minus pt-fixed"></button>
-      <input type="text" class="pt-input" placeholder="Enter a value..." />
-      <button class="pt-button pt-icon-plus pt-fixed"></button>
-    </div>
+    <button class="pt-button pt-intent-primary">Add</button>
+  </div>
+  <div class="pt-control-group pt-fill">
+    <button class="pt-button pt-icon-minus pt-fixed"></button>
+    <input type="text" class="pt-input" placeholder="Enter a value..." />
+    <button class="pt-button pt-icon-plus pt-fixed"></button>
   </div>
 
   Styleguide pt-control-group.pt-fill

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -569,6 +569,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     Third
   </label>
 
-  Styleguide pt-control.pt-inline
+  Styleguide pt-checkbox.pt-inline
   */
 }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -134,6 +134,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   /*
+  Checkbox
+
   Markup:
   <label class="pt-control pt-checkbox {{.modifier}}">
     <input type="checkbox" {{:modifier}} />
@@ -147,6 +149,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
                    <code>input.indeterminate = true</code>.
   .pt-align-right - Right-aligned indicator
   .pt-large - Large
+
+  Styleguide pt-checkbox
   */
 
   &.pt-checkbox {
@@ -172,6 +176,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   /*
+  Radio
+
   Markup:
   <label class="pt-control pt-radio {{.modifier}}">
     <input type="radio" name="docs-radio-regular" {{:modifier}} />
@@ -183,6 +189,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   :disabled - Disabled. Also add <code>.pt-disabled</code> to <code>.pt-control</code> to change text color (not shown below).
   .pt-align-right - Right-aligned indicator
   .pt-large - Large
+
+  Styleguide pt-radio
   */
 
   $radio-indicator-font-size: $pt-grid-size * 0.6 !default;
@@ -217,6 +225,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   /*
+  Switch
+
   Markup:
   <label class="pt-control pt-switch {{.modifier}}">
     <input type="checkbox" {{:modifier}} />
@@ -228,6 +238,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   :disabled - Disabled. Also add <code>.pt-disabled</code> to <code>.pt-control</code> to change text color (not shown below).
   .pt-align-right - Right-aligned indicator
   .pt-large - Large
+
+  Styleguide pt-switch
   */
 
   $switch-height: $control-indicator-size !default;
@@ -537,6 +549,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   /*
+  Inline labels
+
   Markup:
   <label class="pt-label">A group of related options</label>
   <label class="pt-control pt-checkbox pt-inline">
@@ -554,5 +568,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     <span class="pt-control-indicator"></span>
     Third
   </label>
+
+  Styleguide pt-control.pt-inline
   */
 }

--- a/packages/core/src/components/forms/_file-upload.scss
+++ b/packages/core/src/components/forms/_file-upload.scss
@@ -7,6 +7,8 @@
 @import "../button/common";
 
 /*
+File upload
+
 Markup:
 <label class="pt-file-upload">
   <input type="file" {{:modifier}}/>
@@ -14,6 +16,8 @@ Markup:
 </label>
 
 :disabled - Disabled
+
+Styleguide pt-file-upload
 */
 
 .pt-file-upload {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -7,6 +7,8 @@
 @import "../../common/mixins";
 
 /*
+Form groups
+
 Markup:
 <div class="pt-form-group">
   <label class="pt-label" for="example-form-group-input-a">
@@ -44,6 +46,8 @@ Markup:
     <div class="pt-form-helper-text">Helper text with details / user feedback</div>
   </div>
 </div>
+
+Styleguide pt-form-group
 */
 
 .pt-form-group {

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -8,6 +8,8 @@
 @import "../spinner/common";
 
 /*
+Input groups
+
 Markup:
 <div class="pt-input-group {{.modifier}}">
   <span class="pt-icon pt-icon-filter"></span>
@@ -27,6 +29,8 @@ Markup:
 .pt-round - Rounded caps. Button will also be rounded.
 .pt-large - Large group. Children will adjust size accordingly.
 .pt-intent-primary - Primary intent. (All 4 intents are supported.)
+
+Styleguide pt-input-group
 */
 
 // 3px space between small button and regular input

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -6,6 +6,8 @@
 @import "../../common/variables";
 
 /*
+Text inputs
+
 Markup:
 <input class="pt-input {{.modifier}}" {{:modifier}} type="text" placeholder="Text input" dir="auto" />
 
@@ -18,6 +20,8 @@ Markup:
 .pt-intent-warning - Warning intent
 .pt-intent-danger - Danger intent
 .pt-fill - Take up full width of parent element
+
+Styleguide pt-input
 */
 
 .pt-input {
@@ -51,6 +55,8 @@ Markup:
 }
 
 /*
+Search inputs
+
 Markup:
 <div class="pt-input-group {{.modifier}}">
   <span class="pt-icon pt-icon-search"></span>
@@ -59,9 +65,13 @@ Markup:
 
 :disabled - Disabled. Also add <code>.pt-disabled</code> to <code>.pt-input-group</code> for icon coloring (not shown below).
 .pt-large - Large
+
+Styleguide pt-input.pt-search
 */
 
 /*
+Textareas
+
 Markup:
 <textarea class="pt-input {{.modifier}}" {{:modifier}} dir="auto"></textarea>
 
@@ -71,6 +81,8 @@ Markup:
 .pt-intent-primary - Primary intent
 .pt-intent-danger  - Danger intent
 .pt-fill  - Take up full width of parent element
+
+Styleguide pt-textarea
 */
 
 // stylelint-disable selector-no-qualifying-type

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -6,6 +6,8 @@
 @import "../../common/variables";
 
 /*
+Labels
+
 Markup:
 <label class="pt-label {{.modifier}}">
   Label A
@@ -22,6 +24,8 @@ Markup:
 </label>
 
 .pt-inline - Inline
+
+Styleguide pt-label
 */
 
 // stylelint-disable-next-line selector-no-qualifying-type
@@ -63,6 +67,8 @@ label.pt-label {
   }
 
   /*
+  Disabled labels
+
   Markup:
   <label class="pt-label pt-disabled">
     Label A
@@ -85,6 +91,8 @@ label.pt-label {
       </select>
     </div>
   </label>
+
+  Styleguide pt-label.pt-disabled
   */
 
   &.pt-disabled {

--- a/packages/core/src/components/forms/_select.scss
+++ b/packages/core/src/components/forms/_select.scss
@@ -7,6 +7,8 @@
 @import "../popover/common";
 
 /*
+Selects
+
 Markup:
 <div class="pt-select {{.modifier}}">
   <select {{:modifier}}>
@@ -22,6 +24,8 @@ Markup:
 .pt-minimal - Minimal appearance
 .pt-large - Large
 .pt-fill - Expand to fill parent container
+
+Styleguide pt-select
 */
 
 .pt-select {
@@ -87,6 +91,8 @@ Markup:
 }
 
 /*
+Inline
+
 Markup:
 <label class="pt-label {{.modifier}}">
   Label A
@@ -99,4 +105,6 @@ Markup:
 </label>
 
 .pt-inline - Inline
+
+Styleguide pt-select.pt-inline
 */

--- a/packages/core/src/components/forms/checkbox.md
+++ b/packages/core/src/components/forms/checkbox.md
@@ -10,6 +10,8 @@ component supports it handily with a prop).
 
 @## CSS API
 
+@css pt-checkbox
+
 @## JavaScript API
 
 The `Checkbox` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/components/forms/checkbox.md
+++ b/packages/core/src/components/forms/checkbox.md
@@ -33,3 +33,14 @@ Use `checked` instead of `value` in controlled mode to avoid typings issues.
 The most common options are detailed below.
 
 @interface ICheckboxProps
+
+@## Inline controls
+
+Checkboxes, radios, and switches all support the `.pt-inline` modifier to make them `display:
+inline-block`. Note that this modifier functions slightly differently on these elements than it
+does on `.pt-label`. On `.pt-label`, it only adjusts the layout of text _within_ the label and not
+the display of the label itself.
+
+Here's an example of how you might group together some controls and label them.
+
+@css pt-checkbox.pt-inline

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -18,6 +18,8 @@ child must be marked individually as `.pt-large` for uniform large appearance.
     should be promoted to live in a control group.</p>
 </div>
 
+@css pt-control-group
+
 @## Responsive control groups
 
 Add the class `pt-fill` to a control group to make all elements expand equally to fill the
@@ -29,7 +31,11 @@ to expand it to fill the available space while other elements retain their origi
 
 You can adjust the specific size of an element with the `flex-basis` CSS property.
 
+@css pt-control-group.pt-fill
+
 @## Vertical control groups
 
 Add the class `pt-vertical` to create a vertical control group. Controls in a vertical group
 will all have the same width as the widest control.
+
+@css pt-control-group.pt-vertical

--- a/packages/core/src/components/forms/file-upload.md
+++ b/packages/core/src/components/forms/file-upload.md
@@ -8,3 +8,5 @@ Wrap that all in a `label` with class `pt-file-upload`.
     File name does not update on file selection. To get this behavior,
     you must implement it separately in JS.
 </div>
+
+@css pt-file-upload

--- a/packages/core/src/components/forms/form-group.md
+++ b/packages/core/src/components/forms/form-group.md
@@ -13,3 +13,5 @@ Similar to labels, nested controls need to be styled separately.
 - Add `.pt-inline` to `.pt-form-group` to place the label to the left of the control.
 
 - Add `.pt-large` to `.pt-form-group` to align the label when used with large inline Blueprint controls.
+
+@css pt-form-group

--- a/packages/core/src/components/forms/input-group.md
+++ b/packages/core/src/components/forms/input-group.md
@@ -21,6 +21,8 @@ the parent input.
     arbitrary content in its right element.
 </div>
 
+@css pt-input-group
+
 @## JavaScript API
 
 The `InputGroup` component is available in the __@blueprintjs/core__ package. Make sure to review

--- a/packages/core/src/components/forms/input.md
+++ b/packages/core/src/components/forms/input.md
@@ -4,6 +4,8 @@ Use the `pt-input` class on an `input[type="text"]`. You should also specify `di
 support RTL languages](http://www.w3.org/International/questions/qa-html-dir#dirauto) (in all
 browsers except Internet Explorer).
 
+@css pt-input
+
 @## Search field
 
 Changing the `<input>` element's `type` attribute to `"search"` styles it to look like a search
@@ -11,3 +13,5 @@ field, giving it a rounded appearance. This style is equivalent to the `.pt-roun
 is applied automatically for `[type="search"]` inputs.
 
 Note that some browsers also implement a handler for the `esc` key to clear the text in a search field.
+
+@css pt-input.pt-search

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -18,6 +18,8 @@ Simple labels are useful for basic forms for a single `<input>`.
 - Putting the `<input>` element _inside_ a `<label>` element increases the area where the user
 can click to activate the control. Notice how in the examples below, clicking a `<label>` focuses its `<input>`.
 
+@css pt-label
+
 @## Disabled labels
 
 Add the `.pt-label` and `.pt-disabled` class modifiers to a `<label>` to make the label appear
@@ -26,3 +28,5 @@ disabled.
 This styles the label text, but does not disable any nested children like inputs or selects. You
 must add the `:disabled` attribute directly to any nested elements to disable them. Similarly the respective
 `pt-*` form control will need a `.pt-disabled` modifier. See the examples below.
+
+@css pt-label.pt-disabled

--- a/packages/core/src/components/forms/radio.md
+++ b/packages/core/src/components/forms/radio.md
@@ -9,6 +9,8 @@ element.
 
 @## CSS API
 
+@css pt-radio
+
 @## JavaScript API
 
 The `Radio` and `RadioGroup` components are available in the __@blueprintjs/core__ package. Make

--- a/packages/core/src/components/forms/select.md
+++ b/packages/core/src/components/forms/select.md
@@ -8,6 +8,10 @@ modifiers on the wrapper and attribute modifiers directly on the `<select>`.
     to the `<select>` tag.
 </div>
 
+@css pt-select
+
 @## Labeled static dropdown
 
 You can label `<select>` tags, similar to how you label any other form control.
+
+@css pt-select.pt-inline

--- a/packages/core/src/components/forms/switch.md
+++ b/packages/core/src/components/forms/switch.md
@@ -20,12 +20,3 @@ Note that this component supports the full range of props available on HTML `inp
 The most common options are detailed below.
 
 @interface ISwitchProps
-
-@## Inline controls
-
-Checkboxes, radios, and switches all support the `.pt-inline` modifier to make them `display:
-inline-block`. Note that this modifier functions slightly differently on these elements than it
-does on `.pt-label`. On `.pt-label`, it only adjusts the layout of text _within_ the label and not
-the display of the label itself.
-
-Here's an example of how you might group together some controls and label them.

--- a/packages/core/src/components/forms/switch.md
+++ b/packages/core/src/components/forms/switch.md
@@ -5,6 +5,8 @@ simulates on/off instead of checked/unchecked.
 
 @## CSS API
 
+@css pt-switch
+
 @## JavaScript API
 
 The `Switch` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -5,3 +5,5 @@ Text areas are similar to text inputs, but they are resizable and support multil
 You should also specify `dir="auto"` on text areas
 [to better support RTL languages](http://www.w3.org/International/questions/qa-html-dir#dirauto)
 (in all browsers except Internet Explorer).
+
+@css pt-textarea

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -11,6 +11,8 @@
 @import "./submenu";
 
 /*
+Menus
+
 Markup:
 <ul class="pt-menu {{.modifier}} pt-elevation-1">
   <li>
@@ -29,6 +31,8 @@ Markup:
 </ul>
 
 .pt-large - Large size (only supported on <code>.pt-menu</code>)
+
+Styleguide pt-menu
 */
 
 .pt-menu {
@@ -123,6 +127,8 @@ button.pt-menu-item {
 }
 
 /*
+Menu headers
+
 Markup:
 <ul class="pt-menu pt-elevation-1">
   <li class="pt-menu-header"><h6>Layouts</h6></li>
@@ -134,6 +140,8 @@ Markup:
   <li><button type="button" class="pt-menu-item pt-icon-star">Favorites</button></li>
   <li><button type="button" class="pt-menu-item pt-icon-envelope">Messages</button></li>
 </ul>
+
+Styleguide pt-menu.pt-menu-header
 */
 
 .pt-menu-header {

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -170,6 +170,10 @@ defined as part of `.pt-menu-item`.</small>
     menu width in your own usage.
 </div>
 
+@css pt-menu
+
 @### Section headers
 
 Add an `li.pt-menu-header`. Wrap the text in an `<h6>` tag for proper typography and borders.
+
+@css pt-menu.pt-menu-header

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -7,6 +7,8 @@
 @import "../../common/variables";
 
 /*
+Navbars
+
 Markup:
 <nav class="pt-navbar {{.modifier}}">
   <div class="pt-navbar-group pt-align-left">
@@ -24,6 +26,8 @@ Markup:
 </nav>
 
 .pt-dark - Dark theme
+
+Styleguide pt-navbar
 */
 
 $navbar-padding: $pt-grid-size * 1.5 !default;
@@ -90,6 +94,8 @@ $dark-navbar-background-color: $dark-gray5 !default;
 }
 
 /*
+Fixed width
+
 Markup:
 <nav class="pt-navbar pt-dark">
   <div style="margin: 0 auto; width: 480px;"> <!-- ADD ME -->
@@ -106,4 +112,6 @@ Markup:
     </div>
   </div>
 </nav>
+
+Styleguide pt-navbar.pt-container
 */

--- a/packages/core/src/components/navbar/navbar.md
+++ b/packages/core/src/components/navbar/navbar.md
@@ -14,6 +14,8 @@ Use the following classes to construct a navbar:
 - `.pt-navbar-heading` &ndash; Larger text for your application title.
 - `.pt-navbar-divider` &ndash; Thin vertical line that can be placed between groups of elements.
 
+@css pt-navbar
+
 @### Fixed to viewport top
 
 Add the `.pt-fixed-top` class to the `.pt-navbar` to attach it to the top of the viewport using
@@ -36,3 +38,5 @@ can align the navbar to match.
 
 Wrap your `.pt-navbar-group`s in an element with your desired `width` and `margin: 0 auto;` to
 horizontally center it.
+
+@css pt-navbar.pt-container

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -8,6 +8,8 @@
 @import "../../common/icons";
 
 /*
+Non-ideal state
+
 Markup:
 <div class="pt-non-ideal-state">
   <div class="pt-non-ideal-state-visual pt-non-ideal-state-icon">
@@ -18,6 +20,8 @@ Markup:
     Create a new file to populate the folder.
   </div>
 </div>
+
+Styleguide pt-non-ideal-state
 */
 
 .pt-non-ideal-state {

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -21,6 +21,8 @@ In this case, a good practice is to add a call to action directing the user what
 You may use the provided styles without using the [React component](#components.nonidealstate.js).
 See the example below.
 
+@css pt-non-ideal-state
+
 @## JavaScript API
 
 The `NonIdealState` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -8,6 +8,8 @@
 @import "../progress/common";
 
 /*
+Progress bars
+
 Markup:
 <div class="pt-progress-bar {{.modifier}}">
   <div class="pt-progress-meter" style="width: 25%"></div>
@@ -24,6 +26,8 @@ Markup:
 
 .pt-no-stripes   - No stripes
 .pt-no-animation - No animation
+
+Styleguide pt-progress-bar
 */
 
 $progress-bar-stripes-color: rgba($white, 0.2) !default;

--- a/packages/core/src/components/progress/progress-bar.md
+++ b/packages/core/src/components/progress/progress-bar.md
@@ -11,6 +11,8 @@ limited: values above `100%` appear as 100% progress and values below `0%` appea
 
 Omitting `width` will result in an "indeterminate" progress meter that fills the entire bar.
 
+@css pt-progress-bar
+
 @## JavaScript API
 
 The `ProgressBar` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -6,6 +6,8 @@
 @import "./common";
 
 /*
+Skeletons
+
 Markup:
 <div class="pt-card">
   <h5><a class="{{.modifier}}" href="#" tabindex="-1">Card heading</a></h5>
@@ -15,6 +17,10 @@ Markup:
   </p>
   <button type="button" class="pt-button {{.modifier}}" tabindex="-1">Submit</button>
 </div>
+
+.pt-skeleton - Render this element as a skeleton, an outline of its true self.
+
+Styleguide pt-skeleton
 */
 
 @keyframes glow {

--- a/packages/core/src/components/skeleton/skeleton.md
+++ b/packages/core/src/components/skeleton/skeleton.md
@@ -15,3 +15,5 @@ approximately the length of your expected text.
     disable the element, via either the `disabled` or `tabindex="-1"` attributes. Failing to do so
     will allow these skeleton elements to be focused when they shouldn't be.
 </div>
+
+@css pt-skeleton

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -9,6 +9,8 @@
 @import "./common";
 
 /*
+Spinners
+
 Markup:
 <div class="pt-spinner {{.modifier}}">
   <div class="pt-spinner-svg-container">
@@ -21,6 +23,8 @@ Markup:
 
 .pt-small - Small spinner
 .pt-large - Large spinner
+
+Styleguide pt-spinner
 */
 
 @keyframes pt-spinner-animation {

--- a/packages/core/src/components/spinner/spinner.md
+++ b/packages/core/src/components/spinner/spinner.md
@@ -8,6 +8,8 @@ You can create spinners manually by inserting their whole markup into your HTML.
 Spinners created via markup use same modifier classes as the
 [React `Spinner` component](#components.progress.spinner.js).
 
+@css pt-spinner
+
 @## JavaScript API
 
 The `Spinner` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/components/table/_table.scss
+++ b/packages/core/src/components/table/_table.scss
@@ -6,6 +6,8 @@
 @import "../../common/variables";
 
 /*
+Tables
+
 Markup:
 <table class="pt-table {{.modifier}}">
   <thead>
@@ -36,6 +38,8 @@ Markup:
 .pt-striped   - Striped appearance
 .pt-bordered  - Bordered appearance
 .pt-interactive  - Enables hover styles on rows
+
+Styleguide pt-table
 */
 
 $table-row-height: $pt-grid-size * 4 !default;

--- a/packages/core/src/components/table/table.md
+++ b/packages/core/src/components/table/table.md
@@ -12,3 +12,5 @@ This component adds Blueprint styling to native HTML tables.
 @## CSS API
 
 Apply the `pt-table` class to a `<table>` element. You can apply modifiers as additional classes.
+
+@css pt-table

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -7,6 +7,8 @@
 @import "../../common/mixins";
 
 /*
+Tabs
+
 Markup:
 <div class="pt-tabs">
     <ul class="pt-tab-list {{.modifier}}" role="tablist">
@@ -20,6 +22,8 @@ Markup:
 </div>
 
 .pt-large - Large tabs
+
+Styleguide pt-tabs
 */
 
 $tab-color-selected: $pt-link-color !default;

--- a/packages/core/src/components/tabs/tabs.md
+++ b/packages/core/src/components/tabs/tabs.md
@@ -16,6 +16,8 @@ class `pt-tabs`. You should add the proper accessibility attributes (`role`, `ar
 You may also simply omit hidden tabs from your markup to improve performance (the `Tabs`
 JavaScript component does this by default).
 
+@css pt-tabs
+
 @## Deprecated JavaScript API
 
 <div class="pt-callout pt-intent-danger pt-icon-error">

--- a/packages/core/src/components/tabs2/tabs2.md
+++ b/packages/core/src/components/tabs2/tabs2.md
@@ -12,6 +12,8 @@ class `pt-tabs`. You should add the proper accessibility attributes (`role`, `ar
 You may also simply omit hidden tabs from your markup to improve performance (the `Tabs`
 JavaScript component does this by default).
 
+@css pt-tabs
+
 @## JavaScript API
 
 <div class="pt-callout pt-intent-danger pt-icon-error">

--- a/packages/core/src/components/tag/_tag.scss
+++ b/packages/core/src/components/tag/_tag.scss
@@ -7,6 +7,8 @@
 @import "./common";
 
 /*
+Tags
+
 Markup:
 <p>
   <span class="pt-tag {{.modifier}}">125</span>
@@ -32,6 +34,8 @@ Markup:
 .pt-intent-success - Success intent
 .pt-intent-warning - Warning intent
 .pt-intent-danger  - Danger intent
+
+Styleguide pt-tag
 */
 
 .pt-tag {
@@ -49,6 +53,8 @@ Markup:
   }
 
   /*
+  Minimal tags
+
   Markup:
   <div class="pt-tag pt-minimal {{.modifier}}">125</div>
   <div class="pt-tag pt-minimal {{.modifier}}">Done</div>
@@ -63,6 +69,8 @@ Markup:
   .pt-intent-success - Success intent
   .pt-intent-warning - Warning intent
   .pt-intent-danger  - Danger intent
+
+  Styleguide pt-tag.pt-minimal
   */
 
   &.pt-minimal {

--- a/packages/core/src/components/tag/tag.md
+++ b/packages/core/src/components/tag/tag.md
@@ -10,10 +10,14 @@ element to support interaction handlers in your framework of choice.
 
 A simple `.pt-tag` without the remove button can easily function as a badge.
 
+@css pt-tag
+
 @### Minimal tags
 
 Add the `.pt-minimal` modifier for a lighter tag appearance. The translucent background color
 will adapt to its container's background color.
+
+@css pt-tag.pt-minimal
 
 @## JavaScript API
 

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -8,6 +8,8 @@
 @import "../../common/icons";
 
 /*
+Trees
+
 Markup:
 <div class="pt-tree pt-elevation-0">
   <ul class="pt-tree-node-list pt-tree-root">
@@ -37,6 +39,8 @@ Markup:
     </li>
   </ul>
 </div>
+
+Styleguide pt-tree
 */
 
 $tree-row-height: $pt-grid-size * 3 !default;

--- a/packages/core/src/components/tree/tree.md
+++ b/packages/core/src/components/tree/tree.md
@@ -12,6 +12,8 @@ may also use the provided styles by themselves, without using the component.
     you may want to do this as well in your own usage.
 </div>
 
+@css pt-tree
+
 @## JavaScript API
 
 The `Tree` component is available in the __@blueprintjs/core__ package.

--- a/packages/core/src/docs/typography.md
+++ b/packages/core/src/docs/typography.md
@@ -17,20 +17,12 @@ Instead, reference the classes and variables we provide in Blueprint (`.pt-ui-te
 Blueprint does not include any fonts of its own; it will use the default sans-serif operating system
 font. We provide a class to use the default monospace font instead.
 
-Markup:
-<div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
 
-.pt-monospace-text - Use a monospace font (ideal for code)
+@css fonts
 
 @## Headings
 
-Markup:
-<h1>H1 heading</h1>
-<h2>H2 heading</h2>
-<h3>H3 heading</h3>
-<h4>H4 heading</h4>
-<h5>H5 heading</h5>
-<h6>H6 heading</h6>
+@css headings
 
 @## UI text
 
@@ -39,39 +31,19 @@ for most short strings of text which are not headings or titles. If you wish to 
 element's font size and line height to the default base styles, use the `.pt-ui-text` class.
 For longer running text, see [running text styles](#typography.running-text).
 
-Markup:
-<div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
-
-.pt-ui-text - Default UI text. This is applied to the document body as part of core styles.
-.pt-ui-text-large - Larger UI text.
+@css pt-ui-text
 
 @## Running text
 
-Large blocks of _running text_ should use `.pt-running-text` styles.
+Longform text, such as rendered Markdown documents, benefit from additional spacing and slightly
+large font size. Apply `.pt-running-text` to the parent element to adjust spacing for the following
+elements:
 
-Note that `<p>` elements by default don't add any styles; they just inherit the base typography.
-This is a conservative design; `<p>` elements are so ubiquitous that they're more often used for UI
-text than long form text. It's up to the user to decide which blocks of text in an application
-should get running text styles.
+- `<p>` tags have increased line-height and font size.
+- `<h*>` tag margins are adjusted to provide clear separation between sections in a document.
+- `<ul>` and `<ol>` tags receive [`.pt-list`](#typography.lists) styles for legibility.
 
-Markup:
-<p>
-    Default paragraphs have base typography styles.
-</p>
-<p class="pt-running-text">
-    Running text is larger and more spaced out.
-    <br />
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
-    nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-    esse cillum dolore eu fugiat nulla pariatur.
-    <br />
-    <a href="#">Excepteur sint occaecat cupidatat non proident.</a>
-</p>
-<div class="pt-running-text">
-    Includes support for <strong>strong</strong>, <em>emphasized</em>, and <u>underlined</u> text.
-    <a href="#">Also links!</a>
-</div>
+@css pt-running-text
 
 @## Links
 
@@ -85,47 +57,13 @@ Putting an icon inside a link will cause it to inherit the link's text color.
 Use `<pre>` for code blocks, and `<code>` for inline code. Note that `<pre>` blocks will
 retain _all_ whitespace so you'll have to format the content accordingly.
 
-Markup:
-```html
-<code>$ npm install</code>
-<pre>
-    %pt-select {
-        @include pt-button();
-        @include prefixer(appearance, none, webkit moz);
-        border-radius: $pt-border-radius;
-        height: $pt-button-height;
-        padding: 0 ($input-padding-horizontal * 3) 0 $input-padding-horizontal;
-    }
-</pre>
-<pre><code>export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.SyntaxKind[]) {
-    if (modifiers == null || modifierKinds == null) {
-        return false;
-    }
-    return modifiers.some((m) => {
-        return modifierKinds.some((k) => m.kind === k);
-    });
-}</code></pre>
-```
+@css preformatted
 
 @## Block quotes
 
 Block quotes are treated as running text.
 
-Markup:
-<blockquote>
-<p>
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-</p>
-<p>
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-</p>
-</blockquote>
+@css blockquote
 
 @## Lists
 
@@ -134,34 +72,14 @@ Blueprint provides a small amount of global styling and a few modifier classes f
 `<ul>` and `<ol>` elements in blocks with the `.pt-running-text` modifier class will
 automatically assume the `.pt-list` styles to promote readability.
 
-Markup:
-<ul class="{{.modifier}}">
-    <li>Item the first</li>
-    <li>Item the second</li>
-    <li>Item the third</li>
-</ul>
-<ol class="{{.modifier}}">
-    <li>Item the first</li>
-    <li>Item the second</li>
-    <li>Item the third</li>
-</ol>
-
-.pt-list - Add a little spacing between items for readability.
-.pt-list-unstyled - Remove all list styling (including indicators) so you can add your own.
+@css lists
 
 @## Text utilities
 
 Blueprint provides a small handful of class-based text utilities which can applied to any element
 that contains text.
 
-Markup:
-<div class="{{.modifier}}" style="width: 320px;">
-Blueprint components react overlay date picker. Breadcrumbs dialog progress non-ideal state.
-</div>
-
-.pt-text-muted - Changes text color to a gentler gray.
-.pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
-container.
+@css utilities
 
 @## Internationalization
 
@@ -169,17 +87,7 @@ container.
 
 Use the utility class `.pt-rtl`.
 
-Markup:
-<h4>Arabic:</h4>
-<p class="pt-rtl">
-    لكل لأداء بمحاولة من. مدينة الواقعة يبق أي, وإعلان وقوعها، حول كل, حدى عجّل مشروط الخاسرة قد.
-    من الذود تكبّد بين, و لها واحدة الأراضي. عل الصفحة والروسية يتم, أي للحكومة استعملت شيء. أم وصل زهاء اليا
-</p>
-<h4>Hebrew:</h4>
-<p class="pt-rtl">
-    כדי על עזרה יידיש הבהרה, מלא באגים טכניים דת. תנך או ברית ביולי. כתב בה הטבע למנוע, דת כלים פיסיקה החופשית זכר.
-    מתן החלל מאמרשיחהצפה ב. הספרות אנציקלופדיה אם זכר, על שימושי שימושיים תאולוגיה עזה
-</p>
+@css pt-rtl
 
 @## Dark theme
 

--- a/packages/docs/src/common/cssExample.tsx
+++ b/packages/docs/src/common/cssExample.tsx
@@ -1,0 +1,46 @@
+import { IKssExample, IKssModifier } from "documentalist/dist/plugins";
+import * as React from "react";
+import { ModifierTable } from "../components/modifierTable";
+
+const MODIFIER_PLACEHOLDER = /\{\{([\.\:]?)modifier\}\}/g;
+const DEFAULT_MODIFIER: IKssModifier = {
+    documentation: "Default",
+    name: "default",
+};
+
+export const CssExample: React.SFC<IKssExample> = ({ markup, modifiers, reference }) => {
+    if (reference === undefined) {
+        throw new Error(`Unkown @css example: ${reference}`);
+    }
+    return (
+        <div>
+            {modifiers.length > 0 ? <ModifierTable modifiers={modifiers} /> : undefined}
+            <div className="kss-example-wrapper" data-reference={reference}>
+                {renderMarkupForModifier(markup, DEFAULT_MODIFIER)}
+                {modifiers.map((mod) => renderMarkupForModifier(markup, mod))}
+            </div>
+            <div className="kss-markup">
+                <pre className="editor">{markup}</pre>
+            </div>
+        </div>
+    );
+};
+
+function renderMarkupForModifier(markup: string, modifier: IKssModifier) {
+    const { name } = modifier;
+    const html = markup.replace(MODIFIER_PLACEHOLDER, (_, prefix) => {
+        if (prefix && name.charAt(0) === prefix) {
+            return name.slice(1);
+        } else if (!prefix) {
+            return name;
+        } else {
+            return "";
+        }
+    });
+    return (
+        <div className="kss-example" data-modifier={modifier.name} key={modifier.name}>
+            <code>{modifier.name}</code>
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+        </div>
+    );
+}

--- a/packages/docs/src/common/cssExample.tsx
+++ b/packages/docs/src/common/cssExample.tsx
@@ -8,23 +8,16 @@ const DEFAULT_MODIFIER: IKssModifier = {
     name: "default",
 };
 
-export const CssExample: React.SFC<IKssExample> = ({ markup, modifiers, reference }) => {
-    if (reference === undefined) {
-        throw new Error(`Unkown @css example: ${reference}`);
-    }
-    return (
-        <div>
-            {modifiers.length > 0 ? <ModifierTable modifiers={modifiers} /> : undefined}
-            <div className="kss-example-wrapper" data-reference={reference}>
-                {renderMarkupForModifier(markup, DEFAULT_MODIFIER)}
-                {modifiers.map((mod) => renderMarkupForModifier(markup, mod))}
-            </div>
-            <div className="kss-markup">
-                <pre className="editor">{markup}</pre>
-            </div>
+export const CssExample: React.SFC<IKssExample> = ({ markup, markupHtml, modifiers, reference }) => (
+    <div>
+        {modifiers.length > 0 ? <ModifierTable modifiers={modifiers} /> : undefined}
+        <div className="kss-example-wrapper" data-reference={reference}>
+            {renderMarkupForModifier(markup, DEFAULT_MODIFIER)}
+            {modifiers.map((mod) => renderMarkupForModifier(markup, mod))}
         </div>
-    );
-};
+        <div className="kss-markup" dangerouslySetInnerHTML={{ __html: markupHtml }} />
+    </div>
+);
 
 function renderMarkupForModifier(markup: string, modifier: IKssModifier) {
     const { name } = modifier;

--- a/packages/docs/src/common/propsStore.tsx
+++ b/packages/docs/src/common/propsStore.tsx
@@ -1,21 +1,21 @@
-import { IInterfaceEntry, IPropertyEntry } from "documentalist/dist/plugins/typescript";
+import { ITsInterfaceEntry, ITsPropertyEntry } from "documentalist/dist/plugins/typescript";
 
-export interface IInheritedPropertyEntry extends IPropertyEntry {
+export interface IInheritedPropertyEntry extends ITsPropertyEntry {
     inheritedFrom?: string;
 }
 
 export class PropsStore {
-    constructor(private props: IInterfaceEntry[]) {}
+    constructor(private props: { [name: string]: ITsInterfaceEntry }) {}
 
     public getProps = (name: string): IInheritedPropertyEntry[] => {
-        const entry = this.props.filter((props) => props.name === name)[0];
+        const entry = this.props[name];
         if (entry == null) {
             return [];
         } else if (entry.extends == null) {
             return entry.properties;
         } else {
             // dirty deduplication for overridden/inherited props
-            const props: {[name: string]: IPropertyEntry} = {};
+            const props: {[name: string]: ITsPropertyEntry} = {};
             entry.extends.map(this.getInheritedProps).forEach((inherited) => {
                 inherited.forEach((prop) => props[prop.name] = prop);
             });

--- a/packages/docs/src/components/modifierTable.tsx
+++ b/packages/docs/src/components/modifierTable.tsx
@@ -7,18 +7,18 @@
 
 import * as React from "react";
 
-import { IStyleguideModifier } from "./styleguide";
+import { IKssModifier } from "documentalist/dist/client";
 
-function renderModifier(modifier: IStyleguideModifier, index: number) {
+function renderModifier(modifier: IKssModifier, index: number) {
     return (
         <tr key={index}>
             <td data-modifier={modifier.name}><code>{modifier.name}</code></td>
-            <td dangerouslySetInnerHTML={{ __html: modifier.description }} />
+            <td dangerouslySetInnerHTML={{ __html: modifier.documentation }} />
         </tr>
     );
 }
 
-export const ModifierTable: React.SFC<{ modifiers: IStyleguideModifier[] }> = ({ modifiers }) => (
+export const ModifierTable: React.SFC<{ modifiers: IKssModifier[] }> = ({ modifiers }) => (
     <div className="kss-modifiers">
         <table className="pt-table">
             <thead>

--- a/packages/docs/src/components/page.tsx
+++ b/packages/docs/src/components/page.tsx
@@ -12,7 +12,7 @@ export interface IPageProps {
 export const Page: React.SFC<IPageProps> = ({ tagRenderers, page }) => {
     const pageContents = page.contents.map((node, i) => {
         if (typeof node === "string") {
-            return <div className="docs-section" dangerouslySetInnerHTML={{ __html: node }} key={i} />;
+            return <div className="docs-section pt-running-text" dangerouslySetInnerHTML={{ __html: node }} key={i} />;
         }
 
         // try rendering the tag,

--- a/packages/docs/src/components/styleguide.tsx
+++ b/packages/docs/src/components/styleguide.tsx
@@ -124,7 +124,7 @@ export class Styleguide extends React.Component<IStyleguideProps, IStyleguideSta
                             onItemClick={this.handleNavigation}
                         />
                     </div>
-                    <article className="docs-content pt-running-text" ref={this.refHandlers.content} role="main">
+                    <article className="docs-content" ref={this.refHandlers.content} role="main">
                         <Page page={pages[activePageId]} tagRenderers={this.props.tagRenderers} />
                     </article>
                 </div>

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -11,6 +11,7 @@ import { FocusStyleManager } from "@blueprintjs/core";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import { CssExample } from "./common/cssExample";
 import { PropsStore } from "./common/propsStore";
 import { resolveDocs } from "./common/resolveDocs";
 import { resolveExample } from "./common/resolveExample";
@@ -38,6 +39,11 @@ const versions = require<string[]>("./generated/versions.json")
         version,
     } as IPackageInfo));
 /* tslint:enable:no-var-requires */
+
+function resolveCssExample(reference: string, key: React.Key) {
+    const example = docs.css[reference];
+    return <CssExample {...example} key={key} />;
+}
 
 const propsStore = new PropsStore(docs.ts);
 function resolveInterface(name: string, key: React.Key) {
@@ -70,6 +76,7 @@ const TAGS = {
     "##": renderHeading(2),
     "###": renderHeading(3),
     "####": renderHeading(4),
+    css: resolveCssExample,
     interface: resolveInterface,
     page: () => undefined as JSX.Element,
     reactDocs: resolveDocs,

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -42,6 +42,9 @@ const versions = require<string[]>("./generated/versions.json")
 
 function resolveCssExample(reference: string, key: React.Key) {
     const example = docs.css[reference];
+    if (example === undefined || example.reference === undefined) {
+        throw new Error(`Unknown @css reference: ${reference}`);
+    }
     return <CssExample {...example} key={key} />;
 }
 

--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -17,9 +17,10 @@ import { resolveExample } from "./common/resolveExample";
 import { PropsTable } from "./components/propsTable";
 import { IPackageInfo, Styleguide } from "./components/styleguide";
 
-import { IDocumentalistData, IPageData, IPageNode, slugify } from "documentalist/dist/client";
+import { IPageData, IPageNode, slugify } from "documentalist/dist/client";
+import { IKssPluginData, IMarkdownPluginData, ITypescriptPluginData } from "documentalist/dist/plugins";
 
-interface IDocsData extends IDocumentalistData {
+interface IDocsData extends IKssPluginData, IMarkdownPluginData, ITypescriptPluginData {
     layout: IPageNode[];
 }
 

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -19,6 +19,18 @@
   @return '[data-section-id#{$comparator}"#{$id}"]';
 }
 
+// Generate a selector for a KSS example by reference
+@function reference($ref, $comparator: "=") {
+  @return '.kss-example-wrapper[data-reference#{$comparator}"#{$ref}"]';
+}
+
+// Generate a selector for KSS examples that match or are nested inside this reference.
+@function reference-all($ref) {
+  // exact reference + children, not a simple prefix.
+  // so "pt-button" captures "pt-button.pt-minimal", not "pt-button-group"
+  @return reference($ref), reference($ref + ".", "^=");
+}
+
 // stylelint-enable string-quotes
 
 // Adjust the flex-basis of examples to fit X per row.
@@ -38,91 +50,34 @@
 
 // Section-Specific Styles
 
-#{section-id("components.button-group")} {
-  .docs-button-group-example-set .pt-button-group {
-    margin-top: $pt-grid-size * 2;
-    margin-left: $pt-grid-size * 2;
-  }
+#{reference("pt-file-upload")},
+#{reference("pt-label")},
+#{reference("pt-menu")},
+#{reference("pt-select.pt-inline")},
+#{reference("pt-skeleton")},
+#{reference("pt-tag")} {
+  @include examples-per-row(2);
 }
 
-#{section-id("components.forms.checkbox")},
-#{section-id("components.forms.radio")},
-#{section-id("components.forms.switch")} {
+#{reference-all("pt-input")},
+#{reference("pt-button")},
+#{reference("pt-button.pt-minimal")},
+#{reference("pt-card")},
+#{reference("pt-progress-bar")},
+#{reference("pt-spinner")},
+#{reference("pt-textarea")} {
+  @include examples-per-row(3);
+}
+
+#{reference("pt-checkbox")},
+#{reference("pt-radio")},
+#{reference("pt-switch")} {
   .kss-example {
     flex-basis: 10%;
   }
 }
 
-#{section-id("icons.ui.non-standard")} {
-  @include examples-per-row(4);
-}
-
-.pt-control-group-example {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-
-  > .pt-control-group:not(:last-child) {
-    margin-bottom: $pt-grid-size * 2;
-  }
-}
-
-#{section-name("Inline controls")} {
-  // override "components.forms.checkbox" above for this one child
-  @include examples-per-row(1);
-}
-
-#{section-name("Vertical Control Groups")} {
-  .pt-control-group {
-    width: $pt-grid-size * 25;
-  }
-}
-
-#{section-name("Labels")},
-#{section-id("components.tag.css")},
-#{section-id("components.menu.css")},
-#{section-id("components.progress.skeleton.css")} {
-  @include examples-per-row(2);
-}
-
-#{section-name("Cards")} > .kss-example-wrapper,
-#{section-name("Text inputs")},
-#{section-id("components.forms.input-group.css")},
-#{section-id("components.button.css")} > .kss-example-wrapper,
-#{section-name("Minimal buttons")} > .kss-example-wrapper,
-#{section-name("Text areas")},
-#{section-name("Selects")},
-#{section-id("components.progress.bar.css")},
-#{section-id("components.progress.spinner.css")} {
-  @include examples-per-row(3);
-}
-
-#{section-name("Selects")} {
-  @include examples-per-row(4);
-
-  .kss-example {
-    padding-right: $pt-grid-size / 2;
-  }
-}
-
-#{section-name("Labeled static dropdown")} {
-  .kss-example-wrapper {
-    justify-content: initial;
-  }
-
-  .kss-example {
-    flex-basis: $pt-grid-size * 25;
-    margin-right: $options-margin;
-  }
-}
-
-#{section-name("Alerts")} {
-  .pt-button + .pt-button {
-    margin-left: $pt-grid-size;
-  }
-}
-
-#{section-name("Buttons")} {
+#{reference-all("pt-button")} {
   // put more space between buttons in all button sections
   .pt-button + .pt-button:not(.pt-fill) {
     margin-left: $pt-grid-size;
@@ -130,6 +85,98 @@
 
   .pt-button.pt-fill + .pt-button.pt-fill {
     margin-top: $pt-grid-size;
+  }
+}
+
+#{reference("pt-button-group.pt-vertical")} {
+  .pt-button-group {
+    margin-right: $pt-grid-size * 2;
+  }
+}
+
+#{reference-all("pt-control-group")} {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .pt-control-group:not(:last-child) {
+    margin-bottom: $pt-grid-size * 2;
+  }
+}
+
+#{reference("pt-input-group")} {
+  .pt-input-group {
+    margin-bottom: $pt-grid-size;
+  }
+}
+
+#{reference("pt-select")} {
+  @include examples-per-row(4);
+
+  .kss-example {
+    padding-right: 0;
+  }
+}
+
+#{reference("pt-select.pt-inline")} {
+  justify-content: initial;
+
+  .kss-example {
+    flex-basis: $pt-grid-size * 25;
+    margin-right: $options-margin;
+  }
+}
+
+#{reference("pt-dialog")} {
+  .kss-example {
+    height: $pt-grid-size * 27;
+  }
+
+  .pt-dialog {
+    top: $content-padding;
+    transform: translateX(50%);
+    z-index: $pt-z-index-base;
+  }
+}
+
+#{reference("pt-menu")},
+#{reference("pt-menu.pt-menu-header")} {
+  justify-content: initial;
+
+  .kss-example {
+    flex-basis: $pt-grid-size * 15;
+    margin-right: $pt-grid-size * 8;
+    padding-right: 0;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+#{reference("pt-spinner")} {
+  .docs-react-example > svg {
+    width: $pt-grid-size * 10;
+    height: $pt-grid-size * 10;
+  }
+}
+
+#{reference("pt-tree")} {
+  .pt-tree {
+    background-color: $white;
+    width: $pt-grid-size * 35;
+
+    .pt-dark & {
+      background-color: $dark-gray4;
+    }
+  }
+}
+
+
+
+#{section-name("Alerts")} {
+  .pt-button + .pt-button {
+    margin-left: $pt-grid-size;
   }
 }
 
@@ -162,12 +209,6 @@
 #{section-id("components.datetime.daterangepicker")} {
   .docs-react-options-column {
     flex: 0 0 270px;
-  }
-}
-
-#{section-name("Text input groups")} {
-  .pt-input-group {
-    margin-bottom: $pt-grid-size;
   }
 }
 
@@ -281,19 +322,6 @@
   }
 }
 
-// static markup examples for js components
-#{section-id("components.dialog.css")} {
-  .kss-example {
-    height: $pt-grid-size * 27;
-  }
-
-  .pt-dialog {
-    top: $content-padding;
-    transform: translateX(50%);
-    z-index: $pt-z-index-base;
-  }
-}
-
 .docs-overlay-example-transition {
   $overlay-example-width: $pt-grid-size * 40;
 
@@ -301,19 +329,6 @@
   left: calc(50% - #{$overlay-example-width / 2});
   z-index: $pt-z-index-overlay + 1;
   width: $overlay-example-width;
-}
-
-#{section-name("Non-ideal State")} {
-  .kss-example-wrapper {
-    padding: $options-margin 0;
-  }
-}
-
-#{section-name("Spinners")} {
-  .docs-react-example > svg {
-    width: $pt-grid-size * 10;
-    height: $pt-grid-size * 10;
-  }
 }
 
 #{section-name("Toasts")} {
@@ -326,82 +341,5 @@
 #{section-name("Popovers")} {
   .pt-label {
     width: $pt-grid-size * 21;
-  }
-}
-
-#{section-id("components.menu.css")},
-#{section-id("components.menu.css.header")},
-#{section-id("components.menu.css.submenu")} {
-  .kss-example-wrapper {
-    justify-content: initial;
-  }
-
-  .kss-example {
-    flex-basis: $pt-grid-size * 15;
-  }
-}
-
-#{section-id("components.menu.css")} {
-  .kss-example {
-    margin-right: $pt-grid-size * 8;
-    padding-right: 0;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
-}
-
-#{section-name("Trees")} {
-  .pt-tree {
-    background-color: $white;
-    width: $pt-grid-size * 35;
-
-    .pt-dark & {
-      background-color: $dark-gray4;
-    }
-  }
-}
-
-@function components-per-row($amount, $margin) {
-  @return ($content-width - $margin * ($amount - 1)) / $amount;
-}
-
-$component-margin: $pt-grid-size * 4;
-
-.docs-components-list {
-  display: flex;
-  flex-wrap: wrap;
-
-  .pt-container {
-    position: relative;
-    margin-right: $component-margin;
-    margin-bottom: $component-margin;
-    width: components-per-row(4, $component-margin);
-    text-decoration: none;
-
-    &:nth-child(4n) {
-      margin-right: 0;
-    }
-
-    &:hover strong {
-      text-decoration: underline;
-    }
-
-    p:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  strong {
-    display: block;
-    margin-bottom: $pt-grid-size;
-    font-size: $pt-font-size-large;
-  }
-
-  .pt-tag {
-    margin-top: $pt-grid-size;
-
-    &.pt-intent-success { float: right; }
   }
 }


### PR DESCRIPTION
#### Addresses #796 

#### Changes proposed in this pull request:

- the first commit updates all the scss and md files in `core` (it's big and repetitive)
  - **scss files:** make them all valid KSS blocks again by adding header and reference.
references are now reflective of the CSS class being documented.
  - **md files:** add `@css reference` tags in all the CSS API sections
- update to documentalist@0.0.3, which includes a `KssPlugin` that does all the work 😮 
- write a theme handler for `@css reference` tags _(voila css examples are back)_
  - reuses the existing structure almost exactly, except references have changed quite significantly, which necessitated:
- ♻️  a major refactor to `_sections.scss` to support changes in how css examples are rendered
  - a new function `reference()` to target these new KSS examples. refactored as many selectors as I could, and removed a bunch of obsolete ones.

TODO

- [x] `pt-running-text` nesting issues
- [ ] syntax highlighting for the markup blocks (markup is missing until palantir/documentalist#16)
- [ ] markdown support in modifier docs (can anyone find broken examples?)

#### Reviewers should focus on:

- do all the CSS examples and modifier tables look good? any rough edges I missed?

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/464822/23733706/44ee7dba-042f-11e7-8c1f-cfc208b35057.png)
