### PR TITLE
[DRP] Assign right and left together, keep them 1 month apart

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -279,7 +279,8 @@ export class DateRangePicker
     public componentWillReceiveProps(nextProps: IDateRangePickerProps) {
         super.componentWillReceiveProps(nextProps);
 
-        const nextState = getStateChange(this.props.value, nextProps.value, this.state, nextProps.contiguousCalendarMonths);
+        const nextState = getStateChange(this.props.value, nextProps.value, this.state,
+            nextProps.contiguousCalendarMonths);
         this.setState(nextState);
     }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -619,7 +619,7 @@ export class DateRangePicker
 function getStateChange(value: DateRange,
                         nextValue: DateRange,
                         state: IDateRangePickerState,
-                        contiguousCalendarMonths: Boolean): IDateRangePickerState {
+                        contiguousCalendarMonths: boolean): IDateRangePickerState {
     let returnVal: IDateRangePickerState;
 
     if (value != null && nextValue == null) {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -279,7 +279,7 @@ export class DateRangePicker
     public componentWillReceiveProps(nextProps: IDateRangePickerProps) {
         super.componentWillReceiveProps(nextProps);
 
-        const nextState = getStateChange(this.props.value, nextProps.value, this.state);
+        const nextState = getStateChange(this.props.value, nextProps.value, this.state, nextProps);
         this.setState(nextState);
     }
 
@@ -515,7 +515,7 @@ export class DateRangePicker
 
     private handleNextState(nextValue: DateRange) {
         const { value } = this.state;
-        const nextState = getStateChange(value, nextValue, this.state);
+        const nextState = getStateChange(value, nextValue, this.state, this.props);
 
         if (!this.isControlled) {
             this.setState(nextState);
@@ -618,7 +618,8 @@ export class DateRangePicker
 
 function getStateChange(value: DateRange,
                         nextValue: DateRange,
-                        state: IDateRangePickerState): IDateRangePickerState {
+                        state: IDateRangePickerState,
+                        props: IDateRangePickerProps): IDateRangePickerState {
     let returnVal: IDateRangePickerState;
 
     if (value != null && nextValue == null) {
@@ -692,9 +693,9 @@ function getStateChange(value: DateRange,
                 if (!leftView.isSame(nextValueStartMonthAndYear)) {
                     leftView = nextValueStartMonthAndYear;
                     rightView = nextValueStartMonthAndYear.getNextMonth();
-                } else if (!rightView.isSame(nextValueEndMonthAndYear)) {
+                }
+                if (!props.contiguousCalendarMonths && !rightView.isSame(nextValueEndMonthAndYear)) {
                     rightView = nextValueEndMonthAndYear;
-                    leftView = nextValueEndMonthAndYear.getPreviousMonth();
                 }
             }
         }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -694,9 +694,7 @@ function getStateChange(value: DateRange,
                     rightView = nextValueStartMonthAndYear.getNextMonth();
                 } else if (!rightView.isSame(nextValueEndMonthAndYear)) {
                     rightView = nextValueEndMonthAndYear;
-                    if (!rightView.isAfter(leftView)) {
-                        leftView = rightView.getPreviousMonth();
-                    }
+                    leftView = rightView.getPreviousMonth();
                 }
             }
         }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -691,9 +691,12 @@ function getStateChange(value: DateRange,
             } else {
                 if (!leftView.isSame(nextValueStartMonthAndYear)) {
                     leftView = nextValueStartMonthAndYear;
-                }
-                if (!rightView.isSame(nextValueEndMonthAndYear)) {
+                    rightView = nextValueStartMonthAndYear.getNextMonth();
+                } else if (!rightView.isSame(nextValueEndMonthAndYear)) {
                     rightView = nextValueEndMonthAndYear;
+                    if (!rightView.isAfter(leftView)) {
+                        leftView = rightView.getPreviousMonth();
+                    }
                 }
             }
         }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -279,7 +279,7 @@ export class DateRangePicker
     public componentWillReceiveProps(nextProps: IDateRangePickerProps) {
         super.componentWillReceiveProps(nextProps);
 
-        const nextState = getStateChange(this.props.value, nextProps.value, this.state, nextProps);
+        const nextState = getStateChange(this.props.value, nextProps.value, this.state, nextProps.contiguousCalendarMonths);
         this.setState(nextState);
     }
 
@@ -515,7 +515,7 @@ export class DateRangePicker
 
     private handleNextState(nextValue: DateRange) {
         const { value } = this.state;
-        const nextState = getStateChange(value, nextValue, this.state, this.props);
+        const nextState = getStateChange(value, nextValue, this.state, this.props.contiguousCalendarMonths);
 
         if (!this.isControlled) {
             this.setState(nextState);
@@ -619,7 +619,7 @@ export class DateRangePicker
 function getStateChange(value: DateRange,
                         nextValue: DateRange,
                         state: IDateRangePickerState,
-                        props: IDateRangePickerProps): IDateRangePickerState {
+                        contiguousCalendarMonths: Boolean): IDateRangePickerState {
     let returnVal: IDateRangePickerState;
 
     if (value != null && nextValue == null) {
@@ -694,7 +694,7 @@ function getStateChange(value: DateRange,
                     leftView = nextValueStartMonthAndYear;
                     rightView = nextValueStartMonthAndYear.getNextMonth();
                 }
-                if (!props.contiguousCalendarMonths && !rightView.isSame(nextValueEndMonthAndYear)) {
+                if (contiguousCalendarMonths === false && !rightView.isSame(nextValueEndMonthAndYear)) {
                     rightView = nextValueEndMonthAndYear;
                 }
             }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -694,7 +694,7 @@ function getStateChange(value: DateRange,
                     rightView = nextValueStartMonthAndYear.getNextMonth();
                 } else if (!rightView.isSame(nextValueEndMonthAndYear)) {
                     rightView = nextValueEndMonthAndYear;
-                    leftView = rightView.getPreviousMonth();
+                    leftView = nextValueEndMonthAndYear.getPreviousMonth();
                 }
             }
         }

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -606,8 +606,8 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(dateRange[1], onDateRangePickerChangeSpy.args[0][0][1]));
         });
         
-        it("custom shortcuts set the displayed months correctly", () => {
-            const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.DECEMBER, 31)] as DateRange;
+        it("custom shortcuts set the displayed months correctly when start month changes", () => {
+            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
             renderDateRangePicker({
                 initialMonth: new Date(2015, Months.JANUARY, 1),
                 shortcuts: [{label: "custom shortcut", dateRange}],
@@ -616,9 +616,24 @@ describe("<DateRangePicker>", () => {
             clickFirstShortcut();
             assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.JANUARY);
-            assert.equal(dateRangePicker.state.leftView.getYear(), 2015);
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2016);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.FEBRUARY);
-            assert.equal(dateRangePicker.state.rightView.getYear(), 2015);
+            assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
+        });
+
+        it("custom shortcuts set the displayed months correctly when start month stays the same, but end month changes", () => {
+            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
+            renderDateRangePicker({
+                initialMonth: new Date(2016, Months.JANUARY, 1),
+                shortcuts: [{label: "custom shortcut", dateRange}],
+            });
+
+            clickFirstShortcut();
+            assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.NOVEMBER);
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2016);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.DECEMBER);
+            assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
         });
     });
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -605,7 +605,7 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(dateRange[0], onDateRangePickerChangeSpy.args[0][0][0]));
             assert.isTrue(DateUtils.areSameDay(dateRange[1], onDateRangePickerChangeSpy.args[0][0][1]));
         });
-        
+
         it("custom shortcuts set the displayed months correctly when start month changes", () => {
             const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
             renderDateRangePicker({
@@ -621,7 +621,8 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
         });
 
-        it("custom shortcuts set the displayed months correctly when start month stays the same, but end month changes", () => {
+        it("custom shortcuts set the displayed months correctly " +
+            "when start month stays the same, but end month changes", () => {
             const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
             renderDateRangePicker({
                 initialMonth: new Date(2016, Months.JANUARY, 1),

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -621,8 +621,24 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
         });
 
-        it("custom shortcuts set the displayed months correctly " +
-            "when start month stays the same, but end month changes", () => {
+        it("custom shortcuts set the displayed months correctly when start month changes " +
+            "and contiguousCalendarMonths is false", () => {
+            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
+            renderDateRangePicker({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+                shortcuts: [{label: "custom shortcut", dateRange}],
+                contiguousCalendarMonths: false,
+            });
+
+            clickFirstShortcut();
+            assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.JANUARY);
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2016);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.DECEMBER);
+            assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
+        });
+
+        it("custom shortcuts set the displayed months correctly when start month stays the same", () => {
             const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
             renderDateRangePicker({
                 initialMonth: new Date(2016, Months.JANUARY, 1),
@@ -631,9 +647,15 @@ describe("<DateRangePicker>", () => {
 
             clickFirstShortcut();
             assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
-            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.NOVEMBER);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.JANUARY);
             assert.equal(dateRangePicker.state.leftView.getYear(), 2016);
-            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.DECEMBER);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.FEBRUARY);
+            assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
+
+            clickFirstShortcut();
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.JANUARY);
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2016);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.FEBRUARY);
             assert.equal(dateRangePicker.state.rightView.getYear(), 2016);
         });
     });

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -625,9 +625,9 @@ describe("<DateRangePicker>", () => {
             "and contiguousCalendarMonths is false", () => {
             const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
             renderDateRangePicker({
+                contiguousCalendarMonths: false,
                 initialMonth: new Date(2015, Months.JANUARY, 1),
                 shortcuts: [{label: "custom shortcut", dateRange}],
-                contiguousCalendarMonths: false,
             });
 
             clickFirstShortcut();

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -605,6 +605,21 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(dateRange[0], onDateRangePickerChangeSpy.args[0][0][0]));
             assert.isTrue(DateUtils.areSameDay(dateRange[1], onDateRangePickerChangeSpy.args[0][0][1]));
         });
+        
+        it("custom shortcuts set the displayed months correctly", () => {
+            const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.DECEMBER, 31)] as DateRange;
+            renderDateRangePicker({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+                shortcuts: [{label: "custom shortcut", dateRange}],
+            });
+
+            clickFirstShortcut();
+            assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.JANUARY);
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2015);
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.FEBRUARY);
+            assert.equal(dateRangePicker.state.rightView.getYear(), 2015);
+        });
     });
 
     describe("when uncontrolled", () => {


### PR DESCRIPTION
#### Fixes #829 

#### Changes proposed in this pull request:

1. During getStateChange, when setting a date range that spans months, left view and right view are kept only 1 month apart. Previous to this fix, the right view would get set to the end month of the range even though the start month and the following month are what gets displayed in the component. This then causes a no-op the following round trip through when selecting a single date range that lies within the previous range's end month.

#### Reviewers should focus on:

Behavior with other settings like `contiguousCalendarMonths`, but that is not taken into account throughout the existing code.

#### Screenshots

Selected "Past 3 months"
<img width="644" alt="screen shot 2017-03-12 at 6 20 26 pm" src="https://cloud.githubusercontent.com/assets/759752/23838230/a1882192-0750-11e7-80b5-5942e1bc25d1.png">

Selected "Past week"
<img width="653" alt="screen shot 2017-03-12 at 6 20 34 pm" src="https://cloud.githubusercontent.com/assets/759752/23838231/a3599cc6-0750-11e7-9f2a-62be9542f50e.png">

