### PR TITLE
[DateRangeInput] Add selectAllOnFocus prop

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -16,6 +16,7 @@ export interface IDateRangeInputExampleState {
     closeOnSelection?: boolean;
     disabled?: boolean;
     format?: string;
+    selectAllOnFocus?: boolean;
 }
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
@@ -23,11 +24,13 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
         closeOnSelection: false,
         disabled: false,
         format: FORMATS[0],
+        selectAllOnFocus: false,
     };
 
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
+    private toggleSelectAllOnFocus = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
 
     protected renderExample() {
         return <DateRangeInput {...this.state} />;
@@ -47,6 +50,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     label="Disabled"
                     key="Disabled"
                     onChange={this.toggleDisabled}
+                />,
+                <Switch
+                    checked={this.state.selectAllOnFocus}
+                    label="Select all on focus"
+                    key="Select all on focus"
+                    onChange={this.toggleSelectAllOnFocus}
                 />,
             ], [
                 <FormatSelect

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -129,6 +129,54 @@ describe("<DateRangeInput>", () => {
         expect(root.state("isOpen")).to.be.false;
     });
 
+    describe("selectAllOnFocus", () => {
+
+        it("if false (the default), does not select any text on focus", () => {
+            const attachTo = document.createElement("div");
+            const { root } = wrap(<DateRangeInput defaultValue={[START_DATE, null]} />, attachTo);
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            const startInputNode = attachTo.querySelectorAll("input")[0] as HTMLInputElement;
+            expect(startInputNode.selectionStart).to.equal(startInputNode.selectionEnd);
+        });
+
+        // selectionStart/End works in Chrome but not Phantom. disabling to not fail builds.
+        it.skip("if true, selects all text on focus", () => {
+            const attachTo = document.createElement("div");
+            const { root } = wrap(
+                <DateRangeInput
+                    defaultValue={[START_DATE, null]}
+                    selectAllOnFocus={true}
+                />, attachTo);
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            const startInputNode = attachTo.querySelectorAll("input")[0] as HTMLInputElement;
+            expect(startInputNode.selectionStart).to.equal(0);
+            expect(startInputNode.selectionEnd).to.equal(START_STR.length);
+        });
+
+        it.skip("if true, selects all text on day mouseenter in calendar", () => {
+            const attachTo = document.createElement("div");
+            const { root, getDayElement } = wrap(
+                <DateRangeInput
+                    defaultValue={[START_DATE, null]}
+                    selectAllOnFocus={true}
+                />, attachTo);
+
+            root.setState({ isOpen: true });
+            // getDay is 0-indexed, but getDayElement is 1-indexed
+            getDayElement(START_DATE_2.getDay() + 1).simulate("mouseenter");
+
+            const startInputNode = attachTo.querySelectorAll("input")[0] as HTMLInputElement;
+            expect(startInputNode.selectionStart).to.equal(0);
+            expect(startInputNode.selectionEnd).to.equal(START_STR.length);
+        });
+    });
+
     describe("when uncontrolled", () => {
         it("Shows empty fields when defaultValue is [null, null]", () => {
             const { root } = wrap(<DateRangeInput defaultValue={[null, null]} />);
@@ -2113,8 +2161,8 @@ describe("<DateRangeInput>", () => {
         expect(actualEnd).to.equal(expectedEnd);
     }
 
-    function wrap(dateRangeInput: JSX.Element) {
-        const wrapper = mount(dateRangeInput);
+    function wrap(dateRangeInput: JSX.Element, attachTo?: HTMLElement) {
+        const wrapper = mount(dateRangeInput, { attachTo });
         return {
             getDayElement: (dayNumber = 1, fromLeftMonth = true) => {
                 const monthElement = wrapper.find(".DayPicker-Month").at(fromLeftMonth ? 0 : 1);


### PR DESCRIPTION
#### Addresses #805

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] ~Include tests~ (Phantom doesn't let you test `selectAllOnFocus`, see https://github.com/palantir/blueprint/blob/master/packages/core/test/editable-text/editableTextTests.tsx#L134)
- [x] Update documentation (prop automatically added to `IDateRangeInputProps` docs)

#### Changes proposed in this pull request:

Add `selectAllOnFocus` prop that, when `true`, selects the text in the field:
- On manual focus
- On day hover in the calendar

Also added a "Select all on focus" toggle to the `DateRangeInput` example. 

#### Reviewers should focus on:

Can't unit test this in Phantom, hence the lack of tests. :(

#### Screenshot

![2017-03-17 11 53 43](https://cloud.githubusercontent.com/assets/443450/24058487/745bdb80-0b08-11e7-96c6-1d1a568e291f.gif)