### PR TITLE
[DM] update documentalist for syntax highlighting

### DIFF
--- a/gulp/util/text.js
+++ b/gulp/util/text.js
@@ -35,7 +35,7 @@ var renderer = new marked.Renderer();
 renderer.code = (textContent, language) => {
     // massage markdown language hint into TM language scope
     if (language === "html") {
-        language = "text.html.basic";
+        language = "text.html.handlebars";
     } else if (language != null && !/^source\./.test(language)) {
         language = `source.${language}`;
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "better-handlebars": "github:wmeldon/better-handlebars",
     "chai": "3.5.0",
     "del": "2.2.2",
-    "documentalist": "0.0.3",
+    "documentalist": "0.0.4",
     "enzyme": "2.6.0",
     "gulp": "3.9.1",
     "gulp-concat": "2.6.0",


### PR DESCRIPTION
[documentalist@0.0.4](https://github.com/palantir/documentalist/releases/tag/release-0.0.4) enables markdown rendering in the KSS plugin for documentation and markup code.

![image](https://cloud.githubusercontent.com/assets/464822/23974888/f6171816-099a-11e7-8383-75c8335fe251.png)
