### PR TITLE
Add select all styles and interactions to table

### DIFF
--- a/packages/table/src/common/_variables.scss
+++ b/packages/table/src/common/_variables.scss
@@ -40,6 +40,7 @@ Cursors
 // Selecting
 $select-column-cursor: s-resize !default;
 $select-row-cursor: e-resize !default;
+$select-table-cursor: se-resize !default;
 $select-cell-cursor: cell !default;
 $select-text-cursor: text !default;
 

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -16,6 +16,10 @@ $resize-handle-dragging-color: $pt-intent-primary !default;
     cursor: $select-row-cursor;
   }
 
+  &.bp-table-menu {
+    cursor: $select-table-cursor;
+  }
+
   .pt-editable-text::before,
   .pt-editable-content {
     cursor: $select-cell-cursor;

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -41,6 +41,7 @@ export enum RegionCardinality {
  */
 export const SelectionModes = {
     ALL: [
+        RegionCardinality.FULL_TABLE,
         RegionCardinality.FULL_COLUMNS,
         RegionCardinality.FULL_ROWS,
         RegionCardinality.CELLS,
@@ -161,6 +162,13 @@ export class Regions {
      */
     public static column(col: number, col2?: number): IRegion  {
         return { cols: this.normalizeInterval(col, col2) };
+    }
+
+    /**
+     * Returns a region containing the entire table.
+     */
+    public static table(): IRegion  {
+        return {};
     }
 
     /**

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -119,6 +119,17 @@ export class Regions {
      *     }
      *
      * In this case, this method would return RegionCardinality.FULL_COLUMNS.
+     *
+     * If both rows and columns are unbounded, then the region covers the
+     * entire table. Therefore, a region like this:
+     *
+     *     {
+     *         rows: null,
+     *         cols: null
+     *     }
+     *
+     * will return RegionCardinality.FULL_TABLE.
+     *
      * An example of a region containing a single cell in the table would be:
      *
      *     {

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -118,7 +118,7 @@ export class Regions {
      *         cols: [1, 2]
      *     }
      *
-     * In this case, this method would return RegionCardinality.FULL_COLUMNS.
+     * In this case, this method would return `RegionCardinality.FULL_COLUMNS`.
      *
      * If both rows and columns are unbounded, then the region covers the
      * entire table. Therefore, a region like this:
@@ -128,7 +128,7 @@ export class Regions {
      *         cols: null
      *     }
      *
-     * will return RegionCardinality.FULL_TABLE.
+     * will return `RegionCardinality.FULL_TABLE`.
      *
      * An example of a region containing a single cell in the table would be:
      *
@@ -137,7 +137,7 @@ export class Regions {
      *         cols: [2, 2]
      *     }
      *
-     * In this case, this method would return RegionCardinality.CELLS.
+     * In this case, this method would return `RegionCardinality.CELLS`.
      */
     public static getRegionCardinality(region: IRegion) {
         if (region.cols != null && region.rows != null) {

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -88,6 +88,9 @@ $menu-z-index: $row-z-index + 1 !default;
 }
 
 .bp-table-row-headers {
+  // let header's height resize based on height of child element
+  display: table;
+
   flex: 0 0 auto;
   // allow absolute position for region overlay
   position: relative;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -870,6 +870,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             switch (cardinality) {
                 case RegionCardinality.FULL_TABLE:
                     style.left = "-1px";
+                    style.borderLeft = "none";
                     style.bottom = "-1px";
                     style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
                     return style;
@@ -897,6 +898,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             switch (cardinality) {
                 case RegionCardinality.FULL_TABLE:
                     style.top = "-1px";
+                    style.borderTop = "none";
                     style.right = "-1px";
                     style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
                     return style;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -386,12 +386,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     public renderHotkeys() {
-        let hotkeys = [this.maybeRenderCopyHotkey(), this.maybeRenderSelectAllHotkey()];
-        // remove null elements
-        hotkeys = hotkeys.filter((element) => element != null);
+        const hotkeys = [this.maybeRenderCopyHotkey(), this.maybeRenderSelectAllHotkey()];
         return (
             <Hotkeys>
-                {hotkeys}
+                {/* filter to remove null elements */}
+                {hotkeys.filter((element) => element !== undefined)}
             </Hotkeys>
         );
     }
@@ -477,12 +476,17 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private renderMenu() {
+        const classes = classNames(Classes.TABLE_MENU, {
+            [Classes.TABLE_SELECTION_ENABLED]: this.isSelectionModeEnabled(RegionCardinality.FULL_TABLE),
+        });
         return (
             <div
-                className={Classes.TABLE_MENU}
+                className={classes}
                 ref={this.setMenuRef}
                 onClick={this.selectAll}
-            />
+            >
+                {this.maybeRenderMenuRegions()}
+            </div>
         );
     }
 
@@ -826,6 +830,33 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         return this.maybeRenderRegions(styler);
     }
 
+    private maybeRenderMenuRegions() {
+        const styler = (region: IRegion): React.CSSProperties => {
+            const { grid } = this;
+            const { viewportRect } = this.state;
+            if (viewportRect == null) {
+                return {};
+            }
+            const cardinality = Regions.getRegionCardinality(region);
+            const style = grid.getRegionStyle(region);
+
+            switch (cardinality) {
+                case RegionCardinality.FULL_TABLE:
+                    style.right = "0px";
+                    style.bottom = "0px";
+                    style.top = "0px";
+                    style.left = "0px";
+                    style.borderBottom = "none";
+                    style.borderRight = "none";
+                    return style;
+
+                default:
+                    return { display: "none" };
+            }
+        };
+        return this.maybeRenderRegions(styler);
+    }
+
     private maybeRenderColumnHeaderRegions() {
         const styler = (region: IRegion): React.CSSProperties => {
             const { grid } = this;
@@ -838,6 +869,10 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
             switch (cardinality) {
                 case RegionCardinality.FULL_TABLE:
+                    style.left = "-1px";
+                    style.bottom = "-1px";
+                    style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
+                    return style;
                 case RegionCardinality.FULL_COLUMNS:
                     style.bottom = "-1px";
                     style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
@@ -861,6 +896,10 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             const style = grid.getRegionStyle(region);
             switch (cardinality) {
                 case RegionCardinality.FULL_TABLE:
+                    style.top = "-1px";
+                    style.right = "-1px";
+                    style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
+                    return style;
                 case RegionCardinality.FULL_ROWS:
                     style.right = "-1px";
                     style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -389,7 +389,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const hotkeys = [this.maybeRenderCopyHotkey(), this.maybeRenderSelectAllHotkey()];
         return (
             <Hotkeys>
-                {/* filter to remove null elements */}
                 {hotkeys.filter((element) => element !== undefined)}
             </Hotkeys>
         );

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -787,7 +787,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             return (
                 <Hotkey
                     key="select-all-hotkey"
-                    label="Select All"
+                    label="Select all"
                     group="Table"
                     combo="mod+a"
                     onKeyDown={this.handleSelectAllHotkey}

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -88,9 +88,7 @@ describe("<Table>", () => {
     });
 
     it("Selects all on click of upper-left corner", () => {
-        const renderCell = () => {
-            return <Cell>gg</Cell>;
-        };
+        const renderCell = () => <Cell>gg</Cell>;
         const onSelection = sinon.spy();
 
         const table = harness.mount(
@@ -109,9 +107,7 @@ describe("<Table>", () => {
     });
 
     it("Resizes selected rows together", () => {
-        const renderCell = () => {
-            return <Cell>gg</Cell>;
-        };
+        const renderCell = () => <Cell>gg</Cell>;
 
         const selectedRegions = [Regions.row(0, 1), Regions.row(4, 6), Regions.row(8)];
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -87,6 +87,27 @@ describe("<Table>", () => {
         rowHeaders.forEach((rowHeader) => expectCellLoading(rowHeader, CellType.ROW_HEADER));
     });
 
+    it("Selects all on click of upper-left corner", () => {
+        const renderCell = () => {
+            return <Cell>gg</Cell>;
+        };
+        const onSelection = sinon.spy();
+
+        const table = harness.mount(
+            <Table
+                onSelection={onSelection}
+                numRows={10}
+            >
+                <Column renderCell={renderCell}/>
+                <Column renderCell={renderCell}/>
+                <Column renderCell={renderCell}/>
+            </Table>,
+        );
+        const menu = table.find(`.${Classes.TABLE_MENU}`);
+        menu.mouse("click");
+        expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
+    });
+
     it("Resizes selected rows together", () => {
         const renderCell = () => {
             return <Cell>gg</Cell>;


### PR DESCRIPTION
#### Changes proposed in this pull request:

Add styles for select-all for table

Added select-all interactions -- clicking on the upper left hand corner, or pressing mod+a 

#### Reviewers should focus on:

The "display: table" style change is weird because I have no idea why it works -- does anyone know a better way to make it have the height of its child? 

The "table" method in regions.ts is one of the most hillarious functions I've ever written. 

I added "full table" selection to all -- should we add a ROWS_COLUMNS_AND_CELLS selection mode to the thing? Or leave as-is? 

#### Screenshot

![mar-10-2017 14-12-46](https://cloud.githubusercontent.com/assets/2463526/23809427/adc3d1b0-059b-11e7-8549-c49ab05a46e4.gif)

