### PR TITLE
Prepare Release 1.12.0

### DIFF
--- a/docs/blueprint-landing.css
+++ b/docs/blueprint-landing.css
@@ -1,8 +1,10 @@
 @charset "UTF-8";
-/** Copyright 2015 Palantir Technologies, Inc. All rights reserved.
-// Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
-// of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
-// and https://github.com/palantir/blueprint/blob/master/PATENTS */
+/**
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
 html {
   -moz-box-sizing: border-box;
        box-sizing: border-box; }
@@ -4036,7 +4038,7 @@ a.pt-button {
       border-radius: 3px;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      width: 70px;
+      width: 71px;
       height: 30px;
       padding: 0 10px;
       text-align: center;
@@ -4123,6 +4125,8 @@ a.pt-button {
         box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
         background-color: #202b33;
         background-image: none; }
+  .pt-file-upload.pt-fill {
+    width: 100%; }
 
 .pt-form-group {
   display: -webkit-flex;

--- a/docs/blueprint-landing.js
+++ b/docs/blueprint-landing.js
@@ -94,9 +94,9 @@
 	"use strict";
 	var core_1 = __webpack_require__(17);
 	core_1.FocusStyleManager.onlyShowFocusOnTabs();
-	var Logo = __webpack_require__(283);
+	var Logo = __webpack_require__(284);
 	Logo.init(document.querySelector("header canvas.pt-logo"), document.querySelector("header canvas.pt-logo-background"));
-	var SVGs = __webpack_require__(284);
+	var SVGs = __webpack_require__(285);
 	SVGs.init(document.querySelector(".pt-wireframes"));
 	var copyright = ".pt-copyright .pt-container > div:first-child";
 	document.querySelector(copyright).innerHTML = "\u00A9 2014\u2013" + new Date().getFullYear() + " Palantir Technologies";
@@ -116,12 +116,13 @@
 	function __export(m) {
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
+	Object.defineProperty(exports, "__esModule", { value: true });
 	__export(__webpack_require__(18));
 	__export(__webpack_require__(21));
 	__export(__webpack_require__(63));
-	var iconClasses_1 = __webpack_require__(281);
+	var iconClasses_1 = __webpack_require__(282);
 	exports.IconClasses = iconClasses_1.IconClasses;
-	var iconStrings_1 = __webpack_require__(282);
+	var iconStrings_1 = __webpack_require__(283);
 	exports.IconContents = iconStrings_1.IconContents;
 
 	//# sourceMappingURL=index.js.map
@@ -141,6 +142,7 @@
 	function __export(m) {
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
+	Object.defineProperty(exports, "__esModule", { value: true });
 	__export(__webpack_require__(19));
 
 	//# sourceMappingURL=index.js.map
@@ -157,6 +159,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var interactionMode_1 = __webpack_require__(20);
 	exports.FOCUS_DISABLED_CLASS = "pt-focus-disabled";
 	/* istanbul ignore next */
@@ -191,6 +194,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var TAB_KEY_CODE = 9;
 	/* istanbul ignore next */
 	/**
@@ -257,6 +261,7 @@
 	function __export(m) {
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
+	Object.defineProperty(exports, "__esModule", { value: true });
 	__export(__webpack_require__(22));
 	__export(__webpack_require__(55));
 	__export(__webpack_require__(56));
@@ -285,6 +290,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	/**
@@ -323,8 +329,8 @@
 	     * All stored timeouts will be cleared when component unmounts.
 	     * @returns a "cancel" function that will clear timeout when invoked.
 	     */
-	    AbstractComponent.prototype.setTimeout = function (handler, timeout) {
-	        var handle = setTimeout(handler, timeout);
+	    AbstractComponent.prototype.setTimeout = function (callback, timeout) {
+	        var handle = setTimeout(callback, timeout);
 	        this.timeoutIds.push(handle);
 	        return function () { return clearTimeout(handle); };
 	    };
@@ -4622,6 +4628,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.Colors = {
 	    BLACK: "#10161A",
 	    BLUE1: "#0E5A8A",
@@ -4726,6 +4733,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	/**
 	 * The four basic intents.
 	 */
@@ -4752,6 +4760,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var Position;
 	(function (Position) {
 	    Position[Position["TOP_LEFT"] = 0] = "TOP_LEFT";
@@ -4794,12 +4803,12 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	/** A collection of curated prop keys used across our Components which are not valid HTMLElement props. */
 	var INVALID_PROPS = [
 	    "active",
 	    "containerRef",
-	    "defaultIndeterminate",
 	    "elementRef",
 	    "iconName",
 	    "inputRef",
@@ -4849,6 +4858,8 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
+	var tslib_1 = __webpack_require__(23);
 	var position_1 = __webpack_require__(57);
 	var DEFAULT_CONSTRAINTS = {
 	    attachment: "together",
@@ -4863,19 +4874,13 @@
 	    appendChild: function () { },
 	};
 	/** @internal */
-	function createTetherOptions(element, target, position, useSmartPositioning, constraints) {
-	    if (constraints == null && useSmartPositioning) {
-	        constraints = [DEFAULT_CONSTRAINTS];
+	function createTetherOptions(element, target, position, useSmartPositioning, tetherOptions) {
+	    if (tetherOptions === void 0) { tetherOptions = {}; }
+	    if (tetherOptions.constraints == null && useSmartPositioning) {
+	        tetherOptions.constraints = [DEFAULT_CONSTRAINTS];
 	    }
-	    var options = {
-	        attachment: getPopoverAttachment(position),
-	        bodyElement: fakeHtmlElement,
-	        classPrefix: "pt-tether",
-	        constraints: constraints,
-	        element: element,
-	        target: target,
-	        targetAttachment: getTargetAttachment(position),
-	    };
+	    var options = tslib_1.__assign({}, tetherOptions, { attachment: getPopoverAttachment(position), bodyElement: fakeHtmlElement, classPrefix: "pt-tether", element: element,
+	        target: target, targetAttachment: getTargetAttachment(position) });
 	    return options;
 	}
 	exports.createTetherOptions = createTetherOptions;
@@ -4945,6 +4950,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var intent_1 = __webpack_require__(56);
 	// modifiers
 	exports.DARK = "pt-dark";
@@ -5120,6 +5126,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.TAB = 9;
 	exports.ENTER = 13;
 	exports.SHIFT = 16;
@@ -5144,16 +5151,19 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	/** Returns whether `process.env.NODE_ENV` exists and equals `env`. */
 	function isNodeEnv(env) {
 	    return typeof process !== "undefined" && process.env && process.env.NODE_ENV === env;
 	}
 	exports.isNodeEnv = isNodeEnv;
 	/** Returns whether the value is a function. Acts as a type guard. */
+	// tslint:disable-next-line:ban-types
 	function isFunction(value) {
 	    return typeof value === "function";
 	}
 	exports.isFunction = isFunction;
+	// tslint:disable-next-line:ban-types
 	function safeInvoke(func) {
 	    var args = [];
 	    for (var _i = 1; _i < arguments.length; _i++) {
@@ -5188,7 +5198,7 @@
 	    return Math.abs(a - b) <= tolerance;
 	}
 	exports.approxEqual = approxEqual;
-	/* Clamps the given number between min and max values. Returns value if within range, or closest bound. */
+	/** Clamps the given number between min and max values. Returns value if within range, or closest bound. */
 	function clamp(val, min, max) {
 	    if (max < min) {
 	        throw new Error("clamp: max cannot be less than min");
@@ -5196,6 +5206,14 @@
 	    return Math.min(Math.max(val, min), max);
 	}
 	exports.clamp = clamp;
+	/** Returns the number of decimal places in the given number. */
+	function countDecimalPlaces(num) {
+	    if (typeof num !== "number" || Math.floor(num) === num) {
+	        return 0;
+	    }
+	    return num.toString().split(".")[1].length;
+	}
+	exports.countDecimalPlaces = countDecimalPlaces;
 	/**
 	 * Throttle an event on an EventTarget by wrapping it in `requestAnimationFrame` call.
 	 * Returns the event handler that was bound to given eventName so you can clean up after yourself.
@@ -5238,9 +5256,11 @@
 	function __export(m) {
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
+	Object.defineProperty(exports, "__esModule", { value: true });
 	if (typeof window !== "undefined" && typeof document !== "undefined") {
 	    // tslint:disable-next-line:no-var-requires
 	    __webpack_require__(64); // only import actual dom4 if we're in the browser (not server-compatible)
+	    // we'll still need dom4 types for the TypeScript to compile, these are included in package.json
 	}
 	var contextMenu = __webpack_require__(65);
 	exports.ContextMenu = contextMenu;
@@ -5262,27 +5282,28 @@
 	__export(__webpack_require__(243));
 	__export(__webpack_require__(260));
 	__export(__webpack_require__(217));
-	__export(__webpack_require__(212));
 	__export(__webpack_require__(261));
-	__export(__webpack_require__(231));
+	__export(__webpack_require__(212));
 	__export(__webpack_require__(262));
+	__export(__webpack_require__(231));
 	__export(__webpack_require__(263));
 	__export(__webpack_require__(264));
-	__export(__webpack_require__(267));
-	__export(__webpack_require__(237));
+	__export(__webpack_require__(265));
 	__export(__webpack_require__(268));
+	__export(__webpack_require__(237));
 	__export(__webpack_require__(269));
 	__export(__webpack_require__(270));
 	__export(__webpack_require__(271));
 	__export(__webpack_require__(272));
 	__export(__webpack_require__(273));
 	__export(__webpack_require__(274));
-	__export(__webpack_require__(276));
+	__export(__webpack_require__(275));
 	__export(__webpack_require__(277));
 	__export(__webpack_require__(278));
-	__export(__webpack_require__(232));
 	__export(__webpack_require__(279));
+	__export(__webpack_require__(232));
 	__export(__webpack_require__(280));
+	__export(__webpack_require__(281));
 
 	//# sourceMappingURL=index.js.map
 
@@ -6286,6 +6307,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var ReactDOM = __webpack_require__(66);
@@ -23733,6 +23755,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -23783,12 +23806,31 @@
 	                _this.isContentMounting = false;
 	            }
 	        };
+	        _this.handleTargetFocus = function (e) {
+	            if (_this.props.openOnTargetFocus && _this.isHoverInteractionKind()) {
+	                _this.handleMouseEnter(e);
+	            }
+	        };
+	        _this.handleTargetBlur = function (e) {
+	            if (_this.props.openOnTargetFocus && _this.isHoverInteractionKind()) {
+	                // if the next element to receive focus is within the popover, we'll want to leave the
+	                // popover open. we must do this check *after* the next element focuses, so we use a
+	                // timeout of 0 to flush the rest of the event queue before proceeding.
+	                _this.setTimeout(function () {
+	                    var popoverElement = _this.popoverElement;
+	                    if (popoverElement == null || !popoverElement.contains(document.activeElement)) {
+	                        _this.handleMouseLeave(e);
+	                    }
+	                }, 0);
+	            }
+	        };
 	        _this.handleMouseEnter = function (e) {
 	            // if we're entering the popover, and the mode is set to be HOVER_TARGET_ONLY, we want to manually
 	            // trigger the mouse leave event, as hovering over the popover shouldn't count.
 	            if (_this.props.inline
 	                && _this.isElementInPopover(e.target)
-	                && _this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY) {
+	                && _this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY
+	                && !_this.props.openOnTargetFocus) {
 	                _this.handleMouseLeave(e);
 	            }
 	            else if (!_this.props.isDisabled) {
@@ -23840,38 +23882,43 @@
 	        return _this;
 	    }
 	    Popover.prototype.render = function () {
-	        var _a = this.props, className = _a.className, interactionKind = _a.interactionKind;
+	        var className = this.props.className;
 	        var targetProps;
-	        if (interactionKind === PopoverInteractionKind.HOVER
-	            || interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY) {
+	        if (this.isHoverInteractionKind()) {
 	            targetProps = {
+	                onBlur: this.handleTargetBlur,
+	                onFocus: this.handleTargetFocus,
 	                onMouseEnter: this.handleMouseEnter,
 	                onMouseLeave: this.handleMouseLeave,
 	            };
+	            // any one of the CLICK* values
 	        }
 	        else {
 	            targetProps = {
 	                onClick: this.handleTargetClick,
 	            };
 	        }
-	        targetProps.className = classNames(Classes.POPOVER_TARGET, (_b = {},
-	            _b[Classes.POPOVER_OPEN] = this.state.isOpen,
-	            _b), className);
+	        targetProps.className = classNames(Classes.POPOVER_TARGET, (_a = {},
+	            _a[Classes.POPOVER_OPEN] = this.state.isOpen,
+	            _a), className);
 	        targetProps.ref = this.refHandlers.target;
+	        var childrenBaseProps = this.props.openOnTargetFocus && this.isHoverInteractionKind()
+	            ? { tabIndex: 0 }
+	            : {};
 	        var children = this.props.children;
 	        if (typeof this.props.children === "string") {
 	            // wrap text in a <span> so that we have a consistent way to interact with the target node(s)
-	            children = React.DOM.span({}, this.props.children);
+	            children = React.DOM.span(childrenBaseProps, this.props.children);
 	        }
 	        else {
 	            var child = React.Children.only(this.props.children);
 	            // force disable single Tooltip child when popover is open (BLUEPRINT-552)
-	            if (this.state.isOpen && child.type === tooltip_1.Tooltip) {
-	                children = React.cloneElement(child, { isDisabled: true });
-	            }
+	            var childProps = (this.state.isOpen && child.type === tooltip_1.Tooltip)
+	                ? tslib_1.__assign({}, childrenBaseProps, { isDisabled: true }) : childrenBaseProps;
+	            children = React.cloneElement(child, childProps);
 	        }
 	        return React.createElement(this.props.rootElementTag, targetProps, children, React.createElement(overlay_1.Overlay, { autoFocus: this.props.autoFocus, backdropClassName: Classes.POPOVER_BACKDROP, backdropProps: this.props.backdropProps, canEscapeKeyClose: this.props.canEscapeKeyClose, canOutsideClickClose: this.props.interactionKind === PopoverInteractionKind.CLICK, className: this.props.portalClassName, didOpen: this.handleContentMount, enforceFocus: this.props.enforceFocus, hasBackdrop: this.props.isModal, inline: this.props.inline, isOpen: this.state.isOpen, lazy: this.props.lazy, onClose: this.handleOverlayClose, transitionDuration: this.props.transitionDuration, transitionName: Classes.POPOVER }, this.renderPopover()));
-	        var _b;
+	        var _a;
 	    };
 	    Popover.prototype.componentDidMount = function () {
 	        this.componentDOMChange();
@@ -24012,7 +24059,11 @@
 	            // so instead, we'll position tether based off of its first child.
 	            // NOTE: use findDOMNode(this) directly because this.targetElement may not exist yet
 	            var target = react_dom_1.findDOMNode(this).childNodes[0];
-	            var tetherOptions = TetherUtils.createTetherOptions(this.popoverElement, target, this.props.position, this.props.useSmartPositioning, this.props.constraints);
+	            // constraints is deprecated but must still be supported through tetherOptions until v2.0
+	            if (this.props.constraints != null) {
+	                this.props.tetherOptions.constraints = this.props.constraints;
+	            }
+	            var tetherOptions = TetherUtils.createTetherOptions(this.popoverElement, target, this.props.position, this.props.useSmartPositioning, this.props.tetherOptions);
 	            if (this.tether == null) {
 	                this.tether = new Tether(tetherOptions);
 	            }
@@ -24056,6 +24107,10 @@
 	    Popover.prototype.isElementInPopover = function (element) {
 	        return this.popoverElement != null && this.popoverElement.contains(element);
 	    };
+	    Popover.prototype.isHoverInteractionKind = function () {
+	        return this.props.interactionKind === PopoverInteractionKind.HOVER
+	            || this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
+	    };
 	    return Popover;
 	}(abstractComponent_1.AbstractComponent));
 	Popover.defaultProps = {
@@ -24070,9 +24125,11 @@
 	    interactionKind: PopoverInteractionKind.CLICK,
 	    isDisabled: false,
 	    isModal: false,
+	    openOnTargetFocus: true,
 	    popoverClassName: "",
 	    position: PosUtils.Position.RIGHT,
 	    rootElementTag: "span",
+	    tetherOptions: {},
 	    transitionDuration: 300,
 	    useSmartArrowPositioning: true,
 	    useSmartPositioning: false,
@@ -26040,6 +26097,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var ns = "[Blueprint]";
 	var deprec = ns + " DEPRECATION:";
 	function deprecationWarning(oldName, newName, message) {
@@ -26063,10 +26121,12 @@
 	exports.POPOVER_UNCONTROLLED_ONINTERACTION = ns + " <Popover> onInteraction is ignored when uncontrolled";
 	exports.POPOVER_MODAL_INLINE = ns + " <Popover isModal={true}> requires inline={false}.";
 	exports.POPOVER_MODAL_INTERACTION = ns + " <Popover isModal={true}> requires interactionKind={PopoverInteractionKind.CLICK}.";
-	exports.POPOVER_SMART_POSITIONING_INLINE = "{ns} <Popover useSmartPositioning={true}> requires inline={false}.";
+	exports.POPOVER_SMART_POSITIONING_INLINE = ns + " <Popover useSmartPositioning={true}> requires inline={false}.";
 	exports.RADIOGROUP_RADIO_CHILDREN = ns + " <RadioGroup> only supports <Radio> children";
 	exports.RADIOGROUP_CHILDREN_OPTIONS_MUTEX = ns + " <RadioGroup> children and options props are mutually exclusive.";
-	exports.RANGESLIDER_NULL_VALUE = ns + " <RangeSlider> value prop must be an array of two non-null numbers";
+	exports.SLIDER_ZERO_STEP = ns + " <Slider> stepSize must be greater than zero.";
+	exports.SLIDER_ZERO_LABEL_STEP = ns + " <Slider> labelStepSize must be greater than zero.";
+	exports.RANGESLIDER_NULL_VALUE = ns + " <RangeSlider> value prop must be an array of two non-null numbers.";
 	exports.TABS_FIRST_CHILD = ns + " First child of <Tabs> component should be a <TabList>";
 	exports.TABS_MISMATCH = ns + " Number of <Tab> components should equal number of <TabPanel> components";
 	exports.TABS_DEPRECATED = ns + " <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>."
@@ -26089,6 +26149,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -28440,6 +28501,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var ReactDOM = __webpack_require__(66);
@@ -28496,6 +28558,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -28511,21 +28574,19 @@
 	        return _this;
 	    }
 	    Tooltip.prototype.render = function () {
-	        var _a = this.props, children = _a.children, intent = _a.intent, tooltipClassName = _a.tooltipClassName;
+	        var _a = this.props, children = _a.children, intent = _a.intent, openOnTargetFocus = _a.openOnTargetFocus, tooltipClassName = _a.tooltipClassName;
 	        var classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
-	        return (React.createElement(popover_1.Popover, tslib_1.__assign({}, this.props, { arrowSize: 22, autoFocus: false, canEscapeKeyClose: false, enforceFocus: false, interactionKind: popover_1.PopoverInteractionKind.HOVER_TARGET_ONLY, lazy: true, popoverClassName: classes }), children));
+	        return (React.createElement(popover_1.Popover, tslib_1.__assign({}, this.props, { arrowSize: 22, autoFocus: false, canEscapeKeyClose: false, enforceFocus: false, interactionKind: popover_1.PopoverInteractionKind.HOVER_TARGET_ONLY, lazy: true, openOnTargetFocus: openOnTargetFocus, popoverClassName: classes }), children));
 	    };
 	    return Tooltip;
 	}(React.Component));
 	Tooltip.defaultProps = {
-	    className: "",
-	    content: "",
 	    hoverCloseDelay: 0,
 	    hoverOpenDelay: 100,
 	    isDisabled: false,
+	    openOnTargetFocus: true,
 	    position: position_1.Position.TOP,
 	    rootElementTag: "span",
-	    tooltipClassName: "",
 	    transitionDuration: 100,
 	    useSmartArrowPositioning: true,
 	    useSmartPositioning: false,
@@ -28544,6 +28605,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var position_1 = __webpack_require__(57);
 	// this value causes popover and target edges to line up on 50px targets
 	exports.MIN_ARROW_SPACING = 18;
@@ -28631,6 +28693,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -28697,6 +28760,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	// HACKHACK: these components should go in separate files
 	// tslint:disable max-classes-per-file
@@ -28746,6 +28810,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -28846,6 +28911,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -28913,6 +28979,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -28990,6 +29057,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(60);
@@ -29015,6 +29083,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -29173,6 +29242,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -29264,6 +29334,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -29296,6 +29367,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -29327,7 +29399,8 @@
 	                    submenuLeft += adjustmentWidth;
 	                    submenuRight += adjustmentWidth;
 	                }
-	                var _a = _this.props.submenuViewportMargin, _b = _a.left, left = _b === void 0 ? 0 : _b, _c = _a.right, right = _c === void 0 ? 0 : _c;
+	                var _a = _this.props.submenuViewportMargin.left, left = _a === void 0 ? 0 : _a;
+	                var _b = _this.props.submenuViewportMargin.right, right = _b === void 0 ? 0 : _b;
 	                if (typeof document !== "undefined"
 	                    && typeof document.documentElement !== "undefined"
 	                    && Number(document.documentElement.clientWidth)) {
@@ -29354,16 +29427,21 @@
 	            var _a = _this.props, children = _a.children, submenu = _a.submenu;
 	            if (children != null) {
 	                var childProps_1 = _this.cascadeProps();
-	                if (Object.keys(childProps_1).length !== 0) {
-	                    children = React.Children.map(children, function (child) {
+	                if (Object.keys(childProps_1).length === 0) {
+	                    return children;
+	                }
+	                else {
+	                    return React.Children.map(children, function (child) {
 	                        return React.cloneElement(child, childProps_1);
 	                    });
 	                }
 	            }
 	            else if (submenu != null) {
-	                children = submenu.map(_this.cascadeProps).map(renderMenuItem);
+	                return submenu.map(_this.cascadeProps).map(renderMenuItem);
 	            }
-	            return children;
+	            else {
+	                return undefined;
+	            }
 	        };
 	        /**
 	         * Evalutes this.props and cascades prop values into new props when:
@@ -29455,6 +29533,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var React = __webpack_require__(24);
 	var utils_1 = __webpack_require__(62);
 	var ContextMenu = __webpack_require__(65);
@@ -29507,6 +29586,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -29676,7 +29756,8 @@
 	    EditableText.prototype.updateInputDimensions = function () {
 	        if (this.valueElement != null) {
 	            var _a = this.props, maxLines = _a.maxLines, minLines = _a.minLines, minWidth = _a.minWidth, multiline = _a.multiline;
-	            var _b = this.valueElement, parentElement_1 = _b.parentElement, scrollHeight_1 = _b.scrollHeight, scrollWidth = _b.scrollWidth, textContent = _b.textContent;
+	            var _b = this.valueElement, parentElement_1 = _b.parentElement, textContent = _b.textContent;
+	            var _c = this.valueElement, scrollHeight_1 = _c.scrollHeight, scrollWidth = _c.scrollWidth;
 	            var lineHeight = getLineHeight(this.valueElement);
 	            // add one line to computed <span> height if text ends in newline
 	            // because <span> collapses that trailing whitespace but <textarea> shows it
@@ -29778,6 +29859,7 @@
 	function __export(m) {
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
+	Object.defineProperty(exports, "__esModule", { value: true });
 	__export(__webpack_require__(247));
 
 	//# sourceMappingURL=index.js.map
@@ -29794,6 +29876,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
 	var browser = {
 	    isEdge: !!userAgent.match(/Edge/),
@@ -29820,14 +29903,23 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	// HACKHACK: these components should go in separate files
 	// tslint:disable max-classes-per-file
+	// we need some empty interfaces to show up in docs
+	// tslint:disable no-empty-interface
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(60);
 	var props_1 = __webpack_require__(58);
 	var utils_1 = __webpack_require__(62);
+	var INVALID_PROPS = [
+	    // we spread props to `<input>` but render `children` as its sibling
+	    "children",
+	    "defaultIndeterminate",
+	    "indeterminate",
+	];
 	/** Base Component class for all Controls */
 	var Control = (function (_super) {
 	    tslib_1.__extends(Control, _super);
@@ -29839,8 +29931,9 @@
 	    Control.prototype.renderControl = function (type, typeClassName, inputRef) {
 	        if (inputRef === void 0) { inputRef = this.props.inputRef; }
 	        var className = classNames(Classes.CONTROL, typeClassName, (_a = {}, _a[Classes.DISABLED] = this.props.disabled, _a), this.props.className);
+	        var inputProps = props_1.removeNonHTMLProps(this.props, INVALID_PROPS, true);
 	        return (React.createElement("label", { className: className, style: this.props.style },
-	            React.createElement("input", tslib_1.__assign({}, props_1.removeNonHTMLProps(this.props, ["children", "indeterminate"], true), { ref: inputRef, type: type })),
+	            React.createElement("input", tslib_1.__assign({}, inputProps, { ref: inputRef, type: type })),
 	            React.createElement("span", { className: Classes.CONTROL_INDICATOR }),
 	            this.props.label,
 	            this.props.children));
@@ -29922,6 +30015,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -30008,6 +30102,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -30126,6 +30221,7 @@
 	        };
 	        _this.state = {
 	            shouldSelectAfterUpdate: false,
+	            stepMaxPrecision: _this.getStepMaxPrecision(props),
 	            value: _this.getValueOrEmptyValue(props.value),
 	        };
 	        return _this;
@@ -30136,19 +30232,18 @@
 	        var didMinChange = nextProps.min !== this.props.min;
 	        var didMaxChange = nextProps.max !== this.props.max;
 	        var didBoundsChange = didMinChange || didMaxChange;
+	        var sanitizedValue = (value !== NumericInput_1.VALUE_EMPTY)
+	            ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
+	            : NumericInput_1.VALUE_EMPTY;
+	        var stepMaxPrecision = this.getStepMaxPrecision(nextProps);
 	        // if a new min and max were provided that cause the existing value to fall
 	        // outside of the new bounds, then clamp the value to the new valid range.
-	        if (didBoundsChange) {
-	            var sanitizedValue = (value !== NumericInput_1.VALUE_EMPTY)
-	                ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
-	                : NumericInput_1.VALUE_EMPTY;
-	            if (sanitizedValue !== this.state.value) {
-	                this.setState({ value: sanitizedValue });
-	                this.invokeOnChangeCallbacks(sanitizedValue);
-	            }
+	        if (didBoundsChange && sanitizedValue !== this.state.value) {
+	            this.setState({ stepMaxPrecision: stepMaxPrecision, value: sanitizedValue });
+	            this.invokeOnChangeCallbacks(sanitizedValue);
 	        }
 	        else {
-	            this.setState({ value: value });
+	            this.setState({ stepMaxPrecision: stepMaxPrecision, value: value });
 	        }
 	    };
 	    NumericInput.prototype.render = function () {
@@ -30156,6 +30251,7 @@
 	        var inputGroupHtmlProps = common_1.removeNonHTMLProps(this.props, [
 	            "allowNumericCharactersOnly",
 	            "buttonPosition",
+	            "className",
 	            "majorStepSize",
 	            "minorStepSize",
 	            "onValueChange",
@@ -30176,7 +30272,7 @@
 	        else {
 	            var incrementButton = this.renderButton(NumericInput_1.INCREMENT_KEY, NumericInput_1.INCREMENT_ICON_NAME, this.handleIncrementButtonClick);
 	            var decrementButton = this.renderButton(NumericInput_1.DECREMENT_KEY, NumericInput_1.DECREMENT_ICON_NAME, this.handleDecrementButtonClick);
-	            var buttonGroup = (React.createElement("div", { key: "button-group", className: classNames(common_1.Classes.BUTTON_GROUP, common_1.Classes.VERTICAL) },
+	            var buttonGroup = (React.createElement("div", { key: "button-group", className: classNames(common_1.Classes.BUTTON_GROUP, common_1.Classes.VERTICAL, common_1.Classes.FIXED) },
 	                incrementButton,
 	                decrementButton));
 	            var inputElems = (buttonPosition === common_1.Position.LEFT)
@@ -30257,9 +30353,7 @@
 	        if (!this.isValueNumeric(value)) {
 	            return NumericInput_1.VALUE_EMPTY;
 	        }
-	        // truncate floating-point result to avoid precision issues when adding
-	        // non-integer, binary-unfriendly deltas like 0.1
-	        var nextValue = parseFloat((parseFloat(value) + delta).toFixed(2));
+	        var nextValue = this.toMaxPrecision(parseFloat(value) + delta);
 	        // defaultProps won't work if the user passes in null, so just default
 	        // to +/- infinity here instead, as a catch-all.
 	        var adjustedMin = (min != null) ? min : -Infinity;
@@ -30305,9 +30399,26 @@
 	    NumericInput.prototype.isFloatingPointNumericCharacter = function (char) {
 	        return NumericInput_1.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(char);
 	    };
+	    NumericInput.prototype.getStepMaxPrecision = function (props) {
+	        if (props.minorStepSize != null) {
+	            return common_1.Utils.countDecimalPlaces(props.minorStepSize);
+	        }
+	        else {
+	            return common_1.Utils.countDecimalPlaces(props.stepSize);
+	        }
+	    };
+	    NumericInput.prototype.toMaxPrecision = function (value) {
+	        // round the value to have the specified maximum precision (toFixed is the wrong choice,
+	        // because it would show trailing zeros in the decimal part out to the specified precision)
+	        // source: http://stackoverflow.com/a/18358056/5199574
+	        var scaleFactor = Math.pow(10, this.state.stepMaxPrecision);
+	        return Math.round(value * scaleFactor) / scaleFactor;
+	    };
 	    return NumericInput;
 	}(common_1.AbstractComponent));
 	NumericInput.displayName = "Blueprint.NumericInput";
+	NumericInput.VALUE_EMPTY = "";
+	NumericInput.VALUE_ZERO = "0";
 	NumericInput.defaultProps = {
 	    allowNumericCharactersOnly: true,
 	    buttonPosition: common_1.Position.RIGHT,
@@ -30322,8 +30433,6 @@
 	NumericInput.INCREMENT_KEY = "increment";
 	NumericInput.DECREMENT_ICON_NAME = "chevron-down";
 	NumericInput.INCREMENT_ICON_NAME = "chevron-up";
-	NumericInput.VALUE_EMPTY = "";
-	NumericInput.VALUE_ZERO = "0";
 	/**
 	 * A regex that matches a string of length 1 (i.e. a standalone character)
 	 * if and only if it is a floating-point number character as defined by W3C:
@@ -30357,6 +30466,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var abstractComponent_1 = __webpack_require__(22);
@@ -30433,6 +30543,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var react_1 = __webpack_require__(24);
 	var React = __webpack_require__(24);
@@ -30510,6 +30621,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var common_1 = __webpack_require__(21);
@@ -30554,6 +30666,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var hotkeyParser_1 = __webpack_require__(255);
@@ -30612,6 +30725,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.KeyCodes = {
 	    8: "backspace",
 	    9: "tab",
@@ -30812,6 +30926,7 @@
 	    }
 	    var which = normalizeKeyCode(e);
 	    if (exports.Modifiers[which] != null) {
+	        // no action key
 	    }
 	    else if (exports.KeyCodes[which] != null) {
 	        keys.push(exports.KeyCodes[which]);
@@ -30832,6 +30947,7 @@
 	    var key = null;
 	    var which = normalizeKeyCode(e);
 	    if (exports.Modifiers[which] != null) {
+	        // keep key null
 	    }
 	    else if (exports.KeyCodes[which] != null) {
 	        key = exports.KeyCodes[which];
@@ -30883,6 +30999,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var React = __webpack_require__(24);
 	var utils_1 = __webpack_require__(62);
 	var hotkeysEvents_1 = __webpack_require__(257);
@@ -30961,6 +31078,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var react_1 = __webpack_require__(24);
 	var utils_1 = __webpack_require__(62);
 	var hotkey_1 = __webpack_require__(253);
@@ -31070,6 +31188,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -31193,6 +31312,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -31234,6 +31354,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -31298,12 +31419,73 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
+	 * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+	 * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+	 * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
+	 */
+	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
+	var tslib_1 = __webpack_require__(23);
+	var classNames = __webpack_require__(213);
+	var PureRender = __webpack_require__(214);
+	var React = __webpack_require__(24);
+	var Classes = __webpack_require__(60);
+	var Text = (function (_super) {
+	    tslib_1.__extends(Text, _super);
+	    function Text() {
+	        var _this = _super !== null && _super.apply(this, arguments) || this;
+	        _this.state = {
+	            isContentOverflowing: false,
+	            textContent: "",
+	        };
+	        _this.refHandlers = {
+	            text: function (overflowElement) { return _this.textRef = overflowElement; },
+	        };
+	        return _this;
+	    }
+	    Text.prototype.componentDidMount = function () {
+	        this.update();
+	    };
+	    Text.prototype.componentDidUpdate = function () {
+	        this.update();
+	    };
+	    Text.prototype.render = function () {
+	        var classes = classNames((_a = {},
+	            _a[Classes.TEXT_OVERFLOW_ELLIPSIS] = this.props.ellipsize,
+	            _a), this.props.className);
+	        return (React.createElement("div", { className: classes, ref: this.refHandlers.text, title: this.state.isContentOverflowing ? this.state.textContent : undefined }, this.props.children));
+	        var _a;
+	    };
+	    Text.prototype.update = function () {
+	        var newState = {
+	            isContentOverflowing: this.props.ellipsize && this.textRef.scrollWidth > this.textRef.clientWidth,
+	            textContent: this.textRef.textContent,
+	        };
+	        this.setState(newState);
+	    };
+	    return Text;
+	}(React.Component));
+	Text = tslib_1.__decorate([
+	    PureRender
+	], Text);
+	exports.Text = Text;
+
+	//# sourceMappingURL=text.js.map
+
+
+/***/ },
+/* 262 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/*
 	 * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 	 * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
 	 * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var popover_1 = __webpack_require__(212);
@@ -31324,7 +31506,7 @@
 
 
 /***/ },
-/* 262 */
+/* 263 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31334,6 +31516,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -31366,7 +31549,7 @@
 
 
 /***/ },
-/* 263 */
+/* 264 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31376,6 +31559,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var tooltip_1 = __webpack_require__(232);
@@ -31396,7 +31580,7 @@
 
 
 /***/ },
-/* 264 */
+/* 265 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31406,14 +31590,15 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(60);
 	var Errors = __webpack_require__(216);
 	var utils_1 = __webpack_require__(62);
-	var coreSlider_1 = __webpack_require__(265);
-	var handle_1 = __webpack_require__(266);
+	var coreSlider_1 = __webpack_require__(266);
+	var handle_1 = __webpack_require__(267);
 	var RangeEnd;
 	(function (RangeEnd) {
 	    RangeEnd[RangeEnd["LEFT"] = 0] = "LEFT";
@@ -31515,7 +31700,7 @@
 
 
 /***/ },
-/* 265 */
+/* 266 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31525,20 +31710,19 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
 	var React = __webpack_require__(24);
 	var abstractComponent_1 = __webpack_require__(22);
 	var Classes = __webpack_require__(60);
+	var Errors = __webpack_require__(216);
 	var utils_1 = __webpack_require__(62);
 	var CoreSlider = (function (_super) {
 	    tslib_1.__extends(CoreSlider, _super);
-	    function CoreSlider() {
-	        var _this = _super !== null && _super.apply(this, arguments) || this;
-	        _this.state = {
-	            tickSize: 0,
-	        };
+	    function CoreSlider(props) {
+	        var _this = _super.call(this, props) || this;
 	        _this.className = Classes.SLIDER;
 	        _this.refHandlers = {
 	            track: function (el) { return _this.trackElement = el; },
@@ -31557,6 +31741,10 @@
 	            var target = event.target;
 	            // ensure event does not come from inside the handle
 	            return !_this.props.disabled && target.closest("." + Classes.SLIDER_HANDLE) == null;
+	        };
+	        _this.state = {
+	            labelPrecision: _this.getLabelPrecision(props),
+	            tickSize: 0,
 	        };
 	        return _this;
 	    }
@@ -31579,6 +31767,10 @@
 	    CoreSlider.prototype.componentDidUpdate = function () {
 	        this.updateTickSize();
 	    };
+	    CoreSlider.prototype.componentWillReceiveProps = function (props) {
+	        _super.prototype.componentWillReceiveProps.call(this, props);
+	        this.setState({ labelPrecision: this.getLabelPrecision(props) });
+	    };
 	    CoreSlider.prototype.formatLabel = function (value) {
 	        var renderLabel = this.props.renderLabel;
 	        if (renderLabel === false) {
@@ -31588,7 +31780,15 @@
 	            return renderLabel(value);
 	        }
 	        else {
-	            return value;
+	            return value.toFixed(this.state.labelPrecision);
+	        }
+	    };
+	    CoreSlider.prototype.validateProps = function (props) {
+	        if (props.stepSize <= 0) {
+	            throw new Error(Errors.SLIDER_ZERO_STEP);
+	        }
+	        if (props.labelStepSize <= 0) {
+	            throw new Error(Errors.SLIDER_ZERO_LABEL_STEP);
 	        }
 	    };
 	    CoreSlider.prototype.maybeRenderAxis = function () {
@@ -31610,6 +31810,13 @@
 	        }
 	        return undefined;
 	    };
+	    CoreSlider.prototype.getLabelPrecision = function (_a) {
+	        var labelPrecision = _a.labelPrecision, stepSize = _a.stepSize;
+	        // infer default label precision from stepSize because that's how much the handle moves.
+	        return (labelPrecision == null)
+	            ? utils_1.countDecimalPlaces(stepSize)
+	            : labelPrecision;
+	    };
 	    CoreSlider.prototype.updateTickSize = function () {
 	        if (this.trackElement != null) {
 	            var tickSize = this.trackElement.clientWidth / (this.props.max - this.props.min);
@@ -31627,7 +31834,7 @@
 
 
 /***/ },
-/* 266 */
+/* 267 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31637,6 +31844,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -31781,7 +31989,7 @@
 
 
 /***/ },
-/* 267 */
+/* 268 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31791,12 +31999,13 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(60);
 	var utils_1 = __webpack_require__(62);
-	var coreSlider_1 = __webpack_require__(265);
-	var handle_1 = __webpack_require__(266);
+	var coreSlider_1 = __webpack_require__(266);
+	var handle_1 = __webpack_require__(267);
 	var Slider = (function (_super) {
 	    tslib_1.__extends(Slider, _super);
 	    function Slider() {
@@ -31849,7 +32058,7 @@
 
 
 /***/ },
-/* 268 */
+/* 269 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31859,6 +32068,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -31883,7 +32093,7 @@
 
 
 /***/ },
-/* 269 */
+/* 270 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31893,6 +32103,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -31924,7 +32135,7 @@
 
 
 /***/ },
-/* 270 */
+/* 271 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31934,6 +32145,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -31944,9 +32156,9 @@
 	var Errors = __webpack_require__(216);
 	var Keys = __webpack_require__(61);
 	var Utils = __webpack_require__(62);
-	var tab_1 = __webpack_require__(269);
-	var tabList_1 = __webpack_require__(271);
-	var tabPanel_1 = __webpack_require__(272);
+	var tab_1 = __webpack_require__(270);
+	var tabList_1 = __webpack_require__(272);
+	var tabPanel_1 = __webpack_require__(273);
 	var TAB_CSS_SELECTOR = "li[role=tab]";
 	var Tabs = (function (_super) {
 	    tslib_1.__extends(Tabs, _super);
@@ -32233,7 +32445,7 @@
 
 
 /***/ },
-/* 271 */
+/* 272 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32243,6 +32455,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32283,7 +32496,7 @@
 
 
 /***/ },
-/* 272 */
+/* 273 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32293,6 +32506,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32320,7 +32534,7 @@
 
 
 /***/ },
-/* 273 */
+/* 274 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32330,6 +32544,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32360,11 +32575,11 @@
 	exports.Tab2 = Tab2;
 	exports.Tab2Factory = React.createFactory(Tab2);
 
-	//# sourceMappingURL=tab.js.map
+	//# sourceMappingURL=tab2.js.map
 
 
 /***/ },
-/* 274 */
+/* 275 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32374,6 +32589,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32382,8 +32598,8 @@
 	var Classes = __webpack_require__(60);
 	var Keys = __webpack_require__(61);
 	var utils_1 = __webpack_require__(62);
-	var tab_1 = __webpack_require__(273);
-	var tabTitle_1 = __webpack_require__(275);
+	var tab2_1 = __webpack_require__(274);
+	var tabTitle_1 = __webpack_require__(276);
 	exports.Expander = function () { return React.createElement("div", { className: "pt-flex-expander" }); };
 	var TAB_SELECTOR = "." + Classes.TAB;
 	var Tabs2 = (function (_super) {
@@ -32536,7 +32752,7 @@
 	}(abstractComponent_1.AbstractComponent));
 	/** Insert a `Tabs2.Expander` between any two children to right-align all subsequent children. */
 	Tabs2.Expander = exports.Expander;
-	Tabs2.Tab = tab_1.Tab2;
+	Tabs2.Tab = tab2_1.Tab2;
 	Tabs2.defaultProps = {
 	    animate: true,
 	    renderActiveTabPanelOnly: false,
@@ -32555,14 +32771,14 @@
 	    return codes.indexOf(e.which) >= 0;
 	}
 	function isTab(child) {
-	    return child.type === tab_1.Tab2;
+	    return child.type === tab2_1.Tab2;
 	}
 
-	//# sourceMappingURL=tabs.js.map
+	//# sourceMappingURL=tabs2.js.map
 
 
 /***/ },
-/* 275 */
+/* 276 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32572,6 +32788,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32610,7 +32827,7 @@
 
 
 /***/ },
-/* 276 */
+/* 277 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32620,6 +32837,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32657,7 +32875,7 @@
 
 
 /***/ },
-/* 277 */
+/* 278 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32667,6 +32885,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32754,7 +32973,7 @@
 
 
 /***/ },
-/* 278 */
+/* 279 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32764,6 +32983,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var PureRender = __webpack_require__(214);
@@ -32776,7 +32996,7 @@
 	var position_1 = __webpack_require__(57);
 	var utils_1 = __webpack_require__(62);
 	var overlay_1 = __webpack_require__(217);
-	var toast_1 = __webpack_require__(277);
+	var toast_1 = __webpack_require__(278);
 	var Toaster = Toaster_1 = (function (_super) {
 	    tslib_1.__extends(Toaster, _super);
 	    function Toaster() {
@@ -32886,7 +33106,7 @@
 
 
 /***/ },
-/* 279 */
+/* 280 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32896,12 +33116,13 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(60);
 	var utils_1 = __webpack_require__(62);
-	var treeNode_1 = __webpack_require__(280);
+	var treeNode_1 = __webpack_require__(281);
 	var Tree = (function (_super) {
 	    tslib_1.__extends(Tree, _super);
 	    function Tree() {
@@ -32978,7 +33199,7 @@
 
 
 /***/ },
-/* 280 */
+/* 281 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32988,6 +33209,7 @@
 	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var classNames = __webpack_require__(213);
 	var React = __webpack_require__(24);
@@ -33065,13 +33287,14 @@
 
 
 /***/ },
-/* 281 */
+/* 282 */
 /***/ function(module, exports) {
 
 	/*
 	 * Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	// tslint:disable:object-literal-sort-keys
 	exports.IconClasses = {
 	    BLANK: "pt-icon-blank",
@@ -33467,13 +33690,14 @@
 
 
 /***/ },
-/* 282 */
+/* 283 */
 /***/ function(module, exports) {
 
 	/*
 	 * Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
 	 */
 	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
 	// tslint:disable:object-literal-sort-keys
 	exports.IconContents = {
 	    BLANK: "\ue900",
@@ -33869,7 +34093,7 @@
 
 
 /***/ },
-/* 283 */
+/* 284 */
 /***/ function(module, exports) {
 
 	/**
@@ -34963,7 +35187,7 @@
 
 
 /***/ },
-/* 284 */
+/* 285 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -34975,20 +35199,20 @@
 	"use strict";
 	// tslint:disable no-var-requires
 	var HERO_SVGS = {
-	    "alert": __webpack_require__(285),
-	    "buttons": __webpack_require__(286),
-	    "calendar": __webpack_require__(287),
-	    "checkboxes": __webpack_require__(288),
-	    "file-upload": __webpack_require__(289),
-	    "input-groups": __webpack_require__(290),
-	    "inputs": __webpack_require__(291),
-	    "labels": __webpack_require__(292),
-	    "radios": __webpack_require__(293),
-	    "select-menus": __webpack_require__(294),
-	    "sliders": __webpack_require__(295),
-	    "switches": __webpack_require__(296),
-	    "time-selections": __webpack_require__(297),
-	    "toggles": __webpack_require__(298),
+	    "alert": __webpack_require__(286),
+	    "buttons": __webpack_require__(287),
+	    "calendar": __webpack_require__(288),
+	    "checkboxes": __webpack_require__(289),
+	    "file-upload": __webpack_require__(290),
+	    "input-groups": __webpack_require__(291),
+	    "inputs": __webpack_require__(292),
+	    "labels": __webpack_require__(293),
+	    "radios": __webpack_require__(294),
+	    "select-menus": __webpack_require__(295),
+	    "sliders": __webpack_require__(296),
+	    "switches": __webpack_require__(297),
+	    "time-selections": __webpack_require__(298),
+	    "toggles": __webpack_require__(299),
 	};
 	var injectSVG = function (elem, id) {
 	    var wrapper = document.createElement("div");
@@ -35005,85 +35229,85 @@
 
 
 /***/ },
-/* 285 */
+/* 286 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"406\" height=\"165\" viewBox=\"0 0 406 165\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        ALERT\n    </title>\n    <defs>\n        <rect id=\"alert-a\" x=\"16\" y=\"13\" width=\"371\" height=\"143\" rx=\"10\"/>\n        <mask id=\"alert-i\" x=\"0\" y=\"0\" width=\"371\" height=\"143\" fill=\"#fff\">\n            <use xlink:href=\"#alert-a\"/>\n        </mask>\n        <circle id=\"alert-b\" cx=\"17\" cy=\"14\" r=\"6\"/>\n        <mask id=\"alert-j\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-b\"/>\n        </mask>\n        <circle id=\"alert-c\" cx=\"17\" cy=\"155\" r=\"6\"/>\n        <mask id=\"alert-k\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-c\"/>\n        </mask>\n        <circle id=\"alert-d\" cx=\"386\" cy=\"155\" r=\"6\"/>\n        <mask id=\"alert-l\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-d\"/>\n        </mask>\n        <circle id=\"alert-e\" cx=\"386\" cy=\"14\" r=\"6\"/>\n        <mask id=\"alert-m\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-e\"/>\n        </mask>\n        <path d=\"M57.72 38.98c-.36-.58-.98-.98-1.72-.98s-1.36.42-1.7 1L40.28 62.98c-.16.32-.28.64-.28 1.02 0 1.1.9 2 2 2h28c1.1 0 2-.9 2-2 0-.36-.12-.7-.3-1L57.72 38.98zM54 62v-4h4v4h-4zm0-6V46h4v10h-4z\" id=\"alert-f\"/>\n        <mask id=\"alert-n\" x=\"-2\" y=\"-2\" width=\"36\" height=\"32\">\n            <path fill=\"#fff\" d=\"M38 36h36v32H38z\"/>\n            <use xlink:href=\"#alert-f\"/>\n        </mask>\n        <path d=\"M195 102.994a3 3 0 0 1 3.004-2.994h54.992a3 3 0 0 1 3.004 2.994v23.012a3 3 0 0 1-3.004 2.994h-54.992a3 3 0 0 1-3.004-2.994v-23.012z\" id=\"alert-g\"/>\n        <mask id=\"alert-o\" x=\"0\" y=\"0\" width=\"61\" height=\"29\" fill=\"#fff\">\n            <use xlink:href=\"#alert-g\"/>\n        </mask>\n        <rect id=\"alert-h\" x=\"266\" y=\"100\" width=\"96\" height=\"29\" rx=\"3\"/>\n        <mask id=\"alert-p\" x=\"0\" y=\"0\" width=\"96\" height=\"29\" fill=\"#fff\">\n            <use xlink:href=\"#alert-h\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#alert-i)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#alert-a\"/>\n                        <path d=\"M.5 14h401M17 0v164.5M386 0v164.5M2.5 155h403\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#alert-j)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-b\"/>\n                        <use mask=\"url(#alert-k)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-c\"/>\n                        <use mask=\"url(#alert-l)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-d\"/>\n                        <use mask=\"url(#alert-m)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-e\"/>\n                        <use mask=\"url(#alert-n)\" stroke-width=\"4\" xlink:href=\"#alert-f\"/>\n                        <use mask=\"url(#alert-o)\" stroke-width=\"4\" xlink:href=\"#alert-g\"/>\n                        <use mask=\"url(#alert-p)\" stroke-width=\"4\" xlink:href=\"#alert-h\"/>\n                        <path d=\"M95 48.5h235M95 68.5h145\" stroke-width=\"5\" stroke-linecap=\"square\"/>\n                        <path d=\"M208 114.5h35M277.5 114.5H347\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 286 */
+/* 287 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"454\" height=\"115\" viewBox=\"0 0 454 115\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        BUTTONS\n    </title>\n    <defs>\n        <rect id=\"buttons-a\" x=\"6\" y=\"7\" width=\"111\" height=\"31\" rx=\"3\"/>\n        <mask id=\"buttons-I\" x=\"0\" y=\"0\" width=\"111\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-a\"/>\n        </mask>\n        <circle id=\"buttons-b\" cx=\"7\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-J\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-b\"/>\n        </mask>\n        <circle id=\"buttons-c\" cx=\"7\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-K\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-c\"/>\n        </mask>\n        <circle id=\"buttons-d\" cx=\"116\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-L\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-d\"/>\n        </mask>\n        <circle id=\"buttons-e\" cx=\"116\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-M\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-e\"/>\n        </mask>\n        <rect id=\"buttons-f\" x=\"9\" y=\"7\" width=\"111\" height=\"31\" rx=\"3\"/>\n        <mask id=\"buttons-N\" x=\"0\" y=\"0\" width=\"111\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-f\"/>\n        </mask>\n        <path d=\"M108 19c-.28 0-.53.11-.71.29L104 22.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 108 19z\" id=\"buttons-g\"/>\n        <mask id=\"buttons-O\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-g\"/>\n        </mask>\n        <circle id=\"buttons-h\" cx=\"10\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-h\"/>\n        </mask>\n        <circle id=\"buttons-i\" cx=\"10\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-i\"/>\n        </mask>\n        <circle id=\"buttons-j\" cx=\"119\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-R\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-j\"/>\n        </mask>\n        <circle id=\"buttons-k\" cx=\"119\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-S\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-k\"/>\n        </mask>\n        <rect id=\"buttons-l\" x=\"9\" y=\"7\" width=\"131\" height=\"31\" rx=\"3\"/>\n        <mask id=\"buttons-T\" x=\"0\" y=\"0\" width=\"131\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-l\"/>\n        </mask>\n        <circle id=\"buttons-m\" cx=\"10\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-U\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-m\"/>\n        </mask>\n        <circle id=\"buttons-n\" cx=\"10\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-V\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-n\"/>\n        </mask>\n        <circle id=\"buttons-o\" cx=\"139\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-W\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-o\"/>\n        </mask>\n        <circle id=\"buttons-p\" cx=\"139\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-X\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-p\"/>\n        </mask>\n        <path d=\"M30 21h-2v-2c0-.55-.45-1-1-1s-1 .45-1 1v2h-2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1zm-3-7c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6z\" id=\"buttons-q\"/>\n        <mask id=\"buttons-Y\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-q\"/>\n        </mask>\n        <rect id=\"buttons-r\" x=\"6\" y=\"7\" width=\"121\" height=\"41\" rx=\"3\"/>\n        <mask id=\"buttons-Z\" x=\"0\" y=\"0\" width=\"121\" height=\"41\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-r\"/>\n        </mask>\n        <circle id=\"buttons-s\" cx=\"7\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-aa\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-s\"/>\n        </mask>\n        <circle id=\"buttons-t\" cx=\"7\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ab\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-t\"/>\n        </mask>\n        <circle id=\"buttons-u\" cx=\"126\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ac\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-u\"/>\n        </mask>\n        <circle id=\"buttons-v\" cx=\"126\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-ad\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-v\"/>\n        </mask>\n        <rect id=\"buttons-w\" x=\"9\" y=\"7\" width=\"121\" height=\"41\" rx=\"3\"/>\n        <mask id=\"buttons-ae\" x=\"0\" y=\"0\" width=\"121\" height=\"41\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-w\"/>\n        </mask>\n        <path d=\"M113 24c-.28 0-.53.11-.71.29L109 27.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 113 24z\" id=\"buttons-x\"/>\n        <mask id=\"buttons-af\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-x\"/>\n        </mask>\n        <circle id=\"buttons-y\" cx=\"10\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-ag\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-y\"/>\n        </mask>\n        <circle id=\"buttons-z\" cx=\"10\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ah\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-z\"/>\n        </mask>\n        <circle id=\"buttons-A\" cx=\"129\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ai\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-A\"/>\n        </mask>\n        <circle id=\"buttons-B\" cx=\"129\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-aj\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-B\"/>\n        </mask>\n        <rect id=\"buttons-C\" x=\"9\" y=\"7\" width=\"141\" height=\"41\" rx=\"3\"/>\n        <mask id=\"buttons-ak\" x=\"0\" y=\"0\" width=\"141\" height=\"41\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-C\"/>\n        </mask>\n        <circle id=\"buttons-D\" cx=\"10\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-al\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-D\"/>\n        </mask>\n        <circle id=\"buttons-E\" cx=\"10\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-am\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-E\"/>\n        </mask>\n        <circle id=\"buttons-F\" cx=\"149\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-an\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-F\"/>\n        </mask>\n        <circle id=\"buttons-G\" cx=\"149\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-ao\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-G\"/>\n        </mask>\n        <path d=\"M35 26h-2v-2c0-.55-.45-1-1-1s-1 .45-1 1v2h-2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1zm-3-7c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6z\" id=\"buttons-H\"/>\n        <mask id=\"buttons-ap\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-H\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <g>\n                            <use mask=\"url(#buttons-I)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-a\"/>\n                            <path d=\"M7 0v44M116 2v42M0 8h124M1 37h121\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-J)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-b\"/>\n                            <use mask=\"url(#buttons-K)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-c\"/>\n                            <use mask=\"url(#buttons-L)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-d\"/>\n                            <use mask=\"url(#buttons-M)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-e\"/>\n                            <path d=\"M20.5 22.5H103\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(147)\">\n                            <use mask=\"url(#buttons-N)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-f\"/>\n                            <path d=\"M10 0v44M119 2v42M90 2v42M0 8h124M0 37h124\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-O)\" stroke-width=\"4\" xlink:href=\"#buttons-g\"/>\n                            <use mask=\"url(#buttons-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-h\"/>\n                            <use mask=\"url(#buttons-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-i\"/>\n                            <use mask=\"url(#buttons-R)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-j\"/>\n                            <use mask=\"url(#buttons-S)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-k\"/>\n                            <path d=\"M21.5 22.5H74\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(297)\">\n                            <use mask=\"url(#buttons-T)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-l\"/>\n                            <path d=\"M10 0v44M139 2v42M0 8h144M2 37h141\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-U)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-m\"/>\n                            <use mask=\"url(#buttons-V)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-n\"/>\n                            <use mask=\"url(#buttons-W)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-o\"/>\n                            <use mask=\"url(#buttons-X)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-p\"/>\n                            <path d=\"M42.5 22.5H125\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#buttons-Y)\" stroke-width=\"4\" xlink:href=\"#buttons-q\"/>\n                        </g>\n                        <g transform=\"translate(0 61)\">\n                            <use mask=\"url(#buttons-Z)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-r\"/>\n                            <path d=\"M7 0v54M126 2v52M0 8h134M2 47h131\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-aa)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-s\"/>\n                            <use mask=\"url(#buttons-ab)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-t\"/>\n                            <use mask=\"url(#buttons-ac)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-u\"/>\n                            <use mask=\"url(#buttons-ad)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-v\"/>\n                            <path d=\"M20.5 27.5H111\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(147 61)\">\n                            <use mask=\"url(#buttons-ae)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-w\"/>\n                            <path d=\"M10 0v54M129 2v52M90 2v52M0 8h134\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-af)\" stroke-width=\"4\" xlink:href=\"#buttons-x\"/>\n                            <path d=\"M2 47h133\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-ag)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-y\"/>\n                            <use mask=\"url(#buttons-ah)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-z\"/>\n                            <use mask=\"url(#buttons-ai)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-A\"/>\n                            <use mask=\"url(#buttons-aj)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-B\"/>\n                            <path d=\"M21.5 27.5H74\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(297 61)\">\n                            <use mask=\"url(#buttons-ak)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-C\"/>\n                            <path d=\"M10 0v54M149 2v52M0 8h157M2 47h154\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-al)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-D\"/>\n                            <use mask=\"url(#buttons-am)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-E\"/>\n                            <use mask=\"url(#buttons-an)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-F\"/>\n                            <use mask=\"url(#buttons-ao)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-G\"/>\n                            <path d=\"M52 27.5h82\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#buttons-ap)\" stroke-width=\"4\" xlink:href=\"#buttons-H\"/>\n                        </g>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 287 */
+/* 288 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"475\" height=\"293\" viewBox=\"0 0 475 293\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        CALENDAR\n    </title>\n    <defs>\n        <path id=\"calendar-a\" d=\"M13 10h451v274H13z\"/>\n        <mask id=\"calendar-j\" x=\"0\" y=\"0\" width=\"451\" height=\"274\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-a\"/>\n        </mask>\n        <circle id=\"calendar-b\" cx=\"14\" cy=\"11\" r=\"6\"/>\n        <mask id=\"calendar-k\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-b\"/>\n        </mask>\n        <circle id=\"calendar-c\" cx=\"14\" cy=\"283\" r=\"6\"/>\n        <mask id=\"calendar-l\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-c\"/>\n        </mask>\n        <circle id=\"calendar-d\" cx=\"463\" cy=\"282\" r=\"6\"/>\n        <mask id=\"calendar-m\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-d\"/>\n        </mask>\n        <circle id=\"calendar-e\" cx=\"463\" cy=\"11\" r=\"6\"/>\n        <mask id=\"calendar-n\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-e\"/>\n        </mask>\n        <path d=\"M32.42 42l3.29-3.29a1.003 1.003 0 0 0-1.42-1.42l-4 4c-.18.18-.29.43-.29.71 0 .28.11.53.29.71l4 4a1.003 1.003 0 0 0 1.42-1.42L32.42 42z\" id=\"calendar-f\"/>\n        <mask id=\"calendar-o\" x=\"0\" y=\"0\" width=\"6\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-f\"/>\n        </mask>\n        <path d=\"M446.42 42l3.29-3.29a1.003 1.003 0 0 0-1.42-1.42l-4 4c-.18.18-.29.43-.29.71 0 .28.11.53.29.71l4 4a1.003 1.003 0 0 0 1.42-1.42L446.42 42z\" id=\"calendar-g\"/>\n        <mask id=\"calendar-p\" x=\"0\" y=\"0\" width=\"6\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-g\"/>\n        </mask>\n        <path d=\"M113 154c0-1.657 1.347-3 3-3h24c1.657 0 3 1.347 3 3v24c0 1.657-1.344 3-3.002 3H116c-1.657 0-3-1.347-3-3v-24z\" id=\"calendar-h\"/>\n        <mask id=\"calendar-q\" x=\"0\" y=\"0\" width=\"30\" height=\"30\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-h\"/>\n        </mask>\n        <path id=\"calendar-i\" d=\"M243 181h30v30h-30z\"/>\n        <mask id=\"calendar-r\" x=\"0\" y=\"0\" width=\"30\" height=\"30\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-i\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#calendar-j)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#calendar-a\"/>\n                        <path d=\"M14 0v292.5M.5 11h473M.5 11h463M3.5 283h471M463 0v292.5\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#calendar-k)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-b\"/>\n                        <use mask=\"url(#calendar-l)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-c\"/>\n                        <use mask=\"url(#calendar-m)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-d\"/>\n                        <use mask=\"url(#calendar-n)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-e\"/>\n                        <path d=\"M99 41.5h64M317 41.5h64\" stroke-width=\"5\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#calendar-o)\" stroke-width=\"4\" xlink:href=\"#calendar-f\"/>\n                        <use mask=\"url(#calendar-p)\" stroke-width=\"4\" transform=\"rotate(-180 447 42)\" xlink:href=\"#calendar-g\"/>\n                        <g stroke-width=\"4\" stroke-linecap=\"square\">\n                            <path d=\"M44 76H32M74 76H62M104 76H92M134 76h-12M164 76h-12M194 76h-12M224 76h-12\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 106H33M73 106H63M103 106H93M133 106h-10M163 106h-10M193 106h-10M223 106h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 136H33M73 136H63M103 136H93M133 136h-10M163 136h-10M193 136h-10M223 136h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 166H33M73 166H63M103 166H93M133 166h-10M163 166h-10M193 166h-10M223 166h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 196H33M73 196H63M103 196H93M133 196h-10M163 196h-10M193 196h-10M223 196h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 226H33M73 226H63M103 226H93M133 226h-10M163 226h-10M193 226h-10M223 226h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 256H33M73 256H63M103 256H93M133 256h-10M163 256h-10M193 256h-10M223 256h-10\"/>\n                        </g>\n                        <g stroke-width=\"4\" stroke-linecap=\"square\">\n                            <path d=\"M264 76h-12M294 76h-12M324 76h-12M354 76h-12M384 76h-12M414 76h-12M444 76h-12\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 106h-10M293 106h-10M323 106h-10M353 106h-10M383 106h-10M413 106h-10M443 106h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 136h-10M293 136h-10M323 136h-10M353 136h-10M383 136h-10M413 136h-10M443 136h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 166h-10M293 166h-10M323 166h-10M353 166h-10M383 166h-10M413 166h-10M443 166h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 196h-10M293 196h-10M323 196h-10M353 196h-10M383 196h-10M413 196h-10M443 196h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 226h-10M293 226h-10M323 226h-10M353 226h-10M383 226h-10M413 226h-10M443 226h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 256h-10M293 256h-10M323 256h-10M353 256h-10M383 256h-10M413 256h-10M443 256h-10\"/>\n                        </g>\n                        <use mask=\"url(#calendar-q)\" stroke-width=\"4\" xlink:href=\"#calendar-h\"/>\n                        <use mask=\"url(#calendar-r)\" stroke-width=\"4\" xlink:href=\"#calendar-i\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 288 */
+/* 289 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"168\" height=\"77\" viewBox=\"0 0 168 77\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        CHECKBOXES\n    </title>\n    <defs>\n        <path id=\"checkboxes-a\" d=\"M0 .977h16v16H0z\"/>\n        <mask id=\"checkboxes-f\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-a\"/>\n        </mask>\n        <path id=\"checkboxes-b\" d=\"M0 30.977h16v16H0z\"/>\n        <mask id=\"checkboxes-g\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-b\"/>\n        </mask>\n        <path d=\"M12 36c-.28 0-.53.11-.71.29L7 40.58l-2.29-2.29a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 36z\" id=\"checkboxes-c\"/>\n        <mask id=\"checkboxes-h\" x=\"0\" y=\"0\" width=\"10\" height=\"7\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-c\"/>\n        </mask>\n        <path id=\"checkboxes-d\" d=\"M0 60.977h16v16H0z\"/>\n        <mask id=\"checkboxes-i\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-d\"/>\n        </mask>\n        <path d=\"M11 68H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z\" id=\"checkboxes-e\"/>\n        <mask id=\"checkboxes-j\" x=\"0\" y=\"0\" width=\"8\" height=\"2\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-e\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <use mask=\"url(#checkboxes-f)\" stroke-width=\"4\" xlink:href=\"#checkboxes-a\"/>\n                    <path d=\"M26.5 8.5H76\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#checkboxes-g)\" stroke-width=\"4\" xlink:href=\"#checkboxes-b\"/>\n                    <use mask=\"url(#checkboxes-h)\" stroke-width=\"4\" xlink:href=\"#checkboxes-c\"/>\n                    <path d=\"M26.5 38.5H132\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#checkboxes-i)\" stroke-width=\"4\" xlink:href=\"#checkboxes-d\"/>\n                    <use mask=\"url(#checkboxes-j)\" stroke-width=\"4\" xlink:href=\"#checkboxes-e\"/>\n                    <path d=\"M26.5 68.5H166\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 289 */
+/* 290 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"446\" height=\"44\" viewBox=\"0 0 446 44\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        UPLOAD\n    </title>\n    <defs>\n        <rect id=\"file-upload-a\" x=\"9\" y=\"7\" width=\"431\" height=\"31\" rx=\"3\"/>\n        <mask id=\"file-upload-f\" x=\"0\" y=\"0\" width=\"431\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-a\"/>\n        </mask>\n        <circle id=\"file-upload-b\" cx=\"10\" cy=\"8\" r=\"4\"/>\n        <mask id=\"file-upload-g\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-b\"/>\n        </mask>\n        <circle id=\"file-upload-c\" cx=\"10\" cy=\"37\" r=\"4\"/>\n        <mask id=\"file-upload-h\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-c\"/>\n        </mask>\n        <circle id=\"file-upload-d\" cx=\"439\" cy=\"37\" r=\"4\"/>\n        <mask id=\"file-upload-i\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-d\"/>\n        </mask>\n        <circle id=\"file-upload-e\" cx=\"439\" cy=\"8\" r=\"4\"/>\n        <mask id=\"file-upload-j\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-e\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <use mask=\"url(#file-upload-f)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#file-upload-a\"/>\n                    <path d=\"M10 0v44M439 2v42M340 2v42M0 8h446M0 37h444\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                    <use mask=\"url(#file-upload-g)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-b\"/>\n                    <use mask=\"url(#file-upload-h)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-c\"/>\n                    <use mask=\"url(#file-upload-i)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-d\"/>\n                    <use mask=\"url(#file-upload-j)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-e\"/>\n                    <path d=\"M21.5 22.5H94M352.5 22.5H415\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 290 */
+/* 291 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"314\" height=\"194\" viewBox=\"0 0 314 194\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        INPUTS\n    </title>\n    <defs>\n        <rect id=\"input-groups-a\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-w\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-a\"/>\n        </mask>\n        <circle id=\"input-groups-b\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-x\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-b\"/>\n        </mask>\n        <circle id=\"input-groups-c\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-y\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-c\"/>\n        </mask>\n        <circle id=\"input-groups-d\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-z\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-d\"/>\n        </mask>\n        <circle id=\"input-groups-e\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-A\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-e\"/>\n        </mask>\n        <rect id=\"input-groups-f\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-B\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-f\"/>\n        </mask>\n        <mask id=\"input-groups-C\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M4 3h305v35H4z\"/>\n            <use xlink:href=\"#input-groups-f\"/>\n        </mask>\n        <circle id=\"input-groups-g\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-D\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-g\"/>\n        </mask>\n        <circle id=\"input-groups-h\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-E\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-h\"/>\n        </mask>\n        <circle id=\"input-groups-i\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-F\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-i\"/>\n        </mask>\n        <circle id=\"input-groups-j\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-G\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-j\"/>\n        </mask>\n        <rect id=\"input-groups-k\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-H\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-k\"/>\n        </mask>\n        <mask id=\"input-groups-I\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M4 3h305v35H4z\"/>\n            <use xlink:href=\"#input-groups-k\"/>\n        </mask>\n        <path d=\"M298.56 25.44l-2.67-2.68A6.94 6.94 0 0 0 297 19c0-3.87-3.13-7-7-7s-7 3.13-7 7 3.13 7 7 7c1.39 0 2.68-.42 3.76-1.11l2.68 2.67a1.498 1.498 0 1 0 2.12-2.12zM290 24c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\" id=\"input-groups-l\"/>\n        <mask id=\"input-groups-J\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-l\"/>\n        </mask>\n        <circle id=\"input-groups-m\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-K\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-m\"/>\n        </mask>\n        <circle id=\"input-groups-n\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-L\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-n\"/>\n        </mask>\n        <circle id=\"input-groups-o\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-M\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-o\"/>\n        </mask>\n        <circle id=\"input-groups-p\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-N\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-p\"/>\n        </mask>\n        <rect id=\"input-groups-q\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-O\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-q\"/>\n        </mask>\n        <circle id=\"input-groups-r\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-r\"/>\n        </mask>\n        <circle id=\"input-groups-s\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-s\"/>\n        </mask>\n        <circle id=\"input-groups-t\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-R\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-t\"/>\n        </mask>\n        <circle id=\"input-groups-u\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-S\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-u\"/>\n        </mask>\n        <path d=\"M292.42 20l3.29-3.29a1.003 1.003 0 0 0-1.42-1.42L291 18.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l3.29 3.29-3.29 3.29a1.003 1.003 0 0 0 1.42 1.42l3.29-3.29 3.29 3.29a1.003 1.003 0 0 0 1.42-1.42L292.42 20z\" id=\"input-groups-v\"/>\n        <mask id=\"input-groups-T\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-v\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <g>\n                            <use mask=\"url(#input-groups-w)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#input-groups-a\"/>\n                            <path d=\"M7 0v42M306 0v42M0 6h314M0 6h314M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-x)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-b\"/>\n                            <use mask=\"url(#input-groups-y)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-c\"/>\n                            <use mask=\"url(#input-groups-z)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-d\"/>\n                            <use mask=\"url(#input-groups-A)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-e\"/>\n                            <path d=\"M18.5 20.5H71\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 50)\">\n                            <g opacity=\".4\" stroke-width=\"4\">\n                                <use mask=\"url(#input-groups-B)\" xlink:href=\"#input-groups-f\"/>\n                                <use mask=\"url(#input-groups-C)\" xlink:href=\"#input-groups-f\"/>\n                            </g>\n                            <path d=\"M7 0v42M306 0v42M0 6h314M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-D)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-g\"/>\n                            <use mask=\"url(#input-groups-E)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-h\"/>\n                            <use mask=\"url(#input-groups-F)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-i\"/>\n                            <use mask=\"url(#input-groups-G)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-j\"/>\n                            <path d=\"M18.5 20.5H71\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 101)\">\n                            <g opacity=\".4\" stroke-width=\"4\">\n                                <use mask=\"url(#input-groups-H)\" xlink:href=\"#input-groups-k\"/>\n                                <use mask=\"url(#input-groups-I)\" xlink:href=\"#input-groups-k\"/>\n                            </g>\n                            <path d=\"M306 0v42M7 0v42M0 6h314M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-J)\" stroke-width=\"4\" xlink:href=\"#input-groups-l\"/>\n                            <use mask=\"url(#input-groups-K)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-m\"/>\n                            <use mask=\"url(#input-groups-L)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-n\"/>\n                            <use mask=\"url(#input-groups-M)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-o\"/>\n                            <use mask=\"url(#input-groups-N)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-p\"/>\n                            <path d=\"M18.5 20.5H111\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 152)\">\n                            <use mask=\"url(#input-groups-O)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#input-groups-q\"/>\n                            <path d=\"M306 0v42M0 6h314M7 0v42M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-r\"/>\n                            <use mask=\"url(#input-groups-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-s\"/>\n                            <use mask=\"url(#input-groups-R)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-t\"/>\n                            <use mask=\"url(#input-groups-S)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-u\"/>\n                            <use mask=\"url(#input-groups-T)\" stroke-width=\"4\" xlink:href=\"#input-groups-v\"/>\n                            <path d=\"M18.5 20.5H111\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 291 */
+/* 292 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"317\" height=\"238\" viewBox=\"0 0 317 238\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        INPUTS\n    </title>\n    <defs>\n        <rect id=\"inputs-a\" x=\"7\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-x\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-a\"/>\n        </mask>\n        <circle id=\"inputs-b\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"inputs-y\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-b\"/>\n        </mask>\n        <circle id=\"inputs-c\" cx=\"8\" cy=\"35\" r=\"4\"/>\n        <mask id=\"inputs-z\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-c\"/>\n        </mask>\n        <circle id=\"inputs-d\" cx=\"307\" cy=\"35\" r=\"4\"/>\n        <mask id=\"inputs-A\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-d\"/>\n        </mask>\n        <circle id=\"inputs-e\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"inputs-B\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-e\"/>\n        </mask>\n        <rect id=\"inputs-f\" x=\"6\" y=\"6\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-C\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-f\"/>\n        </mask>\n        <circle id=\"inputs-g\" cx=\"7\" cy=\"7\" r=\"4\"/>\n        <mask id=\"inputs-D\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-g\"/>\n        </mask>\n        <circle id=\"inputs-h\" cx=\"7\" cy=\"36\" r=\"4\"/>\n        <mask id=\"inputs-E\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-h\"/>\n        </mask>\n        <circle id=\"inputs-i\" cx=\"306\" cy=\"36\" r=\"4\"/>\n        <mask id=\"inputs-F\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-i\"/>\n        </mask>\n        <circle id=\"inputs-j\" cx=\"306\" cy=\"7\" r=\"4\"/>\n        <mask id=\"inputs-G\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-j\"/>\n        </mask>\n        <rect id=\"inputs-k\" x=\"7\" y=\"7\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-H\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-k\"/>\n        </mask>\n        <mask id=\"inputs-I\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M5 5h305v35H5z\"/>\n            <use xlink:href=\"#inputs-k\"/>\n        </mask>\n        <circle id=\"inputs-l\" cx=\"8\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-J\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-l\"/>\n        </mask>\n        <circle id=\"inputs-m\" cx=\"8\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-K\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-m\"/>\n        </mask>\n        <circle id=\"inputs-n\" cx=\"307\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-L\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-n\"/>\n        </mask>\n        <circle id=\"inputs-o\" cx=\"307\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-M\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-o\"/>\n        </mask>\n        <rect id=\"inputs-p\" x=\"8\" y=\"7\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-N\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-p\"/>\n        </mask>\n        <circle id=\"inputs-q\" cx=\"9\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-O\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-q\"/>\n        </mask>\n        <circle id=\"inputs-r\" cx=\"9\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-r\"/>\n        </mask>\n        <circle id=\"inputs-s\" cx=\"308\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-s\"/>\n        </mask>\n        <circle id=\"inputs-t\" cx=\"308\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-R\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-t\"/>\n        </mask>\n        <path d=\"M26 18c.55 0 1-.45 1-1v-1c0-.55-.45-1-1-1s-1 .45-1 1v1c0 .55.45 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2v-1h-3v1c0 1.1-.9 2-2 2s-2-.9-2-2v-1h-1c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h13c.55 0 1-.45 1-1V17c0-.55-.45-1-1-1zm-9 12h-3v-3h3v3zm0-4h-3v-3h3v3zm4 4h-3v-3h3v3zm0-4h-3v-3h3v3zm4 4h-3v-3h3v3zm0-4h-3v-3h3v3zm-9-6c.55 0 1-.45 1-1v-1c0-.55-.45-1-1-1s-1 .45-1 1v1c0 .55.45 1 1 1z\" id=\"inputs-u\"/>\n        <mask id=\"inputs-S\" x=\"0\" y=\"0\" width=\"15\" height=\"15\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-u\"/>\n        </mask>\n        <rect id=\"inputs-v\" x=\"4\" width=\"301\" height=\"31\" rx=\"15\"/>\n        <mask id=\"inputs-T\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-v\"/>\n        </mask>\n        <path d=\"M26.56 20.44l-2.67-2.68A6.94 6.94 0 0 0 25 14c0-3.87-3.13-7-7-7s-7 3.13-7 7 3.13 7 7 7c1.39 0 2.68-.42 3.76-1.11l2.68 2.67a1.498 1.498 0 1 0 2.12-2.12zM18 19c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\" id=\"inputs-w\"/>\n        <mask id=\"inputs-U\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-w\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <g transform=\"translate(1)\">\n                            <use mask=\"url(#inputs-x)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-a\"/>\n                            <path d=\"M1 6h314M0 35h314M8 0v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-y)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-b\"/>\n                            <use mask=\"url(#inputs-z)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-c\"/>\n                            <use mask=\"url(#inputs-A)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-d\"/>\n                            <use mask=\"url(#inputs-B)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-e\"/>\n                            <path d=\"M20 20h31.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(2 49)\">\n                            <use mask=\"url(#inputs-C)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-f\"/>\n                            <path d=\"M0 7h314M0 36h314M7 1v42M306 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-D)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-g\"/>\n                            <use mask=\"url(#inputs-E)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-h\"/>\n                            <use mask=\"url(#inputs-F)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-i\"/>\n                            <use mask=\"url(#inputs-G)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-j\"/>\n                            <path d=\"M19 21h70.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(1 99)\">\n                            <g opacity=\".4\" stroke-width=\"4\">\n                                <use mask=\"url(#inputs-H)\" xlink:href=\"#inputs-k\"/>\n                                <use mask=\"url(#inputs-I)\" xlink:href=\"#inputs-k\"/>\n                            </g>\n                            <path d=\"M2 8h314M0 37h314M8 2v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-J)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-l\"/>\n                            <use mask=\"url(#inputs-K)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-m\"/>\n                            <use mask=\"url(#inputs-L)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-n\"/>\n                            <use mask=\"url(#inputs-M)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-o\"/>\n                            <path d=\"M20 22h81.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 149)\">\n                            <use mask=\"url(#inputs-N)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-p\"/>\n                            <path d=\"M2 8h314M0 37h314M9 2v42M308 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-O)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-q\"/>\n                            <use mask=\"url(#inputs-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-r\"/>\n                            <use mask=\"url(#inputs-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-s\"/>\n                            <use mask=\"url(#inputs-R)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-t\"/>\n                            <path d=\"M39 22h88.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#inputs-S)\" stroke-width=\"4\" xlink:href=\"#inputs-u\"/>\n                        </g>\n                        <g transform=\"translate(4 207)\">\n                            <use mask=\"url(#inputs-T)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-v\"/>\n                            <path d=\"M0 1h310M2 30h306\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <path d=\"M32 15h73.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#inputs-U)\" stroke-width=\"4\" xlink:href=\"#inputs-w\"/>\n                        </g>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 292 */
+/* 293 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"315\" height=\"104\" viewBox=\"0 0 315 104\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        LABELS\n    </title>\n    <defs>\n        <rect id=\"labels-a\" x=\"7\" y=\"16\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"labels-k\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#labels-a\"/>\n        </mask>\n        <circle id=\"labels-b\" cx=\"8\" cy=\"17\" r=\"4\"/>\n        <mask id=\"labels-l\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-b\"/>\n        </mask>\n        <circle id=\"labels-c\" cx=\"8\" cy=\"46\" r=\"4\"/>\n        <mask id=\"labels-m\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-c\"/>\n        </mask>\n        <circle id=\"labels-d\" cx=\"307\" cy=\"46\" r=\"4\"/>\n        <mask id=\"labels-n\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-d\"/>\n        </mask>\n        <circle id=\"labels-e\" cx=\"307\" cy=\"17\" r=\"4\"/>\n        <mask id=\"labels-o\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-e\"/>\n        </mask>\n        <rect id=\"labels-f\" x=\"117\" y=\"5\" width=\"181\" height=\"31\" rx=\"3\"/>\n        <mask id=\"labels-p\" x=\"0\" y=\"0\" width=\"181\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#labels-f\"/>\n        </mask>\n        <circle id=\"labels-g\" cx=\"118\" cy=\"6\" r=\"4\"/>\n        <mask id=\"labels-q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-g\"/>\n        </mask>\n        <circle id=\"labels-h\" cx=\"118\" cy=\"35\" r=\"4\"/>\n        <mask id=\"labels-r\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-h\"/>\n        </mask>\n        <circle id=\"labels-i\" cx=\"297\" cy=\"35\" r=\"4\"/>\n        <mask id=\"labels-s\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-i\"/>\n        </mask>\n        <circle id=\"labels-j\" cx=\"297\" cy=\"6\" r=\"4\"/>\n        <mask id=\"labels-t\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-j\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g transform=\"translate(0 1)\">\n                        <use mask=\"url(#labels-k)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#labels-a\"/>\n                        <path d=\"M1 17h314M0 46h314M8 11v42M307 11v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#labels-l)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-b\"/>\n                        <use mask=\"url(#labels-m)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-c\"/>\n                        <use mask=\"url(#labels-n)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-d\"/>\n                        <use mask=\"url(#labels-o)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-e\"/>\n                        <path d=\"M9 1h45M19 31h35\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    </g>\n                    <g transform=\"translate(10 62)\">\n                        <use mask=\"url(#labels-p)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#labels-f\"/>\n                        <path d=\"M111 6h194M110 35h194M118 0v42M297 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#labels-q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-g\"/>\n                        <use mask=\"url(#labels-r)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-h\"/>\n                        <use mask=\"url(#labels-s)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-i\"/>\n                        <use mask=\"url(#labels-t)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-j\"/>\n                        <path d=\"M0 20h97M129 20h35\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 293 */
+/* 294 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"115\" height=\"46\" viewBox=\"0 0 115 46\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        RADIOS\n    </title>\n    <defs>\n        <circle id=\"radios-a\" cx=\"8\" cy=\"8\" r=\"8\"/>\n        <mask id=\"radios-d\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#radios-a\"/>\n        </mask>\n        <circle id=\"radios-b\" cx=\"8\" cy=\"38\" r=\"8\"/>\n        <mask id=\"radios-e\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#radios-b\"/>\n        </mask>\n        <circle id=\"radios-c\" cx=\"8\" cy=\"38\" r=\"3\"/>\n        <mask id=\"radios-f\" x=\"0\" y=\"0\" width=\"6\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#radios-c\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <path d=\"M23.5 7.5H53\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#radios-d)\" stroke-width=\"4\" xlink:href=\"#radios-a\"/>\n                    <use mask=\"url(#radios-e)\" stroke-width=\"4\" xlink:href=\"#radios-b\"/>\n                    <use mask=\"url(#radios-f)\" stroke-width=\"4\" xlink:href=\"#radios-c\"/>\n                    <path d=\"M23.5 37.5H113\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 294 */
+/* 295 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"315\" height=\"92\" viewBox=\"0 0 315 92\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        SELECT MENUS\n    </title>\n    <defs>\n        <rect id=\"select-menus-a\" x=\"7\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"select-menus-m\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-a\"/>\n        </mask>\n        <circle id=\"select-menus-b\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-n\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-b\"/>\n        </mask>\n        <circle id=\"select-menus-c\" cx=\"8\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-o\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-c\"/>\n        </mask>\n        <circle id=\"select-menus-d\" cx=\"307\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-p\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-d\"/>\n        </mask>\n        <circle id=\"select-menus-e\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-e\"/>\n        </mask>\n        <path d=\"M295 18h-6a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l3-3A1.003 1.003 0 0 0 295 18z\" id=\"select-menus-f\"/>\n        <mask id=\"select-menus-r\" x=\"0\" y=\"0\" width=\"8\" height=\"5\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-f\"/>\n        </mask>\n        <rect id=\"select-menus-g\" x=\"7\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"select-menus-s\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-g\"/>\n        </mask>\n        <mask id=\"select-menus-t\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M5 3h305v35H5z\"/>\n            <use xlink:href=\"#select-menus-g\"/>\n        </mask>\n        <circle id=\"select-menus-h\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-u\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-h\"/>\n        </mask>\n        <circle id=\"select-menus-i\" cx=\"8\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-v\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-i\"/>\n        </mask>\n        <circle id=\"select-menus-j\" cx=\"307\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-w\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-j\"/>\n        </mask>\n        <circle id=\"select-menus-k\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-x\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-k\"/>\n        </mask>\n        <path d=\"M295 18h-6a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l3-3A1.003 1.003 0 0 0 295 18z\" id=\"select-menus-l\"/>\n        <mask id=\"select-menus-y\" x=\"0\" y=\"0\" width=\"8\" height=\"5\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-l\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#select-menus-m)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#select-menus-a\"/>\n                        <path d=\"M1 6h314M0 35h314M8 0v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#select-menus-n)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-b\"/>\n                        <use mask=\"url(#select-menus-o)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-c\"/>\n                        <use mask=\"url(#select-menus-p)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-d\"/>\n                        <use mask=\"url(#select-menus-q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-e\"/>\n                        <path d=\"M20 20h85\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#select-menus-r)\" stroke-width=\"4\" xlink:href=\"#select-menus-f\"/>\n                    </g>\n                    <g transform=\"translate(0 50)\">\n                        <g opacity=\".4\" stroke-width=\"4\">\n                            <use mask=\"url(#select-menus-s)\" xlink:href=\"#select-menus-g\"/>\n                            <use mask=\"url(#select-menus-t)\" xlink:href=\"#select-menus-g\"/>\n                        </g>\n                        <path d=\"M1 6h314M0 35h314M8 0v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#select-menus-u)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-h\"/>\n                        <use mask=\"url(#select-menus-v)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-i\"/>\n                        <use mask=\"url(#select-menus-w)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-j\"/>\n                        <use mask=\"url(#select-menus-x)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-k\"/>\n                        <path d=\"M20 20h85\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#select-menus-y)\" stroke-width=\"4\" xlink:href=\"#select-menus-l\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 295 */
+/* 296 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"317\" height=\"70\" viewBox=\"0 0 317 70\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        SLIDERS\n    </title>\n    <defs>\n        <rect id=\"sliders-a\" x=\"7\" y=\"6\" width=\"74\" height=\"9\" rx=\"4.5\"/>\n        <mask id=\"sliders-q\" x=\"0\" y=\"0\" width=\"74\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-a\"/>\n        </mask>\n        <path d=\"M148 6h156.505A4.5 4.5 0 0 1 309 10.5c0 2.485-2.006 4.5-4.495 4.5H148V6z\" id=\"sliders-b\"/>\n        <mask id=\"sliders-r\" x=\"0\" y=\"0\" width=\"161\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-b\"/>\n        </mask>\n        <circle id=\"sliders-c\" cx=\"8\" cy=\"7\" r=\"4\"/>\n        <mask id=\"sliders-s\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-c\"/>\n        </mask>\n        <circle id=\"sliders-d\" cx=\"8\" cy=\"14\" r=\"4\"/>\n        <mask id=\"sliders-t\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-d\"/>\n        </mask>\n        <circle id=\"sliders-e\" cx=\"307\" cy=\"14\" r=\"4\"/>\n        <mask id=\"sliders-u\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-e\"/>\n        </mask>\n        <circle id=\"sliders-f\" cx=\"307\" cy=\"7\" r=\"4\"/>\n        <mask id=\"sliders-v\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-f\"/>\n        </mask>\n        <path id=\"sliders-g\" d=\"M79 .977h19v19H79z\"/>\n        <mask id=\"sliders-w\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-g\"/>\n        </mask>\n        <path id=\"sliders-h\" d=\"M131 .977h19v19h-19z\"/>\n        <mask id=\"sliders-x\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-h\"/>\n        </mask>\n        <rect id=\"sliders-i\" x=\"7\" y=\"5\" width=\"73\" height=\"9\" rx=\"4.5\"/>\n        <mask id=\"sliders-y\" x=\"0\" y=\"0\" width=\"73\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-i\"/>\n        </mask>\n        <path d=\"M237 5h66.505A4.5 4.5 0 0 1 308 9.5c0 2.485-2.01 4.5-4.495 4.5H237V5z\" id=\"sliders-j\"/>\n        <mask id=\"sliders-z\" x=\"0\" y=\"0\" width=\"71\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-j\"/>\n        </mask>\n        <circle id=\"sliders-k\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"sliders-A\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-k\"/>\n        </mask>\n        <circle id=\"sliders-l\" cx=\"8\" cy=\"13\" r=\"4\"/>\n        <mask id=\"sliders-B\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-l\"/>\n        </mask>\n        <circle id=\"sliders-m\" cx=\"307\" cy=\"14\" r=\"4\"/>\n        <mask id=\"sliders-C\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-m\"/>\n        </mask>\n        <circle id=\"sliders-n\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"sliders-D\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-n\"/>\n        </mask>\n        <path id=\"sliders-o\" d=\"M78 .977h19v19H78z\"/>\n        <mask id=\"sliders-E\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-o\"/>\n        </mask>\n        <path id=\"sliders-p\" d=\"M219 .977h19v19h-19z\"/>\n        <mask id=\"sliders-F\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-p\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#sliders-q)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-a\"/>\n                        <use mask=\"url(#sliders-r)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-b\"/>\n                        <path d=\"M1 7h79M150 7h162M0 14h80M150 14h167M8 1v20M307 1v20\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#sliders-s)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-c\"/>\n                        <use mask=\"url(#sliders-t)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-d\"/>\n                        <use mask=\"url(#sliders-u)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-e\"/>\n                        <use mask=\"url(#sliders-v)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-f\"/>\n                        <use mask=\"url(#sliders-w)\" stroke-width=\"4\" xlink:href=\"#sliders-g\"/>\n                        <use mask=\"url(#sliders-x)\" stroke-width=\"4\" xlink:href=\"#sliders-h\"/>\n                        <path d=\"M98 7h32M98 13h32M97.661 11.839l2.679-3.679M102.661 11.839l2.679-3.679M107.661 11.839l2.679-3.679M112.661 11.839l2.679-3.679M117.661 11.839l2.679-3.679M122.661 11.839l2.679-3.679M127.661 11.839l2.679-3.679\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                    </g>\n                    <g transform=\"translate(0 41)\">\n                        <use mask=\"url(#sliders-y)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-i\"/>\n                        <use mask=\"url(#sliders-z)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-j\"/>\n                        <path d=\"M1 6h78M238 6h78M0 13h79M238 13h79M8 0v19M307 0v18\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#sliders-A)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-k\"/>\n                        <use mask=\"url(#sliders-B)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-l\"/>\n                        <use mask=\"url(#sliders-C)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-m\"/>\n                        <use mask=\"url(#sliders-D)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-n\"/>\n                        <use mask=\"url(#sliders-E)\" stroke-width=\"4\" xlink:href=\"#sliders-o\"/>\n                        <use mask=\"url(#sliders-F)\" stroke-width=\"4\" xlink:href=\"#sliders-p\"/>\n                        <path d=\"M23 28H13M93 28H83M163 28h-10M233 28h-10M303 28h-10M98 6h121M98 12h121M96.661 10.839L99.34 7.16M101.661 10.839l2.679-3.679M106.661 10.839l2.679-3.679M111.661 10.839l2.679-3.679M116.661 10.839l2.679-3.679M121.661 10.839l2.679-3.679M126.661 10.839l2.679-3.679M131.661 10.839l2.679-3.679M136.661 10.839l2.679-3.679M141.661 10.839l2.679-3.679M146.661 10.839l2.679-3.679M151.661 10.839l2.679-3.679M156.661 10.839l2.679-3.679M161.661 10.839l2.679-3.679M166.661 10.839l2.679-3.679M171.661 10.839l2.679-3.679M176.661 10.839l2.679-3.679M181.661 10.839l2.679-3.679M186.661 10.839l2.679-3.679M191.661 10.839l2.679-3.679M196.661 10.839l2.679-3.679M201.661 10.839l2.679-3.679M206.661 10.839l2.679-3.679M211.661 10.839l2.679-3.679M216.661 10.839l2.679-3.679\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 296 */
+/* 297 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"51\" height=\"46\" viewBox=\"0 0 51 46\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        SWITCHES\n    </title>\n    <defs>\n        <circle id=\"switches-a\" cx=\"9\" cy=\"8\" r=\"5\"/>\n        <mask id=\"switches-e\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#switches-a\"/>\n        </mask>\n        <path d=\"M0 8c0-4.418 3.588-8 7.995-8h10.01C22.42 0 26 3.59 26 8c0 4.418-3.588 8-7.995 8H7.995C3.58 16 0 12.41 0 8z\" id=\"switches-b\"/>\n        <mask id=\"switches-f\" x=\"0\" y=\"0\" width=\"26\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#switches-b\"/>\n        </mask>\n        <circle id=\"switches-c\" cx=\"18\" cy=\"38\" r=\"5\"/>\n        <mask id=\"switches-g\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#switches-c\"/>\n        </mask>\n        <path d=\"M0 38c0-4.418 3.588-8 7.995-8h10.01C22.42 30 26 33.59 26 38c0 4.418-3.588 8-7.995 8H7.995C3.58 46 0 42.41 0 38z\" id=\"switches-d\"/>\n        <mask id=\"switches-h\" x=\"0\" y=\"0\" width=\"26\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#switches-d\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <path d=\"M34.5 7.5H49\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#switches-e)\" stroke-width=\"4\" xlink:href=\"#switches-a\"/>\n                    <use mask=\"url(#switches-f)\" stroke-width=\"4\" xlink:href=\"#switches-b\"/>\n                    <use mask=\"url(#switches-g)\" stroke-width=\"4\" xlink:href=\"#switches-c\"/>\n                    <use mask=\"url(#switches-h)\" stroke-width=\"4\" xlink:href=\"#switches-d\"/>\n                    <path d=\"M34.5 37.5H46\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 297 */
+/* 298 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"215\" height=\"154\" viewBox=\"0 0 215 154\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        TIME SELECTIONS\n    </title>\n    <defs>\n        <rect id=\"time-selections-a\" x=\"7\" y=\"16\" width=\"201\" height=\"31\" rx=\"3\"/>\n        <mask id=\"time-selections-M\" x=\"0\" y=\"0\" width=\"201\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-a\"/>\n        </mask>\n        <circle id=\"time-selections-b\" cx=\"8\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-N\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-b\"/>\n        </mask>\n        <circle id=\"time-selections-c\" cx=\"8\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-O\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-c\"/>\n        </mask>\n        <circle id=\"time-selections-d\" cx=\"207\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-d\"/>\n        </mask>\n        <circle id=\"time-selections-e\" cx=\"207\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-e\"/>\n        </mask>\n        <path id=\"time-selections-f\" d=\"M46 28h3v3h-3z\"/>\n        <mask id=\"time-selections-R\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-f\"/>\n        </mask>\n        <path id=\"time-selections-g\" d=\"M46 34h3v3h-3z\"/>\n        <mask id=\"time-selections-S\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-g\"/>\n        </mask>\n        <path id=\"time-selections-h\" d=\"M83 28h3v3h-3z\"/>\n        <mask id=\"time-selections-T\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-h\"/>\n        </mask>\n        <path id=\"time-selections-i\" d=\"M83 34h3v3h-3z\"/>\n        <mask id=\"time-selections-U\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-i\"/>\n        </mask>\n        <path id=\"time-selections-j\" d=\"M121 28h3v3h-3z\"/>\n        <mask id=\"time-selections-V\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-j\"/>\n        </mask>\n        <path id=\"time-selections-k\" d=\"M121 34h3v3h-3z\"/>\n        <mask id=\"time-selections-W\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-k\"/>\n        </mask>\n        <path id=\"time-selections-l\" d=\"M159 28h3v3h-3z\"/>\n        <mask id=\"time-selections-X\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-l\"/>\n        </mask>\n        <path id=\"time-selections-m\" d=\"M159 34h3v3h-3z\"/>\n        <mask id=\"time-selections-Y\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-m\"/>\n        </mask>\n        <path d=\"M34 58c-.28 0-.53.11-.71.29L30 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 34 58z\" id=\"time-selections-n\"/>\n        <mask id=\"time-selections-Z\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-n\"/>\n        </mask>\n        <path d=\"M72 58c-.28 0-.53.11-.71.29L68 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 72 58z\" id=\"time-selections-o\"/>\n        <mask id=\"time-selections-aa\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-o\"/>\n        </mask>\n        <path d=\"M110 58c-.28 0-.53.11-.71.29L106 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 110 58z\" id=\"time-selections-p\"/>\n        <mask id=\"time-selections-ab\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-p\"/>\n        </mask>\n        <path d=\"M147 58c-.28 0-.53.11-.71.29L143 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 147 58z\" id=\"time-selections-q\"/>\n        <mask id=\"time-selections-ac\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-q\"/>\n        </mask>\n        <path d=\"M185 58c-.28 0-.53.11-.71.29L181 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 185 58z\" id=\"time-selections-r\"/>\n        <mask id=\"time-selections-ad\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-r\"/>\n        </mask>\n        <path d=\"M33.29.29L30 3.58 26.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 33.29.29z\" id=\"time-selections-s\"/>\n        <mask id=\"time-selections-ae\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-s\"/>\n        </mask>\n        <path d=\"M71.29.29L68 3.58 64.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 71.29.29z\" id=\"time-selections-t\"/>\n        <mask id=\"time-selections-af\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-t\"/>\n        </mask>\n        <path d=\"M109.29.29L106 3.58 102.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-u\"/>\n        <mask id=\"time-selections-ag\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-u\"/>\n        </mask>\n        <path d=\"M146.29.29L143 3.58 139.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-v\"/>\n        <mask id=\"time-selections-ah\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-v\"/>\n        </mask>\n        <path d=\"M184.29.29L181 3.58 177.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-w\"/>\n        <mask id=\"time-selections-ai\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-w\"/>\n        </mask>\n        <rect id=\"time-selections-x\" x=\"7\" y=\"16\" width=\"121\" height=\"31\" rx=\"3\"/>\n        <mask id=\"time-selections-aj\" x=\"0\" y=\"0\" width=\"121\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-x\"/>\n        </mask>\n        <circle id=\"time-selections-y\" cx=\"8\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-ak\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-y\"/>\n        </mask>\n        <circle id=\"time-selections-z\" cx=\"8\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-al\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-z\"/>\n        </mask>\n        <circle id=\"time-selections-A\" cx=\"127\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-am\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-A\"/>\n        </mask>\n        <circle id=\"time-selections-B\" cx=\"127\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-an\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-B\"/>\n        </mask>\n        <path id=\"time-selections-C\" d=\"M46 28h3v3h-3z\"/>\n        <mask id=\"time-selections-ao\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-C\"/>\n        </mask>\n        <path id=\"time-selections-D\" d=\"M46 34h3v3h-3z\"/>\n        <mask id=\"time-selections-ap\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-D\"/>\n        </mask>\n        <path id=\"time-selections-E\" d=\"M83 28h3v3h-3z\"/>\n        <mask id=\"time-selections-aq\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-E\"/>\n        </mask>\n        <path id=\"time-selections-F\" d=\"M83 34h3v3h-3z\"/>\n        <mask id=\"time-selections-ar\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-F\"/>\n        </mask>\n        <path d=\"M34 58c-.28 0-.53.11-.71.29L30 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 34 58z\" id=\"time-selections-G\"/>\n        <mask id=\"time-selections-as\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-G\"/>\n        </mask>\n        <path d=\"M72 58c-.28 0-.53.11-.71.29L68 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 72 58z\" id=\"time-selections-H\"/>\n        <mask id=\"time-selections-at\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-H\"/>\n        </mask>\n        <path d=\"M110 58c-.28 0-.53.11-.71.29L106 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 110 58z\" id=\"time-selections-I\"/>\n        <mask id=\"time-selections-au\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-I\"/>\n        </mask>\n        <path d=\"M33.29.29L30 3.58 26.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 33.29.29z\" id=\"time-selections-J\"/>\n        <mask id=\"time-selections-av\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-J\"/>\n        </mask>\n        <path d=\"M71.29.29L68 3.58 64.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 71.29.29z\" id=\"time-selections-K\"/>\n        <mask id=\"time-selections-aw\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-K\"/>\n        </mask>\n        <path d=\"M109.29.29L106 3.58 102.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-L\"/>\n        <mask id=\"time-selections-ax\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-L\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#time-selections-M)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#time-selections-a\"/>\n                        <path d=\"M1 17h214M0 46h214M8 11v42M207 11v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#time-selections-N)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-b\"/>\n                        <use mask=\"url(#time-selections-O)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-c\"/>\n                        <use mask=\"url(#time-selections-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-d\"/>\n                        <use mask=\"url(#time-selections-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-e\"/>\n                        <path d=\"M23 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-R)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-f\"/>\n                        <use mask=\"url(#time-selections-S)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-g\"/>\n                        <path d=\"M60 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-T)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-h\"/>\n                        <use mask=\"url(#time-selections-U)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-i\"/>\n                        <path d=\"M98 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-V)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-j\"/>\n                        <use mask=\"url(#time-selections-W)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-k\"/>\n                        <path d=\"M136 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-X)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-l\"/>\n                        <use mask=\"url(#time-selections-Y)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-m\"/>\n                        <path d=\"M174 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-Z)\" stroke-width=\"4\" xlink:href=\"#time-selections-n\"/>\n                        <use mask=\"url(#time-selections-aa)\" stroke-width=\"4\" xlink:href=\"#time-selections-o\"/>\n                        <use mask=\"url(#time-selections-ab)\" stroke-width=\"4\" xlink:href=\"#time-selections-p\"/>\n                        <use mask=\"url(#time-selections-ac)\" stroke-width=\"4\" xlink:href=\"#time-selections-q\"/>\n                        <use mask=\"url(#time-selections-ad)\" stroke-width=\"4\" xlink:href=\"#time-selections-r\"/>\n                        <use mask=\"url(#time-selections-ae)\" stroke-width=\"4\" transform=\"rotate(-180 30 3)\" xlink:href=\"#time-selections-s\"/>\n                        <use mask=\"url(#time-selections-af)\" stroke-width=\"4\" transform=\"rotate(-180 68 3)\" xlink:href=\"#time-selections-t\"/>\n                        <use mask=\"url(#time-selections-ag)\" stroke-width=\"4\" transform=\"rotate(-180 106 3)\" xlink:href=\"#time-selections-u\"/>\n                        <use mask=\"url(#time-selections-ah)\" stroke-width=\"4\" transform=\"rotate(-180 143 3)\" xlink:href=\"#time-selections-v\"/>\n                        <use mask=\"url(#time-selections-ai)\" stroke-width=\"4\" transform=\"rotate(-180 181 3)\" xlink:href=\"#time-selections-w\"/>\n                    </g>\n                    <g transform=\"translate(0 90)\">\n                        <use mask=\"url(#time-selections-aj)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#time-selections-x\"/>\n                        <path d=\"M1 17h134M0 46h134M8 11v42M127 11v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#time-selections-ak)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-y\"/>\n                        <use mask=\"url(#time-selections-al)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-z\"/>\n                        <use mask=\"url(#time-selections-am)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-A\"/>\n                        <use mask=\"url(#time-selections-an)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-B\"/>\n                        <path d=\"M23 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-ao)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-C\"/>\n                        <use mask=\"url(#time-selections-ap)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-D\"/>\n                        <path d=\"M60 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-aq)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-E\"/>\n                        <use mask=\"url(#time-selections-ar)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-F\"/>\n                        <path d=\"M98 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-as)\" stroke-width=\"4\" xlink:href=\"#time-selections-G\"/>\n                        <use mask=\"url(#time-selections-at)\" stroke-width=\"4\" xlink:href=\"#time-selections-H\"/>\n                        <use mask=\"url(#time-selections-au)\" stroke-width=\"4\" xlink:href=\"#time-selections-I\"/>\n                        <use mask=\"url(#time-selections-av)\" stroke-width=\"4\" transform=\"rotate(-180 30 3)\" xlink:href=\"#time-selections-J\"/>\n                        <use mask=\"url(#time-selections-aw)\" stroke-width=\"4\" transform=\"rotate(-180 68 3)\" xlink:href=\"#time-selections-K\"/>\n                        <use mask=\"url(#time-selections-ax)\" stroke-width=\"4\" transform=\"rotate(-180 106 3)\" xlink:href=\"#time-selections-L\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 298 */
+/* 299 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"450\" height=\"346\" viewBox=\"0 0 450 346\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        TOGGLES\n    </title>\n    <defs>\n        <path d=\"M43.816 40h174.181A3.004 3.004 0 0 1 221 43v288.696c0 1.654-1.344 3-3.003 3H13.003a3.004 3.004 0 0 1-3.003-3V43.001C10 41.346 11.344 40 13.003 40h13.18c.051-.05.1-.1.145-.15l7.344-8.246c.733-.823 1.924-.822 2.656 0l7.344 8.245c.045.051.094.101.144.151z\" id=\"toggles-a\"/>\n        <mask id=\"toggles-M\" x=\"0\" y=\"0\" width=\"211\" height=\"303.71\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-a\"/>\n        </mask>\n        <circle id=\"toggles-b\" cx=\"11\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-N\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-b\"/>\n        </mask>\n        <circle id=\"toggles-c\" cx=\"220\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-O\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-c\"/>\n        </mask>\n        <circle id=\"toggles-d\" cx=\"220\" cy=\"334\" r=\"5\"/>\n        <mask id=\"toggles-P\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-d\"/>\n        </mask>\n        <circle id=\"toggles-e\" cx=\"10\" cy=\"334\" r=\"5\"/>\n        <mask id=\"toggles-Q\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-e\"/>\n        </mask>\n        <path id=\"toggles-f\" d=\"M192 60l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-R\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-f\"/>\n        </mask>\n        <path id=\"toggles-g\" d=\"M192 100l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-S\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-g\"/>\n        </mask>\n        <path id=\"toggles-h\" d=\"M192 140l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-T\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-h\"/>\n        </mask>\n        <path id=\"toggles-i\" d=\"M192 180l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-U\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-i\"/>\n        </mask>\n        <path id=\"toggles-j\" d=\"M192 220l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-V\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-j\"/>\n        </mask>\n        <path id=\"toggles-k\" d=\"M192 260l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-W\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-k\"/>\n        </mask>\n        <path id=\"toggles-l\" d=\"M192 300l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-X\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-l\"/>\n        </mask>\n        <path d=\"M44 8h-2.31c-.14-.46-.33-.89-.56-1.3l1.7-1.7a.996.996 0 0 0 0-1.41l-1.41-1.41a.996.996 0 0 0-1.41 0l-1.7 1.7c-.41-.22-.84-.41-1.3-.55V1c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v2.33c-.48.14-.94.35-1.37.59l-1.63-1.63a.972.972 0 0 0-1.36 0l-1.36 1.36c-.37.38-.37.98 0 1.36l1.62 1.62c-.24.43-.45.89-.6 1.38H26c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1h2.31c.14.46.33.89.56 1.3l-1.7 1.7a.996.996 0 0 0 0 1.41l1.41 1.41c.39.39 1.02.39 1.41 0l1.7-1.7c.41.22.84.41 1.3.55v2.33c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.33c.48-.14.94-.35 1.37-.59l1.63 1.63c.37.37.98.37 1.36 0l1.36-1.36c.37-.38.37-.98 0-1.36l-1.62-1.62c.24-.43.45-.89.6-1.38H44c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-9 6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z\" id=\"toggles-m\"/>\n        <mask id=\"toggles-Y\" x=\"0\" y=\"0\" width=\"20\" height=\"20.01\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-m\"/>\n        </mask>\n        <path d=\"M43 70.99c-.53 0-1.01.21-1.37.55l-4.72-2.95c.06-.19.1-.39.1-.6 0-.21-.04-.41-.1-.6l4.72-2.95c.36.34.84.55 1.37.55 1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2c0 .21.04.41.1.6l-4.73 2.96c-.24-.23-.54-.4-.87-.48v-4.14c.86-.22 1.5-1 1.5-1.93 0-1.1-.9-2-2-2s-2 .9-2 2c0 .93.64 1.71 1.5 1.93v4.14c-.33.09-.63.26-.87.48l-4.73-2.96c.06-.19.1-.39.1-.6 0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2c.53 0 1.01-.21 1.37-.55l4.72 2.95c-.06.19-.1.39-.1.6 0 .21.04.41.1.6l-4.72 2.95c-.36-.34-.84-.55-1.37-.55-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2c0-.21-.04-.41-.1-.6l4.73-2.96c.24.23.54.4.87.48v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93v-4.14c.33-.09.63-.26.87-.48l4.73 2.96c-.06.19-.1.39-.1.6 0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2z\" id=\"toggles-n\"/>\n        <mask id=\"toggles-Z\" x=\"0\" y=\"0\" width=\"20\" height=\"19.98\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-n\"/>\n        </mask>\n        <path d=\"M43.3 106c-.2-.9-.6-1.7-1.1-2.5.2-.3.3-.7.3-1 0-1.1-.9-2-2-2-.4 0-.7.1-1 .3-.8-.5-1.6-.8-2.5-1.1-.1-1-1-1.7-2-1.7s-1.8.8-2 1.7c-.9.3-1.7.6-2.5 1.1-.3-.2-.7-.3-1-.3-1.1 0-2 .9-2 2 0 .4.1.7.3 1-.5.8-.8 1.6-1.1 2.5-.9.2-1.7 1-1.7 2s.8 1.8 1.7 2c.2.9.6 1.7 1.1 2.5-.2.3-.3.7-.3 1 0 1.1.9 2 2 2 .4 0 .7-.1 1-.3.8.5 1.6.8 2.5 1.1.1 1 1 1.7 2 1.7s1.8-.8 2-1.7c.9-.2 1.7-.6 2.5-1.1.3.2.7.3 1 .3 1.1 0 2-.9 2-2 0-.4-.1-.7-.3-1 .5-.8.8-1.6 1.1-2.5 1-.1 1.7-1 1.7-2s-.8-1.8-1.7-2zm-1.8 5.8c-.3-.2-.6-.3-1-.3-1.1 0-2 .9-2 2 0 .4.1.7.3 1-.6.3-1.2.6-1.9.8-.3-.7-1-1.3-1.9-1.3-.8 0-1.6.5-1.9 1.3-.7-.2-1.3-.4-1.9-.8.2-.3.3-.6.3-1 0-1.1-.9-2-2-2-.4 0-.7.1-1 .3-.3-.6-.6-1.2-.8-1.9.8-.3 1.3-1.1 1.3-1.9 0-.8-.5-1.6-1.2-1.8.2-.7.4-1.3.8-1.9.3.2.6.3 1 .3 1.1 0 2-.9 2-2 0-.4-.1-.7-.3-1 .6-.3 1.2-.6 1.9-.8.2.7 1 1.2 1.8 1.2s1.6-.5 1.9-1.3c.7.2 1.3.4 1.9.8-.2.3-.3.6-.3 1 0 1.1.9 2 2 2 .4 0 .7-.1 1-.3.3.6.6 1.2.8 1.9-.8.3-1.3 1.1-1.3 1.9 0 .8.5 1.6 1.2 1.8-.1.7-.4 1.4-.7 2z\" id=\"toggles-o\"/>\n        <mask id=\"toggles-aa\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-o\"/>\n        </mask>\n        <path d=\"M27 146c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16-12c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-16-4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm8 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm8 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-8-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z\" id=\"toggles-p\"/>\n        <mask id=\"toggles-ab\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-p\"/>\n        </mask>\n        <path d=\"M27 178c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16-12c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-16 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-8 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z\" id=\"toggles-q\"/>\n        <mask id=\"toggles-ac\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-q\"/>\n        </mask>\n        <path d=\"M43.5 234.07v-4.14c.86-.22 1.5-1 1.5-1.93 0-1.1-.9-2-2-2-.93 0-1.71.64-1.93 1.5h-4.14c-.18-.7-.73-1.25-1.43-1.43v-4.14c.86-.22 1.5-1 1.5-1.93 0-1.1-.9-2-2-2s-2 .9-2 2c0 .93.64 1.71 1.5 1.93v4.14c-.7.18-1.25.73-1.43 1.43h-4.14c-.22-.86-1-1.5-1.93-1.5-1.1 0-2 .9-2 2 0 .93.64 1.71 1.5 1.93v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93v-4.14c.7-.18 1.25-.73 1.43-1.43h4.14c.18.7.73 1.25 1.43 1.43v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93v-4.14c.7-.18 1.25-.73 1.43-1.43h4.14c.18.7.73 1.25 1.43 1.43v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93z\" id=\"toggles-r\"/>\n        <mask id=\"toggles-ad\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-r\"/>\n        </mask>\n        <path d=\"M27 272c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-12c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16 2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-16 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm11 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm5-4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-5-12c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z\" id=\"toggles-s\"/>\n        <mask id=\"toggles-ae\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-s\"/>\n        </mask>\n        <path d=\"M42.5 306a2.5 2.5 0 0 0-2.45 2h-2.1a2.5 2.5 0 0 0-4.9 0h-2.1a2.5 2.5 0 1 0 0 1h2.1a2.5 2.5 0 0 0 4.9 0h2.1a2.5 2.5 0 1 0 2.45-3z\" id=\"toggles-t\"/>\n        <mask id=\"toggles-af\" x=\"0\" y=\"0\" width=\"19\" height=\"5\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-t\"/>\n        </mask>\n        <path d=\"M43.816 40H188.01A3.002 3.002 0 0 1 191 42.996v127.008a2.991 2.991 0 0 1-2.99 2.996H12.99a3.002 3.002 0 0 1-2.99-2.996V42.996A2.991 2.991 0 0 1 12.99 40h13.194c.05-.05.099-.1.144-.15l7.344-8.246c.733-.823 1.924-.822 2.656 0l7.344 8.245c.045.051.094.101.144.151z\" id=\"toggles-u\"/>\n        <mask id=\"toggles-ag\" x=\"0\" y=\"0\" width=\"181\" height=\"142.013\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-u\"/>\n        </mask>\n        <path id=\"toggles-v\" d=\"M25 54.977h20v20H25z\"/>\n        <mask id=\"toggles-ah\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-v\"/>\n        </mask>\n        <path id=\"toggles-w\" d=\"M25 94.977h20v20H25z\"/>\n        <mask id=\"toggles-ai\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-w\"/>\n        </mask>\n        <path id=\"toggles-x\" d=\"M25 134.977h20v20H25z\"/>\n        <mask id=\"toggles-aj\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-x\"/>\n        </mask>\n        <circle id=\"toggles-y\" cx=\"11\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-ak\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-y\"/>\n        </mask>\n        <circle id=\"toggles-z\" cx=\"190\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-al\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-z\"/>\n        </mask>\n        <circle id=\"toggles-A\" cx=\"190\" cy=\"172\" r=\"5\"/>\n        <mask id=\"toggles-am\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-A\"/>\n        </mask>\n        <circle id=\"toggles-B\" cx=\"10\" cy=\"172\" r=\"5\"/>\n        <mask id=\"toggles-an\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-B\"/>\n        </mask>\n        <path d=\"M44 8h-2.31c-.14-.46-.33-.89-.56-1.3l1.7-1.7a.996.996 0 0 0 0-1.41l-1.41-1.41a.996.996 0 0 0-1.41 0l-1.7 1.7c-.41-.22-.84-.41-1.3-.55V1c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v2.33c-.48.14-.94.35-1.37.59l-1.63-1.63a.972.972 0 0 0-1.36 0l-1.36 1.36c-.37.38-.37.98 0 1.36l1.62 1.62c-.24.43-.45.89-.6 1.38H26c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1h2.31c.14.46.33.89.56 1.3l-1.7 1.7a.996.996 0 0 0 0 1.41l1.41 1.41c.39.39 1.02.39 1.41 0l1.7-1.7c.41.22.84.41 1.3.55v2.33c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.33c.48-.14.94-.35 1.37-.59l1.63 1.63c.37.37.98.37 1.36 0l1.36-1.36c.37-.38.37-.98 0-1.36l-1.62-1.62c.24-.43.45-.89.6-1.38H44c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-9 6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z\" id=\"toggles-C\"/>\n        <mask id=\"toggles-ao\" x=\"0\" y=\"0\" width=\"20\" height=\"20.01\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-C\"/>\n        </mask>\n        <path d=\"M43.816 40H188.01A3.005 3.005 0 0 1 191 43v98.998a2.998 2.998 0 0 1-2.99 3H12.99a3.005 3.005 0 0 1-2.99-3V43A2.998 2.998 0 0 1 12.99 40h13.194c.05-.05.099-.1.144-.15l7.344-8.246c.733-.823 1.924-.822 2.656 0l7.344 8.245c.045.051.094.101.144.15z\" id=\"toggles-D\"/>\n        <mask id=\"toggles-ap\" x=\"0\" y=\"0\" width=\"181\" height=\"114.013\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-D\"/>\n        </mask>\n        <path id=\"toggles-E\" d=\"M25 54.977h16v16H25z\"/>\n        <mask id=\"toggles-aq\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-E\"/>\n        </mask>\n        <path id=\"toggles-F\" d=\"M25 84.977h16v16H25z\"/>\n        <mask id=\"toggles-ar\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-F\"/>\n        </mask>\n        <path id=\"toggles-G\" d=\"M25 114.977h16v16H25z\"/>\n        <mask id=\"toggles-as\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-G\"/>\n        </mask>\n        <circle id=\"toggles-H\" cx=\"11\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-at\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-H\"/>\n        </mask>\n        <circle id=\"toggles-I\" cx=\"190\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-au\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-I\"/>\n        </mask>\n        <circle id=\"toggles-J\" cx=\"190\" cy=\"144\" r=\"5\"/>\n        <mask id=\"toggles-av\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-J\"/>\n        </mask>\n        <circle id=\"toggles-K\" cx=\"11\" cy=\"144\" r=\"5\"/>\n        <mask id=\"toggles-aw\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-K\"/>\n        </mask>\n        <path d=\"M44 8h-2.31c-.14-.46-.33-.89-.56-1.3l1.7-1.7a.996.996 0 0 0 0-1.41l-1.41-1.41a.996.996 0 0 0-1.41 0l-1.7 1.7c-.41-.22-.84-.41-1.3-.55V1c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v2.33c-.48.14-.94.35-1.37.59l-1.63-1.63a.972.972 0 0 0-1.36 0l-1.36 1.36c-.37.38-.37.98 0 1.36l1.62 1.62c-.24.43-.45.89-.6 1.38H26c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1h2.31c.14.46.33.89.56 1.3l-1.7 1.7a.996.996 0 0 0 0 1.41l1.41 1.41c.39.39 1.02.39 1.41 0l1.7-1.7c.41.22.84.41 1.3.55v2.33c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.33c.48-.14.94-.35 1.37-.59l1.63 1.63c.37.37.98.37 1.36 0l1.36-1.36c.37-.38.37-.98 0-1.36l-1.62-1.62c.24-.43.45-.89.6-1.38H44c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-9 6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z\" id=\"toggles-L\"/>\n        <mask id=\"toggles-ax\" x=\"0\" y=\"0\" width=\"20\" height=\"20.01\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-L\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <g>\n                        <use mask=\"url(#toggles-M)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#toggles-a\"/>\n                        <path d=\"M11 34v312M220 34v312M0 334h230M0 41h230\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#toggles-N)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-b\"/>\n                        <use mask=\"url(#toggles-O)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-c\"/>\n                        <use mask=\"url(#toggles-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-d\"/>\n                        <use mask=\"url(#toggles-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-e\"/>\n                        <use mask=\"url(#toggles-R)\" stroke-width=\"4\" xlink:href=\"#toggles-f\"/>\n                        <use mask=\"url(#toggles-S)\" stroke-width=\"4\" xlink:href=\"#toggles-g\"/>\n                        <use mask=\"url(#toggles-T)\" stroke-width=\"4\" xlink:href=\"#toggles-h\"/>\n                        <use mask=\"url(#toggles-U)\" stroke-width=\"4\" xlink:href=\"#toggles-i\"/>\n                        <use mask=\"url(#toggles-V)\" stroke-width=\"4\" xlink:href=\"#toggles-j\"/>\n                        <use mask=\"url(#toggles-W)\" stroke-width=\"4\" xlink:href=\"#toggles-k\"/>\n                        <use mask=\"url(#toggles-X)\" stroke-width=\"4\" xlink:href=\"#toggles-l\"/>\n                        <path d=\"M62.5 68.5H92M62.5 108.5H116M62.5 148.5H89M62.5 188.5H131M62.5 228.5H127M62.5 268.5H123M62.5 308.5H104\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#toggles-Y)\" stroke-width=\"4\" xlink:href=\"#toggles-m\"/>\n                        <use mask=\"url(#toggles-Z)\" stroke-width=\"4\" xlink:href=\"#toggles-n\"/>\n                        <use mask=\"url(#toggles-aa)\" stroke-width=\"4\" xlink:href=\"#toggles-o\"/>\n                        <use mask=\"url(#toggles-ab)\" stroke-width=\"4\" xlink:href=\"#toggles-p\"/>\n                        <use mask=\"url(#toggles-ac)\" stroke-width=\"4\" xlink:href=\"#toggles-q\"/>\n                        <use mask=\"url(#toggles-ad)\" stroke-width=\"4\" xlink:href=\"#toggles-r\"/>\n                        <use mask=\"url(#toggles-ae)\" stroke-width=\"4\" xlink:href=\"#toggles-s\"/>\n                        <use mask=\"url(#toggles-af)\" stroke-width=\"4\" xlink:href=\"#toggles-t\"/>\n                    </g>\n                    <g transform=\"translate(250)\">\n                        <use mask=\"url(#toggles-ag)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#toggles-u\"/>\n                        <use mask=\"url(#toggles-ah)\" stroke-width=\"4\" xlink:href=\"#toggles-v\"/>\n                        <use mask=\"url(#toggles-ai)\" stroke-width=\"4\" xlink:href=\"#toggles-w\"/>\n                        <use mask=\"url(#toggles-aj)\" stroke-width=\"4\" xlink:href=\"#toggles-x\"/>\n                        <path d=\"M11 34v146M190 34v146M0 172h200M0 41h200\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <path d=\"M56.5 64.5H86M56.5 104.5H86M56.5 144.5H86\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#toggles-ak)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-y\"/>\n                        <use mask=\"url(#toggles-al)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-z\"/>\n                        <use mask=\"url(#toggles-am)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-A\"/>\n                        <use mask=\"url(#toggles-an)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-B\"/>\n                        <use mask=\"url(#toggles-ao)\" stroke-width=\"4\" xlink:href=\"#toggles-C\"/>\n                    </g>\n                    <g transform=\"translate(250 190)\">\n                        <use mask=\"url(#toggles-ap)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#toggles-D\"/>\n                        <use mask=\"url(#toggles-aq)\" stroke-width=\"4\" xlink:href=\"#toggles-E\"/>\n                        <use mask=\"url(#toggles-ar)\" stroke-width=\"4\" xlink:href=\"#toggles-F\"/>\n                        <use mask=\"url(#toggles-as)\" stroke-width=\"4\" xlink:href=\"#toggles-G\"/>\n                        <path d=\"M11 34v119M190 34v120M0 144h200M0 41h200\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#toggles-at)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-H\"/>\n                        <use mask=\"url(#toggles-au)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-I\"/>\n                        <use mask=\"url(#toggles-av)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-J\"/>\n                        <use mask=\"url(#toggles-aw)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-K\"/>\n                        <path d=\"M52.5 62.5H82M52.5 92.5H82M52.5 122.5H82\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#toggles-ax)\" stroke-width=\"4\" xlink:href=\"#toggles-L\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"

--- a/docs/docs/docs.css
+++ b/docs/docs/docs.css
@@ -338,10 +338,12 @@ textarea {
   font: inherit; 
 }
 @charset "UTF-8";
-/** Copyright 2015 Palantir Technologies, Inc. All rights reserved.
-// Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
-// of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
-// and https://github.com/palantir/blueprint/blob/master/PATENTS */
+/**
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
 html {
   -moz-box-sizing: border-box;
        box-sizing: border-box; }
@@ -3880,7 +3882,7 @@ a.pt-button.pt-disabled {
       border-radius: 3px;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      width: 70px;
+      width: 71px;
       height: 30px;
       padding: 0 10px;
       text-align: center;
@@ -3967,6 +3969,8 @@ a.pt-button.pt-disabled {
         box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.6), inset 0 1px 2px rgba(16, 22, 26, 0.2);
         background-color: #202b33;
         background-image: none; }
+.pt-file-upload.pt-fill {
+    width: 100%; }
 .pt-form-group {
   display: -webkit-flex;
   display: flex;
@@ -6739,6 +6743,8 @@ table.pt-table.pt-interactive tbody tr:hover td {
     cursor: text; }
 .bp-table-selection-enabled .bp-table-cell {
     cursor: cell; }
+.bp-table-cell.bp-table-truncated-cell {
+    overflow: hidden; }
 .bp-table-cell.pt-large,
   .pt-large .bp-table-cell {
     height: 30px;
@@ -6773,8 +6779,7 @@ table.pt-table.pt-interactive tbody tr:hover td {
   bottom: 0;
   left: 10px;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap; }
+  text-overflow: ellipsis; }
 .bp-table-truncated-popover-target {
   position: absolute;
   top: 0;
@@ -6987,8 +6992,10 @@ table.pt-table.pt-interactive tbody tr:hover td {
           flex-grow: 1;
   pointer-events: none; }
 .bp-table-truncated-text {
+  height: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: ellipsis; }
+.bp-table-no-wrap-text {
   white-space: nowrap; }
 .bp-table-column-name-text {
   padding: 0 10px; }
@@ -7074,6 +7081,8 @@ table.pt-table.pt-interactive tbody tr:hover td {
   cursor: s-resize; }
 .bp-table-selection-enabled.bp-table-row-headers .bp-table-header {
   cursor: e-resize; }
+.bp-table-selection-enabled.bp-table-menu {
+  cursor: se-resize; }
 .bp-table-selection-enabled .pt-editable-text::before,
 .bp-table-selection-enabled .pt-editable-content {
   cursor: cell; }
@@ -7208,6 +7217,7 @@ table.pt-table.pt-interactive tbody tr:hover td {
     background-color: #30404d;
     color: #f5f8fa; }
 .bp-table-row-headers {
+  display: table;
   -webkit-flex: 0 0 auto;
           flex: 0 0 auto;
   position: relative;
@@ -8283,6 +8293,8 @@ input[type="search"] {
   display: inline-block;
   margin-right: 30px;
   width: 250px; }
+[data-section-id="components.forms.numeric-input"] .docs-react-example .docs-react-numeric-input-example {
+  width: 100%; }
 [data-section-id="components.forms.numeric-input.extended-example"] .docs-react-example input {
   width: 230px; }
 [data-section-name="Color aliases"] .pt-table {

--- a/docs/docs/docs.js
+++ b/docs/docs/docs.js
@@ -50,22 +50,22 @@
 	var core_1 = __webpack_require__(2);
 	var React = __webpack_require__(9);
 	var ReactDOM = __webpack_require__(47);
-	var propsStore_1 = __webpack_require__(252);
-	var resolveDocs_1 = __webpack_require__(253);
-	var resolveExample_1 = __webpack_require__(268);
-	var styleguide_1 = __webpack_require__(485);
-	var pages = __webpack_require__(499);
-	var releases = __webpack_require__(500)
+	var propsStore_1 = __webpack_require__(255);
+	var resolveDocs_1 = __webpack_require__(256);
+	var resolveExample_1 = __webpack_require__(271);
+	var styleguide_1 = __webpack_require__(490);
+	var pages = __webpack_require__(504);
+	var releases = __webpack_require__(505)
 	    .map(function (pkg) {
 	    pkg.url = "https://www.npmjs.com/package/" + pkg.name;
 	    return pkg;
 	});
-	var versions = __webpack_require__(501)
+	var versions = __webpack_require__(506)
 	    .map(function (version) { return ({
 	    url: "https://palantir.github.io/blueprint/docs/" + version,
 	    version: version,
 	}); });
-	var propsStore = new propsStore_1.PropsStore(__webpack_require__(502));
+	var propsStore = new propsStore_1.PropsStore(__webpack_require__(507));
 	var updateExamples = function () {
 	    document.queryAll(".pt-checkbox input[indeterminate]").forEach(function (el) {
 	        el.indeterminate = true;
@@ -1088,9 +1088,9 @@
 	__export(__webpack_require__(3));
 	__export(__webpack_require__(6));
 	__export(__webpack_require__(45));
-	var iconClasses_1 = __webpack_require__(250);
+	var iconClasses_1 = __webpack_require__(253);
 	exports.IconClasses = iconClasses_1.IconClasses;
-	var iconStrings_1 = __webpack_require__(251);
+	var iconStrings_1 = __webpack_require__(254);
 	exports.IconContents = iconStrings_1.IconContents;
 	
 
@@ -1634,8 +1634,15 @@
 /* 11 */
 /***/ function(module, exports) {
 
+	/*
+	object-assign
+	(c) Sindre Sorhus
+	@license MIT
+	*/
+	
 	'use strict';
 	/* eslint-disable no-unused-vars */
+	var getOwnPropertySymbols = Object.getOwnPropertySymbols;
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 	var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 	
@@ -1656,7 +1663,7 @@
 			// Detect buggy property enumeration order in older V8 versions.
 	
 			// https://bugs.chromium.org/p/v8/issues/detail?id=4118
-			var test1 = new String('abc');  // eslint-disable-line
+			var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
 			test1[5] = 'de';
 			if (Object.getOwnPropertyNames(test1)[0] === '5') {
 				return false;
@@ -1685,7 +1692,7 @@
 			}
 	
 			return true;
-		} catch (e) {
+		} catch (err) {
 			// We don't expect any of the above to throw, but better to be safe.
 			return false;
 		}
@@ -1705,8 +1712,8 @@
 				}
 			}
 	
-			if (Object.getOwnPropertySymbols) {
-				symbols = Object.getOwnPropertySymbols(from);
+			if (getOwnPropertySymbols) {
+				symbols = getOwnPropertySymbols(from);
 				for (var i = 0; i < symbols.length; i++) {
 					if (propIsEnumerable.call(from, symbols[i])) {
 						to[symbols[i]] = from[symbols[i]];
@@ -2112,12 +2119,18 @@
 	 * will remain to ensure logic does not differ in production.
 	 */
 	
-	function invariant(condition, format, a, b, c, d, e, f) {
-	  if (false) {
+	var validateFormat = function validateFormat(format) {};
+	
+	if (false) {
+	  validateFormat = function validateFormat(format) {
 	    if (format === undefined) {
 	      throw new Error('invariant requires an error message argument');
 	    }
-	  }
+	  };
+	}
+	
+	function invariant(condition, format, a, b, c, d, e, f) {
+	  validateFormat(format);
 	
 	  if (!condition) {
 	    var error;
@@ -4899,7 +4912,6 @@
 	var INVALID_PROPS = [
 	    "active",
 	    "containerRef",
-	    "defaultIndeterminate",
 	    "elementRef",
 	    "iconName",
 	    "inputRef",
@@ -4949,6 +4961,7 @@
 	 */
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
+	var tslib_1 = __webpack_require__(8);
 	var position_1 = __webpack_require__(38);
 	var DEFAULT_CONSTRAINTS = {
 	    attachment: "together",
@@ -4963,19 +4976,13 @@
 	    appendChild: function () { },
 	};
 	/** @internal */
-	function createTetherOptions(element, target, position, useSmartPositioning, constraints) {
-	    if (constraints == null && useSmartPositioning) {
-	        constraints = [DEFAULT_CONSTRAINTS];
+	function createTetherOptions(element, target, position, useSmartPositioning, tetherOptions) {
+	    if (tetherOptions === void 0) { tetherOptions = {}; }
+	    if (tetherOptions.constraints == null && useSmartPositioning) {
+	        tetherOptions.constraints = [DEFAULT_CONSTRAINTS];
 	    }
-	    var options = {
-	        attachment: getPopoverAttachment(position),
-	        bodyElement: fakeHtmlElement,
-	        classPrefix: "pt-tether",
-	        constraints: constraints,
-	        element: element,
-	        target: target,
-	        targetAttachment: getTargetAttachment(position),
-	    };
+	    var options = tslib_1.__assign({}, tetherOptions, { attachment: getPopoverAttachment(position), bodyElement: fakeHtmlElement, classPrefix: "pt-tether", element: element,
+	        target: target, targetAttachment: getTargetAttachment(position) });
 	    return options;
 	}
 	exports.createTetherOptions = createTetherOptions;
@@ -5290,7 +5297,7 @@
 	    return Math.abs(a - b) <= tolerance;
 	}
 	exports.approxEqual = approxEqual;
-	/* Clamps the given number between min and max values. Returns value if within range, or closest bound. */
+	/** Clamps the given number between min and max values. Returns value if within range, or closest bound. */
 	function clamp(val, min, max) {
 	    if (max < min) {
 	        throw new Error("clamp: max cannot be less than min");
@@ -5298,6 +5305,14 @@
 	    return Math.min(Math.max(val, min), max);
 	}
 	exports.clamp = clamp;
+	/** Returns the number of decimal places in the given number. */
+	function countDecimalPlaces(num) {
+	    if (typeof num !== "number" || Math.floor(num) === num) {
+	        return 0;
+	    }
+	    return num.toString().split(".")[1].length;
+	}
+	exports.countDecimalPlaces = countDecimalPlaces;
 	/**
 	 * Throttle an event on an EventTarget by wrapping it in `requestAnimationFrame` call.
 	 * Returns the event handler that was bound to given eventName so you can clean up after yourself.
@@ -5533,45 +5548,46 @@
 	}
 	var contextMenu = __webpack_require__(46);
 	exports.ContextMenu = contextMenu;
-	__export(__webpack_require__(203));
-	__export(__webpack_require__(208));
-	__export(__webpack_require__(204));
-	__export(__webpack_require__(209));
+	__export(__webpack_require__(205));
 	__export(__webpack_require__(210));
-	__export(__webpack_require__(213));
-	__export(__webpack_require__(207));
-	__export(__webpack_require__(214));
-	__export(__webpack_require__(217));
-	__export(__webpack_require__(218));
+	__export(__webpack_require__(206));
+	__export(__webpack_require__(211));
+	__export(__webpack_require__(212));
+	__export(__webpack_require__(215));
+	__export(__webpack_require__(209));
+	__export(__webpack_require__(216));
 	__export(__webpack_require__(219));
 	__export(__webpack_require__(220));
 	__export(__webpack_require__(221));
-	__export(__webpack_require__(211));
-	__export(__webpack_require__(228));
-	__export(__webpack_require__(212));
-	__export(__webpack_require__(229));
-	__export(__webpack_require__(190));
-	__export(__webpack_require__(184));
+	__export(__webpack_require__(222));
+	__export(__webpack_require__(223));
+	__export(__webpack_require__(213));
 	__export(__webpack_require__(230));
-	__export(__webpack_require__(200));
+	__export(__webpack_require__(214));
 	__export(__webpack_require__(231));
+	__export(__webpack_require__(192));
 	__export(__webpack_require__(232));
+	__export(__webpack_require__(184));
 	__export(__webpack_require__(233));
+	__export(__webpack_require__(202));
+	__export(__webpack_require__(234));
+	__export(__webpack_require__(235));
 	__export(__webpack_require__(236));
-	__export(__webpack_require__(206));
-	__export(__webpack_require__(237));
-	__export(__webpack_require__(238));
 	__export(__webpack_require__(239));
+	__export(__webpack_require__(208));
 	__export(__webpack_require__(240));
 	__export(__webpack_require__(241));
 	__export(__webpack_require__(242));
 	__export(__webpack_require__(243));
+	__export(__webpack_require__(244));
 	__export(__webpack_require__(245));
 	__export(__webpack_require__(246));
-	__export(__webpack_require__(247));
-	__export(__webpack_require__(201));
 	__export(__webpack_require__(248));
 	__export(__webpack_require__(249));
+	__export(__webpack_require__(250));
+	__export(__webpack_require__(203));
+	__export(__webpack_require__(251));
+	__export(__webpack_require__(252));
 	
 
 
@@ -22423,16 +22439,16 @@
 	var PureRender = __webpack_require__(186);
 	var React = __webpack_require__(9);
 	var react_dom_1 = __webpack_require__(47);
-	var Tether = __webpack_require__(188);
+	var Tether = __webpack_require__(190);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
+	var Errors = __webpack_require__(191);
 	var PosUtils = __webpack_require__(38);
 	var TetherUtils = __webpack_require__(40);
 	var Utils = __webpack_require__(43);
-	var overlay_1 = __webpack_require__(190);
-	var tooltip_1 = __webpack_require__(201);
-	var Arrows = __webpack_require__(202);
+	var overlay_1 = __webpack_require__(192);
+	var tooltip_1 = __webpack_require__(203);
+	var Arrows = __webpack_require__(204);
 	var SVG_SHADOW_PATH = "M8.11 6.302c1.015-.936 1.887-2.922 1.887-4.297v26c0-1.378" +
 	    "-.868-3.357-1.888-4.297L.925 17.09c-1.237-1.14-1.233-3.034 0-4.17L8.11 6.302z";
 	var SVG_ARROW_PATH = "M8.787 7.036c1.22-1.125 2.21-3.376 2.21-5.03V0v30-2.005" +
@@ -22468,12 +22484,31 @@
 	                _this.isContentMounting = false;
 	            }
 	        };
+	        _this.handleTargetFocus = function (e) {
+	            if (_this.props.openOnTargetFocus && _this.isHoverInteractionKind()) {
+	                _this.handleMouseEnter(e);
+	            }
+	        };
+	        _this.handleTargetBlur = function (e) {
+	            if (_this.props.openOnTargetFocus && _this.isHoverInteractionKind()) {
+	                // if the next element to receive focus is within the popover, we'll want to leave the
+	                // popover open. we must do this check *after* the next element focuses, so we use a
+	                // timeout of 0 to flush the rest of the event queue before proceeding.
+	                _this.setTimeout(function () {
+	                    var popoverElement = _this.popoverElement;
+	                    if (popoverElement == null || !popoverElement.contains(document.activeElement)) {
+	                        _this.handleMouseLeave(e);
+	                    }
+	                }, 0);
+	            }
+	        };
 	        _this.handleMouseEnter = function (e) {
 	            // if we're entering the popover, and the mode is set to be HOVER_TARGET_ONLY, we want to manually
 	            // trigger the mouse leave event, as hovering over the popover shouldn't count.
 	            if (_this.props.inline
 	                && _this.isElementInPopover(e.target)
-	                && _this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY) {
+	                && _this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY
+	                && !_this.props.openOnTargetFocus) {
 	                _this.handleMouseLeave(e);
 	            }
 	            else if (!_this.props.isDisabled) {
@@ -22525,11 +22560,12 @@
 	        return _this;
 	    }
 	    Popover.prototype.render = function () {
-	        var _a = this.props, className = _a.className, interactionKind = _a.interactionKind;
+	        var className = this.props.className;
 	        var targetProps;
-	        if (interactionKind === PopoverInteractionKind.HOVER
-	            || interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY) {
+	        if (this.isHoverInteractionKind()) {
 	            targetProps = {
+	                onBlur: this.handleTargetBlur,
+	                onFocus: this.handleTargetFocus,
 	                onMouseEnter: this.handleMouseEnter,
 	                onMouseLeave: this.handleMouseLeave,
 	            };
@@ -22540,24 +22576,27 @@
 	                onClick: this.handleTargetClick,
 	            };
 	        }
-	        targetProps.className = classNames(Classes.POPOVER_TARGET, (_b = {},
-	            _b[Classes.POPOVER_OPEN] = this.state.isOpen,
-	            _b), className);
+	        targetProps.className = classNames(Classes.POPOVER_TARGET, (_a = {},
+	            _a[Classes.POPOVER_OPEN] = this.state.isOpen,
+	            _a), className);
 	        targetProps.ref = this.refHandlers.target;
+	        var childrenBaseProps = this.props.openOnTargetFocus && this.isHoverInteractionKind()
+	            ? { tabIndex: 0 }
+	            : {};
 	        var children = this.props.children;
 	        if (typeof this.props.children === "string") {
 	            // wrap text in a <span> so that we have a consistent way to interact with the target node(s)
-	            children = React.DOM.span({}, this.props.children);
+	            children = React.DOM.span(childrenBaseProps, this.props.children);
 	        }
 	        else {
 	            var child = React.Children.only(this.props.children);
 	            // force disable single Tooltip child when popover is open (BLUEPRINT-552)
-	            if (this.state.isOpen && child.type === tooltip_1.Tooltip) {
-	                children = React.cloneElement(child, { isDisabled: true });
-	            }
+	            var childProps = (this.state.isOpen && child.type === tooltip_1.Tooltip)
+	                ? tslib_1.__assign({}, childrenBaseProps, { isDisabled: true }) : childrenBaseProps;
+	            children = React.cloneElement(child, childProps);
 	        }
 	        return React.createElement(this.props.rootElementTag, targetProps, children, React.createElement(overlay_1.Overlay, { autoFocus: this.props.autoFocus, backdropClassName: Classes.POPOVER_BACKDROP, backdropProps: this.props.backdropProps, canEscapeKeyClose: this.props.canEscapeKeyClose, canOutsideClickClose: this.props.interactionKind === PopoverInteractionKind.CLICK, className: this.props.portalClassName, didOpen: this.handleContentMount, enforceFocus: this.props.enforceFocus, hasBackdrop: this.props.isModal, inline: this.props.inline, isOpen: this.state.isOpen, lazy: this.props.lazy, onClose: this.handleOverlayClose, transitionDuration: this.props.transitionDuration, transitionName: Classes.POPOVER }, this.renderPopover()));
-	        var _b;
+	        var _a;
 	    };
 	    Popover.prototype.componentDidMount = function () {
 	        this.componentDOMChange();
@@ -22698,7 +22737,11 @@
 	            // so instead, we'll position tether based off of its first child.
 	            // NOTE: use findDOMNode(this) directly because this.targetElement may not exist yet
 	            var target = react_dom_1.findDOMNode(this).childNodes[0];
-	            var tetherOptions = TetherUtils.createTetherOptions(this.popoverElement, target, this.props.position, this.props.useSmartPositioning, this.props.constraints);
+	            // constraints is deprecated but must still be supported through tetherOptions until v2.0
+	            if (this.props.constraints != null) {
+	                this.props.tetherOptions.constraints = this.props.constraints;
+	            }
+	            var tetherOptions = TetherUtils.createTetherOptions(this.popoverElement, target, this.props.position, this.props.useSmartPositioning, this.props.tetherOptions);
 	            if (this.tether == null) {
 	                this.tether = new Tether(tetherOptions);
 	            }
@@ -22742,6 +22785,10 @@
 	    Popover.prototype.isElementInPopover = function (element) {
 	        return this.popoverElement != null && this.popoverElement.contains(element);
 	    };
+	    Popover.prototype.isHoverInteractionKind = function () {
+	        return this.props.interactionKind === PopoverInteractionKind.HOVER
+	            || this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
+	    };
 	    return Popover;
 	}(abstractComponent_1.AbstractComponent));
 	Popover.defaultProps = {
@@ -22756,9 +22803,11 @@
 	    interactionKind: PopoverInteractionKind.CLICK,
 	    isDisabled: false,
 	    isModal: false,
+	    openOnTargetFocus: true,
 	    popoverClassName: "",
 	    position: PosUtils.Position.RIGHT,
 	    rootElementTag: "span",
+	    tetherOptions: {},
 	    transitionDuration: 300,
 	    useSmartArrowPositioning: true,
 	    useSmartPositioning: false,
@@ -22835,7 +22884,10 @@
 	 */
 	'use strict';
 	
-	var shallowEqual = __webpack_require__(187);
+	var warning = __webpack_require__(187);
+	var shallowEqual = __webpack_require__(189);
+	
+	
 	
 	/**
 	 * Tells if a component should update given it's next props
@@ -22849,11 +22901,42 @@
 	}
 	
 	/**
+	 * Returns a text description of the component that can be
+	 * used to identify it in error messages.
+	 *
+	 * @see https://github.com/facebook/react/blob/v15.4.0-rc.3/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L1143
+	 * @param {function} component The component.
+	 * @return {string} The name of the component.
+	 */
+	function getComponentName(component) {
+	  var constructor = component.prototype && component.prototype.constructor;
+	
+	  return (
+	    component.displayName
+	    || (constructor && constructor.displayName)
+	    || component.name
+	    || (constructor && constructor.name)
+	    || 'a component'
+	  );
+	}
+	
+	/**
 	 * Makes the given component "pure".
 	 *
 	 * @param object component Component.
 	 */
 	function pureRenderDecorator(component) {
+	  if (component.prototype.shouldComponentUpdate !== undefined) {
+	    // We're not using the condition mecanism of warning()
+	    // here to avoid useless calls to getComponentName().
+	    warning(
+	      false,
+	      'Cannot decorate `%s` with @pureRenderDecorator, '
+	      + 'because it already implements `shouldComponentUpdate().',
+	      getComponentName(component)
+	    )
+	  }
+	
 	  component.prototype.shouldComponentUpdate = shouldComponentUpdate;
 	  return component;
 	}
@@ -22865,6 +22948,120 @@
 
 /***/ },
 /* 187 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright 2014-2015, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 */
+	
+	'use strict';
+	
+	var emptyFunction = __webpack_require__(188);
+	
+	/**
+	 * Similar to invariant but only logs a warning if the condition is not met.
+	 * This can be used to log issues in development environments in critical
+	 * paths. Removing the logging code for production environments will keep the
+	 * same logic and follow the same code paths.
+	 */
+	
+	var warning = emptyFunction;
+	
+	if (false) {
+	  (function () {
+	    var printWarning = function printWarning(format) {
+	      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	        args[_key - 1] = arguments[_key];
+	      }
+	
+	      var argIndex = 0;
+	      var message = 'Warning: ' + format.replace(/%s/g, function () {
+	        return args[argIndex++];
+	      });
+	      if (typeof console !== 'undefined') {
+	        console.error(message);
+	      }
+	      try {
+	        // --- Welcome to debugging React ---
+	        // This error was thrown as a convenience so that you can use this stack
+	        // to find the callsite that caused this warning to fire.
+	        throw new Error(message);
+	      } catch (x) {}
+	    };
+	
+	    warning = function warning(condition, format) {
+	      if (format === undefined) {
+	        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+	      }
+	
+	      if (format.indexOf('Failed Composite propType: ') === 0) {
+	        return; // Ignore CompositeComponent proptype check.
+	      }
+	
+	      if (!condition) {
+	        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+	          args[_key2 - 2] = arguments[_key2];
+	        }
+	
+	        printWarning.apply(undefined, [format].concat(args));
+	      }
+	    };
+	  })();
+	}
+	
+	module.exports = warning;
+
+/***/ },
+/* 188 */
+/***/ function(module, exports) {
+
+	"use strict";
+	
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+	
+	function makeEmptyFunction(arg) {
+	  return function () {
+	    return arg;
+	  };
+	}
+	
+	/**
+	 * This function accepts and discards inputs; it has no side effects. This is
+	 * primarily useful idiomatically for overridable function endpoints which
+	 * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
+	 */
+	var emptyFunction = function emptyFunction() {};
+	
+	emptyFunction.thatReturns = makeEmptyFunction;
+	emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
+	emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
+	emptyFunction.thatReturnsNull = makeEmptyFunction(null);
+	emptyFunction.thatReturnsThis = function () {
+	  return this;
+	};
+	emptyFunction.thatReturnsArgument = function (arg) {
+	  return arg;
+	};
+	
+	module.exports = emptyFunction;
+
+/***/ },
+/* 189 */
 /***/ function(module, exports) {
 
 	/**
@@ -22936,7 +23133,7 @@
 	module.exports = shallowEqual;
 
 /***/ },
-/* 188 */
+/* 190 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/*! tether 1.4.0 */
@@ -24753,7 +24950,7 @@
 
 
 /***/ },
-/* 189 */
+/* 191 */
 /***/ function(module, exports) {
 
 	/*
@@ -24787,10 +24984,12 @@
 	exports.POPOVER_UNCONTROLLED_ONINTERACTION = ns + " <Popover> onInteraction is ignored when uncontrolled";
 	exports.POPOVER_MODAL_INLINE = ns + " <Popover isModal={true}> requires inline={false}.";
 	exports.POPOVER_MODAL_INTERACTION = ns + " <Popover isModal={true}> requires interactionKind={PopoverInteractionKind.CLICK}.";
-	exports.POPOVER_SMART_POSITIONING_INLINE = "{ns} <Popover useSmartPositioning={true}> requires inline={false}.";
+	exports.POPOVER_SMART_POSITIONING_INLINE = ns + " <Popover useSmartPositioning={true}> requires inline={false}.";
 	exports.RADIOGROUP_RADIO_CHILDREN = ns + " <RadioGroup> only supports <Radio> children";
 	exports.RADIOGROUP_CHILDREN_OPTIONS_MUTEX = ns + " <RadioGroup> children and options props are mutually exclusive.";
-	exports.RANGESLIDER_NULL_VALUE = ns + " <RangeSlider> value prop must be an array of two non-null numbers";
+	exports.SLIDER_ZERO_STEP = ns + " <Slider> stepSize must be greater than zero.";
+	exports.SLIDER_ZERO_LABEL_STEP = ns + " <Slider> labelStepSize must be greater than zero.";
+	exports.RANGESLIDER_NULL_VALUE = ns + " <RangeSlider> value prop must be an array of two non-null numbers.";
 	exports.TABS_FIRST_CHILD = ns + " First child of <Tabs> component should be a <TabList>";
 	exports.TABS_MISMATCH = ns + " Number of <Tab> components should equal number of <TabPanel> components";
 	exports.TABS_DEPRECATED = ns + " <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>."
@@ -24802,7 +25001,7 @@
 
 
 /***/ },
-/* 190 */
+/* 192 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -24817,11 +25016,11 @@
 	var classNames = __webpack_require__(185);
 	var PureRender = __webpack_require__(186);
 	var React = __webpack_require__(9);
-	var CSSTransitionGroup = __webpack_require__(191);
+	var CSSTransitionGroup = __webpack_require__(193);
 	var Classes = __webpack_require__(41);
 	var Keys = __webpack_require__(42);
 	var utils_1 = __webpack_require__(43);
-	var portal_1 = __webpack_require__(200);
+	var portal_1 = __webpack_require__(202);
 	var Overlay = Overlay_1 = (function (_super) {
 	    tslib_1.__extends(Overlay, _super);
 	    function Overlay(props, context) {
@@ -25019,13 +25218,13 @@
 
 
 /***/ },
-/* 191 */
+/* 193 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(192);
+	module.exports = __webpack_require__(194);
 
 /***/ },
-/* 192 */
+/* 194 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25050,8 +25249,8 @@
 	
 	var React = __webpack_require__(10);
 	
-	var ReactTransitionGroup = __webpack_require__(193);
-	var ReactCSSTransitionGroupChild = __webpack_require__(197);
+	var ReactTransitionGroup = __webpack_require__(195);
+	var ReactCSSTransitionGroupChild = __webpack_require__(199);
 	
 	function createTransitionTimeoutPropValidator(transitionType) {
 	  var timeoutPropName = 'transition' + transitionType + 'Timeout';
@@ -25134,7 +25333,7 @@
 	module.exports = ReactCSSTransitionGroup;
 
 /***/ },
-/* 193 */
+/* 195 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25158,8 +25357,8 @@
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 	
 	var React = __webpack_require__(10);
-	var ReactAddonsDOMDependencies = __webpack_require__(194);
-	var ReactTransitionChildMapping = __webpack_require__(195);
+	var ReactAddonsDOMDependencies = __webpack_require__(196);
+	var ReactTransitionChildMapping = __webpack_require__(197);
 	
 	var emptyFunction = __webpack_require__(19);
 	
@@ -25388,7 +25587,7 @@
 	module.exports = ReactTransitionGroup;
 
 /***/ },
-/* 194 */
+/* 196 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25428,7 +25627,7 @@
 	}
 
 /***/ },
-/* 195 */
+/* 197 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25443,7 +25642,7 @@
 	
 	'use strict';
 	
-	var flattenChildren = __webpack_require__(196);
+	var flattenChildren = __webpack_require__(198);
 	
 	var ReactTransitionChildMapping = {
 	  /**
@@ -25535,7 +25734,7 @@
 	module.exports = ReactTransitionChildMapping;
 
 /***/ },
-/* 196 */
+/* 198 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
@@ -25616,7 +25815,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(44)))
 
 /***/ },
-/* 197 */
+/* 199 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25632,10 +25831,10 @@
 	'use strict';
 	
 	var React = __webpack_require__(10);
-	var ReactAddonsDOMDependencies = __webpack_require__(194);
+	var ReactAddonsDOMDependencies = __webpack_require__(196);
 	
-	var CSSCore = __webpack_require__(198);
-	var ReactTransitionEvents = __webpack_require__(199);
+	var CSSCore = __webpack_require__(200);
+	var ReactTransitionEvents = __webpack_require__(201);
 	
 	var onlyChild = __webpack_require__(35);
 	
@@ -25787,7 +25986,7 @@
 	module.exports = ReactCSSTransitionGroupChild;
 
 /***/ },
-/* 198 */
+/* 200 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -25913,7 +26112,7 @@
 	module.exports = CSSCore;
 
 /***/ },
-/* 199 */
+/* 201 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25990,7 +26189,7 @@
 	module.exports = ReactTransitionEvents;
 
 /***/ },
-/* 200 */
+/* 202 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26046,7 +26245,7 @@
 
 
 /***/ },
-/* 201 */
+/* 203 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26072,21 +26271,19 @@
 	        return _this;
 	    }
 	    Tooltip.prototype.render = function () {
-	        var _a = this.props, children = _a.children, intent = _a.intent, tooltipClassName = _a.tooltipClassName;
+	        var _a = this.props, children = _a.children, intent = _a.intent, openOnTargetFocus = _a.openOnTargetFocus, tooltipClassName = _a.tooltipClassName;
 	        var classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
-	        return (React.createElement(popover_1.Popover, tslib_1.__assign({}, this.props, { arrowSize: 22, autoFocus: false, canEscapeKeyClose: false, enforceFocus: false, interactionKind: popover_1.PopoverInteractionKind.HOVER_TARGET_ONLY, lazy: true, popoverClassName: classes }), children));
+	        return (React.createElement(popover_1.Popover, tslib_1.__assign({}, this.props, { arrowSize: 22, autoFocus: false, canEscapeKeyClose: false, enforceFocus: false, interactionKind: popover_1.PopoverInteractionKind.HOVER_TARGET_ONLY, lazy: true, openOnTargetFocus: openOnTargetFocus, popoverClassName: classes }), children));
 	    };
 	    return Tooltip;
 	}(React.Component));
 	Tooltip.defaultProps = {
-	    className: "",
-	    content: "",
 	    hoverCloseDelay: 0,
 	    hoverOpenDelay: 100,
 	    isDisabled: false,
+	    openOnTargetFocus: true,
 	    position: position_1.Position.TOP,
 	    rootElementTag: "span",
-	    tooltipClassName: "",
 	    transitionDuration: 100,
 	    useSmartArrowPositioning: true,
 	    useSmartPositioning: false,
@@ -26100,7 +26297,7 @@
 
 
 /***/ },
-/* 202 */
+/* 204 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -26181,7 +26378,7 @@
 
 
 /***/ },
-/* 203 */
+/* 205 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26196,9 +26393,9 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var common_1 = __webpack_require__(6);
-	var Errors = __webpack_require__(189);
-	var buttons_1 = __webpack_require__(204);
-	var dialog_1 = __webpack_require__(207);
+	var Errors = __webpack_require__(191);
+	var buttons_1 = __webpack_require__(206);
+	var dialog_1 = __webpack_require__(209);
 	var Alert = (function (_super) {
 	    tslib_1.__extends(Alert, _super);
 	    function Alert() {
@@ -26247,7 +26444,7 @@
 
 
 /***/ },
-/* 204 */
+/* 206 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26263,7 +26460,7 @@
 	// tslint:disable max-classes-per-file
 	var React = __webpack_require__(9);
 	var props_1 = __webpack_require__(39);
-	var abstractButton_1 = __webpack_require__(205);
+	var abstractButton_1 = __webpack_require__(207);
 	var Button = (function (_super) {
 	    tslib_1.__extends(Button, _super);
 	    function Button() {
@@ -26296,7 +26493,7 @@
 
 
 /***/ },
-/* 205 */
+/* 207 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26313,7 +26510,7 @@
 	var Classes = __webpack_require__(41);
 	var Keys = __webpack_require__(42);
 	var utils_1 = __webpack_require__(43);
-	var spinner_1 = __webpack_require__(206);
+	var spinner_1 = __webpack_require__(208);
 	var AbstractButton = (function (_super) {
 	    tslib_1.__extends(AbstractButton, _super);
 	    function AbstractButton() {
@@ -26396,7 +26593,7 @@
 
 
 /***/ },
-/* 206 */
+/* 208 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26463,7 +26660,7 @@
 
 
 /***/ },
-/* 207 */
+/* 209 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26479,8 +26676,8 @@
 	var React = __webpack_require__(9);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
-	var overlay_1 = __webpack_require__(190);
+	var Errors = __webpack_require__(191);
+	var overlay_1 = __webpack_require__(192);
 	var Dialog = (function (_super) {
 	    tslib_1.__extends(Dialog, _super);
 	    function Dialog() {
@@ -26540,7 +26737,7 @@
 
 
 /***/ },
-/* 208 */
+/* 210 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26565,7 +26762,7 @@
 
 
 /***/ },
-/* 209 */
+/* 211 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26723,7 +26920,7 @@
 
 
 /***/ },
-/* 210 */
+/* 212 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26738,10 +26935,10 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
+	var Errors = __webpack_require__(191);
 	var position_1 = __webpack_require__(38);
-	var menu_1 = __webpack_require__(211);
-	var menuItem_1 = __webpack_require__(212);
+	var menu_1 = __webpack_require__(213);
+	var menuItem_1 = __webpack_require__(214);
 	var popover_1 = __webpack_require__(184);
 	var CollapseFrom;
 	(function (CollapseFrom) {
@@ -26814,7 +27011,7 @@
 
 
 /***/ },
-/* 211 */
+/* 213 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26846,7 +27043,7 @@
 
 
 /***/ },
-/* 212 */
+/* 214 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -26863,10 +27060,10 @@
 	var ReactDOM = __webpack_require__(47);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
+	var Errors = __webpack_require__(191);
 	var position_1 = __webpack_require__(38);
 	var popover_1 = __webpack_require__(184);
-	var menu_1 = __webpack_require__(211);
+	var menu_1 = __webpack_require__(213);
 	var REACT_CONTEXT_TYPES = { alignLeft: React.PropTypes.bool };
 	var MenuItem = (function (_super) {
 	    tslib_1.__extends(MenuItem, _super);
@@ -27011,7 +27208,7 @@
 
 
 /***/ },
-/* 213 */
+/* 215 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27063,7 +27260,7 @@
 
 
 /***/ },
-/* 214 */
+/* 216 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27082,7 +27279,7 @@
 	var Classes = __webpack_require__(41);
 	var Keys = __webpack_require__(42);
 	var utils_1 = __webpack_require__(43);
-	var compatibility_1 = __webpack_require__(215);
+	var compatibility_1 = __webpack_require__(217);
 	var BUFFER_WIDTH_EDGE = 5;
 	var BUFFER_WIDTH_IE = 30;
 	var EditableText = (function (_super) {
@@ -27332,7 +27529,7 @@
 
 
 /***/ },
-/* 215 */
+/* 217 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27346,12 +27543,12 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(216));
+	__export(__webpack_require__(218));
 	
 
 
 /***/ },
-/* 216 */
+/* 218 */
 /***/ function(module, exports) {
 
 	/*
@@ -27377,7 +27574,7 @@
 
 
 /***/ },
-/* 217 */
+/* 219 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27398,6 +27595,12 @@
 	var Classes = __webpack_require__(41);
 	var props_1 = __webpack_require__(39);
 	var utils_1 = __webpack_require__(43);
+	var INVALID_PROPS = [
+	    // we spread props to `<input>` but render `children` as its sibling
+	    "children",
+	    "defaultIndeterminate",
+	    "indeterminate",
+	];
 	/** Base Component class for all Controls */
 	var Control = (function (_super) {
 	    tslib_1.__extends(Control, _super);
@@ -27409,8 +27612,9 @@
 	    Control.prototype.renderControl = function (type, typeClassName, inputRef) {
 	        if (inputRef === void 0) { inputRef = this.props.inputRef; }
 	        var className = classNames(Classes.CONTROL, typeClassName, (_a = {}, _a[Classes.DISABLED] = this.props.disabled, _a), this.props.className);
+	        var inputProps = props_1.removeNonHTMLProps(this.props, INVALID_PROPS, true);
 	        return (React.createElement("label", { className: className, style: this.props.style },
-	            React.createElement("input", tslib_1.__assign({}, props_1.removeNonHTMLProps(this.props, ["children", "indeterminate"], true), { ref: inputRef, type: type })),
+	            React.createElement("input", tslib_1.__assign({}, inputProps, { ref: inputRef, type: type })),
 	            React.createElement("span", { className: Classes.CONTROL_INDICATOR }),
 	            this.props.label,
 	            this.props.children));
@@ -27481,7 +27685,7 @@
 
 
 /***/ },
-/* 218 */
+/* 220 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27567,7 +27771,7 @@
 
 
 /***/ },
-/* 219 */
+/* 221 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27583,9 +27787,9 @@
 	var PureRender = __webpack_require__(186);
 	var React = __webpack_require__(9);
 	var common_1 = __webpack_require__(6);
-	var Errors = __webpack_require__(189);
-	var buttons_1 = __webpack_require__(204);
-	var inputGroup_1 = __webpack_require__(218);
+	var Errors = __webpack_require__(191);
+	var buttons_1 = __webpack_require__(206);
+	var inputGroup_1 = __webpack_require__(220);
 	var IncrementDirection;
 	(function (IncrementDirection) {
 	    IncrementDirection[IncrementDirection["DOWN"] = -1] = "DOWN";
@@ -27696,6 +27900,7 @@
 	        };
 	        _this.state = {
 	            shouldSelectAfterUpdate: false,
+	            stepMaxPrecision: _this.getStepMaxPrecision(props),
 	            value: _this.getValueOrEmptyValue(props.value),
 	        };
 	        return _this;
@@ -27706,19 +27911,18 @@
 	        var didMinChange = nextProps.min !== this.props.min;
 	        var didMaxChange = nextProps.max !== this.props.max;
 	        var didBoundsChange = didMinChange || didMaxChange;
+	        var sanitizedValue = (value !== NumericInput_1.VALUE_EMPTY)
+	            ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
+	            : NumericInput_1.VALUE_EMPTY;
+	        var stepMaxPrecision = this.getStepMaxPrecision(nextProps);
 	        // if a new min and max were provided that cause the existing value to fall
 	        // outside of the new bounds, then clamp the value to the new valid range.
-	        if (didBoundsChange) {
-	            var sanitizedValue = (value !== NumericInput_1.VALUE_EMPTY)
-	                ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
-	                : NumericInput_1.VALUE_EMPTY;
-	            if (sanitizedValue !== this.state.value) {
-	                this.setState({ value: sanitizedValue });
-	                this.invokeOnChangeCallbacks(sanitizedValue);
-	            }
+	        if (didBoundsChange && sanitizedValue !== this.state.value) {
+	            this.setState({ stepMaxPrecision: stepMaxPrecision, value: sanitizedValue });
+	            this.invokeOnChangeCallbacks(sanitizedValue);
 	        }
 	        else {
-	            this.setState({ value: value });
+	            this.setState({ stepMaxPrecision: stepMaxPrecision, value: value });
 	        }
 	    };
 	    NumericInput.prototype.render = function () {
@@ -27726,6 +27930,7 @@
 	        var inputGroupHtmlProps = common_1.removeNonHTMLProps(this.props, [
 	            "allowNumericCharactersOnly",
 	            "buttonPosition",
+	            "className",
 	            "majorStepSize",
 	            "minorStepSize",
 	            "onValueChange",
@@ -27746,7 +27951,7 @@
 	        else {
 	            var incrementButton = this.renderButton(NumericInput_1.INCREMENT_KEY, NumericInput_1.INCREMENT_ICON_NAME, this.handleIncrementButtonClick);
 	            var decrementButton = this.renderButton(NumericInput_1.DECREMENT_KEY, NumericInput_1.DECREMENT_ICON_NAME, this.handleDecrementButtonClick);
-	            var buttonGroup = (React.createElement("div", { key: "button-group", className: classNames(common_1.Classes.BUTTON_GROUP, common_1.Classes.VERTICAL) },
+	            var buttonGroup = (React.createElement("div", { key: "button-group", className: classNames(common_1.Classes.BUTTON_GROUP, common_1.Classes.VERTICAL, common_1.Classes.FIXED) },
 	                incrementButton,
 	                decrementButton));
 	            var inputElems = (buttonPosition === common_1.Position.LEFT)
@@ -27827,9 +28032,7 @@
 	        if (!this.isValueNumeric(value)) {
 	            return NumericInput_1.VALUE_EMPTY;
 	        }
-	        // truncate floating-point result to avoid precision issues when adding
-	        // non-integer, binary-unfriendly deltas like 0.1
-	        var nextValue = parseFloat((parseFloat(value) + delta).toFixed(2));
+	        var nextValue = this.toMaxPrecision(parseFloat(value) + delta);
 	        // defaultProps won't work if the user passes in null, so just default
 	        // to +/- infinity here instead, as a catch-all.
 	        var adjustedMin = (min != null) ? min : -Infinity;
@@ -27875,6 +28078,21 @@
 	    NumericInput.prototype.isFloatingPointNumericCharacter = function (char) {
 	        return NumericInput_1.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(char);
 	    };
+	    NumericInput.prototype.getStepMaxPrecision = function (props) {
+	        if (props.minorStepSize != null) {
+	            return common_1.Utils.countDecimalPlaces(props.minorStepSize);
+	        }
+	        else {
+	            return common_1.Utils.countDecimalPlaces(props.stepSize);
+	        }
+	    };
+	    NumericInput.prototype.toMaxPrecision = function (value) {
+	        // round the value to have the specified maximum precision (toFixed is the wrong choice,
+	        // because it would show trailing zeros in the decimal part out to the specified precision)
+	        // source: http://stackoverflow.com/a/18358056/5199574
+	        var scaleFactor = Math.pow(10, this.state.stepMaxPrecision);
+	        return Math.round(value * scaleFactor) / scaleFactor;
+	    };
 	    return NumericInput;
 	}(common_1.AbstractComponent));
 	NumericInput.displayName = "Blueprint.NumericInput";
@@ -27916,7 +28134,7 @@
 
 
 /***/ },
-/* 220 */
+/* 222 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -27931,8 +28149,8 @@
 	var React = __webpack_require__(9);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
-	var controls_1 = __webpack_require__(217);
+	var Errors = __webpack_require__(191);
+	var controls_1 = __webpack_require__(219);
 	var counter = 0;
 	function nextName() { return RadioGroup.displayName + "-" + counter++; }
 	var RadioGroup = (function (_super) {
@@ -27992,7 +28210,7 @@
 
 
 /***/ },
-/* 221 */
+/* 223 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28007,19 +28225,19 @@
 	var react_1 = __webpack_require__(9);
 	var React = __webpack_require__(9);
 	var common_1 = __webpack_require__(6);
-	var hotkey_1 = __webpack_require__(222);
-	var hotkey_2 = __webpack_require__(222);
+	var hotkey_1 = __webpack_require__(224);
+	var hotkey_2 = __webpack_require__(224);
 	exports.Hotkey = hotkey_2.Hotkey;
-	var keyCombo_1 = __webpack_require__(223);
+	var keyCombo_1 = __webpack_require__(225);
 	exports.KeyCombo = keyCombo_1.KeyCombo;
-	var hotkeysTarget_1 = __webpack_require__(225);
+	var hotkeysTarget_1 = __webpack_require__(227);
 	exports.HotkeysTarget = hotkeysTarget_1.HotkeysTarget;
-	var hotkeyParser_1 = __webpack_require__(224);
+	var hotkeyParser_1 = __webpack_require__(226);
 	exports.comboMatches = hotkeyParser_1.comboMatches;
 	exports.getKeyCombo = hotkeyParser_1.getKeyCombo;
 	exports.getKeyComboString = hotkeyParser_1.getKeyComboString;
 	exports.parseKeyCombo = hotkeyParser_1.parseKeyCombo;
-	var hotkeysDialog_1 = __webpack_require__(227);
+	var hotkeysDialog_1 = __webpack_require__(229);
 	exports.hideHotkeysDialog = hotkeysDialog_1.hideHotkeysDialog;
 	exports.setHotkeysDialogProps = hotkeysDialog_1.setHotkeysDialogProps;
 	var Hotkeys = (function (_super) {
@@ -28069,7 +28287,7 @@
 
 
 /***/ },
-/* 222 */
+/* 224 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28083,7 +28301,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var common_1 = __webpack_require__(6);
-	var keyCombo_1 = __webpack_require__(223);
+	var keyCombo_1 = __webpack_require__(225);
 	var Hotkey = (function (_super) {
 	    tslib_1.__extends(Hotkey, _super);
 	    function Hotkey() {
@@ -28113,7 +28331,7 @@
 
 
 /***/ },
-/* 223 */
+/* 225 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -28126,7 +28344,7 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
-	var hotkeyParser_1 = __webpack_require__(224);
+	var hotkeyParser_1 = __webpack_require__(226);
 	var KeyIcons = {
 	    alt: "pt-icon-key-option",
 	    ctrl: "pt-icon-key-control",
@@ -28171,7 +28389,7 @@
 
 
 /***/ },
-/* 224 */
+/* 226 */
 /***/ function(module, exports) {
 
 	/*
@@ -28444,7 +28662,7 @@
 
 
 /***/ },
-/* 225 */
+/* 227 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28457,7 +28675,7 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var React = __webpack_require__(9);
 	var utils_1 = __webpack_require__(43);
-	var hotkeysEvents_1 = __webpack_require__(226);
+	var hotkeysEvents_1 = __webpack_require__(228);
 	function HotkeysTarget(constructor) {
 	    var _a = constructor.prototype, componentWillMount = _a.componentWillMount, componentDidMount = _a.componentDidMount, componentWillUnmount = _a.componentWillUnmount, render = _a.render, renderHotkeys = _a.renderHotkeys;
 	    if (!utils_1.isFunction(renderHotkeys)) {
@@ -28522,7 +28740,7 @@
 
 
 /***/ },
-/* 226 */
+/* 228 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28535,9 +28753,9 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var react_1 = __webpack_require__(9);
 	var utils_1 = __webpack_require__(43);
-	var hotkey_1 = __webpack_require__(222);
-	var hotkeyParser_1 = __webpack_require__(224);
-	var hotkeysDialog_1 = __webpack_require__(227);
+	var hotkey_1 = __webpack_require__(224);
+	var hotkeyParser_1 = __webpack_require__(226);
+	var hotkeysDialog_1 = __webpack_require__(229);
 	var SHOW_DIALOG_KEY = "?";
 	var HotkeyScope;
 	(function (HotkeyScope) {
@@ -28631,7 +28849,7 @@
 
 
 /***/ },
-/* 227 */
+/* 229 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28648,8 +28866,8 @@
 	var ReactDOM = __webpack_require__(47);
 	var common_1 = __webpack_require__(6);
 	var components_1 = __webpack_require__(45);
-	var hotkey_1 = __webpack_require__(222);
-	var hotkeys_1 = __webpack_require__(221);
+	var hotkey_1 = __webpack_require__(224);
+	var hotkeys_1 = __webpack_require__(223);
 	var HotkeysDialog = (function () {
 	    function HotkeysDialog() {
 	        var _this = this;
@@ -28754,7 +28972,7 @@
 
 
 /***/ },
-/* 228 */
+/* 230 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28795,7 +29013,7 @@
 
 
 /***/ },
-/* 229 */
+/* 231 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28865,7 +29083,66 @@
 
 
 /***/ },
-/* 230 */
+/* 232 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/*
+	 * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+	 * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+	 * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+	 * and https://github.com/palantir/blueprint/blob/master/PATENTS
+	 */
+	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
+	var tslib_1 = __webpack_require__(8);
+	var classNames = __webpack_require__(185);
+	var PureRender = __webpack_require__(186);
+	var React = __webpack_require__(9);
+	var Classes = __webpack_require__(41);
+	var Text = (function (_super) {
+	    tslib_1.__extends(Text, _super);
+	    function Text() {
+	        var _this = _super !== null && _super.apply(this, arguments) || this;
+	        _this.state = {
+	            isContentOverflowing: false,
+	            textContent: "",
+	        };
+	        _this.refHandlers = {
+	            text: function (overflowElement) { return _this.textRef = overflowElement; },
+	        };
+	        return _this;
+	    }
+	    Text.prototype.componentDidMount = function () {
+	        this.update();
+	    };
+	    Text.prototype.componentDidUpdate = function () {
+	        this.update();
+	    };
+	    Text.prototype.render = function () {
+	        var classes = classNames((_a = {},
+	            _a[Classes.TEXT_OVERFLOW_ELLIPSIS] = this.props.ellipsize,
+	            _a), this.props.className);
+	        return (React.createElement("div", { className: classes, ref: this.refHandlers.text, title: this.state.isContentOverflowing ? this.state.textContent : undefined }, this.props.children));
+	        var _a;
+	    };
+	    Text.prototype.update = function () {
+	        var newState = {
+	            isContentOverflowing: this.props.ellipsize && this.textRef.scrollWidth > this.textRef.clientWidth,
+	            textContent: this.textRef.textContent,
+	        };
+	        this.setState(newState);
+	    };
+	    return Text;
+	}(React.Component));
+	Text = tslib_1.__decorate([
+	    PureRender
+	], Text);
+	exports.Text = Text;
+	
+
+
+/***/ },
+/* 233 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28895,7 +29172,7 @@
 
 
 /***/ },
-/* 231 */
+/* 234 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28937,7 +29214,7 @@
 
 
 /***/ },
-/* 232 */
+/* 235 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28950,7 +29227,7 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
-	var tooltip_1 = __webpack_require__(201);
+	var tooltip_1 = __webpack_require__(203);
 	var SVGTooltip = (function (_super) {
 	    tslib_1.__extends(SVGTooltip, _super);
 	    function SVGTooltip() {
@@ -28967,7 +29244,7 @@
 
 
 /***/ },
-/* 233 */
+/* 236 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28982,10 +29259,10 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
+	var Errors = __webpack_require__(191);
 	var utils_1 = __webpack_require__(43);
-	var coreSlider_1 = __webpack_require__(234);
-	var handle_1 = __webpack_require__(235);
+	var coreSlider_1 = __webpack_require__(237);
+	var handle_1 = __webpack_require__(238);
 	var RangeEnd;
 	(function (RangeEnd) {
 	    RangeEnd[RangeEnd["LEFT"] = 0] = "LEFT";
@@ -29086,7 +29363,7 @@
 
 
 /***/ },
-/* 234 */
+/* 237 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29103,14 +29380,12 @@
 	var React = __webpack_require__(9);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
+	var Errors = __webpack_require__(191);
 	var utils_1 = __webpack_require__(43);
 	var CoreSlider = (function (_super) {
 	    tslib_1.__extends(CoreSlider, _super);
-	    function CoreSlider() {
-	        var _this = _super !== null && _super.apply(this, arguments) || this;
-	        _this.state = {
-	            tickSize: 0,
-	        };
+	    function CoreSlider(props) {
+	        var _this = _super.call(this, props) || this;
 	        _this.className = Classes.SLIDER;
 	        _this.refHandlers = {
 	            track: function (el) { return _this.trackElement = el; },
@@ -29129,6 +29404,10 @@
 	            var target = event.target;
 	            // ensure event does not come from inside the handle
 	            return !_this.props.disabled && target.closest("." + Classes.SLIDER_HANDLE) == null;
+	        };
+	        _this.state = {
+	            labelPrecision: _this.getLabelPrecision(props),
+	            tickSize: 0,
 	        };
 	        return _this;
 	    }
@@ -29151,6 +29430,10 @@
 	    CoreSlider.prototype.componentDidUpdate = function () {
 	        this.updateTickSize();
 	    };
+	    CoreSlider.prototype.componentWillReceiveProps = function (props) {
+	        _super.prototype.componentWillReceiveProps.call(this, props);
+	        this.setState({ labelPrecision: this.getLabelPrecision(props) });
+	    };
 	    CoreSlider.prototype.formatLabel = function (value) {
 	        var renderLabel = this.props.renderLabel;
 	        if (renderLabel === false) {
@@ -29160,7 +29443,15 @@
 	            return renderLabel(value);
 	        }
 	        else {
-	            return value;
+	            return value.toFixed(this.state.labelPrecision);
+	        }
+	    };
+	    CoreSlider.prototype.validateProps = function (props) {
+	        if (props.stepSize <= 0) {
+	            throw new Error(Errors.SLIDER_ZERO_STEP);
+	        }
+	        if (props.labelStepSize <= 0) {
+	            throw new Error(Errors.SLIDER_ZERO_LABEL_STEP);
 	        }
 	    };
 	    CoreSlider.prototype.maybeRenderAxis = function () {
@@ -29182,6 +29473,13 @@
 	        }
 	        return undefined;
 	    };
+	    CoreSlider.prototype.getLabelPrecision = function (_a) {
+	        var labelPrecision = _a.labelPrecision, stepSize = _a.stepSize;
+	        // infer default label precision from stepSize because that's how much the handle moves.
+	        return (labelPrecision == null)
+	            ? utils_1.countDecimalPlaces(stepSize)
+	            : labelPrecision;
+	    };
 	    CoreSlider.prototype.updateTickSize = function () {
 	        if (this.trackElement != null) {
 	            var tickSize = this.trackElement.clientWidth / (this.props.max - this.props.min);
@@ -29198,7 +29496,7 @@
 
 
 /***/ },
-/* 235 */
+/* 238 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29352,7 +29650,7 @@
 
 
 /***/ },
-/* 236 */
+/* 239 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29367,8 +29665,8 @@
 	var React = __webpack_require__(9);
 	var Classes = __webpack_require__(41);
 	var utils_1 = __webpack_require__(43);
-	var coreSlider_1 = __webpack_require__(234);
-	var handle_1 = __webpack_require__(235);
+	var coreSlider_1 = __webpack_require__(237);
+	var handle_1 = __webpack_require__(238);
 	var Slider = (function (_super) {
 	    tslib_1.__extends(Slider, _super);
 	    function Slider() {
@@ -29420,7 +29718,7 @@
 
 
 /***/ },
-/* 237 */
+/* 240 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29436,7 +29734,7 @@
 	var React = __webpack_require__(9);
 	var Classes = __webpack_require__(41);
 	// import * to avoid "cannot be named" error on factory
-	var spinner = __webpack_require__(206);
+	var spinner = __webpack_require__(208);
 	var SVGSpinner = (function (_super) {
 	    tslib_1.__extends(SVGSpinner, _super);
 	    function SVGSpinner() {
@@ -29454,7 +29752,7 @@
 
 
 /***/ },
-/* 238 */
+/* 241 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29495,7 +29793,7 @@
 
 
 /***/ },
-/* 239 */
+/* 242 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29513,12 +29811,12 @@
 	var react_dom_1 = __webpack_require__(47);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
-	var Errors = __webpack_require__(189);
+	var Errors = __webpack_require__(191);
 	var Keys = __webpack_require__(42);
 	var Utils = __webpack_require__(43);
-	var tab_1 = __webpack_require__(238);
-	var tabList_1 = __webpack_require__(240);
-	var tabPanel_1 = __webpack_require__(241);
+	var tab_1 = __webpack_require__(241);
+	var tabList_1 = __webpack_require__(243);
+	var tabPanel_1 = __webpack_require__(244);
 	var TAB_CSS_SELECTOR = "li[role=tab]";
 	var Tabs = (function (_super) {
 	    tslib_1.__extends(Tabs, _super);
@@ -29804,7 +30102,7 @@
 
 
 /***/ },
-/* 240 */
+/* 243 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29854,7 +30152,7 @@
 
 
 /***/ },
-/* 241 */
+/* 244 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29891,7 +30189,7 @@
 
 
 /***/ },
-/* 242 */
+/* 245 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29935,7 +30233,7 @@
 
 
 /***/ },
-/* 243 */
+/* 246 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29954,8 +30252,8 @@
 	var Classes = __webpack_require__(41);
 	var Keys = __webpack_require__(42);
 	var utils_1 = __webpack_require__(43);
-	var tab2_1 = __webpack_require__(242);
-	var tabTitle_1 = __webpack_require__(244);
+	var tab2_1 = __webpack_require__(245);
+	var tabTitle_1 = __webpack_require__(247);
 	exports.Expander = function () { return React.createElement("div", { className: "pt-flex-expander" }); };
 	var TAB_SELECTOR = "." + Classes.TAB;
 	var Tabs2 = (function (_super) {
@@ -30133,7 +30431,7 @@
 
 
 /***/ },
-/* 244 */
+/* 247 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30181,7 +30479,7 @@
 
 
 /***/ },
-/* 245 */
+/* 248 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30228,7 +30526,7 @@
 
 
 /***/ },
-/* 246 */
+/* 249 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30246,7 +30544,7 @@
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
 	var utils_1 = __webpack_require__(43);
-	var buttons_1 = __webpack_require__(204);
+	var buttons_1 = __webpack_require__(206);
 	var Toast = (function (_super) {
 	    tslib_1.__extends(Toast, _super);
 	    function Toast() {
@@ -30325,7 +30623,7 @@
 
 
 /***/ },
-/* 247 */
+/* 250 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30343,12 +30641,12 @@
 	var ReactDOM = __webpack_require__(47);
 	var abstractComponent_1 = __webpack_require__(7);
 	var Classes = __webpack_require__(41);
-	var errors_1 = __webpack_require__(189);
+	var errors_1 = __webpack_require__(191);
 	var keys_1 = __webpack_require__(42);
 	var position_1 = __webpack_require__(38);
 	var utils_1 = __webpack_require__(43);
-	var overlay_1 = __webpack_require__(190);
-	var toast_1 = __webpack_require__(246);
+	var overlay_1 = __webpack_require__(192);
+	var toast_1 = __webpack_require__(249);
 	var Toaster = Toaster_1 = (function (_super) {
 	    tslib_1.__extends(Toaster, _super);
 	    function Toaster() {
@@ -30457,7 +30755,7 @@
 
 
 /***/ },
-/* 248 */
+/* 251 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30473,7 +30771,7 @@
 	var React = __webpack_require__(9);
 	var Classes = __webpack_require__(41);
 	var utils_1 = __webpack_require__(43);
-	var treeNode_1 = __webpack_require__(249);
+	var treeNode_1 = __webpack_require__(252);
 	var Tree = (function (_super) {
 	    tslib_1.__extends(Tree, _super);
 	    function Tree() {
@@ -30549,7 +30847,7 @@
 
 
 /***/ },
-/* 249 */
+/* 252 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30565,7 +30863,7 @@
 	var React = __webpack_require__(9);
 	var Classes = __webpack_require__(41);
 	var utils_1 = __webpack_require__(43);
-	var collapse_1 = __webpack_require__(209);
+	var collapse_1 = __webpack_require__(211);
 	var TreeNode = (function (_super) {
 	    tslib_1.__extends(TreeNode, _super);
 	    function TreeNode() {
@@ -30636,7 +30934,7 @@
 
 
 /***/ },
-/* 250 */
+/* 253 */
 /***/ function(module, exports) {
 
 	/*
@@ -31038,7 +31336,7 @@
 
 
 /***/ },
-/* 251 */
+/* 254 */
 /***/ function(module, exports) {
 
 	/*
@@ -31440,7 +31738,7 @@
 
 
 /***/ },
-/* 252 */
+/* 255 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -31479,12 +31777,12 @@
 
 
 /***/ },
-/* 253 */
+/* 256 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var ReactDocs = __webpack_require__(254);
+	var ReactDocs = __webpack_require__(257);
 	;
 	function resolveDocs(componentName, components) {
 	    if (components === void 0) { components = {}; }
@@ -31501,7 +31799,7 @@
 
 
 /***/ },
-/* 254 */
+/* 257 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -31509,22 +31807,22 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(255));
-	__export(__webpack_require__(261));
-	__export(__webpack_require__(265));
-	__export(__webpack_require__(266));
+	__export(__webpack_require__(258));
+	__export(__webpack_require__(264));
+	__export(__webpack_require__(268));
+	__export(__webpack_require__(269));
 
 
 /***/ },
-/* 255 */
+/* 258 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var classNames = __webpack_require__(256);
+	var classNames = __webpack_require__(259);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var clickToCopy_1 = __webpack_require__(257);
+	var clickToCopy_1 = __webpack_require__(260);
 	function expand(color) {
 	    return [color + "1", color + "2", color + "3", color + "4", color + "5"];
 	}
@@ -31602,7 +31900,7 @@
 
 
 /***/ },
-/* 256 */
+/* 259 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -31656,17 +31954,17 @@
 
 
 /***/ },
-/* 257 */
+/* 260 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
-	var classNames = __webpack_require__(256);
-	var PureRender = __webpack_require__(259);
+	var tslib_1 = __webpack_require__(261);
+	var classNames = __webpack_require__(259);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var utils_1 = __webpack_require__(260);
+	var utils_1 = __webpack_require__(263);
 	var ClickToCopy = (function (_super) {
 	    tslib_1.__extends(ClickToCopy, _super);
 	    function ClickToCopy() {
@@ -31716,7 +32014,7 @@
 
 
 /***/ },
-/* 258 */
+/* 261 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(global) {/*! *****************************************************************************
@@ -31851,7 +32149,7 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 259 */
+/* 262 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -31889,7 +32187,7 @@
 
 
 /***/ },
-/* 260 */
+/* 263 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -31940,20 +32238,20 @@
 
 
 /***/ },
-/* 261 */
+/* 264 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
-	var chroma = __webpack_require__(262);
-	var classNames = __webpack_require__(256);
-	var PureRender = __webpack_require__(259);
+	var tslib_1 = __webpack_require__(261);
+	var chroma = __webpack_require__(265);
+	var classNames = __webpack_require__(259);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var utils_1 = __webpack_require__(260);
-	var colorPalettes_1 = __webpack_require__(255);
+	var baseExample_1 = __webpack_require__(267);
+	var utils_1 = __webpack_require__(263);
+	var colorPalettes_1 = __webpack_require__(258);
 	var MIN_STEPS = 3;
 	var MAX_STEPS = 20;
 	var QUALITATIVE = [
@@ -32095,7 +32393,7 @@
 
 
 /***/ },
-/* 262 */
+/* 265 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(module) {
@@ -34564,10 +34862,10 @@
 	
 	}).call(this);
 	
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(263)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(266)(module)))
 
 /***/ },
-/* 263 */
+/* 266 */
 /***/ function(module, exports) {
 
 	module.exports = function(module) {
@@ -34583,7 +34881,7 @@
 
 
 /***/ },
-/* 264 */
+/* 267 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -34637,17 +34935,17 @@
 
 
 /***/ },
-/* 265 */
+/* 268 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
-	var classNames = __webpack_require__(256);
-	var PureRender = __webpack_require__(259);
+	var tslib_1 = __webpack_require__(261);
+	var classNames = __webpack_require__(259);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var clickToCopy_1 = __webpack_require__(257);
+	var clickToCopy_1 = __webpack_require__(260);
 	var GITHUB_PATH = "https://github.com/palantir/blueprint/blob/master/resources/icons";
 	var Icon = (function (_super) {
 	    tslib_1.__extends(Icon, _super);
@@ -34682,16 +34980,16 @@
 
 
 /***/ },
-/* 266 */
+/* 269 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
-	var PureRender = __webpack_require__(259);
+	var tslib_1 = __webpack_require__(261);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
-	var utils_1 = __webpack_require__(260);
-	var icon_1 = __webpack_require__(265);
+	var utils_1 = __webpack_require__(263);
+	var icon_1 = __webpack_require__(268);
 	var ICONS_PER_ROW = 5;
 	;
 	var Icons = (function (_super) {
@@ -34753,7 +35051,7 @@
 	Icons.defaultProps = {
 	    iconFilter: isIconFiltered,
 	    iconRenderer: renderIcon,
-	    icons: __webpack_require__(267),
+	    icons: __webpack_require__(270),
 	};
 	Icons = tslib_1.__decorate([
 	    PureRender
@@ -34768,7 +35066,7 @@
 
 
 /***/ },
-/* 267 */
+/* 270 */
 /***/ function(module, exports) {
 
 	module.exports = [
@@ -37484,14 +37782,14 @@
 	];
 
 /***/ },
-/* 268 */
+/* 271 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var CoreExamples = __webpack_require__(269);
-	var DateExamples = __webpack_require__(302);
-	var TableExamples = __webpack_require__(433);
+	var CoreExamples = __webpack_require__(272);
+	var DateExamples = __webpack_require__(307);
+	var TableExamples = __webpack_require__(438);
 	var Examples = {
 	    core: CoreExamples,
 	    datetime: DateExamples,
@@ -37529,7 +37827,7 @@
 
 
 /***/ },
-/* 269 */
+/* 272 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -37537,15 +37835,12 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(270));
-	__export(__webpack_require__(271));
-	__export(__webpack_require__(275));
-	__export(__webpack_require__(276));
-	__export(__webpack_require__(277));
+	__export(__webpack_require__(273));
+	__export(__webpack_require__(274));
 	__export(__webpack_require__(278));
+	__export(__webpack_require__(279));
 	__export(__webpack_require__(280));
 	__export(__webpack_require__(281));
-	__export(__webpack_require__(282));
 	__export(__webpack_require__(283));
 	__export(__webpack_require__(284));
 	__export(__webpack_require__(285));
@@ -37553,23 +37848,27 @@
 	__export(__webpack_require__(287));
 	__export(__webpack_require__(288));
 	__export(__webpack_require__(289));
-	__export(__webpack_require__(279));
 	__export(__webpack_require__(290));
 	__export(__webpack_require__(291));
 	__export(__webpack_require__(292));
+	__export(__webpack_require__(282));
 	__export(__webpack_require__(293));
 	__export(__webpack_require__(294));
 	__export(__webpack_require__(295));
 	__export(__webpack_require__(296));
 	__export(__webpack_require__(297));
-	__export(__webpack_require__(298));
 	__export(__webpack_require__(299));
 	__export(__webpack_require__(300));
 	__export(__webpack_require__(301));
+	__export(__webpack_require__(302));
+	__export(__webpack_require__(303));
+	__export(__webpack_require__(304));
+	__export(__webpack_require__(305));
+	__export(__webpack_require__(306));
 
 
 /***/ },
-/* 270 */
+/* 273 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -37577,7 +37876,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var AlertExample = (function (_super) {
 	    tslib_1.__extends(AlertExample, _super);
 	    function AlertExample() {
@@ -37623,7 +37922,7 @@
 
 
 /***/ },
-/* 271 */
+/* 274 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -37632,8 +37931,8 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var intentSelect_1 = __webpack_require__(272);
+	var baseExample_1 = __webpack_require__(267);
+	var intentSelect_1 = __webpack_require__(275);
 	var ButtonsExample = (function (_super) {
 	    tslib_1.__extends(ButtonsExample, _super);
 	    function ButtonsExample() {
@@ -37700,13 +37999,13 @@
 
 
 /***/ },
-/* 272 */
+/* 275 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var Classes = __webpack_require__(273);
-	var intent_1 = __webpack_require__(274);
+	var Classes = __webpack_require__(276);
+	var intent_1 = __webpack_require__(277);
 	var React = __webpack_require__(9);
 	var INTENTS = [
 	    { label: "None", value: intent_1.Intent.NONE },
@@ -37722,12 +38021,12 @@
 
 
 /***/ },
-/* 273 */
+/* 276 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var intent_1 = __webpack_require__(274);
+	var intent_1 = __webpack_require__(277);
 	exports.DARK = "pt-dark";
 	exports.ACTIVE = "pt-active";
 	exports.MINIMAL = "pt-minimal";
@@ -37886,7 +38185,7 @@
 
 
 /***/ },
-/* 274 */
+/* 277 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -37902,7 +38201,7 @@
 
 
 /***/ },
-/* 275 */
+/* 278 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -37910,7 +38209,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var CollapseExample = (function (_super) {
 	    tslib_1.__extends(CollapseExample, _super);
 	    function CollapseExample() {
@@ -37946,7 +38245,7 @@
 
 
 /***/ },
-/* 276 */
+/* 279 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -37955,7 +38254,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var COLLAPSE_FROM_RADIOS = [
 	    { className: core_1.Classes.INLINE, label: "Start", value: core_1.CollapseFrom.START.toString() },
 	    { className: core_1.Classes.INLINE, label: "End", value: core_1.CollapseFrom.END.toString() },
@@ -38005,7 +38304,7 @@
 
 
 /***/ },
-/* 277 */
+/* 280 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38013,7 +38312,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var ControlsExample = (function (_super) {
 	    tslib_1.__extends(ControlsExample, _super);
 	    function ControlsExample() {
@@ -38046,7 +38345,7 @@
 
 
 /***/ },
-/* 278 */
+/* 281 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38054,7 +38353,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var overlayExample_1 = __webpack_require__(279);
+	var overlayExample_1 = __webpack_require__(282);
 	var DialogExample = (function (_super) {
 	    tslib_1.__extends(DialogExample, _super);
 	    function DialogExample() {
@@ -38082,7 +38381,7 @@
 
 
 /***/ },
-/* 279 */
+/* 282 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38091,7 +38390,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var OVERLAY_EXAMPLE_CLASS = "docs-overlay-example-transition";
 	var OverlayExample = (function (_super) {
 	    tslib_1.__extends(OverlayExample, _super);
@@ -38156,7 +38455,7 @@
 
 
 /***/ },
-/* 280 */
+/* 283 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38166,7 +38465,7 @@
 	var PureRender = __webpack_require__(186);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var GraphNode = (function (_super) {
 	    tslib_1.__extends(GraphNode, _super);
 	    function GraphNode() {
@@ -38230,7 +38529,7 @@
 
 
 /***/ },
-/* 281 */
+/* 284 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38238,7 +38537,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var DropdownMenuExample = (function (_super) {
 	    tslib_1.__extends(DropdownMenuExample, _super);
 	    function DropdownMenuExample() {
@@ -38263,7 +38562,7 @@
 
 
 /***/ },
-/* 282 */
+/* 285 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38271,8 +38570,8 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var intentSelect_1 = __webpack_require__(272);
+	var baseExample_1 = __webpack_require__(267);
+	var intentSelect_1 = __webpack_require__(275);
 	var EditableTextExample = (function (_super) {
 	    tslib_1.__extends(EditableTextExample, _super);
 	    function EditableTextExample() {
@@ -38329,7 +38628,7 @@
 
 
 /***/ },
-/* 283 */
+/* 286 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38337,7 +38636,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var FocusExample = (function (_super) {
 	    tslib_1.__extends(FocusExample, _super);
 	    function FocusExample() {
@@ -38375,7 +38674,7 @@
 
 
 /***/ },
-/* 284 */
+/* 287 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38384,7 +38683,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var Oscillator = (function () {
 	    function Oscillator(context, freq) {
 	        this.context = context;
@@ -38580,7 +38879,7 @@
 
 
 /***/ },
-/* 285 */
+/* 288 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38588,7 +38887,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var HotkeyTester = (function (_super) {
 	    tslib_1.__extends(HotkeyTester, _super);
 	    function HotkeyTester() {
@@ -38623,7 +38922,7 @@
 
 
 /***/ },
-/* 286 */
+/* 289 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38631,7 +38930,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var MenuExample = (function (_super) {
 	    tslib_1.__extends(MenuExample, _super);
 	    function MenuExample() {
@@ -38679,16 +38978,17 @@
 
 
 /***/ },
-/* 287 */
+/* 290 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(8);
+	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var intentSelect_1 = __webpack_require__(272);
+	var baseExample_1 = __webpack_require__(267);
+	var intentSelect_1 = __webpack_require__(275);
 	var MIN_VALUES = [
 	    { label: "None", value: null },
 	    { label: "-10", value: -10 },
@@ -38700,20 +39000,6 @@
 	    { label: "20", value: 20 },
 	    { label: "50", value: 50 },
 	    { label: "100", value: 100 },
-	];
-	var STEP_SIZES = [
-	    { label: "1", value: 1 },
-	    { label: "1", value: 2 },
-	];
-	var MINOR_STEP_SIZES = [
-	    { label: "None", value: null },
-	    { label: "0.1", value: 0.1 },
-	    { label: "0.2", value: 0.2 },
-	];
-	var MAJOR_STEP_SIZES = [
-	    { label: "None", value: null },
-	    { label: "10", value: 10 },
-	    { label: "20", value: 20 },
 	];
 	var BUTTON_POSITIONS = [
 	    { label: "None", value: null },
@@ -38735,6 +39021,7 @@
 	            selectAllOnFocus: false,
 	            selectAllOnIncrement: false,
 	            showDisabled: false,
+	            showFullWidth: false,
 	            showLeftIcon: false,
 	            showReadOnly: false,
 	            stepSizeIndex: 0,
@@ -38749,6 +39036,7 @@
 	        _this.toggleDisabled = baseExample_1.handleBooleanChange(function (showDisabled) { return _this.setState({ showDisabled: showDisabled }); });
 	        _this.toggleLeftIcon = baseExample_1.handleBooleanChange(function (showLeftIcon) { return _this.setState({ showLeftIcon: showLeftIcon }); });
 	        _this.toggleReadOnly = baseExample_1.handleBooleanChange(function (showReadOnly) { return _this.setState({ showReadOnly: showReadOnly }); });
+	        _this.toggleFullWidth = baseExample_1.handleBooleanChange(function (showFullWidth) { return _this.setState({ showFullWidth: showFullWidth }); });
 	        _this.toggleNumericCharsOnly = baseExample_1.handleBooleanChange(function (numericCharsOnly) { return _this.setState({ numericCharsOnly: numericCharsOnly }); });
 	        _this.toggleSelectAllOnFocus = baseExample_1.handleBooleanChange(function (selectAllOnFocus) { return _this.setState({ selectAllOnFocus: selectAllOnFocus }); });
 	        _this.toggleSelectAllOnIncrement = baseExample_1.handleBooleanChange(function (selectAllOnIncrement) {
@@ -38760,15 +39048,9 @@
 	        return _this;
 	    }
 	    NumericInputBasicExample.prototype.renderOptions = function () {
-	        var _a = this.state, buttonPositionIndex = _a.buttonPositionIndex, intent = _a.intent, maxValueIndex = _a.maxValueIndex, minValueIndex = _a.minValueIndex, numericCharsOnly = _a.numericCharsOnly, selectAllOnFocus = _a.selectAllOnFocus, selectAllOnIncrement = _a.selectAllOnIncrement, showDisabled = _a.showDisabled, showReadOnly = _a.showReadOnly, showLeftIcon = _a.showLeftIcon;
+	        var _a = this.state, buttonPositionIndex = _a.buttonPositionIndex, intent = _a.intent, maxValueIndex = _a.maxValueIndex, minValueIndex = _a.minValueIndex, numericCharsOnly = _a.numericCharsOnly, selectAllOnFocus = _a.selectAllOnFocus, selectAllOnIncrement = _a.selectAllOnIncrement, showDisabled = _a.showDisabled, showFullWidth = _a.showFullWidth, showReadOnly = _a.showReadOnly, showLeftIcon = _a.showLeftIcon;
 	        return [
 	            [
-	                this.renderSelectMenu("Minimum value", minValueIndex, MIN_VALUES, this.handleMinValueChange),
-	                this.renderSelectMenu("Maximum value", maxValueIndex, MAX_VALUES, this.handleMaxValueChange),
-	            ], [
-	                this.renderSelectMenu("Button position", buttonPositionIndex, BUTTON_POSITIONS, this.handleButtonPositionChange),
-	                React.createElement(intentSelect_1.IntentSelect, { intent: intent, key: "intent", onChange: this.handleIntentChange }),
-	            ], [
 	                React.createElement("label", { className: core_1.Classes.LABEL, key: "modifierslabel" }, "Modifiers"),
 	                this.renderSwitch("Numeric characters only", numericCharsOnly, this.toggleNumericCharsOnly),
 	                this.renderSwitch("Select all on focus", selectAllOnFocus, this.toggleSelectAllOnFocus),
@@ -38776,12 +39058,20 @@
 	                this.renderSwitch("Disabled", showDisabled, this.toggleDisabled),
 	                this.renderSwitch("Read-only", showReadOnly, this.toggleReadOnly),
 	                this.renderSwitch("Left icon", showLeftIcon, this.toggleLeftIcon),
+	                this.renderSwitch("Full width", showFullWidth, this.toggleFullWidth),
+	            ], [
+	                this.renderSelectMenu("Minimum value", minValueIndex, MIN_VALUES, this.handleMinValueChange),
+	                this.renderSelectMenu("Maximum value", maxValueIndex, MAX_VALUES, this.handleMaxValueChange),
+	            ], [
+	                this.renderSelectMenu("Button position", buttonPositionIndex, BUTTON_POSITIONS, this.handleButtonPositionChange),
+	                React.createElement(intentSelect_1.IntentSelect, { intent: intent, key: "intent", onChange: this.handleIntentChange }),
 	            ],
 	        ];
 	    };
 	    NumericInputBasicExample.prototype.renderExample = function () {
-	        return (React.createElement("div", null,
-	            React.createElement(core_1.NumericInput, { allowNumericCharactersOnly: this.state.numericCharsOnly, buttonPosition: BUTTON_POSITIONS[this.state.buttonPositionIndex].value, intent: this.state.intent, min: MIN_VALUES[this.state.minValueIndex].value, max: MAX_VALUES[this.state.maxValueIndex].value, stepSize: STEP_SIZES[this.state.stepSizeIndex].value, majorStepSize: MAJOR_STEP_SIZES[this.state.majorStepSizeIndex].value, minorStepSize: MINOR_STEP_SIZES[this.state.minorStepSizeIndex].value, disabled: this.state.showDisabled, readOnly: this.state.showReadOnly, leftIconName: this.state.showLeftIcon ? "dollar" : null, placeholder: "Enter a number...", selectAllOnFocus: this.state.selectAllOnFocus, selectAllOnIncrement: this.state.selectAllOnIncrement, onValueChange: this.handleValueChange, value: this.state.value })));
+	        return (React.createElement("div", { className: "docs-react-numeric-input-example" },
+	            React.createElement(core_1.NumericInput, { allowNumericCharactersOnly: this.state.numericCharsOnly, buttonPosition: BUTTON_POSITIONS[this.state.buttonPositionIndex].value, className: classNames((_a = {}, _a[core_1.Classes.FILL] = this.state.showFullWidth, _a)), intent: this.state.intent, min: MIN_VALUES[this.state.minValueIndex].value, max: MAX_VALUES[this.state.maxValueIndex].value, disabled: this.state.showDisabled, readOnly: this.state.showReadOnly, leftIconName: this.state.showLeftIcon ? "dollar" : null, placeholder: "Enter a number...", selectAllOnFocus: this.state.selectAllOnFocus, selectAllOnIncrement: this.state.selectAllOnIncrement, onValueChange: this.handleValueChange, value: this.state.value })));
+	        var _a;
 	    };
 	    NumericInputBasicExample.prototype.renderSwitch = function (label, checked, onChange) {
 	        return (React.createElement(core_1.Switch, { checked: checked, label: label, key: label, onChange: onChange }));
@@ -38803,7 +39093,7 @@
 
 
 /***/ },
-/* 288 */
+/* 291 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38811,7 +39101,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var NumberAbbreviation = {
 	    BILLION: "b",
 	    MILLION: "m",
@@ -38927,7 +39217,7 @@
 
 
 /***/ },
-/* 289 */
+/* 292 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38935,7 +39225,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var NonIdealStateExample = (function (_super) {
 	    tslib_1.__extends(NonIdealStateExample, _super);
 	    function NonIdealStateExample() {
@@ -38954,7 +39244,7 @@
 
 
 /***/ },
-/* 290 */
+/* 293 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -38963,7 +39253,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var INTERACTION_KINDS = [
 	    { label: "Click", value: core_1.PopoverInteractionKind.CLICK.toString() },
 	    { label: "Click (target only)", value: core_1.PopoverInteractionKind.CLICK_TARGET_ONLY.toString() },
@@ -39127,7 +39417,7 @@
 
 
 /***/ },
-/* 291 */
+/* 294 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39135,8 +39425,8 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var intentSelect_1 = __webpack_require__(272);
+	var baseExample_1 = __webpack_require__(267);
+	var intentSelect_1 = __webpack_require__(275);
 	var ProgressExample = (function (_super) {
 	    tslib_1.__extends(ProgressExample, _super);
 	    function ProgressExample() {
@@ -39171,7 +39461,7 @@
 
 
 /***/ },
-/* 292 */
+/* 295 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39179,7 +39469,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var RangeSliderExample = (function (_super) {
 	    tslib_1.__extends(RangeSliderExample, _super);
 	    function RangeSliderExample() {
@@ -39200,7 +39490,7 @@
 
 
 /***/ },
-/* 293 */
+/* 296 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39208,21 +39498,21 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var SliderExample = (function (_super) {
 	    tslib_1.__extends(SliderExample, _super);
 	    function SliderExample() {
 	        var _this = _super !== null && _super.apply(this, arguments) || this;
 	        _this.state = {
 	            value1: 0,
-	            value2: 25,
+	            value2: 2.5,
 	            value3: 30,
 	        };
 	        return _this;
 	    }
 	    SliderExample.prototype.renderExample = function () {
 	        return (React.createElement("div", { style: { width: "100%" } },
-	            React.createElement(core_1.Slider, { min: 0, max: 100, stepSize: 1, labelStepSize: 10, onChange: this.getChangeHandler("value2"), value: this.state.value2 }),
+	            React.createElement(core_1.Slider, { min: 0, max: 10, stepSize: 0.1, labelStepSize: 10, onChange: this.getChangeHandler("value2"), value: this.state.value2 }),
 	            React.createElement(core_1.Slider, { min: 0, max: 0.7, stepSize: 0.01, labelStepSize: 0.14, onChange: this.getChangeHandler("value1"), renderLabel: this.renderLabel1, value: this.state.value1 }),
 	            React.createElement(core_1.Slider, { min: -12, max: 48, stepSize: 6, labelStepSize: 10, onChange: this.getChangeHandler("value3"), renderLabel: this.renderLabel3, showTrackFill: false, value: this.state.value3 })));
 	    };
@@ -39245,7 +39535,96 @@
 
 
 /***/ },
-/* 294 */
+/* 297 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
+	var tslib_1 = __webpack_require__(8);
+	var classNames = __webpack_require__(185);
+	var React = __webpack_require__(9);
+	var Classes = __webpack_require__(276);
+	var text_1 = __webpack_require__(298);
+	var baseExample_1 = __webpack_require__(267);
+	var baseExample_2 = __webpack_require__(267);
+	var TextExample = (function (_super) {
+	    tslib_1.__extends(TextExample, _super);
+	    function TextExample() {
+	        var _this = _super !== null && _super.apply(this, arguments) || this;
+	        _this.state = {
+	            textContent: "You can change the text in the input below. Hover to see full text. " +
+	                "If the text is long enough, then the content will overflow. This is done by setting " +
+	                "ellipsize to true.",
+	        };
+	        _this.onInputChange = baseExample_2.handleStringChange(function (textContent) { return _this.setState({ textContent: textContent }); });
+	        return _this;
+	    }
+	    TextExample.prototype.renderExample = function () {
+	        return (React.createElement("div", { style: { width: "100%" } },
+	            React.createElement(text_1.Text, { ellipsize: true },
+	                this.state.textContent,
+	                "\u00A0"),
+	            React.createElement("textarea", { className: classNames(Classes.INPUT, Classes.FILL), onChange: this.onInputChange, style: { marginTop: 20 }, value: this.state.textContent })));
+	    };
+	    return TextExample;
+	}(baseExample_1.default));
+	exports.TextExample = TextExample;
+
+
+/***/ },
+/* 298 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
+	var tslib_1 = __webpack_require__(8);
+	var classNames = __webpack_require__(185);
+	var PureRender = __webpack_require__(186);
+	var React = __webpack_require__(9);
+	var Classes = __webpack_require__(276);
+	var Text = (function (_super) {
+	    tslib_1.__extends(Text, _super);
+	    function Text() {
+	        var _this = _super !== null && _super.apply(this, arguments) || this;
+	        _this.state = {
+	            isContentOverflowing: false,
+	            textContent: "",
+	        };
+	        _this.refHandlers = {
+	            text: function (overflowElement) { return _this.textRef = overflowElement; },
+	        };
+	        return _this;
+	    }
+	    Text.prototype.componentDidMount = function () {
+	        this.update();
+	    };
+	    Text.prototype.componentDidUpdate = function () {
+	        this.update();
+	    };
+	    Text.prototype.render = function () {
+	        var classes = classNames((_a = {},
+	            _a[Classes.TEXT_OVERFLOW_ELLIPSIS] = this.props.ellipsize,
+	            _a), this.props.className);
+	        return (React.createElement("div", { className: classes, ref: this.refHandlers.text, title: this.state.isContentOverflowing ? this.state.textContent : undefined }, this.props.children));
+	        var _a;
+	    };
+	    Text.prototype.update = function () {
+	        var newState = {
+	            isContentOverflowing: this.props.ellipsize && this.textRef.scrollWidth > this.textRef.clientWidth,
+	            textContent: this.textRef.textContent,
+	        };
+	        this.setState(newState);
+	    };
+	    return Text;
+	}(React.Component));
+	Text = tslib_1.__decorate([
+	    PureRender
+	], Text);
+	exports.Text = Text;
+
+
+/***/ },
+/* 299 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39253,8 +39632,8 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var progressExample_1 = __webpack_require__(291);
+	var baseExample_1 = __webpack_require__(267);
+	var progressExample_1 = __webpack_require__(294);
 	var SIZES = [
 	    { label: "Default", value: "" },
 	    { label: "Small", value: core_1.Classes.SMALL },
@@ -39287,7 +39666,7 @@
 
 
 /***/ },
-/* 295 */
+/* 300 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39295,7 +39674,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var TabsExample = (function (_super) {
 	    tslib_1.__extends(TabsExample, _super);
 	    function TabsExample() {
@@ -39339,7 +39718,7 @@
 
 
 /***/ },
-/* 296 */
+/* 301 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39348,7 +39727,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var Tabs2Example = (function (_super) {
 	    tslib_1.__extends(Tabs2Example, _super);
 	    function Tabs2Example() {
@@ -39412,7 +39791,7 @@
 
 
 /***/ },
-/* 297 */
+/* 302 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39421,7 +39800,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var InputGroupExample = (function (_super) {
 	    tslib_1.__extends(InputGroupExample, _super);
 	    function InputGroupExample() {
@@ -39474,7 +39853,7 @@
 
 
 /***/ },
-/* 298 */
+/* 303 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39482,7 +39861,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var TagExample = (function (_super) {
 	    tslib_1.__extends(TagExample, _super);
 	    function TagExample() {
@@ -39518,7 +39897,7 @@
 
 
 /***/ },
-/* 299 */
+/* 304 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39527,7 +39906,7 @@
 	var classNames = __webpack_require__(185);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var ToastExample = (function (_super) {
 	    tslib_1.__extends(ToastExample, _super);
 	    function ToastExample() {
@@ -39649,7 +40028,7 @@
 
 
 /***/ },
-/* 300 */
+/* 305 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39657,7 +40036,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var TooltipExample = (function (_super) {
 	    tslib_1.__extends(TooltipExample, _super);
 	    function TooltipExample() {
@@ -39707,7 +40086,7 @@
 
 
 /***/ },
-/* 301 */
+/* 306 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39715,7 +40094,7 @@
 	var tslib_1 = __webpack_require__(8);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var TreeExample = (function (_super) {
 	    tslib_1.__extends(TreeExample, _super);
 	    function TreeExample() {
@@ -39799,7 +40178,7 @@
 
 
 /***/ },
-/* 302 */
+/* 307 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -39807,26 +40186,26 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(303));
-	__export(__webpack_require__(428));
-	__export(__webpack_require__(429));
-	__export(__webpack_require__(430));
-	__export(__webpack_require__(431));
-	__export(__webpack_require__(432));
+	__export(__webpack_require__(308));
+	__export(__webpack_require__(433));
+	__export(__webpack_require__(434));
+	__export(__webpack_require__(435));
+	__export(__webpack_require__(436));
+	__export(__webpack_require__(437));
 
 
 /***/ },
-/* 303 */
+/* 308 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var React = __webpack_require__(9);
-	var src_1 = __webpack_require__(305);
-	var formatSelect_1 = __webpack_require__(427);
+	var src_1 = __webpack_require__(310);
+	var formatSelect_1 = __webpack_require__(432);
 	var DateInputExample = (function (_super) {
 	    tslib_1.__extends(DateInputExample, _super);
 	    function DateInputExample() {
@@ -39863,7 +40242,7 @@
 
 
 /***/ },
-/* 304 */
+/* 309 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(global) {/*! *****************************************************************************
@@ -40075,35 +40454,35 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 305 */
+/* 310 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var classes = __webpack_require__(306);
+	var classes = __webpack_require__(311);
 	exports.Classes = classes;
-	var dateUtils_1 = __webpack_require__(307);
+	var dateUtils_1 = __webpack_require__(312);
 	exports.DateRangeBoundary = dateUtils_1.DateRangeBoundary;
-	var dateInput_1 = __webpack_require__(414);
+	var dateInput_1 = __webpack_require__(419);
 	exports.DateInput = dateInput_1.DateInput;
-	var datePicker_1 = __webpack_require__(416);
+	var datePicker_1 = __webpack_require__(421);
 	exports.DatePicker = datePicker_1.DatePicker;
 	exports.DatePickerFactory = datePicker_1.DatePickerFactory;
-	var dateTimePicker_1 = __webpack_require__(422);
+	var dateTimePicker_1 = __webpack_require__(427);
 	exports.DateTimePicker = dateTimePicker_1.DateTimePicker;
-	var dateRangeInput_1 = __webpack_require__(424);
+	var dateRangeInput_1 = __webpack_require__(429);
 	exports.DateRangeInput = dateRangeInput_1.DateRangeInput;
-	var dateRangePicker_1 = __webpack_require__(425);
+	var dateRangePicker_1 = __webpack_require__(430);
 	exports.DateRangePicker = dateRangePicker_1.DateRangePicker;
 	exports.DateRangePickerFactory = dateRangePicker_1.DateRangePickerFactory;
-	var timePicker_1 = __webpack_require__(423);
+	var timePicker_1 = __webpack_require__(428);
 	exports.TimePicker = timePicker_1.TimePicker;
 	exports.TimePickerFactory = timePicker_1.TimePickerFactory;
 	exports.TimePickerPrecision = timePicker_1.TimePickerPrecision;
 
 
 /***/ },
-/* 306 */
+/* 311 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -40139,12 +40518,12 @@
 
 
 /***/ },
-/* 307 */
+/* 312 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var moment = __webpack_require__(308);
+	var moment = __webpack_require__(313);
 	var DateRangeBoundary;
 	(function (DateRangeBoundary) {
 	    DateRangeBoundary[DateRangeBoundary["START"] = 0] = "START";
@@ -40326,7 +40705,7 @@
 
 
 /***/ },
-/* 308 */
+/* 313 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(module) {//! moment.js
@@ -42125,7 +42504,7 @@
 	                module && module.exports) {
 	            try {
 	                oldLocale = globalLocale._abbr;
-	                __webpack_require__(309)("./" + name);
+	                __webpack_require__(314)("./" + name);
 	                // because defineLocale currently also sets the global locale, we
 	                // want to undo that for lazy loaded locales
 	                locale_locales__getSetGlobalLocale(oldLocale);
@@ -44563,221 +44942,221 @@
 	    return _moment;
 	
 	}));
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(263)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(266)(module)))
 
 /***/ },
-/* 309 */
+/* 314 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var map = {
-		"./af": 310,
-		"./af.js": 310,
-		"./ar": 311,
-		"./ar-ly": 312,
-		"./ar-ly.js": 312,
-		"./ar-ma": 313,
-		"./ar-ma.js": 313,
-		"./ar-sa": 314,
-		"./ar-sa.js": 314,
-		"./ar-tn": 315,
-		"./ar-tn.js": 315,
-		"./ar.js": 311,
-		"./az": 316,
-		"./az.js": 316,
-		"./be": 317,
-		"./be.js": 317,
-		"./bg": 318,
-		"./bg.js": 318,
-		"./bn": 319,
-		"./bn.js": 319,
-		"./bo": 320,
-		"./bo.js": 320,
-		"./br": 321,
-		"./br.js": 321,
-		"./bs": 322,
-		"./bs.js": 322,
-		"./ca": 323,
-		"./ca.js": 323,
-		"./cs": 324,
-		"./cs.js": 324,
-		"./cv": 325,
-		"./cv.js": 325,
-		"./cy": 326,
-		"./cy.js": 326,
-		"./da": 327,
-		"./da.js": 327,
-		"./de": 328,
-		"./de-at": 329,
-		"./de-at.js": 329,
-		"./de.js": 328,
-		"./dv": 330,
-		"./dv.js": 330,
-		"./el": 331,
-		"./el.js": 331,
-		"./en-au": 332,
-		"./en-au.js": 332,
-		"./en-ca": 333,
-		"./en-ca.js": 333,
-		"./en-gb": 334,
-		"./en-gb.js": 334,
-		"./en-ie": 335,
-		"./en-ie.js": 335,
-		"./en-nz": 336,
-		"./en-nz.js": 336,
-		"./eo": 337,
-		"./eo.js": 337,
-		"./es": 338,
-		"./es-do": 339,
-		"./es-do.js": 339,
-		"./es.js": 338,
-		"./et": 340,
-		"./et.js": 340,
-		"./eu": 341,
-		"./eu.js": 341,
-		"./fa": 342,
-		"./fa.js": 342,
-		"./fi": 343,
-		"./fi.js": 343,
-		"./fo": 344,
-		"./fo.js": 344,
-		"./fr": 345,
-		"./fr-ca": 346,
-		"./fr-ca.js": 346,
-		"./fr-ch": 347,
-		"./fr-ch.js": 347,
-		"./fr.js": 345,
-		"./fy": 348,
-		"./fy.js": 348,
-		"./gd": 349,
-		"./gd.js": 349,
-		"./gl": 350,
-		"./gl.js": 350,
-		"./he": 351,
-		"./he.js": 351,
-		"./hi": 352,
-		"./hi.js": 352,
-		"./hr": 353,
-		"./hr.js": 353,
-		"./hu": 354,
-		"./hu.js": 354,
-		"./hy-am": 355,
-		"./hy-am.js": 355,
-		"./id": 356,
-		"./id.js": 356,
-		"./is": 357,
-		"./is.js": 357,
-		"./it": 358,
-		"./it.js": 358,
-		"./ja": 359,
-		"./ja.js": 359,
-		"./jv": 360,
-		"./jv.js": 360,
-		"./ka": 361,
-		"./ka.js": 361,
-		"./kk": 362,
-		"./kk.js": 362,
-		"./km": 363,
-		"./km.js": 363,
-		"./ko": 364,
-		"./ko.js": 364,
-		"./ky": 365,
-		"./ky.js": 365,
-		"./lb": 366,
-		"./lb.js": 366,
-		"./lo": 367,
-		"./lo.js": 367,
-		"./lt": 368,
-		"./lt.js": 368,
-		"./lv": 369,
-		"./lv.js": 369,
-		"./me": 370,
-		"./me.js": 370,
-		"./mi": 371,
-		"./mi.js": 371,
-		"./mk": 372,
-		"./mk.js": 372,
-		"./ml": 373,
-		"./ml.js": 373,
-		"./mr": 374,
-		"./mr.js": 374,
-		"./ms": 375,
-		"./ms-my": 376,
-		"./ms-my.js": 376,
-		"./ms.js": 375,
-		"./my": 377,
-		"./my.js": 377,
-		"./nb": 378,
-		"./nb.js": 378,
-		"./ne": 379,
-		"./ne.js": 379,
-		"./nl": 380,
-		"./nl.js": 380,
-		"./nn": 381,
-		"./nn.js": 381,
-		"./pa-in": 382,
-		"./pa-in.js": 382,
-		"./pl": 383,
-		"./pl.js": 383,
-		"./pt": 384,
-		"./pt-br": 385,
-		"./pt-br.js": 385,
-		"./pt.js": 384,
-		"./ro": 386,
-		"./ro.js": 386,
-		"./ru": 387,
-		"./ru.js": 387,
-		"./se": 388,
-		"./se.js": 388,
-		"./si": 389,
-		"./si.js": 389,
-		"./sk": 390,
-		"./sk.js": 390,
-		"./sl": 391,
-		"./sl.js": 391,
-		"./sq": 392,
-		"./sq.js": 392,
-		"./sr": 393,
-		"./sr-cyrl": 394,
-		"./sr-cyrl.js": 394,
-		"./sr.js": 393,
-		"./ss": 395,
-		"./ss.js": 395,
-		"./sv": 396,
-		"./sv.js": 396,
-		"./sw": 397,
-		"./sw.js": 397,
-		"./ta": 398,
-		"./ta.js": 398,
-		"./te": 399,
-		"./te.js": 399,
-		"./th": 400,
-		"./th.js": 400,
-		"./tl-ph": 401,
-		"./tl-ph.js": 401,
-		"./tlh": 402,
-		"./tlh.js": 402,
-		"./tr": 403,
-		"./tr.js": 403,
-		"./tzl": 404,
-		"./tzl.js": 404,
-		"./tzm": 405,
-		"./tzm-latn": 406,
-		"./tzm-latn.js": 406,
-		"./tzm.js": 405,
-		"./uk": 407,
-		"./uk.js": 407,
-		"./uz": 408,
-		"./uz.js": 408,
-		"./vi": 409,
-		"./vi.js": 409,
-		"./x-pseudo": 410,
-		"./x-pseudo.js": 410,
-		"./zh-cn": 411,
-		"./zh-cn.js": 411,
-		"./zh-hk": 412,
-		"./zh-hk.js": 412,
-		"./zh-tw": 413,
-		"./zh-tw.js": 413
+		"./af": 315,
+		"./af.js": 315,
+		"./ar": 316,
+		"./ar-ly": 317,
+		"./ar-ly.js": 317,
+		"./ar-ma": 318,
+		"./ar-ma.js": 318,
+		"./ar-sa": 319,
+		"./ar-sa.js": 319,
+		"./ar-tn": 320,
+		"./ar-tn.js": 320,
+		"./ar.js": 316,
+		"./az": 321,
+		"./az.js": 321,
+		"./be": 322,
+		"./be.js": 322,
+		"./bg": 323,
+		"./bg.js": 323,
+		"./bn": 324,
+		"./bn.js": 324,
+		"./bo": 325,
+		"./bo.js": 325,
+		"./br": 326,
+		"./br.js": 326,
+		"./bs": 327,
+		"./bs.js": 327,
+		"./ca": 328,
+		"./ca.js": 328,
+		"./cs": 329,
+		"./cs.js": 329,
+		"./cv": 330,
+		"./cv.js": 330,
+		"./cy": 331,
+		"./cy.js": 331,
+		"./da": 332,
+		"./da.js": 332,
+		"./de": 333,
+		"./de-at": 334,
+		"./de-at.js": 334,
+		"./de.js": 333,
+		"./dv": 335,
+		"./dv.js": 335,
+		"./el": 336,
+		"./el.js": 336,
+		"./en-au": 337,
+		"./en-au.js": 337,
+		"./en-ca": 338,
+		"./en-ca.js": 338,
+		"./en-gb": 339,
+		"./en-gb.js": 339,
+		"./en-ie": 340,
+		"./en-ie.js": 340,
+		"./en-nz": 341,
+		"./en-nz.js": 341,
+		"./eo": 342,
+		"./eo.js": 342,
+		"./es": 343,
+		"./es-do": 344,
+		"./es-do.js": 344,
+		"./es.js": 343,
+		"./et": 345,
+		"./et.js": 345,
+		"./eu": 346,
+		"./eu.js": 346,
+		"./fa": 347,
+		"./fa.js": 347,
+		"./fi": 348,
+		"./fi.js": 348,
+		"./fo": 349,
+		"./fo.js": 349,
+		"./fr": 350,
+		"./fr-ca": 351,
+		"./fr-ca.js": 351,
+		"./fr-ch": 352,
+		"./fr-ch.js": 352,
+		"./fr.js": 350,
+		"./fy": 353,
+		"./fy.js": 353,
+		"./gd": 354,
+		"./gd.js": 354,
+		"./gl": 355,
+		"./gl.js": 355,
+		"./he": 356,
+		"./he.js": 356,
+		"./hi": 357,
+		"./hi.js": 357,
+		"./hr": 358,
+		"./hr.js": 358,
+		"./hu": 359,
+		"./hu.js": 359,
+		"./hy-am": 360,
+		"./hy-am.js": 360,
+		"./id": 361,
+		"./id.js": 361,
+		"./is": 362,
+		"./is.js": 362,
+		"./it": 363,
+		"./it.js": 363,
+		"./ja": 364,
+		"./ja.js": 364,
+		"./jv": 365,
+		"./jv.js": 365,
+		"./ka": 366,
+		"./ka.js": 366,
+		"./kk": 367,
+		"./kk.js": 367,
+		"./km": 368,
+		"./km.js": 368,
+		"./ko": 369,
+		"./ko.js": 369,
+		"./ky": 370,
+		"./ky.js": 370,
+		"./lb": 371,
+		"./lb.js": 371,
+		"./lo": 372,
+		"./lo.js": 372,
+		"./lt": 373,
+		"./lt.js": 373,
+		"./lv": 374,
+		"./lv.js": 374,
+		"./me": 375,
+		"./me.js": 375,
+		"./mi": 376,
+		"./mi.js": 376,
+		"./mk": 377,
+		"./mk.js": 377,
+		"./ml": 378,
+		"./ml.js": 378,
+		"./mr": 379,
+		"./mr.js": 379,
+		"./ms": 380,
+		"./ms-my": 381,
+		"./ms-my.js": 381,
+		"./ms.js": 380,
+		"./my": 382,
+		"./my.js": 382,
+		"./nb": 383,
+		"./nb.js": 383,
+		"./ne": 384,
+		"./ne.js": 384,
+		"./nl": 385,
+		"./nl.js": 385,
+		"./nn": 386,
+		"./nn.js": 386,
+		"./pa-in": 387,
+		"./pa-in.js": 387,
+		"./pl": 388,
+		"./pl.js": 388,
+		"./pt": 389,
+		"./pt-br": 390,
+		"./pt-br.js": 390,
+		"./pt.js": 389,
+		"./ro": 391,
+		"./ro.js": 391,
+		"./ru": 392,
+		"./ru.js": 392,
+		"./se": 393,
+		"./se.js": 393,
+		"./si": 394,
+		"./si.js": 394,
+		"./sk": 395,
+		"./sk.js": 395,
+		"./sl": 396,
+		"./sl.js": 396,
+		"./sq": 397,
+		"./sq.js": 397,
+		"./sr": 398,
+		"./sr-cyrl": 399,
+		"./sr-cyrl.js": 399,
+		"./sr.js": 398,
+		"./ss": 400,
+		"./ss.js": 400,
+		"./sv": 401,
+		"./sv.js": 401,
+		"./sw": 402,
+		"./sw.js": 402,
+		"./ta": 403,
+		"./ta.js": 403,
+		"./te": 404,
+		"./te.js": 404,
+		"./th": 405,
+		"./th.js": 405,
+		"./tl-ph": 406,
+		"./tl-ph.js": 406,
+		"./tlh": 407,
+		"./tlh.js": 407,
+		"./tr": 408,
+		"./tr.js": 408,
+		"./tzl": 409,
+		"./tzl.js": 409,
+		"./tzm": 410,
+		"./tzm-latn": 411,
+		"./tzm-latn.js": 411,
+		"./tzm.js": 410,
+		"./uk": 412,
+		"./uk.js": 412,
+		"./uz": 413,
+		"./uz.js": 413,
+		"./vi": 414,
+		"./vi.js": 414,
+		"./x-pseudo": 415,
+		"./x-pseudo.js": 415,
+		"./zh-cn": 416,
+		"./zh-cn.js": 416,
+		"./zh-hk": 417,
+		"./zh-hk.js": 417,
+		"./zh-tw": 418,
+		"./zh-tw.js": 418
 	};
 	function webpackContext(req) {
 		return __webpack_require__(webpackContextResolve(req));
@@ -44790,11 +45169,11 @@
 	};
 	webpackContext.resolve = webpackContextResolve;
 	module.exports = webpackContext;
-	webpackContext.id = 309;
+	webpackContext.id = 314;
 
 
 /***/ },
-/* 310 */
+/* 315 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -44802,7 +45181,7 @@
 	//! author : Werner Mollentze : https://github.com/wernerm
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -44871,7 +45250,7 @@
 	}));
 
 /***/ },
-/* 311 */
+/* 316 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -44881,7 +45260,7 @@
 	//! author : forabi https://github.com/forabi
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45012,7 +45391,7 @@
 	}));
 
 /***/ },
-/* 312 */
+/* 317 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45020,7 +45399,7 @@
 	//! author : Ali Hmer: https://github.com/kikoanis
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45138,7 +45517,7 @@
 	}));
 
 /***/ },
-/* 313 */
+/* 318 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45147,7 +45526,7 @@
 	//! author : Abdel Said : https://github.com/abdelsaid
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45202,7 +45581,7 @@
 	}));
 
 /***/ },
-/* 314 */
+/* 319 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45210,7 +45589,7 @@
 	//! author : Suhail Alkowaileet : https://github.com/xsoh
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45310,7 +45689,7 @@
 	}));
 
 /***/ },
-/* 315 */
+/* 320 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45318,7 +45697,7 @@
 	//! author : Nader Toukabri : https://github.com/naderio
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45373,7 +45752,7 @@
 	}));
 
 /***/ },
-/* 316 */
+/* 321 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45381,7 +45760,7 @@
 	//! author : topchiyev : https://github.com/topchiyev
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45482,7 +45861,7 @@
 	}));
 
 /***/ },
-/* 317 */
+/* 322 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45492,7 +45871,7 @@
 	//! Author : Menelion Elensúle : https://github.com/Oire
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45620,7 +45999,7 @@
 	}));
 
 /***/ },
-/* 318 */
+/* 323 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45628,7 +46007,7 @@
 	//! author : Krasen Borisov : https://github.com/kraz
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45714,7 +46093,7 @@
 	}));
 
 /***/ },
-/* 319 */
+/* 324 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45722,7 +46101,7 @@
 	//! author : Kaushik Gandhi : https://github.com/kaushikgandhi
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45837,7 +46216,7 @@
 	}));
 
 /***/ },
-/* 320 */
+/* 325 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45845,7 +46224,7 @@
 	//! author : Thupten N. Chakrishar : https://github.com/vajradog
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -45960,7 +46339,7 @@
 	}));
 
 /***/ },
-/* 321 */
+/* 326 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -45968,7 +46347,7 @@
 	//! author : Jean-Baptiste Le Duigou : https://github.com/jbleduigou
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46072,7 +46451,7 @@
 	}));
 
 /***/ },
-/* 322 */
+/* 327 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46081,7 +46460,7 @@
 	//! based on (hr) translation by Bojan Marković
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46219,7 +46598,7 @@
 	}));
 
 /***/ },
-/* 323 */
+/* 328 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46227,7 +46606,7 @@
 	//! author : Juan G. Hurtado : https://github.com/juanghurtado
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46304,7 +46683,7 @@
 	}));
 
 /***/ },
-/* 324 */
+/* 329 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46312,7 +46691,7 @@
 	//! author : petrbela : https://github.com/petrbela
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46480,7 +46859,7 @@
 	}));
 
 /***/ },
-/* 325 */
+/* 330 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46488,7 +46867,7 @@
 	//! author : Anatoly Mironov : https://github.com/mirontoli
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46547,7 +46926,7 @@
 	}));
 
 /***/ },
-/* 326 */
+/* 331 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46556,7 +46935,7 @@
 	//! author : https://github.com/ryangreaves
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46632,7 +47011,7 @@
 	}));
 
 /***/ },
-/* 327 */
+/* 332 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46640,7 +47019,7 @@
 	//! author : Ulrik Nielsen : https://github.com/mrbase
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46696,7 +47075,7 @@
 	}));
 
 /***/ },
-/* 328 */
+/* 333 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46706,7 +47085,7 @@
 	//! author : Mikolaj Dadela : https://github.com/mik01aj
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46778,7 +47157,7 @@
 	}));
 
 /***/ },
-/* 329 */
+/* 334 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46789,7 +47168,7 @@
 	//! author : Mikolaj Dadela : https://github.com/mik01aj
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46861,7 +47240,7 @@
 	}));
 
 /***/ },
-/* 330 */
+/* 335 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46869,7 +47248,7 @@
 	//! author : Jawish Hameed : https://github.com/jawish
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -46964,7 +47343,7 @@
 	}));
 
 /***/ },
-/* 331 */
+/* 336 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -46972,7 +47351,7 @@
 	//! author : Aggelos Karalias : https://github.com/mehiel
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47066,7 +47445,7 @@
 	}));
 
 /***/ },
-/* 332 */
+/* 337 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47074,7 +47453,7 @@
 	//! author : Jared Morse : https://github.com/jarcoal
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47137,7 +47516,7 @@
 	}));
 
 /***/ },
-/* 333 */
+/* 338 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47145,7 +47524,7 @@
 	//! author : Jonathan Abourbih : https://github.com/jonbca
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47204,7 +47583,7 @@
 	}));
 
 /***/ },
-/* 334 */
+/* 339 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47212,7 +47591,7 @@
 	//! author : Chris Gedrim : https://github.com/chrisgedrim
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47275,7 +47654,7 @@
 	}));
 
 /***/ },
-/* 335 */
+/* 340 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47283,7 +47662,7 @@
 	//! author : Chris Cartlidge : https://github.com/chriscartlidge
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47346,7 +47725,7 @@
 	}));
 
 /***/ },
-/* 336 */
+/* 341 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47354,7 +47733,7 @@
 	//! author : Luke McGregor : https://github.com/lukemcgregor
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47417,7 +47796,7 @@
 	}));
 
 /***/ },
-/* 337 */
+/* 342 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47427,7 +47806,7 @@
 	//!          Se ne, bonvolu korekti kaj avizi min por ke mi povas lerni!
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47494,7 +47873,7 @@
 	}));
 
 /***/ },
-/* 338 */
+/* 343 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47502,7 +47881,7 @@
 	//! author : Julio Napurí : https://github.com/julionc
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47579,14 +47958,14 @@
 	}));
 
 /***/ },
-/* 339 */
+/* 344 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
 	//! locale : Spanish (Dominican Republic) [es-do]
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47663,7 +48042,7 @@
 	}));
 
 /***/ },
-/* 340 */
+/* 345 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47672,7 +48051,7 @@
 	//! improvements : Illimar Tambek : https://github.com/ragulka
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47747,7 +48126,7 @@
 	}));
 
 /***/ },
-/* 341 */
+/* 346 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47755,7 +48134,7 @@
 	//! author : Eneko Illarramendi : https://github.com/eillarra
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47817,7 +48196,7 @@
 	}));
 
 /***/ },
-/* 342 */
+/* 347 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47825,7 +48204,7 @@
 	//! author : Ebrahim Byagowi : https://github.com/ebraminio
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -47927,7 +48306,7 @@
 	}));
 
 /***/ },
-/* 343 */
+/* 348 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -47935,7 +48314,7 @@
 	//! author : Tarmo Aidantausta : https://github.com/bleadof
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48038,7 +48417,7 @@
 	}));
 
 /***/ },
-/* 344 */
+/* 349 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48046,7 +48425,7 @@
 	//! author : Ragnar Johannesen : https://github.com/ragnar123
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48102,7 +48481,7 @@
 	}));
 
 /***/ },
-/* 345 */
+/* 350 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48110,7 +48489,7 @@
 	//! author : John Fischer : https://github.com/jfroffice
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48170,7 +48549,7 @@
 	}));
 
 /***/ },
-/* 346 */
+/* 351 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48178,7 +48557,7 @@
 	//! author : Jonathan Abourbih : https://github.com/jonbca
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48234,7 +48613,7 @@
 	}));
 
 /***/ },
-/* 347 */
+/* 352 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48242,7 +48621,7 @@
 	//! author : Gaspard Bucher : https://github.com/gaspard
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48302,7 +48681,7 @@
 	}));
 
 /***/ },
-/* 348 */
+/* 353 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48310,7 +48689,7 @@
 	//! author : Robin van der Vliet : https://github.com/robin0van0der0v
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48379,7 +48758,7 @@
 	}));
 
 /***/ },
-/* 349 */
+/* 354 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48387,7 +48766,7 @@
 	//! author : Jon Ashdown : https://github.com/jonashdown
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48459,7 +48838,7 @@
 	}));
 
 /***/ },
-/* 350 */
+/* 355 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48467,7 +48846,7 @@
 	//! author : Juan G. Hurtado : https://github.com/juanghurtado
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48540,7 +48919,7 @@
 	}));
 
 /***/ },
-/* 351 */
+/* 356 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48550,7 +48929,7 @@
 	//! author : Tal Ater : https://github.com/TalAter
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48643,7 +49022,7 @@
 	}));
 
 /***/ },
-/* 352 */
+/* 357 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48651,7 +49030,7 @@
 	//! author : Mayank Singhal : https://github.com/mayanksinghal
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48771,7 +49150,7 @@
 	}));
 
 /***/ },
-/* 353 */
+/* 358 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48779,7 +49158,7 @@
 	//! author : Bojan Marković : https://github.com/bmarkovic
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -48920,7 +49299,7 @@
 	}));
 
 /***/ },
-/* 354 */
+/* 359 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -48928,7 +49307,7 @@
 	//! author : Adam Brunner : https://github.com/adambrunner
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49033,7 +49412,7 @@
 	}));
 
 /***/ },
-/* 355 */
+/* 360 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49041,7 +49420,7 @@
 	//! author : Armendarabyan : https://github.com/armendarabyan
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49132,7 +49511,7 @@
 	}));
 
 /***/ },
-/* 356 */
+/* 361 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49141,7 +49520,7 @@
 	//! reference: http://id.wikisource.org/wiki/Pedoman_Umum_Ejaan_Bahasa_Indonesia_yang_Disempurnakan
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49219,7 +49598,7 @@
 	}));
 
 /***/ },
-/* 357 */
+/* 362 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49227,7 +49606,7 @@
 	//! author : Hinrik Örn Sigurðsson : https://github.com/hinrik
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49350,7 +49729,7 @@
 	}));
 
 /***/ },
-/* 358 */
+/* 363 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49359,7 +49738,7 @@
 	//! author: Mattia Larentis: https://github.com/nostalgiaz
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49424,7 +49803,7 @@
 	}));
 
 /***/ },
-/* 359 */
+/* 364 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49432,7 +49811,7 @@
 	//! author : LI Long : https://github.com/baryon
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49504,7 +49883,7 @@
 	}));
 
 /***/ },
-/* 360 */
+/* 365 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49513,7 +49892,7 @@
 	//! reference: http://jv.wikipedia.org/wiki/Basa_Jawa
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49591,7 +49970,7 @@
 	}));
 
 /***/ },
-/* 361 */
+/* 366 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49599,7 +49978,7 @@
 	//! author : Irakli Janiashvili : https://github.com/irakli-janiashvili
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49684,7 +50063,7 @@
 	}));
 
 /***/ },
-/* 362 */
+/* 367 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49692,7 +50071,7 @@
 	//! authors : Nurlan Rakhimzhanov : https://github.com/nurlan
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49775,7 +50154,7 @@
 	}));
 
 /***/ },
-/* 363 */
+/* 368 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49783,7 +50162,7 @@
 	//! author : Kruy Vanna : https://github.com/kruyvanna
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49837,7 +50216,7 @@
 	}));
 
 /***/ },
-/* 364 */
+/* 369 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49846,7 +50225,7 @@
 	//! author : Jeeeyul Lee <jeeeyul@gmail.com>
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49906,7 +50285,7 @@
 	}));
 
 /***/ },
-/* 365 */
+/* 370 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -49914,7 +50293,7 @@
 	//! author : Chyngyz Arystan uulu : https://github.com/chyngyz
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -49998,7 +50377,7 @@
 	}));
 
 /***/ },
-/* 366 */
+/* 371 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50007,7 +50386,7 @@
 	//! author : David Raison : https://github.com/kwisatz
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50139,7 +50518,7 @@
 	}));
 
 /***/ },
-/* 367 */
+/* 372 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50147,7 +50526,7 @@
 	//! author : Ryan Hart : https://github.com/ryanhart2
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50213,7 +50592,7 @@
 	}));
 
 /***/ },
-/* 368 */
+/* 373 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50221,7 +50600,7 @@
 	//! author : Mindaugas Mozūras : https://github.com/mmozuras
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50334,7 +50713,7 @@
 	}));
 
 /***/ },
-/* 369 */
+/* 374 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50343,7 +50722,7 @@
 	//! author : Jānis Elmeris : https://github.com/JanisE
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50435,7 +50814,7 @@
 	}));
 
 /***/ },
-/* 370 */
+/* 375 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50443,7 +50822,7 @@
 	//! author : Miodrag Nikač <miodrag@restartit.me> : https://github.com/miodragnikac
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50550,7 +50929,7 @@
 	}));
 
 /***/ },
-/* 371 */
+/* 376 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50558,7 +50937,7 @@
 	//! author : John Corrigan <robbiecloset@gmail.com> : https://github.com/johnideal
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50618,7 +50997,7 @@
 	}));
 
 /***/ },
-/* 372 */
+/* 377 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50626,7 +51005,7 @@
 	//! author : Borislav Mickov : https://github.com/B0k0
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50712,7 +51091,7 @@
 	}));
 
 /***/ },
-/* 373 */
+/* 378 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50720,7 +51099,7 @@
 	//! author : Floyd Pink : https://github.com/floydpink
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50797,7 +51176,7 @@
 	}));
 
 /***/ },
-/* 374 */
+/* 379 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50806,7 +51185,7 @@
 	//! author : Vivek Athalye : https://github.com/vnathalye
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -50960,7 +51339,7 @@
 	}));
 
 /***/ },
-/* 375 */
+/* 380 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -50968,7 +51347,7 @@
 	//! author : Weldan Jamili : https://github.com/weldan
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51046,7 +51425,7 @@
 	}));
 
 /***/ },
-/* 376 */
+/* 381 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51055,7 +51434,7 @@
 	//! author : Weldan Jamili : https://github.com/weldan
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51133,7 +51512,7 @@
 	}));
 
 /***/ },
-/* 377 */
+/* 382 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51143,7 +51522,7 @@
 	//! author : Tin Aung Lin : https://github.com/thanyawzinmin
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51232,7 +51611,7 @@
 	}));
 
 /***/ },
-/* 378 */
+/* 383 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51241,7 +51620,7 @@
 	//!           Sigurd Gartmann : https://github.com/sigurdga
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51299,7 +51678,7 @@
 	}));
 
 /***/ },
-/* 379 */
+/* 384 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51307,7 +51686,7 @@
 	//! author : suvash : https://github.com/suvash
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51426,7 +51805,7 @@
 	}));
 
 /***/ },
-/* 380 */
+/* 385 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51435,7 +51814,7 @@
 	//! author : Jacob Middag : https://github.com/middagj
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51516,7 +51895,7 @@
 	}));
 
 /***/ },
-/* 381 */
+/* 386 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51524,7 +51903,7 @@
 	//! author : https://github.com/mechuwind
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51580,7 +51959,7 @@
 	}));
 
 /***/ },
-/* 382 */
+/* 387 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51588,7 +51967,7 @@
 	//! author : Harpreet Singh : https://github.com/harpreetkhalsagtbit
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51708,7 +52087,7 @@
 	}));
 
 /***/ },
-/* 383 */
+/* 388 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51716,7 +52095,7 @@
 	//! author : Rafal Hirsz : https://github.com/evoL
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51817,7 +52196,7 @@
 	}));
 
 /***/ },
-/* 384 */
+/* 389 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51825,7 +52204,7 @@
 	//! author : Jefferson : https://github.com/jalex79
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51886,7 +52265,7 @@
 	}));
 
 /***/ },
-/* 385 */
+/* 390 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51894,7 +52273,7 @@
 	//! author : Caio Ribeiro Pereira : https://github.com/caio-ribeiro-pereira
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -51951,7 +52330,7 @@
 	}));
 
 /***/ },
-/* 386 */
+/* 391 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -51960,7 +52339,7 @@
 	//! author : Valentin Agachi : https://github.com/avaly
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52030,7 +52409,7 @@
 	}));
 
 /***/ },
-/* 387 */
+/* 392 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52040,7 +52419,7 @@
 	//! author : Коренберг Марк : https://github.com/socketpair
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52217,7 +52596,7 @@
 	}));
 
 /***/ },
-/* 388 */
+/* 393 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52225,7 +52604,7 @@
 	//! authors : Bård Rolstad Henriksen : https://github.com/karamell
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52282,7 +52661,7 @@
 	}));
 
 /***/ },
-/* 389 */
+/* 394 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52290,7 +52669,7 @@
 	//! author : Sampath Sitinamaluwa : https://github.com/sampathsris
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52357,7 +52736,7 @@
 	}));
 
 /***/ },
-/* 390 */
+/* 395 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52366,7 +52745,7 @@
 	//! based on work of petrbela : https://github.com/petrbela
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52511,7 +52890,7 @@
 	}));
 
 /***/ },
-/* 391 */
+/* 396 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52519,7 +52898,7 @@
 	//! author : Robert Sedovšek : https://github.com/sedovsek
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52677,7 +53056,7 @@
 	}));
 
 /***/ },
-/* 392 */
+/* 397 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52687,7 +53066,7 @@
 	//! author : Oerd Cukalla : https://github.com/oerd
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52751,7 +53130,7 @@
 	}));
 
 /***/ },
-/* 393 */
+/* 398 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52759,7 +53138,7 @@
 	//! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52865,7 +53244,7 @@
 	}));
 
 /***/ },
-/* 394 */
+/* 399 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52873,7 +53252,7 @@
 	//! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -52979,7 +53358,7 @@
 	}));
 
 /***/ },
-/* 395 */
+/* 400 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -52987,7 +53366,7 @@
 	//! author : Nicolai Davies<mail@nicolai.io> : https://github.com/nicolaidavies
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53072,7 +53451,7 @@
 	}));
 
 /***/ },
-/* 396 */
+/* 401 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53080,7 +53459,7 @@
 	//! author : Jens Alm : https://github.com/ulmus
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53145,7 +53524,7 @@
 	}));
 
 /***/ },
-/* 397 */
+/* 402 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53153,7 +53532,7 @@
 	//! author : Fahad Kassim : https://github.com/fadsel
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53208,7 +53587,7 @@
 	}));
 
 /***/ },
-/* 398 */
+/* 403 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53216,7 +53595,7 @@
 	//! author : Arjunkumar Krishnamoorthy : https://github.com/tk120404
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53341,7 +53720,7 @@
 	}));
 
 /***/ },
-/* 399 */
+/* 404 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53349,7 +53728,7 @@
 	//! author : Krishna Chaitanya Thota : https://github.com/kcthota
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53434,7 +53813,7 @@
 	}));
 
 /***/ },
-/* 400 */
+/* 405 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53442,7 +53821,7 @@
 	//! author : Kridsada Thanabulpong : https://github.com/sirn
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53505,7 +53884,7 @@
 	}));
 
 /***/ },
-/* 401 */
+/* 406 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53513,7 +53892,7 @@
 	//! author : Dan Hagman : https://github.com/hagmandan
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53571,7 +53950,7 @@
 	}));
 
 /***/ },
-/* 402 */
+/* 407 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53579,7 +53958,7 @@
 	//! author : Dominika Kruk : https://github.com/amaranthrose
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53695,7 +54074,7 @@
 	}));
 
 /***/ },
-/* 403 */
+/* 408 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53704,7 +54083,7 @@
 	//!           Burak Yiğit Kaya: https://github.com/BYK
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53789,7 +54168,7 @@
 	}));
 
 /***/ },
-/* 404 */
+/* 409 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53798,7 +54177,7 @@
 	//! author : Iustì Canun
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53884,7 +54263,7 @@
 	}));
 
 /***/ },
-/* 405 */
+/* 410 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53892,7 +54271,7 @@
 	//! author : Abdel Said : https://github.com/abdelsaid
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53946,7 +54325,7 @@
 	}));
 
 /***/ },
-/* 406 */
+/* 411 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53954,7 +54333,7 @@
 	//! author : Abdel Said : https://github.com/abdelsaid
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54008,7 +54387,7 @@
 	}));
 
 /***/ },
-/* 407 */
+/* 412 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54017,7 +54396,7 @@
 	//! Author : Menelion Elensúle : https://github.com/Oire
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54158,7 +54537,7 @@
 	}));
 
 /***/ },
-/* 408 */
+/* 413 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54166,7 +54545,7 @@
 	//! author : Sardor Muminov : https://github.com/muminoff
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54220,7 +54599,7 @@
 	}));
 
 /***/ },
-/* 409 */
+/* 414 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54228,7 +54607,7 @@
 	//! author : Bang Nguyen : https://github.com/bangnk
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54303,7 +54682,7 @@
 	}));
 
 /***/ },
-/* 410 */
+/* 415 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54311,7 +54690,7 @@
 	//! author : Andrew Hood : https://github.com/andrewhood125
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54375,7 +54754,7 @@
 	}));
 
 /***/ },
-/* 411 */
+/* 416 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54384,7 +54763,7 @@
 	//! author : Zeno Zeng : https://github.com/zenozeng
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54506,7 +54885,7 @@
 	}));
 
 /***/ },
-/* 412 */
+/* 417 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54516,7 +54895,7 @@
 	//! author : Konstantin : https://github.com/skfd
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54615,7 +54994,7 @@
 	}));
 
 /***/ },
-/* 413 */
+/* 418 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54624,7 +55003,7 @@
 	//! author : Chris Lam : https://github.com/hehachris
 	
 	;(function (global, factory) {
-	    true ? factory(__webpack_require__(308)) :
+	    true ? factory(__webpack_require__(313)) :
 	   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54723,19 +55102,19 @@
 	}));
 
 /***/ },
-/* 414 */
+/* 419 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
-	var classNames = __webpack_require__(415);
-	var moment = __webpack_require__(308);
+	var tslib_1 = __webpack_require__(309);
+	var classNames = __webpack_require__(420);
+	var moment = __webpack_require__(313);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var dateUtils_1 = __webpack_require__(307);
-	var datePicker_1 = __webpack_require__(416);
-	var datePickerCore_1 = __webpack_require__(421);
+	var dateUtils_1 = __webpack_require__(312);
+	var datePicker_1 = __webpack_require__(421);
+	var datePickerCore_1 = __webpack_require__(426);
 	var DateInput = (function (_super) {
 	    tslib_1.__extends(DateInput, _super);
 	    function DateInput(props, context) {
@@ -54902,7 +55281,7 @@
 
 
 /***/ },
-/* 415 */
+/* 420 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -54956,21 +55335,21 @@
 
 
 /***/ },
-/* 416 */
+/* 421 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(415);
+	var classNames = __webpack_require__(420);
 	var React = __webpack_require__(9);
-	var ReactDayPicker = __webpack_require__(417);
-	var Classes = __webpack_require__(306);
-	var DateUtils = __webpack_require__(307);
-	var Errors = __webpack_require__(418);
-	var datePickerCaption_1 = __webpack_require__(419);
-	var datePickerCore_1 = __webpack_require__(421);
+	var ReactDayPicker = __webpack_require__(422);
+	var Classes = __webpack_require__(311);
+	var DateUtils = __webpack_require__(312);
+	var Errors = __webpack_require__(423);
+	var datePickerCaption_1 = __webpack_require__(424);
+	var datePickerCore_1 = __webpack_require__(426);
 	var DatePicker = (function (_super) {
 	    tslib_1.__extends(DatePicker, _super);
 	    function DatePicker(props, context) {
@@ -55180,14 +55559,14 @@
 
 
 /***/ },
-/* 417 */
+/* 422 */
 /***/ function(module, exports, __webpack_require__) {
 
 	!function(e,t){ true?module.exports=t(__webpack_require__(9)):"function"==typeof define&&define.amd?define(["react"],t):"object"==typeof exports?exports.DayPicker=t(require("react")):e.DayPicker=t(e.React)}(this,function(e){return function(e){function t(n){if(o[n])return o[n].exports;var r=o[n]={exports:{},id:n,loaded:!1};return e[n].call(r.exports,r,r.exports,t),r.loaded=!0,r.exports}var o={};return t.m=e,t.c=o,t.p="",t(0)}([function(e,t,o){var n=o(10),r=o(3),a=o(4),s=o(7),i=o(6),l=o(2);e.exports=n["default"]||n,e.exports.DateUtils=r["default"]||r,e.exports.LocaleUtils=a["default"]||a,e.exports.WeekdayPropTypes=s.WeekdayPropTypes,e.exports.NavbarPropTypes=i.NavbarPropTypes,e.exports.PropTypes=l},function(t,o){t.exports=e},function(e,t,o){"use strict";Object.defineProperty(t,"__esModule",{value:!0});var n=o(1);t["default"]={localeUtils:n.PropTypes.shape({formatMonthTitle:n.PropTypes.func,formatWeekdayShort:n.PropTypes.func,formatWeekdayLong:n.PropTypes.func,getFirstDayOfWeek:n.PropTypes.func})}},function(e,t){"use strict";function o(e){return new Date(e.getTime())}function n(e,t){var n=o(e);return n.setMonth(e.getMonth()+t),n}function r(e,t){return!(!e||!t)&&(e.getDate()===t.getDate()&&e.getMonth()===t.getMonth()&&e.getFullYear()===t.getFullYear())}function a(e){var t=new Date;return t.setHours(0,0,0,0),e<t}function s(e){var t=new Date((new Date).getTime()+864e5);return t.setHours(0,0,0,0),e>=t}function i(e,t,n){var r=o(e),a=o(t),s=o(n);return r.setHours(0,0,0,0),a.setHours(0,0,0,0),s.setHours(0,0,0,0),a<r&&r<s||s<r&&r<a}function l(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{from:null,to:null},o=t.from,n=t.to;return o?o&&n&&r(o,n)&&r(e,o)?(o=null,n=null):n&&e<o?o=e:n&&r(e,n)?(o=e,n=e):(n=e,n<o&&(n=o,o=e)):o=e,{from:o,to:n}}function u(e,t){var o=t.from,n=t.to;return o&&r(e,o)||n&&r(e,n)||o&&n&&i(e,o,n)}Object.defineProperty(t,"__esModule",{value:!0}),t.clone=o,t.addMonths=n,t.isSameDay=r,t.isPastDay=a,t.isFutureDay=s,t.isDayBetween=i,t.addDayToRange=l,t.isDayInRange=u,t["default"]={addDayToRange:l,addMonths:n,clone:o,isSameDay:r,isDayInRange:u,isDayBetween:i,isPastDay:a,isFutureDay:s}},function(e,t){"use strict";function o(e){return e.toDateString()}function n(e){return c[e.getMonth()]+" "+e.getFullYear()}function r(e){return u[e]}function a(e){return l[e]}function s(){return 0}function i(){return c}Object.defineProperty(t,"__esModule",{value:!0}),t.formatDay=o,t.formatMonthTitle=n,t.formatWeekdayShort=r,t.formatWeekdayLong=a,t.getFirstDayOfWeek=s,t.getMonths=i;var l=["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],u=["Su","Mo","Tu","We","Th","Fr","Sa"],c=["January","February","March","April","May","June","July","August","September","October","November","December"];t["default"]={formatDay:o,formatMonthTitle:n,formatWeekdayShort:r,formatWeekdayLong:a,getFirstDayOfWeek:s,getMonths:i}},function(e,t,o){"use strict";function n(e){e.preventDefault(),e.stopPropagation()}function r(e,t){var o={};return Object.keys(e).filter(function(e){return!{}.hasOwnProperty.call(t,e)}).forEach(function(t){o[t]=e[t]}),o}function a(e){return new Date(e.getFullYear(),e.getMonth(),1,12)}function s(e){var t=a(e);return t.setMonth(t.getMonth()+1),t.setDate(t.getDate()-1),t.getDate()}function i(e){var t=h({},e.modifiers);return e.selectedDays&&(t.selected=e.selectedDays),e.disabledDays&&(t.disabled=e.disabledDays),t}function l(e){var t=e.firstDayOfWeek,o=e.locale,n=void 0===o?"en":o,r=e.localeUtils,a=void 0===r?{}:r;return isNaN(t)?a.getFirstDayOfWeek?a.getFirstDayOfWeek(n):0:t}function u(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};return Object.keys(t).reduce(function(o,n){var r=t[n];return r(e)&&o.push(n),o},[])}function c(e,t){return t.getMonth()-e.getMonth()+12*(t.getFullYear()-e.getFullYear())}function p(e){for(var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:(0,d.getFirstDayOfWeek)(),o=arguments[2],n=s(e),r=[],a=[],i=[],l=1;l<=n;l+=1)r.push(new Date(e.getFullYear(),e.getMonth(),l,12));r.forEach(function(e){a.length>0&&e.getDay()===t&&(i.push(a),a=[]),a.push(e),r.indexOf(e)===r.length-1&&i.push(a)});for(var u=i[0],c=7-u.length;c>0;c-=1){var p=(0,y.clone)(u[0]);p.setDate(u[0].getDate()-1),u.unshift(p)}for(var f=i[i.length-1],h=f.length;h<7;h+=1){var v=(0,y.clone)(f[f.length-1]);v.setDate(f[f.length-1].getDate()+1),f.push(v)}if(o&&i.length<6)for(var P=void 0,g=i.length;g<6;g+=1){P=i[i.length-1];for(var D=P[P.length-1],k=[],M=0;M<7;M+=1){var m=(0,y.clone)(D);m.setDate(D.getDate()+M+1),k.push(m)}i.push(k)}return i}function f(e){var t=(0,y.clone)(e);return t.setDate(1),t.setHours(12,0,0,0),t}Object.defineProperty(t,"__esModule",{value:!0});var h=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var o=arguments[t];for(var n in o)Object.prototype.hasOwnProperty.call(o,n)&&(e[n]=o[n])}return e};t.cancelEvent=n,t.getCustomProps=r,t.getFirstDayOfMonth=a,t.getDaysInMonth=s,t.getModifiersFromProps=i,t.getFirstDayOfWeekFromProps=l,t.getModifiersForDay=u,t.getMonthsDiff=c,t.getWeekArray=p,t.startOfMonth=f;var y=o(3),d=o(4)},function(e,t,o){"use strict";function n(e){return e&&e.__esModule?e:{"default":e}}function r(e){var t=e.className,o=e.showPreviousButton,n=e.showNextButton,r=e.onPreviousClick,a=e.onNextClick,l=e.dir,u="rtl"===l?a:r,c="rtl"===l?r:a,p=o&&s["default"].createElement("span",{role:"button",key:"previous",className:i+"--prev",onClick:function(){return u()}}),f=n&&s["default"].createElement("span",{role:"button",key:"right",className:i+"--next",onClick:function(){return c()}});return s["default"].createElement("div",{className:t},"rtl"===l?[f,p]:[p,f])}Object.defineProperty(t,"__esModule",{value:!0}),t.NavbarPropTypes=void 0,t["default"]=r;var a=o(1),s=n(a),i="DayPicker-NavButton DayPicker-NavButton",l=t.NavbarPropTypes={className:a.PropTypes.string,showPreviousButton:a.PropTypes.bool,showNextButton:a.PropTypes.bool,onPreviousClick:a.PropTypes.func,onNextClick:a.PropTypes.func,dir:a.PropTypes.string};r.propTypes=l,r.defaultProps={className:"DayPicker-NavBar",dir:"ltr",showPreviousButton:!0,showNextButton:!0}},function(e,t,o){"use strict";function n(e){return e&&e.__esModule?e:{"default":e}}function r(e){var t=e.weekday,o=e.className,n=e.weekdaysLong,r=e.weekdaysShort,a=e.localeUtils,i=e.locale,l=void 0;l=n?n[t]:a.formatWeekdayLong(t,i);var u=void 0;return u=r?r[t]:a.formatWeekdayShort(t,i),s["default"].createElement("div",{className:o},s["default"].createElement("abbr",{title:l},u))}Object.defineProperty(t,"__esModule",{value:!0}),t.WeekdayPropTypes=void 0,t["default"]=r;var a=o(1),s=n(a),i=o(2),l=n(i),u=t.WeekdayPropTypes={weekday:a.PropTypes.number,className:a.PropTypes.string,locale:a.PropTypes.string,localeUtils:l["default"].localeUtils,weekdaysLong:a.PropTypes.arrayOf(a.PropTypes.string),weekdaysShort:a.PropTypes.arrayOf(a.PropTypes.string)};r.propTypes=u},function(e,t,o){"use strict";function n(e){return e&&e.__esModule?e:{"default":e}}function r(e){var t=e.date,o=e.months,n=e.locale,r=e.localeUtils,a=e.onClick;return s["default"].createElement("div",{className:"DayPicker-Caption",onClick:a,role:"heading"},o?o[t.getMonth()]+" "+t.getFullYear():r.formatMonthTitle(t,n))}Object.defineProperty(t,"__esModule",{value:!0}),t["default"]=r;var a=o(1),s=n(a),i=o(2),l=n(i);r.propTypes={date:a.PropTypes.instanceOf(Date),months:s["default"].PropTypes.arrayOf(s["default"].PropTypes.string),locale:a.PropTypes.string,localeUtils:l["default"].localeUtils,onClick:a.PropTypes.func}},function(e,t,o){"use strict";function n(e){return e&&e.__esModule?e:{"default":e}}function r(e,t,o){if(e){var n={};return o.forEach(function(e){n[e]=!0}),function(o){o.persist(),e(o,t,n)}}}function a(e){var t=e.day,o=e.tabIndex,n=e.empty,a=e.modifiers,s=e.onMouseEnter,l=e.onMouseLeave,u=e.onClick,c=e.onKeyDown,p=e.onTouchStart,f=e.onTouchEnd,h=e.onFocus,y=e.ariaLabel,d=e.ariaDisabled,v=e.ariaSelected,P=e.children,g="DayPicker-Day";return g+=a.map(function(e){return" "+g+"--"+e}).join(""),n?i["default"].createElement("div",{role:"gridcell","aria-disabled":!0,className:g}):i["default"].createElement("div",{className:g,tabIndex:o,role:"gridcell","aria-label":y,"aria-disabled":d.toString(),"aria-selected":v.toString(),onClick:r(u,t,a),onKeyDown:r(c,t,a),onMouseEnter:r(s,t,a),onMouseLeave:r(l,t,a),onTouchEnd:r(f,t,a),onTouchStart:r(p,t,a),onFocus:r(h,t,a)},P)}Object.defineProperty(t,"__esModule",{value:!0}),t["default"]=a;var s=o(1),i=n(s);a.propTypes={day:s.PropTypes.instanceOf(Date).isRequired,children:s.PropTypes.node.isRequired,ariaDisabled:s.PropTypes.bool,ariaLabel:s.PropTypes.string,ariaSelected:s.PropTypes.bool,empty:s.PropTypes.bool,modifiers:s.PropTypes.array,onClick:s.PropTypes.func,onKeyDown:s.PropTypes.func,onMouseEnter:s.PropTypes.func,onMouseLeave:s.PropTypes.func,onTouchEnd:s.PropTypes.func,onTouchStart:s.PropTypes.func,onFocus:s.PropTypes.func,tabIndex:s.PropTypes.number},a.defaultProps={modifiers:[],empty:!1}},function(e,t,o){"use strict";function n(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var o in e)Object.prototype.hasOwnProperty.call(e,o)&&(t[o]=e[o]);return t["default"]=e,t}function r(e){return e&&e.__esModule?e:{"default":e}}function a(e,t){var o={};for(var n in e)t.indexOf(n)>=0||Object.prototype.hasOwnProperty.call(e,n)&&(o[n]=e[n]);return o}function s(e){if(Array.isArray(e)){for(var t=0,o=Array(e.length);t<e.length;t++)o[t]=e[t];return o}return Array.from(e)}function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function l(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function u(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t);e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0});var c=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var o=arguments[t];for(var n in o)Object.prototype.hasOwnProperty.call(o,n)&&(e[n]=o[n])}return e},p=function(){function e(e,t){for(var o=0;o<t.length;o++){var n=t[o];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,o,n){return o&&e(t.prototype,o),n&&e(t,n),t}}(),f=o(1),h=r(f),y=o(8),d=r(y),v=o(6),P=r(v),g=o(11),D=r(g),k=o(9),M=r(k),m=o(7),T=r(m),w=o(5),b=n(w),O=o(3),N=n(O),E=o(4),x=n(E),C=o(13),W=r(C),_=o(2),S=r(_),F=function(e){function t(e){i(this,t);var o=l(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e));return j.call(o),o.renderDayInMonth=o.renderDayInMonth.bind(o),o.showNextMonth=o.showNextMonth.bind(o),o.showPreviousMonth=o.showPreviousMonth.bind(o),o.handleKeyDown=o.handleKeyDown.bind(o),o.handleDayClick=o.handleDayClick.bind(o),o.handleDayKeyDown=o.handleDayKeyDown.bind(o),o.state=o.getStateFromProps(e),o}return u(t,e),p(t,[{key:"componentWillReceiveProps",value:function(e){this.props.initialMonth!==e.initialMonth&&this.setState(this.getStateFromProps(e))}},{key:"getDayNodes",value:function(){return this.dayPicker.querySelectorAll(".DayPicker-Day:not(.DayPicker-Day--outside)")}},{key:"getNextNavigableMonth",value:function(){return N.addMonths(this.state.currentMonth,this.props.numberOfMonths)}},{key:"getPreviousNavigableMonth",value:function(){return N.addMonths(this.state.currentMonth,-1)}},{key:"allowPreviousMonth",value:function(){var e=N.addMonths(this.state.currentMonth,-1);return this.allowMonth(e)}},{key:"allowNextMonth",value:function(){var e=N.addMonths(this.state.currentMonth,this.props.numberOfMonths);return this.allowMonth(e)}},{key:"allowMonth",value:function(e){var t=this.props,o=t.fromMonth,n=t.toMonth,r=t.canChangeMonth;return!(!r||o&&b.getMonthsDiff(o,e)<0||n&&b.getMonthsDiff(n,e)>0)}},{key:"allowYearChange",value:function(){return this.props.canChangeMonth}},{key:"showMonth",value:function(e,t){var o=this;this.allowMonth(e)&&this.setState({currentMonth:b.startOfMonth(e)},function(){t&&t(),o.props.onMonthChange&&o.props.onMonthChange(o.state.currentMonth)})}},{key:"showNextMonth",value:function(e){if(this.allowNextMonth()){var t=this.props.pagedNavigation?this.props.numberOfMonths:1,o=N.addMonths(this.state.currentMonth,t);this.showMonth(o,e)}}},{key:"showPreviousMonth",value:function(e){if(this.allowPreviousMonth()){var t=this.props.pagedNavigation?this.props.numberOfMonths:1,o=N.addMonths(this.state.currentMonth,-t);this.showMonth(o,e)}}},{key:"showNextYear",value:function(){if(this.allowYearChange()){var e=N.addMonths(this.state.currentMonth,12);this.showMonth(e)}}},{key:"showPreviousYear",value:function(){if(this.allowYearChange()){var e=N.addMonths(this.state.currentMonth,-12);this.showMonth(e)}}},{key:"focusFirstDayOfMonth",value:function(){this.getDayNodes()[0].focus()}},{key:"focusLastDayOfMonth",value:function(){var e=this.getDayNodes();e[e.length-1].focus()}},{key:"focusPreviousDay",value:function(e){var t=this,o=this.getDayNodes(),n=[].concat(s(o)).indexOf(e);0===n?this.showPreviousMonth(function(){return t.focusLastDayOfMonth()}):o[n-1].focus()}},{key:"focusNextDay",value:function(e){var t=this,o=this.getDayNodes(),n=[].concat(s(o)).indexOf(e);n===o.length-1?this.showNextMonth(function(){return t.focusFirstDayOfMonth()}):o[n+1].focus()}},{key:"focusNextWeek",value:function(e){var t=this,o=this.getDayNodes(),n=[].concat(s(o)).indexOf(e),r=n>o.length-8;r?this.showNextMonth(function(){var e=o.length-n,r=7-e;t.getDayNodes()[r].focus()}):o[n+7].focus()}},{key:"focusPreviousWeek",value:function(e){var t=this,o=this.getDayNodes(),n=[].concat(s(o)).indexOf(e),r=n<=6;r?this.showPreviousMonth(function(){var e=t.getDayNodes(),o=e.length-7,r=o+n;e[r].focus()}):o[n-7].focus()}},{key:"handleKeyDown",value:function(e){switch(e.persist(),e.keyCode){case W["default"].LEFT:this.showPreviousMonth();break;case W["default"].RIGHT:this.showNextMonth();break;case W["default"].UP:this.showPreviousYear();break;case W["default"].DOWN:this.showNextYear()}this.props.onKeyDown&&this.props.onKeyDown(e)}},{key:"handleDayKeyDown",value:function(e,t,o){switch(e.persist(),e.keyCode){case W["default"].LEFT:b.cancelEvent(e),this.focusPreviousDay(e.target);break;case W["default"].RIGHT:b.cancelEvent(e),this.focusNextDay(e.target);break;case W["default"].UP:b.cancelEvent(e),this.focusPreviousWeek(e.target);break;case W["default"].DOWN:b.cancelEvent(e),this.focusNextWeek(e.target);break;case W["default"].ENTER:case W["default"].SPACE:b.cancelEvent(e),this.props.onDayClick&&this.handleDayClick(e,t,o)}this.props.onDayKeyDown&&this.props.onDayKeyDown(e,t,o)}},{key:"handleDayClick",value:function(e,t,o){e.persist(),o.outside&&this.handleOutsideDayClick(t),this.props.onDayClick(e,t,o)}},{key:"handleOutsideDayClick",value:function(e){var t=this.state.currentMonth,o=this.props.numberOfMonths,n=b.getMonthsDiff(t,e);n>0&&n>=o?this.showNextMonth():n<0&&this.showPreviousMonth()}},{key:"renderNavbar",value:function(){var e=this.props,t=e.locale,o=e.localeUtils,n=e.canChangeMonth,r=e.navbarElement,s=a(e,["locale","localeUtils","canChangeMonth","navbarElement"]);if(!n)return null;var i={className:"DayPicker-NavBar",nextMonth:this.getNextNavigableMonth(),previousMonth:this.getPreviousNavigableMonth(),showPreviousButton:this.allowPreviousMonth(),showNextButton:this.allowNextMonth(),onNextClick:this.showNextMonth,onPreviousClick:this.showPreviousMonth,dir:s.dir,locale:t,localeUtils:o};return h["default"].cloneElement(r,i)}},{key:"renderDayInMonth",value:function(e,t){var o=[];N.isSameDay(e,new Date)&&o.push("today"),e.getMonth()!==t.getMonth()&&o.push("outside"),o=[].concat(s(o),s(b.getModifiersForDay(e,b.getModifiersFromProps(this.props))));var n=e.getMonth()!==t.getMonth(),r=null;this.props.onDayClick&&!n&&(r=-1,1===e.getDate()&&(r=this.props.tabIndex));var a=""+e.getFullYear()+e.getMonth()+e.getDate();return h["default"].createElement(M["default"],{key:""+(n?"outside-":"")+a,day:e,modifiers:o,empty:n&&!this.props.enableOutsideDays&&!this.props.fixedWeeks,tabIndex:r,ariaLabel:this.props.localeUtils.formatDay(e,this.props.locale),ariaDisabled:n||o.indexOf("disabled")>-1,ariaSelected:o.indexOf("selected")>-1,onMouseEnter:this.props.onDayMouseEnter,onMouseLeave:this.props.onDayMouseLeave,onKeyDown:this.handleDayKeyDown,onTouchStart:this.props.onDayTouchStart,onTouchEnd:this.props.onDayTouchEnd,onFocus:this.props.onDayFocus,onClick:this.props.onDayClick?this.handleDayClick:void 0},this.props.renderDay(e))}},{key:"renderMonths",value:function(){for(var e=[],t=b.getFirstDayOfWeekFromProps(this.props),o=0;o<this.props.numberOfMonths;o+=1){var n=N.addMonths(this.state.currentMonth,o);e.push(h["default"].createElement(D["default"],{key:o,month:n,months:this.props.months,weekdaysShort:this.props.weekdaysShort,weekdaysLong:this.props.weekdaysLong,locale:this.props.locale,localeUtils:this.props.localeUtils,firstDayOfWeek:t,fixedWeeks:this.props.fixedWeeks,className:"DayPicker-Month",wrapperClassName:"DayPicker-Body",weekClassName:"DayPicker-Week",weekdayComponent:this.props.weekdayComponent,weekdayElement:this.props.weekdayElement,captionElement:this.props.captionElement,onCaptionClick:this.props.onCaptionClick},this.renderDayInMonth))}return this.props.reverseMonths&&e.reverse(),e}},{key:"render",value:function(){var e=this,o=b.getCustomProps(this.props,t.propTypes),n="DayPicker DayPicker--"+this.props.locale;return this.props.onDayClick||(n+=" DayPicker--interactionDisabled"),this.props.className&&(n=n+" "+this.props.className),h["default"].createElement("div",c({},o,{className:n,ref:function(t){e.dayPicker=t},role:"application",tabIndex:this.props.canChangeMonth&&this.props.tabIndex,onKeyDown:this.handleKeyDown}),this.renderNavbar(),this.renderMonths())}}]),t}(f.Component);F.VERSION="3.1.1",F.propTypes={initialMonth:f.PropTypes.instanceOf(Date),numberOfMonths:f.PropTypes.number,selectedDays:f.PropTypes.func,disabledDays:f.PropTypes.func,modifiers:f.PropTypes.object,locale:f.PropTypes.string,localeUtils:S["default"].localeUtils,enableOutsideDays:f.PropTypes.bool,fixedWeeks:f.PropTypes.bool,canChangeMonth:f.PropTypes.bool,reverseMonths:f.PropTypes.bool,pagedNavigation:f.PropTypes.bool,fromMonth:f.PropTypes.instanceOf(Date),toMonth:f.PropTypes.instanceOf(Date),firstDayOfWeek:f.PropTypes.oneOf([0,1,2,3,4,5,6]),months:f.PropTypes.arrayOf(f.PropTypes.string),weekdaysLong:f.PropTypes.arrayOf(f.PropTypes.string),weekdaysShort:f.PropTypes.arrayOf(f.PropTypes.string),onKeyDown:f.PropTypes.func,onDayClick:f.PropTypes.func,onDayKeyDown:f.PropTypes.func,onDayMouseEnter:f.PropTypes.func,onDayMouseLeave:f.PropTypes.func,onDayTouchStart:f.PropTypes.func,onDayTouchEnd:f.PropTypes.func,onDayFocus:f.PropTypes.func,onMonthChange:f.PropTypes.func,onCaptionClick:f.PropTypes.func,renderDay:f.PropTypes.func,weekdayElement:f.PropTypes.element,navbarElement:f.PropTypes.element,captionElement:f.PropTypes.element,dir:f.PropTypes.string,className:f.PropTypes.string,tabIndex:f.PropTypes.number},F.defaultProps={tabIndex:0,initialMonth:new Date,numberOfMonths:1,locale:"en",localeUtils:x,enableOutsideDays:!1,fixedWeeks:!1,canChangeMonth:!0,reverseMonths:!1,pagedNavigation:!1,renderDay:function(e){return e.getDate()},weekdayElement:h["default"].createElement(T["default"],null),navbarElement:h["default"].createElement(P["default"],null),captionElement:h["default"].createElement(d["default"],null)};var j=function(){this.getStateFromProps=function(e){var t=b.startOfMonth(e.initialMonth),o=t;if(e.pagedNavigation&&e.numberOfMonths>1&&e.fromMonth){var n=b.getMonthsDiff(e.fromMonth,o);o=N.addMonths(e.fromMonth,Math.floor(n/e.numberOfMonths)*e.numberOfMonths)}return{currentMonth:o}},this.dayPicker=null};t["default"]=F},function(e,t,o){"use strict";function n(e){return e&&e.__esModule?e:{"default":e}}function r(e){var t=e.month,o=e.months,n=e.weekdaysLong,r=e.weekdaysShort,a=e.locale,i=e.localeUtils,l=e.captionElement,u=e.onCaptionClick,f=e.children,h=e.firstDayOfWeek,y=e.className,d=e.wrapperClassName,v=e.weekClassName,P=e.weekdayElement,g=e.fixedWeeks,D={date:t,months:o,localeUtils:i,locale:a,onClick:u?function(e){return u(e,t)}:void 0},k=(0,p.getWeekArray)(t,h,g);return s["default"].createElement("div",{className:y},s["default"].cloneElement(l,D),s["default"].createElement(c["default"],{weekdaysShort:r,weekdaysLong:n,firstDayOfWeek:h,locale:a,localeUtils:i,weekdayElement:P}),s["default"].createElement("div",{className:d,role:"grid"},k.map(function(e,o){return s["default"].createElement("div",{key:o,className:v,role:"gridcell"},e.map(function(e){return f(e,t)}))})))}Object.defineProperty(t,"__esModule",{value:!0}),t["default"]=r;var a=o(1),s=n(a),i=o(2),l=n(i),u=o(12),c=n(u),p=o(5);r.propTypes={month:a.PropTypes.instanceOf(Date).isRequired,months:s["default"].PropTypes.arrayOf(s["default"].PropTypes.string),captionElement:a.PropTypes.node.isRequired,firstDayOfWeek:a.PropTypes.number.isRequired,weekdaysLong:a.PropTypes.arrayOf(a.PropTypes.string),weekdaysShort:a.PropTypes.arrayOf(a.PropTypes.string),locale:a.PropTypes.string.isRequired,localeUtils:l["default"].localeUtils.isRequired,onCaptionClick:a.PropTypes.func,children:a.PropTypes.func.isRequired,className:a.PropTypes.string,wrapperClassName:a.PropTypes.string,weekClassName:a.PropTypes.string,weekdayElement:a.PropTypes.element,fixedWeeks:a.PropTypes.bool}},function(e,t,o){"use strict";function n(e){return e&&e.__esModule?e:{"default":e}}function r(e){for(var t=e.firstDayOfWeek,o=e.weekdaysLong,n=e.weekdaysShort,r=e.locale,a=e.localeUtils,i=e.weekdayElement,l=[],u=0;u<7;u+=1){var c=(u+t)%7,p={key:u,className:"DayPicker-Weekday",weekday:c,weekdaysLong:o,weekdaysShort:n,localeUtils:a,locale:r},f=s["default"].cloneElement(i,p);l.push(f)}return s["default"].createElement("div",{className:"DayPicker-Weekdays",role:"rowgroup"},s["default"].createElement("div",{className:"DayPicker-WeekdaysRow",role:"columnheader"},l))}Object.defineProperty(t,"__esModule",{value:!0}),t["default"]=r;var a=o(1),s=n(a),i=o(2),l=n(i);r.propTypes={firstDayOfWeek:a.PropTypes.number.isRequired,weekdaysLong:a.PropTypes.arrayOf(a.PropTypes.string),weekdaysShort:a.PropTypes.arrayOf(a.PropTypes.string),locale:a.PropTypes.string.isRequired,localeUtils:l["default"].localeUtils.isRequired,weekdayElement:a.PropTypes.element}},function(e,t){"use strict";Object.defineProperty(t,"__esModule",{value:!0}),t["default"]={LEFT:37,UP:38,RIGHT:39,DOWN:40,ENTER:13,SPACE:32}}])});
 
 
 /***/ },
-/* 418 */
+/* 423 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -55205,17 +55584,17 @@
 
 
 /***/ },
-/* 419 */
+/* 424 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(415);
+	var classNames = __webpack_require__(420);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(306);
-	var Utils = __webpack_require__(420);
+	var Classes = __webpack_require__(311);
+	var Utils = __webpack_require__(425);
 	var DatePickerCaption = (function (_super) {
 	    tslib_1.__extends(DatePickerCaption, _super);
 	    function DatePickerCaption() {
@@ -55285,7 +55664,7 @@
 
 
 /***/ },
-/* 420 */
+/* 425 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -55317,7 +55696,7 @@
 
 
 /***/ },
-/* 421 */
+/* 426 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -55369,19 +55748,19 @@
 
 
 /***/ },
-/* 422 */
+/* 427 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
-	var classNames = __webpack_require__(415);
+	var tslib_1 = __webpack_require__(309);
+	var classNames = __webpack_require__(420);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var Classes = __webpack_require__(306);
-	var DateUtils = __webpack_require__(307);
-	var datePicker_1 = __webpack_require__(416);
-	var timePicker_1 = __webpack_require__(423);
+	var Classes = __webpack_require__(311);
+	var DateUtils = __webpack_require__(312);
+	var datePicker_1 = __webpack_require__(421);
+	var timePicker_1 = __webpack_require__(428);
 	var DateTimePicker = (function (_super) {
 	    tslib_1.__extends(DateTimePicker, _super);
 	    function DateTimePicker(props, context) {
@@ -55431,18 +55810,18 @@
 
 
 /***/ },
-/* 423 */
+/* 428 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(415);
+	var classNames = __webpack_require__(420);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(306);
-	var DateUtils = __webpack_require__(307);
-	var Utils = __webpack_require__(420);
+	var Classes = __webpack_require__(311);
+	var DateUtils = __webpack_require__(312);
+	var Utils = __webpack_require__(425);
 	var TimePickerPrecision;
 	(function (TimePickerPrecision) {
 	    TimePickerPrecision[TimePickerPrecision["MINUTE"] = 0] = "MINUTE";
@@ -55719,19 +56098,19 @@
 
 
 /***/ },
-/* 424 */
+/* 429 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
-	var classNames = __webpack_require__(415);
-	var moment = __webpack_require__(308);
+	var tslib_1 = __webpack_require__(309);
+	var classNames = __webpack_require__(420);
+	var moment = __webpack_require__(313);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var dateUtils_1 = __webpack_require__(307);
-	var datePickerCore_1 = __webpack_require__(421);
-	var dateRangePicker_1 = __webpack_require__(425);
+	var dateUtils_1 = __webpack_require__(312);
+	var datePickerCore_1 = __webpack_require__(426);
+	var dateRangePicker_1 = __webpack_require__(430);
 	;
 	;
 	var DateRangeInput = (function (_super) {
@@ -55750,6 +56129,9 @@
 	            },
 	        };
 	        _this.handleDateRangePickerChange = function (selectedRange) {
+	            if (!_this.state.isOpen) {
+	                return;
+	            }
 	            if (_this.props.value === undefined) {
 	                var _a = dateUtils_1.fromDateRangeToMomentDateRange(selectedRange), selectedStart = _a[0], selectedEnd = _a[1];
 	                var isOpen = true;
@@ -55796,6 +56178,9 @@
 	            core_1.Utils.safeInvoke(_this.props.onChange, selectedRange);
 	        };
 	        _this.handleDateRangePickerHoverChange = function (hoveredRange) {
+	            if (!_this.state.isOpen) {
+	                return;
+	            }
 	            if (hoveredRange == null) {
 	                var isEndInputFocused_1 = (_this.state.boundaryToModify === dateUtils_1.DateRangeBoundary.END);
 	                var isStartInputFocused_1 = !isEndInputFocused_1;
@@ -56271,23 +56656,23 @@
 
 
 /***/ },
-/* 425 */
+/* 430 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(415);
+	var classNames = __webpack_require__(420);
 	var React = __webpack_require__(9);
-	var DayPicker = __webpack_require__(417);
-	var DateClasses = __webpack_require__(306);
-	var DateUtils = __webpack_require__(307);
-	var dateUtils_1 = __webpack_require__(307);
-	var Errors = __webpack_require__(418);
-	var monthAndYear_1 = __webpack_require__(426);
-	var datePickerCaption_1 = __webpack_require__(419);
-	var datePickerCore_1 = __webpack_require__(421);
+	var DayPicker = __webpack_require__(422);
+	var DateClasses = __webpack_require__(311);
+	var DateUtils = __webpack_require__(312);
+	var dateUtils_1 = __webpack_require__(312);
+	var Errors = __webpack_require__(423);
+	var monthAndYear_1 = __webpack_require__(431);
+	var datePickerCaption_1 = __webpack_require__(424);
+	var datePickerCore_1 = __webpack_require__(426);
 	var DateRangePicker = (function (_super) {
 	    tslib_1.__extends(DateRangePicker, _super);
 	    function DateRangePicker(props, context) {
@@ -56474,7 +56859,7 @@
 	    };
 	    DateRangePicker.prototype.componentWillReceiveProps = function (nextProps) {
 	        _super.prototype.componentWillReceiveProps.call(this, nextProps);
-	        var nextState = getStateChange(this.props.value, nextProps.value, this.state);
+	        var nextState = getStateChange(this.props.value, nextProps.value, this.state, nextProps.contiguousCalendarMonths);
 	        this.setState(nextState);
 	    };
 	    DateRangePicker.prototype.validateProps = function (props) {
@@ -56625,7 +57010,7 @@
 	    };
 	    DateRangePicker.prototype.handleNextState = function (nextValue) {
 	        var value = this.state.value;
-	        var nextState = getStateChange(value, nextValue, this.state);
+	        var nextState = getStateChange(value, nextValue, this.state, this.props.contiguousCalendarMonths);
 	        if (!this.isControlled) {
 	            this.setState(nextState);
 	        }
@@ -56640,7 +57025,7 @@
 	    };
 	    DateRangePicker.prototype.updateRightView = function (rightView) {
 	        var leftView = this.state.leftView.clone();
-	        if (!rightView.isBefore(rightView)) {
+	        if (!rightView.isAfter(leftView)) {
 	            leftView = rightView.getPreviousMonth();
 	        }
 	        this.setViews(leftView, rightView);
@@ -56658,7 +57043,7 @@
 	    shortcuts: true,
 	};
 	exports.DateRangePicker = DateRangePicker;
-	function getStateChange(value, nextValue, state) {
+	function getStateChange(value, nextValue, state, contiguousCalendarMonths) {
 	    var returnVal;
 	    if (value != null && nextValue == null) {
 	        returnVal = { value: [null, null] };
@@ -56701,8 +57086,9 @@
 	            else {
 	                if (!leftView.isSame(nextValueStartMonthAndYear)) {
 	                    leftView = nextValueStartMonthAndYear;
+	                    rightView = nextValueStartMonthAndYear.getNextMonth();
 	                }
-	                if (!rightView.isSame(nextValueEndMonthAndYear)) {
+	                if (contiguousCalendarMonths === false && !rightView.isSame(nextValueEndMonthAndYear)) {
 	                    rightView = nextValueEndMonthAndYear;
 	                }
 	            }
@@ -56748,12 +57134,12 @@
 
 
 /***/ },
-/* 426 */
+/* 431 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var dateUtils_1 = __webpack_require__(307);
+	var dateUtils_1 = __webpack_require__(312);
 	var MonthAndYear = (function () {
 	    function MonthAndYear(month, year) {
 	        if (month !== null && year !== null) {
@@ -56810,7 +57196,7 @@
 
 
 /***/ },
-/* 427 */
+/* 432 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -56826,18 +57212,18 @@
 
 
 /***/ },
-/* 428 */
+/* 433 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var classNames = __webpack_require__(415);
-	var moment = __webpack_require__(308);
+	var baseExample_1 = __webpack_require__(267);
+	var classNames = __webpack_require__(420);
+	var moment = __webpack_require__(313);
 	var React = __webpack_require__(9);
-	var src_1 = __webpack_require__(305);
+	var src_1 = __webpack_require__(310);
 	var FORMAT = "dddd, LL";
 	exports.Moment = function (_a) {
 	    var date = _a.date, _b = _a.format, format = _b === void 0 ? FORMAT : _b;
@@ -56879,17 +57265,17 @@
 
 
 /***/ },
-/* 429 */
+/* 434 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var React = __webpack_require__(9);
-	var src_1 = __webpack_require__(305);
-	var formatSelect_1 = __webpack_require__(427);
+	var src_1 = __webpack_require__(310);
+	var formatSelect_1 = __webpack_require__(432);
 	var DateRangeInputExample = (function (_super) {
 	    tslib_1.__extends(DateRangeInputExample, _super);
 	    function DateRangeInputExample() {
@@ -56923,17 +57309,17 @@
 
 
 /***/ },
-/* 430 */
+/* 435 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var React = __webpack_require__(9);
-	var src_1 = __webpack_require__(305);
-	var datePickerExample_1 = __webpack_require__(428);
+	var src_1 = __webpack_require__(310);
+	var datePickerExample_1 = __webpack_require__(433);
 	var DateRangePickerExample = (function (_super) {
 	    tslib_1.__extends(DateRangePickerExample, _super);
 	    function DateRangePickerExample() {
@@ -56976,17 +57362,17 @@
 
 
 /***/ },
-/* 431 */
+/* 436 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var React = __webpack_require__(9);
-	var src_1 = __webpack_require__(305);
-	var datePickerExample_1 = __webpack_require__(428);
+	var src_1 = __webpack_require__(310);
+	var datePickerExample_1 = __webpack_require__(433);
 	var DateTimePickerExample = (function (_super) {
 	    tslib_1.__extends(DateTimePickerExample, _super);
 	    function DateTimePickerExample() {
@@ -57008,16 +57394,16 @@
 
 
 /***/ },
-/* 432 */
+/* 437 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(304);
+	var tslib_1 = __webpack_require__(309);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
+	var baseExample_1 = __webpack_require__(267);
 	var React = __webpack_require__(9);
-	var src_1 = __webpack_require__(305);
+	var src_1 = __webpack_require__(310);
 	var TimePickerExample = (function (_super) {
 	    tslib_1.__extends(TimePickerExample, _super);
 	    function TimePickerExample() {
@@ -57060,7 +57446,7 @@
 
 
 /***/ },
-/* 433 */
+/* 438 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -57068,27 +57454,27 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(434));
-	__export(__webpack_require__(478));
-	__export(__webpack_require__(479));
-	__export(__webpack_require__(480));
-	__export(__webpack_require__(481));
-	__export(__webpack_require__(482));
+	__export(__webpack_require__(439));
 	__export(__webpack_require__(483));
+	__export(__webpack_require__(484));
+	__export(__webpack_require__(485));
+	__export(__webpack_require__(486));
+	__export(__webpack_require__(487));
+	__export(__webpack_require__(488));
 
 
 /***/ },
-/* 434 */
+/* 439 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
-	var bigSpaceRocks = __webpack_require__(477);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
+	var bigSpaceRocks = __webpack_require__(482);
 	exports.CellsLoadingConfiguration = {
 	    ALL: "all",
 	    FIRST_COLUMN: "first-column",
@@ -57178,7 +57564,7 @@
 
 
 /***/ },
-/* 435 */
+/* 440 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(global) {/*! *****************************************************************************
@@ -57390,57 +57776,57 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 436 */
+/* 441 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__webpack_require__(437);
-	var cell_1 = __webpack_require__(438);
+	__webpack_require__(442);
+	var cell_1 = __webpack_require__(443);
 	exports.Cell = cell_1.Cell;
-	var editableCell_1 = __webpack_require__(446);
+	var editableCell_1 = __webpack_require__(451);
 	exports.EditableCell = editableCell_1.EditableCell;
-	var jsonFormat_1 = __webpack_require__(450);
+	var jsonFormat_1 = __webpack_require__(455);
 	exports.JSONFormat = jsonFormat_1.JSONFormat;
-	var truncatedFormat_1 = __webpack_require__(451);
+	var truncatedFormat_1 = __webpack_require__(456);
 	exports.TruncatedPopoverMode = truncatedFormat_1.TruncatedPopoverMode;
 	exports.TruncatedFormat = truncatedFormat_1.TruncatedFormat;
-	var column_1 = __webpack_require__(452);
+	var column_1 = __webpack_require__(457);
 	exports.Column = column_1.Column;
-	var index_1 = __webpack_require__(453);
+	var index_1 = __webpack_require__(458);
 	exports.Clipboard = index_1.Clipboard;
 	exports.Grid = index_1.Grid;
 	exports.Rect = index_1.Rect;
 	exports.Utils = index_1.Utils;
-	var draggable_1 = __webpack_require__(447);
+	var draggable_1 = __webpack_require__(452);
 	exports.Draggable = draggable_1.Draggable;
-	var menus_1 = __webpack_require__(459);
+	var menus_1 = __webpack_require__(464);
 	exports.CopyCellsMenuItem = menus_1.CopyCellsMenuItem;
-	var resizeHandle_1 = __webpack_require__(462);
+	var resizeHandle_1 = __webpack_require__(467);
 	exports.Orientation = resizeHandle_1.Orientation;
 	exports.ResizeHandle = resizeHandle_1.ResizeHandle;
-	var selectable_1 = __webpack_require__(463);
+	var selectable_1 = __webpack_require__(468);
 	exports.DragSelectable = selectable_1.DragSelectable;
-	var columnHeaderCell_1 = __webpack_require__(464);
+	var columnHeaderCell_1 = __webpack_require__(469);
 	exports.ColumnHeaderCell = columnHeaderCell_1.ColumnHeaderCell;
 	exports.HorizontalCellDivider = columnHeaderCell_1.HorizontalCellDivider;
-	var rowHeaderCell_1 = __webpack_require__(465);
+	var rowHeaderCell_1 = __webpack_require__(470);
 	exports.RowHeaderCell = rowHeaderCell_1.RowHeaderCell;
-	var editableName_1 = __webpack_require__(466);
+	var editableName_1 = __webpack_require__(471);
 	exports.EditableName = editableName_1.EditableName;
-	var regions_1 = __webpack_require__(456);
+	var regions_1 = __webpack_require__(461);
 	exports.ColumnLoadingOption = regions_1.ColumnLoadingOption;
 	exports.RegionCardinality = regions_1.RegionCardinality;
 	exports.Regions = regions_1.Regions;
 	exports.RowLoadingOption = regions_1.RowLoadingOption;
 	exports.SelectionModes = regions_1.SelectionModes;
 	exports.TableLoadingOption = regions_1.TableLoadingOption;
-	var table_1 = __webpack_require__(467);
+	var table_1 = __webpack_require__(472);
 	exports.Table = table_1.Table;
 
 
 /***/ },
-/* 437 */
+/* 442 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(global, process) { /*!
@@ -57650,6 +58036,12 @@
 	  var ArrayIterator; // make our implementation private
 	  var noop = function () {};
 	
+	  var OrigMap = globals.Map;
+	  var origMapDelete = OrigMap && OrigMap.prototype['delete'];
+	  var origMapGet = OrigMap && OrigMap.prototype.get;
+	  var origMapHas = OrigMap && OrigMap.prototype.has;
+	  var origMapSet = OrigMap && OrigMap.prototype.set;
+	
 	  var Symbol = globals.Symbol || {};
 	  var symbolSpecies = Symbol.species || '@@species';
 	
@@ -57701,6 +58093,7 @@
 	    Value.preserveToString(object[property], original);
 	  };
 	
+	  // eslint-disable-next-line no-restricted-properties
 	  var hasSymbols = typeof Symbol === 'function' && typeof Symbol['for'] === 'function' && Type.symbol(Symbol());
 	
 	  // This is a private name in the es6 spec, equal to '[Symbol.iterator]'
@@ -57724,6 +58117,17 @@
 	
 	  var $String = String;
 	
+	  /* global document */
+	  var domAll = (typeof document === 'undefined' || !document) ? null : document.all;
+	  /* jshint eqnull:true */
+	  var isNullOrUndefined = domAll == null ? function isNullOrUndefined(x) {
+	    /* jshint eqnull:true */
+	    return x == null;
+	  } : function isNullOrUndefinedAndNotDocumentAll(x) {
+	    /* jshint eqnull:true */
+	    return x == null && x !== domAll;
+	  };
+	
 	  var ES = {
 	    // http://www.ecma-international.org/ecma-262/6.0/#sec-call
 	    Call: function Call(F, V) {
@@ -57735,8 +58139,7 @@
 	    },
 	
 	    RequireObjectCoercible: function (x, optMessage) {
-	      /* jshint eqnull:true */
-	      if (x == null) {
+	      if (isNullOrUndefined(x)) {
 	        throw new TypeError(optMessage || 'Cannot call method on ' + x);
 	      }
 	      return x;
@@ -57755,7 +58158,7 @@
 	      if (x === void 0 || x === null || x === true || x === false) {
 	        return false;
 	      }
-	      return typeof x === 'function' || typeof x === 'object';
+	      return typeof x === 'function' || typeof x === 'object' || x === domAll;
 	    },
 	
 	    ToObject: function (o, optMessage) {
@@ -57835,7 +58238,7 @@
 	
 	    GetMethod: function (o, p) {
 	      var func = ES.ToObject(o)[p];
-	      if (func === void 0 || func === null) {
+	      if (isNullOrUndefined(func)) {
 	        return void 0;
 	      }
 	      if (!ES.IsCallable(func)) {
@@ -57915,7 +58318,7 @@
 	        throw new TypeError('Bad constructor');
 	      }
 	      var S = C[symbolSpecies];
-	      if (S === void 0 || S === null) {
+	      if (isNullOrUndefined(S)) {
 	        return defaultConstructor;
 	      }
 	      if (!ES.IsConstructor(S)) {
@@ -57959,6 +58362,7 @@
 	      if (Type.symbol(Symbol[name])) {
 	        return Symbol[name];
 	      }
+	      // eslint-disable-next-line no-restricted-properties
 	      var sym = Symbol['for']('Symbol.' + name);
 	      Object.defineProperty(Symbol, name, {
 	        configurable: false,
@@ -57976,7 +58380,7 @@
 	      });
 	      var searchShim = function search(regexp) {
 	        var O = ES.RequireObjectCoercible(this);
-	        if (regexp !== null && typeof regexp !== 'undefined') {
+	        if (!isNullOrUndefined(regexp)) {
 	          var searcher = ES.GetMethod(regexp, symbolSearch);
 	          if (typeof searcher !== 'undefined') {
 	            return ES.Call(searcher, regexp, [O]);
@@ -57994,7 +58398,7 @@
 	      });
 	      var replaceShim = function replace(searchValue, replaceValue) {
 	        var O = ES.RequireObjectCoercible(this);
-	        if (searchValue !== null && typeof searchValue !== 'undefined') {
+	        if (!isNullOrUndefined(searchValue)) {
 	          var replacer = ES.GetMethod(searchValue, symbolReplace);
 	          if (typeof replacer !== 'undefined') {
 	            return ES.Call(replacer, searchValue, [O, replaceValue]);
@@ -58012,7 +58416,7 @@
 	      });
 	      var splitShim = function split(separator, limit) {
 	        var O = ES.RequireObjectCoercible(this);
-	        if (separator !== null && typeof separator !== 'undefined') {
+	        if (!isNullOrUndefined(separator)) {
 	          var splitter = ES.GetMethod(separator, symbolSplit);
 	          if (typeof splitter !== 'undefined') {
 	            return ES.Call(splitter, separator, [O, limit]);
@@ -58040,7 +58444,7 @@
 	
 	      var matchShim = function match(regexp) {
 	        var O = ES.RequireObjectCoercible(this);
-	        if (regexp !== null && typeof regexp !== 'undefined') {
+	        if (!isNullOrUndefined(regexp)) {
 	          var matcher = ES.GetMethod(regexp, symbolMatch);
 	          if (typeof matcher !== 'undefined') {
 	            return ES.Call(matcher, regexp, [O]);
@@ -58336,7 +58740,7 @@
 	  };
 	  var nonWS = ['\u0085', '\u200b', '\ufffe'].join('');
 	  var nonWSregex = new RegExp('[' + nonWS + ']', 'g');
-	  var isBadHexRegex = /^[\-+]0x[0-9a-f]+$/i;
+	  var isBadHexRegex = /^[-+]0x[0-9a-f]+$/i;
 	  var hasStringTrimBug = nonWS.trim().length !== nonWS.length;
 	  defineProperty(String.prototype, 'trim', trimShim, hasStringTrimBug);
 	
@@ -58850,12 +59254,12 @@
 	      POSITIVE_INFINITY: OrigNumber.POSITIVE_INFINITY
 	    });
 	    /* globals Number: true */
-	    /* eslint-disable no-undef */
+	    /* eslint-disable no-undef, no-global-assign */
 	    /* jshint -W020 */
 	    Number = NumberShim;
 	    Value.redefine(globals, 'Number', NumberShim);
 	    /* jshint +W020 */
-	    /* eslint-enable no-undef */
+	    /* eslint-enable no-undef, no-global-assign */
 	    /* globals Number: false */
 	  }
 	
@@ -58889,10 +59293,10 @@
 	  // methods of Number, so this test has to happen down here.)
 	  /*jshint elision: true */
 	  /* eslint-disable no-sparse-arrays */
-	  if (![, 1].find(function (item, idx) { return idx === 0; })) {
+	  if ([, 1].find(function () { return true; }) === 1) {
 	    overrideNative(Array.prototype, 'find', ArrayPrototypeShims.find);
 	  }
-	  if ([, 1].findIndex(function (item, idx) { return idx === 0; }) !== 0) {
+	  if ([, 1].findIndex(function () { return true; }) !== 0) {
 	    overrideNative(Array.prototype, 'findIndex', ArrayPrototypeShims.findIndex);
 	  }
 	  /* eslint-enable no-sparse-arrays */
@@ -59226,7 +59630,10 @@
 	  if (supportsDescriptors && (!regExpSupportsFlagsWithRegex || regExpNeedsToSupportSymbolMatch)) {
 	    var flagsGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get;
 	    var sourceDesc = Object.getOwnPropertyDescriptor(RegExp.prototype, 'source') || {};
-	    var legacySourceGetter = function () { return this.source; }; // prior to it being a getter, it's own + nonconfigurable
+	    var legacySourceGetter = function () {
+	      // prior to it being a getter, it's own + nonconfigurable
+	      return this.source;
+	    };
 	    var sourceGetter = ES.IsCallable(sourceDesc.get) ? sourceDesc.get : legacySourceGetter;
 	
 	    var OrigRegExp = RegExp;
@@ -59255,12 +59662,12 @@
 	      $input: true // Chrome < v39 & Opera < 26 have a nonstandard "$input" property
 	    });
 	    /* globals RegExp: true */
-	    /* eslint-disable no-undef */
+	    /* eslint-disable no-undef, no-global-assign */
 	    /* jshint -W020 */
 	    RegExp = RegExpShim;
 	    Value.redefine(globals, 'RegExp', RegExpShim);
 	    /* jshint +W020 */
-	    /* eslint-enable no-undef */
+	    /* eslint-enable no-undef, no-global-assign */
 	    /* globals RegExp: false */
 	  }
 	
@@ -59302,7 +59709,7 @@
 	      if (numberIsNaN(x) || value < 1) { return NaN; }
 	      if (x === 1) { return 0; }
 	      if (x === Infinity) { return x; }
-	      return _log(x / E + _sqrt(x + 1) * _sqrt(x - 1) / E) + 1;
+	      return _log((x / E) + (_sqrt(x + 1) * _sqrt(x - 1) / E)) + 1;
 	    },
 	
 	    asinh: function asinh(value) {
@@ -59310,7 +59717,7 @@
 	      if (x === 0 || !globalIsFinite(x)) {
 	        return x;
 	      }
-	      return x < 0 ? -asinh(-x) : _log(x + _sqrt(x * x + 1));
+	      return x < 0 ? -asinh(-x) : _log(x + _sqrt((x * x) + 1));
 	    },
 	
 	    atanh: function atanh(value) {
@@ -59335,7 +59742,7 @@
 	      } else {
 	        result = _exp(_log(x) / 3);
 	        // from http://en.wikipedia.org/wiki/Cube_root#Numerical_methods
-	        result = (x / (result * result) + (2 * result)) / 3;
+	        result = ((x / (result * result)) + (2 * result)) / 3;
 	      }
 	      return negate ? -result : result;
 	    },
@@ -59450,7 +59857,7 @@
 	      var bl = b & 0xffff;
 	      // the shift by 0 fixes the sign on the high part
 	      // the final |0 converts the unsigned value into a signed value
-	      return (al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0;
+	      return (al * bl) + ((((ah * bl) + (al * bh)) << 16) >>> 0) | 0;
 	    },
 	
 	    fround: function fround(x) {
@@ -59461,10 +59868,12 @@
 	      var sign = _sign(v);
 	      var abs = _abs(v);
 	      if (abs < BINARY_32_MIN_VALUE) {
-	        return sign * roundTiesToEven(abs / BINARY_32_MIN_VALUE / BINARY_32_EPSILON) * BINARY_32_MIN_VALUE * BINARY_32_EPSILON;
+	        return sign * roundTiesToEven(
+	          abs / BINARY_32_MIN_VALUE / BINARY_32_EPSILON
+	        ) * BINARY_32_MIN_VALUE * BINARY_32_EPSILON;
 	      }
 	      // Veltkamp's splitting (?)
-	      var a = (1 + BINARY_32_EPSILON / Number.EPSILON) * abs;
+	      var a = (1 + (BINARY_32_EPSILON / Number.EPSILON)) * abs;
 	      var result = a - (a - abs);
 	      if (result > BINARY_32_MAX_VALUE || numberIsNaN(result)) {
 	        return sign * Infinity;
@@ -59482,7 +59891,7 @@
 	  // Chrome 40 loses Math.acosh precision with high numbers
 	  defineProperty(Math, 'acosh', MathShims.acosh, Math.acosh(Number.MAX_VALUE) === Infinity);
 	  // Firefox 38 on Windows
-	  defineProperty(Math, 'cbrt', MathShims.cbrt, Math.abs(1 - Math.cbrt(1e-300) / 1e-100) / Number.EPSILON > 8);
+	  defineProperty(Math, 'cbrt', MathShims.cbrt, Math.abs(1 - (Math.cbrt(1e-300) / 1e-100)) / Number.EPSILON > 8);
 	  // node 0.11 has an imprecise Math.sinh with very small numbers
 	  defineProperty(Math, 'sinh', MathShims.sinh, Math.sinh(-2e-17) !== -2e-17);
 	  // FF 35 on Linux reports 22025.465794806725 for Math.expm1(10)
@@ -59491,15 +59900,19 @@
 	
 	  var origMathRound = Math.round;
 	  // breaks in e.g. Safari 8, Internet Explorer 11, Opera 12
-	  var roundHandlesBoundaryConditions = Math.round(0.5 - Number.EPSILON / 4) === 0 && Math.round(-0.5 + Number.EPSILON / 3.99) === 1;
+	  var roundHandlesBoundaryConditions = Math.round(0.5 - (Number.EPSILON / 4)) === 0 &&
+	    Math.round(-0.5 + (Number.EPSILON / 3.99)) === 1;
 	
 	  // When engines use Math.floor(x + 0.5) internally, Math.round can be buggy for large integers.
 	  // This behavior should be governed by "round to nearest, ties to even mode"
 	  // see http://www.ecma-international.org/ecma-262/6.0/#sec-terms-and-definitions-number-type
 	  // These are the boundary cases where it breaks.
 	  var smallestPositiveNumberWhereRoundBreaks = inverseEpsilon + 1;
-	  var largestPositiveNumberWhereRoundBreaks = 2 * inverseEpsilon - 1;
-	  var roundDoesNotIncreaseIntegers = [smallestPositiveNumberWhereRoundBreaks, largestPositiveNumberWhereRoundBreaks].every(function (num) {
+	  var largestPositiveNumberWhereRoundBreaks = (2 * inverseEpsilon) - 1;
+	  var roundDoesNotIncreaseIntegers = [
+	    smallestPositiveNumberWhereRoundBreaks,
+	    largestPositiveNumberWhereRoundBreaks
+	  ].every(function (num) {
 	    return Math.round(num) === num;
 	  });
 	  defineProperty(Math, 'round', function round(x) {
@@ -60031,7 +60444,9 @@
 	    var promiseSupportsSubclassing = supportsSubclassing(globals.Promise, function (S) {
 	      return S.resolve(42).then(function () {}) instanceof S;
 	    });
-	    var promiseIgnoresNonFunctionThenCallbacks = !throwsError(function () { globals.Promise.reject(42).then(null, 5).then(null, noop); });
+	    var promiseIgnoresNonFunctionThenCallbacks = !throwsError(function () {
+	      globals.Promise.reject(42).then(null, 5).then(null, noop);
+	    });
 	    var promiseRequiresObjectContext = throwsError(function () { globals.Promise.call(3, noop); });
 	    // Promise.resolve() was errata'ed late in the ES6 process.
 	    // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1170742
@@ -60075,11 +60490,11 @@
 	        !promiseRequiresObjectContext || promiseResolveBroken ||
 	        !getsThenSynchronously || hasBadResolverPromise) {
 	      /* globals Promise: true */
-	      /* eslint-disable no-undef */
+	      /* eslint-disable no-undef, no-global-assign */
 	      /* jshint -W020 */
 	      Promise = PromiseShim;
 	      /* jshint +W020 */
-	      /* eslint-enable no-undef */
+	      /* eslint-enable no-undef, no-global-assign */
 	      /* globals Promise: false */
 	      overrideNative(globals, 'Promise', PromiseShim);
 	    }
@@ -60130,11 +60545,11 @@
 	
 	  if (supportsDescriptors) {
 	
-	    var fastkey = function fastkey(key) {
-	      if (!preservesInsertionOrder) {
+	    var fastkey = function fastkey(key, skipInsertionOrderCheck) {
+	      if (!skipInsertionOrderCheck && !preservesInsertionOrder) {
 	        return null;
 	      }
-	      if (typeof key === 'undefined' || key === null) {
+	      if (isNullOrUndefined(key)) {
 	        return '^' + ES.ToString(key);
 	      } else if (typeof key === 'string') {
 	        return '$' + key;
@@ -60169,7 +60584,7 @@
 	        });
 	      } else {
 	        var iter, adder;
-	        if (iterable !== null && typeof iterable !== 'undefined') {
+	        if (!isNullOrUndefined(iterable)) {
 	          adder = map.set;
 	          if (!ES.IsCallable(adder)) { throw new TypeError('bad map'); }
 	          iter = ES.GetIterator(iterable);
@@ -60203,7 +60618,7 @@
 	        });
 	      } else {
 	        var iter, adder;
-	        if (iterable !== null && typeof iterable !== 'undefined') {
+	        if (!isNullOrUndefined(iterable)) {
 	          adder = set.add;
 	          if (!ES.IsCallable(adder)) { throw new TypeError('bad set'); }
 	          iter = ES.GetIterator(iterable);
@@ -60303,12 +60718,14 @@
 	          var map = emulateES6construct(this, Map, Map$prototype, {
 	            _es6map: true,
 	            _head: null,
-	            _storage: emptyObject(),
-	            _size: 0
+	            _map: OrigMap ? new OrigMap() : null,
+	            _size: 0,
+	            _storage: emptyObject()
 	          });
 	
 	          var head = new MapEntry(null, null);
 	          // circular doubly-linked list.
+	          /* eslint no-multi-assign: 1 */
 	          head.next = head.prev = head;
 	          map._head = head;
 	
@@ -60330,10 +60747,20 @@
 	        defineProperties(Map$prototype, {
 	          get: function get(key) {
 	            requireMapSlot(this, 'get');
-	            var fkey = fastkey(key);
+	            var entry;
+	            var fkey = fastkey(key, true);
 	            if (fkey !== null) {
 	              // fast O(1) path
-	              var entry = this._storage[fkey];
+	              entry = this._storage[fkey];
+	              if (entry) {
+	                return entry.value;
+	              } else {
+	                return;
+	              }
+	            }
+	            if (this._map) {
+	              // fast object key path
+	              entry = origMapGet.call(this._map, key);
 	              if (entry) {
 	                return entry.value;
 	              } else {
@@ -60351,10 +60778,14 @@
 	
 	          has: function has(key) {
 	            requireMapSlot(this, 'has');
-	            var fkey = fastkey(key);
+	            var fkey = fastkey(key, true);
 	            if (fkey !== null) {
 	              // fast O(1) path
 	              return typeof this._storage[fkey] !== 'undefined';
+	            }
+	            if (this._map) {
+	              // fast object key path
+	              return origMapHas.call(this._map, key);
 	            }
 	            var head = this._head;
 	            var i = head;
@@ -60371,14 +60802,24 @@
 	            var head = this._head;
 	            var i = head;
 	            var entry;
-	            var fkey = fastkey(key);
+	            var fkey = fastkey(key, true);
 	            if (fkey !== null) {
 	              // fast O(1) path
 	              if (typeof this._storage[fkey] !== 'undefined') {
 	                this._storage[fkey].value = value;
 	                return this;
 	              } else {
-	                entry = this._storage[fkey] = new MapEntry(key, value);
+	                entry = this._storage[fkey] = new MapEntry(key, value); /* eslint no-multi-assign: 1 */
+	                i = head.prev;
+	                // fall through
+	              }
+	            } else if (this._map) {
+	              // fast object key path
+	              if (origMapHas.call(this._map, key)) {
+	                origMapGet.call(this._map, key).value = value;
+	              } else {
+	                entry = new MapEntry(key, value);
+	                origMapSet.call(this._map, key, entry);
 	                i = head.prev;
 	                // fall through
 	              }
@@ -60405,7 +60846,7 @@
 	            requireMapSlot(this, 'delete');
 	            var head = this._head;
 	            var i = head;
-	            var fkey = fastkey(key);
+	            var fkey = fastkey(key, true);
 	            if (fkey !== null) {
 	              // fast O(1) path
 	              if (typeof this._storage[fkey] === 'undefined') {
@@ -60414,10 +60855,19 @@
 	              i = this._storage[fkey].prev;
 	              delete this._storage[fkey];
 	              // fall through
+	            } else if (this._map) {
+	              // fast object key path
+	              if (!origMapHas.call(this._map, key)) {
+	                return false;
+	              }
+	              i = origMapGet.call(this._map, key).prev;
+	              origMapDelete.call(this._map, key);
+	              // fall through
 	            }
 	            while ((i = i.next) !== head) {
 	              if (ES.SameValueZero(i.key, key)) {
-	                i.key = i.value = empty;
+	                i.key = empty;
+	                i.value = empty;
 	                i.prev.next = i.next;
 	                i.next.prev = i.prev;
 	                this._size -= 1;
@@ -60428,14 +60878,17 @@
 	          },
 	
 	          clear: function clear() {
+	             /* eslint no-multi-assign: 1 */
 	            requireMapSlot(this, 'clear');
+	            this._map = OrigMap ? new OrigMap() : null;
 	            this._size = 0;
 	            this._storage = emptyObject();
 	            var head = this._head;
 	            var i = head;
 	            var p = i.next;
 	            while ((i = p) !== head) {
-	              i.key = i.value = empty;
+	              i.key = empty;
+	              i.value = empty;
 	              p = i.next;
 	              i.next = i.prev = head;
 	            }
@@ -60536,7 +60989,8 @@
 	        // Switch from the object backing storage to a full Map.
 	        var ensureMap = function ensureMap(set) {
 	          if (!set['[[SetData]]']) {
-	            var m = set['[[SetData]]'] = new collectionShims.Map();
+	            var m = new collectionShims.Map();
+	            set['[[SetData]]'] = m;
 	            _forEach(keys(set._storage), function (key) {
 	              var k = decodeKey(key);
 	              m.set(k, k);
@@ -60636,12 +61090,11 @@
 	      // Safari 8, for example, doesn't accept an iterable.
 	      var mapAcceptsArguments = valueOrFalseIfThrows(function () { return new Map([[1, 2]]).get(1) === 2; });
 	      if (!mapAcceptsArguments) {
-	        var OrigMapNoArgs = globals.Map;
 	        globals.Map = function Map() {
 	          if (!(this instanceof Map)) {
 	            throw new TypeError('Constructor Map requires "new"');
 	          }
-	          var m = new OrigMapNoArgs();
+	          var m = new OrigMap();
 	          if (arguments.length > 0) {
 	            addIterableToMap(Map, m, arguments[0]);
 	          }
@@ -60649,9 +61102,9 @@
 	          Object.setPrototypeOf(m, globals.Map.prototype);
 	          return m;
 	        };
-	        globals.Map.prototype = create(OrigMapNoArgs.prototype);
+	        globals.Map.prototype = create(OrigMap.prototype);
 	        defineProperty(globals.Map.prototype, 'constructor', globals.Map, true);
-	        Value.preserveToString(globals.Map, OrigMapNoArgs);
+	        Value.preserveToString(globals.Map, OrigMap);
 	      }
 	      var testMap = new Map();
 	      var mapUsesSameValueZero = (function () {
@@ -60662,15 +61115,12 @@
 	      }());
 	      var mapSupportsChaining = testMap.set(1, 2) === testMap;
 	      if (!mapUsesSameValueZero || !mapSupportsChaining) {
-	        var origMapSet = Map.prototype.set;
 	        overrideNative(Map.prototype, 'set', function set(k, v) {
 	          _call(origMapSet, this, k === 0 ? 0 : k, v);
 	          return this;
 	        });
 	      }
 	      if (!mapUsesSameValueZero) {
-	        var origMapGet = Map.prototype.get;
-	        var origMapHas = Map.prototype.has;
 	        defineProperties(Map.prototype, {
 	          get: function get(k) {
 	            return _call(origMapGet, this, k === 0 ? 0 : k);
@@ -60716,7 +61166,8 @@
 	        m.set(42, 42);
 	        return m instanceof M;
 	      });
-	      var mapFailsToSupportSubclassing = Object.setPrototypeOf && !mapSupportsSubclassing; // without Object.setPrototypeOf, subclassing is not possible
+	      // without Object.setPrototypeOf, subclassing is not possible
+	      var mapFailsToSupportSubclassing = Object.setPrototypeOf && !mapSupportsSubclassing;
 	      var mapRequiresNew = (function () {
 	        try {
 	          return !(globals.Map() instanceof globals.Map);
@@ -60725,7 +61176,6 @@
 	        }
 	      }());
 	      if (globals.Map.length !== 0 || mapFailsToSupportSubclassing || !mapRequiresNew) {
-	        var OrigMap = globals.Map;
 	        globals.Map = function Map() {
 	          if (!(this instanceof Map)) {
 	            throw new TypeError('Constructor Map requires "new"');
@@ -60747,7 +61197,8 @@
 	        s.add(42, 42);
 	        return s instanceof S;
 	      });
-	      var setFailsToSupportSubclassing = Object.setPrototypeOf && !setSupportsSubclassing; // without Object.setPrototypeOf, subclassing is not possible
+	      // without Object.setPrototypeOf, subclassing is not possible
+	      var setFailsToSupportSubclassing = Object.setPrototypeOf && !setSupportsSubclassing;
 	      var setRequiresNew = (function () {
 	        try {
 	          return !(globals.Set() instanceof globals.Set);
@@ -61224,18 +61675,18 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }()), __webpack_require__(44)))
 
 /***/ },
-/* 438 */
+/* 443 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var core_1 = __webpack_require__(2);
-	var loadableContent_1 = __webpack_require__(445);
+	var loadableContent_1 = __webpack_require__(450);
 	exports.emptyCellRenderer = function () { return React.createElement(Cell, null); };
 	var Cell = (function (_super) {
 	    tslib_1.__extends(Cell, _super);
@@ -61243,21 +61694,26 @@
 	        return _super !== null && _super.apply(this, arguments) || this;
 	    }
 	    Cell.prototype.render = function () {
-	        var _a = this.props, style = _a.style, intent = _a.intent, interactive = _a.interactive, loading = _a.loading, tooltip = _a.tooltip, truncated = _a.truncated, className = _a.className;
+	        var _a = this.props, style = _a.style, intent = _a.intent, interactive = _a.interactive, loading = _a.loading, tooltip = _a.tooltip, truncated = _a.truncated, className = _a.className, wrapText = _a.wrapText;
 	        var classes = classNames(Classes.TABLE_CELL, core_1.Classes.intentClass(intent), (_b = {},
 	            _b[Classes.TABLE_CELL_INTERACTIVE] = interactive,
 	            _b[core_1.Classes.LOADING] = loading,
+	            _b[Classes.TABLE_TRUNCATED_CELL] = truncated,
 	            _b), className);
-	        var content = truncated ?
-	            React.createElement("div", { className: Classes.TABLE_TRUNCATED_TEXT }, this.props.children) : this.props.children;
+	        var textClasses = classNames((_c = {},
+	            _c[Classes.TABLE_TRUNCATED_TEXT] = truncated,
+	            _c[Classes.TABLE_NO_WRAP_TEXT] = !wrapText,
+	            _c));
+	        var content = React.createElement("div", { className: textClasses }, this.props.children);
 	        return (React.createElement("div", { className: classes, style: style, title: tooltip },
 	            React.createElement(loadableContent_1.LoadableContent, { loading: loading, variableLength: true }, content)));
-	        var _b;
+	        var _b, _c;
 	    };
 	    return Cell;
 	}(React.Component));
 	Cell.defaultProps = {
 	    truncated: true,
+	    wrapText: false,
 	};
 	Cell = tslib_1.__decorate([
 	    PureRender
@@ -61266,7 +61722,7 @@
 
 
 /***/ },
-/* 439 */
+/* 444 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -61320,7 +61776,7 @@
 
 
 /***/ },
-/* 440 */
+/* 445 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -61329,8 +61785,8 @@
 	 */
 	'use strict';
 	
-	var warning = __webpack_require__(441);
-	var shallowEqual = __webpack_require__(443);
+	var warning = __webpack_require__(446);
+	var shallowEqual = __webpack_require__(448);
 	
 	
 	
@@ -61392,7 +61848,7 @@
 
 
 /***/ },
-/* 441 */
+/* 446 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -61407,7 +61863,7 @@
 	
 	'use strict';
 	
-	var emptyFunction = __webpack_require__(442);
+	var emptyFunction = __webpack_require__(447);
 	
 	/**
 	 * Similar to invariant but only logs a warning if the condition is not met.
@@ -61463,7 +61919,7 @@
 	module.exports = warning;
 
 /***/ },
-/* 442 */
+/* 447 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -61506,7 +61962,7 @@
 	module.exports = emptyFunction;
 
 /***/ },
-/* 443 */
+/* 448 */
 /***/ function(module, exports) {
 
 	/**
@@ -61578,7 +62034,7 @@
 	module.exports = shallowEqual;
 
 /***/ },
-/* 444 */
+/* 449 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -61614,6 +62070,7 @@
 	exports.TABLE_NO_HORIZONTAL_SCROLL = "bp-table-no-horizontal-scroll";
 	exports.TABLE_NO_LAYOUT = "bp-table-no-layout";
 	exports.TABLE_NO_VERTICAL_SCROLL = "bp-table-no-vertical-scroll";
+	exports.TABLE_NO_WRAP_TEXT = "bp-table-no-wrap-text";
 	exports.TABLE_NULL = "bp-table-null";
 	exports.TABLE_OVERLAY = "bp-table-overlay";
 	exports.TABLE_OVERLAY_LAYER = "bp-table-overlay-layer";
@@ -61637,6 +62094,7 @@
 	exports.TABLE_TH_MENU = "bp-table-th-menu";
 	exports.TABLE_THEAD = "bp-table-thead";
 	exports.TABLE_TOP_CONTAINER = "bp-table-top-container";
+	exports.TABLE_TRUNCATED_CELL = "bp-table-truncated-cell";
 	exports.TABLE_TRUNCATED_FORMAT = "bp-table-truncated-format";
 	exports.TABLE_TRUNCATED_POPOVER = "bp-table-truncated-popover";
 	exports.TABLE_TRUNCATED_POPOVER_TARGET = "bp-table-truncated-popover-target";
@@ -61671,12 +62129,12 @@
 
 
 /***/ },
-/* 445 */
+/* 450 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
 	var LoadableContent = (function (_super) {
@@ -61707,19 +62165,19 @@
 
 
 /***/ },
-/* 446 */
+/* 451 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
 	var ReactDOM = __webpack_require__(47);
 	var core_1 = __webpack_require__(2);
-	var Classes = __webpack_require__(444);
-	var draggable_1 = __webpack_require__(447);
-	var cell_1 = __webpack_require__(438);
+	var Classes = __webpack_require__(449);
+	var draggable_1 = __webpack_require__(452);
+	var cell_1 = __webpack_require__(443);
 	var EditableCell = (function (_super) {
 	    tslib_1.__extends(EditableCell, _super);
 	    function EditableCell() {
@@ -61773,17 +62231,17 @@
 
 
 /***/ },
-/* 447 */
+/* 452 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
 	var ReactDOM = __webpack_require__(47);
-	var utils_1 = __webpack_require__(448);
-	var dragEvents_1 = __webpack_require__(449);
+	var utils_1 = __webpack_require__(453);
+	var dragEvents_1 = __webpack_require__(454);
 	var REATTACH_PROPS_KEYS = [
 	    "stopPropagation",
 	    "preventDefault",
@@ -61822,12 +62280,12 @@
 
 
 /***/ },
-/* 448 */
+/* 453 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var classNames = __webpack_require__(439);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
 	;
 	var CSS_FONT_PROPERTIES = [
@@ -61936,7 +62394,7 @@
 
 
 /***/ },
-/* 449 */
+/* 454 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -62079,16 +62537,16 @@
 
 
 /***/ },
-/* 450 */
+/* 455 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
-	var truncatedFormat_1 = __webpack_require__(451);
+	var Classes = __webpack_require__(449);
+	var truncatedFormat_1 = __webpack_require__(456);
 	var JSONFormat = (function (_super) {
 	    tslib_1.__extends(JSONFormat, _super);
 	    function JSONFormat() {
@@ -62126,16 +62584,16 @@
 
 
 /***/ },
-/* 451 */
+/* 456 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(439);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var TruncatedPopoverMode;
 	(function (TruncatedPopoverMode) {
 	    TruncatedPopoverMode[TruncatedPopoverMode["ALWAYS"] = 0] = "ALWAYS";
@@ -62169,7 +62627,7 @@
 	            var iconClasses = classNames(core_1.Classes.ICON_STANDARD, core_1.Classes.iconClass("more"));
 	            return (React.createElement("div", { className: className },
 	                React.createElement("div", { className: Classes.TABLE_TRUNCATED_VALUE, ref: this.handleContentDivRef }, cellContent),
-	                React.createElement(core_1.Popover, { className: Classes.TABLE_TRUNCATED_POPOVER_TARGET, constraints: constraints, content: popoverContent, position: core_1.Position.BOTTOM, useSmartArrowPositioning: true, useSmartPositioning: true },
+	                React.createElement(core_1.Popover, { className: Classes.TABLE_TRUNCATED_POPOVER_TARGET, tetherOptions: { constraints: constraints }, content: popoverContent, position: core_1.Position.BOTTOM, useSmartArrowPositioning: true, useSmartPositioning: true },
 	                    React.createElement("span", { className: iconClasses }))));
 	        }
 	        else {
@@ -62202,7 +62660,9 @@
 	        if (!this.props.detectTruncation) {
 	            return;
 	        }
-	        var isTruncated = this.contentDiv !== undefined && this.contentDiv.scrollWidth > this.contentDiv.clientWidth;
+	        var isTruncated = this.contentDiv !== undefined &&
+	            (this.contentDiv.scrollWidth > this.contentDiv.clientWidth ||
+	                this.contentDiv.scrollHeight > this.contentDiv.clientHeight);
 	        if (this.state.isTruncated !== isTruncated) {
 	            this.setState({ isTruncated: isTruncated });
 	        }
@@ -62220,14 +62680,14 @@
 
 
 /***/ },
-/* 452 */
+/* 457 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
-	var cell_1 = __webpack_require__(438);
+	var cell_1 = __webpack_require__(443);
 	var Column = (function (_super) {
 	    tslib_1.__extends(Column, _super);
 	    function Column() {
@@ -62242,25 +62702,25 @@
 
 
 /***/ },
-/* 453 */
+/* 458 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var clipboard_1 = __webpack_require__(454);
+	var clipboard_1 = __webpack_require__(459);
 	exports.Clipboard = clipboard_1.Clipboard;
-	var grid_1 = __webpack_require__(455);
+	var grid_1 = __webpack_require__(460);
 	exports.Grid = grid_1.Grid;
-	var rect_1 = __webpack_require__(457);
+	var rect_1 = __webpack_require__(462);
 	exports.Rect = rect_1.Rect;
-	var roundSize_1 = __webpack_require__(458);
+	var roundSize_1 = __webpack_require__(463);
 	exports.RoundSize = roundSize_1.RoundSize;
-	var utils_1 = __webpack_require__(448);
+	var utils_1 = __webpack_require__(453);
 	exports.Utils = utils_1.Utils;
 
 
 /***/ },
-/* 454 */
+/* 459 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -62329,16 +62789,16 @@
 
 
 /***/ },
-/* 455 */
+/* 460 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var regions_1 = __webpack_require__(456);
-	var Classes = __webpack_require__(444);
-	var rect_1 = __webpack_require__(457);
-	var utils_1 = __webpack_require__(448);
+	var tslib_1 = __webpack_require__(440);
+	var regions_1 = __webpack_require__(461);
+	var Classes = __webpack_require__(449);
+	var rect_1 = __webpack_require__(462);
+	var utils_1 = __webpack_require__(453);
 	var Grid = (function () {
 	    function Grid(rowHeights, columnWidths, bleed, ghostHeight, ghostWidth) {
 	        if (bleed === void 0) { bleed = Grid.DEFAULT_BLEED; }
@@ -62587,13 +63047,13 @@
 
 
 /***/ },
-/* 456 */
+/* 461 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var Classes = __webpack_require__(444);
-	var utils_1 = __webpack_require__(448);
+	var Classes = __webpack_require__(449);
+	var utils_1 = __webpack_require__(453);
 	var RegionCardinality;
 	(function (RegionCardinality) {
 	    RegionCardinality[RegionCardinality["CELLS"] = 0] = "CELLS";
@@ -62603,6 +63063,7 @@
 	})(RegionCardinality = exports.RegionCardinality || (exports.RegionCardinality = {}));
 	exports.SelectionModes = {
 	    ALL: [
+	        RegionCardinality.FULL_TABLE,
 	        RegionCardinality.FULL_COLUMNS,
 	        RegionCardinality.FULL_ROWS,
 	        RegionCardinality.CELLS,
@@ -62665,6 +63126,9 @@
 	    Regions.column = function (col, col2) {
 	        return { cols: this.normalizeInterval(col, col2) };
 	    };
+	    Regions.table = function () {
+	        return {};
+	    };
 	    Regions.add = function (regions, region) {
 	        var copy = regions.slice();
 	        copy.push(region);
@@ -62726,12 +63190,25 @@
 	        }
 	        return false;
 	    };
-	    Regions.containsRegion = function (regions, query) {
-	        if (regions == null || query == null) {
+	    Regions.hasFullTable = function (regions) {
+	        if (regions == null) {
 	            return false;
 	        }
 	        for (var _i = 0, regions_3 = regions; _i < regions_3.length; _i++) {
 	            var region = regions_3[_i];
+	            var cardinality = Regions.getRegionCardinality(region);
+	            if (cardinality === RegionCardinality.FULL_TABLE) {
+	                return true;
+	            }
+	        }
+	        return false;
+	    };
+	    Regions.containsRegion = function (regions, query) {
+	        if (regions == null || query == null) {
+	            return false;
+	        }
+	        for (var _i = 0, regions_4 = regions; _i < regions_4.length; _i++) {
+	            var region = regions_4[_i];
 	            var cardinality = Regions.getRegionCardinality(region);
 	            switch (cardinality) {
 	                case RegionCardinality.FULL_TABLE:
@@ -62775,14 +63252,31 @@
 	            }
 	        });
 	    };
+	    Regions.eachUniqueFullRow = function (regions, iteratee) {
+	        if (regions == null || regions.length === 0 || iteratee == null) {
+	            return;
+	        }
+	        var seen = {};
+	        regions.forEach(function (region) {
+	            if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_ROWS) {
+	                var _a = region.rows, start = _a[0], end = _a[1];
+	                for (var row = start; row <= end; row++) {
+	                    if (!seen[row]) {
+	                        seen[row] = true;
+	                        iteratee(row);
+	                    }
+	                }
+	            }
+	        });
+	    };
 	    Regions.enumerateUniqueCells = function (regions, numRows, numCols) {
 	        if (regions == null || regions.length === 0) {
 	            return [];
 	        }
 	        var seen = {};
 	        var list = [];
-	        for (var _i = 0, regions_4 = regions; _i < regions_4.length; _i++) {
-	            var region = regions_4[_i];
+	        for (var _i = 0, regions_5 = regions; _i < regions_5.length; _i++) {
+	            var region = regions_5[_i];
 	            Regions.eachCellInRegion(region, numRows, numCols, function (row, col) {
 	                var key = row + "-" + col;
 	                if (seen[key] !== true) {
@@ -62939,7 +63433,7 @@
 
 
 /***/ },
-/* 457 */
+/* 462 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -63012,14 +63506,14 @@
 
 
 /***/ },
-/* 458 */
+/* 463 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var RoundSize = (function (_super) {
 	    tslib_1.__extends(RoundSize, _super);
 	    function RoundSize() {
@@ -63053,7 +63547,7 @@
 
 
 /***/ },
-/* 459 */
+/* 464 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -63061,21 +63555,21 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(460));
-	__export(__webpack_require__(461));
+	__export(__webpack_require__(465));
+	__export(__webpack_require__(466));
 
 
 /***/ },
-/* 460 */
+/* 465 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var core_1 = __webpack_require__(2);
 	var React = __webpack_require__(9);
-	var clipboard_1 = __webpack_require__(454);
-	var regions_1 = __webpack_require__(456);
+	var clipboard_1 = __webpack_require__(459);
+	var regions_1 = __webpack_require__(461);
 	var CopyCellsMenuItem = (function (_super) {
 	    tslib_1.__extends(CopyCellsMenuItem, _super);
 	    function CopyCellsMenuItem() {
@@ -63100,12 +63594,12 @@
 
 
 /***/ },
-/* 461 */
+/* 466 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var regions_1 = __webpack_require__(456);
+	var regions_1 = __webpack_require__(461);
 	var MenuContext = (function () {
 	    function MenuContext(target, selectedRegions, numRows, numCols) {
 	        this.target = target;
@@ -63132,16 +63626,16 @@
 
 
 /***/ },
-/* 462 */
+/* 467 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
-	var draggable_1 = __webpack_require__(447);
+	var Classes = __webpack_require__(449);
+	var draggable_1 = __webpack_require__(452);
 	var Orientation;
 	(function (Orientation) {
 	    Orientation[Orientation["HORIZONTAL"] = 1] = "HORIZONTAL";
@@ -63215,17 +63709,17 @@
 
 
 /***/ },
-/* 463 */
+/* 468 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var dragEvents_1 = __webpack_require__(449);
-	var draggable_1 = __webpack_require__(447);
-	var regions_1 = __webpack_require__(456);
+	var dragEvents_1 = __webpack_require__(454);
+	var draggable_1 = __webpack_require__(452);
+	var regions_1 = __webpack_require__(461);
 	var DragSelectable = DragSelectable_1 = (function (_super) {
 	    tslib_1.__extends(DragSelectable, _super);
 	    function DragSelectable() {
@@ -63319,18 +63813,18 @@
 
 
 /***/ },
-/* 464 */
+/* 469 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var Classes = __webpack_require__(444);
-	var loadableContent_1 = __webpack_require__(445);
+	var Classes = __webpack_require__(449);
+	var loadableContent_1 = __webpack_require__(450);
 	function HorizontalCellDivider() {
 	    return React.createElement("div", { className: Classes.TABLE_HORIZONTAL_CELL_DIVIDER });
 	}
@@ -63403,7 +63897,7 @@
 	                pin: true,
 	                to: "window",
 	            }];
-	        return (React.createElement(core_1.Popover, { constraints: constraints, content: menu, position: core_1.Position.BOTTOM, className: Classes.TABLE_TH_MENU, popoverDidOpen: this.getPopoverStateChangeHandler(true), popoverWillClose: this.getPopoverStateChangeHandler(false), useSmartArrowPositioning: true },
+	        return (React.createElement(core_1.Popover, { tetherOptions: { constraints: constraints }, content: menu, position: core_1.Position.BOTTOM, className: Classes.TABLE_TH_MENU, popoverDidOpen: this.getPopoverStateChangeHandler(true), popoverWillClose: this.getPopoverStateChangeHandler(false), useSmartArrowPositioning: true },
 	            React.createElement("span", { className: popoverTargetClasses })));
 	    };
 	    return ColumnHeaderCell;
@@ -63421,17 +63915,17 @@
 
 
 /***/ },
-/* 465 */
+/* 470 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var Classes = __webpack_require__(444);
-	var loadableContent_1 = __webpack_require__(445);
+	var Classes = __webpack_require__(449);
+	var loadableContent_1 = __webpack_require__(450);
 	var RowHeaderCell = (function (_super) {
 	    tslib_1.__extends(RowHeaderCell, _super);
 	    function RowHeaderCell() {
@@ -63469,16 +63963,16 @@
 
 
 /***/ },
-/* 466 */
+/* 471 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(439);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var EditableName = (function (_super) {
 	    tslib_1.__extends(EditableName, _super);
 	    function EditableName() {
@@ -63494,31 +63988,31 @@
 
 
 /***/ },
-/* 467 */
+/* 472 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var core_1 = __webpack_require__(2);
 	var core_2 = __webpack_require__(2);
-	var classNames = __webpack_require__(439);
-	var PureRender = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var column_1 = __webpack_require__(452);
-	var Classes = __webpack_require__(444);
-	var clipboard_1 = __webpack_require__(454);
-	var grid_1 = __webpack_require__(455);
-	var utils_1 = __webpack_require__(448);
-	var columnHeader_1 = __webpack_require__(468);
-	var columnHeaderCell_1 = __webpack_require__(464);
-	var rowHeader_1 = __webpack_require__(470);
-	var resizeSensor_1 = __webpack_require__(471);
-	var guides_1 = __webpack_require__(472);
-	var regions_1 = __webpack_require__(473);
-	var locator_1 = __webpack_require__(474);
-	var regions_2 = __webpack_require__(456);
-	var tableBody_1 = __webpack_require__(475);
+	var column_1 = __webpack_require__(457);
+	var Classes = __webpack_require__(449);
+	var clipboard_1 = __webpack_require__(459);
+	var grid_1 = __webpack_require__(460);
+	var utils_1 = __webpack_require__(453);
+	var columnHeader_1 = __webpack_require__(473);
+	var columnHeaderCell_1 = __webpack_require__(469);
+	var rowHeader_1 = __webpack_require__(475);
+	var resizeSensor_1 = __webpack_require__(476);
+	var guides_1 = __webpack_require__(477);
+	var regions_1 = __webpack_require__(478);
+	var locator_1 = __webpack_require__(479);
+	var regions_2 = __webpack_require__(461);
+	var tableBody_1 = __webpack_require__(480);
 	var Table = Table_1 = (function (_super) {
 	    tslib_1.__extends(Table, _super);
 	    function Table(props, context) {
@@ -63538,6 +64032,15 @@
 	                var success = clipboard_1.Clipboard.copyCells(sparse);
 	                core_1.Utils.safeInvoke(onCopy, success);
 	            }
+	        };
+	        _this.selectAll = function () {
+	            var selectionHandler = _this.getEnabledSelectionHandler(regions_2.RegionCardinality.FULL_TABLE);
+	            selectionHandler([regions_2.Regions.table()]);
+	        };
+	        _this.handleSelectAllHotkey = function (e) {
+	            e.preventDefault();
+	            e.stopPropagation();
+	            _this.selectAll();
 	        };
 	        _this.columnHeaderCellRenderer = function (columnIndex) {
 	            var props = _this.getColumnProps(columnIndex);
@@ -63567,8 +64070,21 @@
 	            return React.cloneElement(cell, tslib_1.__assign({}, columnProps, { loading: loading }));
 	        };
 	        _this.handleColumnWidthChanged = function (columnIndex, width) {
+	            var selectedRegions = _this.state.selectedRegions;
 	            var columnWidths = _this.state.columnWidths.slice();
-	            columnWidths[columnIndex] = width;
+	            if (regions_2.Regions.hasFullTable(selectedRegions)) {
+	                for (var col = 0; col < columnWidths.length; col++) {
+	                    columnWidths[col] = width;
+	                }
+	            }
+	            if (regions_2.Regions.hasFullColumn(selectedRegions, columnIndex)) {
+	                regions_2.Regions.eachUniqueFullColumn(selectedRegions, function (col) {
+	                    columnWidths[col] = width;
+	                });
+	            }
+	            else {
+	                columnWidths[columnIndex] = width;
+	            }
 	            _this.invalidateGrid();
 	            _this.setState({ columnWidths: columnWidths });
 	            var onColumnWidthChanged = _this.props.onColumnWidthChanged;
@@ -63577,8 +64093,21 @@
 	            }
 	        };
 	        _this.handleRowHeightChanged = function (rowIndex, height) {
+	            var selectedRegions = _this.state.selectedRegions;
 	            var rowHeights = _this.state.rowHeights.slice();
-	            rowHeights[rowIndex] = height;
+	            if (regions_2.Regions.hasFullTable(selectedRegions)) {
+	                for (var row = 0; row < rowHeights.length; row++) {
+	                    rowHeights[row] = height;
+	                }
+	            }
+	            if (regions_2.Regions.hasFullRow(selectedRegions, rowIndex)) {
+	                regions_2.Regions.eachUniqueFullRow(selectedRegions, function (row) {
+	                    rowHeights[row] = height;
+	                });
+	            }
+	            else {
+	                rowHeights[rowIndex] = height;
+	            }
 	            _this.invalidateGrid();
 	            _this.setState({ rowHeights: rowHeights });
 	            var onRowHeightChanged = _this.props.onRowHeightChanged;
@@ -63695,7 +64224,8 @@
 	                this.renderBody())));
 	    };
 	    Table.prototype.renderHotkeys = function () {
-	        return React.createElement(core_2.Hotkeys, null, this.maybeRenderCopyHotkey());
+	        var hotkeys = [this.maybeRenderCopyHotkey(), this.maybeRenderSelectAllHotkey()];
+	        return (React.createElement(core_2.Hotkeys, null, hotkeys.filter(function (element) { return element !== undefined; })));
 	    };
 	    Table.prototype.componentDidMount = function () {
 	        var _this = this;
@@ -63740,7 +64270,11 @@
 	        });
 	    };
 	    Table.prototype.renderMenu = function () {
-	        return (React.createElement("div", { className: Classes.TABLE_MENU, ref: this.setMenuRef }));
+	        var classes = classNames(Classes.TABLE_MENU, (_a = {},
+	            _a[Classes.TABLE_SELECTION_ENABLED] = this.isSelectionModeEnabled(regions_2.RegionCardinality.FULL_TABLE),
+	            _a));
+	        return (React.createElement("div", { className: classes, ref: this.setMenuRef, onClick: this.selectAll }, this.maybeRenderMenuRegions()));
+	        var _a;
 	    };
 	    Table.prototype.syncMenuWidth = function () {
 	        var _a = this, menuElement = _a.menuElement, rowHeaderElement = _a.rowHeaderElement;
@@ -63842,7 +64376,15 @@
 	    Table.prototype.maybeRenderCopyHotkey = function () {
 	        var getCellClipboardData = this.props.getCellClipboardData;
 	        if (getCellClipboardData != null) {
-	            return (React.createElement(core_2.Hotkey, { label: "Copy selected table cells", group: "Table", combo: "mod+c", onKeyDown: this.handleCopy }));
+	            return (React.createElement(core_2.Hotkey, { key: "copy-hotkey", label: "Copy selected table cells", group: "Table", combo: "mod+c", onKeyDown: this.handleCopy }));
+	        }
+	        else {
+	            return undefined;
+	        }
+	    };
+	    Table.prototype.maybeRenderSelectAllHotkey = function () {
+	        if (this.isSelectionModeEnabled(regions_2.RegionCardinality.FULL_TABLE)) {
+	            return (React.createElement(core_2.Hotkey, { key: "select-all-hotkey", label: "Select all", group: "Table", combo: "mod+a", onKeyDown: this.handleSelectAllHotkey }));
 	        }
 	        else {
 	            return undefined;
@@ -63862,6 +64404,35 @@
 	                case regions_2.RegionCardinality.FULL_ROWS:
 	                    style.left = "-1px";
 	                    return style;
+	                case regions_2.RegionCardinality.FULL_TABLE:
+	                    style.left = "-1px";
+	                    style.top = "-1px";
+	                    return style;
+	                default:
+	                    return { display: "none" };
+	            }
+	        };
+	        return this.maybeRenderRegions(styler);
+	    };
+	    Table.prototype.maybeRenderMenuRegions = function () {
+	        var _this = this;
+	        var styler = function (region) {
+	            var grid = _this.grid;
+	            var viewportRect = _this.state.viewportRect;
+	            if (viewportRect == null) {
+	                return {};
+	            }
+	            var cardinality = regions_2.Regions.getRegionCardinality(region);
+	            var style = grid.getRegionStyle(region);
+	            switch (cardinality) {
+	                case regions_2.RegionCardinality.FULL_TABLE:
+	                    style.right = "0px";
+	                    style.bottom = "0px";
+	                    style.top = "0px";
+	                    style.left = "0px";
+	                    style.borderBottom = "none";
+	                    style.borderRight = "none";
+	                    return style;
 	                default:
 	                    return { display: "none" };
 	            }
@@ -63879,6 +64450,12 @@
 	            var cardinality = regions_2.Regions.getRegionCardinality(region);
 	            var style = grid.getRegionStyle(region);
 	            switch (cardinality) {
+	                case regions_2.RegionCardinality.FULL_TABLE:
+	                    style.left = "-1px";
+	                    style.borderLeft = "none";
+	                    style.bottom = "-1px";
+	                    style.transform = "translate3d(" + -viewportRect.left + "px, 0, 0)";
+	                    return style;
 	                case regions_2.RegionCardinality.FULL_COLUMNS:
 	                    style.bottom = "-1px";
 	                    style.transform = "translate3d(" + -viewportRect.left + "px, 0, 0)";
@@ -63900,6 +64477,12 @@
 	            var cardinality = regions_2.Regions.getRegionCardinality(region);
 	            var style = grid.getRegionStyle(region);
 	            switch (cardinality) {
+	                case regions_2.RegionCardinality.FULL_TABLE:
+	                    style.top = "-1px";
+	                    style.borderTop = "none";
+	                    style.right = "-1px";
+	                    style.transform = "translate3d(0, " + -viewportRect.top + "px, 0)";
+	                    return style;
 	                case regions_2.RegionCardinality.FULL_ROWS:
 	                    style.right = "-1px";
 	                    style.transform = "translate3d(0, " + -viewportRect.top + "px, 0)";
@@ -63934,22 +64517,22 @@
 
 
 /***/ },
-/* 468 */
+/* 473 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
-	var index_1 = __webpack_require__(453);
-	var resizable_1 = __webpack_require__(469);
-	var resizeHandle_1 = __webpack_require__(462);
-	var selectable_1 = __webpack_require__(463);
-	var regions_1 = __webpack_require__(456);
-	var columnHeaderCell_1 = __webpack_require__(464);
+	var Classes = __webpack_require__(449);
+	var index_1 = __webpack_require__(458);
+	var resizable_1 = __webpack_require__(474);
+	var resizeHandle_1 = __webpack_require__(467);
+	var selectable_1 = __webpack_require__(468);
+	var regions_1 = __webpack_require__(461);
+	var columnHeaderCell_1 = __webpack_require__(469);
 	var ColumnHeader = (function (_super) {
 	    tslib_1.__extends(ColumnHeader, _super);
 	    function ColumnHeader() {
@@ -64037,16 +64620,16 @@
 
 
 /***/ },
-/* 469 */
+/* 474 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var index_1 = __webpack_require__(453);
-	var resizeHandle_1 = __webpack_require__(462);
+	var index_1 = __webpack_require__(458);
+	var resizeHandle_1 = __webpack_require__(467);
 	var Resizable = (function (_super) {
 	    tslib_1.__extends(Resizable, _super);
 	    function Resizable(props, context) {
@@ -64127,22 +64710,22 @@
 
 
 /***/ },
-/* 470 */
+/* 475 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
-	var roundSize_1 = __webpack_require__(458);
-	var resizable_1 = __webpack_require__(469);
-	var resizeHandle_1 = __webpack_require__(462);
-	var selectable_1 = __webpack_require__(463);
-	var regions_1 = __webpack_require__(456);
-	var rowHeaderCell_1 = __webpack_require__(465);
+	var Classes = __webpack_require__(449);
+	var roundSize_1 = __webpack_require__(463);
+	var resizable_1 = __webpack_require__(474);
+	var resizeHandle_1 = __webpack_require__(467);
+	var selectable_1 = __webpack_require__(468);
+	var regions_1 = __webpack_require__(461);
+	var rowHeaderCell_1 = __webpack_require__(470);
 	var RowHeader = (function (_super) {
 	    tslib_1.__extends(RowHeader, _super);
 	    function RowHeader() {
@@ -64222,12 +64805,12 @@
 
 
 /***/ },
-/* 471 */
+/* 476 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var ResizeSensor = (function () {
 	    function ResizeSensor() {
 	    }
@@ -64300,15 +64883,15 @@
 
 
 /***/ },
-/* 472 */
+/* 477 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var GuideLayer = (function (_super) {
 	    tslib_1.__extends(GuideLayer, _super);
 	    function GuideLayer() {
@@ -64343,16 +64926,16 @@
 
 
 /***/ },
-/* 473 */
+/* 478 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
-	var PureRender = __webpack_require__(440);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
+	var PureRender = __webpack_require__(445);
 	var React = __webpack_require__(9);
-	var Classes = __webpack_require__(444);
+	var Classes = __webpack_require__(449);
 	var RegionLayer = (function (_super) {
 	    tslib_1.__extends(RegionLayer, _super);
 	    function RegionLayer() {
@@ -64382,14 +64965,14 @@
 
 
 /***/ },
-/* 474 */
+/* 479 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var Classes = __webpack_require__(444);
-	var rect_1 = __webpack_require__(457);
-	var utils_1 = __webpack_require__(448);
+	var Classes = __webpack_require__(449);
+	var rect_1 = __webpack_require__(462);
+	var utils_1 = __webpack_require__(453);
 	var Locator = (function () {
 	    function Locator(tableElement, bodyElement, grid) {
 	        var _this = this;
@@ -64413,7 +64996,7 @@
 	    };
 	    Locator.prototype.getWidestVisibleCellInColumn = function (columnIndex) {
 	        var cellClasses = [
-	            "." + Classes.columnIndexClass(columnIndex),
+	            "." + Classes.columnCellIndexClass(columnIndex),
 	            "." + Classes.TABLE_COLUMN_NAME,
 	        ];
 	        var cells = this.tableElement.querySelectorAll(cellClasses.join(", "));
@@ -64465,22 +65048,22 @@
 
 
 /***/ },
-/* 475 */
+/* 480 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
-	var classNames = __webpack_require__(439);
+	var tslib_1 = __webpack_require__(440);
+	var classNames = __webpack_require__(444);
 	var React = __webpack_require__(9);
-	var cell_1 = __webpack_require__(438);
-	var Classes = __webpack_require__(444);
-	var contextMenuTargetWrapper_1 = __webpack_require__(476);
-	var rect_1 = __webpack_require__(457);
-	var utils_1 = __webpack_require__(448);
-	var menus_1 = __webpack_require__(459);
-	var selectable_1 = __webpack_require__(463);
-	var regions_1 = __webpack_require__(456);
+	var cell_1 = __webpack_require__(443);
+	var Classes = __webpack_require__(449);
+	var contextMenuTargetWrapper_1 = __webpack_require__(481);
+	var rect_1 = __webpack_require__(462);
+	var utils_1 = __webpack_require__(453);
+	var menus_1 = __webpack_require__(464);
+	var selectable_1 = __webpack_require__(468);
+	var regions_1 = __webpack_require__(461);
 	var UPDATE_PROPS_KEYS = [
 	    "grid",
 	    "locator",
@@ -64566,12 +65149,12 @@
 
 
 /***/ },
-/* 476 */
+/* 481 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var core_1 = __webpack_require__(2);
 	var React = __webpack_require__(9);
 	var ContextMenuTargetWrapper = (function (_super) {
@@ -64595,7 +65178,7 @@
 
 
 /***/ },
-/* 477 */
+/* 482 */
 /***/ function(module, exports) {
 
 	module.exports = [
@@ -64778,17 +65361,17 @@
 	];
 
 /***/ },
-/* 478 */
+/* 483 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
-	var bigSpaceRocks = __webpack_require__(477);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
+	var bigSpaceRocks = __webpack_require__(482);
 	var ColumnLoadingExample = (function (_super) {
 	    tslib_1.__extends(ColumnLoadingExample, _super);
 	    function ColumnLoadingExample() {
@@ -64843,15 +65426,15 @@
 
 
 /***/ },
-/* 479 */
+/* 484 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
 	var TableDollarExample = (function (_super) {
 	    tslib_1.__extends(TableDollarExample, _super);
 	    function TableDollarExample() {
@@ -64868,16 +65451,16 @@
 
 
 /***/ },
-/* 480 */
+/* 485 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
 	var TableEditableExample = (function (_super) {
 	    tslib_1.__extends(TableEditableExample, _super);
 	    function TableEditableExample() {
@@ -64969,15 +65552,15 @@
 
 
 /***/ },
-/* 481 */
+/* 486 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
 	var LOCAL_TIMEZONE_OFFSET_MSEC = new Date().getTimezoneOffset() * 60 * 1000;
 	var TIME_ZONES = [
 	    ["-12:00", -12.0, "Etc/GMT+12"],
@@ -65067,17 +65650,17 @@
 
 
 /***/ },
-/* 482 */
+/* 487 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
-	var bigSpaceRocks = __webpack_require__(477);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
+	var bigSpaceRocks = __webpack_require__(482);
 	var TableLoadingExample = (function (_super) {
 	    tslib_1.__extends(TableLoadingExample, _super);
 	    function TableLoadingExample() {
@@ -65138,17 +65721,17 @@
 
 
 /***/ },
-/* 483 */
+/* 488 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(435);
+	var tslib_1 = __webpack_require__(440);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var src_1 = __webpack_require__(436);
-	var sumo = __webpack_require__(484);
+	var baseExample_1 = __webpack_require__(267);
+	var src_1 = __webpack_require__(441);
+	var sumo = __webpack_require__(489);
 	var AbstractSortableColumn = (function () {
 	    function AbstractSortableColumn(name, index) {
 	        this.name = name;
@@ -65310,7 +65893,7 @@
 
 
 /***/ },
-/* 484 */
+/* 489 */
 /***/ function(module, exports) {
 
 	module.exports = [
@@ -66067,21 +66650,21 @@
 	];
 
 /***/ },
-/* 485 */
+/* 490 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
-	var classNames = __webpack_require__(256);
-	var PureRender = __webpack_require__(259);
+	var tslib_1 = __webpack_require__(261);
+	var classNames = __webpack_require__(259);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
 	var core_1 = __webpack_require__(2);
-	var theme_1 = __webpack_require__(486);
-	var navbar_1 = __webpack_require__(487);
-	var navigator_1 = __webpack_require__(488);
-	var navMenu_1 = __webpack_require__(495);
-	var section_1 = __webpack_require__(496);
+	var theme_1 = __webpack_require__(491);
+	var navbar_1 = __webpack_require__(492);
+	var navigator_1 = __webpack_require__(493);
+	var navMenu_1 = __webpack_require__(500);
+	var section_1 = __webpack_require__(501);
 	var DARK_THEME = "pt-dark";
 	var LIGHT_THEME = "";
 	var DEFAULT_PAGE = "overview";
@@ -66232,7 +66815,7 @@
 
 
 /***/ },
-/* 486 */
+/* 491 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -66249,15 +66832,15 @@
 
 
 /***/ },
-/* 487 */
+/* 492 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
+	var tslib_1 = __webpack_require__(261);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(256);
-	var PureRender = __webpack_require__(259);
+	var classNames = __webpack_require__(259);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
 	var Navbar = (function (_super) {
 	    tslib_1.__extends(Navbar, _super);
@@ -66321,20 +66904,20 @@
 
 
 /***/ },
-/* 488 */
+/* 493 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
+	var tslib_1 = __webpack_require__(261);
 	var core_1 = __webpack_require__(2);
-	var baseExample_1 = __webpack_require__(264);
-	var classNames = __webpack_require__(256);
-	var fuzzaldrin_plus_1 = __webpack_require__(489);
-	var PureRender = __webpack_require__(259);
+	var baseExample_1 = __webpack_require__(267);
+	var classNames = __webpack_require__(259);
+	var fuzzaldrin_plus_1 = __webpack_require__(494);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
 	var react_dom_1 = __webpack_require__(47);
-	var utils_1 = __webpack_require__(260);
+	var utils_1 = __webpack_require__(263);
 	var Navigator = (function (_super) {
 	    tslib_1.__extends(Navigator, _super);
 	    function Navigator() {
@@ -66448,21 +67031,21 @@
 
 
 /***/ },
-/* 489 */
+/* 494 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function() {
 	  var PathSeparator, filter, legacy_scorer, matcher, prepQueryCache, scorer;
 	
-	  scorer = __webpack_require__(490);
+	  scorer = __webpack_require__(495);
 	
-	  legacy_scorer = __webpack_require__(492);
+	  legacy_scorer = __webpack_require__(497);
 	
-	  filter = __webpack_require__(493);
+	  filter = __webpack_require__(498);
 	
-	  matcher = __webpack_require__(494);
+	  matcher = __webpack_require__(499);
 	
-	  PathSeparator = __webpack_require__(491).sep;
+	  PathSeparator = __webpack_require__(496).sep;
 	
 	  prepQueryCache = null;
 	
@@ -66537,13 +67120,13 @@
 
 
 /***/ },
-/* 490 */
+/* 495 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function() {
 	  var AcronymResult, PathSeparator, Query, basenameScore, coreChars, countDir, doScore, emptyAcronymResult, file_coeff, isMatch, isSeparator, isWordEnd, isWordStart, miss_coeff, opt_char_re, pos_bonus, scoreAcronyms, scoreCharacter, scoreConsecutives, scoreExact, scoreExactMatch, scorePattern, scorePosition, scoreSize, tau_depth, tau_size, truncatedUpperCase, wm;
 	
-	  PathSeparator = __webpack_require__(491).sep;
+	  PathSeparator = __webpack_require__(496).sep;
 	
 	  wm = 150;
 	
@@ -66930,7 +67513,7 @@
 
 
 /***/ },
-/* 491 */
+/* 496 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {// Copyright Joyent, Inc. and other Node contributors.
@@ -67161,13 +67744,13 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(44)))
 
 /***/ },
-/* 492 */
+/* 497 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function() {
 	  var PathSeparator, queryIsLastPathSegment;
 	
-	  PathSeparator = __webpack_require__(491).sep;
+	  PathSeparator = __webpack_require__(496).sep;
 	
 	  exports.basenameScore = function(string, query, score) {
 	    var base, depth, index, lastCharacter, segmentCount, slashCount;
@@ -67295,15 +67878,15 @@
 
 
 /***/ },
-/* 493 */
+/* 498 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function() {
 	  var PathSeparator, legacy_scorer, pluckCandidates, scorer, sortCandidates;
 	
-	  scorer = __webpack_require__(490);
+	  scorer = __webpack_require__(495);
 	
-	  legacy_scorer = __webpack_require__(492);
+	  legacy_scorer = __webpack_require__(497);
 	
 	  pluckCandidates = function(a) {
 	    return a.candidate;
@@ -67313,7 +67896,7 @@
 	    return b.score - a.score;
 	  };
 	
-	  PathSeparator = __webpack_require__(491).sep;
+	  PathSeparator = __webpack_require__(496).sep;
 	
 	  module.exports = function(candidates, query, _arg) {
 	    var allowErrors, bAllowErrors, bKey, candidate, coreQuery, key, legacy, maxInners, maxResults, prepQuery, queryHasSlashes, score, scoredCandidates, spotLeft, string, _i, _j, _len, _len1, _ref;
@@ -67374,15 +67957,15 @@
 
 
 /***/ },
-/* 494 */
+/* 499 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function() {
 	  var PathSeparator, scorer;
 	
-	  PathSeparator = __webpack_require__(491).sep;
+	  PathSeparator = __webpack_require__(496).sep;
 	
-	  scorer = __webpack_require__(490);
+	  scorer = __webpack_require__(495);
 	
 	  exports.basenameMatch = function(subject, subject_lw, prepQuery) {
 	    var basePos, depth, end;
@@ -67527,14 +68110,14 @@
 
 
 /***/ },
-/* 495 */
+/* 500 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
+	var tslib_1 = __webpack_require__(261);
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(256);
+	var classNames = __webpack_require__(259);
 	var React = __webpack_require__(9);
 	exports.NavMenuItem = function (props) {
 	    var classes = classNames("docs-menu-item", "depth-" + props.depth, props.className);
@@ -67564,18 +68147,18 @@
 
 
 /***/ },
-/* 496 */
+/* 501 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
-	var tslib_1 = __webpack_require__(258);
-	var classNames = __webpack_require__(256);
-	var PureRender = __webpack_require__(259);
+	var tslib_1 = __webpack_require__(261);
+	var classNames = __webpack_require__(259);
+	var PureRender = __webpack_require__(262);
 	var React = __webpack_require__(9);
-	var theme_1 = __webpack_require__(486);
-	var modifierTable_1 = __webpack_require__(497);
-	var propsTable_1 = __webpack_require__(498);
+	var theme_1 = __webpack_require__(491);
+	var modifierTable_1 = __webpack_require__(502);
+	var propsTable_1 = __webpack_require__(503);
 	var MODIFIER_PLACEHOLDER = /\{\{([\.\:]?)modifier\}\}/g;
 	var DEFAULT_MODIFIER = {
 	    description: "Default",
@@ -67689,7 +68272,7 @@
 
 
 /***/ },
-/* 497 */
+/* 502 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -67714,13 +68297,13 @@
 
 
 /***/ },
-/* 498 */
+/* 503 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var core_1 = __webpack_require__(2);
-	var classNames = __webpack_require__(256);
+	var classNames = __webpack_require__(259);
 	var React = __webpack_require__(9);
 	function dirtyMarkdown(text) {
 	    return { __html: text.replace("<", "&lt;")
@@ -67786,7 +68369,7 @@
 
 
 /***/ },
-/* 499 */
+/* 504 */
 /***/ function(module, exports) {
 
 	module.exports = [
@@ -69667,15 +70250,20 @@
 									"name": ":disabled",
 									"description": "Disabled",
 									"className": ".pseudo-class-disabled"
+								},
+								{
+									"name": ".pt-fill",
+									"description": "Take up full width of parent element",
+									"className": ".pt-fill"
 								}
 							],
 							"parameters": [],
-							"markup": "<label class=\"pt-file-upload\">\n  <input type=\"file\" {{:modifier}}/>\n  <span class=\"pt-file-upload-input\">Choose file...</span>\n</label>",
+							"markup": "<label class=\"pt-file-upload {{.modifier}}\">\n  <input type=\"file\" {{:modifier}}/>\n  <span class=\"pt-file-upload-input\">Choose file...</span>\n</label>",
 							"reference": "components.forms.fileupload",
 							"deprecated": false,
 							"experimental": false,
 							"depth": 3,
-							"highlightedMarkup": "<pre class=\"editor editor-colors\"><div class=\"line\"><span class=\"text html handlebars\"><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;</span></span><span class=\"entity name tag inline any html\"><span>label</span></span><span>&nbsp;</span><span class=\"entity other attribute-name html\"><span class=\"entity other attribute-name generic html\"><span>class</span></span><span class=\"punctuation separator key-value html\"><span>=</span></span></span><span class=\"string quoted double handlebars\"><span class=\"punctuation definition string begin html\"><span>&quot;</span></span><span>pt-file-upload</span><span class=\"punctuation definition string end html\"><span>&quot;</span></span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span></span></div><div class=\"line\"><span class=\"text html handlebars\"><span>&nbsp;&nbsp;</span><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;</span></span><span class=\"entity name tag inline any html\"><span>input</span></span><span>&nbsp;</span><span class=\"entity other attribute-name html\"><span class=\"entity other attribute-name generic html\"><span>type</span></span><span class=\"punctuation separator key-value html\"><span>=</span></span></span><span class=\"string quoted double handlebars\"><span class=\"punctuation definition string begin html\"><span>&quot;</span></span><span>file</span><span class=\"punctuation definition string end html\"><span>&quot;</span></span></span><span>&nbsp;</span><span class=\"meta function inline other handlebars\"><span class=\"support constant handlebars\"><span>{{</span></span><span>:modifier</span><span class=\"support constant handlebars\"><span>}}</span></span></span><span class=\"punctuation definition tag html\"><span>/&gt;</span></span></span></span></div><div class=\"line\"><span class=\"text html handlebars\"><span>&nbsp;&nbsp;</span><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;</span></span><span class=\"entity name tag inline any html\"><span>span</span></span><span>&nbsp;</span><span class=\"entity other attribute-name html\"><span class=\"entity other attribute-name generic html\"><span>class</span></span><span class=\"punctuation separator key-value html\"><span>=</span></span></span><span class=\"string quoted double handlebars\"><span class=\"punctuation definition string begin html\"><span>&quot;</span></span><span>pt-file-upload-input</span><span class=\"punctuation definition string end html\"><span>&quot;</span></span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span><span>Choose&nbsp;file...</span><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;/</span></span><span class=\"entity name tag inline any html\"><span>span</span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span></span></div><div class=\"line\"><span class=\"text html handlebars\"><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;/</span></span><span class=\"entity name tag inline any html\"><span>label</span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span></span></div></pre>",
+							"highlightedMarkup": "<pre class=\"editor editor-colors\"><div class=\"line\"><span class=\"text html handlebars\"><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;</span></span><span class=\"entity name tag inline any html\"><span>label</span></span><span>&nbsp;</span><span class=\"entity other attribute-name html\"><span class=\"entity other attribute-name generic html\"><span>class</span></span><span class=\"punctuation separator key-value html\"><span>=</span></span></span><span class=\"string quoted double handlebars\"><span class=\"punctuation definition string begin html\"><span>&quot;</span></span><span>pt-file-upload&nbsp;</span><span class=\"meta function inline other handlebars\"><span class=\"support constant handlebars\"><span>{{</span></span><span class=\"variable parameter handlebars\"><span>.modifier</span></span><span class=\"support constant handlebars\"><span>}}</span></span></span><span class=\"punctuation definition string end html\"><span>&quot;</span></span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span></span></div><div class=\"line\"><span class=\"text html handlebars\"><span>&nbsp;&nbsp;</span><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;</span></span><span class=\"entity name tag inline any html\"><span>input</span></span><span>&nbsp;</span><span class=\"entity other attribute-name html\"><span class=\"entity other attribute-name generic html\"><span>type</span></span><span class=\"punctuation separator key-value html\"><span>=</span></span></span><span class=\"string quoted double handlebars\"><span class=\"punctuation definition string begin html\"><span>&quot;</span></span><span>file</span><span class=\"punctuation definition string end html\"><span>&quot;</span></span></span><span>&nbsp;</span><span class=\"meta function inline other handlebars\"><span class=\"support constant handlebars\"><span>{{</span></span><span>:modifier</span><span class=\"support constant handlebars\"><span>}}</span></span></span><span class=\"punctuation definition tag html\"><span>/&gt;</span></span></span></span></div><div class=\"line\"><span class=\"text html handlebars\"><span>&nbsp;&nbsp;</span><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;</span></span><span class=\"entity name tag inline any html\"><span>span</span></span><span>&nbsp;</span><span class=\"entity other attribute-name html\"><span class=\"entity other attribute-name generic html\"><span>class</span></span><span class=\"punctuation separator key-value html\"><span>=</span></span></span><span class=\"string quoted double handlebars\"><span class=\"punctuation definition string begin html\"><span>&quot;</span></span><span>pt-file-upload-input</span><span class=\"punctuation definition string end html\"><span>&quot;</span></span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span><span>Choose&nbsp;file...</span><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;/</span></span><span class=\"entity name tag inline any html\"><span>span</span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span></span></div><div class=\"line\"><span class=\"text html handlebars\"><span class=\"meta tag inline any html\"><span class=\"punctuation definition tag html\"><span>&lt;/</span></span><span class=\"entity name tag inline any html\"><span>label</span></span><span class=\"punctuation definition tag html\"><span>&gt;</span></span></span></span></div></pre>",
 							"sections": []
 						},
 						{
@@ -69733,6 +70321,17 @@
 									"experimental": false,
 									"depth": 4,
 									"sections": [
+										{
+											"header": "Responsive numeric inputs",
+											"description": "<p><code>NumericInput</code> can be styled with the same set of CSS classes that modify\nregular <a href=\"#components.forms.input-group\">control groups</a>. The most appropriate\nsuch modifier for <code>NumericInput</code> is <code>pt-fill</code>, which when passed as a\n<code>className</code> will make the component expand to fill all available width.</p>\n",
+											"modifiers": [],
+											"parameters": [],
+											"reference": "components.forms.numeric-input.js.fill",
+											"deprecated": false,
+											"experimental": false,
+											"depth": 5,
+											"sections": []
+										},
 										{
 											"header": "Uncontrolled mode",
 											"description": "<p>By default, this component will function in uncontrolled mode, managing all of\nits own state. In uncontrolled mode, simply provide an <code>onValueChange</code> callback\nin the props to access the value as the user manipulates it. The value will be\nprovided to the callback both as a number and as a string.</p>\n<pre class=\"editor editor-colors\"><div class=\"line\"><span class=\"source tsx\"><span class=\"keyword other ts\"><span>import</span></span><span>&nbsp;{&nbsp;NumericInput&nbsp;}&nbsp;</span><span class=\"keyword other ts\"><span>from</span></span><span>&nbsp;</span><span class=\"es6import path string quoted\"><span>&quot;@blueprintjs/core&quot;</span></span><span>;</span></span></div><div class=\"line\"><span class=\"source tsx\"><span>&nbsp;</span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"storage type tsx\"><span>export</span></span><span>&nbsp;</span><span class=\"storage type tsx\"><span>class</span></span><span>&nbsp;</span><span class=\"meta object name tsx\"><span class=\"entity name class tsx\"><span>NumericInputExample</span></span></span><span>&nbsp;</span><span class=\"meta object heritage tsx\"><span class=\"keyword other tsx\"><span>extends</span></span><span>&nbsp;</span><span class=\"meta object heritage parent tsx\"><span class=\"support type tsx\"><span>React</span></span></span><span>.</span><span class=\"meta type parameters tsx\"><span class=\"entity name type tsx\"><span>Component</span></span><span class=\"meta brace angle tsx\"><span>&lt;</span></span><span class=\"meta object type tsx\"><span class=\"meta brace curly tsx\"><span>{</span><span>}</span></span></span><span>,&nbsp;</span><span class=\"meta object type tsx\"><span class=\"meta brace curly tsx\"><span>{</span><span>}</span></span></span><span>&gt;</span></span><span>&nbsp;</span></span><span class=\"meta object body tsx\"><span class=\"meta brace curly tsx\"><span>{</span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"meta method declaration tsx\"><span class=\"storage modifier tsx\"><span>public</span></span><span>&nbsp;</span><span class=\"entity name function tsx\"><span>render</span></span><span class=\"meta function type parameter tsx\"><span class=\"meta brace round tsx\"><span>(</span><span>)</span></span></span><span>&nbsp;</span><span class=\"meta decl block tsx\"><span class=\"meta brace curly tsx\"><span>{</span></span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta method declaration tsx\"><span class=\"meta decl block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"keyword control tsx\"><span>return</span></span><span>&nbsp;</span><span class=\"meta brace paren tsx\"><span>(</span></span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta method declaration tsx\"><span class=\"meta decl block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"tag open tsx\"><span class=\"punctuation definition tag begin tsx\"><span>&lt;</span></span><span class=\"entity name tag tsx\"><span>NumericInput</span></span><span class=\"meta tag attribute-name tsx\"><span>&nbsp;</span><span class=\"entity other attribute-name tsx\"><span>onValueChange</span></span></span><span class=\"keyword operator assignment tsx\"><span>=</span></span><span class=\"meta brace curly tsx\"><span class=\"punctuation definition brace curly start tsx\"><span>{</span></span><span class=\"constant language this tsx\"><span>this</span></span><span>.handleValueChange</span><span class=\"punctuation definition brace curly end tsx\"><span>}</span></span></span><span>&nbsp;</span><span class=\"punctuation definition tag end tsx\"><span>/&gt;</span></span></span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta method declaration tsx\"><span class=\"meta decl block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"meta brace paren tsx\"><span>)</span></span><span>;</span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta method declaration tsx\"><span class=\"meta decl block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"meta brace curly tsx\"><span>}</span></span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span>&nbsp;</span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"storage modifier tsx\"><span>private</span></span><span class=\"meta field declaration tsx\"><span>&nbsp;</span><span class=\"variable tsx\"><span>handleValueChange</span></span><span>&nbsp;</span><span class=\"keyword operator comparison tsx\"><span>=</span></span><span>&nbsp;</span><span class=\"meta brace paren tsx\"><span>(</span></span><span>valueAsNumber:&nbsp;</span><span class=\"meta type primitive tsx\"><span class=\"support type tsx\"><span>number</span></span></span><span>,&nbsp;valueAsString:&nbsp;</span><span class=\"meta type primitive tsx\"><span class=\"support type tsx\"><span>string</span></span></span><span class=\"meta brace paren tsx\"><span>)</span></span><span>&nbsp;</span><span class=\"keyword operator tsx\"><span>=&gt;</span></span><span>&nbsp;</span><span class=\"meta block tsx\"><span class=\"meta brace curly tsx\"><span>{</span></span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta field declaration tsx\"><span class=\"meta block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;console.log</span><span class=\"meta brace paren tsx\"><span>(</span></span><span class=\"string quoted double tsx\"><span>&quot;</span><span>Value&nbsp;as&nbsp;number:</span><span>&quot;</span></span><span>,&nbsp;valueAsNumber</span><span class=\"meta brace paren tsx\"><span>)</span></span><span>;</span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta field declaration tsx\"><span class=\"meta block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;console.log</span><span class=\"meta brace paren tsx\"><span>(</span></span><span class=\"string quoted double tsx\"><span>&quot;</span><span>Value&nbsp;as&nbsp;string:</span><span>&quot;</span></span><span>,&nbsp;valueAsString</span><span class=\"meta brace paren tsx\"><span>)</span></span><span>;</span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta field declaration tsx\"><span class=\"meta block tsx\"><span>&nbsp;&nbsp;&nbsp;&nbsp;</span><span class=\"meta brace curly tsx\"><span>}</span></span></span></span></span></span></span></div><div class=\"line\"><span class=\"source tsx\"><span class=\"meta declaration object tsx\"><span class=\"meta object body tsx\"><span class=\"meta brace curly tsx\"><span>}</span></span></span></span></span></div></pre>",
@@ -70170,7 +70769,7 @@
 								},
 								{
 									"header": "Sizing popovers",
-									"description": "<p>Popovers by default have a max-width but no max-height. To constrain the height of a popover\nand make its content scrollable, set the appropriate CSS rules on <code>.pt-popover-content</code>:</p>\n<pre class=\"editor editor-colors\"><div class=\"line\"><span class=\"source css less\"><span class=\"comment line double-slash less\"><span class=\"punctuation definition comment less\"><span>//</span></span><span>&nbsp;pass&nbsp;&quot;my-popover&quot;&nbsp;to&nbsp;`popoverClassName`&nbsp;prop.</span><span>&nbsp;</span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"entity other attribute-name class css\"><span class=\"punctuation definition entity css\"><span>.</span></span><span>my-popover</span></span><span>&nbsp;</span><span class=\"entity other attribute-name class css\"><span class=\"punctuation definition entity css\"><span>.</span></span><span>pt-popover-content</span></span><span>&nbsp;</span><span class=\"meta property-list css\"><span class=\"punctuation section property-list begin css\"><span>{</span></span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"meta property-list css\"><span>&nbsp;&nbsp;</span><span class=\"support type property-name css\"><span>max-height</span></span><span class=\"punctuation separator key-value css\"><span>:</span></span><span>&nbsp;</span><span class=\"meta property-value css\"><span>$</span><span class=\"entity name tag custom css\"><span>pt-grid-size</span></span><span>&nbsp;</span><span class=\"keyword operator less\"><span>*</span></span><span>&nbsp;</span><span class=\"constant numeric css\"><span>30</span></span></span><span class=\"punctuation terminator rule css\"><span>;</span></span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"meta property-list css\"><span>&nbsp;&nbsp;</span><span class=\"support type property-name css\"><span>overflow-y</span></span><span class=\"punctuation separator key-value css\"><span>:</span></span><span>&nbsp;</span><span class=\"meta property-value css\"><span class=\"support constant property-value css\"><span>auto</span></span></span><span class=\"punctuation terminator rule css\"><span>;</span></span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"meta property-list css\"><span class=\"punctuation section property-list end css\"><span>}</span></span></span></span></div></pre>",
+									"description": "<p>Popovers by default have a max-width but no max-height. To constrain the height of a popover\nand make its content scrollable, set the appropriate CSS rules on <code>.pt-popover-content</code>:</p>\n<pre class=\"editor editor-colors\"><div class=\"line\"><span class=\"source css less\"><span class=\"comment line double-slash less\"><span class=\"punctuation definition comment less\"><span>//</span></span><span>&nbsp;pass&nbsp;&quot;my-popover&quot;&nbsp;to&nbsp;`popoverClassName`&nbsp;prop.</span><span>&nbsp;</span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"entity other attribute-name class css\"><span class=\"punctuation definition entity css\"><span>.</span></span><span>my-popover</span></span><span>&nbsp;</span><span class=\"entity other attribute-name class css\"><span class=\"punctuation definition entity css\"><span>.</span></span><span>pt-popover-content</span></span><span>&nbsp;</span><span class=\"meta property-list css\"><span class=\"punctuation section property-list begin bracket curly css\"><span>{</span></span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"meta property-list css\"><span>&nbsp;&nbsp;</span><span class=\"support type property-name css\"><span>max-height</span></span><span class=\"punctuation separator key-value css\"><span>:</span></span><span>&nbsp;</span><span class=\"meta property-value css\"><span>$</span><span class=\"entity name tag custom css\"><span>pt-grid-size</span></span><span>&nbsp;</span><span class=\"keyword operator less\"><span>*</span></span><span>&nbsp;</span><span class=\"constant numeric css\"><span>30</span></span></span><span class=\"punctuation terminator rule css\"><span>;</span></span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"meta property-list css\"><span>&nbsp;&nbsp;</span><span class=\"support type property-name css\"><span>overflow-y</span></span><span class=\"punctuation separator key-value css\"><span>:</span></span><span>&nbsp;</span><span class=\"meta property-value css\"><span class=\"support constant property-value css\"><span>auto</span></span></span><span class=\"punctuation terminator rule css\"><span>;</span></span></span></span></div><div class=\"line\"><span class=\"source css less\"><span class=\"meta property-list css\"><span class=\"punctuation section property-list end bracket curly css\"><span>}</span></span></span></span></div></pre>",
 									"modifiers": [],
 									"parameters": [],
 									"reference": "components.popover.js.sizing",
@@ -70950,6 +71549,31 @@
 					]
 				},
 				{
+					"header": "Text",
+					"description": "<p>The <code>Text</code> component adds accessible overflow behavior to a line of text by\nconditionally adding the title attribute and truncating with an ellipsis when content overflows its container.</p>\n",
+					"modifiers": [],
+					"parameters": [],
+					"reference": "components.text",
+					"deprecated": false,
+					"experimental": false,
+					"depth": 2,
+					"sections": [
+						{
+							"header": "JavaScript API",
+							"description": "<p>The <code>Text</code> component is available in the <strong>@blueprintjs/core</strong> package.\nMake sure to review the <a href=\"#components.usage\">general usage docs for JS components</a>.</p>\n<p><code>Text</code> accepts and renders arbitrary children. It is intended that these children render as text.</p>\n\n\n",
+							"modifiers": [],
+							"parameters": [],
+							"reference": "components.text.js",
+							"deprecated": false,
+							"experimental": false,
+							"depth": 3,
+							"sections": [],
+							"interfaceName": "ITextProps",
+							"reactExample": "TextExample"
+						}
+					]
+				},
+				{
 					"header": "Toasts",
 					"description": "<p>A toast is a lightweight, ephemeral notice from an application in direct response to a user&#39;s action.</p>\n<p><code>Toast</code>s have a built-in timeout of five seconds. Users can also dismiss them manually by clicking the &times; button.\nHovering the cursor over a toast prevents it from disappearing. When the cursor leaves the toast, the toast&#39;s timeout restarts.\nSimilarly, focusing the toast (for example, by hitting the <kbd class=\"pt-key\">tab</kbd> key) halts the timeout, and\nblurring restarts the timeout.</p>\n<p>You can add one additional action button to a toast. You might use this to undo the user&#39;s action, for example.</p>\n<p>You can also apply the same visual intent styles to <code>Toast</code>s that you can to <a href=\"components.button.css\"><code>Button</code>s</a>.</p>\n<p>Toasts can be configured to appear at either the top or the bottom of an application window, and it is possible to\nhave more than one toast onscreen at a time.</p>\n\n",
 					"modifiers": [],
@@ -71179,34 +71803,34 @@
 	];
 
 /***/ },
-/* 500 */
+/* 505 */
 /***/ function(module, exports) {
 
 	module.exports = [
 		{
 			"name": "@blueprintjs/core",
-			"version": "1.11.1"
+			"version": "1.12.0"
 		},
 		{
 			"name": "@blueprintjs/datetime",
-			"version": "1.9.1"
+			"version": "1.10.0"
 		},
 		{
 			"name": "@blueprintjs/table",
-			"version": "1.8.1"
+			"version": "1.9.0"
 		}
 	];
 
 /***/ },
-/* 501 */
+/* 506 */
 /***/ function(module, exports) {
 
 	module.exports = [
-		"1.11.1"
+		"1.12.0"
 	];
 
 /***/ },
-/* 502 */
+/* 507 */
 /***/ function(module, exports) {
 
 	module.exports = [
@@ -73285,7 +73909,7 @@
 			"fileName": "packages/core/dist/common/index.d.ts",
 			"name": "Classes",
 			"tags": {},
-			"type": "typeof \"/Users/adi/dev/github/open-source/blueprint/packages/core/dist/common/classes\"",
+			"type": "typeof \"/Users/ggray/palantir/blueprint-public/packages/core/dist/common/classes\"",
 			"properties": [
 				{
 					"documentation": "",
@@ -74288,7 +74912,7 @@
 			"fileName": "packages/core/dist/common/index.d.ts",
 			"name": "Keys",
 			"tags": {},
-			"type": "typeof \"/Users/adi/dev/github/open-source/blueprint/packages/core/dist/common/keys\"",
+			"type": "typeof \"/Users/ggray/palantir/blueprint-public/packages/core/dist/common/keys\"",
 			"properties": [
 				{
 					"documentation": "",
@@ -74360,7 +74984,7 @@
 			"fileName": "packages/core/dist/common/index.d.ts",
 			"name": "Utils",
 			"tags": {},
-			"type": "typeof \"/Users/adi/dev/github/open-source/blueprint/packages/core/dist/common/utils\"",
+			"type": "typeof \"/Users/ggray/palantir/blueprint-public/packages/core/dist/common/utils\"",
 			"properties": [
 				{
 					"documentation": "<p>Returns whether <code>process.env.NODE_ENV</code> exists and equals <code>env</code>.</p>\n",
@@ -74405,11 +75029,18 @@
 					"type": "(a: number, b: number, tolerance?: number) => boolean"
 				},
 				{
-					"documentation": "",
+					"documentation": "<p>Clamps the given number between min and max values. Returns value if within range, or closest bound.</p>\n",
 					"fileName": "packages/core/dist/common/index.d.ts",
 					"name": "clamp",
 					"tags": {},
 					"type": "(val: number, min: number, max: number) => number"
+				},
+				{
+					"documentation": "<p>Returns the number of decimal places in the given number.</p>\n",
+					"fileName": "packages/core/dist/common/index.d.ts",
+					"name": "countDecimalPlaces",
+					"tags": {},
+					"type": "(num: number) => number"
 				},
 				{
 					"documentation": "<p>Throttle an event on an EventTarget by wrapping it in <code>requestAnimationFrame</code> call.\nReturns the event handler that was bound to given eventName so you can clean up after yourself.</p>\n",
@@ -74921,10 +75552,12 @@
 					"optional": true
 				},
 				{
-					"documentation": "<p>Constraints for the underlying Tether instance.\nSee <a href=\"http://tether.io/#constraints\">http://tether.io/#constraints</a>.</p>\n",
+					"documentation": "<p>Constraints for the underlying Tether instance.\nIf defined, this will overwrite <code>tetherOptions.constraints</code>.\nSee <a href=\"http://tether.io/#constraints\">http://tether.io/#constraints</a>.</p>\n",
 					"fileName": "packages/core/dist/components/popover/popover.d.ts",
 					"name": "constraints",
-					"tags": {},
+					"tags": {
+						"deprecated": "since v1.12.0; use `tetherOptions` instead."
+					},
 					"type": "ITetherConstraint[]",
 					"optional": true
 				},
@@ -75025,6 +75658,16 @@
 					"optional": true
 				},
 				{
+					"documentation": "<p>Whether the popover should open when its target is focused.\nIf <code>true</code>, target will render with <code>tabindex=&quot;0&quot;</code> to make it focusable via keyboard navigation.\nThis prop is only available when <code>interactionKind</code> is <code>HOVER</code> or <code>HOVER_TARGET_ONLY</code>.</p>\n",
+					"fileName": "packages/core/dist/components/popover/popover.d.ts",
+					"name": "openOnTargetFocus",
+					"tags": {
+						"default": ": true"
+					},
+					"type": "boolean",
+					"optional": true
+				},
+				{
 					"documentation": "<p>A space-delimited string of class names that are applied to the popover (but not the target).</p>\n",
 					"fileName": "packages/core/dist/components/popover/popover.d.ts",
 					"name": "popoverClassName",
@@ -75082,6 +75725,14 @@
 						"default": "\"span\""
 					},
 					"type": "string",
+					"optional": true
+				},
+				{
+					"documentation": "<p>Options for the underlying Tether instance.\nSee <a href=\"http://tether.io/#options\">http://tether.io/#options</a></p>\n",
+					"fileName": "packages/core/dist/components/popover/popover.d.ts",
+					"name": "tetherOptions",
+					"tags": {},
+					"type": "Partial<ITetherOptions>",
 					"optional": true
 				},
 				{
@@ -76086,7 +76737,7 @@
 			],
 			"properties": [
 				{
-					"documentation": "",
+					"documentation": "<p>An action that&#39;s attached to the non-ideal state.</p>\n",
 					"fileName": "packages/core/dist/components/non-ideal-state/nonIdealState.d.ts",
 					"name": "action",
 					"tags": {},
@@ -76115,6 +76766,28 @@
 					"name": "visual",
 					"tags": {},
 					"type": "string | Element",
+					"optional": true
+				}
+			]
+		},
+		{
+			"documentation": "",
+			"fileName": "packages/core/dist/components/text/text.d.ts",
+			"name": "ITextProps",
+			"tags": {},
+			"type": "interface",
+			"extends": [
+				"IProps"
+			],
+			"properties": [
+				{
+					"documentation": "<p>Indicates that this component should be truncated with an ellipsis if it overflows its container.\nThe <code>title</code> attribute will also be added when content overflows to show the full text of the children on hover.</p>\n",
+					"fileName": "packages/core/dist/components/text/text.d.ts",
+					"name": "ellipsize",
+					"tags": {
+						"default": "false"
+					},
+					"type": "boolean",
 					"optional": true
 				}
 			]
@@ -76184,7 +76857,9 @@
 					"documentation": "<p>Constraints for the underlying Tether instance.\nSee <a href=\"http://github.hubspot.com/tether/#constraints\">http://github.hubspot.com/tether/#constraints</a></p>\n",
 					"fileName": "packages/core/dist/components/tooltip/tooltip.d.ts",
 					"name": "constraints",
-					"tags": {},
+					"tags": {
+						"deprecated": "since v1.12.0; use `tetherOptions` instead."
+					},
 					"type": "ITetherConstraint[]",
 					"optional": true
 				},
@@ -76265,6 +76940,16 @@
 					"optional": true
 				},
 				{
+					"documentation": "<p>Whether the tooltip should open when its target is focused.\nIf <code>true</code>, target will render with <code>tabindex=&quot;0&quot;</code> to make it focusable via keyboard navigation.</p>\n",
+					"fileName": "packages/core/dist/components/tooltip/tooltip.d.ts",
+					"name": "openOnTargetFocus",
+					"tags": {
+						"default": ": true"
+					},
+					"type": "boolean",
+					"optional": true
+				},
+				{
 					"documentation": "<p>Space-delimited string of class names applied to the\nportal which holds the tooltip if <code>inline</code> is set to <code>false</code>.</p>\n",
 					"fileName": "packages/core/dist/components/tooltip/tooltip.d.ts",
 					"name": "portalClassName",
@@ -76290,6 +76975,14 @@
 						"default": "\"span\""
 					},
 					"type": "string",
+					"optional": true
+				},
+				{
+					"documentation": "<p>Options for the underlying Tether instance.\nSee <a href=\"http://tether.io/#options\">http://tether.io/#options</a></p>\n",
+					"fileName": "packages/core/dist/components/tooltip/tooltip.d.ts",
+					"name": "tetherOptions",
+					"tags": {},
+					"type": "Partial<ITetherOptions>",
 					"optional": true
 				},
 				{
@@ -76353,7 +77046,17 @@
 					"optional": true
 				},
 				{
-					"documentation": "<p>Increment between successive labels.</p>\n",
+					"documentation": "<p>Number of decimal places to use when rendering label value. Default value is the number of\ndecimals used in the <code>stepSize</code> prop. This prop has <em>no effect</em> if you supply a custom\n<code>renderLabel</code> callback.</p>\n",
+					"fileName": "packages/core/dist/components/slider/coreSlider.d.ts",
+					"name": "labelPrecision",
+					"tags": {
+						"default": "inferred from stepSize"
+					},
+					"type": "number",
+					"optional": true
+				},
+				{
+					"documentation": "<p>Increment between successive labels. Must be greater than zero.</p>\n",
 					"fileName": "packages/core/dist/components/slider/coreSlider.d.ts",
 					"name": "labelStepSize",
 					"tags": {
@@ -76383,7 +77086,7 @@
 					"optional": true
 				},
 				{
-					"documentation": "<p>Callback to render a single label. Useful for formatting numbers as currency or percentages.\nIf <code>true</code>, labels will use number value. If <code>false</code>, labels will not be shown.</p>\n",
+					"documentation": "<p>Callback to render a single label. Useful for formatting numbers as currency or percentages.\nIf <code>true</code>, labels will use number value formatted to <code>labelPrecision</code> decimal places.\nIf <code>false</code>, labels will not be shown.</p>\n",
 					"fileName": "packages/core/dist/components/slider/coreSlider.d.ts",
 					"name": "renderLabel",
 					"tags": {
@@ -76403,7 +77106,7 @@
 					"optional": true
 				},
 				{
-					"documentation": "<p>Increment between successive values; amount by which the handle moves.</p>\n",
+					"documentation": "<p>Increment between successive values; amount by which the handle moves. Must be greater than zero.</p>\n",
 					"fileName": "packages/core/dist/components/slider/coreSlider.d.ts",
 					"name": "stepSize",
 					"tags": {
@@ -77283,7 +77986,7 @@
 			"fileName": "packages/core/dist/components/index.d.ts",
 			"name": "ContextMenu",
 			"tags": {},
-			"type": "typeof \"/Users/adi/dev/github/open-source/blueprint/packages/core/dist/components/context-menu/co...",
+			"type": "typeof \"/Users/ggray/palantir/blueprint-public/packages/core/dist/components/context-menu/context...",
 			"properties": [
 				{
 					"documentation": "<p>Show the given menu element at the given offset from the top-left corner of the viewport.\nThe menu will appear below-right of this point and will flip to below-left if there is not enough\nroom onscreen. The optional callback will be invoked when this menu closes.</p>\n",
@@ -83703,7 +84406,7 @@
 			"fileName": "packages/datetime/dist/index.d.ts",
 			"name": "Classes",
 			"tags": {},
-			"type": "typeof \"/Users/adi/dev/github/open-source/blueprint/packages/datetime/dist/common/classes\"",
+			"type": "typeof \"/Users/ggray/palantir/blueprint-public/packages/datetime/dist/common/classes\"",
 			"properties": [
 				{
 					"documentation": "",
@@ -83964,6 +84667,16 @@
 					"name": "truncated",
 					"tags": {
 						"default": "true"
+					},
+					"type": "boolean",
+					"optional": true
+				},
+				{
+					"documentation": "<p>If <code>true</code>, the cell contents will be wrapped in a <code>div</code> with\nstyling that will cause text to wrap, rather than displaying it on a single line.</p>\n",
+					"fileName": "packages/table/dist/cell/cell.d.ts",
+					"name": "wrapText",
+					"tags": {
+						"default": "false"
 					},
 					"type": "boolean",
 					"optional": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprint",
-  "version": "1.10.0",
+  "version": "1.12.0",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Core styles & components",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -29,7 +29,9 @@ export interface ICoreSliderProps extends IProps {
     labelStepSize?: number;
 
     /**
-     * Number of decimal places to use when rendering label value.
+     * Number of decimal places to use when rendering label value. Default value is the number of
+     * decimals used in the `stepSize` prop. This prop has _no effect_ if you supply a custom
+     * `renderLabel` callback.
      * @default inferred from stepSize
      */
     labelPrecision?: number;

--- a/packages/core/test/text/textTests.tsx
+++ b/packages/core/test/text/textTests.tsx
@@ -16,7 +16,7 @@ describe("<Text>", () => {
         const textContent = "textContent";
         const className = "bp-test-class";
         const wrapper = mount(<Text className={className}>{textContent}</Text>);
-        let element = wrapper.find(`.${className}`);
+        const element = wrapper.find(`.${className}`);
         assert.lengthOf(element, 1, `expected to find 1 .${className}`);
         assert.strictEqual(element.text(), textContent, "content incorrect value");
     });
@@ -77,7 +77,7 @@ describe("<Text>", () => {
         it("doesn't truncate string children", () => {
             const textContent = "textContent";
             const wrapper = mount(<Text>{textContent}</Text>);
-            let element = wrapper.find(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
+            const element = wrapper.find(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
             assert.lengthOf(element, 0, `unexpected ${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
         });
     });

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/datetime",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Components for interacting with dates and times",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@blueprintjs/docs",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Blueprint Docs",
   "main": "dist/index.html",
   "private": true,
   "dependencies": {
-    "@blueprintjs/core": "^1.11.1",
-    "@blueprintjs/datetime": "^1.9.1",
-    "@blueprintjs/table": "^1.8.1",
+    "@blueprintjs/core": "^1.12.0",
+    "@blueprintjs/datetime": "^1.10.0",
+    "@blueprintjs/table": "^1.9.0",
     "chroma-js": "1.1.1",
     "classnames": "2.2.5",
     "dom4": "1.8.3",

--- a/packages/table/examples/tableFormatsExample.tsx
+++ b/packages/table/examples/tableFormatsExample.tsx
@@ -10,7 +10,6 @@ import * as React from "react";
 import BaseExample from "@blueprintjs/core/examples/common/baseExample";
 
 import { Cell, Column, JSONFormat, Table, TruncatedFormat } from "../src";
-import { TruncatedPopoverMode } from "../src/cell/formats/truncatedFormat";
 
 interface ITimezone {
     name: string;

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
:fireworks: **Highlights**: new `Text` component, tooltips can open on focus, `Table` select all, `Table` resize all selected rows/columns, `Cell` text wrapping!

:book: **Latest docs**: [blueprintjs.com/docs](http://blueprintjs.com/docs)

## @blueprintjs/core `1.12.0`
- 🌟  __NEW__ `Text` component conditionally adds the `title` attribute and truncates with an ellipsis when content overflows its container (:tophat: @ryanmcnamara) #765 
- 🌟  __NEW__ `Popover`/`Tooltip` `openOnTargetFocus` prop (default `true`) triggers the popover when its target is focused #734 
  - this prop is only available when `interactionKind` is `HOVER` or `HOVER_TARGET_ONLY`
- __NEW__ `Popover`/`Tooltip` `tetherOptions` prop exposes the remaining [Tether options](http://tether.io/#options) (:tophat: @Binck360) #750 #789 
  - this may allow you to resolve some issues with blurry popovers (see #394 for more info)
- __NEW__ `Slider`/`RangeSlider` `labelPrecision` prop determines decimal places for default label formatting #725 
  - default value of the prop is the number of decimals used in the `stepSize` prop
  - this new prop has _no effect_ if you supply a custom `renderLabel` callback
- __Fixed__ `Slider`/`RangeSlider` throw errors if given negative or zero for `stepSize` or `labelStepSize` #828 
- __Fixed__ `NumericInput` supports step sizes smaller than 0.1, and infers precision (decimal places) based on smallest step size #833 
- __Fixed__ `NumericInput` supports `.pt-fill` CSS modifier #792 
- __Fixed__ `.pt-file-upload` supports `.pt-fill` CSS modifier #751 
- 📠  __Deprecated__ `Popover`/`Tooltip` `constraints` prop in favor of new `tetherOptions` which has `constraints` property. #750  
    ```diff
    <Popover
    -   constraints={constraints}
    +   tetherOptions={{ constraints }}
    >...</Popover>
    ```

## @blueprintjs/datetime `1.10.0`
- __Fixed__ `DateRangePicker` calendar ordering when changing right calendar (:tophat: @chux0519) #785 
- __Fixed__ `DateRangePicker` popover does not reopen if mouse moved while it is closing #771
- __Fixed__ `DateRangePicker` display months do not update when selecting a shortcut with a range in a single month (:tophat: @omegdadi) #829 

## @blueprintjs/table `1.9.0`
- 🌟 __NEW__ "select all" styles and interactions: click in the upper-left corner or press <kbd>mod+a</kbd> #822 TODO MEDIA
- 🌟 __NEW__ resizing one row or column in a selection will resize all selected #802 
(Note that the entire row/column must be selected by clicking the header, not individual cells.)
![table-linked-resize](https://cloud.githubusercontent.com/assets/2463526/23679059/8f16a632-0354-11e7-9d4c-81d258841ab3.gif)
- 🌟 __NEW__ `Cell` `wrapText` prop (default `false`) allows text wrapping to multiple lines #809 
  - this prop, in conjunction with selection resizing (noted above), allows users to easily enlarge multiple rows for quick visual comparisons
- __Fixed__ `Column` auto-resizing behavior #783 

## Documentation
- 🏆  an _excellent_ pun from @ryanmcnamara #812 