### PR TITLE
[DM] React examples styles

### DIFF
--- a/packages/core/examples/common/baseExample.tsx
+++ b/packages/core/examples/common/baseExample.tsx
@@ -5,21 +5,27 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
+
+export interface IBaseExampleProps {
+    getTheme: () => string;
+    id: string;
+}
 
 /**
  * Starter class for all React example components.
  * Examples and options are rendered into separate containers.
  */
 @PureRender
-export default class BaseExample<S> extends React.Component<{ getTheme: () => string }, S> {
+export default class BaseExample<S> extends React.Component<IBaseExampleProps, S> {
     /** Define this prop to add a className to the example container */
     protected className: string;
 
     public render() {
         return (
-            <div className={this.className}>
+            <div className={classNames("kss-example", this.className)} data-example-id={this.props.id}>
                 <div className="docs-react-example">{this.renderExample()}</div>
                 <div className="docs-react-options">{this.actuallyRenderOptions()}</div>
             </div>

--- a/packages/core/examples/contextMenuExample.tsx
+++ b/packages/core/examples/contextMenuExample.tsx
@@ -52,15 +52,7 @@ class GraphNode extends React.Component<{}, { isContextMenuOpen: boolean }> {
  */
 @ContextMenuTarget
 export class ContextMenuExample extends BaseExample<{}> {
-    public renderExample() {
-        return (
-            <div className="docs-context-menu-example">
-                <div className="context-menu-application">
-                    <GraphNode />
-                </div>
-            </div>
-        );
-    }
+    public className = "docs-context-menu-example";
 
     public renderContextMenu(e: React.MouseEvent<HTMLElement>) {
         return <Menu>
@@ -80,7 +72,11 @@ export class ContextMenuExample extends BaseExample<{}> {
         </Menu>;
     }
 
+    public renderExample() {
+        return <GraphNode />;
+    }
+
     protected renderOptions() {
-        return <p>Right-click on node or background.</p>;
+        return <span>Right-click on node or background.</span>;
     }
 }

--- a/packages/core/examples/index.ts
+++ b/packages/core/examples/index.ts
@@ -5,6 +5,8 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+export * from "./common/baseExample";
+
 export * from "./alertExample";
 export * from "./buttonsExample";
 export * from "./collapseExample";

--- a/packages/core/examples/inputGroupExample.tsx
+++ b/packages/core/examples/inputGroupExample.tsx
@@ -81,8 +81,8 @@ export class InputGroupExample extends BaseExample<IInputGroupExampleState> {
         );
 
         return (
-            <div>
-                <div>
+            <div className="docs-input-group-example docs-flex-row">
+                <div className="docs-flex-column">
                     <InputGroup
                         className={largeClassName}
                         disabled={disabled}
@@ -100,7 +100,7 @@ export class InputGroupExample extends BaseExample<IInputGroupExampleState> {
                         type={showPassword ? "text" : "password"}
                     />
                 </div>
-                <div>
+                <div className="docs-flex-column">
                     <InputGroup
                         className={largeClassName}
                         disabled={disabled}

--- a/packages/docs/src/common/resolveExample.tsx
+++ b/packages/docs/src/common/resolveExample.tsx
@@ -14,9 +14,8 @@ import * as TableExamples from "@blueprintjs/table/examples";
 import { getTheme } from "./theme";
 
 // tslint:disable-next-line no-empty-interface
-export interface IExampleComponentClass extends React.ComponentClass<{
-    getTheme: () => string,
-}> {};
+export interface IExampleComponentClass extends React.ComponentClass<CoreExamples.IBaseExampleProps> {
+}
 
 // construct a map of package name to all examples defined in that package.
 // packageName must match directory name as it is used to generate sourceUrl.
@@ -50,14 +49,13 @@ const SRC_HREF_BASE = "https://github.com/palantir/blueprint/blob/master/package
 
 export interface IExampleProps {
     component: IExampleComponentClass;
+    name: string;
     sourceUrl: string;
 }
 
 const Example: React.SFC<IExampleProps> = (props) => (
     <div className="kss-example-wrapper">
-        <div className="kss-example">
-            {React.createElement(props.component, { getTheme })}
-        </div>
+        {React.createElement(props.component, { getTheme, id: props.name })}
         <a className="view-example-source" href={props.sourceUrl} target="_blank">
             <span className="pt-icon-standard pt-icon-code">&nbsp;</span>View source on GitHub
         </a>
@@ -82,6 +80,7 @@ export function resolveExample(exampleName: string, key: React.Key) {
     return <Example
         component={component}
         key={key}
+        name={exampleName}
         sourceUrl={[SRC_HREF_BASE, packageName, "examples", fileName].join("/")}
     />;
 }

--- a/packages/docs/src/components/page.tsx
+++ b/packages/docs/src/components/page.tsx
@@ -27,5 +27,5 @@ export const Page: React.SFC<IPageProps> = ({ tagRenderers, page }) => {
             return <h3><code>{ex.message}</code></h3>;
         }
     });
-    return <div className="docs-page">{pageContents}</div>;
+    return <div className="docs-page" data-page-id={page.reference}>{pageContents}</div>;
 };

--- a/packages/docs/src/styles/_examples.scss
+++ b/packages/docs/src/styles/_examples.scss
@@ -64,10 +64,6 @@ $options-margin: $pt-grid-size * 3;
   .pt-slider:not(:last-child) {
     margin-bottom: $options-margin;
   }
-
-  :not(.pt-control-group) > .pt-input-group + .pt-input-group {
-    margin-top: $pt-grid-size * 2;
-  }
 }
 
 .docs-card-example {
@@ -189,6 +185,20 @@ $options-margin: $pt-grid-size * 3;
 
     &.context-menu-open {
       box-shadow: $pt-elevation-shadow-2, 0 0 0 4px $orange4;
+    }
+  }
+}
+
+.docs-input-group-example {
+  .docs-flex-column {
+    margin-right: $options-margin;
+  }
+
+  .pt-input-group {
+    width: $pt-grid-size * 30;
+
+    &:first-child {
+      margin-bottom: $options-margin;
     }
   }
 }

--- a/packages/docs/src/styles/_examples.scss
+++ b/packages/docs/src/styles/_examples.scss
@@ -154,18 +154,20 @@ $options-margin: $pt-grid-size * 3;
   $icon-size: $pt-icon-size-standard * 2;
   $node-border-width: 4px;
 
-  height: $pt-grid-size * 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 
-  .context-menu-application {
-    @include position(absolute, 0);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  border-radius: $pt-border-radius;
+  background: $light-gray3;
+  padding: $options-margin;
+
+  .pt-dark & {
+    background: $dark-gray5;
   }
 
   .context-menu-node {
-    margin-bottom: $options-margin;
     border: $node-border-width solid $white;
     border-radius: 50%;
     box-shadow: $pt-elevation-shadow-2;

--- a/packages/docs/src/styles/_examples.scss
+++ b/packages/docs/src/styles/_examples.scss
@@ -144,6 +144,13 @@ $options-margin: $pt-grid-size * 3;
     $pt-transition-duration * 5,
     $before: "&"
   );
+
+  $overlay-example-width: $pt-grid-size * 40;
+
+  top: $overlay-example-width / 2;
+  left: calc(50% - #{$overlay-example-width / 2});
+  z-index: $pt-z-index-overlay + 1;
+  width: $overlay-example-width;
 }
 
 .docs-context-menu-example {
@@ -211,10 +218,6 @@ $options-margin: $pt-grid-size * 3;
 
 .pt-popover .docs-popover-example {
   padding: $pt-grid-size;
-}
-
-.slider-min-width {
-  min-width: 300px;
 }
 
 .docs-wiggle {

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -21,7 +21,7 @@
 
 // Generate a selector for a KSS example by reference
 @function reference($ref, $comparator: "=") {
-  @return '.kss-example-wrapper[data-reference#{$comparator}"#{$ref}"]';
+  @return "[data-reference#{$comparator}\"#{$ref}\"]";
 }
 
 // Generate a selector for KSS examples that match or are nested inside this reference.
@@ -31,7 +31,10 @@
   @return reference($ref), reference($ref + ".", "^=");
 }
 
-// stylelint-enable string-quotes
+// Generate a selector for a React example by name
+@function example($NameExample) {
+  @return "[data-example-id=\"#{$NameExample}\"]";
+}
 
 // Adjust the flex-basis of examples to fit X per row.
 // `.pt-fill` modifiers will always occupy an entire row.
@@ -48,7 +51,7 @@
   }
 }
 
-// Section-Specific Styles
+// CSS examples
 
 #{reference("pt-file-upload")},
 #{reference("pt-label")},
@@ -63,6 +66,7 @@
 #{reference("pt-button")},
 #{reference("pt-button.pt-minimal")},
 #{reference("pt-card")},
+#{reference("pt-input-group")},
 #{reference("pt-progress-bar")},
 #{reference("pt-spinner")},
 #{reference("pt-textarea")} {
@@ -77,7 +81,9 @@
   }
 }
 
-#{reference-all("pt-button")} {
+#{reference-all("pt-button")},
+#{example("AlertExample")},
+#{example("ToastExample")} {
   // put more space between buttons in all button sections
   .pt-button + .pt-button:not(.pt-fill) {
     margin-left: $pt-grid-size;
@@ -172,16 +178,9 @@
   }
 }
 
-
-
-#{section-name("Alerts")} {
-  .pt-button + .pt-button {
-    margin-left: $pt-grid-size;
-  }
-}
-
-#{section-name("Collapse")} {
-  .docs-react-example > div {
+// React examples
+#{example("CollapseExample")} {
+  .docs-react-example {
     height: $pt-grid-size * 18;
   }
 }
@@ -206,7 +205,7 @@
   }
 }
 
-#{section-id("components.datetime.daterangepicker")} {
+#{example("DateRangePickerExample")} {
   .docs-react-options-column {
     flex: 0 0 270px;
   }
@@ -221,13 +220,9 @@
   }
 }
 
-#{section-id("components.forms.numeric-input.extended-example")} {
-  .docs-react-example input {
-    width: $pt-grid-size * 23;
-  }
-}
+#{example("HotkeyPiano")} {
+  height: auto;
 
-#{section-id("components.hotkeys")} {
   .piano-example {
     opacity: 0.5;
   }
@@ -289,25 +284,20 @@
     opacity: 0.5;
   }
 
-  .hotkey-tester-example .pt-key-combo {
-    display: inline-block;
-  }
-
-  .kss-example {
-    height: auto;
-  }
 }
 
+#{example("HotkeyTester")} .pt-key-combo {
+  display: inline-block;
 }
 
-#{section-name("Toasts")} {
-  .pt-button + .pt-button {
-    margin-left: $pt-grid-size;
-    vertical-align: top;
+#{example("NumericInputExtendedExample")} {
+  .docs-react-example input {
+    width: $pt-grid-size * 23;
   }
 }
 
-#{section-name("Popovers")} {
+#{example("PopoverExample")} {
+  // wider lines for this example so labels wrap less
   .pt-label {
     width: $pt-grid-size * 21;
   }

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -185,26 +185,6 @@
   }
 }
 
-#{section-name("Context menus")} {
-  .kss-example-wrapper {
-    margin-bottom: $options-margin;
-    border-radius: $pt-border-radius;
-    background: $light-gray3;
-
-    .pt-dark & {
-      background: $dark-gray5;
-    }
-  }
-
-  .docs-react-options {
-    text-align: center;
-
-    > p {
-      width: 100%;
-    }
-  }
-}
-
 #{example("DateRangePickerExample")} {
   .docs-react-options-column {
     flex: 0 0 270px;

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -211,15 +211,6 @@
   }
 }
 
-#{section-id("components.forms.input-group.js")} {
-  // target the two children div examples
-  .docs-react-example > div > div {
-    display: inline-block;
-    margin-right: $options-margin;
-    width: $pt-grid-size * 25;
-  }
-}
-
 #{example("HotkeyPiano")} {
   height: auto;
 

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -298,13 +298,6 @@
   }
 }
 
-.docs-overlay-example-transition {
-  $overlay-example-width: $pt-grid-size * 40;
-
-  top: $overlay-example-width / 2;
-  left: calc(50% - #{$overlay-example-width / 2});
-  z-index: $pt-z-index-overlay + 1;
-  width: $overlay-example-width;
 }
 
 #{section-name("Toasts")} {

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -5,20 +5,6 @@
 
 @import "variables";
 
-// using single quotes to avoid escaping double quotes
-// stylelint-disable string-quotes
-
-// Generate a selector for a section by name.
-// Optional $comparator arg affects the selector comparator (default is "=")
-@function section-name($name, $comparator: "=") {
-  @return '[data-section-name#{$comparator}"#{$name}"]';
-}
-
-// Generate a selector for a section by ID.
-@function section-id($id, $comparator: "=") {
-  @return '[data-section-id#{$comparator}"#{$id}"]';
-}
-
 // Generate a selector for a KSS example by reference
 @function reference($ref, $comparator: "=") {
   @return "[data-reference#{$comparator}\"#{$ref}\"]";

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -298,14 +298,6 @@
   }
 }
 
-#{section-id("components.table-js")} {
-  .bp-table-container,
-  .docs-react-example {
-    width: 100%;
-    height: $pt-grid-size * 30;
-  }
-}
-
 .docs-overlay-example-transition {
   $overlay-example-width: $pt-grid-size * 40;
 
@@ -325,5 +317,14 @@
 #{section-name("Popovers")} {
   .pt-label {
     width: $pt-grid-size * 21;
+  }
+}
+
+// give all Table examples a fixed height
+[data-page-id="table-js"] {
+  .bp-table-container,
+  .docs-react-example {
+    width: 100%;
+    height: $pt-grid-size * 30;
   }
 }


### PR DESCRIPTION
#### Addresses #796

Definitely read the individual commits to follow the individual threads here.

- `BaseExample` exports its props interface so docs example renderer can reuse it.
- add more `data-` attributes and corresponding sass helper functions so we can target specific pages (`[data-page-id="table-js"]`) and react examples (`[data-example-id="ButtonsExample"]`).
- refactor some of the more involved examples so their custom styles are hopefully simpler. see `ContextMenuExample` and `InputGroupExample` commits.

@themadcreator this PR should fix the table examples.