### PR TITLE
[Table] Remove invalid selection regions when getting new props

### DIFF
--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -467,6 +467,16 @@ export class Regions {
         return true;
     }
 
+    public static isRegionValidForTable(region: IRegion, numRows: number, numCols: number) {
+        if (region.rows != null && (region.rows[0] >= numRows || region.rows[1] >= numRows)) {
+            return false;
+        }
+        if (region.cols != null && (region.cols[0] >= numCols || region.cols[1] >= numCols)) {
+            return false;
+        }
+        return true;
+    }
+
     public static joinStyledRegionGroups(selectedRegions: IRegion[], otherRegions: IStyledRegionGroup[]) {
         let regionGroups: IStyledRegionGroup[] = [];
         if (otherRegions != null) {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -356,7 +356,20 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
 
-        const newSelectedRegions = (selectedRegions == null) ? this.state.selectedRegions : selectedRegions;
+        const numCols = newColumnWidths.length;
+
+        let newSelectedRegions = selectedRegions;
+        if (selectedRegions == null) {
+            newSelectedRegions = this.state.selectedRegions.filter((region) => {
+                if (region.rows != null && (region.rows[0] >= numRows || region.rows[1] >= numRows)) {
+                    return false;
+                }
+                if (region.cols != null && (region.cols[0] >= numCols || region.cols[1] >= numCols)) {
+                    return false;
+                }
+                return true;
+            });
+        }
 
         this.childrenArray = newChildArray;
         this.columnIdToIndex = Table.createColumnIdIndex(this.childrenArray);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -360,14 +360,10 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
         let newSelectedRegions = selectedRegions;
         if (selectedRegions == null) {
+            // if we're in uncontrolled mode, filter out all selected regions that don't
+            // fit in the current new table dimensions
             newSelectedRegions = this.state.selectedRegions.filter((region) => {
-                if (region.rows != null && (region.rows[0] >= numRows || region.rows[1] >= numRows)) {
-                    return false;
-                }
-                if (region.cols != null && (region.cols[0] >= numCols || region.cols[1] >= numCols)) {
-                    return false;
-                }
-                return true;
+                return Regions.isRegionValidForTable(region, numRows, numCols);
             });
         }
 


### PR DESCRIPTION
#### Fixes #881 

#### Changes proposed in this pull request:

When receiving new props, if regions are in uncontrolled mode, check all regions to make sure they still fit. Remove the ones that don't. 

#### Reviewers should focus on:

I'm doing this in uncontrolled mode only. Should I do it in controlled mode too? 
