### PR TITLE
Fix collapse overflow

### DIFF
--- a/packages/core/src/components/collapse/_collapse.scss
+++ b/packages/core/src/components/collapse/_collapse.scss
@@ -9,7 +9,7 @@ $collapse-transition: ($pt-transition-duration * 2) $pt-transition-ease !default
 
 .pt-collapse {
   height: 0;
-  overflow: hidden;
+  overflow-y: hidden;
   transition: height $collapse-transition;
 
   .pt-collapse-body {


### PR DESCRIPTION
#938 broke collapse styles by changing the TS overflow to `overflow-y`, but leaving scss overflow as `overflow` (which is not overridden by the latter). That means that shadows and other overflowing elements are cut off.

This PR fixes the issue by also switching scss overflow to `overflow-y`.

@adidahiya for SA