### PR TITLE
[Table] Add back fixed size to table example but increase width

### DIFF
--- a/packages/table/preview/index.html
+++ b/packages/table/preview/index.html
@@ -28,7 +28,7 @@
     }
 
     .fixed-size-table {
-      width: 600px;
+      width: 700px;
       height: 300px;
     }
 
@@ -119,7 +119,7 @@
   <br /><br />
 
   <h4>Menus &amp; Extended Headers</h4>
-  <div id="table-6"></div>
+  <div id="table-6" class="fixed-size-table"></div>
   <br /><br />
 
   <h4>Custom Column Header Wrapper</h4>


### PR DESCRIPTION
Interestingly I never tried to view the examples below the custom header example when I first made this change. Now I did and I don't like the unbounded table, but I do want it to be wider

@cmslewis - sorry for the churn