### PR TITLE
Popover useSmartPositioning should not mutate defaultProps

### DIFF
--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -45,12 +45,11 @@ export function createTetherOptions(element: Element,
                                     position: Position,
                                     useSmartPositioning: boolean,
                                     tetherOptions: Partial<Tether.ITetherOptions> = {}) {
-    if (tetherOptions.constraints == null && useSmartPositioning) {
-        tetherOptions.constraints = [DEFAULT_CONSTRAINTS];
-    }
-
     const options: Tether.ITetherOptions = {
+        constraints: useSmartPositioning ? [DEFAULT_CONSTRAINTS] : undefined,
         ...tetherOptions,
+        // spread is not handled by rule https://github.com/palantir/tslint/issues/2554
+        // tslint:disable-next-line:object-literal-sort-keys
         attachment: getPopoverAttachment(position),
         bodyElement: fakeHtmlElement,
         classPrefix: "pt-tether",

--- a/packages/core/src/common/tetherUtils.ts
+++ b/packages/core/src/common/tetherUtils.ts
@@ -17,11 +17,6 @@ import * as Tether from "tether";
 
 import { Position } from "./position";
 
-const DEFAULT_CONSTRAINTS = {
-    attachment: "together",
-    to: "scrollParent",
-};
-
 // per https://github.com/HubSpot/tether/pull/204, Tether now exposes a `bodyElement` option that,
 // when present, gets the tethered element injected into *it* instead of into the document body.
 // but both approaches still cause React to freak out, because it loses its handle on the DOM
@@ -40,16 +35,14 @@ export interface ITetherConstraint {
 }
 
 /** @internal */
-export function createTetherOptions(element: Element,
-                                    target: Node,
-                                    position: Position,
-                                    useSmartPositioning: boolean,
-                                    tetherOptions: Partial<Tether.ITetherOptions> = {}) {
-    const options: Tether.ITetherOptions = {
-        constraints: useSmartPositioning ? [DEFAULT_CONSTRAINTS] : undefined,
+export function createTetherOptions(
+    element: Element,
+    target: Node,
+    position: Position,
+    tetherOptions: Partial<Tether.ITetherOptions> = {},
+): Tether.ITetherOptions {
+    return {
         ...tetherOptions,
-        // spread is not handled by rule https://github.com/palantir/tslint/issues/2554
-        // tslint:disable-next-line:object-literal-sort-keys
         attachment: getPopoverAttachment(position),
         bodyElement: fakeHtmlElement,
         classPrefix: "pt-tether",
@@ -57,7 +50,6 @@ export function createTetherOptions(element: Element,
         target,
         targetAttachment: getTargetAttachment(position),
     };
-    return options;
 }
 
 /** @internal */

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -55,7 +55,7 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
      * Constraints for the underlying Tether instance.
      * If defined, this will overwrite `tetherOptions.constraints`.
      * See http://tether.io/#constraints.
-     * @deprecated since v1.12.0; use `tetherOptions` instead.
+     * @deprecated since v1.12.0; use `tetherOptions.constraints` instead.
      */
     constraints?: TetherUtils.ITetherConstraint[];
 
@@ -183,11 +183,15 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     useSmartArrowPositioning?: boolean;
 
     /**
-     * Whether the popover will try to reposition itself
-     * if there isn't room for it in its current position.
-     * The popover will try to flip to the opposite side of the target element but
-     * will not move to an adjacent side.
+     * Whether the popover will flip to the opposite side of the target element if there is not
+     * enough room in the viewport. This is equivalent to:
+     * ```
+     * const tetherOptions = {
+     *     constraints: { attachment: "together", to: "scrollParent" },
+     * };
+     * ```
      * @default false
+     * @deprecated since v1.15.0; use `tetherOptions.constraints` directly.
      */
     useSmartPositioning?: boolean;
 }
@@ -444,7 +448,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     private getPopoverTransformOrigin(): string {
-        // if smart positioning is enabled then we must rely CSS classes to put transform origin
+        // if smart positioning is enabled then we must rely on CSS classes to put transform origin
         // on the correct side and cannot override it in JS. (https://github.com/HubSpot/tether/issues/154)
         if (this.props.useSmartArrowPositioning && !this.props.useSmartPositioning) {
             const dimensions = { height: this.state.targetHeight, width: this.state.targetWidth };

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -166,6 +166,11 @@ describe("<Popover>", () => {
         assert.lengthOf(document.getElementsByClassName(Classes.POPOVER_BACKDROP), 1);
     });
 
+    it("useSmartPositioning does not mutate defaultProps", () => {
+        renderPopover({ inline: false, isOpen: true, useSmartPositioning: true });
+        assert.deepEqual(Popover.defaultProps.tetherOptions, {});
+    });
+
     describe("openOnTargetFocus", () => {
         describe("if true (default)", () => {
             it("adds tabindex=\"0\" to target's child node when interactionKind is HOVER", () => {


### PR DESCRIPTION
#### Fixes https://pl.ntr/eJ

#### Changes proposed in this pull request:

- fixes a super subtle bug whereby the implementation for `useSmartPositioning` modified the `tetherOptions` argument. in the default state, `tetherOptions` refers to the static `Popover.defaultProps.tetherOptions` object so all popovers would inherit the smart positioning constraints. mutation removed!
- :x: deprecate `useSmartPositioning`
