### PR TITLE
Shows input borders in Mobile Safari on iOS

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -95,6 +95,7 @@ $control-group-stack: (
   font-size: $pt-font-size;
   font-weight: $input-font-weight;
   transition: $input-transition;
+  -webkit-appearance: none;
 
   &::placeholder {
     // normalize.css sets an opacity less than 1, we don't want this

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -95,7 +95,7 @@ $control-group-stack: (
   font-size: $pt-font-size;
   font-weight: $input-font-weight;
   transition: $input-transition;
-  -webkit-appearance: none;
+  appearance: none;
 
   &::placeholder {
     // normalize.css sets an opacity less than 1, we don't want this


### PR DESCRIPTION
#### Fixes #675

#### Changes proposed in this pull request:

Restores input borders in Mobile Safari on iOS

#### Screenshot

![img_7877](https://cloud.githubusercontent.com/assets/4642599/24415361/42814744-13af-11e7-81f1-73dd6ab6a36a.PNG)
