### PR TITLE
[Tabs2] fix NPEs with null children

### DIFF
--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -157,6 +157,7 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
     }
 
     private getInitialSelectedTabId() {
+        // NOTE: providing an unknown ID will hide the selection
         const { defaultSelectedTabId, selectedTabId } = this.props;
         if (selectedTabId !== undefined) {
             return selectedTabId;
@@ -164,8 +165,8 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
             return defaultSelectedTabId;
         } else {
             // select first tab in absence of user input
-            // NOTE: providing an unknown ID will hide the selection
-            return this.getTabChildren()[0].props.id;
+            const firstChild = this.getTabChildren()[0];
+            return firstChild === undefined ? undefined : firstChild.props.id;
         }
     }
 

--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -290,5 +290,5 @@ function isEventKeyCode(e: React.KeyboardEvent<HTMLElement>, ...codes: number[])
 }
 
 function isTab(child: React.ReactChild): child is TabElement {
-    return (child as JSX.Element).type === Tab2;
+    return child != null && (child as JSX.Element).type === Tab2;
 }

--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -165,8 +165,8 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
             return defaultSelectedTabId;
         } else {
             // select first tab in absence of user input
-            const firstChild = this.getTabChildren()[0];
-            return firstChild === undefined ? undefined : firstChild.props.id;
+            const tabs = this.getTabChildren();
+            return tabs.length === 0 ? undefined : tabs[0].props.id;
         }
     }
 

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -40,12 +40,24 @@ describe("<Tabs2>", () => {
     it("supports non-existent children", () => {
         assert.doesNotThrow(() => mount(
             <Tabs2 id={ID}>
+                {null}
                 <Tab2 id="one" />
                 {undefined}
-                {null}
                 <Tab2 id="two" />
             </Tabs2>,
         ));
+    });
+
+    it("default selectedTabId is first non-null Tab id", () => {
+        const wrapper = mount(
+            <Tabs2 id={ID}>
+                {null}
+                {<button id="btn" />}
+                {getTabsContents()}
+            </Tabs2>,
+        );
+        assert.lengthOf(wrapper.find(TAB), 3);
+        assert.strictEqual(wrapper.state("selectedTabId"), TAB_IDS[0]);
     });
 
     it("renders one TabTitle for each Tab", () => {

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -14,7 +14,7 @@ import * as Keys from "../../src/common/keys";
 import { Tab2 } from "../../src/components/tabs2/tab2";
 import { ITabs2Props, ITabs2State, Tabs2 } from "../../src/components/tabs2/tabs2";
 
-describe("<Tabs2>", () => {
+describe.only("<Tabs2>", () => {
     const ID = "tabsTests";
     // default tabs content is generated from these IDs in each test
     const TAB_IDS = ["first", "second", "third"];
@@ -32,6 +32,21 @@ describe("<Tabs2>", () => {
     });
 
     afterEach(() => testsContainerElement.remove());
+
+    it("gets by without children", () => {
+        assert.doesNotThrow(() => mount(<Tabs2 id="childless" />));
+    })
+
+    it("doesn't care where its kids are", () => {
+        assert.doesNotThrow(() => mount(
+            <Tabs2 id={ID}>
+                <Tab2 id="one" />
+                {undefined}
+                {null}
+                <Tab2 id="two" />
+            </Tabs2>,
+        ));
+    })
 
     it("renders one TabTitle for each Tab", () => {
         const wrapper = mount(<Tabs2 id={ID}>{getTabsContents()}</Tabs2>);

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -14,7 +14,7 @@ import * as Keys from "../../src/common/keys";
 import { Tab2 } from "../../src/components/tabs2/tab2";
 import { ITabs2Props, ITabs2State, Tabs2 } from "../../src/components/tabs2/tabs2";
 
-describe.only("<Tabs2>", () => {
+describe("<Tabs2>", () => {
     const ID = "tabsTests";
     // default tabs content is generated from these IDs in each test
     const TAB_IDS = ["first", "second", "third"];
@@ -35,9 +35,9 @@ describe.only("<Tabs2>", () => {
 
     it("gets by without children", () => {
         assert.doesNotThrow(() => mount(<Tabs2 id="childless" />));
-    })
+    });
 
-    it("doesn't care where its kids are", () => {
+    it("supports non-existent children", () => {
         assert.doesNotThrow(() => mount(
             <Tabs2 id={ID}>
                 <Tab2 id="one" />
@@ -46,7 +46,7 @@ describe.only("<Tabs2>", () => {
                 <Tab2 id="two" />
             </Tabs2>,
         ));
-    })
+    });
 
     it("renders one TabTitle for each Tab", () => {
         const wrapper = mount(<Tabs2 id={ID}>{getTabsContents()}</Tabs2>);
@@ -136,7 +136,7 @@ describe.only("<Tabs2>", () => {
         const tabList = wrapper.find(TAB_LIST);
         const tabElements = testsContainerElement.queryAll(TAB);
 
-        // must target different elements each time as onChange is only called when index changes
+        // must target different elements each time as onChange is only called when id changes
         tabList.simulate("keypress", { target: tabElements[1], which: Keys.ENTER });
         tabList.simulate("keypress", { target: tabElements[2], which: Keys.SPACE });
 
@@ -218,9 +218,9 @@ describe.only("<Tabs2>", () => {
             assert.strictEqual(tabs.state("selectedTabId"), SELECTED_TAB_ID);
         });
 
-        it("selects nothing if invalid index provided", () => {
+        it("selects nothing if invalid id provided", () => {
             const tabs = mount(
-                <Tabs2 id={ID} selectedTabId={"unknown"}>
+                <Tabs2 id={ID} selectedTabId="unknown">
                     {getTabsContents()}
                 </Tabs2>,
             );


### PR DESCRIPTION
#### Fixes #838, Fixes #841 

#### Changes proposed in this pull request:

basically, `isTab` first checks `!= null`.
new rule: type guards must first check existence.