### PR TITLE
[DateRangeInput] [DateRangePicker] Support the same props in DRI as in DRP

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -15,6 +15,7 @@ import { FORMATS, FormatSelect } from "./common/formatSelect";
 export interface IDateRangeInputExampleState {
     allowSingleDayRange?: boolean;
     closeOnSelection?: boolean;
+    contiguousCalendarMonths?: boolean;
     disabled?: boolean;
     format?: string;
     selectAllOnFocus?: boolean;
@@ -24,11 +25,15 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     public state: IDateRangeInputExampleState = {
         allowSingleDayRange: false,
         closeOnSelection: false,
+        contiguousCalendarMonths: true,
         disabled: false,
         format: FORMATS[0],
         selectAllOnFocus: false,
     };
 
+    private toggleContiguous = handleBooleanChange((contiguous) => {
+        this.setState({ contiguousCalendarMonths: contiguous });
+    });
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
@@ -42,6 +47,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     protected renderOptions() {
         return [
             [
+                <FormatSelect
+                    key="Format"
+                    onChange={this.toggleFormat}
+                    selectedValue={this.state.format}
+                />,
+            ], [
                 <Switch
                     checked={this.state.allowSingleDayRange}
                     label="Allow single day range"
@@ -55,6 +66,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     onChange={this.toggleSelection}
                 />,
                 <Switch
+                    checked={this.state.contiguousCalendarMonths}
+                    label="Constrain calendar to contiguous months"
+                    key="Constraint calendar to contiguous months"
+                    onChange={this.toggleContiguous}
+                />,
+                <Switch
                     checked={this.state.disabled}
                     label="Disabled"
                     key="Disabled"
@@ -65,12 +82,6 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     label="Select all on focus"
                     key="Select all on focus"
                     onChange={this.toggleSelectAllOnFocus}
-                />,
-            ], [
-                <FormatSelect
-                    key="Format"
-                    onChange={this.toggleFormat}
-                    selectedValue={this.state.format}
                 />,
             ],
         ];

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -266,12 +266,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const popoverContent = (
             <DateRangePicker
                 allowSingleDayRange={this.props.allowSingleDayRange}
+                boundaryToModify={this.state.boundaryToModify}
                 contiguousCalendarMonths={this.props.contiguousCalendarMonths}
                 onChange={this.handleDateRangePickerChange}
                 onHoverChange={this.handleDateRangePickerHoverChange}
                 maxDate={this.props.maxDate}
                 minDate={this.props.minDate}
-                boundaryToModify={this.state.boundaryToModify}
                 shortcuts={this.props.shortcuts}
                 value={this.getSelectedRange()}
             />

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -57,6 +57,13 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     closeOnSelection?: boolean;
 
     /**
+     * Whether displayed months in the calendar are contiguous.
+     * If false, each side of the calendar can move independently to non-contiguous months.
+     * @default true
+     */
+    contiguousCalendarMonths?: boolean;
+
+    /**
      * The default date range to be used in the component when uncontrolled.
      * This will be ignored if `value` is set.
      */
@@ -181,6 +188,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     public static defaultProps: IDateRangeInputProps = {
         allowSingleDayRange: false,
         closeOnSelection: true,
+        contiguousCalendarMonths: true,
         disabled: false,
         endInputProps: {},
         format: "YYYY-MM-DD",
@@ -247,6 +255,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const popoverContent = (
             <DateRangePicker
                 allowSingleDayRange={this.props.allowSingleDayRange}
+                contiguousCalendarMonths={this.props.contiguousCalendarMonths}
                 onChange={this.handleDateRangePickerChange}
                 onHoverChange={this.handleDateRangePickerHoverChange}
                 maxDate={this.props.maxDate}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -39,6 +39,7 @@ import {
 } from "./datePickerCore";
 import {
     DateRangePicker,
+    IDateRangeShortcut,
 } from "./dateRangePicker";
 
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
@@ -130,6 +131,15 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     selectAllOnFocus?: boolean;
 
     /**
+     * Whether shortcuts to quickly select a range of dates are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     * @default true
+     */
+    shortcuts?: boolean | IDateRangeShortcut[];
+
+    /**
      * Props to pass to the start-date input.
      */
     startInputProps?: IInputGroupProps;
@@ -198,6 +208,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         outOfRangeMessage: "Out of range",
         overlappingDatesMessage: "Overlapping dates",
         selectAllOnFocus: false,
+        shortcuts: true,
         startInputProps: {},
     };
 
@@ -261,6 +272,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 maxDate={this.props.maxDate}
                 minDate={this.props.minDate}
                 boundaryToModify={this.state.boundaryToModify}
+                shortcuts={this.props.shortcuts}
                 value={this.getSelectedRange()}
             />
         );

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -51,17 +51,17 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     boundaryToModify?: DateRangeBoundary;
 
     /**
-     * Initial `DateRange` the calendar will display as selected.
-     * This should not be set if `value` is set.
-     */
-    defaultValue?: DateRange;
-
-    /**
      * Whether displayed months in the calendar are contiguous.
      * If false, each side of the calendar can move independently to non-contiguous months.
      * @default true
      */
     contiguousCalendarMonths?: boolean;
+
+    /**
+     * Initial `DateRange` the calendar will display as selected.
+     * This should not be set if `value` is set.
+     */
+    defaultValue?: DateRange;
 
     /**
      * Called when the user selects a day.

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -11,7 +11,7 @@ import * as React from "react";
 
 import { InputGroup, Popover } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
-import { Classes as DateClasses, DateRange, DateRangeBoundary, DateRangeInput } from "../src/index";
+import { Classes as DateClasses, DateRange, DateRangeBoundary, DateRangeInput, DateRangePicker } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
 
 type WrappedComponentRoot = ReactWrapper<any, {}>;
@@ -186,6 +186,18 @@ describe("<DateRangeInput>", () => {
         getDayElement(1).simulate("click");
         getDayElement(10).simulate("click");
         expect(root.state("isOpen")).to.be.false;
+    });
+
+    it("accepts contiguousCalendarMonths prop and passes it to the date range picker", () => {
+        const { root } = wrap(<DateRangeInput contiguousCalendarMonths={false} />);
+        root.setState({ isOpen: true });
+        expect(root.find(DateRangePicker).prop("contiguousCalendarMonths")).to.be.false;
+    });
+
+    it("accepts shortcuts prop and passes it to the date range picker", () => {
+        const { root } = wrap(<DateRangeInput shortcuts={false} />);
+        root.setState({ isOpen: true });
+        expect(root.find(DateRangePicker).prop("shortcuts")).to.be.false;
     });
 
     describe("selectAllOnFocus", () => {

--- a/packages/docs/src/styles/_sections.scss
+++ b/packages/docs/src/styles/_sections.scss
@@ -159,10 +159,23 @@
   }
 }
 
-#{section-id("components.datetime.daterangepicker")},
-#{section-id("components.datetime.daterangeinput")} {
+#{section-id("components.datetime.daterangepicker")} {
   .docs-react-options-column {
     flex: 0 0 270px;
+  }
+}
+
+#{section-id("components.datetime.daterangeinput")} {
+  .docs-react-options-column {
+    // date-format selector doesn't need to be as wide
+    &:first-child {
+      flex: 0 0 180px;
+    }
+
+    // other options have some long labels, so make the column wider
+    &:last-child {
+      flex: 0 0 360px;
+    }
   }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Quick PR to ensure users can configure all `DateRangePicker` props from `DateRangeInput`. In particular:

- Add `contiguousCalendarMonths` prop to `DRI`
- Add `shortcuts` prop to `DRI`
- Add unit tests
- Add `contiguousCalendarMonths` toggle to `DRI` example

#### Reviewers should focus on:

- This PR was motivated by internal requests.
- Possible to get in for today's release?