### PR TITLE
[Table] Delete special styles for last cells in row

### DIFF
--- a/packages/table/src/cell/_borders.scss
+++ b/packages/table/src/cell/_borders.scss
@@ -81,18 +81,8 @@ for all borders with minimal duplication. See the bottom of this file.
   }
 
   .bp-table-body {
-    .bp-table-last-in-row {
-      box-shadow: inset 0 (-$border-width) 0 $border-color,
-                  $border-width 0 0 $border-color;
-    }
-
     .bp-table-last-in-column {
       box-shadow: inset (-$border-width) 0 0 $border-color,
-                  0 $border-width 0 $border-color;
-    }
-
-    .bp-table-last-in-row.bp-table-last-in-column {
-      box-shadow: $border-width 0 0 $border-color,
                   0 $border-width 0 $border-color;
     }
   }


### PR DESCRIPTION
#### Fixes #628, Partly addresses #516 


#### Changes proposed in this pull request:

Delete special styles for last cell in row and last cell in table. These styles were presumably present to hide borders appropriately when cells filled the table horizontally, but the styles didn't actually look perfect in that case. Removing them looks generally better all around.

#### Reviewers should focus on:

- Are you okay with the After style in each screenshot? (@themadcreator would love your thoughts especially)
- Am I missing any edge cases?

#### Screenshot

##### Chrome

_Before:_
![before3](https://cloud.githubusercontent.com/assets/443450/23919522/5fb83ddc-08b4-11e7-9d6b-610ecaf0558f.png)
![before2](https://cloud.githubusercontent.com/assets/443450/23919524/5fb9d890-08b4-11e7-8727-2a8227e0649f.png)
![before1](https://cloud.githubusercontent.com/assets/443450/23919523/5fb8862a-08b4-11e7-9b53-1d1e97ddb687.png)

_After:_
![after3](https://cloud.githubusercontent.com/assets/443450/23919545/6e750ff8-08b4-11e7-8d5d-b7f38c3966de.png)
![after2](https://cloud.githubusercontent.com/assets/443450/23919547/6e79cc64-08b4-11e7-9887-e7c7b628fc2b.png)
![after1](https://cloud.githubusercontent.com/assets/443450/23919546/6e76c4f6-08b4-11e7-8916-97cccd302eb1.png)

##### Firefox

_Before:_
![image](https://cloud.githubusercontent.com/assets/443450/23920041/6327f79e-08b6-11e7-8c85-f588b79f846e.png)
![image](https://cloud.githubusercontent.com/assets/443450/23920099/944be7f4-08b6-11e7-9745-acc4413290ba.png)
![image](https://cloud.githubusercontent.com/assets/443450/23920078/883cf084-08b6-11e7-8b69-f97cfc769fd3.png)

_After:_
![image](https://cloud.githubusercontent.com/assets/443450/23919987/26e382ee-08b6-11e7-970f-4853ce7ba1c9.png)
![image](https://cloud.githubusercontent.com/assets/443450/23920002/357fcec0-08b6-11e7-9b15-5fe7d38d05b2.png)
![image](https://cloud.githubusercontent.com/assets/443450/23919975/1a6750d6-08b6-11e7-9b18-a3a3d7cbce1f.png)

Note: This PR also partly addresses #516:
![image](https://cloud.githubusercontent.com/assets/443450/23920387/a503e73a-08b7-11e7-9bd4-64925d4fc974.png)
