### PR TITLE
[Table] Change header menu icon to chevron and add a bounding box for better affordance

### DIFF
--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -68,12 +68,13 @@
   flex-shrink: 0;
   position: absolute;
   top: 0;
-  right: $cell-border-width + ($pt-grid-size / 2); // don't overlap box-shadow border
+  right: $cell-border-width; // don't overlap box-shadow border
   opacity: 0; // hide until header is hovered
   background: none;
   cursor: $action-cursor;
   width: $column-header-min-height + $pt-grid-size;
   height: $column-header-min-height;
+  padding-right: $pt-grid-size / 2 + $cell-border-width * 2; // icon has a border
   text-align: right;
   pointer-events: all;
 
@@ -83,33 +84,45 @@
     height: $interaction-bar-height;
     text-align: center;
 
-    > span {
+    > [class*="pt-icon"] {
+      $icon-margin: ($interaction-bar-height - $pt-icon-size-standard) / 2;
+
+      margin: $icon-margin;
+      margin-left: $icon-margin + $cell-border-width;
       vertical-align: top;
-      line-height: $interaction-bar-height;
     }
   }
 
   [class*="pt-icon"] {
+    border-radius: $pt-border-radius;
+    box-shadow: inset 0 0 0 1px rgba($black, $pt-drop-shadow-opacity);
     color: $pt-icon-color;
 
     .pt-dark & {
+      box-shadow: inset 0 0 0 1px rgba($white, $pt-drop-shadow-opacity);
       color: $pt-dark-icon-color;
     }
   }
 
   &:hover [class*="pt-icon"] {
+    box-shadow: inset 0 0 0 1px rgba($black, $pt-drop-shadow-opacity * 2);
     color: $pt-icon-color-hover;
 
     .pt-dark & {
+      box-shadow: inset 0 0 0 1px rgba($white, $pt-drop-shadow-opacity * 2);
       color: $pt-dark-icon-color-hover;
     }
   }
 
   &.pt-popover-open [class*="pt-icon"] {
-    color: $pt-icon-color-selected;
+    box-shadow: none;
+    background-color: $pt-icon-color-selected;
+    color: $white;
 
     .pt-dark & {
-      color: $pt-dark-icon-color-selected;
+      box-shadow: none;
+      background-color: $pt-dark-icon-color-selected;
+      color: $white;
     }
   }
 

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -84,7 +84,7 @@
     height: $interaction-bar-height;
     text-align: center;
 
-    > [class*="pt-icon"] {
+    .pt-icon-standard {
       $icon-margin: ($interaction-bar-height - $pt-icon-size-standard) / 2;
 
       margin: $icon-margin;
@@ -93,7 +93,7 @@
     }
   }
 
-  [class*="pt-icon"] {
+  .pt-icon-standard {
     border-radius: $pt-border-radius;
     box-shadow: inset 0 0 0 1px rgba($black, $pt-drop-shadow-opacity);
     color: $pt-icon-color;
@@ -104,7 +104,7 @@
     }
   }
 
-  &:hover [class*="pt-icon"] {
+  &:hover .pt-icon-standard {
     box-shadow: inset 0 0 0 1px rgba($black, $pt-drop-shadow-opacity * 2);
     color: $pt-icon-color-hover;
 
@@ -114,7 +114,7 @@
     }
   }
 
-  &.pt-popover-open [class*="pt-icon"] {
+  &.pt-popover-open .pt-icon-standard {
     box-shadow: none;
     background-color: $pt-icon-color-selected;
     color: $white;

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -89,6 +89,14 @@
     }
   }
 
+  [class*="pt-icon"] {
+    color: $pt-icon-color;
+
+    .pt-dark & {
+      color: $pt-dark-icon-color;
+    }
+  }
+
   &:hover [class*="pt-icon"] {
     color: $pt-icon-color-hover;
 

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -78,7 +78,7 @@ export interface IColumnHeaderCellProps extends IColumnNameProps, IProps {
 
     /**
      * The icon name for the header's menu button.
-     * @default 'more'
+     * @default 'chevron-down'
      */
     menuIconName?: string;
 
@@ -108,7 +108,7 @@ export function HorizontalCellDivider(): JSX.Element {
 export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IColumnHeaderState> {
     public static defaultProps: IColumnHeaderCellProps = {
         isActive: false,
-        menuIconName: "more",
+        menuIconName: "chevron-down",
         useInteractionBar: false,
     };
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

Quick little thing. In the spirit of aggressively opening PRs and then asking for feedback, I propose that we change the default header-menu icon from `pt-icon-more` (···) to `pt-icon-chevron-down` (⌄), which looks and feels much more intuitive to me.

Also, I found it annoying that the icon looked the same whether you were hovering inside or outside of it within the header cell. This PR shows the icon with `$pt-icon-color` when you hover in the header cell but NOT within the icon, showing `$pt-icon-color-hover` only when you mouse over the clickable icon area.

_Before:_
![2017-03-27 14 41 22](https://cloud.githubusercontent.com/assets/443450/24379334/8682af3c-12fb-11e7-9d47-15f2f59fc635.gif)


_After (Light theme):_
![2017-03-27 14 29 16](https://cloud.githubusercontent.com/assets/443450/24379193/d0546b56-12fa-11e7-850b-a16834be3730.gif)

_After (Dark theme):_
![2017-03-27 14 30 31](https://cloud.githubusercontent.com/assets/443450/24379191/cda4e552-12fa-11e7-9ae9-96d662e006f7.gif)

For what it's worth, these changes seem consistent with the original mocks for the Table from way back when (although the chevron in the mocks feels too big):
![image](https://cloud.githubusercontent.com/assets/443450/24379274/40447da2-12fb-11e7-902a-4e2d7bef6ee3.png)

#### Reviewers should focus on:

- I think the second piece (the hover/non-hover color) should merge regardless—do you agree?
- Do you like the icon change?