### PR TITLE
[Table] Make row and column heights/widths sparse arrays types correct

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -95,7 +95,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * index. Note that if you want to update these values when the user
      * drag-resizes a column, you may define a callback for `onColumnWidthChanged`.
      */
-    columnWidths?: number[];
+    columnWidths?: Array<number | null | undefined>;
 
     /**
      * If `false`, disables resizing of rows.
@@ -115,7 +115,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * index. Note that if you want to update these values when the user
      * drag-resizes a row, you may define a callback for `onRowHeightChanged`.
      */
-    rowHeights?: number[];
+    rowHeights?: Array<number | null | undefined>;
 
     /**
      * If `false`, hides the row headers and settings menu.


### PR DESCRIPTION
#### Fixes #879 

#### Changes proposed in this pull request:

In a world with strict-null-checks, the typing is wrong -- make it so the typing actually supports sparse arrays in a strict null check world. 
