### PR TITLE
fix DateInput composition of DateTimePicker

### DIFF
--- a/packages/datetime/examples/dateInputExample.tsx
+++ b/packages/datetime/examples/dateInputExample.tsx
@@ -13,6 +13,10 @@ import { DateInput, TimePickerPrecision } from "../src";
 import { FORMATS, FormatSelect } from "./common/formatSelect";
 import { PrecisionSelect } from "./common/precisionSelect";
 
+const MAX = new Date(2020, 5, 5);
+const MIN = new Date(1990, 5, 5);
+const DATE = new Date(2019, 4, 20);
+
 export interface IDateInputExampleState {
     closeOnSelection?: boolean;
     disabled?: boolean;
@@ -40,7 +44,7 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
 
     protected renderExample() {
         return (
-            <DateInput {...this.state} defaultValue={new Date()} />
+            <DateInput {...this.state} defaultValue={DATE} maxDate={MAX} minDate={MIN} />
         );
     }
 

--- a/packages/datetime/examples/dateInputExample.tsx
+++ b/packages/datetime/examples/dateInputExample.tsx
@@ -13,10 +13,6 @@ import { DateInput, TimePickerPrecision } from "../src";
 import { FORMATS, FormatSelect } from "./common/formatSelect";
 import { PrecisionSelect } from "./common/precisionSelect";
 
-const MAX = new Date(2020, 5, 5);
-const MIN = new Date(1990, 5, 5);
-const DATE = new Date(2019, 4, 20);
-
 export interface IDateInputExampleState {
     closeOnSelection?: boolean;
     disabled?: boolean;
@@ -44,7 +40,7 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
 
     protected renderExample() {
         return (
-            <DateInput {...this.state} defaultValue={DATE} maxDate={MAX} minDate={MIN} />
+            <DateInput {...this.state} defaultValue={new Date()} />
         );
     }
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -169,18 +169,17 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     public render() {
-        const dateString = this.state.isInputFocused ? this.state.valueString : this.getDateString(this.state.value);
-        const date = this.state.isInputFocused ? moment(this.state.valueString, this.props.format) : this.state.value;
+        const { value, valueString } = this.state;
+        const dateString = this.state.isInputFocused ? valueString : this.getDateString(value);
+        const date = this.state.isInputFocused ? moment(valueString, this.props.format) : value;
+        const dateValue = this.isMomentValidAndInRange(value) ? fromMomentToDate(value) : null;
 
-        const sharedProps: IDatePickerBaseProps = {
-            ...this.props,
-            onChange: this.handleDateChange,
-            value: this.isMomentValidAndInRange(this.state.value) ? fromMomentToDate(this.state.value) : null,
-        };
         const popoverContent = this.props.timePrecision === undefined
-            ? <DatePicker {...sharedProps} />
+            ? <DatePicker {...this.props} onChange={this.handleDateChange} value={dateValue} />
             : <DateTimePicker
-                {...sharedProps}
+                onChange={this.handleDateChange}
+                value={dateValue}
+                datePickerProps={this.props}
                 timePickerProps={{ precision: this.props.timePrecision }}
             />;
         // assign default empty object here to prevent mutation
@@ -255,7 +254,8 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private handleClosePopover = (e: React.SyntheticEvent<HTMLElement>) => {
-        Utils.safeInvoke(this.props.popoverProps.onClose, e);
+        const { popoverProps = {} } = this.props;
+        Utils.safeInvoke(popoverProps.onClose, e);
         this.setState({ isOpen: false });
     }
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -53,6 +53,20 @@ describe("<DateInput>", () => {
         assert.isTrue(wrapper.find(TimePicker).isEmpty());
     });
 
+    it("with TimePicker passes props correctly to DateTimePicker", () => {
+        // verifies fixed https://github.com/palantir/blueprint/issues/980
+        assert.doesNotThrow(() => {
+            // max date and value are both well after default max date (end of this year).
+            // if props are not passed correctly then validation will fail as value > default max date.
+            mount(<DateInput
+                maxDate={new Date(2050, 5, 4)}
+                timePrecision={TimePickerPrecision.SECOND}
+                value={new Date(2030, 4, 5)}
+            />).setState({ isOpen: true });
+            // must open the popover so DateTimePicker is rendered
+        });
+    });
+
     it("popoverProps are passed to Popover", () => {
         const popoverWillOpen = sinon.spy();
         const wrapper = mount(<DateInput


### PR DESCRIPTION
#### Fixes #980 

#### Changes proposed in this pull request:

- must set `datePickerProps` rather than spreading all props. (cc @mfedderly)