### PR TITLE
[DateInput] Delete calendar icon, add optional rightElement prop

### DIFF
--- a/packages/datetime/examples/dateInputExample.tsx
+++ b/packages/datetime/examples/dateInputExample.tsx
@@ -17,7 +17,6 @@ export interface IDateInputExampleState {
     disabled?: boolean;
     format?: string;
     openOnFocus?: boolean;
-    showIcon?: boolean;
 }
 
 export class DateInputExample extends BaseExample<IDateInputExampleState> {
@@ -26,13 +25,11 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
         disabled: false,
         format: FORMATS[0],
         openOnFocus: true,
-        showIcon: true,
     };
 
     private toggleFocus = handleBooleanChange((openOnFocus) => this.setState({ openOnFocus }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
-    private toggleShowIcon = handleBooleanChange((showIcon) => this.setState({ showIcon }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
 
     protected renderExample() {
@@ -55,12 +52,6 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     label="Close on selection"
                     key="Selection"
                     onChange={this.toggleSelection}
-                />,
-                <Switch
-                    checked={this.state.showIcon}
-                    label="Show icon"
-                    key="Show icon"
-                    onChange={this.toggleShowIcon}
                 />,
                 <Switch
                     checked={this.state.disabled}

--- a/packages/datetime/examples/dateInputExample.tsx
+++ b/packages/datetime/examples/dateInputExample.tsx
@@ -17,6 +17,7 @@ export interface IDateInputExampleState {
     disabled?: boolean;
     format?: string;
     openOnFocus?: boolean;
+    showIcon?: boolean;
 }
 
 export class DateInputExample extends BaseExample<IDateInputExampleState> {
@@ -25,11 +26,13 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
         disabled: false,
         format: FORMATS[0],
         openOnFocus: true,
+        showIcon: true,
     };
 
     private toggleFocus = handleBooleanChange((openOnFocus) => this.setState({ openOnFocus }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
+    private toggleShowIcon = handleBooleanChange((showIcon) => this.setState({ showIcon }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
 
     protected renderExample() {
@@ -52,6 +55,12 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     label="Close on selection"
                     key="Selection"
                     onChange={this.toggleSelection}
+                />,
+                <Switch
+                    checked={this.state.showIcon}
+                    label="Show icon"
+                    key="Show icon"
+                    onChange={this.toggleShowIcon}
                 />,
                 <Switch
                     checked={this.state.disabled}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -105,6 +105,12 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverPosition?: Position;
 
     /**
+     * Whether to show the calendar icon.
+     * @default true
+     */
+    showIcon?: boolean;
+
+    /**
      * The currently selected day. If this prop is provided, the component acts in a controlled manner.
      * To display no date in the input field, pass `null` to the value prop. To display an invalid date error
      * in the input field, pass `new Date(undefined)` to the value prop.
@@ -130,6 +136,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
         popoverPosition: Position.BOTTOM,
+        showIcon: true,
     };
 
     public displayName = "Blueprint.DateInput";
@@ -167,16 +174,6 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             "pt-intent-danger": !(this.isMomentValidAndInRange(date) || isMomentNull(date) || dateString === ""),
         });
 
-        const calendarIcon = (
-            <Button
-                className={Classes.MINIMAL}
-                disabled={this.props.disabled}
-                iconName="calendar"
-                intent={Intent.PRIMARY}
-                onClick={this.handleIconClick}
-            />
-        );
-
         return (
             <Popover
                 autoFocus={false}
@@ -198,7 +195,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                     onClick={this.handleInputClick}
                     onFocus={this.handleInputFocus}
                     placeholder={this.props.format}
-                    rightElement={calendarIcon}
+                    rightElement={this.maybeRenderCalendarIcon()}
                     value={dateString}
                 />
             </Popover>
@@ -211,6 +208,18 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         }
 
         super.componentWillReceiveProps(nextProps);
+    }
+
+    private maybeRenderCalendarIcon = () => {
+        return !this.props.showIcon ? undefined : (
+            <Button
+                className={Classes.MINIMAL}
+                disabled={this.props.disabled}
+                iconName="calendar"
+                intent={Intent.PRIMARY}
+                onClick={this.handleIconClick}
+            />
+        );
     }
 
     private getDateString = (value: moment.Moment) => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -244,20 +244,6 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         Utils.safeInvoke(this.props.onChange, date === null ? null : fromMomentToDate(momentDate));
     }
 
-    private handleIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
-        if (this.state.isOpen) {
-            if (this.inputRef != null) {
-                this.inputRef.blur();
-            }
-        } else {
-            this.setState({ isOpen: true });
-            e.stopPropagation();
-            if (this.inputRef != null) {
-                this.inputRef.focus();
-            }
-        }
-    }
-
     private handleInputFocus = () => {
         const valueString = isMomentNull(this.state.value) ? "" : this.state.value.format(this.props.format);
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -11,10 +11,7 @@ import * as React from "react";
 
 import {
     AbstractComponent,
-    Button,
-    Classes,
     InputGroup,
-    Intent,
     IProps,
     Popover,
     Position,

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -105,10 +105,9 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverPosition?: Position;
 
     /**
-     * Whether to show the calendar icon.
-     * @default true
+     * Element to render on right side of input.
      */
-    showIcon?: boolean;
+    rightElement?: JSX.Element;
 
     /**
      * The currently selected day. If this prop is provided, the component acts in a controlled manner.
@@ -136,7 +135,6 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
         popoverPosition: Position.BOTTOM,
-        showIcon: true,
     };
 
     public displayName = "Blueprint.DateInput";
@@ -195,7 +193,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                     onClick={this.handleInputClick}
                     onFocus={this.handleInputFocus}
                     placeholder={this.props.format}
-                    rightElement={this.maybeRenderCalendarIcon()}
+                    rightElement={this.props.rightElement}
                     value={dateString}
                 />
             </Popover>
@@ -208,18 +206,6 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         }
 
         super.componentWillReceiveProps(nextProps);
-    }
-
-    private maybeRenderCalendarIcon = () => {
-        return !this.props.showIcon ? undefined : (
-            <Button
-                className={Classes.MINIMAL}
-                disabled={this.props.disabled}
-                iconName="calendar"
-                intent={Intent.PRIMARY}
-                onClick={this.handleIconClick}
-            />
-        );
     }
 
     private getDateString = (value: moment.Moment) => {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -56,6 +56,12 @@ describe("<DateInput>", () => {
         assert.isFalse(wrapper.find(Popover).prop("isOpen"));
     });
 
+    it("Calendar icon doesn't show if showIcon=false", () => {
+        const wrapper = mount(<DateInput showIcon={false} />);
+        const calendarIcon = wrapper.find(".pt-input-action");
+        assert.isTrue(calendarIcon.isEmpty());
+    });
+
     describe("when uncontrolled", () => {
         it("Clicking a date puts it in the input box and closes the popover", () => {
             const wrapper = mount(<DateInput />).setState({ isOpen: true });

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -56,12 +56,6 @@ describe("<DateInput>", () => {
         assert.isFalse(wrapper.find(Popover).prop("isOpen"));
     });
 
-    it("Calendar icon doesn't show if showIcon=false", () => {
-        const wrapper = mount(<DateInput showIcon={false} />);
-        const calendarIcon = wrapper.find(".pt-input-action");
-        assert.isTrue(calendarIcon.isEmpty());
-    });
-
     describe("when uncontrolled", () => {
         it("Clicking a date puts it in the input box and closes the popover", () => {
             const wrapper = mount(<DateInput />).setState({ isOpen: true });

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -36,23 +36,9 @@ describe("<DateInput>", () => {
         assert.isFalse(wrapper.find(Popover).prop("isOpen"));
     });
 
-    it("Popover opens on icon click", () => {
-        const wrapper = mount(<DateInput />);
-        wrapper.find(Button).simulate("click");
-        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
-    });
-
-    it("Popover closes on icon click if open", () => {
-        const wrapper = mount(<DateInput />);
-        wrapper.setState({ isOpen: true });
-        wrapper.find(Button).simulate("click");
-        assert.isFalse(wrapper.find(Popover).prop("isOpen"));
-    });
-
     it("Popover doesn't open if disabled=true", () => {
         const wrapper = mount(<DateInput disabled />);
         wrapper.find(InputGroup).simulate("focus");
-        wrapper.find(Button).simulate("click");
         assert.isFalse(wrapper.find(Popover).prop("isOpen"));
     });
 


### PR DESCRIPTION
Got a request in person to add support for hiding the calendar icon in `DateInput`. Seemed reasonable and easy, hence this PR. After initially adding a `showIcon` prop to accomplish this, @llorca and I agreed that deleting the calendar icon altogether would be preferable (this is what we did with `DateRangeInput`).

Related: see #867, which I've assigned to Milestone 2.X due to its API-breaking nature (goal is to remove `openOnFocus` if we go through with deleting the icon element now).

#### Checklist

- [x] Update documentation (auto-updated props table)

#### Changes proposed in this pull request:

- Add `rightElement` prop to `DateInput` to allow customizable right element (particularly: nothing, static icon, interactive icon)

#### Reviewers should focus on:

- Does this sound reasonable?
- Is this considered a breaking change or not?
- Is the prop description text okay?

#### Screenshot

_Before_
![image](https://cloud.githubusercontent.com/assets/443450/24172139/53fbefc6-0e44-11e7-9025-f5137910a4e8.png)

_After_
![image](https://cloud.githubusercontent.com/assets/443450/24172166/72df03ec-0e44-11e7-899f-f870c92d8df9.png)
