### PR TITLE
[DateRangeInput] Support full HTMLInputProps on each input

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -468,6 +468,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             case "focus": this.handleInputFocus(e, boundary); break;
             case "keydown": this.handleInputKeyDown(e as React.KeyboardEvent<HTMLInputElement>); break;
             case "mousedown": this.handleInputMouseDown(); break;
+            default: break;
         }
 
         const inputProps = this.getInputProps(boundary);

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -764,13 +764,23 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private getInputPlaceholderString = (boundary: DateRangeBoundary) => {
-        const { isInputFocused } = this.getStateKeysAndValuesForBoundary(boundary).values;
         const isStartBoundary = boundary === DateRangeBoundary.START;
+        const isEndBoundary = boundary === DateRangeBoundary.END;
 
-        const dateString = isStartBoundary ? this.state.formattedMinDateString : this.state.formattedMaxDateString;
-        const defaultString = isStartBoundary ? "Start date" : "End date";
+        const { isInputFocused } = this.getStateKeysAndValuesForBoundary(boundary).values;
 
-        return isInputFocused ? dateString : defaultString;
+        // use the custom placeholder text for each field if providied
+        if (isStartBoundary && this.props.startInputProps.placeholder != null) {
+            return this.props.startInputProps.placeholder;
+        } else if (isEndBoundary && this.props.endInputProps.placeholder != null) {
+            return this.props.endInputProps.placeholder;
+        } else if (isStartBoundary) {
+            return isInputFocused ? this.state.formattedMinDateString : "Start date";
+        } else if (isEndBoundary) {
+            return isInputFocused ? this.state.formattedMaxDateString : "End date";
+        } else {
+            return "";
+        }
     }
 
     private getFormattedDateString = (momentDate: moment.Moment, format?: string) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -710,13 +710,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }) as DateRange;
     }
 
-    private getInputClasses = (boundary: DateRangeBoundary) => {
-        const inputProps = this.getInputProps(boundary);
-        return classNames(inputProps.className, {
-            [Classes.INTENT_DANGER]: this.isInputInErrorState(boundary),
-        });
-    }
-
     private getInputDisplayString = (boundary: DateRangeBoundary) => {
         const { values } = this.getStateKeysAndValuesForBoundary(boundary);
         const { isInputFocused, inputString, selectedValue, hoverString } = values;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -332,15 +332,24 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private renderInputGroup = (boundary: DateRangeBoundary) => {
-        const inputProps = boundary === DateRangeBoundary.START ? this.props.startInputProps : this.props.endInputProps;
-        const htmlProps = this.getHtmlPropsFromInputProps(inputProps);
+        const inputProps = this.getInputProps(boundary);
 
-        const handleInputEvent = (e: React.SyntheticEvent<HTMLInputElement>) => this.handleInputEvent(e, boundary);
+        // don't include `ref` in the returned HTML props, because passing it to the InputGroup
+        // leads to TS typing errors.
+        const { ref, ...htmlProps } = inputProps;
+
+        const handleInputEvent = (boundary === DateRangeBoundary.START)
+            ? this.handleStartInputEvent
+            : this.handleEndInputEvent;
+
+        const classes = classNames(inputProps.className, {
+            [Classes.INTENT_DANGER]: this.isInputInErrorState(boundary),
+        });
 
         return (
             <InputGroup
                 {...htmlProps}
-                className={this.getInputClasses(boundary)}
+                className={classes}
                 disabled={this.props.disabled}
                 inputRef={this.getInputRef(boundary)}
                 onBlur={handleInputEvent}
@@ -459,6 +468,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     // Callbacks - Input
     // =================
+
+    // instantiate these two functions once so we don't have to for each callback on each render.
+
+    private handleStartInputEvent = (e: React.SyntheticEvent<HTMLInputElement>) => {
+        this.handleInputEvent(e, DateRangeBoundary.START);
+    }
+
+    private handleEndInputEvent = (e: React.SyntheticEvent<HTMLInputElement>) => {
+        this.handleInputEvent(e, DateRangeBoundary.END);
+    }
 
     private handleInputEvent = (e: React.SyntheticEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {
         switch (e.type) {
@@ -662,13 +681,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             return moment(null);
         }
         return moment(dateString, this.props.format);
-    }
-
-    private getHtmlPropsFromInputProps = (inputProps: HTMLInputProps & IInputGroupProps) => {
-        // don't include ref in the returned HTML props, because passing it to the InputGroup leads
-        // to TS errors.
-        const { ref, ...htmlProps } = inputProps;
-        return htmlProps;
     }
 
     private getInitialRange = (props = this.props) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -79,7 +79,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Props to pass to the end-date input.
-     * `disabled` will be ignored in favor of the top-level `disabled` prop on this component.
+     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      */
     endInputProps?: HTMLInputProps & IInputGroupProps;
 
@@ -149,7 +149,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Props to pass to the start-date input.
-     * `disabled` will be ignored in favor of the top-level `disabled` prop on this component.
+     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      */
     startInputProps?: HTMLInputProps & IInputGroupProps;
 
@@ -560,10 +560,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleStartInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputFocus(e, DateRangeBoundary.START);
+        Utils.safeInvoke(this.props.startInputProps.onFocus, e);
     }
 
     private handleEndInputFocus = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputFocus(e, DateRangeBoundary.END);
+        Utils.safeInvoke(this.props.endInputProps.onFocus, e);
     }
 
     private handleInputFocus = (_e: React.FormEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import {
     AbstractComponent,
     Classes,
+    HTMLInputProps,
     IInputGroupProps,
     InputGroup,
     IPopoverProps,
@@ -78,8 +79,9 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Props to pass to the end-date input.
+     * `disabled` will be ignored in favor of the top-level `disabled` prop on this component.
      */
-    endInputProps?: IInputGroupProps;
+    endInputProps?: HTMLInputProps & IInputGroupProps;
 
     /**
      * The format of each date in the date range. See options
@@ -147,8 +149,9 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Props to pass to the start-date input.
+     * `disabled` will be ignored in favor of the top-level `disabled` prop on this component.
      */
-    startInputProps?: IInputGroupProps;
+    startInputProps?: HTMLInputProps & IInputGroupProps;
 
     /**
      * The currently selected date range.
@@ -299,30 +302,33 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             >
                 <div className={Classes.CONTROL_GROUP}>
                     <InputGroup
-                        {...startInputProps}
+                        // cast as `any` to` ignore the following error for now:
+                        //   "Property 'ref' of JSX spread attribute is not assignable to target property"
+                        // need to find a better approach here when addressing #943
+                        {...startInputProps as any}
                         className={this.getInputClasses(DateRangeBoundary.START, startInputProps)}
                         disabled={this.props.disabled}
                         inputRef={this.refHandlers.startInputRef}
                         onBlur={this.handleStartInputBlur}
                         onChange={this.handleStartInputChange}
-                        onClick={this.handleInputClick}
+                        onClick={this.handleStartInputClick}
                         onFocus={this.handleStartInputFocus}
-                        onKeyDown={this.handleInputKeyDown}
-                        onMouseDown={this.handleInputMouseDown}
+                        onKeyDown={this.handleStartInputKeyDown}
+                        onMouseDown={this.handleStartInputMouseDown}
                         placeholder={this.getInputPlaceholderString(DateRangeBoundary.START)}
                         value={this.getInputDisplayString(DateRangeBoundary.START)}
                     />
                     <InputGroup
-                        {...endInputProps}
+                        {...endInputProps as any}
                         className={this.getInputClasses(DateRangeBoundary.END, endInputProps)}
                         disabled={this.props.disabled}
                         inputRef={this.refHandlers.endInputRef}
                         onBlur={this.handleEndInputBlur}
                         onChange={this.handleEndInputChange}
-                        onClick={this.handleInputClick}
+                        onClick={this.handleEndInputClick}
                         onFocus={this.handleEndInputFocus}
-                        onKeyDown={this.handleInputKeyDown}
-                        onMouseDown={this.handleInputMouseDown}
+                        onKeyDown={this.handleEndInputKeyDown}
+                        onMouseDown={this.handleEndInputMouseDown}
                         placeholder={this.getInputPlaceholderString(DateRangeBoundary.END)}
                         value={this.getInputDisplayString(DateRangeBoundary.END)}
                     />
@@ -463,6 +469,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     // Key down
 
+    private handleStartInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        this.handleInputKeyDown(e);
+        Utils.safeInvoke(this.props.startInputProps.onKeyDown, e);
+    }
+
+    private handleEndInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        this.handleInputKeyDown(e);
+        Utils.safeInvoke(this.props.endInputProps.onKeyDown, e);
+    }
+
     // add a keydown listener to persistently change focus when tabbing:
     // - if focused in start field, Tab moves focus to end field
     // - if focused in end field, Shift+Tab moves focus to start field
@@ -505,6 +521,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     // Mouse down
 
+    private handleStartInputMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+        this.handleInputMouseDown();
+        Utils.safeInvoke(this.props.startInputProps.onMouseDown, e);
+    }
+
+    private handleEndInputMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+        this.handleInputMouseDown();
+        Utils.safeInvoke(this.props.endInputProps.onMouseDown, e);
+    }
+
     private handleInputMouseDown = () => {
         // clicking in the field constitutes an explicit focus change. we update
         // the flag on "mousedown" instead of on "click", because it needs to be
@@ -513,6 +539,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     // Click
+
+    private handleStartInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+        this.handleInputClick(e);
+        Utils.safeInvoke(this.props.startInputProps.onClick, e);
+    }
+
+    private handleEndInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+        this.handleInputClick(e);
+        Utils.safeInvoke(this.props.endInputProps.onClick, e);
+    }
 
     private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
         // unless we stop propagation on this event, a click within an input
@@ -555,10 +591,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleStartInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputBlur(e, DateRangeBoundary.START);
+        Utils.safeInvoke(this.props.startInputProps.onBlur, e);
     }
 
     private handleEndInputBlur = (e: React.FormEvent<HTMLInputElement>) => {
         this.handleInputBlur(e, DateRangeBoundary.END);
+        Utils.safeInvoke(this.props.endInputProps.onBlur, e);
     }
 
     private handleInputBlur = (_e: React.FormEvent<HTMLInputElement>, boundary: DateRangeBoundary) => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -342,9 +342,9 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             ? this.handleStartInputEvent
             : this.handleEndInputEvent;
 
-        const classes = classNames(inputProps.className, {
+        const classes = classNames({
             [Classes.INTENT_DANGER]: this.isInputInErrorState(boundary),
-        });
+        }, inputProps.className);
 
         return (
             <InputGroup
@@ -494,20 +494,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const callbackFn = this.getInputGroupCallbackForEvent(e, inputProps);
 
         Utils.safeInvoke(callbackFn, e);
-    }
-
-    private getInputGroupCallbackForEvent = (e: React.SyntheticEvent<HTMLInputElement>,
-                                             inputProps: HTMLInputProps & IInputGroupProps) => {
-        // use explicit switch cases to ensure callback function names remain grep-able in the codebase.
-        switch (e.type) {
-            case "blur": return inputProps.onBlur;
-            case "change": return inputProps.onChange;
-            case "click": return inputProps.onClick;
-            case "focus": return inputProps.onFocus;
-            case "keydown": return inputProps.onKeyDown;
-            case "mousedown": return inputProps.onMouseDown;
-            default: return undefined;
-        }
     }
 
     // add a keydown listener to persistently change focus when tabbing:
@@ -708,6 +694,20 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 ? fromMomentToDate(selectedBound)
                 : undefined;
         }) as DateRange;
+    }
+
+    private getInputGroupCallbackForEvent = (e: React.SyntheticEvent<HTMLInputElement>,
+                                             inputProps: HTMLInputProps & IInputGroupProps) => {
+        // use explicit switch cases to ensure callback function names remain grep-able in the codebase.
+        switch (e.type) {
+            case "blur": return inputProps.onBlur;
+            case "change": return inputProps.onChange;
+            case "click": return inputProps.onClick;
+            case "focus": return inputProps.onFocus;
+            case "keydown": return inputProps.onKeyDown;
+            case "mousedown": return inputProps.onMouseDown;
+            default: return undefined;
+        }
     }
 
     private getInputDisplayString = (boundary: DateRangeBoundary) => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -100,42 +100,24 @@ describe("<DateRangeInput>", () => {
                 expect(getInputPlaceholderText(inputGetterFn(root))).to.equal("Hello");
             });
 
-            // check only the callbacks that we override. (we should still be invoking these
-            // callbacks after responding to these events ourselves within the component.)
+            // verify custom callbacks are called for each event that we listen for internally.
+            // (note: we could be more clever and accept just one string param here, but this
+            // approach keeps both string params grep-able in the codebase.)
+            runCallbackTest("onChange", "change");
+            runCallbackTest("onFocus", "focus");
+            runCallbackTest("onBlur", "blur");
+            runCallbackTest("onClick", "click");
+            runCallbackTest("onKeyDown", "keydown");
+            runCallbackTest("onMouseDown", "mousedown");
 
-            it("fires custom onChange callback", () => {
-                assertEventCallbackFired("change", (onChange) => ({ onChange }));
-            });
-
-            it("fires custom onFocus callback", () => {
-                assertEventCallbackFired("focus", (onFocus) => ({ onFocus }));
-            });
-
-            it("fires custom onBlur callback", () => {
-                assertEventCallbackFired("blur", (onBlur) => ({ onBlur }));
-            });
-
-            it("fires custom onClick callback", () => {
-                assertEventCallbackFired("click", (onClick) => ({ onClick }));
-            });
-
-            it("fires custom onKeyDown callback", () => {
-                assertEventCallbackFired("keydown", (onKeyDown) => ({ onKeyDown }));
-            });
-
-            it("fires custom onMouseDown callback", () => {
-                assertEventCallbackFired("mousedown", (onMouseDown) => ({ onMouseDown }));
-            });
-
-            // cast as `any` so that we don't have to cast returned values as `HTMLInputProps &
-            // IInputGroupProps` above.
-            function assertEventCallbackFired(eventName: string,
-                                              buildProps: (spy: Sinon.SinonSpy) => HTMLInputProps & IInputGroupProps) {
-                const spy = sinon.spy();
-                const component = mountFn(buildProps(spy));
-                const input = inputGetterFn(component);
-                input.simulate(eventName);
-                expect(spy.calledOnce).to.be.true;
+            function runCallbackTest(callbackName: string, eventName: string) {
+                it(`fires custom ${callbackName} callback`, () => {
+                    const spy = sinon.spy();
+                    const component = mountFn({ [callbackName]: spy });
+                    const input = inputGetterFn(component);
+                    input.simulate(eventName);
+                    expect(spy.calledOnce).to.be.true;
+                });
             }
         }
     });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -104,27 +104,27 @@ describe("<DateRangeInput>", () => {
             // callbacks after responding to these events ourselves within the component.)
 
             it("fires custom onChange callback", () => {
-                assertEventCallbackFired("change", (spy) => ({ onChange: spy }));
+                assertEventCallbackFired("change", (onChange) => ({ onChange }));
             });
 
             it("fires custom onFocus callback", () => {
-                assertEventCallbackFired("focus", (spy) => ({ onFocus: spy }));
+                assertEventCallbackFired("focus", (onFocus) => ({ onFocus }));
             });
 
             it("fires custom onBlur callback", () => {
-                assertEventCallbackFired("blur", (spy) => ({ onBlur: spy }));
+                assertEventCallbackFired("blur", (onBlur) => ({ onBlur }));
             });
 
             it("fires custom onClick callback", () => {
-                assertEventCallbackFired("click", (spy) => ({ onClick: spy }));
+                assertEventCallbackFired("click", (onClick) => ({ onClick }));
             });
 
             it("fires custom onKeyDown callback", () => {
-                assertEventCallbackFired("keydown", (spy) => ({ onKeyDown: spy }));
+                assertEventCallbackFired("keydown", (onKeyDown) => ({ onKeyDown }));
             });
 
             it("fires custom onMouseDown callback", () => {
-                assertEventCallbackFired("mousedown", (spy) => ({ onMouseDown: spy }));
+                assertEventCallbackFired("mousedown", (onMouseDown) => ({ onMouseDown }));
             });
 
             // cast as `any` so that we don't have to cast returned values as `HTMLInputProps &

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -26,7 +26,7 @@ type InvalidDateTestFunction = (input: WrappedComponentInput,
                                 boundary: DateRangeBoundary,
                                 otherInput: WrappedComponentInput) => void;
 
-describe("<DateRangeInput>", () => {
+describe.only("<DateRangeInput>", () => {
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
     const START_STR = DateTestUtils.toHyphenatedDateString(START_DATE);
@@ -78,20 +78,18 @@ describe("<DateRangeInput>", () => {
         type InputGetterFunction = (root: WrappedComponentRoot) => WrappedComponentInput;
 
         describe("startInputProps", () => {
-            const _mount = (inputGroupProps: HTMLInputProps & IInputGroupProps) => {
+            runTestSuite(getStartInput, (inputGroupProps) => {
                 return mount(<DateRangeInput startInputProps={inputGroupProps} />);
-            };
-            runTestSuite(_mount, getStartInput);
+            });
         });
 
         describe("endInputProps", () => {
-            const _mount = (inputGroupProps: HTMLInputProps & IInputGroupProps) => {
+            runTestSuite(getEndInput, (inputGroupProps) => {
                 return mount(<DateRangeInput endInputProps={inputGroupProps} />);
-            };
-            runTestSuite(_mount, getEndInput);
+            });
         });
 
-        function runTestSuite(mountFn: MountFunction, inputGetterFn: InputGetterFunction) {
+        function runTestSuite(inputGetterFn: InputGetterFunction, mountFn: MountFunction) {
             it("inputRef receives reference to HTML input element", () => {
                 const inputRef = sinon.spy();
                 mountFn({ inputRef });
@@ -108,44 +106,32 @@ describe("<DateRangeInput>", () => {
             // callbacks after responding to these events ourselves within the component.)
 
             it("fires custom onChange callback", () => {
-                assertEventCallbackFired("change", (spy) => {
-                    return { onChange: spy };
-                });
+                assertEventCallbackFired("change", (spy) => ({ onChange: spy }));
             });
 
             it("fires custom onFocus callback", () => {
-                assertEventCallbackFired("focus", (spy) => {
-                    return { onFocus: spy };
-                });
+                assertEventCallbackFired("focus", (spy) => ({ onFocus: spy }));
             });
 
             it("fires custom onBlur callback", () => {
-                assertEventCallbackFired("blur", (spy) => {
-                    return { onBlur: spy };
-                });
+                assertEventCallbackFired("blur", (spy) => ({ onBlur: spy }));
             });
 
             it("fires custom onClick callback", () => {
-                assertEventCallbackFired("click", (spy) => {
-                    return { onClick: spy };
-                });
+                assertEventCallbackFired("click", (spy) => ({ onClick: spy }));
             });
 
             it("fires custom onKeyDown callback", () => {
-                assertEventCallbackFired("keydown", (spy) => {
-                    return { onKeyDown: spy };
-                });
+                assertEventCallbackFired("keydown", (spy) => ({ onKeyDown: spy }));
             });
 
             it("fires custom onMouseDown callback", () => {
-                assertEventCallbackFired("mousedown", (spy) => {
-                    return { onMouseDown: spy };
-                });
+                assertEventCallbackFired("mousedown", (spy) => ({ onMouseDown: spy }));
             });
 
             // cast as `any` so that we don't have to cast returned values as `HTMLInputProps &
             // IInputGroupProps` above.
-            function assertEventCallbackFired(eventName: string, buildProps: (spy: Sinon.SinonSpy) => any) {
+            function assertEventCallbackFired(eventName: string, buildProps: (spy: Sinon.SinonSpy) => HTMLInputProps & IInputGroupProps) {
                 const spy = sinon.spy();
                 const component = mountFn(buildProps(spy));
                 const input = inputGetterFn(component);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -26,7 +26,7 @@ type InvalidDateTestFunction = (input: WrappedComponentInput,
                                 boundary: DateRangeBoundary,
                                 otherInput: WrappedComponentInput) => void;
 
-describe.only("<DateRangeInput>", () => {
+describe("<DateRangeInput>", () => {
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
     const START_STR = DateTestUtils.toHyphenatedDateString(START_DATE);
@@ -74,9 +74,6 @@ describe.only("<DateRangeInput>", () => {
 
     describe("startInputProps and endInputProps", () => {
 
-        type MountFunction = (inputGroupProps: HTMLInputProps & IInputGroupProps) => any;
-        type InputGetterFunction = (root: WrappedComponentRoot) => WrappedComponentInput;
-
         describe("startInputProps", () => {
             runTestSuite(getStartInput, (inputGroupProps) => {
                 return mount(<DateRangeInput startInputProps={inputGroupProps} />);
@@ -89,7 +86,8 @@ describe.only("<DateRangeInput>", () => {
             });
         });
 
-        function runTestSuite(inputGetterFn: InputGetterFunction, mountFn: MountFunction) {
+        function runTestSuite(inputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
+                              mountFn: (inputGroupProps: HTMLInputProps & IInputGroupProps) => any) {
             it("inputRef receives reference to HTML input element", () => {
                 const inputRef = sinon.spy();
                 mountFn({ inputRef });
@@ -131,7 +129,8 @@ describe.only("<DateRangeInput>", () => {
 
             // cast as `any` so that we don't have to cast returned values as `HTMLInputProps &
             // IInputGroupProps` above.
-            function assertEventCallbackFired(eventName: string, buildProps: (spy: Sinon.SinonSpy) => HTMLInputProps & IInputGroupProps) {
+            function assertEventCallbackFired(eventName: string,
+                                              buildProps: (spy: Sinon.SinonSpy) => HTMLInputProps & IInputGroupProps) {
                 const spy = sinon.spy();
                 const component = mountFn(buildProps(spy));
                 const input = inputGetterFn(component);


### PR DESCRIPTION
#### Addresses #805

#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Literal changes:
- Change `IInputGroupProps` to `HTMLInputProps & IInputGroupProps` for each input
    - Can now add custom callbacks for `onFocus`, `onBlur`, `onClick`, and so on.
    - Can now add custom placeholder text.
- Add tests
- Update descriptions for `startInputProps` and `endInputProps` to mention the props you can't customize.

#### Reviewers should focus on:

- Ended up casting the input-group props as `any` when spreading. Is there a better way? See #943 as well.
- The `handleXInputY` callbacks are a little repetitive. There's probably a cute way to make all of those wrappers more concise.