### PR TITLE
[DateRangeInput] Add popoverProps prop

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -14,6 +14,7 @@ import {
     Classes,
     IInputGroupProps,
     InputGroup,
+    IPopoverProps,
     IProps,
     Keys,
     Popover,
@@ -124,6 +125,11 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     overlappingDatesMessage?: string;
 
     /**
+     * The props to pass to the popover.
+     */
+    popoverProps?: IPopoverProps;
+
+    /**
      * Whether the entire text field should be selected on focus.
      * @default false
      */
@@ -206,6 +212,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         minDate: getDefaultMinDate(),
         outOfRangeMessage: "Out of range",
         overlappingDatesMessage: "Overlapping dates",
+        popoverProps: {},
         selectAllOnFocus: false,
         shortcuts: true,
         startInputProps: {},
@@ -276,17 +283,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             />
         );
 
-        // allow custom props for each input group, but pass them in an order
-        // that guarantees only some props are overridable.
+        // allow custom props the popover and each input group, but pass them in an order that
+        // guarantees only some props are overridable.
         return (
             <Popover
+                inline={true}
+                isOpen={this.state.isOpen}
+                position={Position.BOTTOM_LEFT}
+                {...this.props.popoverProps}
                 autoFocus={false}
                 content={popoverContent}
                 enforceFocus={false}
-                inline={true}
-                isOpen={this.state.isOpen}
                 onClose={this.handlePopoverClose}
-                position={Position.BOTTOM_LEFT}
             >
                 <div className={Classes.CONTROL_GROUP}>
                     <InputGroup
@@ -646,6 +654,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handlePopoverClose = () => {
         this.setState({ isOpen: false });
+        Utils.safeInvoke(this.props.popoverProps.onClose);
     }
 
     // Helpers

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -126,8 +126,9 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * The props to pass to the popover.
+     * `autoFocus`, `content`, and `enforceFocus` will be ignored to avoid compromising usability.
      */
-    popoverProps?: IPopoverProps;
+    popoverProps?: Partial<IPopoverProps>;
 
     /**
      * Whether the entire text field should be selected on focus.
@@ -283,7 +284,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             />
         );
 
-        // allow custom props the popover and each input group, but pass them in an order that
+        // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
             <Popover

--- a/packages/datetime/src/daterangeinput.md
+++ b/packages/datetime/src/daterangeinput.md
@@ -6,7 +6,7 @@ The `DateRangeInput` component is a [control group](#core/components/forms/contr
 
 Use this component in forms where the user must enter a date range.
 
-@react-example DateRangeInputExample
+@reactExample DateRangeInputExample
 
 @## JavaScript API
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -9,7 +9,7 @@ import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
-import { InputGroup, Popover } from "@blueprintjs/core";
+import { InputGroup, Popover, Position } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes as DateClasses, DateRange, DateRangeBoundary, DateRangeInput, DateRangePicker } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -268,6 +268,44 @@ describe("<DateRangeInput>", () => {
             changeEndInputText(root, "");
             changeEndInputText(root, START_STR);
             assertInputTextsEqual(root, START_STR, START_STR);
+        });
+    });
+
+    describe("popoverProps", () => {
+        it("accepts custom popoverProps", () => {
+            const popoverProps = {
+                popoverDidOpen: sinon.spy(),
+                popoverWillOpen: sinon.spy(),
+                popoverWillClose: sinon.spy(),
+                position: Position.TOP_LEFT,
+            };
+            const { root } = wrap(<DateRangeInput popoverProps={popoverProps} />);
+
+            expect(root.find(Popover).prop("position")).to.equal(Position.TOP_LEFT);
+
+            root.setState({ isOpen: true });
+            expect(popoverProps.popoverWillOpen.calledOnce).to.be.true;
+            expect(popoverProps.popoverDidOpen.calledOnce).to.be.true;
+
+            // not testing popoverProps.onClose, because it has some setTimeout stuff to work around
+            root.setState({ isOpen: false });
+            expect(popoverProps.popoverWillClose.calledOnce).to.be.true;
+        });
+
+        it("ignores autoFocus, enforceFocus, and content in custom popoverProps", () => {
+            const CUSTOM_CONTENT = "Here is some custom content";
+            const popoverProps = {
+                autoFocus: true,
+                enforceFocus: true,
+                content: CUSTOM_CONTENT,
+            };
+            const { root } = wrap(<DateRangeInput popoverProps={popoverProps} />);
+
+            // this test assumes the following values will be the defaults internally
+            const popover = root.find(Popover);
+            expect(popover.prop("autoFocus")).to.be.false;
+            expect(popover.prop("enforceFocus")).to.be.false;
+            expect(popover.prop("content")).to.not.equal(CUSTOM_CONTENT));
         });
     });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -275,8 +275,8 @@ describe("<DateRangeInput>", () => {
         it("accepts custom popoverProps", () => {
             const popoverProps = {
                 popoverDidOpen: sinon.spy(),
-                popoverWillOpen: sinon.spy(),
                 popoverWillClose: sinon.spy(),
+                popoverWillOpen: sinon.spy(),
                 position: Position.TOP_LEFT,
             };
             const { root } = wrap(<DateRangeInput popoverProps={popoverProps} />);
@@ -296,8 +296,8 @@ describe("<DateRangeInput>", () => {
             const CUSTOM_CONTENT = "Here is some custom content";
             const popoverProps = {
                 autoFocus: true,
-                enforceFocus: true,
                 content: CUSTOM_CONTENT,
+                enforceFocus: true,
             };
             const { root } = wrap(<DateRangeInput popoverProps={popoverProps} />);
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -305,7 +305,7 @@ describe("<DateRangeInput>", () => {
             const popover = root.find(Popover);
             expect(popover.prop("autoFocus")).to.be.false;
             expect(popover.prop("enforceFocus")).to.be.false;
-            expect(popover.prop("content")).to.not.equal(CUSTOM_CONTENT));
+            expect(popover.prop("content")).to.not.equal(CUSTOM_CONTENT);
         });
     });
 


### PR DESCRIPTION
#### Addresses #805

#### Checklist

- [x] Include tests
- [x] Update documentation (props table will auto-update with new prop)

#### Changes proposed in this pull request:

- Add a `popoverProps` prop to `DateRangeInput` to support custom callbacks for `popoverWillOpen`, `onClose`, etc.
- *DO NOT* allow users to override `autoFocus`, `content`, or `enforceFocus`, because that would lead to sad times w/r/t UX.
- *DO* allow for overriding of `isOpen` and other popover props.

#### Reviewers should focus on:

- Does it make sense to allow overriding of `isOpen`?
- Should we throw an error or print a warning or otherwise notify the user when certain props they included are being ignored?
