### PR TITLE
[DateRangeInput] Show formatted min/max dates on focus when inputs empty

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -42,7 +42,6 @@ import {
 } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
-
     /**
      * Whether the calendar popover should close when a date range is fully selected.
      * @default true
@@ -231,9 +230,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     public render() {
         const { startInputProps, endInputProps } = this.props;
 
-        const startInputString = this.getInputDisplayString(DateRangeBoundary.START);
-        const endInputString = this.getInputDisplayString(DateRangeBoundary.END);
-
         const popoverContent = (
             <DateRangePicker
                 onChange={this.handleDateRangePickerChange}
@@ -244,13 +240,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 value={this.getSelectedRange()}
             />
         );
-
-        const startInputClasses = classNames(startInputProps.className, {
-            [Classes.INTENT_DANGER]: this.isInputInErrorState(DateRangeBoundary.START),
-        });
-        const endInputClasses = classNames(endInputProps.className, {
-            [Classes.INTENT_DANGER]: this.isInputInErrorState(DateRangeBoundary.END),
-        });
 
         // allow custom props for each input group, but pass them in an order
         // that guarantees only some props are overridable.
@@ -266,9 +255,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             >
                 <div className={Classes.CONTROL_GROUP}>
                     <InputGroup
-                        placeholder="Start date"
                         {...startInputProps}
-                        className={startInputClasses}
+                        className={this.getInputClasses(DateRangeBoundary.START, startInputProps)}
                         disabled={this.props.disabled}
                         inputRef={this.refHandlers.startInputRef}
                         onBlur={this.handleStartInputBlur}
@@ -277,12 +265,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         onFocus={this.handleStartInputFocus}
                         onKeyDown={this.handleInputKeyDown}
                         onMouseDown={this.handleInputMouseDown}
-                        value={startInputString}
+                        placeholder={this.getInputPlaceholderString(DateRangeBoundary.START)}
+                        value={this.getInputDisplayString(DateRangeBoundary.START)}
                     />
                     <InputGroup
-                        placeholder="End date"
                         {...endInputProps}
-                        className={endInputClasses}
+                        className={this.getInputClasses(DateRangeBoundary.END, endInputProps)}
                         disabled={this.props.disabled}
                         inputRef={this.refHandlers.endInputRef}
                         onBlur={this.handleEndInputBlur}
@@ -291,7 +279,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                         onFocus={this.handleEndInputFocus}
                         onKeyDown={this.handleInputKeyDown}
                         onMouseDown={this.handleInputMouseDown}
-                        value={endInputString}
+                        placeholder={this.getInputPlaceholderString(DateRangeBoundary.END)}
+                        value={this.getInputDisplayString(DateRangeBoundary.END)}
                     />
                 </div>
             </Popover>
@@ -745,6 +734,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         return [startDate, (startDate >= endDate) ? null : endDate] as DateRange;
     }
 
+    private getInputClasses = (boundary: DateRangeBoundary, boundaryInputProps: IInputGroupProps) => {
+        return classNames(boundaryInputProps.className, {
+            [Classes.INTENT_DANGER]: this.isInputInErrorState(boundary),
+        });
+    }
+
     private getInputDisplayString = (boundary: DateRangeBoundary) => {
         const { values } = this.getStateKeysAndValuesForBoundary(boundary);
         const { isInputFocused, inputString, selectedValue, hoverString } = values;
@@ -763,6 +758,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         } else {
             return this.getFormattedDateString(selectedValue);
         }
+    }
+
+    private getInputPlaceholderString = (boundary: DateRangeBoundary) => {
+        const { isInputFocused } = this.getStateKeysAndValuesForBoundary(boundary).values;
+        const isStartBoundary = boundary === DateRangeBoundary.START;
+
+        const boundDate = isStartBoundary ? this.props.minDate : this.props.maxDate;
+        const defaultString = isStartBoundary ? "Start date" : "End date";
+
+        // TODO: it's inefficient to keep creating new moment objects on every render. create one
+        // instance per input when the props update, then store it in this.state.
+        return isInputFocused ? this.getFormattedDateString(moment(boundDate)) : defaultString;
     }
 
     private getFormattedDateString = (momentDate: moment.Moment) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -788,12 +788,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const { isInputFocused } = this.getStateKeysAndValuesForBoundary(boundary).values;
         const isStartBoundary = boundary === DateRangeBoundary.START;
 
-        const formattedDate = isStartBoundary ? this.state.formattedMinDateString : this.state.formattedMaxDateString;
+        const dateString = isStartBoundary ? this.state.formattedMinDateString : this.state.formattedMaxDateString;
         const defaultString = isStartBoundary ? "Start date" : "End date";
 
-        // TODO: it's inefficient to keep creating new moment objects on every render. create one
-        // instance per input when the props update, then store it in this.state.
-        return isInputFocused ? formattedDate : defaultString;
+        return isInputFocused ? dateString : defaultString;
     }
 
     private getFormattedDateString = (momentDate: moment.Moment, format?: string) => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -123,6 +123,34 @@ describe("<DateRangeInput>", () => {
         expect(getInputPlaceholderText(endInput)).to.equal(DateTestUtils.toHyphenatedDateString(MAX_DATE));
     });
 
+    // need to check this case, because formatted min/max date strings are cached internally until props change again
+    it("updates placeholder text properly when min/max dates change", () => {
+        const MIN_DATE_1 = new Date(2017, Months.JANUARY, 1);
+        const MAX_DATE_1 = new Date(2017, Months.JANUARY, 31);
+        const MIN_DATE_2 = new Date(2017, Months.JANUARY, 2);
+        const MAX_DATE_2 = new Date(2017, Months.FEBRUARY, 1);
+        const { root } = wrap(<DateRangeInput minDate={MIN_DATE_1} maxDate={MAX_DATE_1} />);
+
+        const startInput = getStartInput(root);
+        const endInput = getEndInput(root);
+
+        startInput.simulate("focus");
+        expect(getInputPlaceholderText(startInput)).to.equal(DateTestUtils.toHyphenatedDateString(MIN_DATE_1));
+        startInput.simulate("blur");
+        endInput.simulate("focus");
+        expect(getInputPlaceholderText(endInput)).to.equal(DateTestUtils.toHyphenatedDateString(MAX_DATE_1));
+
+        // change while end input is still focused to make sure things change properly in spite of that
+        root.setProps({ minDate: MIN_DATE_2, maxDate: MAX_DATE_2 });
+
+        endInput.simulate("blur");
+        startInput.simulate("focus");
+        expect(getInputPlaceholderText(startInput)).to.equal(DateTestUtils.toHyphenatedDateString(MIN_DATE_2));
+        startInput.simulate("blur");
+        endInput.simulate("focus");
+        expect(getInputPlaceholderText(endInput)).to.equal(DateTestUtils.toHyphenatedDateString(MAX_DATE_2));
+    });
+
     it("inputs disable and popover doesn't open if disabled=true", () => {
         const { root } = wrap(<DateRangeInput disabled={true} />);
         const startInput = getStartInput(root);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -106,8 +106,8 @@ describe("<DateRangeInput>", () => {
 
     it("shows proper placeholder text when empty inputs are focused and unfocused", () => {
         // arbitrarily choose the out-of-range tests' min/max dates for this test
-        const MIN_DATE = OUT_OF_RANGE_TEST_MIN;
-        const MAX_DATE = OUT_OF_RANGE_TEST_MAX;
+        const MIN_DATE = new Date(2017, Months.JANUARY, 1);
+        const MAX_DATE = new Date(2017, Months.JANUARY, 31);
         const { root } = wrap(<DateRangeInput minDate={MIN_DATE} maxDate={MAX_DATE} />);
 
         const startInput = getStartInput(root);
@@ -134,13 +134,8 @@ describe("<DateRangeInput>", () => {
         const startInput = getStartInput(root);
         const endInput = getEndInput(root);
 
-        startInput.simulate("focus");
-        expect(getInputPlaceholderText(startInput)).to.equal(DateTestUtils.toHyphenatedDateString(MIN_DATE_1));
-        startInput.simulate("blur");
-        endInput.simulate("focus");
-        expect(getInputPlaceholderText(endInput)).to.equal(DateTestUtils.toHyphenatedDateString(MAX_DATE_1));
-
         // change while end input is still focused to make sure things change properly in spite of that
+        endInput.simulate("focus");
         root.setProps({ minDate: MIN_DATE_2, maxDate: MAX_DATE_2 });
 
         endInput.simulate("blur");
@@ -149,6 +144,23 @@ describe("<DateRangeInput>", () => {
         startInput.simulate("blur");
         endInput.simulate("focus");
         expect(getInputPlaceholderText(endInput)).to.equal(DateTestUtils.toHyphenatedDateString(MAX_DATE_2));
+    });
+
+    it("updates placeholder text properly when format changes", () => {
+        const MIN_DATE = new Date(2017, Months.JANUARY, 1);
+        const MAX_DATE = new Date(2017, Months.JANUARY, 31);
+        const { root } = wrap(<DateRangeInput minDate={MIN_DATE} maxDate={MAX_DATE} />);
+
+        const startInput = getStartInput(root);
+        const endInput = getEndInput(root);
+
+        root.setProps({ format: "MM/DD/YYYY" });
+
+        startInput.simulate("focus");
+        expect(getInputPlaceholderText(startInput)).to.equal("01/01/2017");
+        startInput.simulate("blur");
+        endInput.simulate("focus");
+        expect(getInputPlaceholderText(endInput)).to.equal("01/31/2017");
     });
 
     it("inputs disable and popover doesn't open if disabled=true", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -104,6 +104,25 @@ describe("<DateRangeInput>", () => {
         assertInputTextsEqual(root, "", "");
     });
 
+    it("shows proper placeholder text when empty inputs are focused and unfocused", () => {
+        // arbitrarily choose the out-of-range tests' min/max dates for this test
+        const MIN_DATE = OUT_OF_RANGE_TEST_MIN;
+        const MAX_DATE = OUT_OF_RANGE_TEST_MAX;
+        const { root } = wrap(<DateRangeInput minDate={MIN_DATE} maxDate={MAX_DATE} />);
+
+        const startInput = getStartInput(root);
+        const endInput = getEndInput(root);
+
+        expect(getInputPlaceholderText(startInput)).to.equal("Start date");
+        expect(getInputPlaceholderText(endInput)).to.equal("End date");
+
+        startInput.simulate("focus");
+        expect(getInputPlaceholderText(startInput)).to.equal(DateTestUtils.toHyphenatedDateString(MIN_DATE));
+        startInput.simulate("blur");
+        endInput.simulate("focus");
+        expect(getInputPlaceholderText(endInput)).to.equal(DateTestUtils.toHyphenatedDateString(MAX_DATE));
+    });
+
     it("inputs disable and popover doesn't open if disabled=true", () => {
         const { root } = wrap(<DateRangeInput disabled={true} />);
         const startInput = getStartInput(root);
@@ -2106,6 +2125,10 @@ describe("<DateRangeInput>", () => {
 
     function getInputText(input: WrappedComponentInput) {
         return input.props().value;
+    }
+
+    function getInputPlaceholderText(input: WrappedComponentInput) {
+        return input.prop("placeholder");
     }
 
     function isStartInputFocused(root: WrappedComponentRoot) {


### PR DESCRIPTION
#### Addresses #805

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Show formatted min/max dates on focus in an empty start/end input

#### Reviewers should focus on:

- Things break if `min/max === null`, but that's already not really a supported case. Can address that more generally in a future PR if we want.
- See comments about caching the formatted min/max date strings. If we don't cache the formatted min/max date strings in `this.state`, then we'll have to cast those vanilla JS dates to `moment`s on every render just to achieve properly formatted placeholder dates, which is exceedingly wasteful.

#### Screenshot

![2017-03-21 14 25 43](https://cloud.githubusercontent.com/assets/443450/24171585/5cea023c-0e42-11e7-9c0c-39440b3026df.gif)
