### PR TITLE
[DateRangeInput] Add allowSingleDayRange prop

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -13,6 +13,7 @@ import { DateRangeInput } from "../src";
 import { FORMATS, FormatSelect } from "./common/formatSelect";
 
 export interface IDateRangeInputExampleState {
+    allowSingleDayRange?: boolean;
     closeOnSelection?: boolean;
     disabled?: boolean;
     format?: string;
@@ -21,6 +22,7 @@ export interface IDateRangeInputExampleState {
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
     public state: IDateRangeInputExampleState = {
+        allowSingleDayRange: false,
         closeOnSelection: false,
         disabled: false,
         format: FORMATS[0],
@@ -31,6 +33,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
     private toggleSelectAllOnFocus = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
+    private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
 
     protected renderExample() {
         return <DateRangeInput {...this.state} />;
@@ -39,6 +42,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     protected renderOptions() {
         return [
             [
+                <Switch
+                    checked={this.state.allowSingleDayRange}
+                    label="Allow single day range"
+                    key="Allow single day range"
+                    onChange={this.toggleSingleDay}
+                />,
                 <Switch
                     checked={this.state.closeOnSelection}
                     label="Close on selection"

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -68,12 +68,6 @@ export function clone(d: Date) {
     return new Date(d.getTime());
 }
 
-export function clearTime(date: Date) {
-    const day = new Date(date);
-    day.setHours(0, 0, 0, 0);
-    return day;
-}
-
 export function isDayInRange(date: Date, dateRange: DateRange, exclusive = false) {
     if (date == null) {
         return false;

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -68,6 +68,12 @@ export function clone(d: Date) {
     return new Date(d.getTime());
 }
 
+export function clearTime(date: Date) {
+    const day = new Date(date);
+    day.setHours(0, 0, 0, 0);
+    return day;
+}
+
 export function isDayInRange(date: Date, dateRange: DateRange, exclusive = false) {
     if (date == null) {
         return false;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -22,6 +22,7 @@ import {
 } from "@blueprintjs/core";
 
 import {
+    clearTime,
     DateRange,
     DateRangeBoundary,
     fromDateRangeToMomentDateRange,
@@ -749,8 +750,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 : undefined;
         });
         const selectedRange = this.props.allowSingleDayRange
-            ? [startDate, (startDate > endDate) ? null : endDate]
-            : [startDate, (startDate >= endDate) ? null : endDate];
+            ? [startDate, (clearTime(startDate) > clearTime(endDate)) ? null : endDate]
+            : [startDate, (clearTime(startDate) >= clearTime(endDate)) ? null : endDate];
         return selectedRange as DateRange;
     }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -456,10 +456,10 @@ export class DateRangePicker
                     const nextOtherBoundaryDate = isSingleDayRangeSelected ? null : otherBoundaryDate;
                     nextValue = this.createRangeForBoundary(null, nextOtherBoundaryDate, boundary);
                 } else if (DateUtils.areSameDay(day, otherBoundaryDate)) {
-                    // special case: it's more intuitive to deselect the other boundary date than to
-                    // specify a new date for this boundary
-                    const nextOtherBoundaryDate = (allowSingleDayRange) ? otherBoundaryDate : null;
-                    nextValue = this.createRangeForBoundary(boundaryDate, nextOtherBoundaryDate, boundary);
+                    const [nextBoundaryDate, nextOtherBoundaryDate] = (allowSingleDayRange)
+                        ? [otherBoundaryDate, otherBoundaryDate]
+                        : [boundaryDate, null];
+                    nextValue = this.createRangeForBoundary(nextBoundaryDate, nextOtherBoundaryDate, boundary);
                 } else if (this.isDateOverlappingOtherBoundary(day, otherBoundaryDate, boundary)) {
                     nextValue = this.createRangeForBoundary(day, null, boundary);
                 } else {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -183,16 +183,9 @@ describe("<DateRangeInput>", () => {
                 allowSingleDayRange={true}
                 defaultValue={[START_DATE, END_DATE]}
             />);
-
-            // edit the end boundary
             getEndInput(root).simulate("focus");
-
-            // deselect current end date
             getDayElement(END_DAY).simulate("click");
-
-            // click on same date as start date
             getDayElement(START_DAY).simulate("click");
-
             assertInputTextsEqual(root, START_STR, START_STR);
         });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -177,6 +177,36 @@ describe("<DateRangeInput>", () => {
         });
     });
 
+    describe("allowSingleDayRange", () => {
+        it("allows start and end to be the same day when clicking", () => {
+            const { root, getDayElement } = wrap(<DateRangeInput
+                allowSingleDayRange={true}
+                defaultValue={[START_DATE, END_DATE]}
+            />);
+
+            // edit the end boundary
+            getEndInput(root).simulate("focus");
+
+            // deselect current end date
+            getDayElement(END_DAY).simulate("click");
+
+            // click on same date as start date
+            getDayElement(START_DAY).simulate("click");
+
+            assertInputTextsEqual(root, START_STR, START_STR);
+        });
+
+        it("allows start and end to be the same day when typing", () => {
+            const { root } = wrap(<DateRangeInput
+                allowSingleDayRange={true}
+                defaultValue={[START_DATE, END_DATE]}
+            />);
+            changeEndInputText(root, "");
+            changeEndInputText(root, START_STR);
+            assertInputTextsEqual(root, START_STR, START_STR);
+        });
+    });
+
     describe("when uncontrolled", () => {
         it("Shows empty fields when defaultValue is [null, null]", () => {
             const { root } = wrap(<DateRangeInput defaultValue={[null, null]} />);

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -159,7 +159,8 @@
   }
 }
 
-#{section-id("components.datetime.daterangepicker")} {
+#{section-id("components.datetime.daterangepicker")},
+#{section-id("components.datetime.daterangeinput")} {
   .docs-react-options-column {
     flex: 0 0 270px;
   }


### PR DESCRIPTION
#### Addresses #805

#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Add `allowSingleDayRange` prop to `DateRangeInput`
- Add unit tests
- Add toggle to example

#### Reviewers should focus on
 
- Tricky date comparison logic that needs to ignore hours/minutes/seconds/millis.
- Modified overlapping-dates logic.

#### Screenshot

![2017-03-17 16 16 38](https://cloud.githubusercontent.com/assets/443450/24066127/31c7aac2-0b2d-11e7-9482-51e4f27fc42f.gif)
