### PR TITLE
fix sass argument typo

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -46,7 +46,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   }
 }
 
-@mixin dark-menu-item($disabled-selector: ".pt-disabled", $hover-selector: ": hover") {
+@mixin dark-menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
   color: inherit;
 
   &#{$hover-selector} {


### PR DESCRIPTION
this is causing internal builds to fail (https://pl.ntr/eH). public builds are fine because the default values never get used in blueprint.css

