### PR TITLE
DateRangeInput spreads all props to DateRangePicker

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -272,14 +272,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
         const popoverContent = (
             <DateRangePicker
-                allowSingleDayRange={this.props.allowSingleDayRange}
+                {...this.props}
                 boundaryToModify={this.state.boundaryToModify}
-                contiguousCalendarMonths={this.props.contiguousCalendarMonths}
                 onChange={this.handleDateRangePickerChange}
                 onHoverChange={this.handleDateRangePickerHoverChange}
-                maxDate={this.props.maxDate}
-                minDate={this.props.minDate}
-                shortcuts={this.props.shortcuts}
                 value={this.getSelectedRange()}
             />
         );

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -215,7 +215,7 @@ describe("<DateRangeInput>", () => {
             root.setState({ isOpen: true });
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
-            expect(root.state("isOpen")).to.be.true;g
+            expect(root.state("isOpen")).to.be.true;
         });
 
         it("if closeOnSelection=true, popover closes when full date range is selected", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -67,13 +67,13 @@ describe("<DateRangeInput>", () => {
         expect(component.find(InputGroup).length).to.equal(2);
     });
 
-    it.only("inner DateRangePicker receives all supported props", () => {
+    it("inner DateRangePicker receives all supported props", () => {
         const component = mount(<DateRangeInput locale="uk" contiguousCalendarMonths={false} />);
         component.setState({ isOpen: true });
         const picker = component.find(DateRangePicker);
         expect(picker.prop("locale")).to.equal("uk");
         expect(picker.prop("contiguousCalendarMonths")).to.be.false;
-    })
+    });
 
     it("startInputProps.inputRef receives reference to HTML input element", () => {
         const inputRef = sinon.spy();

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -82,7 +82,7 @@ describe("<DateRangeInput>", () => {
         expect(inputRef.calledOnce).to.be.true;
         expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
     });
-      
+
     it("shows empty fields when no date range is selected", () => {
         const { root } = wrap(<DateRangeInput />);
         assertInputTextsEqual(root, "", "");
@@ -215,7 +215,7 @@ describe("<DateRangeInput>", () => {
             root.setState({ isOpen: true });
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
-            expect(root.state("isOpen")).to.be.true;
+            expect(root.state("isOpen")).to.be.true;g
         });
 
         it("if closeOnSelection=true, popover closes when full date range is selected", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -67,6 +67,14 @@ describe("<DateRangeInput>", () => {
         expect(component.find(InputGroup).length).to.equal(2);
     });
 
+    it.only("inner DateRangePicker receives all supported props", () => {
+        const component = mount(<DateRangeInput locale="uk" contiguousCalendarMonths={false} />);
+        component.setState({ isOpen: true });
+        const picker = component.find(DateRangePicker);
+        expect(picker.prop("locale")).to.equal("uk");
+        expect(picker.prop("contiguousCalendarMonths")).to.be.false;
+    })
+
     it("startInputProps.inputRef receives reference to HTML input element", () => {
         const inputRef = sinon.spy();
         // full DOM rendering here so the ref handler is invoked


### PR DESCRIPTION
#### Fixes #970 

#### Changes proposed in this pull request:

- `IDateRangeInputProps extends IDatePickerBaseProps` but it didn't pass all of them along to `DateRangePicker`
- I changed the props to use a spread so all supported props will be passed along automatically (including `locale`).