### PR TITLE
[Tabs] .pt-large .pt-tab uses simple nesting

### DIFF
--- a/packages/core/examples/tabs2Example.tsx
+++ b/packages/core/examples/tabs2Example.tsx
@@ -42,6 +42,7 @@ export class Tabs2Example extends BaseExample<ITabs2ExampleState> {
                         {/* controlled mode & no panels (see h1 below): */}
                         <Tabs2
                             animate={this.state.animate}
+                            className={Classes.LARGE}
                             id="navbar"
                             onChange={this.handleNavbarTabChange}
                             selectedTabId={this.state.navbarTabId}

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -256,7 +256,6 @@ $tab-indicator-width: 3px !default;
     -moz-outline-radius: 0;
   }
 
-  &.pt-large,
   .pt-large & {
     line-height: $pt-button-height-large;
     font-size: $pt-font-size-large;

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -212,11 +212,6 @@ $tab-indicator-width: 3px !default;
   padding: 0;
   list-style: none;
 
-  &.pt-large .pt-tab {
-    line-height: $pt-button-height-large;
-    font-size: $pt-font-size-large;
-  }
-
   // this is fine.
   // stylelint-disable-next-line selector-no-universal
   > *:not(:last-child) {
@@ -238,9 +233,8 @@ $tab-indicator-width: 3px !default;
   .pt-tab-indicator-wrapper ~ & {
     // the bottom border is only for static markup, therefore
     // we never want a bottom border if there's a tab indicator
-    // stylelint-disable declaration-no-important
+    // stylelint-disable-next-line declaration-no-important
     box-shadow: none !important;
-    // stylelint-enable declaration-no-important
   }
 
   &[aria-disabled="true"] {
@@ -260,6 +254,12 @@ $tab-indicator-width: 3px !default;
 
   &:focus {
     -moz-outline-radius: 0;
+  }
+
+  &.pt-large,
+  .pt-large & {
+    line-height: $pt-button-height-large;
+    font-size: $pt-font-size-large;
   }
 }
 


### PR DESCRIPTION
#### Fixes #799 

#### Changes proposed in this pull request:

- minor change to Tabs CSS API: `.pt-large` modifier can be applied to _any ancestor_ of `.pt-tab`, not just the `.pt-tab-list`: `.pt-large .pt-tab`
- so `<Tabs className={Classes.LARGE}>` will give you nice large tabs

#### Reviewers should focus on:

- an alternative approach to this fix is to add `tabListClassName` prop. is that preferable? might that be desirable anyway, even with this change?