### PR TITLE
Slider labelStepSize=0 hides axis labels

### DIFF
--- a/packages/core/examples/sliderExample.tsx
+++ b/packages/core/examples/sliderExample.tsx
@@ -47,7 +47,7 @@ export class SliderExample extends BaseExample<ISliderExampleState> {
                     min={-12}
                     max={48}
                     stepSize={6}
-                    labelStepSize={10}
+                    labelStepSize={0}
                     onChange={this.getChangeHandler("value3")}
                     renderLabel={this.renderLabel3}
                     showTrackFill={false}

--- a/packages/core/examples/sliderExample.tsx
+++ b/packages/core/examples/sliderExample.tsx
@@ -30,7 +30,7 @@ export class SliderExample extends BaseExample<ISliderExampleState> {
                     min={0}
                     max={10}
                     stepSize={0.1}
-                    labelStepSize={10}
+                    labelStepSize={5}
                     onChange={this.getChangeHandler("value2")}
                     value={this.state.value2}
                 />

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -23,7 +23,7 @@ export interface ICoreSliderProps extends IProps {
 
     /**
      * Increment between successive labels.
-     * Special value of `0` will render only `min` and `max` labels.
+     * Special value of `0` will render only `min` and `max` labels (nothing in between).
      * @default 1
      */
     labelStepSize?: number;
@@ -126,8 +126,12 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
 
     private maybeRenderAxis() {
         const { max, min } = this.props;
-        const labelStepSize = this.props.labelStepSize || (max - min);
-        if (this.props.renderLabel === false) {
+        let { labelStepSize } = this.props;
+        if (labelStepSize === 0) {
+            labelStepSize = (max - min);
+        }
+        // ensure we never have 0 step size, which causes infinite loop
+        if (this.props.renderLabel === false || labelStepSize === 0) {
             return undefined;
         }
 

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -23,6 +23,7 @@ export interface ICoreSliderProps extends IProps {
 
     /**
      * Increment between successive labels.
+     * Special value of `0` will render only `min` and `max` labels.
      * @default 1
      */
     labelStepSize?: number;
@@ -124,8 +125,11 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
     }
 
     private maybeRenderAxis() {
-        const { max, min, labelStepSize } = this.props;
-        if (this.props.renderLabel === false) { return undefined; }
+        const { max, min } = this.props;
+        const labelStepSize = this.props.labelStepSize || (max - min);
+        if (this.props.renderLabel === false) {
+            return undefined;
+        }
 
         const stepSize = Math.round(this.state.tickSize * labelStepSize);
         const labels: JSX.Element[] = [];

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -22,8 +22,8 @@ export interface ICoreSliderProps extends IProps {
     disabled?: boolean;
 
     /**
-     * Increment between successive labels.
-     * Special value of `0` will render only `min` and `max` labels (nothing in between).
+     * Increment between successive labels along the slider axis.
+     * Passing `0` will hide all axis labels, but handle labels will still appear.
      * @default 1
      */
     labelStepSize?: number;
@@ -125,11 +125,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
     }
 
     private maybeRenderAxis() {
-        const { max, min } = this.props;
-        let { labelStepSize } = this.props;
-        if (labelStepSize === 0) {
-            labelStepSize = (max - min);
-        }
+        const { labelStepSize, max, min } = this.props;
         // ensure we never have 0 step size, which causes infinite loop
         if (this.props.renderLabel === false || labelStepSize === 0) {
             return undefined;

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -34,21 +34,21 @@ describe("<Slider>", () => {
     it("renders label for value and for each labelStepSize", () => {
         // [0  10  20  30  40  50]  +  value
         const wrapper = renderSlider(<Slider min={0} max={50} labelStepSize={10} />);
-        assert.lengthOf(wrapper.find(`.${Classes.SLIDER}-label`), 7);
+        assert.lengthOf(wrapper.find(`.${Classes.SLIDER_LABEL}`), 7);
     });
 
     it("renders all labels even when floating point approx would cause the last one to be skipped", () => {
         // [0  0.14  0.28  0.42  0.56  0.70]  +  value
         const wrapper = renderSlider(<Slider min={0} max={0.7} labelStepSize={0.14}/>);
-        assert.lengthOf(wrapper.find(`.${Classes.SLIDER}-label`), 7);
+        assert.lengthOf(wrapper.find(`.${Classes.SLIDER_LABEL}`), 7);
     });
 
     it("labelStepSize=0 renders only min and max axis labels", () => {
         const wrapper = renderSlider(<Slider min={10} max={20} labelStepSize={0}/>);
-        const labels = wrapper.find(`.${Classes.SLIDER}-label`);
-        assert.lengthOf(labels, 3);
-        assert.equal(labels.at(0).text(), "10"); // min label
-        assert.equal(labels.at(1).text(), "20"); // max label
+        const labels = wrapper.find(`.${Classes.SLIDER}-axis .${Classes.SLIDER_LABEL}`);
+        assert.lengthOf(labels, 2);
+        assert.equal(labels.first().text(), "10"); // min label
+        assert.equal(labels.last().text(), "20"); // max label
     });
 
     it("renders result of renderLabel() in each label", () => {
@@ -59,7 +59,7 @@ describe("<Slider>", () => {
 
     it("renderLabel={false} removes all labels", () => {
         const wrapper = renderSlider(<Slider renderLabel={false} />);
-        assert.lengthOf(wrapper.find(`.${Classes.SLIDER}-label`), 0);
+        assert.lengthOf(wrapper.find(`.${Classes.SLIDER_LABEL}`), 0);
     });
 
     it("moving mouse calls onChange with nearest value", () => {

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -43,6 +43,14 @@ describe("<Slider>", () => {
         assert.lengthOf(wrapper.find(`.${Classes.SLIDER}-label`), 7);
     });
 
+    it("labelStepSize=0 renders only min and max axis labels", () => {
+        const wrapper = renderSlider(<Slider min={10} max={20} labelStepSize={0}/>);
+        const labels = wrapper.find(`.${Classes.SLIDER}-label`);
+        assert.lengthOf(labels, 3);
+        assert.equal(labels.at(0).text(), "10"); // min label
+        assert.equal(labels.at(1).text(), "20"); // max label
+    });
+
     it("renders result of renderLabel() in each label", () => {
         const renderLabel = (val: number) => val + "#";
         const wrapper = renderSlider(<Slider min={0} max={50} labelStepSize={10} renderLabel={renderLabel} />);

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -43,12 +43,10 @@ describe("<Slider>", () => {
         assert.lengthOf(wrapper.find(`.${Classes.SLIDER_LABEL}`), 7);
     });
 
-    it("labelStepSize=0 renders only min and max axis labels", () => {
+    it("labelStepSize=0 hides all axis labels", () => {
         const wrapper = renderSlider(<Slider min={10} max={20} labelStepSize={0}/>);
-        const labels = wrapper.find(`.${Classes.SLIDER}-axis .${Classes.SLIDER_LABEL}`);
-        assert.lengthOf(labels, 2);
-        assert.equal(labels.first().text(), "10"); // min label
-        assert.equal(labels.last().text(), "20"); // max label
+        const labels = wrapper.find(`.${Classes.SLIDER_LABEL}`);
+        assert.lengthOf(labels, 1); // value label only
     });
 
     it("renders result of renderLabel() in each label", () => {


### PR DESCRIPTION
#### Fixes #828

#### Changes proposed in this pull request:

passing `labelStepSize={0}` will hide all axis labels (like they're infinitely close together and they all got sucked into a black hole ⚫️).
all labels can be disabled entirely with `renderLabel={false}`, but this option allows for handle labels only!

#### Reviewers should focus on:

is this weird? or is it cool?

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/464822/23882551/9e78d086-081e-11e7-8877-f01b07df3a19.png)
^ note the lack of axis labels on the third one 🙌 