### PR TITLE
Filter out "indeterminate" prop by default

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -82,10 +82,8 @@ export interface IOptionProps extends IProps {
 const INVALID_PROPS = [
     "active",
     "containerRef",
-    "defaultIndeterminate",
     "elementRef",
     "iconName",
-    "indeterminate",
     "inputRef",
     "intent",
     "loading",

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -85,6 +85,7 @@ const INVALID_PROPS = [
     "defaultIndeterminate",
     "elementRef",
     "iconName",
+    "indeterminate",
     "inputRef",
     "intent",
     "loading",

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -52,7 +52,7 @@ export class Control<P extends IControlProps> extends React.Component<React.HTML
         return (
             <label className={className} style={this.props.style}>
                 <input
-                    {...removeNonHTMLProps(this.props, ["children", "indeterminate"], true)}
+                    {...removeNonHTMLProps(this.props, ["children"], true)}
                     ref={inputRef}
                     type={type}
                 />

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -38,6 +38,13 @@ export interface IControlProps extends IProps {
     onChange?: React.FormEventHandler<HTMLInputElement>;
 }
 
+const INVALID_PROPS = [
+    // we spread props to `<input>` but render `children` as its sibling
+    "children",
+    "defaultIndeterminate",
+    "indeterminate",
+];
+
 /** Base Component class for all Controls */
 export class Control<P extends IControlProps> extends React.Component<React.HTMLProps<HTMLInputElement> & P, {}> {
     // generates control markup for given input type.
@@ -49,13 +56,10 @@ export class Control<P extends IControlProps> extends React.Component<React.HTML
             { [Classes.DISABLED]: this.props.disabled },
             this.props.className,
         );
+        const inputProps = removeNonHTMLProps(this.props, INVALID_PROPS, true);
         return (
             <label className={className} style={this.props.style}>
-                <input
-                    {...removeNonHTMLProps(this.props, ["children"], true)}
-                    ref={inputRef}
-                    type={type}
-                />
+                <input {...inputProps} ref={inputRef} type={type} />
                 <span className={Classes.CONTROL_INDICATOR} />
                 {this.props.label}
                 {this.props.children}

--- a/packages/core/test/common/propsTests.ts
+++ b/packages/core/test/common/propsTests.ts
@@ -19,7 +19,6 @@ describe("Props", () => {
                 banana: true,
                 cat: true,
                 containerRef: true,
-                defaultIndeterminate: true,
                 elementRef: true,
                 iconName: true,
                 intent: true,
@@ -39,7 +38,6 @@ describe("Props", () => {
             assert.deepEqual(removeNonHTMLProps(props, ["apple", "banana"]), {
                 cat: true,
                 containerRef: true,
-                defaultIndeterminate: true,
                 elementRef: true,
                 iconName: true,
                 intent: true,


### PR DESCRIPTION
"indeterminate" is not a valid HTML attribute for inputs, so we should filter it out automatically


**Edit:** My original change wasn't necessary on it's own, this PR has been slightly changed in purpose