### PR TITLE
DateInput popoverProps

### DIFF
--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -8,13 +8,13 @@
 const ns = "[Blueprint]";
 
 export const DATEPICKER_DEFAULT_VALUE_INVALID =
-    `${ns} <DatePicker> defaultValue must be within minDate and maxDate bounds`;
+    `${ns} <DatePicker> defaultValue must be within minDate and maxDate bounds.`;
 export const DATEPICKER_INITIAL_MONTH_INVALID =
-    `${ns} <DatePicker> initialMonth must be within minDate and maxDate bounds`;
+    `${ns} <DatePicker> initialMonth must be within minDate and maxDate bounds.`;
 export const DATEPICKER_MAX_DATE_INVALID =
-    `${ns} <DatePicker> maxDate must be later than minDate`;
+    `${ns} <DatePicker> maxDate must be later than minDate.`;
 export const DATEPICKER_VALUE_INVALID =
-    `${ns} <DatePicker> value prop must be within minDate and maxDate bounds`;
+    `${ns} <DatePicker> value prop must be within minDate and maxDate bounds.`;
 
 export const DATERANGEPICKER_DEFAULT_VALUE_INVALID =
     DATEPICKER_DEFAULT_VALUE_INVALID.replace("DatePicker", "DateRangePicker");
@@ -23,4 +23,7 @@ export const DATERANGEPICKER_INITIAL_MONTH_INVALID =
 export const DATERANGEPICKER_MAX_DATE_INVALID = DATEPICKER_MAX_DATE_INVALID.replace("DatePicker", "DateRangePicker");
 export const DATERANGEPICKER_VALUE_INVALID = DATEPICKER_VALUE_INVALID.replace("DatePicker", "DateRangePicker");
 export const DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID =
-    "<DateRangePicker> preferredBoundaryToModify must be a valid DateRangeBoundary if defined";
+    "<DateRangePicker> preferredBoundaryToModify must be a valid DateRangeBoundary if defined.";
+
+export const DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION =
+    `${ns} DEPRECATION: <DateInput> popoverProps is deprecated. Use popoverProps.position.`;

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -104,6 +104,11 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverPosition?: Position;
 
     /**
+     * Props to pass to the `Popover`. Note that `content` cannot be changed.
+     */
+    popoverProps?: Partial<IPopoverProps>;
+
+    /**
      * Element to render on right side of input.
      */
     rightElement?: JSX.Element;
@@ -140,6 +145,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
         popoverPosition: Position.BOTTOM,
+        popoverProps: {},
     };
 
     public displayName = "Blueprint.DateInput";
@@ -182,13 +188,14 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         return (
             <Popover
                 autoFocus={false}
-                content={popoverContent}
                 enforceFocus={false}
                 inline={true}
                 isOpen={this.state.isOpen && !this.props.disabled}
-                onClose={this.handleClosePopover}
-                popoverClassName="pt-dateinput-popover"
                 position={this.props.popoverPosition}
+                {...this.props.popoverProps}
+                content={popoverContent}
+                onClose={this.handleClosePopover}
+                popoverClassName={classNames("pt-dateinput-popover", this.props.popoverProps.popoverClassName)}
             >
                 <InputGroup
                     className={inputClasses}
@@ -237,7 +244,8 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         return isMomentInRange(value, this.props.minDate, this.props.maxDate);
     }
 
-    private handleClosePopover = () => {
+    private handleClosePopover = (e: React.SyntheticEvent<HTMLElement>) => {
+        Utils.safeInvoke(this.props.popoverProps.onClose, e);
         this.setState({ isOpen: false });
     }
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -26,6 +26,7 @@ import {
     isMomentNull,
     isMomentValidAndInRange,
 } from "./common/dateUtils";
+import { DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION } from "./common/errors";
 import { DatePicker } from "./datePicker";
 import {
     getDefaultMaxDate,
@@ -182,6 +183,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 {...sharedProps}
                 timePickerProps={{ precision: this.props.timePrecision }}
             />;
+        // assign default empty object here to prevent mutation
         const { popoverProps = {} } = this.props;
 
         const inputClasses = classNames({
@@ -218,11 +220,16 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     public componentWillReceiveProps(nextProps: IDateInputProps) {
+        super.componentWillReceiveProps(nextProps);
         if (nextProps.value !== this.props.value) {
             this.setState({ value: fromDateToMoment(nextProps.value) });
         }
+    }
 
-        super.componentWillReceiveProps(nextProps);
+    public validateProps(props: IDateInputProps) {
+        if (props.popoverPosition !== DateInput.defaultProps.popoverPosition) {
+            console.warn(DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION);
+        }
     }
 
     private getDateString = (value: moment.Moment) => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import {
     AbstractComponent,
     InputGroup,
+    IPopoverProps,
     IProps,
     Popover,
     Position,
@@ -146,7 +147,6 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
         popoverPosition: Position.BOTTOM,
-        popoverProps: {},
     };
 
     public displayName = "Blueprint.DateInput";
@@ -181,6 +181,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 {...sharedProps}
                 timePickerProps={{ precision: this.props.timePrecision }}
             />;
+        const { popoverProps = {} } = this.props;
 
         const inputClasses = classNames({
             "pt-intent-danger": !(this.isMomentValidAndInRange(date) || isMomentNull(date) || dateString === ""),
@@ -193,10 +194,10 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 inline={true}
                 isOpen={this.state.isOpen && !this.props.disabled}
                 position={this.props.popoverPosition}
-                {...this.props.popoverProps}
+                {...popoverProps}
                 content={popoverContent}
                 onClose={this.handleClosePopover}
-                popoverClassName={classNames("pt-dateinput-popover", this.props.popoverProps.popoverClassName)}
+                popoverClassName={classNames("pt-dateinput-popover", popoverProps.popoverClassName)}
             >
                 <InputGroup
                     className={inputClasses}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -106,9 +106,10 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverPosition?: Position;
 
     /**
-     * Props to pass to the `Popover`. Note that `content` cannot be changed.
+     * Props to pass to the `Popover`.
+     * Note that `content`, `autoFocus`, and `enforceFocus` cannot be changed.
      */
-    popoverProps?: Partial<IPopoverProps>;
+    popoverProps?: Partial<IPopoverProps> & object;
 
     /**
      * Element to render on right side of input.
@@ -189,12 +190,12 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
         return (
             <Popover
-                autoFocus={false}
-                enforceFocus={false}
                 inline={true}
                 isOpen={this.state.isOpen && !this.props.disabled}
                 position={this.props.popoverPosition}
                 {...popoverProps}
+                autoFocus={false}
+                enforceFocus={false}
                 content={popoverContent}
                 onClose={this.handleClosePopover}
                 popoverClassName={classNames("pt-dateinput-popover", popoverProps.popoverClassName)}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -100,6 +100,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     /**
      * The position the date popover should appear in relative to the input box.
      * @default Position.BOTTOM
+     * @deprecated since v1.15.0, use `popoverProps.position`
      */
     popoverPosition?: Position;
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -55,9 +55,14 @@ describe("<DateInput>", () => {
 
     it("popoverProps are passed to Popover", () => {
         const popoverWillOpen = sinon.spy();
-        const wrapper = mount(<DateInput popoverProps={{ inline: true, position: Position.TOP, popoverWillOpen }} />);
+        const wrapper = mount(<DateInput
+            popoverProps={{ autoFocus: true, content: "fail", inline: true, position: Position.TOP, popoverWillOpen }}
+        />);
         wrapper.find("input").simulate("focus");
+
         const popover = wrapper.find(Popover);
+        assert.strictEqual(popover.prop("autoFocus"), false, "autoFocus cannot be changed");
+        assert.notStrictEqual(popover.prop("content"), "fail", "content cannot be changed");
         assert.strictEqual(popover.prop("inline"), true);
         assert.strictEqual(popover.prop("position"), Position.TOP);
         assert.isTrue(popoverWillOpen.calledOnce);

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { InputGroup, Popover } from "@blueprintjs/core";
+import { InputGroup, Popover, Position } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes, DateInput, TimePicker, TimePickerPrecision } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -51,6 +51,16 @@ describe("<DateInput>", () => {
         // assert TimePicker disappears in absence of prop
         wrapper.setProps({ timePrecision: undefined });
         assert.isTrue(wrapper.find(TimePicker).isEmpty());
+    });
+
+    it("popoverProps are passed to Popover", () => {
+        const popoverWillOpen = sinon.spy();
+        const wrapper = mount(<DateInput popoverProps={{ inline: true, position: Position.TOP, popoverWillOpen }} />);
+        wrapper.find("input").simulate("focus");
+        const popover = wrapper.find(Popover);
+        assert.strictEqual(popover.prop("inline"), true);
+        assert.strictEqual(popover.prop("position"), Position.TOP);
+        assert.isTrue(popoverWillOpen.calledOnce);
     });
 
     describe("when uncontrolled", () => {


### PR DESCRIPTION
#### Fixes #560, #974 

#### Changes proposed in this pull request:

- new `popoverProps` prop proxied to `Popover`
- :x: deprecate `popoverPosition`