### PR TITLE
Update table example for ease of use

### DIFF
--- a/packages/table/preview/index.html
+++ b/packages/table/preview/index.html
@@ -119,7 +119,7 @@
   <br /><br />
 
   <h4>Menus &amp; Extended Headers</h4>
-  <div id="table-6" class="fixed-size-table"></div>
+  <div id="table-6"></div>
   <br /><br />
 
   <h4>Custom Column Header Wrapper</h4>

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -471,7 +471,7 @@ ReactDOM.render(
         renderColumnHeader: (columnIndex: number) => {
             const alpha = Utils.toBase26Alpha(columnIndex);
             return (
-                <ColumnHeaderCell name={`${alpha}--- --- --- --- --- --- ---${alpha}`} menu={testMenu}>
+                <ColumnHeaderCell name={`${alpha} Column with a substantially long header name`} menu={testMenu}>
                     <h4>Header {alpha}</h4>
                     <p>Whatever interactive header content goes here lorem ipsum.</p>
                 </ColumnHeaderCell>


### PR DESCRIPTION
The dashes made it harder to grok and were less realistic. The fixed size was unnecessary for this example and cut off the last column awkwardly
@cmslewis 