### PR TITLE
[DateRangeInput] Make on-click behavior more intuitive

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -25,6 +25,7 @@ import {
     DateRange,
     DateRangeBoundary,
     fromDateRangeToMomentDateRange,
+    fromDateToMoment,
     fromMomentToDate,
     isMomentInRange,
     isMomentNull,
@@ -349,7 +350,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
-    private handleDateRangePickerHoverChange = (hoveredRange: DateRange) => {
+    private handleDateRangePickerHoverChange = (hoveredRange: DateRange, day: Date) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
         if (!this.state.isOpen) {
             return;
@@ -380,6 +381,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const [isStartDateSelected, isEndDateSelected] = [selectedStart, selectedEnd].map((d) => !isMomentNull(d));
 
         const isModifyingStartBoundary = boundaryToModify === DateRangeBoundary.START;
+        const isModifyingEndBoundary = !isModifyingStartBoundary;
+
+        const hoveredDay = fromDateToMoment(day);
 
         // pull the existing values from state; we may not overwrite them.
         let { isStartInputFocused, isEndInputFocused } = this.state;
@@ -396,7 +400,11 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     isEndInputFocused = false;
                 }
             } else if (isHoveredStartDefined) {
-                if (isModifyingStartBoundary) {
+                if (isModifyingStartBoundary && this.areSameDay(hoveredDay, selectedEnd)) {
+                    // we'd be deselecting the end date on click
+                    isStartInputFocused = false;
+                    isEndInputFocused = true;
+                } else if (isModifyingStartBoundary) {
                     // we'd be specifying a new start date and clearing the end date on click
                     isStartInputFocused = true;
                     isEndInputFocused = false;
@@ -406,14 +414,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                     isEndInputFocused = true;
                 }
             } else if (isHoveredEndDefined) {
-                if (isModifyingStartBoundary) {
+                if (isModifyingEndBoundary && this.areSameDay(hoveredDay, selectedStart)) {
                     // we'd be deselecting the start date on click
                     isStartInputFocused = true;
                     isEndInputFocused = false;
-                } else {
+                } else if (isModifyingEndBoundary) {
                     // we'd be specifying a new end date (clearing the start date) on click
                     isStartInputFocused = false;
                     isEndInputFocused = true;
+                } else {
+                    // we'd be deselecting the start date on click
+                    isStartInputFocused = true;
+                    isEndInputFocused = false;
                 }
             }
         } else if (isStartDateSelected) {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -447,6 +447,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 // we'd be converting the selected start date to an end date
                 isStartInputFocused = false;
                 isEndInputFocused = true;
+            } else {
+                // we'd be deselecting start date on click
+                isStartInputFocused = true;
+                isEndInputFocused = false;
             }
         } else if (isEndDateSelected) {
             if (isHoveredStartDefined && isHoveredEndDefined) {
@@ -467,6 +471,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 // we'd be converting the selected end date to a start date
                 isStartInputFocused = true;
                 isEndInputFocused = false;
+            } else {
+                // we'd be deselecting end date on click
+                isStartInputFocused = false;
+                isEndInputFocused = true;
             }
         }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -438,8 +438,10 @@ export class DateRangePicker
                 nextValue = this.createRangeForBoundary(nextBoundaryDate, null, boundary);
             } else if (boundaryDate == null && otherBoundaryDate != null) {
                 if (DateUtils.areSameDay(day, otherBoundaryDate)) {
-                    const nextOtherBoundaryDate = allowSingleDayRange ? otherBoundaryDate : null;
-                    nextValue = this.createRangeForBoundary(day, nextOtherBoundaryDate, boundary);
+                    const [nextBoundaryDate, nextOtherBoundaryDate] = (allowSingleDayRange)
+                        ? [otherBoundaryDate, otherBoundaryDate]
+                        : [null, null];
+                    nextValue = this.createRangeForBoundary(nextBoundaryDate, nextOtherBoundaryDate, boundary);
                 } else if (this.isDateOverlappingOtherBoundary(day, otherBoundaryDate, boundary)) {
                     nextValue = this.createRangeForBoundary(otherBoundaryDate, day, boundary);
                 } else {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -76,7 +76,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * When triggered from mouseenter, it will pass the date range that would result from next click.
      * When triggered from mouseleave, it will pass `undefined`.
      */
-    onHoverChange?: (hoveredDates: DateRange) => void;
+    onHoverChange?: (hoveredDates: DateRange, hoveredDay: Date) => void;
 
     /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
@@ -388,18 +388,18 @@ export class DateRangePicker
         }
         const nextHoverValue = this.getNextValue(this.state.value, day);
         this.setState({ hoverValue: nextHoverValue });
-        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
+        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue, day);
     }
 
     private handleDayMouseLeave =
-        (_e: React.SyntheticEvent<HTMLElement>, _day: Date, modifiers: IDatePickerDayModifiers) => {
+        (_e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
 
         if (modifiers.disabled) {
             return;
         }
         const nextHoverValue = undefined as DateRange;
         this.setState({ hoverValue: nextHoverValue });
-        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue);
+        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue, day);
     }
 
     private handleDayClick = (e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {
@@ -452,8 +452,10 @@ export class DateRangePicker
                     const nextOtherBoundaryDate = isSingleDayRangeSelected ? null : otherBoundaryDate;
                     nextValue = this.createRangeForBoundary(null, nextOtherBoundaryDate, boundary);
                 } else if (DateUtils.areSameDay(day, otherBoundaryDate)) {
+                    // special case: it's more intuitive to deselect the other boundary date than to
+                    // specify a new date for this boundary
                     const nextOtherBoundaryDate = (allowSingleDayRange) ? otherBoundaryDate : null;
-                    nextValue = this.createRangeForBoundary(day, nextOtherBoundaryDate, boundary);
+                    nextValue = this.createRangeForBoundary(boundaryDate, nextOtherBoundaryDate, boundary);
                 } else if (this.isDateOverlappingOtherBoundary(day, otherBoundaryDate, boundary)) {
                     nextValue = this.createRangeForBoundary(day, null, boundary);
                 } else {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -929,12 +929,12 @@ describe("<DateRangeInput>", () => {
                             dayElement.simulate("mouseenter");
                         });
 
-                        it("shows [null, <hoveredDate>] in input fields", () => {
-                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        it("shows [null, null] in input fields", () => {
+                            assertInputTextsEqual(root, "", "");
                         });
 
-                        it("keeps focus on end field", () => {
-                            assertEndInputFocused(root);
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
                         });
 
                         describe("on click", () => {
@@ -942,8 +942,8 @@ describe("<DateRangeInput>", () => {
                                 dayElement.simulate("click");
                             });
 
-                            it("sets selection to [null, <hoveredDate>] on click", () => {
-                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            it("sets selection to [null, null] on click", () => {
+                                assertInputTextsEqual(root, "", "");
                             });
 
                             it("leaves focus on start field", () => {
@@ -1078,12 +1078,12 @@ describe("<DateRangeInput>", () => {
                             dayElement.simulate("mouseenter");
                         });
 
-                        it("shows [<hoveredDate>, null] in input fields", () => {
-                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        it("shows [null, null] in input fields", () => {
+                            assertInputTextsEqual(root, "", "");
                         });
 
-                        it("keeps focus on start field", () => {
-                            assertStartInputFocused(root);
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
                         });
 
                         describe("on click", () => {
@@ -1091,12 +1091,12 @@ describe("<DateRangeInput>", () => {
                                 dayElement.simulate("click");
                             });
 
-                            it("sets selection to [<hoveredDate>, null] on click", () => {
-                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            it("sets selection to [null, null] on click", () => {
+                                assertInputTextsEqual(root, "", "");
                             });
 
-                            it("keeps focus on end field", () => {
-                                assertEndInputFocused(root);
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
                             });
                         });
 
@@ -1458,12 +1458,12 @@ describe("<DateRangeInput>", () => {
                             dayElement.simulate("mouseenter");
                         });
 
-                        it("shows [<hoveredDate>, null] in input fields", () => {
-                            assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                        it("shows [<startDate>, null] in input fields", () => {
+                            assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
                         });
 
-                        it("keeps focus on start field", () => {
-                            assertStartInputFocused(root);
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
                         });
 
                         describe("on click", () => {
@@ -1471,11 +1471,11 @@ describe("<DateRangeInput>", () => {
                                 dayElement.simulate("click");
                             });
 
-                            it("sets selection to [<hoveredDate>, null]", () => {
-                                assertInputTextsEqual(root, DATE_CONFIG.str, "");
+                            it("sets selection to [<startDate>, null]", () => {
+                                assertInputTextsEqual(root, SELECTED_RANGE[0].str, "");
                             });
 
-                            it("moves focus to end field", () => {
+                            it("keeps focus on end field", () => {
                                 assertEndInputFocused(root);
                             });
                         });
@@ -1489,7 +1489,7 @@ describe("<DateRangeInput>", () => {
                                 assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
                             });
 
-                            it("keeps focus on start field", () => {
+                            it("moves focus back to start field", () => {
                                 assertStartInputFocused(root);
                             });
                         });
@@ -1644,12 +1644,12 @@ describe("<DateRangeInput>", () => {
                             dayElement.simulate("mouseenter");
                         });
 
-                        it("shows [null, <hoveredDate>] in input fields", () => {
-                            assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                        it("shows [null, <endDate>] in input fields", () => {
+                            assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
                         });
 
-                        it("keeps focus on end field", () => {
-                            assertEndInputFocused(root);
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
                         });
 
                         describe("on click", () => {
@@ -1657,11 +1657,11 @@ describe("<DateRangeInput>", () => {
                                 dayElement.simulate("click");
                             });
 
-                            it("sets selection to [null, <hoveredDate>]", () => {
-                                assertInputTextsEqual(root, "", DATE_CONFIG.str);
+                            it("sets selection to [null, <endDate>]", () => {
+                                assertInputTextsEqual(root, "", SELECTED_RANGE[1].str);
                             });
 
-                            it("moves focus to start field", () => {
+                            it("keeps focus on start field", () => {
                                 assertStartInputFocused(root);
                             });
                         });
@@ -1675,7 +1675,7 @@ describe("<DateRangeInput>", () => {
                                 assertInputTextsEqual(root, SELECTED_RANGE[0].str, SELECTED_RANGE[1].str);
                             });
 
-                            it("keeps focus on end field", () => {
+                            it("moves focus back to end field", () => {
                                 assertEndInputFocused(root);
                             });
                         });
@@ -1998,8 +1998,9 @@ describe("<DateRangeInput>", () => {
             const value = [START_DATE, null] as DateRange;
 
             const { root, getDayElement } = wrap(<DateRangeInput value={value} onChange={onChange} />);
-            root.setState({ isOpen: true });
 
+            // popover opens on focus
+            getStartInput(root).simulate("focus");
             getDayElement(START_DAY).simulate("click");
 
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);


### PR DESCRIPTION
#### Addreses #805 (the first item)

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Before, we let the focused field dictate which end of the boundary the next click would specify.
Now, we simply mirror the behavior of the default `DateRangePicker`, moving focus as necessary to indicate which boundary the next click will modify.

In particular:

- If selection is `[<startDate>, null]` with `END` field focused:
    - _Before:_ Clicking on `<startDate>` sets selection to `[null, <startDate>]`
    - _After:_ Clicking on `<startDate>` sets selection to `[null, null]`
- If selection is `[null, <endDate>]` with `START` field focused:
    - _Before:_ Clicking on `<endDate>` sets selection to `[<endDate>, null]`
    - _After:_ Clicking on `<endDate>` sets selection to `[null, null]`
- If selection is `[<startDate>, <endDate>]` with `START` field focused:
    - _Before:_ Clicking on `<endDate>` sets selection to `[<endDate>, null]`
    - _After:_ Clicking on `<endDate>` sets selection to `[<startDate>, null]`
- If selection is `[<startDate>, <endDate>]` with `END` field focused:
    - _Before:_ Clicking on `<startDate>` sets selection to `[null, <startDate>]`
    - _After:_ Clicking on `<startDate>` sets selection to `[null, <endDate>]`

#### Reviewers should focus on:

- Does the new scheme make more sense?
- We now expose the `hoveredDay` as a second param in `onHoverChange`.
- I still want to split out the dater-range selection logic into a `Strategy` construct. Not for this PR though.

#### Screenshot

![2017-03-16 15 32 02](https://cloud.githubusercontent.com/assets/443450/24021630/16b4e5fc-0a5f-11e7-8f45-06aa974c283e.gif)
