### PR TITLE
[Table] Fix blurry table in dialog

### DIFF
--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -86,17 +86,7 @@ $pt-dark-intent-text-colors: (
   -moz-outline-radius: 6px;
 }
 
-@function border-shadow($alpha, $color: $black, $size: 1px) {
-  @return 0 0 0 $size rgba($color, $alpha);
-}
-
-// returns the padding necessary to center text in a container of the given height.
-// default line-height is that of base typography, 18px assuming 14px font-size.
-@function centered-text($height, $line-height: floor($pt-font-size * $pt-line-height)) {
-  @return floor(($height - $line-height) / 2);
-}
-
-@function force-hardware-acceleration() {
+@mixin force-hardware-acceleration() {
   // CSS animations are typically smoother when they run on the GPU. most browsers trigger GPU
   // ("hardware") acceleration automatically when certain CSS rules are applied (like `transform`).
   //
@@ -117,4 +107,14 @@ $pt-dark-intent-text-colors: (
   // see this post for more on will-change: https://dev.opera.com/articles/css-will-change-property/
   transform: translateZ(0);
   // will-change: transform;
+}
+
+@function border-shadow($alpha, $color: $black, $size: 1px) {
+  @return 0 0 0 $size rgba($color, $alpha);
+}
+
+// returns the padding necessary to center text in a container of the given height.
+// default line-height is that of base typography, 18px assuming 14px font-size.
+@function centered-text($height, $line-height: floor($pt-font-size * $pt-line-height)) {
+  @return floor(($height - $line-height) / 2);
 }

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -95,3 +95,26 @@ $pt-dark-intent-text-colors: (
 @function centered-text($height, $line-height: floor($pt-font-size * $pt-line-height)) {
   @return floor(($height - $line-height) / 2);
 }
+
+@function force-hardware-acceleration() {
+  // CSS animations are typically smoother when they run on the GPU. most browsers trigger GPU
+  // ("hardware") acceleration automatically when certain CSS rules are applied (like `transform`).
+  //
+  // the transform rule below has no visual effect, but it achieves the following:
+  //   - creates a new stacking context
+  //   - creates a new containing block for fixed-position descendants
+  //   - "tricks" the browser into using hardware acceleration
+  //
+  // `will-change: transform` does the same thing, but it suffers from a Chrome bug that could make
+  // the styled element blurry when transform'd (e.g. this happens when a Blueprint Table is in a
+  // Popover that animates open). we should move to `will-change` and delete this mixin once that
+  // bug is fixed (tracking in issue #859).
+  //
+  // see the following YouTube video and Chrome bug report for more:
+  //   - https://www.youtube.com/watch?v=iSvUlSpIbNk
+  //   - https://bugs.chromium.org/p/chromium/issues/detail?id=596382
+  //
+  // see this post for more on will-change: https://dev.opera.com/articles/css-will-change-property/
+  transform: translateZ(0);
+  // will-change: transform;
+}

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -3,7 +3,7 @@
 // of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
 // and https://github.com/palantir/blueprint/blob/master/PATENTS
 
-@import "../../core/src/common/_mixins";
+@import "../../core/src/common/mixins";
 @import "./common/loading";
 @import "./common/variables";
 @import "./cell/cell";

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -3,6 +3,7 @@
 // of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
 // and https://github.com/palantir/blueprint/blob/master/PATENTS
 
+@import "../../core/src/common/_mixins";
 @import "./common/loading";
 @import "./common/variables";
 @import "./cell/cell";
@@ -18,19 +19,9 @@ $row-z-index: $column-z-index + 1 !default;
 $menu-z-index: $row-z-index + 1 !default;
 
 .bp-table-container {
+  @include force-hardware-acceleration();
   display: flex;
   flex-direction: column;
-  // translateZ(0) has no visual effect, but it achieves the following:
-  //   - creates a new stacking context
-  //   - moves this element to a new layer to enable hardware-accelerated animation
-  //
-  // `will-change: transform` does the same thing, but it suffers from a Chrome bug that
-  // makes the Table blurry when transform'd (e.g. when the Table is in a Popover that
-  // animates open). we should move to `will-change` once that bug is fixed.
-  //
-  // further reading: https://dev.opera.com/articles/css-will-change-property/
-  transform: translateZ(0);
-  // will-change: transform;
   background-color: $table-background-color;
   max-width: 100%;
   height: 100%; // IE 11
@@ -134,10 +125,8 @@ $menu-z-index: $row-z-index + 1 !default;
 }
 
 .bp-table-body-scroll-client {
+  @include force-hardware-acceleration();
   position: relative;
-  // see the note above for the reasoning behind this translateZ rule.
-  transform: translateZ(0);
-  // will-change: transform;
   user-select: none;
 }
 

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -20,6 +20,17 @@ $menu-z-index: $row-z-index + 1 !default;
 .bp-table-container {
   display: flex;
   flex-direction: column;
+  // translateZ(0) has no visual effect, but it achieves the following:
+  //   - creates a new stacking context
+  //   - moves this element to a new layer to enable hardware-accelerated animation
+  //
+  // `will-change: transform` does the same thing, but it suffers from a Chrome bug that
+  // makes the Table blurry when transform'd (e.g. when the Table is in a Popover that
+  // animates open). we should move to `will-change` once that bug is fixed.
+  //
+  // further reading: https://dev.opera.com/articles/css-will-change-property/
+  transform: translateZ(0);
+  // will-change: transform;
   background-color: $table-background-color;
   max-width: 100%;
   height: 100%; // IE 11
@@ -124,6 +135,9 @@ $menu-z-index: $row-z-index + 1 !default;
 
 .bp-table-body-scroll-client {
   position: relative;
+  // see the note above for the reasoning behind this translateZ rule.
+  transform: translateZ(0);
+  // will-change: transform;
   user-select: none;
 }
 

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -26,7 +26,6 @@ $menu-z-index: $row-z-index + 1 !default;
   min-height: $pt-grid-size * 6; // For unit tests, we make sure at least one row is visible
   max-height: 100%;
   overflow: hidden;
-  will-change: transform; // Create stacking context to isolate z-indices
 
   .pt-dark & {
     background-color: $dark-table-background-color;
@@ -126,7 +125,6 @@ $menu-z-index: $row-z-index + 1 !default;
 .bp-table-body-scroll-client {
   position: relative;
   user-select: none;
-  will-change: transform; // isolate stacking context for interacive cells
 }
 
 .bp-table-body-virtual-client {


### PR DESCRIPTION
#### Fixes #742

#### Changes proposed in this pull request:

`Table`'s `will-change` rules are not playing nicely with `Popover`'s `transition` rules. Consequently, tables appear blurry in dialogs (see the YouTube video linked from #742 for a good illustration of the Chrome bug that's causing all of this).

This PR deletes these `will-change` rules in favor of old-fashioned `tranform: translateZ(0)` rules to remove the blurriness while keeping the hardware-accelerated benefits intact.

#### Reviewers should focus on:

I made a `TableDialogExample` locally to verify the changes (but didn't push it to the branch). See the screenshots below for the Before/After.

#### Screenshot

_Before:_
![screen shot 2017-03-16 at 12 30 01 pm](https://cloud.githubusercontent.com/assets/443450/24015204/fa1d6a28-0a44-11e7-929a-27d498661271.png)

_After:_
![screen shot 2017-03-16 at 12 30 14 pm](https://cloud.githubusercontent.com/assets/443450/24015208/0005c7b4-0a45-11e7-94eb-8c435ed5e6b4.png)
