### PR TITLE
[NumericInput] Add rightElement prop

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -74,6 +74,12 @@ export interface INumericInputProps extends IIntentProps, IProps {
     minorStepSize?: number;
 
     /**
+     * Element to render on right side of input.
+     * For best results, use a minimal button, tag, or small spinner.
+     */
+    rightElement?: JSX.Element;
+
+    /**
      * Whether the entire text field should be selected on focus.
      * @default false
      */
@@ -214,6 +220,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
                 onKeyDown={this.handleInputKeyDown}
                 onKeyPress={this.handleInputKeyPress}
                 onPaste={this.handleInputPaste}
+                rightElement={this.props.rightElement}
                 value={this.state.value}
             />
         );

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -829,6 +829,11 @@ describe("<NumericInput>", () => {
             expect(placeholderText).to.equal("Enter a number...");
         });
 
+        it("shows right element if provided", () => {
+            const component = mount(<NumericInput rightElement={<Button />} />);
+            expect(component.find(InputGroup).find("pt-input-action")).to.exist;
+        });
+
         it("changes max precision of displayed value to that of the smallest step size defined", () => {
             const component = mount(<NumericInput majorStepSize={1} stepSize={0.1} minorStepSize={0.001} />);
             const incrementButton = component.find(Button).first();


### PR DESCRIPTION
#### Fixes #908

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add `rightElement` prop to `NumericInput`

#### Reviewers should focus on:

- Does it make sense to move to an `inputGroupProps` prop for `NumericInput` in our next major release?

#### Screenshot

![screen shot 2017-04-04 at 10 52 38 am](https://cloud.githubusercontent.com/assets/443450/24671409/3d7ebf34-1926-11e7-80dd-d631740062df.png)
