### PR TITLE
Make minimal button group divider modifier-independent

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -148,7 +148,8 @@ Styleguide components.button-group.css
         @include pt-button-minimal-divider();
         display: inline-block;
         position: absolute;
-        top: 0;
+        top: 10%;
+        bottom: 10%;
         left: 100%;
         content: "";
       }
@@ -268,6 +269,7 @@ Styleguide components.button-group.css
       &::after {
         top: 100%;
         right: 0;
+        bottom: auto;
         left: 0;
         width: auto;
         height: $minimal-button-divider-width;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -428,7 +428,6 @@ $button-intents: (
   margin: ($pt-button-height - $divider-height) / 2;
   background: $pt-divider-black;
   width: $minimal-button-divider-width;
-  height: $divider-height;
 
   .pt-dark & {
     background: $pt-dark-divider-white;


### PR DESCRIPTION
#### Fixes #910

Now works well with `pt-minimal`, `pt-large`, `pt-vertical` or any combination of these.

#### Reviewers should focus on:

The general approach to the solution

#### Screenshot

Before:
![image](https://cloud.githubusercontent.com/assets/199754/24523441/e67a8844-1547-11e7-8f64-a81ea21cc546.png)

After:
![image](https://cloud.githubusercontent.com/assets/199754/24523456/f1a9183e-1547-11e7-9327-8f560cf87389.png)
