### PR TITLE
[Table] Pass custom className to Table, Column, ColumnHeaderCell elements

### DIFF
--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -131,12 +131,12 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
     };
 
     public render() {
-        const { isActive, isColumnSelected, loading, resizeHandle, style } = this.props;
+        const { className, isActive, isColumnSelected, loading, resizeHandle, style } = this.props;
         const classes = classNames(Classes.TABLE_HEADER, {
             [Classes.TABLE_HEADER_ACTIVE]: isActive || this.state.isActive,
             [Classes.TABLE_HEADER_SELECTED]: isColumnSelected,
             [CoreClasses.LOADING]: loading,
-        }, this.props.className);
+        }, className);
 
         return (
             <div className={classes} style={style}>

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -136,7 +136,7 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
             [Classes.TABLE_HEADER_ACTIVE]: isActive || this.state.isActive,
             [Classes.TABLE_HEADER_SELECTED]: isColumnSelected,
             [CoreClasses.LOADING]: loading,
-        });
+        }, this.props.className);
 
         return (
             <div className={classes} style={style}>

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -372,7 +372,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const { isRowHeaderShown } = this.props;
         this.validateGrid();
         return (
-            <div className={Classes.TABLE_CONTAINER} ref={this.setRootTableRef} onScroll={this.handleRootScroll}>
+            <div
+                className={classNames(Classes.TABLE_CONTAINER, this.props.className)}
+                ref={this.setRootTableRef}
+                onScroll={this.handleRootScroll}
+            >
                  <div className={Classes.TABLE_TOP_CONTAINER}>
                     {isRowHeaderShown ? this.renderMenu() : undefined}
                     {this.renderColumnHeader()}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -369,11 +369,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     public render() {
-        const { isRowHeaderShown } = this.props;
+        const { className, isRowHeaderShown } = this.props;
         this.validateGrid();
         return (
             <div
-                className={classNames(Classes.TABLE_CONTAINER, this.props.className)}
+                className={classNames(Classes.TABLE_CONTAINER, className)}
                 ref={this.setRootTableRef}
                 onScroll={this.handleRootScroll}
             >

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -36,8 +36,7 @@ describe("<ColumnHeaderCell>", () => {
     it("renders with custom className if provided", () => {
         const CLASS_NAME = "my-custom-class-name";
         const table = harness.mount(<ColumnHeaderCell className={CLASS_NAME} />);
-        const containerNode = table.find(`.${Classes.TABLE_HEADER}`, 0).element;
-        const hasCustomClass = containerNode.classList.contains(CLASS_NAME);
+        const hasCustomClass = table.find(`.${Classes.TABLE_HEADER}`, 0).hasClass(CLASS_NAME);
         expect(hasCustomClass).to.be.true;
     });
 

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -33,6 +33,14 @@ describe("<ColumnHeaderCell>", () => {
         expect(text).to.equal("B");
     });
 
+    it("renders with custom className if provided", () => {
+        const CLASS_NAME = "my-custom-class-name";
+        const table = harness.mount(<ColumnHeaderCell className={CLASS_NAME} />);
+        const containerNode = table.find(`.${Classes.TABLE_HEADER}`, 0).element;
+        const hasCustomClass = containerNode.classList.contains(CLASS_NAME);
+        expect(hasCustomClass).to.be.true;
+    });
+
     describe("Custom renderer", () => {
         it("renders custom name", () => {
             const renderColumnHeader = (columnIndex: number) => {

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -84,4 +84,15 @@ describe("Column", () => {
         const col2cells = table.element.queryAll(`.${Classes.columnCellIndexClass(2)}`);
         col2cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL, false));
     });
+
+    it("passes custom class name to renderer", () => {
+        const CLASS_NAME = "my-custom-class-name";
+        const table = harness.mount(
+            <Table numRows={5}>
+                <Column className={CLASS_NAME} />
+            </Table>,
+        );
+        const columnNode = table.find(`.${Classes.TABLE_HEADER}`, 0).element;
+        expect(columnNode.classList.contains(CLASS_NAME)).to.be.true;
+    });
 });

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -92,7 +92,7 @@ describe("Column", () => {
                 <Column className={CLASS_NAME} />
             </Table>,
         );
-        const columnNode = table.find(`.${Classes.TABLE_HEADER}`, 0).element;
-        expect(columnNode.classList.contains(CLASS_NAME)).to.be.true;
+        const hasCustomClass = table.find(`.${Classes.TABLE_HEADER}`, 0).hasClass(CLASS_NAME);
+        expect(hasCustomClass).to.be.true;
     });
 });

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -60,6 +60,10 @@ export class ElementHarness {
         return new ElementHarness(this.findElement(query, nth));
     }
 
+    public hasClass(className: string) {
+        return this.element.classList.contains(className);
+    }
+
     public bounds() {
         return this.element.getBoundingClientRect();
     }

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -38,6 +38,20 @@ describe("<Table>", () => {
         expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 1).text()).to.equal("B");
     });
 
+    it("Adds custom className to table container", () => {
+        const CLASS_NAME = "my-custom-class-name";
+        const table = harness.mount(
+            <Table className={CLASS_NAME}>
+                <Column />
+                <Column />
+                <Column name="My Name" />
+            </Table>,
+        );
+        const containerNode = table.find(`.${Classes.TABLE_CONTAINER}`, 0).element;
+        const hasCustomClass = containerNode.classList.contains(CLASS_NAME);
+        expect(hasCustomClass).to.be.true;
+    });
+
     it("Renders without ghost cells", () => {
         const table = harness.mount(
             <Table>

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -47,8 +47,7 @@ describe("<Table>", () => {
                 <Column />
             </Table>,
         );
-        const containerNode = table.find(`.${Classes.TABLE_CONTAINER}`, 0).element;
-        const hasCustomClass = containerNode.classList.contains(CLASS_NAME);
+        const hasCustomClass = table.find(`.${Classes.TABLE_CONTAINER}`, 0).hasClass(CLASS_NAME);
         expect(hasCustomClass).to.be.true;
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -44,7 +44,7 @@ describe("<Table>", () => {
             <Table className={CLASS_NAME}>
                 <Column />
                 <Column />
-                <Column name="My Name" />
+                <Column />
             </Table>,
         );
         const containerNode = table.find(`.${Classes.TABLE_CONTAINER}`, 0).element;


### PR DESCRIPTION
#### Fixes #641, Fixes #690 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Pass through custom `className` for `Table`, `Column`, and `ColumnHeaderCell`
- Add unit tests for each

#### Reviewers should focus on:

- Does this scheme make sense?