### PR TITLE
Convert more errors to warnings

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -12,7 +12,8 @@ export const ALERT_CANCEL_PROPS = `${ns} If either cancelButtonText or onCancel 
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = `${ns} <CollapsibleList> children must be <MenuItem>s`;
 
-export const MENU_CHILDREN_SUBMENU_MUTEX = `${ns} <MenuItem> children and submenu props are mutually exclusive.`;
+export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
+    `${ns} <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;
 
 export const NUMERIC_INPUT_MIN_MAX =
     `${ns} <NumericInput> requires min to be strictly less than max if both are defined.`;

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -12,6 +12,9 @@ export const ALERT_CANCEL_PROPS = `${ns} If either cancelButtonText or onCancel 
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = `${ns} <CollapsibleList> children must be <MenuItem>s`;
 
+export const CONTEXTMENU_WARN_DECORATOR_NO_METHOD =
+    ` ${ns} @ContextMenuTarget-decorated class should implement renderContextMenu.`;
+
 export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
     `${ns} <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;
 

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -8,12 +8,15 @@
 const ns = "[Blueprint]";
 const deprec = `${ns} DEPRECATION:`;
 
-export const ALERT_CANCEL_PROPS = `${ns} If either cancelButtonText or onCancel are set in <Alert>, both must be set.`;
+export const CLAMP_MIN_MAX = `${ns} clamp: max cannot be less than min`;
+
+export const ALERT_WARN_CANCEL_PROPS =
+    `${ns} <Alert> cancelButtonText and onCancel should be set together.`;
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = `${ns} <CollapsibleList> children must be <MenuItem>s`;
 
 export const CONTEXTMENU_WARN_DECORATOR_NO_METHOD =
-    ` ${ns} @ContextMenuTarget-decorated class should implement renderContextMenu.`;
+    `${ns} @ContextMenuTarget-decorated class should implement renderContextMenu.`;
 
 export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
     `${ns} <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;
@@ -50,12 +53,13 @@ export const SLIDER_ZERO_STEP = `${ns} <Slider> stepSize must be greater than ze
 export const SLIDER_ZERO_LABEL_STEP = `${ns} <Slider> labelStepSize must be greater than zero.`;
 export const RANGESLIDER_NULL_VALUE = `${ns} <RangeSlider> value prop must be an array of two non-null numbers.`;
 
-export const TABS_FIRST_CHILD = `${ns} First child of <Tabs> component should be a <TabList>`;
-export const TABS_MISMATCH = `${ns} Number of <Tab> components should equal number of <TabPanel> components`;
+export const TABS_FIRST_CHILD = `${ns} First child of <Tabs> component must be a <TabList>`;
+export const TABS_MISMATCH = `${ns} Number of <Tab> components must equal number of <TabPanel> components`;
 export const TABS_WARN_DEPRECATED = `${deprec} <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>.`
     + " https://blueprintjs.com/#components.tabs.js";
 
 export const TOASTER_WARN_INLINE = `${ns} Toaster.create() ignores inline prop as it always creates a new element.`;
+export const TOASTER_WARN_LEFT_RIGHT = `${ns} Toaster does not support LEFT or RIGHT positions.`;
 
 export const TOOLTIP_WARN_EMPTY_CONTENT = `${ns} Disabling <Tooltip> with empty content...`;
 

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -18,6 +18,8 @@ export const COLLAPSIBLE_LIST_INVALID_CHILD = `${ns} <CollapsibleList> children 
 export const CONTEXTMENU_WARN_DECORATOR_NO_METHOD =
     `${ns} @ContextMenuTarget-decorated class should implement renderContextMenu.`;
 
+export const HOTKEYS_HOTKEY_CHILDREN = `${ns} <Hotkeys> only accepts <Hotkey> children.`;
+
 export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
     `${ns} <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;
 

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -5,6 +5,8 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import { CLAMP_MIN_MAX } from "./errors";
+
 // only accessible within this file, so use `Utils.isNodeEnv` from the outside.
 declare var process: { env: any };
 
@@ -60,7 +62,7 @@ export function approxEqual(a: number, b: number, tolerance = 0.00001) {
 /** Clamps the given number between min and max values. Returns value if within range, or closest bound. */
 export function clamp(val: number, min: number, max: number) {
     if (max < min) {
-        throw new Error("clamp: max cannot be less than min");
+        throw new Error(CLAMP_MIN_MAX);
     }
     return Math.min(Math.max(val, min), max);
 }

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -9,7 +9,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import { AbstractComponent, Classes, Intent, IProps } from "../../common";
-import * as Errors from "../../common/errors";
+import { ALERT_WARN_CANCEL_PROPS } from "../../common/errors";
 import { Button } from "../button/buttons";
 import { Dialog } from "../dialog/dialog";
 
@@ -85,7 +85,7 @@ export class Alert extends AbstractComponent<IAlertProps, {}> {
     protected validateProps(props: IAlertProps) {
         if (props.cancelButtonText != null && props.onCancel == null ||
             props.cancelButtonText == null && props.onCancel != null ) {
-            throw new Error(Errors.ALERT_CANCEL_PROPS);
+            console.warn(ALERT_WARN_CANCEL_PROPS);
         }
     }
 

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -41,10 +41,12 @@ export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(c
                 return;
             }
 
-            const menu = safeInvoke(this.renderContextMenu, e);
-            if (menu != null) {
-                e.preventDefault();
-                ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, onContextMenuClose);
+            if (isFunction(this.renderContextMenu)) {
+                const menu = this.renderContextMenu(e);
+                if (menu != null) {
+                    e.preventDefault();
+                    ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, onContextMenuClose);
+                }
             }
 
             safeInvoke(oldOnContextMenu, e);

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -7,6 +7,7 @@
 
 import * as React from "react";
 
+import { CONTEXTMENU_WARN_DECORATOR_NO_METHOD } from "../../common/errors";
 import { isFunction, safeInvoke } from "../../common/utils";
 import * as ContextMenu from "./contextMenu";
 
@@ -19,7 +20,7 @@ export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(c
     const { render, renderContextMenu, onContextMenuClose } = constructor.prototype;
 
     if (!isFunction(renderContextMenu)) {
-        throw new Error(`@ContextMenuTarget-decorated class must implement \`renderContextMenu\`. ${constructor}`);
+        console.warn(CONTEXTMENU_WARN_DECORATOR_NO_METHOD);
     }
 
     // patching classes like this requires preserving function context
@@ -40,7 +41,7 @@ export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(c
                 return;
             }
 
-            const menu = this.renderContextMenu(e);
+            const menu = safeInvoke(this.renderContextMenu, e);
             if (menu != null) {
                 e.preventDefault();
                 ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, onContextMenuClose);

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -53,8 +53,8 @@ export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
         global: false,
     };
 
-    public static isInstance(element: ReactElement<any>): element is ReactElement<IHotkeyProps> {
-        return element.type === Hotkey;
+    public static isInstance(element: any): element is ReactElement<IHotkeyProps> {
+        return element != null && (element as JSX.Element).type === Hotkey;
     }
 
     public render() {

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -16,6 +16,7 @@ export { KeyCombo, IKeyComboProps } from "./keyCombo";
 export { HotkeysTarget, IHotkeysTarget } from "./hotkeysTarget";
 export { IKeyCombo, comboMatches, getKeyCombo, getKeyComboString, parseKeyCombo } from "./hotkeyParser";
 export { IHotkeysDialogProps, hideHotkeysDialog, setHotkeysDialogProps } from "./hotkeysDialog";
+import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
 
 export interface IHotkeysProps extends IProps {
     /**
@@ -60,8 +61,8 @@ export class Hotkeys extends AbstractComponent<IHotkeysProps, {}> {
 
     protected validateProps(props: IHotkeysProps & { children: React.ReactNode }) {
         Children.forEach(props.children, (child) => {
-            if (typeof child !== "object" || !Hotkey.isInstance(child)) {
-                throw new Error("Hotkeys only accepts <Hotkey> children");
+            if (!Hotkey.isInstance(child)) {
+                throw new Error(HOTKEYS_HOTKEY_CHILDREN);
             }
         });
     }

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -156,7 +156,7 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
 
     protected validateProps(props: IMenuItemProps & {children?: React.ReactNode}) {
         if (props.children != null && props.submenu != null) {
-            throw new Error(Errors.MENU_CHILDREN_SUBMENU_MUTEX);
+            console.warn(Errors.MENU_WARN_CHILDREN_SUBMENU_MUTEX);
         }
     }
 

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -106,7 +106,7 @@ export class Handle extends AbstractComponent<IHandleProps, IHandleState> {
     protected validateProps(props: IHandleProps) {
         for (const prop of NUMBER_PROPS) {
             if (typeof (props as any)[prop] !== "number") {
-                throw new Error(`Handle requires number for ${prop} prop`);
+                throw new Error(`[Blueprint] <Handle> requires number value for ${prop} prop`);
             }
         }
     }

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
-import { TOASTER_WARN_INLINE } from "../../common/errors";
+import { TOASTER_WARN_INLINE, TOASTER_WARN_LEFT_RIGHT } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
@@ -168,7 +168,7 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
 
     protected validateProps(props: IToasterProps) {
         if (props.position === Position.LEFT || props.position === Position.RIGHT) {
-            throw new Error("Toaster does not support LEFT or RIGHT positions.");
+            console.warn(TOASTER_WARN_LEFT_RIGHT);
         }
     }
 

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -67,7 +67,7 @@ describe("ContextMenu", () => {
         /* -- uncomment this test to confirm compilation failure -- */
         // it("TypeScript compilation fails if decorated class does not implement renderContextMenu", () => {
         //     @ContextMenuTarget
-        //     class TypeScriptFail extends React.Component<{}, {}> {
+        //     return class TypeScriptFail extends React.Component<{}, {}> {
         //         public render() { return <article />; }
         //     }
         // });

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -13,6 +13,7 @@ import * as Enzyme from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import { HOTKEYS_HOTKEY_CHILDREN } from "../../src/common/errors";
 import {
     comboMatches,
     getKeyCombo,
@@ -27,6 +28,12 @@ import {
 import { dispatchTestKeyboardEvent } from "../common/utils";
 
 describe("Hotkeys", () => {
+    it("throws error if given non-Hotkey child", () => {
+        expect(() => mount(<Hotkeys><div /></Hotkeys>)).to.throw(HOTKEYS_HOTKEY_CHILDREN, "element");
+        expect(() => mount(<Hotkeys>string contents</Hotkeys>)).to.throw(HOTKEYS_HOTKEY_CHILDREN, "string");
+        expect(() => mount(<Hotkeys>{undefined}{null}</Hotkeys>)).to.throw(HOTKEYS_HOTKEY_CHILDREN, "undefined");
+    });
+
     describe("Local/Global @HotkeysTarget", () => {
 
         let localHotkeySpy: Sinon.SinonSpy = null;

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -11,7 +11,6 @@ import * as React from "react";
 import * as TestUtils from "react-addons-test-utils";
 import * as ReactDOM from "react-dom";
 
-import * as Errors from "../../src/common/errors";
 import { Classes, IMenuItemProps, IMenuProps, Menu, MenuDivider, MenuItem, Popover } from "../../src/index";
 import { MenuDividerFactory, MenuFactory, MenuItemFactory } from "../../src/index";
 
@@ -56,12 +55,15 @@ describe("MenuItem", () => {
         assert.isTrue(wrapper.find(Popover).prop("isDisabled"));
     });
 
-    it("throws error if given children and submenu", () => {
-        assert.throws(() => shallow(
+    it("renders children if given children and submenu", () => {
+        const wrapper = shallow(
             <MenuItem iconName="style" text="Style" submenu={[{text: "foo"}]}>
-                <MenuItem text="bar" />
+                <MenuItem text="one" />
+                <MenuItem text="two" />
             </MenuItem>,
-        ), Errors.MENU_CHILDREN_SUBMENU_MUTEX);
+        );
+        const submenu = findSubmenu(wrapper);
+        assert.lengthOf(submenu.props.children, 2);
     });
 
     it("Clicking MenuItem triggers onClick prop", () => {


### PR DESCRIPTION
#### Continues #977 

#### Changes proposed in this pull request:

- check the commits for exact changes.
- remaining constants in `errors.ts` that do not include the word `WARN` are actual show-stopping errors so it's ok to throw them. (currently; we may want to refactor some components so these aren't show-stopping.)
