### PR TITLE
[DM] only update scroll position when page changes

### DIFF
--- a/packages/docs/src/components/styleguide.tsx
+++ b/packages/docs/src/components/styleguide.tsx
@@ -146,7 +146,8 @@ export class Styleguide extends React.Component<IStyleguideProps, IStyleguideSta
     }
 
     public componentDidMount() {
-        this.maybeScrollActiveMenuItemIntoView(true);
+        this.scrollToActiveSection();
+        this.maybeScrollToActivePageMenuItem();
         this.props.onUpdate(this.state.activePageId);
         // whoa handling future history...
         window.addEventListener("hashchange", () => {
@@ -168,8 +169,13 @@ export class Styleguide extends React.Component<IStyleguideProps, IStyleguideSta
 
     public componentDidUpdate(_prevProps: IStyleguideProps, prevState: IStyleguideState) {
         const { activePageId, themeName } = this.state;
+
         // only scroll to heading when switching pages, but always check if nav item needs scrolling.
-        this.maybeScrollActiveMenuItemIntoView(prevState.activePageId !== activePageId);
+        if (prevState.activePageId !== activePageId) {
+            this.scrollToActiveSection();
+            this.maybeScrollToActivePageMenuItem();
+        }
+
         setHotkeysDialogProps({ className: themeName } as any as IHotkeysDialogProps);
         this.props.onUpdate(activePageId);
     }
@@ -203,20 +209,20 @@ export class Styleguide extends React.Component<IStyleguideProps, IStyleguideSta
         setTheme(themeName);
     }
 
-    private maybeScrollActiveMenuItemIntoView(alsoHeading: boolean) {
-        const { activeSectionId } = this.state;
-
-        if (alsoHeading) {
-            scrollToReference(activeSectionId, this.contentElement);
-        }
-
-        // only scroll nav menu if active item is not visible in viewport
-        const navMenuElement = queryHTMLElement(this.navElement, `a[href="#${activeSectionId}"]`);
+    private maybeScrollToActivePageMenuItem() {
+        const { activePageId } = this.state;
+        // only scroll nav menu if active item is not visible in viewport.
+        // using activePageId so you can see the page title in nav (may not be visible in document).
+        const navMenuElement = this.navElement.query(`a[href="#${activePageId}"]`);
         const innerBounds = navMenuElement.getBoundingClientRect();
         const outerBounds = this.navElement.getBoundingClientRect();
         if (innerBounds.top < outerBounds.top || innerBounds.bottom > outerBounds.bottom) {
             navMenuElement.scrollIntoView();
         }
+    }
+
+    private scrollToActiveSection() {
+        scrollToReference(this.state.activeSectionId, this.contentElement);
     }
 
     private shiftSection(direction: 1 | -1) {


### PR DESCRIPTION
#### Addresses #796

#### Changes proposed in this pull request:

- this solves the overscroll issue we had previously (cuz page doesn't change) while also ensuring that the active section is always visible when the page loads.
- sidebar scrolls the active _page_ into view so you can see the entire layout, rather than just the active section!

#### Screenshots

overscroll issue fixed! notice how the scrollspy still updates the active section when it's offscreen:
![overscroll](https://cloud.githubusercontent.com/assets/464822/23931588/f2d22ebc-08ef-11e7-9beb-02f93294e564.gif)

scroll the active _page_ into view so you can see the entire layout:
![scroll-to-active-page](https://cloud.githubusercontent.com/assets/464822/23931600/043c202c-08f0-11e7-9767-dab3ab95734d.gif)