### PR TITLE
[DateRangeInput] Bugfix: don't shift month view on day hover

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -26,6 +26,20 @@ export function areEqual(date1: Date, date2: Date) {
     }
 }
 
+export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange) {
+    if (dateRange1 == null && dateRange2 == null) {
+        return true;
+    } else if (dateRange1 == null || dateRange2 == null) {
+        return false;
+    } else {
+        const [start1, end1] = dateRange1;
+        const [start2, end2] = dateRange2;
+        const areStartsEqual = (start1 == null && start2 == null) || areSameDay(start1, start2);
+        const areEndsEqual = (end1 == null && end2 == null) || areSameDay(end1, end2);
+        return areStartsEqual && areEndsEqual;
+    }
+}
+
 export function areSameDay(date1: Date, date2: Date) {
     return date1 != null
         && date2 != null

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -279,9 +279,11 @@ export class DateRangePicker
     public componentWillReceiveProps(nextProps: IDateRangePickerProps) {
         super.componentWillReceiveProps(nextProps);
 
-        const nextState = getStateChange(this.props.value, nextProps.value, this.state,
-            nextProps.contiguousCalendarMonths);
-        this.setState(nextState);
+        if (!DateUtils.areRangesEqual(this.props.value, nextProps.value)) {
+            const nextState = getStateChange(this.props.value, nextProps.value, this.state,
+                nextProps.contiguousCalendarMonths);
+            this.setState(nextState);
+        }
     }
 
     protected validateProps(props: IDateRangePickerProps) {

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { expect } from "chai";
+
+import { DateRange } from "../../src/";
+import * as DateUtils from "../../src/common/dateUtils";
+import { Months } from "../../src/common/months";
+
+describe("dateUtils", () => {
+    describe("areRangesEqual", () => {
+        const DATE_1 = new Date(2017, Months.JANUARY, 1);
+        const DATE_2 = new Date(2017, Months.JANUARY, 2);
+        const DATE_3 = new Date(2017, Months.JANUARY, 3);
+        const DATE_4 = new Date(2017, Months.JANUARY, 4);
+
+        describe("returns true for", () => {
+            runTest("null and null", null, null, true);
+            runTest("[null, null] and [null, null]", [null, null], [null, null], true);
+            runTest("[DATE_1, DATE_2] and [DATE_1, DATE_2]", [DATE_1, DATE_2], [DATE_1, DATE_2], true);
+        });
+
+        describe("returns false for", () => {
+            runTest("null and [null, null]", null, [null, null], false);
+            runTest("[DATE_1, null] and [DATE_2, null]", [DATE_1, null], [DATE_2, null], false);
+            runTest("[DATE_1, null] and [null, null]", [DATE_1, null], [null, null], false);
+            runTest("[DATE_1, DATE_2] and [DATE_1, DATE_4]", [DATE_1, DATE_2], [DATE_1, DATE_4], false);
+            runTest("[DATE_1, DATE_4] and [DATE_2, DATE_4]", [DATE_1, DATE_4], [DATE_2, DATE_4], false);
+            runTest("[DATE_1, DATE_2] and [DATE_3, DATE_4]", [DATE_1, DATE_2], [DATE_3, DATE_4], false);
+        });
+
+        function runTest(description: string, dateRange1: DateRange, dateRange2: DateRange, expectedResult: boolean) {
+            it(description, () => {
+                expect(DateUtils.areRangesEqual(dateRange1, dateRange2)).to.equal(expectedResult);
+            });
+        }
+    });
+});

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -529,6 +529,25 @@ describe("<DateRangePicker>", () => {
                 assert.isNull(getHoveredRangeEndDayElement());
             });
         });
+
+        it("hovering on day in month prior to selected start date's month, should not shift calendar view", () => {
+            const INITIAL_MONTH = Months.MARCH;
+            const MONTH_OUT_OF_VIEW = Months.JANUARY;
+            renderDateRangePicker({ initialMonth: new Date(2017, INITIAL_MONTH, 1) });
+
+            clickDay(14);
+            clickDay(18);
+
+            TestUtils.Simulate.change(getMonthSelect(), { target: { value: MONTH_OUT_OF_VIEW } } as any);
+
+            // hover on left month
+            mouseEnterDay(14);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), MONTH_OUT_OF_VIEW);
+
+            // hover on right month
+            mouseEnterDay(14, false);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), MONTH_OUT_OF_VIEW);
+        });
     });
 
     describe("when controlled", () => {

--- a/packages/datetime/test/index.ts
+++ b/packages/datetime/test/index.ts
@@ -4,6 +4,7 @@
 
 import "../src";
 
+import "./common/dateUtilsTests";
 import "./dateInputTests";
 import "./datePickerCaptionTests";
 import "./datePickerTests";


### PR DESCRIPTION
#### Fixes #853 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add `areRangesEqual` in `dateUtils.tsx` plus unit tests
- Fix the bug and guarantee it with a unit test.

#### Reviewers should focus on:

- We should unit-test our utility functions.
- After these changes, the `DateRangePicker` will still shift if you finish selecting a range with a click in the RIGHT month (it shifts the right month to be the new LEFT month).

#### Screenshot

![2017-03-17 02 57 55](https://cloud.githubusercontent.com/assets/443450/24038199/9f534af8-0abd-11e7-8c01-72655a14fea0.gif)
