### PR TITLE
[DateRangePicker] [DateRangeInput] Refactor related logic into DateRangeSelectionStrategy class

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -39,9 +39,6 @@ import {
 import {
     DateRangePicker,
 } from "./dateRangePicker";
-import {
-    DateRangeSelectionStrategy,
-} from "./dateRangeSelectionStrategy";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     /**
@@ -396,35 +393,21 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                                                 _hoveredDay: Date,
                                                 hoveredBoundary: DateRangeBoundary) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
-        if (!this.state.isOpen) {
-            return;
-        }
+        if (!this.state.isOpen) { return; }
 
         if (hoveredRange == null) {
-            // undo whatever focus changes we made while hovering
-            // over various calendar dates
+            // undo whatever focus changes we made while hovering over various calendar dates
             const isEndInputFocused = (this.state.boundaryToModify === DateRangeBoundary.END);
-            const isStartInputFocused = !isEndInputFocused;
-            const lastFocusedField = (isEndInputFocused) ? DateRangeBoundary.END : DateRangeBoundary.START;
 
             this.setState({
                 isEndInputFocused,
-                isStartInputFocused,
-                lastFocusedField,
                 endHoverString: null,
+                isStartInputFocused: !isEndInputFocused,
+                lastFocusedField: this.state.boundaryToModify,
                 startHoverString: null,
             });
         } else {
-            let focusedBoundary: DateRangeBoundary;
-            if (this.state.isStartInputFocused) {
-                focusedBoundary = DateRangeBoundary.START;
-            } else if (this.state.isEndInputFocused) {
-                focusedBoundary = DateRangeBoundary.END;
-            }
-
             const [hoveredStart, hoveredEnd] = fromDateRangeToMomentDateRange(hoveredRange);
-            const startHoverString = this.getFormattedDateString(hoveredStart);
-            const endHoverString = this.getFormattedDateString(hoveredEnd);
 
             const isStartInputFocused = (hoveredBoundary != null)
                 ? hoveredBoundary === DateRangeBoundary.START
@@ -432,15 +415,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             const isEndInputFocused = (hoveredBoundary != null)
                 ? hoveredBoundary === DateRangeBoundary.END
                 : this.state.isEndInputFocused;
-            const lastFocusedField = (isStartInputFocused) ? DateRangeBoundary.START : DateRangeBoundary.END;
 
             this.setState({
-                startHoverString,
-                endHoverString,
                 isStartInputFocused,
                 isEndInputFocused,
-                lastFocusedField,
+                endHoverString: this.getFormattedDateString(hoveredEnd),
+                lastFocusedField: (isStartInputFocused) ? DateRangeBoundary.START : DateRangeBoundary.END,
                 shouldSelectAfterUpdate: this.props.selectAllOnFocus,
+                startHoverString: this.getFormattedDateString(hoveredStart),
                 wasLastFocusChangeDueToHover: true,
             });
         }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -392,7 +392,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
-    private handleDateRangePickerHoverChange = (hoveredRange: DateRange, day: Date) => {
+    private handleDateRangePickerHoverChange = (hoveredRange: DateRange,
+                                                _hoveredDay: Date,
+                                                hoveredBoundary: DateRangeBoundary) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
         if (!this.state.isOpen) {
             return;
@@ -420,22 +422,15 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 focusedBoundary = DateRangeBoundary.END;
             }
 
-            const boundaryToFocusOnHover = DateRangeSelectionStrategy.getNextState(
-                hoveredRange,
-                day,
-                this.state.boundaryToModify,
-                this.props.allowSingleDayRange,
-            ).boundaryToFocusOnHover;
-
             const [hoveredStart, hoveredEnd] = fromDateRangeToMomentDateRange(hoveredRange);
             const startHoverString = this.getFormattedDateString(hoveredStart);
             const endHoverString = this.getFormattedDateString(hoveredEnd);
 
-            const isStartInputFocused = (boundaryToFocusOnHover == null)
-                ? boundaryToFocusOnHover === DateRangeBoundary.START
+            const isStartInputFocused = (hoveredBoundary != null)
+                ? hoveredBoundary === DateRangeBoundary.START
                 : this.state.isStartInputFocused;
-            const isEndInputFocused = (boundaryToFocusOnHover == null)
-                ? boundaryToFocusOnHover === DateRangeBoundary.END
+            const isEndInputFocused = (hoveredBoundary != null)
+                ? hoveredBoundary === DateRangeBoundary.END
                 : this.state.isEndInputFocused;
             const lastFocusedField = (isStartInputFocused) ? DateRangeBoundary.START : DateRangeBoundary.END;
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -390,7 +390,7 @@ export class DateRangePicker
             return;
         }
         const { dateRange, boundary } = DateRangeSelectionStrategy.getNextState(
-            this.state.value, day, this.props.boundaryToModify, this.props.allowSingleDayRange);
+            this.state.value, day, this.props.allowSingleDayRange, this.props.boundaryToModify);
         this.setState({ hoverValue: dateRange });
         Utils.safeInvoke(this.props.onHoverChange, dateRange, day, boundary);
     }
@@ -413,7 +413,7 @@ export class DateRangePicker
         }
 
         const nextValue = DateRangeSelectionStrategy.getNextState(
-            this.state.value, day, this.props.boundaryToModify, this.props.allowSingleDayRange).dateRange;
+            this.state.value, day, this.props.allowSingleDayRange, this.props.boundaryToModify).dateRange;
 
         // update the hovered date range after click to show the newly selected
         // state, at leasts until the mouse moves again

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -77,7 +77,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * When triggered from mouseenter, it will pass the date range that would result from next click.
      * When triggered from mouseleave, it will pass `undefined`.
      */
-    onHoverChange?: (hoveredDates: DateRange, hoveredDay: Date) => void;
+    onHoverChange?: (hoveredDates: DateRange, hoveredDay: Date, hoveredBoundary: DateRangeBoundary) => void;
 
     /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
@@ -389,10 +389,10 @@ export class DateRangePicker
         if (modifiers.disabled) {
             return;
         }
-        const nextHoverValue = DateRangeSelectionStrategy.getNextState(
-            this.state.value, day, this.props.boundaryToModify, this.props.allowSingleDayRange).dateRange;
-        this.setState({ hoverValue: nextHoverValue });
-        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue, day);
+        const { dateRange, boundaryToFocusOnHover } = DateRangeSelectionStrategy.getNextState(
+            this.state.value, day, this.props.boundaryToModify, this.props.allowSingleDayRange);
+        this.setState({ hoverValue: dateRange });
+        Utils.safeInvoke(this.props.onHoverChange, dateRange, day, boundaryToFocusOnHover);
     }
 
     private handleDayMouseLeave =
@@ -402,8 +402,9 @@ export class DateRangePicker
             return;
         }
         const nextHoverValue = undefined as DateRange;
+        const nextHoveredBoundary = undefined as DateRangeBoundary;
         this.setState({ hoverValue: nextHoverValue });
-        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue, day);
+        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue, day, nextHoveredBoundary);
     }
 
     private handleDayClick = (e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -389,10 +389,10 @@ export class DateRangePicker
         if (modifiers.disabled) {
             return;
         }
-        const { dateRange, boundaryToFocusOnHover } = DateRangeSelectionStrategy.getNextState(
+        const { dateRange, boundary } = DateRangeSelectionStrategy.getNextState(
             this.state.value, day, this.props.boundaryToModify, this.props.allowSingleDayRange);
         this.setState({ hoverValue: dateRange });
-        Utils.safeInvoke(this.props.onHoverChange, dateRange, day, boundaryToFocusOnHover);
+        Utils.safeInvoke(this.props.onHoverChange, dateRange, day, boundary);
     }
 
     private handleDayMouseLeave =
@@ -401,10 +401,8 @@ export class DateRangePicker
         if (modifiers.disabled) {
             return;
         }
-        const nextHoverValue = undefined as DateRange;
-        const nextHoveredBoundary = undefined as DateRangeBoundary;
-        this.setState({ hoverValue: nextHoverValue });
-        Utils.safeInvoke(this.props.onHoverChange, nextHoverValue, day, nextHoveredBoundary);
+        this.setState({ hoverValue: undefined });
+        Utils.safeInvoke(this.props.onHoverChange, undefined, day, undefined);
     }
 
     private handleDayClick = (e: React.SyntheticEvent<HTMLElement>, day: Date, modifiers: IDatePickerDayModifiers) => {

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -5,7 +5,7 @@ import {
     DateRangeBoundary,
 } from "./common/dateUtils";
 
-export type DateRangeSelectionState = {
+export interface IDateRangeSelectionState {
     /**
      * The boundary that would be modified by clicking the provided `day`.
      * May be different from `boundaryToModify` in some special cases
@@ -88,7 +88,7 @@ export class DateRangeSelectionStrategy {
             }
         }
 
-        return { dateRange: nextDateRange, boundary: nextBoundary } as DateRangeSelectionState;
+        return { dateRange: nextDateRange, boundary: nextBoundary } as IDateRangeSelectionState;
     }
 
     private static getDefaultNextState(selectedRange: DateRange, day: Date, allowSingleDayRange: boolean) {
@@ -116,7 +116,7 @@ export class DateRangeSelectionStrategy {
             }
         }
 
-        return { dateRange: nextDateRange } as DateRangeSelectionState;
+        return { dateRange: nextDateRange } as IDateRangeSelectionState;
     }
 
     private static getOtherBoundary(boundary: DateRangeBoundary) {

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -56,11 +56,15 @@ export class DateRangeSelectionStrategy {
             nextDateRange = this.createRangeForBoundary(boundary, nextBoundaryDate, null);
         } else if (boundaryDate == null && otherBoundaryDate != null) {
             if (areSameDay(day, otherBoundaryDate)) {
-                const [nextBoundaryDate, nextOtherBoundaryDate] = (allowSingleDayRange)
-                    ? [otherBoundaryDate, otherBoundaryDate]
-                    : [null, null];
-                nextBoundary = allowSingleDayRange ? boundary : otherBoundary;
-                nextDateRange = this.createRangeForBoundary(boundary, nextBoundaryDate, nextOtherBoundaryDate);
+                let nextDate: Date;
+                if (allowSingleDayRange) {
+                    nextBoundary = boundary;
+                    nextDate = otherBoundaryDate;
+                } else {
+                    nextBoundary = otherBoundary;
+                    nextDate = null;
+                }
+                nextDateRange = this.createRangeForBoundary(boundary, nextDate, nextDate);
             } else if (this.isOverlappingOtherBoundary(boundary, day, otherBoundaryDate)) {
                 nextBoundary = otherBoundary;
                 nextDateRange = this.createRangeForBoundary(boundary, otherBoundaryDate, day);

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -22,10 +22,10 @@ export interface IDateRangeSelectionState {
 export class DateRangeSelectionStrategy {
     public static getNextState(currentRange: DateRange,
                                day: Date,
-                               boundaryToModify?: DateRangeBoundary,
-                               allowSingleDayRange?: boolean) {
+                               allowSingleDayRange: boolean,
+                               boundaryToModify?: DateRangeBoundary): IDateRangeSelectionState {
         if (boundaryToModify != null) {
-            return this.getNextStateForBoundary(currentRange, day, boundaryToModify, allowSingleDayRange);
+            return this.getNextStateForBoundary(currentRange, day, allowSingleDayRange, boundaryToModify);
         } else {
             return this.getDefaultNextState(currentRange, day, allowSingleDayRange);
         }
@@ -33,8 +33,11 @@ export class DateRangeSelectionStrategy {
 
     private static getNextStateForBoundary(currentRange: DateRange,
                                            day: Date,
-                                           boundaryToModify: DateRangeBoundary,
-                                           allowSingleDayRange: boolean) {
+                                           allowSingleDayRange: boolean,
+                                           boundaryToModify: DateRangeBoundary) {
+        // `boundaryToModify` is the clearer name for the exposed parameter, but `boundary` is a
+        // nicer name within the function because of the consistent variable naming scheme it yields
+        // (`boundary` v. `otherBoundary`, `boundaryDate` v. `otherBoundaryDate`).
         const boundary = boundaryToModify;
         const boundaryDate = this.getBoundaryDate(boundary, currentRange);
 
@@ -145,7 +148,7 @@ export class DateRangeSelectionStrategy {
             : [otherBoundaryDate, boundaryDate] as DateRange;
     }
 
-    private static createRange(a: Date, b: Date, allowSingleDayRange?: boolean): DateRange {
+    private static createRange(a: Date, b: Date, allowSingleDayRange: boolean): DateRange {
         // clicking the same date again will clear it
         if (!allowSingleDayRange && areSameDay(a, b)) {
             return [null, null];

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -8,8 +8,6 @@ import {
 export interface IDateRangeSelectionState {
     /**
      * The boundary that would be modified by clicking the provided `day`.
-     * May be different from `boundaryToModify` in some special cases
-     * (e.g. when hovering over the other boundary's selected date).
      */
     boundary?: DateRangeBoundary;
 
@@ -20,12 +18,18 @@ export interface IDateRangeSelectionState {
 };
 
 export class DateRangeSelectionStrategy {
+    /**
+     * Returns the new date-range and the boundary that would be affected if `day` were clicked. The
+     * affected boundary may be different from the provided `boundary` in some cases. For example,
+     * clicking a particular boundary's selected date will always deselect it regardless of which
+     * `boundary` you provide to this function (because it's simply a more intuitive interaction).
+     */
     public static getNextState(currentRange: DateRange,
                                day: Date,
                                allowSingleDayRange: boolean,
-                               boundaryToModify?: DateRangeBoundary): IDateRangeSelectionState {
-        if (boundaryToModify != null) {
-            return this.getNextStateForBoundary(currentRange, day, allowSingleDayRange, boundaryToModify);
+                               boundary?: DateRangeBoundary): IDateRangeSelectionState {
+        if (boundary != null) {
+            return this.getNextStateForBoundary(currentRange, day, allowSingleDayRange, boundary);
         } else {
             return this.getDefaultNextState(currentRange, day, allowSingleDayRange);
         }
@@ -34,13 +38,8 @@ export class DateRangeSelectionStrategy {
     private static getNextStateForBoundary(currentRange: DateRange,
                                            day: Date,
                                            allowSingleDayRange: boolean,
-                                           boundaryToModify: DateRangeBoundary) {
-        // `boundaryToModify` is the clearer name for the exposed parameter, but `boundary` is a
-        // nicer name within the function because of the consistent variable naming scheme it yields
-        // (`boundary` v. `otherBoundary`, `boundaryDate` v. `otherBoundaryDate`).
-        const boundary = boundaryToModify;
+                                           boundary: DateRangeBoundary) {
         const boundaryDate = this.getBoundaryDate(boundary, currentRange);
-
         const otherBoundary = this.getOtherBoundary(boundary);
         const otherBoundaryDate = this.getBoundaryDate(otherBoundary, currentRange);
 

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -1,0 +1,257 @@
+
+import * as moment from "moment";
+
+import {
+    areSameDay,
+    DateRange,
+    DateRangeBoundary,
+    // fromDateRangeToMomentDateRange,
+    // fromDateToMoment,
+    // isMomentNull,
+} from "./common/dateUtils";
+import {
+    IDateRangePickerProps,
+} from "./dateRangePicker";
+
+export type DateRangeSelectionState = {
+    boundaryToFocusOnHover?: DateRangeBoundary;
+    dateRange: DateRange;
+};
+
+export class DateRangeSelectionStrategy {
+
+    public static getNextState(currentRange: DateRange,
+                               day: Date,
+                               boundaryToModify?: DateRangeBoundary,
+                               allowSingleDayRange?: boolean): DateRangeSelectionState {
+        if (boundaryToModify != null) {
+            return this.getNextStateForBoundary(currentRange, day, boundaryToModify, allowSingleDayRange);
+        } else {
+            return this.getDefaultNextState(currentRange, day, allowSingleDayRange);
+        }
+    }
+
+    /*public static getBoundaryToFocusOnHover(selectedStart: moment.Moment,
+                                            selectedEnd: moment.Moment,
+                                            hoveredRange: DateRange,
+                                            day: Date,
+                                            boundaryToModify: DateRangeBoundary,
+                                            focusedBoundary: DateRangeBoundary) {
+        if (hoveredRange == null) {
+            return undefined;
+        }
+
+        const [hoveredStart, hoveredEnd] = fromDateRangeToMomentDateRange(hoveredRange);
+        const [isHoveredStartDefined, isHoveredEndDefined] = [hoveredStart, hoveredEnd].map((d) => !isMomentNull(d));
+        const [isStartDateSelected, isEndDateSelected] = [selectedStart, selectedEnd].map((d) => !isMomentNull(d));
+
+        const isModifyingStartBoundary = boundaryToModify === DateRangeBoundary.START;
+        const isModifyingEndBoundary = !isModifyingStartBoundary;
+
+        const hoveredDay = fromDateToMoment(day);
+
+        let boundaryToFocusOnHover: DateRangeBoundary = focusedBoundary;
+
+        if (isStartDateSelected && isEndDateSelected) {
+            if (isHoveredStartDefined && isHoveredEndDefined) {
+                if (hoveredStart.isSame(selectedStart, "day")) {
+                    // we'd be modifying the end date on click
+                    boundaryToFocusOnHover = END;
+                } else if (hoveredEnd.isSame(selectedEnd, "day")) {
+                    // we'd be modifying the start date on click
+                    boundaryToFocusOnHover = START;
+                }
+            } else if (isHoveredStartDefined) {
+                if (isModifyingStartBoundary && hoveredDay.isSame(selectedEnd, "day")) {
+                    // we'd be deselecting the end date on click
+                    boundaryToFocusOnHover = END;
+                } else if (isModifyingStartBoundary) {
+                    // we'd be specifying a new start date and clearing the end date on click
+                    boundaryToFocusOnHover = START;
+                } else {
+                    // we'd be deselecting the end date on click
+                    boundaryToFocusOnHover = END;
+                }
+            } else if (isHoveredEndDefined) {
+                if (isModifyingEndBoundary && hoveredDay.isSame(selectedStart, "day")) {
+                    // we'd be deselecting the start date on click
+                    boundaryToFocusOnHover = START;
+                } else if (isModifyingEndBoundary) {
+                    // we'd be specifying a new end date (clearing the start date) on click
+                    boundaryToFocusOnHover = END;
+                } else {
+                    // we'd be deselecting the start date on click
+                    boundaryToFocusOnHover = START;
+                }
+            }
+        } else if (isStartDateSelected) {
+            if (isHoveredStartDefined && isHoveredEndDefined) {
+                if (hoveredStart.isSame(selectedStart, "day")) {
+                    // we'd be modifying the end date on click, so focus the end field
+                    boundaryToFocusOnHover = END;
+                } else if (hoveredEnd.isSame(selectedStart, "day")) {
+                    // we'd be modifying the start date on click, so focus the start field
+                    boundaryToFocusOnHover = START;
+                }
+            } else if (isHoveredStartDefined) {
+                // we'd be replacing the start date on click
+                boundaryToFocusOnHover = START;
+            } else if (isHoveredEndDefined) {
+                // we'd be converting the selected start date to an end date
+                boundaryToFocusOnHover = END;
+            } else {
+                // we'd be deselecting start date on click
+                boundaryToFocusOnHover = START;
+            }
+        } else if (isEndDateSelected) {
+            if (isHoveredStartDefined && isHoveredEndDefined) {
+                if (hoveredEnd.isSame(selectedEnd, "day")) {
+                    // we'd be modifying the start date on click
+                    boundaryToFocusOnHover = START;
+                } else if (hoveredStart.isSame(selectedEnd, "day")) {
+                    // we'd be modifying the end date on click
+                    boundaryToFocusOnHover = END;
+                }
+            } else if (isHoveredEndDefined) {
+                // we'd be replacing the end date on click
+                boundaryToFocusOnHover = END;
+            } else if (isHoveredStartDefined) {
+                // we'd be converting the selected end date to a start date
+                boundaryToFocusOnHover = START;
+            } else {
+                // we'd be deselecting end date on click
+                boundaryToFocusOnHover = END;
+            }
+        }
+
+        return boundaryToFocusOnHover;
+    }*/
+
+    private static getNextStateForBoundary(currentRange: DateRange,
+                                           day: Date,
+                                           boundaryToModify: DateRangeBoundary,
+                                           allowSingleDayRange: boolean) {
+        const [start, end] = currentRange;
+
+        // rename for conciseness
+        const boundary = boundaryToModify;
+        const otherBoundary = this.getOtherBoundary(boundary);
+
+        const boundaryDate = (boundary === DateRangeBoundary.START) ? start : end;
+        const otherBoundaryDate = (boundary === DateRangeBoundary.START) ? end : start;
+
+        let boundaryToFocusOnHover: DateRangeBoundary;
+        let dateRange: DateRange;
+
+        if (boundaryDate == null && otherBoundaryDate == null) {
+            boundaryToFocusOnHover = boundary;
+            dateRange = this.createRangeForBoundary(day, null, boundary);
+        } else if (boundaryDate != null && otherBoundaryDate == null) {
+            const nextBoundaryDate = areSameDay(boundaryDate, day) ? null : day;
+            boundaryToFocusOnHover = boundary;
+            dateRange = this.createRangeForBoundary(nextBoundaryDate, null, boundary);
+        } else if (boundaryDate == null && otherBoundaryDate != null) {
+            if (areSameDay(day, otherBoundaryDate)) {
+                const [nextBoundaryDate, nextOtherBoundaryDate] = (allowSingleDayRange)
+                    ? [otherBoundaryDate, otherBoundaryDate]
+                    : [null, null];
+                boundaryToFocusOnHover = allowSingleDayRange ? boundary : otherBoundary;
+                dateRange = this.createRangeForBoundary(nextBoundaryDate, nextOtherBoundaryDate, boundary);
+            } else if (this.isDateOverlappingOtherBoundary(day, otherBoundaryDate, boundary)) {
+                boundaryToFocusOnHover = otherBoundary;
+                dateRange = this.createRangeForBoundary(otherBoundaryDate, day, boundary);
+            } else {
+                boundaryToFocusOnHover = boundary;
+                dateRange = this.createRangeForBoundary(day, otherBoundaryDate, boundary);
+            }
+        } else {
+            // both boundaryDate and otherBoundaryDate are already defined
+            if (areSameDay(boundaryDate, day)) {
+                const isSingleDayRangeSelected = areSameDay(boundaryDate, otherBoundaryDate);
+                const nextOtherBoundaryDate = isSingleDayRangeSelected ? null : otherBoundaryDate;
+                boundaryToFocusOnHover = boundary;
+                dateRange = this.createRangeForBoundary(null, nextOtherBoundaryDate, boundary);
+            } else if (areSameDay(day, otherBoundaryDate)) {
+                const [nextBoundaryDate, nextOtherBoundaryDate] = (allowSingleDayRange)
+                    ? [otherBoundaryDate, otherBoundaryDate]
+                    : [boundaryDate, null];
+                boundaryToFocusOnHover = allowSingleDayRange ? boundary : otherBoundary;
+                dateRange = this.createRangeForBoundary(nextBoundaryDate, nextOtherBoundaryDate, boundary);
+            } else if (this.isDateOverlappingOtherBoundary(day, otherBoundaryDate, boundary)) {
+                boundaryToFocusOnHover = otherBoundary;
+                dateRange = this.createRangeForBoundary(day, null, boundary);
+            } else {
+                // extend the date range with an earlier boundaryDate date
+                boundaryToFocusOnHover = boundary;
+                dateRange = this.createRangeForBoundary(day, otherBoundaryDate, boundary);
+            }
+        }
+
+        return { dateRange, boundaryToFocusOnHover } as DateRangeSelectionState;
+    }
+
+    private static getDefaultNextState(selectedRange: DateRange,
+                                               day: Date,
+                                               props: Partial<IDateRangePickerProps>) {
+        const [start, end] = selectedRange;
+        const { allowSingleDayRange } = props;
+
+        let dateRange: DateRange;
+
+        if (start == null && end == null) {
+            dateRange = [day, null];
+        } else if (start != null && end == null) {
+            dateRange = this.createRange(day, start, allowSingleDayRange);
+        } else if (start == null && end != null) {
+            dateRange = this.createRange(day, end, allowSingleDayRange);
+        } else {
+            const isStart = areSameDay(start, day);
+            const isEnd = areSameDay(end, day);
+            if (isStart && isEnd) {
+                dateRange = [null, null];
+            } else if (isStart) {
+                dateRange = [null, end];
+            } else if (isEnd) {
+                dateRange = [start, null];
+            } else {
+                dateRange = [day, null];
+            }
+        }
+
+        return { dateRange } as DateRangeSelectionState;
+    }
+
+    private static isDateOverlappingOtherBoundary(date: Date, otherBoundaryDate: Date, boundary: DateRangeBoundary) {
+        return (boundary === DateRangeBoundary.START)
+            ? date > otherBoundaryDate
+            : date < otherBoundaryDate;
+    }
+
+    private static createRangeForBoundary(boundaryDate: Date, otherBoundaryDate: Date, boundary: DateRangeBoundary) {
+        if (boundary === DateRangeBoundary.START) {
+            return [boundaryDate, otherBoundaryDate] as DateRange;
+        } else if (boundary === DateRangeBoundary.END) {
+            return [otherBoundaryDate, boundaryDate] as DateRange;
+        } else {
+            return this.createRange(boundaryDate, otherBoundaryDate);
+        }
+    }
+
+    private static createRange(a: Date, b: Date, allowSingleDayRange?: boolean): DateRange {
+        // clicking the same date again will clear it
+        if (!allowSingleDayRange && areSameDay(a, b)) {
+            return [null, null];
+        }
+        return a < b ? [a, b] : [b, a];
+    }
+
+    private static getOtherBoundary(boundary: DateRangeBoundary) {
+        if (boundary === DateRangeBoundary.START) {
+            return DateRangeBoundary.END;
+        } else if (boundary === DateRangeBoundary.END) {
+            return DateRangeBoundary.START;
+        } else {
+            return undefined;
+        }
+    }
+}

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -1,6 +1,4 @@
 
-import * as moment from "moment";
-
 import {
     areSameDay,
     DateRange,
@@ -30,102 +28,6 @@ export class DateRangeSelectionStrategy {
             return this.getDefaultNextState(currentRange, day, allowSingleDayRange);
         }
     }
-
-    /*public static getBoundaryToFocusOnHover(selectedStart: moment.Moment,
-                                            selectedEnd: moment.Moment,
-                                            hoveredRange: DateRange,
-                                            day: Date,
-                                            boundaryToModify: DateRangeBoundary,
-                                            focusedBoundary: DateRangeBoundary) {
-        if (hoveredRange == null) {
-            return undefined;
-        }
-
-        const [hoveredStart, hoveredEnd] = fromDateRangeToMomentDateRange(hoveredRange);
-        const [isHoveredStartDefined, isHoveredEndDefined] = [hoveredStart, hoveredEnd].map((d) => !isMomentNull(d));
-        const [isStartDateSelected, isEndDateSelected] = [selectedStart, selectedEnd].map((d) => !isMomentNull(d));
-
-        const isModifyingStartBoundary = boundaryToModify === DateRangeBoundary.START;
-        const isModifyingEndBoundary = !isModifyingStartBoundary;
-
-        const hoveredDay = fromDateToMoment(day);
-
-        let boundaryToFocusOnHover: DateRangeBoundary = focusedBoundary;
-
-        if (isStartDateSelected && isEndDateSelected) {
-            if (isHoveredStartDefined && isHoveredEndDefined) {
-                if (hoveredStart.isSame(selectedStart, "day")) {
-                    // we'd be modifying the end date on click
-                    boundaryToFocusOnHover = END;
-                } else if (hoveredEnd.isSame(selectedEnd, "day")) {
-                    // we'd be modifying the start date on click
-                    boundaryToFocusOnHover = START;
-                }
-            } else if (isHoveredStartDefined) {
-                if (isModifyingStartBoundary && hoveredDay.isSame(selectedEnd, "day")) {
-                    // we'd be deselecting the end date on click
-                    boundaryToFocusOnHover = END;
-                } else if (isModifyingStartBoundary) {
-                    // we'd be specifying a new start date and clearing the end date on click
-                    boundaryToFocusOnHover = START;
-                } else {
-                    // we'd be deselecting the end date on click
-                    boundaryToFocusOnHover = END;
-                }
-            } else if (isHoveredEndDefined) {
-                if (isModifyingEndBoundary && hoveredDay.isSame(selectedStart, "day")) {
-                    // we'd be deselecting the start date on click
-                    boundaryToFocusOnHover = START;
-                } else if (isModifyingEndBoundary) {
-                    // we'd be specifying a new end date (clearing the start date) on click
-                    boundaryToFocusOnHover = END;
-                } else {
-                    // we'd be deselecting the start date on click
-                    boundaryToFocusOnHover = START;
-                }
-            }
-        } else if (isStartDateSelected) {
-            if (isHoveredStartDefined && isHoveredEndDefined) {
-                if (hoveredStart.isSame(selectedStart, "day")) {
-                    // we'd be modifying the end date on click, so focus the end field
-                    boundaryToFocusOnHover = END;
-                } else if (hoveredEnd.isSame(selectedStart, "day")) {
-                    // we'd be modifying the start date on click, so focus the start field
-                    boundaryToFocusOnHover = START;
-                }
-            } else if (isHoveredStartDefined) {
-                // we'd be replacing the start date on click
-                boundaryToFocusOnHover = START;
-            } else if (isHoveredEndDefined) {
-                // we'd be converting the selected start date to an end date
-                boundaryToFocusOnHover = END;
-            } else {
-                // we'd be deselecting start date on click
-                boundaryToFocusOnHover = START;
-            }
-        } else if (isEndDateSelected) {
-            if (isHoveredStartDefined && isHoveredEndDefined) {
-                if (hoveredEnd.isSame(selectedEnd, "day")) {
-                    // we'd be modifying the start date on click
-                    boundaryToFocusOnHover = START;
-                } else if (hoveredStart.isSame(selectedEnd, "day")) {
-                    // we'd be modifying the end date on click
-                    boundaryToFocusOnHover = END;
-                }
-            } else if (isHoveredEndDefined) {
-                // we'd be replacing the end date on click
-                boundaryToFocusOnHover = END;
-            } else if (isHoveredStartDefined) {
-                // we'd be converting the selected end date to a start date
-                boundaryToFocusOnHover = START;
-            } else {
-                // we'd be deselecting end date on click
-                boundaryToFocusOnHover = END;
-            }
-        }
-
-        return boundaryToFocusOnHover;
-    }*/
 
     private static getNextStateForBoundary(currentRange: DateRange,
                                            day: Date,
@@ -178,7 +80,7 @@ export class DateRangeSelectionStrategy {
                 boundaryToFocusOnHover = allowSingleDayRange ? boundary : otherBoundary;
                 dateRange = this.createRangeForBoundary(nextBoundaryDate, nextOtherBoundaryDate, boundary);
             } else if (this.isDateOverlappingOtherBoundary(day, otherBoundaryDate, boundary)) {
-                boundaryToFocusOnHover = otherBoundary;
+                boundaryToFocusOnHover = boundary;
                 dateRange = this.createRangeForBoundary(day, null, boundary);
             } else {
                 // extend the date range with an earlier boundaryDate date
@@ -191,10 +93,9 @@ export class DateRangeSelectionStrategy {
     }
 
     private static getDefaultNextState(selectedRange: DateRange,
-                                               day: Date,
-                                               props: Partial<IDateRangePickerProps>) {
+                                       day: Date,
+                                       allowSingleDayRange: boolean) {
         const [start, end] = selectedRange;
-        const { allowSingleDayRange } = props;
 
         let dateRange: DateRange;
 


### PR DESCRIPTION
#### Addresses #805 

#### Changes proposed in this pull request:

Found some time tonight to refactor related logic around date-range selection and hovered-boundary refocusing into a separate `DateRangeSelectionStrategy` class. We can make the strategy a prop in `IDateRangePickerProps` eventually (perhaps making it a Plain Old JS Object in the process), but for now, this particular strategy is hardcoded into `DateRangePicker`.

#### Reviewers should focus on:

- Tons of code deleted!
- All unit tests still pass!
- Added `hoveredBoundary` as a third parameter to `onHoverChange`; now, the `DateRangeInput` doesn't have to duplicate any work.
- The unit tests we had in place were sufficiently exhaustive to make the correctness of this refactor quite easy to guarantee!