### PR TITLE
Slider labelPrecision

### DIFF
--- a/packages/core/examples/sliderExample.tsx
+++ b/packages/core/examples/sliderExample.tsx
@@ -19,7 +19,7 @@ export interface ISliderExampleState {
 export class SliderExample extends BaseExample<ISliderExampleState> {
     public state: ISliderExampleState = {
         value1: 0,
-        value2: 25,
+        value2: 2.5,
         value3: 30,
     };
 
@@ -28,8 +28,8 @@ export class SliderExample extends BaseExample<ISliderExampleState> {
             <div style={{ width: "100%" }}>
                 <Slider
                     min={0}
-                    max={100}
-                    stepSize={1}
+                    max={10}
+                    stepSize={0.1}
                     labelStepSize={10}
                     onChange={this.getChangeHandler("value2")}
                     value={this.state.value2}

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -57,12 +57,20 @@ export function approxEqual(a: number, b: number, tolerance = 0.00001) {
     return Math.abs(a - b) <= tolerance;
 }
 
-/* Clamps the given number between min and max values. Returns value if within range, or closest bound. */
+/** Clamps the given number between min and max values. Returns value if within range, or closest bound. */
 export function clamp(val: number, min: number, max: number) {
     if (max < min) {
         throw new Error("clamp: max cannot be less than min");
     }
     return Math.min(Math.max(val, min), max);
+}
+
+/** Returns the number of decimal places in the given number. */
+export function countDecimalPlaces(num: number) {
+    if (typeof num !== "number" || Math.floor(num) === num) {
+        return 0;
+    }
+    return num.toString().split(".")[1].length;
 }
 
 /**

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
-import { approxEqual, isFunction } from "../../common/utils";
+import { approxEqual, countDecimalPlaces, isFunction } from "../../common/utils";
 
 export interface ICoreSliderProps extends IProps {
     /**
@@ -190,11 +190,4 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
             this.setState({ tickSize });
         }
     }
-}
-
-function countDecimalPlaces(num: number) {
-    if (Math.floor(num) === num) {
-        return 0;
-    }
-    return num.toString().split(".")[1].length;
 }

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -179,7 +179,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
 
     private getLabelPrecision({ labelPrecision, stepSize }: P) {
         // infer default label precision from stepSize because that's how much the handle moves.
-        return (labelPrecision === undefined)
+        return (labelPrecision == null)
             ? countDecimalPlaces(stepSize)
             : labelPrecision;
     }

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -28,6 +28,12 @@ export interface ICoreSliderProps extends IProps {
     labelStepSize?: number;
 
     /**
+     * Number of decimal places to use when rendering label value.
+     * @default inferred from stepSize
+     */
+    labelPrecision?: number;
+
+    /**
      * Maximum value of the slider.
      * @default 10
      */
@@ -54,10 +60,11 @@ export interface ICoreSliderProps extends IProps {
 
     /**
      * Callback to render a single label. Useful for formatting numbers as currency or percentages.
-     * If `true`, labels will use number value. If `false`, labels will not be shown.
+     * If `true`, labels will use number value formatted to `labelPrecision` decimal places.
+     * If `false`, labels will not be shown.
      * @default true
      */
-    renderLabel?: ((value: number) => string | JSX.Element) | boolean;
+    renderLabel?: boolean | ((value: number) => string | JSX.Element);
 }
 
 export interface ISliderState {
@@ -119,7 +126,12 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
         } else if (isFunction(renderLabel)) {
             return renderLabel(value);
         } else {
-            return value;
+            const { labelPrecision, stepSize } = this.props;
+            // infer default label precision from stepSize because that's how much the handle moves.
+            const precision = (labelPrecision === undefined)
+                ? countDecimalPlaces(stepSize)
+                : labelPrecision;
+            return value.toFixed(precision);
         }
     }
 
@@ -167,4 +179,11 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractCom
             this.setState({ tickSize });
         }
     }
+}
+
+function countDecimalPlaces(num: number) {
+    if (Math.floor(num) === num) {
+        return 0;
+    }
+    return num.toString().split(".")[1].length;
 }

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -53,7 +53,7 @@ describe("<Slider>", () => {
         const wrapper = renderSlider(<Slider labelPrecision={1} value={0.99 / 10} />);
         const labelText = wrapper.find(`.${Classes.SLIDER_HANDLE} .${Classes.SLIDER_LABEL}`).text();
         assert.strictEqual(labelText, "0.1");
-    })
+    });
 
     it("infers precision of default renderLabel from stepSize", () => {
         const wrapper = renderSlider(<Slider stepSize={0.01} />);

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -14,7 +14,7 @@ import { Handle } from "../../src/components/slider/handle";
 import { Classes, Slider } from "../../src/index";
 import { dispatchMouseEvent, dispatchTouchEvent } from "../common/utils";
 
-describe("<Slider>", () => {
+describe.only("<Slider>", () => {
     let testsContainerElement: HTMLElement;
 
     beforeEach(() => {
@@ -47,6 +47,17 @@ describe("<Slider>", () => {
         const renderLabel = (val: number) => val + "#";
         const wrapper = renderSlider(<Slider min={0} max={50} labelStepSize={10} renderLabel={renderLabel} />);
         assert.strictEqual(wrapper.find(`.${Classes.SLIDER}-axis`).text(), "0#10#20#30#40#50#");
+    });
+
+    it("default renderLabel() fixes decimal places to labelPrecision", () => {
+        const wrapper = renderSlider(<Slider labelPrecision={1} value={0.99 / 10} />);
+        const labelText = wrapper.find(`.${Classes.SLIDER_HANDLE} .${Classes.SLIDER_LABEL}`).text();
+        assert.strictEqual(labelText, "0.1");
+    })
+
+    it("infers precision of default renderLabel from stepSize", () => {
+        const wrapper = renderSlider(<Slider stepSize={0.01} />);
+        assert.strictEqual(wrapper.state("labelPrecision"), 2);
     });
 
     it("renderLabel={false} removes all labels", () => {

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -14,7 +14,7 @@ import { Handle } from "../../src/components/slider/handle";
 import { Classes, Slider } from "../../src/index";
 import { dispatchMouseEvent, dispatchTouchEvent } from "../common/utils";
 
-describe.only("<Slider>", () => {
+describe("<Slider>", () => {
     let testsContainerElement: HTMLElement;
 
     beforeEach(() => {


### PR DESCRIPTION
#### Fixes #725 

#### Changes proposed in this pull request:

- `Slider` `labelPrecision` prop for default label formatting
- default value is inferred from `stepSize` prop
- store actual value in state to avoid recomputing it for every label render
- new util `countDecimalPlaces(num)`
