### PR TITLE
[Tooltip] disable empty tooltips

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -37,7 +37,6 @@ export const NUMERIC_INPUT_STEP_SIZE_NULL =
     `${ns} <NumericInput> requires stepSize to be defined`;
 
 export const POPOVER_ONE_CHILD = `${ns} <Popover> requires exactly one target element`;
-export const POPOVER_CONTROLLED_DISABLED = `${ns} <Popover> isOpen and isDisabled props are mutually exclusive`;
 export const POPOVER_UNCONTROLLED_ONINTERACTION = `${ns} <Popover> onInteraction is ignored when uncontrolled`;
 export const POPOVER_MODAL_INLINE =
     `${ns} <Popover isModal={true}> requires inline={false}.`;

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -61,6 +61,8 @@ export const TABS_DEPRECATED = `${ns} <Tabs> is deprecated since v1.11.0; consid
 
 export const TOASTER_INLINE_WARNING = `${ns} Toaster.create() ignores inline prop as it always creates a new element`;
 
+export const TOOLTIP_EMPTY_WARNING = `${ns} Disabling empty <Tooltip>`;
+
 export const WARNING_DIALOG_NO_HEADER_ICON = `${ns} Warning: Dialog iconName prop is ignored if title prop is omitted`;
 export const WARNING_DIALOG_NO_HEADER_CLOSE_BUTTON =
     `${ns} Warning: Dialog isCloseButtonShown prop is ignored if title prop is omitted`;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -247,7 +247,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     public constructor(props?: IPopoverProps, context?: any) {
         super(props, context);
 
-        let isOpen = props.defaultIsOpen;
+        let isOpen = props.defaultIsOpen && !props.isDisabled;
         if (props.isOpen != null) {
             isOpen = props.isOpen;
         }
@@ -328,7 +328,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     public componentWillReceiveProps(nextProps: IPopoverProps) {
         super.componentWillReceiveProps(nextProps);
 
-        if (nextProps.isDisabled && !this.props.isDisabled) {
+        if (nextProps.isOpen == null && nextProps.isDisabled && !this.props.isDisabled) {
             // ok to use setOpenState here because isDisabled and isOpen are mutex.
             this.setOpenState(false);
         } else if (nextProps.isOpen !== this.props.isOpen) {
@@ -359,10 +359,6 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     protected validateProps(props: IPopoverProps & {children?: React.ReactNode}) {
         if (props.isOpen == null && props.onInteraction != null) {
             console.warn(Errors.POPOVER_UNCONTROLLED_ONINTERACTION);
-        }
-
-        if (props.isOpen != null && props.isDisabled) {
-            throw new Error(Errors.POPOVER_CONTROLLED_DISABLED);
         }
 
         if (props.isModal && props.interactionKind !== PopoverInteractionKind.CLICK) {

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -10,9 +10,11 @@ import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
+import { TOOLTIP_EMPTY_WARNING } from "../../common/errors";
 import { Position } from "../../common/position";
 import { IIntentProps, IProps } from "../../common/props";
 import { ITetherConstraint } from "../../common/tetherUtils";
+import { isNodeEnv } from "../../common/utils";
 
 import { Popover, PopoverInteractionKind } from "../popover/popover";
 
@@ -154,8 +156,13 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
     public displayName = "Blueprint.Tooltip";
 
     public render(): JSX.Element {
-        const { children, intent, openOnTargetFocus, tooltipClassName } = this.props;
+        const { content, children, intent, openOnTargetFocus, tooltipClassName } = this.props;
         const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
+
+        const isEmpty = content == null || (typeof content === "string" && content.trim() === "");
+        if (isEmpty && !isNodeEnv("production")) {
+            console.warn(TOOLTIP_EMPTY_WARNING);
+        }
 
         return (
             <Popover
@@ -163,6 +170,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
                 arrowSize={22}
                 autoFocus={false}
                 canEscapeKeyClose={false}
+                isDisabled={this.props.isDisabled || isEmpty}
                 enforceFocus={false}
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -15,11 +15,11 @@ import * as Keys from "../../src/common/keys";
 import {
     Classes,
     IPopoverProps,
+    Overlay,
     Popover,
     PopoverInteractionKind,
     SVGPopover,
     Tooltip,
-    Overlay,
 } from "../../src/index";
 import { dispatchMouseEvent } from "../common/utils";
 
@@ -531,7 +531,7 @@ describe("<Popover>", () => {
         wrapper.assertIsOpen = (isOpen = true) => {
             assert.equal(wrapper.find(Overlay).prop("isOpen"), isOpen);
             return wrapper;
-        }
+        };
         wrapper.findClass = (className: string) => wrapper.find(`.${className}`);
         wrapper.simulateTarget = (eventName: string) => {
             wrapper.findClass(Classes.POPOVER_TARGET).simulate(eventName);

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -19,6 +19,7 @@ import {
     PopoverInteractionKind,
     SVGPopover,
     Tooltip,
+    Overlay,
 } from "../../src/index";
 import { dispatchMouseEvent } from "../common/utils";
 
@@ -284,26 +285,24 @@ describe("<Popover>", () => {
 
     describe("in controlled mode", () => {
         it("state respects isOpen prop", () => {
-            wrapper = renderPopover();
-            assert.isFalse(wrapper.state("isOpen"));
-            wrapper.setProps({ isOpen: true } as any);
-            assert.isTrue(wrapper.state("isOpen"));
+            renderPopover()
+                .assertIsOpen(false)
+                .setProps({ isOpen: true })
+                .assertIsOpen();
         });
 
         it("state does not update on user interaction", () => {
-            wrapper = renderPopover({ isOpen: true }).simulateTarget("click");
-            assert.isTrue(wrapper.state("isOpen"));
-            wrapper.setProps({ isOpen: false }).simulateTarget("click");
-            assert.isFalse(wrapper.state("isOpen"));
-            wrapper = renderPopover({ canEscapeKeyClose: true, isOpen: true }).sendEscapeKey();
-            assert.isTrue(wrapper.state("isOpen"));
+            renderPopover({ isOpen: true }).simulateTarget("click")
+                .assertIsOpen()
+                .setProps({ isOpen: false }).simulateTarget("click")
+                .assertIsOpen(false);
+            renderPopover({ canEscapeKeyClose: true, isOpen: true })
+                .sendEscapeKey()
+                .assertIsOpen();
         });
 
-        it("setting isDisabled=true throws error", () => {
-            assert.throws(() => renderPopover({
-                isDisabled: true,
-                isOpen: true,
-            }), Errors.POPOVER_CONTROLLED_DISABLED);
+        it("isDisabled is ignored", () => {
+            renderPopover({ isDisabled: true, isOpen: true }).assertIsOpen();
         });
 
         it("onClose is invoked with event when popover would close", () => {
@@ -361,36 +360,24 @@ describe("<Popover>", () => {
 
     describe("in uncontrolled mode", () => {
         it("setting defaultIsOpen=true renders open popover", () => {
-            wrapper = renderPopover({ defaultIsOpen: true });
-            assert.isTrue(wrapper.state("isOpen"));
+            renderPopover({ defaultIsOpen: true }).assertIsOpen();
         });
 
         it("with defaultIsOpen=true, popover can still be closed", () => {
-            wrapper = renderPopover({ defaultIsOpen: true });
-            assert.isTrue(wrapper.state("isOpen"));
-
-            wrapper.simulateTarget("click");
-            assert.isFalse(wrapper.state("isOpen"));
+            renderPopover({ defaultIsOpen: true }).assertIsOpen()
+                .simulateTarget("click").assertIsOpen(false);
         });
 
         it("CLICK_TARGET_ONLY works properly", () => {
-            wrapper = renderPopover({ interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY });
-
-            wrapper.simulateTarget("click");
-            assert.isTrue(wrapper.state("isOpen"));
-
-            wrapper.simulateTarget("click");
-            assert.isFalse(wrapper.state("isOpen"));
+            renderPopover({ interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY })
+                .simulateTarget("click").assertIsOpen()
+                .simulateTarget("click").assertIsOpen(false);
         });
 
         it("HOVER_TARGET_ONLY works properly", () => {
-            wrapper = renderPopover({ inline: false, interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY });
-
-            wrapper.simulateTarget("mouseenter");
-            assert.isTrue(wrapper.state("isOpen"));
-
-            wrapper.simulateTarget("mouseleave");
-            assert.isFalse(wrapper.state("isOpen"));
+            renderPopover({ inline: false, interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
+                .simulateTarget("mouseenter").assertIsOpen()
+                .simulateTarget("mouseleave").assertIsOpen(false);
         });
 
         it("inline HOVER_TARGET_ONLY works properly when openOnTargetFocus={false}", () => {
@@ -400,24 +387,22 @@ describe("<Popover>", () => {
                 openOnTargetFocus: false,
             });
 
-            wrapper.simulateTarget("mouseenter");
-            assert.isTrue(wrapper.state("isOpen"));
+            wrapper.simulateTarget("mouseenter").assertIsOpen();
 
             wrapper.findClass(Classes.POPOVER).simulate("mouseenter");
-            assert.isFalse(wrapper.state("isOpen"));
+            wrapper.assertIsOpen(false);
         });
 
         it("inline HOVER works properly", () => {
             wrapper = renderPopover({ inline: true, interactionKind: PopoverInteractionKind.HOVER });
 
-            wrapper.simulateTarget("mouseenter");
-            assert.isTrue(wrapper.state("isOpen"));
+            wrapper.simulateTarget("mouseenter").assertIsOpen();
 
             wrapper.findClass(Classes.POPOVER).simulate("mouseenter");
-            assert.isTrue(wrapper.state("isOpen"));
+            wrapper.assertIsOpen();
 
             wrapper.findClass(Classes.POPOVER).simulate("mouseleave");
-            assert.isFalse(wrapper.state("isOpen"));
+            wrapper.assertIsOpen(false);
         });
 
         it("clicking .pt-popover-dismiss closes popover when inline=false", () => {
@@ -426,11 +411,10 @@ describe("<Popover>", () => {
                 interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
             }, <button className="pt-button pt-popover-dismiss">Dismiss</button>);
 
-            wrapper.simulateTarget("click");
-            assert.isTrue(wrapper.state("isOpen"));
+            wrapper.simulateTarget("click").assertIsOpen();
 
             TestUtils.Simulate.click(document.getElementsByClassName(Classes.POPOVER_DISMISS)[0]);
-            assert.isFalse(wrapper.state("isOpen"));
+            wrapper.assertIsOpen(false);
         });
 
         it("clicking .pt-popover-dismiss closes popover when inline=true", () => {
@@ -439,37 +423,29 @@ describe("<Popover>", () => {
                 interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
             }, <button className="pt-button pt-popover-dismiss">Dismiss</button>);
 
-            wrapper.simulateTarget("click");
-            assert.isTrue(wrapper.state("isOpen"));
+            wrapper.simulateTarget("click").assertIsOpen();
 
             wrapper.findClass(Classes.POPOVER_DISMISS).simulate("click");
-            assert.isFalse(wrapper.state("isOpen"));
+            wrapper.assertIsOpen(false);
         });
 
         it("pressing Escape closes popover when canEscapeKeyClose=true and inline=true", () => {
-            wrapper = renderPopover({ canEscapeKeyClose: true, inline: true });
-            wrapper.simulateTarget("click");
-            assert.isTrue(wrapper.state("isOpen"));
-            wrapper.sendEscapeKey();
-            assert.isFalse(wrapper.state("isOpen"));
+            renderPopover({ canEscapeKeyClose: true, inline: true })
+                .simulateTarget("click").assertIsOpen()
+                .sendEscapeKey().assertIsOpen(false);
         });
 
         it("setting isDisabled=true prevents opening popover", () => {
-            wrapper = renderPopover({
+            renderPopover({
                 interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
                 isDisabled: true,
-            });
-            wrapper.simulateTarget("click");
-            assert.isFalse(wrapper.state("isOpen"));
+            }).simulateTarget("click").assertIsOpen(false);
         });
 
         it("setting isDisabled=true hides open popover", () => {
-            wrapper = renderPopover({ interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY });
-            wrapper.simulateTarget("click");
-            assert.isTrue(wrapper.state("isOpen"));
-
-            wrapper.setProps({ isDisabled: true });
-            assert.isFalse(wrapper.state("isOpen"));
+            renderPopover({ interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY })
+                .simulateTarget("click").assertIsOpen()
+                .setProps({ isDisabled: true }).assertIsOpen(false);
         });
 
         it("console.warns if onInteraction is set", () => {
@@ -539,6 +515,7 @@ describe("<Popover>", () => {
     });
 
     interface IPopoverWrapper extends ReactWrapper<any, any> {
+        assertIsOpen(isOpen?: boolean): this;
         simulateTarget(eventName: string): this;
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
         sendEscapeKey(): this;
@@ -551,6 +528,10 @@ describe("<Popover>", () => {
             </Popover>,
             { attachTo: testsContainerElement },
         ) as IPopoverWrapper;
+        wrapper.assertIsOpen = (isOpen = true) => {
+            assert.equal(wrapper.find(Overlay).prop("isOpen"), isOpen);
+            return wrapper;
+        }
         wrapper.findClass = (className: string) => wrapper.find(`.${className}`);
         wrapper.simulateTarget = (eventName: string) => {
             wrapper.findClass(Classes.POPOVER_TARGET).simulate(eventName);

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -52,7 +52,24 @@ describe("<Tooltip>", () => {
             assert.lengthOf(tooltip.find(`.${Classes.TOOLTIP}.foo`), 1);
             assert.lengthOf(tooltip.find(`.${Classes.POPOVER_TARGET}.bar`), 1);
         });
-        //
+
+        it("empty content disables Popover and warns", () => {
+            const warnSpy = sinon.spy(console, "warn");
+            const tooltip = renderTooltip({ content: "" });
+
+            function assertDisabledPopover(content?: string) {
+                tooltip.setProps({ content });
+                assert.isTrue(tooltip.find(Popover).prop("isDisabled"));
+                assert.isTrue(warnSpy.calledOnce);
+                warnSpy.reset();
+            }
+
+            assertDisabledPopover("");
+            assertDisabledPopover("   ");
+            assertDisabledPopover(null);
+            warnSpy.restore();
+        });
+
         // it("setting isDisabled=true prevents opening tooltip", () => {
         //     const tooltip = renderTooltip({ isDisabled: true });
         //     tooltip.find(Popover).simulate("mouseenter");
@@ -113,7 +130,7 @@ describe("<Tooltip>", () => {
 
     function renderTooltip(props?: Partial<ITooltipProps>) {
         return mount(
-            <Tooltip {...props} content={<p>Text</p>} hoverOpenDelay={0} inline>
+            <Tooltip content={<p>Text</p>} hoverOpenDelay={0} {...props} inline>
                 <button>Target</button>
             </Tooltip>,
         );

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -70,21 +70,11 @@ describe("<Tooltip>", () => {
             warnSpy.restore();
         });
 
-        // it("setting isDisabled=true prevents opening tooltip", () => {
-        //     const tooltip = renderTooltip({ isDisabled: true });
-        //     tooltip.find(Popover).simulate("mouseenter");
-        //     hoverOverTarget();
-        //     assertTooltipExists(false, `.pt-tether-enabled > .${Classes.TOOLTIP}`);
-        // });
-        //
-        // it("setting isDisabled=true hides an already open tooltip", () => {
-        //     renderTooltip();
-        //     hoverOverTarget();
-        //     assertTooltipExists(true, `.pt-tether-enabled > .${Classes.TOOLTIP}`);
-        //
-        //     renderTooltip({ isDisabled: true });
-        //     assertTooltipExists(false, `.pt-tether-enabled > .${Classes.TOOLTIP}`);
-        // });
+        it("setting isDisabled=true prevents opening tooltip", () => {
+            const tooltip = renderTooltip({ isDisabled: true });
+            tooltip.find(Popover).simulate("mouseenter");
+            assert.lengthOf(tooltip.find(TOOLTIP_SELECTOR), 0);
+        });
     });
 
     describe("in controlled mode", () => {
@@ -98,9 +88,12 @@ describe("<Tooltip>", () => {
             assert.lengthOf(tooltip.find(TOOLTIP_SELECTOR), 0);
         });
 
-        it("empty content disables Popover", () => {
+        it("empty content disables Popover and warns", () => {
+            const warnSpy = sinon.spy(console, "warn");
             const tooltip = renderTooltip({ content: "", isOpen: true });
             assert.isTrue(tooltip.find(Popover).prop("isDisabled"));
+            assert.isTrue(warnSpy.calledOnce);
+            warnSpy.restore();
         });
 
         describe("onInteraction()", () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -59,7 +59,7 @@ describe("<Tooltip>", () => {
 
             function assertDisabledPopover(content?: string) {
                 tooltip.setProps({ content });
-                assert.isTrue(tooltip.find(Popover).prop("isDisabled"));
+                assert.isTrue(tooltip.find(Popover).prop("isDisabled"), `"${content}"`);
                 assert.isTrue(warnSpy.calledOnce);
                 warnSpy.reset();
             }
@@ -96,6 +96,11 @@ describe("<Tooltip>", () => {
         it("doesn't render when not open", () => {
             const tooltip = renderTooltip({ isOpen: false });
             assert.lengthOf(tooltip.find(TOOLTIP_SELECTOR), 0);
+        });
+
+        it("empty content disables Popover", () => {
+            const tooltip = renderTooltip({ content: "", isOpen: true });
+            assert.isTrue(tooltip.find(Popover).prop("isDisabled"));
         });
 
         describe("onInteraction()", () => {


### PR DESCRIPTION
#### Fixes #886 

#### Changes proposed in this pull request:

- disable empty tooltips
- empty = null/undefined, empty string, whitespace strings.