### PR TITLE
refactor most validateProps errors to warnings

### DIFF
--- a/packages/core/examples/popoverExample.tsx
+++ b/packages/core/examples/popoverExample.tsx
@@ -21,7 +21,7 @@ import {
     Slider,
     Switch,
 } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs";
+import { BaseExample, handleBooleanChange, handleNumberChange, handleStringChange } from "@blueprintjs/docs";
 
 const INTERACTION_KINDS = [
     { label: "Click", value: PopoverInteractionKind.CLICK.toString() },
@@ -58,34 +58,37 @@ const CONSTRAINTS = [
 
 export interface IPopoverExampleState {
     canEscapeKeyClose?: boolean;
-    constraints?: ITetherConstraint[];
-    contentIndex?: number;
+    exampleIndex?: number;
     inheritDarkTheme?: boolean;
     inline?: boolean;
     interactionKind?: PopoverInteractionKind;
     isModal?: boolean;
     position?: Position;
     sliderValue?: number;
+    tetherConstraints?: ITetherConstraint[];
     useSmartArrowPositioning?: boolean;
 }
 
 export class PopoverExample extends BaseExample<IPopoverExampleState> {
     public state: IPopoverExampleState = {
         canEscapeKeyClose: true,
-        constraints: [],
-        contentIndex: 0,
+        exampleIndex: 0,
         inheritDarkTheme: true,
         inline: false,
         interactionKind: PopoverInteractionKind.CLICK,
         isModal: false,
         position: Position.RIGHT,
         sliderValue: 5,
+        tetherConstraints: [],
         useSmartArrowPositioning: true,
     };
 
     protected className = "docs-popover-example";
 
-    private handleContentIndexChange = handleNumberChange((contentIndex) => this.setState({ contentIndex }));
+    private handleConstraintChange = handleStringChange((constraints) => {
+        this.setState({ tetherConstraints: JSON.parse(constraints) });
+    });
+    private handleExampleIndexChange = handleNumberChange((exampleIndex) => this.setState({ exampleIndex }));
     private handleInteractionChange = handleNumberChange((interactionKind) => {
         const isModal = this.state.isModal && interactionKind === PopoverInteractionKind.CLICK;
         this.setState({ interactionKind, isModal });
@@ -98,27 +101,29 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
     private toggleEscapeKey = handleBooleanChange((canEscapeKeyClose) => this.setState({ canEscapeKeyClose }));
     private toggleInheritDarkTheme = handleBooleanChange((inheritDarkTheme) => this.setState({ inheritDarkTheme }));
     private toggleInline = handleBooleanChange((inline) => {
-        const newState: IPopoverExampleState = { inline };
-        if (newState.inline) {
-            // these options are mutually exclusive
-            newState.isModal = false;
-            newState.constraints = [];
-            newState.inheritDarkTheme = false;
+        if (inline) {
+            this.setState({
+                inline,
+                inheritDarkTheme: false,
+                isModal: false,
+                tetherConstraints: [],
+            });
+        } else {
+            this.setState({ inline });
         }
-        this.setState(newState);
     });
     private toggleModal = handleBooleanChange((isModal) => this.setState({ isModal }));
 
     protected renderExample() {
+        const constraints = this.state.tetherConstraints;
         const popoverClassName = classNames({
-            "pt-popover-content-sizing": this.state.contentIndex <= 2,
+            "pt-popover-content-sizing": this.state.exampleIndex <= 2,
         });
-
         return (
             <Popover
-                content={this.getContents(this.state.contentIndex)}
-                constraints={this.state.constraints}
+                content={this.getContents(this.state.exampleIndex)}
                 popoverClassName={popoverClassName}
+                tetherOptions={{ constraints }}
                 {...this.state}
             >
                 <button className="pt-button pt-intent-primary">Popover target</button>
@@ -133,15 +138,15 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
 
         return [
             [
-                <label className={Classes.LABEL} key="content">
+                <label className={Classes.LABEL} key="example">
                     Example content
                     <div className={Classes.SELECT}>
-                        <select value={this.state.contentIndex} onChange={this.handleContentIndexChange}>
+                        <select value={this.state.exampleIndex} onChange={this.handleExampleIndexChange}>
                             <option value="0">Text</option>
                             <option value="1">Input</option>
                             <option value="2">Slider</option>
                             <option value="3">Menu</option>
-                            <option value="4">Popover Example</option>
+                            <option value="-100">Popover Example</option>
                         </select>
                     </div>
                 </label>,
@@ -212,7 +217,7 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                     label="Constraints"
                     onChange={this.handleConstraintChange}
                     options={CONSTRAINTS}
-                    selectedValue={JSON.stringify(this.state.constraints)}
+                    selectedValue={JSON.stringify(this.state.tetherConstraints)}
                 />,
             ],
         ];
@@ -266,11 +271,5 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
         ][index];
     }
 
-    private handleConstraintChange = (e: React.SyntheticEvent<HTMLElement>) => {
-        this.setState({ constraints: JSON.parse((e.target as HTMLInputElement).value) });
-    }
-
-    private handleSliderChange = (value: number) => {
-        this.setState({ sliderValue: value });
-    }
+    private handleSliderChange = (value: number) => this.setState({ sliderValue: value });
 }

--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -6,6 +6,7 @@
  */
 
 import * as React from "react";
+import { isNodeEnv } from "./utils";
 
 /**
  * An abstract component that Blueprint components can extend
@@ -19,11 +20,15 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
 
     constructor(props?: P, context?: any) {
         super(props, context);
-        this.validateProps(this.props);
+        if (!isNodeEnv("production")) {
+            this.validateProps(this.props);
+        }
     }
 
     public componentWillReceiveProps(nextProps: P & {children?: React.ReactNode}) {
-        this.validateProps(nextProps);
+        if (!isNodeEnv("production")) {
+            this.validateProps(nextProps);
+        }
     }
 
     public componentWillUnmount() {

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -40,9 +40,8 @@ export const POPOVER_WARN_INLINE_NO_TETHER =
     `${ns} <Popover inline={true}> ignores tetherOptions, constraints, and useSmartPositioning.`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = `${ns} <Popover> onInteraction is ignored when uncontrolled.`;
 
-export const RADIOGROUP_RADIO_CHILDREN = `${ns} <RadioGroup> only supports <Radio> children.`;
-export const RADIOGROUP_CHILDREN_OPTIONS_MUTEX =
-    `${ns} <RadioGroup> children and options props are mutually exclusive.`;
+export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
+    `${ns} <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;
 
 export const SLIDER_ZERO_STEP = `${ns} <Slider> stepSize must be greater than zero.`;
 export const SLIDER_ZERO_LABEL_STEP = `${ns} <Slider> labelStepSize must be greater than zero.`;

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -8,45 +8,39 @@
 const ns = "[Blueprint]";
 const deprec = `${ns} DEPRECATION:`;
 
-export function deprecationWarning(oldName: string, newName: string, message: string = "") {
-    return `${deprec} '${oldName}' prop has been replaced by the '${newName}' prop. ${message}
-It will be removed in the next major version of blueprint.`;
-}
 
 export const ALERT_CANCEL_PROPS = `${ns} If either cancelButtonText or onCancel are set in <Alert>, both must be set.`;
 
-export const DEPRECATION_SHOULD_ATTACH_TO_BODY = deprecationWarning("shouldAttachToBody", "inline");
-
 export const COLLAPSIBLE_LIST_INVALID_CHILD = `${ns} <CollapsibleList> children must be <MenuItem>s`;
 
-export const MENU_CHILDREN_SUBMENU_MUTEX = `${ns} <MenuItem> children and submenu props are mutually exclusive`;
+export const MENU_CHILDREN_SUBMENU_MUTEX = `${ns} <MenuItem> children and submenu props are mutually exclusive.`;
 
 export const NUMERIC_INPUT_MIN_MAX =
-    `${ns} <NumericInput> requires min to be strictly less than max if both are defined`;
+    `${ns} <NumericInput> requires min to be strictly less than max if both are defined.`;
 export const NUMERIC_INPUT_MINOR_STEP_SIZE_BOUND =
-    `${ns} <NumericInput> requires minorStepSize to be strictly less than stepSize`;
+    `${ns} <NumericInput> requires minorStepSize to be strictly less than stepSize.`;
 export const NUMERIC_INPUT_MAJOR_STEP_SIZE_BOUND =
-    `${ns} <NumericInput> requires majorStepSize to be strictly greater than stepSize`;
+    `${ns} <NumericInput> requires majorStepSize to be strictly greater than stepSize.`;
 export const NUMERIC_INPUT_MINOR_STEP_SIZE_NON_POSITIVE =
-    `${ns} <NumericInput> requires minorStepSize to be strictly greater than zero`;
+    `${ns} <NumericInput> requires minorStepSize to be strictly greater than zero.`;
 export const NUMERIC_INPUT_MAJOR_STEP_SIZE_NON_POSITIVE =
-    `${ns} <NumericInput> requires majorStepSize to be strictly greater than zero`;
+    `${ns} <NumericInput> requires majorStepSize to be strictly greater than zero.`;
 export const NUMERIC_INPUT_STEP_SIZE_NON_POSITIVE =
-    `${ns} <NumericInput> requires stepSize to be strictly greater than zero`;
+    `${ns} <NumericInput> requires stepSize to be strictly greater than zero.`;
 export const NUMERIC_INPUT_STEP_SIZE_NULL =
-    `${ns} <NumericInput> requires stepSize to be defined`;
+    `${ns} <NumericInput> requires stepSize to be defined.`;
 
 export const POPOVER_ONE_CHILD = `${ns} <Popover> requires exactly one target element`;
 export const POPOVER_MODAL_INTERACTION =
     `${ns} <Popover isModal={true}> requires interactionKind={PopoverInteractionKind.CLICK}.`;
 export const POPOVER_WARN_MODAL_INLINE = `${ns} <Popover inline={true}> ignores isModal`;
 export const POPOVER_WARN_DEPRECATED_CONSTRAINTS =
-    `${ns} <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.`;
+    `${deprec} <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.`;
 export const POPOVER_WARN_INLINE_NO_TETHER =
     `${ns} <Popover inline={true}> ignores tetherOptions, constraints, and useSmartPositioning.`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = `${ns} <Popover> onInteraction is ignored when uncontrolled.`;
 
-export const RADIOGROUP_RADIO_CHILDREN = `${ns} <RadioGroup> only supports <Radio> children`;
+export const RADIOGROUP_RADIO_CHILDREN = `${ns} <RadioGroup> only supports <Radio> children.`;
 export const RADIOGROUP_CHILDREN_OPTIONS_MUTEX =
     `${ns} <RadioGroup> children and options props are mutually exclusive.`;
 
@@ -56,13 +50,13 @@ export const RANGESLIDER_NULL_VALUE = `${ns} <RangeSlider> value prop must be an
 
 export const TABS_FIRST_CHILD = `${ns} First child of <Tabs> component should be a <TabList>`;
 export const TABS_MISMATCH = `${ns} Number of <Tab> components should equal number of <TabPanel> components`;
-export const TABS_DEPRECATED = `${ns} <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>.`
+export const TABS_WARN_DEPRECATED = `${deprec} <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>.`
     + " https://blueprintjs.com/#components.tabs.js";
 
-export const TOASTER_INLINE_WARNING = `${ns} Toaster.create() ignores inline prop as it always creates a new element`;
+export const TOASTER_WARN_INLINE = `${ns} Toaster.create() ignores inline prop as it always creates a new element.`;
 
-export const TOOLTIP_EMPTY_WARNING = `${ns} Disabling empty <Tooltip>`;
+export const TOOLTIP_WARN_EMPTY_CONTENT = `${ns} Disabling <Tooltip> with empty content...`;
 
-export const WARNING_DIALOG_NO_HEADER_ICON = `${ns} Warning: Dialog iconName prop is ignored if title prop is omitted`;
-export const WARNING_DIALOG_NO_HEADER_CLOSE_BUTTON =
-    `${ns} Warning: Dialog isCloseButtonShown prop is ignored if title prop is omitted`;
+export const DIALOG_WARN_NO_HEADER_ICON = `${ns} <Dialog> iconName is ignored if title is omitted.`;
+export const DIALOG_WARN_NO_HEADER_CLOSE_BUTTON =
+    `${ns} <Dialog> isCloseButtonShown prop is ignored if title is omitted.`;

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -37,13 +37,14 @@ export const NUMERIC_INPUT_STEP_SIZE_NULL =
     `${ns} <NumericInput> requires stepSize to be defined`;
 
 export const POPOVER_ONE_CHILD = `${ns} <Popover> requires exactly one target element`;
-export const POPOVER_UNCONTROLLED_ONINTERACTION = `${ns} <Popover> onInteraction is ignored when uncontrolled`;
-export const POPOVER_MODAL_INLINE =
-    `${ns} <Popover isModal={true}> requires inline={false}.`;
 export const POPOVER_MODAL_INTERACTION =
     `${ns} <Popover isModal={true}> requires interactionKind={PopoverInteractionKind.CLICK}.`;
-export const POPOVER_SMART_POSITIONING_INLINE =
-    `${ns} <Popover useSmartPositioning={true}> requires inline={false}.`;
+export const POPOVER_WARN_MODAL_INLINE = `${ns} <Popover inline={true}> ignores isModal`;
+export const POPOVER_WARN_DEPRECATED_CONSTRAINTS =
+    `${ns} <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.`;
+export const POPOVER_WARN_INLINE_NO_TETHER =
+    `${ns} <Popover inline={true}> ignores tetherOptions, constraints, and useSmartPositioning.`;
+export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = `${ns} <Popover> onInteraction is ignored when uncontrolled.`;
 
 export const RADIOGROUP_RADIO_CHILDREN = `${ns} <RadioGroup> only supports <Radio> children`;
 export const RADIOGROUP_CHILDREN_OPTIONS_MUTEX =

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -8,7 +8,6 @@
 const ns = "[Blueprint]";
 const deprec = `${ns} DEPRECATION:`;
 
-
 export const ALERT_CANCEL_PROPS = `${ns} If either cancelButtonText or onCancel are set in <Alert>, both must be set.`;
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = `${ns} <CollapsibleList> children must be <MenuItem>s`;

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -80,10 +80,10 @@ export class Dialog extends AbstractComponent<IDialogProps, {}> {
     protected validateProps(props: IDialogProps) {
         if (props.title == null) {
             if (props.iconName != null) {
-                console.error(Errors.WARNING_DIALOG_NO_HEADER_ICON);
+                console.warn(Errors.DIALOG_WARN_NO_HEADER_ICON);
             }
             if (props.isCloseButtonShown != null) {
-                console.error(Errors.WARNING_DIALOG_NO_HEADER_CLOSE_BUTTON);
+                console.warn(Errors.DIALOG_WARN_NO_HEADER_CLOSE_BUTTON);
             }
         }
     }

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -66,23 +66,18 @@ export class RadioGroup extends AbstractComponent<IRadioGroupProps, {}> {
     }
 
     protected validateProps() {
-        if (this.props.children != null) {
-            if (this.props.options != null) {
-                throw new Error(Errors.RADIOGROUP_CHILDREN_OPTIONS_MUTEX);
-            }
-            React.Children.forEach(this.props.children, (child) => {
-                const radio = child as JSX.Element;
-                if (radio.type !== Radio) {
-                    throw new Error(Errors.RADIOGROUP_RADIO_CHILDREN);
-                }
-            });
+        if (this.props.children != null && this.props.options != null) {
+            console.warn(Errors.RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX);
         }
     }
 
     private renderChildren() {
         return React.Children.map(this.props.children, (child) => {
-            const radio = child as JSX.Element;
-            return React.cloneElement(radio, this.getRadioProps(radio.props));
+            if (isRadio(child)) {
+                return React.cloneElement(child, this.getRadioProps(child.props));
+            } else {
+                return child;
+            }
         });
     }
 
@@ -103,3 +98,7 @@ export class RadioGroup extends AbstractComponent<IRadioGroupProps, {}> {
         };
     }
 };
+
+function isRadio(child: any): child is JSX.Element {
+    return child != null && (child as JSX.Element).type === Radio;
+}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -226,7 +226,6 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
         popoverClassName: "",
         position: PosUtils.Position.RIGHT,
         rootElementTag: "span",
-        tetherOptions: {},
         transitionDuration: 300,
         useSmartArrowPositioning: true,
         useSmartPositioning: false,
@@ -366,28 +365,26 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     protected validateProps(props: IPopoverProps & {children?: React.ReactNode}) {
+        if (props.useSmartPositioning || props.constraints != null) {
+            console.warn(Errors.POPOVER_WARN_DEPRECATED_CONSTRAINTS);
+        }
         if (props.isOpen == null && props.onInteraction != null) {
-            console.warn(Errors.POPOVER_UNCONTROLLED_ONINTERACTION);
+            console.warn(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
+        }
+        if (props.inline && (props.useSmartPositioning || props.constraints != null || props.tetherOptions != null)) {
+            console.warn(Errors.POPOVER_WARN_INLINE_NO_TETHER);
+        }
+        if (props.isModal && props.inline) {
+            console.warn(Errors.POPOVER_WARN_MODAL_INLINE);
         }
 
         if (props.isModal && props.interactionKind !== PopoverInteractionKind.CLICK) {
             throw new Error(Errors.POPOVER_MODAL_INTERACTION);
         }
-
-        if (props.isModal && props.inline) {
-            throw new Error(Errors.POPOVER_MODAL_INLINE);
-        }
-
-        if (props.useSmartPositioning && props.inline) {
-            throw new Error(Errors.POPOVER_SMART_POSITIONING_INLINE);
-        }
-
-        if (typeof props.children !== "string") {
-            try {
-                React.Children.only(props.children);
-            } catch (e) {
-                throw new Error(Errors.POPOVER_ONE_CHILD);
-            }
+        try {
+            React.Children.only(props.children);
+        } catch (e) {
+            throw new Error(Errors.POPOVER_ONE_CHILD);
         }
     }
 
@@ -560,7 +557,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
 
     private updateTether() {
         if (this.state.isOpen && !this.props.inline && this.popoverElement != null) {
-            const { constraints, position, tetherOptions, useSmartPositioning } = this.props;
+            const { constraints, position, tetherOptions = {}, useSmartPositioning } = this.props;
 
             // the .pt-popover-target span we wrap the children in won't always be as big as its children
             // so instead, we'll position tether based off of its first child.

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -77,7 +77,7 @@ export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
         this.state = this.getStateFromProps(this.props);
 
         if (!Utils.isNodeEnv("production")) {
-            console.warn(Errors.TABS_DEPRECATED);
+            console.warn(Errors.TABS_WARN_DEPRECATED);
         }
     }
 

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
-import { TOASTER_INLINE_WARNING } from "../../common/errors";
+import { TOASTER_WARN_INLINE } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
@@ -94,7 +94,7 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
      */
     public static create(props?: IToasterProps, container = document.body): IToaster {
         if (props != null && props.inline != null) {
-            console.warn(TOASTER_INLINE_WARNING);
+            console.warn(TOASTER_WARN_INLINE);
         }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -16,7 +16,7 @@ import { TOASTER_WARN_INLINE } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
+import { isNodeEnv, safeInvoke } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { IToastProps, Toast } from "./toast";
 
@@ -93,7 +93,7 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
      * The `Toaster` will be rendered into a new element appended to the given container.
      */
     public static create(props?: IToasterProps, container = document.body): IToaster {
-        if (props != null && props.inline != null) {
+        if (props != null && props.inline != null && !isNodeEnv("production")) {
             console.warn(TOASTER_WARN_INLINE);
         }
         const containerElement = document.createElement("div");

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -10,7 +10,7 @@ import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { TOOLTIP_EMPTY_WARNING } from "../../common/errors";
+import { TOOLTIP_WARN_EMPTY_CONTENT } from "../../common/errors";
 import { Position } from "../../common/position";
 import { IIntentProps, IProps } from "../../common/props";
 import { ITetherConstraint } from "../../common/tetherUtils";
@@ -161,7 +161,7 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
 
         const isEmpty = content == null || (typeof content === "string" && content.trim() === "");
         if (isEmpty && !isNodeEnv("production")) {
-            console.warn(TOOLTIP_EMPTY_WARNING);
+            console.warn(TOOLTIP_WARN_EMPTY_CONTENT);
         }
 
         return (

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -59,15 +59,14 @@ describe("RadioGroup", () => {
         assert.isTrue(group.find({ value: "c" }).prop("disabled"), "radio c not disabled");
     });
 
-    it("throws error if given both options and children", () => {
-        assert.throws(() => {
-            mount(<RadioGroup onChange={emptyHandler} options={[]}><Radio value="one" /></RadioGroup>);
-        });
+    it("uses options if given both options and children", () => {
+        const group = mount(<RadioGroup onChange={emptyHandler} options={[]}><Radio value="one" /></RadioGroup>);
+        assert.lengthOf(group.find(Radio), 0);
     });
 
-    it("throws error if given non-Radio children", () => {
-        assert.throws(() => {
-            mount(<RadioGroup onChange={emptyHandler}><address /><Radio /></RadioGroup>);
-        });
+    it("renders non-Radio children too", () => {
+        const group = mount(<RadioGroup onChange={emptyHandler}><Radio /><address /><Radio /></RadioGroup>);
+        assert.lengthOf(group.find("address"), 1);
+        assert.lengthOf(group.find(Radio), 2);
     });
 });

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -47,28 +47,6 @@ describe("<Popover>", () => {
                 </Popover>,
             ), Errors.POPOVER_ONE_CHILD);
         });
-
-        it("throws error if isModal=true when interactionKind !== CLICK", () => {
-            assert.throws(() => renderPopover({
-                inline: false,
-                interactionKind: PopoverInteractionKind.HOVER,
-                isModal: true,
-            }), Errors.POPOVER_MODAL_INTERACTION);
-        });
-
-        it("throws error if isModal=true when inline=true", () => {
-            assert.throws(() => renderPopover({
-                inline: true,
-                isModal: true,
-            }), Errors.POPOVER_MODAL_INLINE);
-        });
-
-        it("throws error if useSmartPositioning=true when inline=true", () => {
-            assert.throws(() => renderPopover({
-                inline: true,
-                useSmartPositioning: true,
-            }), Errors.POPOVER_SMART_POSITIONING_INLINE);
-        });
     });
 
     it("propogates class names correctly", () => {
@@ -168,7 +146,7 @@ describe("<Popover>", () => {
 
     it("useSmartPositioning does not mutate defaultProps", () => {
         renderPopover({ inline: false, isOpen: true, useSmartPositioning: true });
-        assert.deepEqual(Popover.defaultProps.tetherOptions, {});
+        assert.isUndefined(Popover.defaultProps.tetherOptions);
     });
 
     describe("openOnTargetFocus", () => {
@@ -456,7 +434,7 @@ describe("<Popover>", () => {
         it("console.warns if onInteraction is set", () => {
             const warnSpy = sinon.spy(console, "warn");
             renderPopover({ onInteraction: () => false });
-            assert.strictEqual(warnSpy.firstCall.args[0], Errors.POPOVER_UNCONTROLLED_ONINTERACTION);
+            assert.strictEqual(warnSpy.firstCall.args[0], Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
             warnSpy.restore();
         });
     });


### PR DESCRIPTION
- Refactor most Popover errors to warnings
- Refactor PopoverExample to avoid warnings
- Refactor most errors into warnings
- Refactor RadioGroup errors to support non-Radio children
- Remove non-error tests, fix others