### PR TITLE
[Table] Eliminate unnecessary re-renders everywhere

### DIFF
--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { ITruncatedFormatProps, TruncatedFormat, TruncatedPopoverMode } from "./truncatedFormat";
@@ -29,6 +30,7 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     stringify?: (obj: any) => string;
 }
 
+@PureRender
 export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
     public static defaultProps: IJSONFormatProps = {
         detectTruncation: true,

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -8,6 +8,7 @@
 import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/core";
 
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -66,6 +67,7 @@ export interface ITruncatedFormatState {
     isTruncated: boolean;
 }
 
+@PureRender
 export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITruncatedFormatState> {
     public static defaultProps: ITruncatedFormatProps = {
         detectTruncation: true,

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -5,6 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { IProps } from "@blueprintjs/core";
@@ -46,6 +47,7 @@ export interface IColumnProps extends IColumnNameProps, IProps {
     renderColumnHeader?: IColumnHeaderRenderer;
 }
 
+@PureRender
 export class Column extends React.Component<IColumnProps, {}> {
     public static defaultProps: IColumnProps = {
         renderCell: emptyCellRenderer,

--- a/packages/table/src/common/contextMenuTargetWrapper.tsx
+++ b/packages/table/src/common/contextMenuTargetWrapper.tsx
@@ -6,6 +6,7 @@
  */
 
 import { ContextMenuTarget, IProps } from "@blueprintjs/core";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 export interface IContextMenuTargetWrapper extends IProps {
@@ -20,6 +21,7 @@ export interface IContextMenuTargetWrapper extends IProps {
  * chains.
  */
 @ContextMenuTarget
+@PureRender
 export class ContextMenuTargetWrapper extends React.Component<IContextMenuTargetWrapper, {}> {
     public render() {
         const { className, children, style } = this.props;

--- a/packages/table/src/common/loadableContent.tsx
+++ b/packages/table/src/common/loadableContent.tsx
@@ -5,6 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
@@ -24,6 +25,7 @@ export interface ILoadableContentProps {
 }
 
 // This class expects a single, non-string child.
+@PureRender
 export class LoadableContent extends React.Component<ILoadableContentProps, {}> {
     private style: React.CSSProperties;
 

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -367,7 +367,7 @@ function shallowCompareKeys(objA: any, objB: any, keys: string[]) {
         return true;
     } else if (objA == null || objB == null) {
         return false;
-    } else if (Array.isArray(objA) !== Array.isArray(objB)) {
+    } else if (Array.isArray(objA) || Array.isArray(objB)) {
         return false;
     }
     return keys

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -204,17 +204,16 @@ export const Utils = {
      * compared; otherwise, all keys will be compared.
      */
     shallowCompareKeys(objA: any, objB: any, keys?: string[]) {
-        if (keys != null) {
+        // treat `null` and `undefined` as the same
+        if (objA == null && objB == null) {
+            return true;
+        } else if (objA == null || objB == null) {
+            return false;
+        } else if (Array.isArray(objA) || Array.isArray(objB)) {
+            return false;
+        } else if (keys != null) {
             return _shallowCompareKeys(objA, objB, keys);
         } else {
-            // treat `null` and `undefined` as the same
-            if (objA == null && objB == null) {
-                return true;
-            } else if (objA == null || objB == null) {
-                return false;
-            } else if (Array.isArray(objA) !== Array.isArray(objB)) {
-                return false;
-            }
             const keysA = Object.keys(objA);
             const keysB = Object.keys(objB);
             return _shallowCompareKeys(objA, objB, keysA)
@@ -365,13 +364,8 @@ export const Utils = {
  * Partial shallow comparison between objects using the given list of keys.
  */
 function _shallowCompareKeys(objA: any, objB: any, keys: string[]) {
-    if (objA == null && objB == null) {
-        return true;
-    } else if (objA == null || objB == null) {
-        return false;
-    } else if (Array.isArray(objA) || Array.isArray(objB)) {
-        return false;
-    } else {
-        return keys.every((key) => objA.hasOwnProperty(key) === objB.hasOwnProperty(key) && objA[key] === objB[key]);
-    }
+    return keys.every((key) => {
+        return objA.hasOwnProperty(key) === objB.hasOwnProperty(key)
+            && objA[key] === objB[key];
+    });
 }

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -205,9 +205,10 @@ export const Utils = {
      */
     shallowCompareKeys(objA: any, objB: any, keys?: string[]) {
         if (keys != null) {
-            return shallowCompareKeys(objA, objB, keys);
+            return _shallowCompareKeys(objA, objB, keys);
         } else {
-            if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
+            // treat `null` and `undefined` as the same
+            if (objA == null && objB == null) {
                 return true;
             } else if (objA == null || objB == null) {
                 return false;
@@ -216,8 +217,8 @@ export const Utils = {
             }
             const keysA = Object.keys(objA);
             const keysB = Object.keys(objB);
-            return shallowCompareKeys(objA, objB, keysA)
-                && shallowCompareKeys(objA, objB, keysB);
+            return _shallowCompareKeys(objA, objB, keysA)
+                && _shallowCompareKeys(objA, objB, keysB);
         }
     },
 
@@ -348,13 +349,14 @@ export const Utils = {
      * Returns true if the arrays are equal. Elements will be shallowly compared by default, or they
      * will be compared using the custom `compare` function if one is provided.
      */
-    arraysEqual(arrA: any[], arrB: any[], compare?: (a: any, b: any) => boolean) {
-        if (bothUndefined(arrA, arrB) || bothNull(arrA, arrB)) {
+    arraysEqual(arrA: any[], arrB: any[], compare = (a: any, b: any) => a === b) {
+        // treat `null` and `undefined` as the same
+        if (arrA == null && arrB == null) {
             return true;
         } else if (arrA == null || arrB == null || arrA.length !== arrB.length) {
             return false;
         } else {
-            return arrA.every((a, i) => compare == null ? a === arrB[i] : compare(a, arrB[i]));
+            return arrA.every((a, i) => compare(a, arrB[i]));
         }
     },
 };
@@ -362,23 +364,14 @@ export const Utils = {
 /**
  * Partial shallow comparison between objects using the given list of keys.
  */
-function shallowCompareKeys(objA: any, objB: any, keys: string[]) {
-    if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
+function _shallowCompareKeys(objA: any, objB: any, keys: string[]) {
+    if (objA == null && objB == null) {
         return true;
     } else if (objA == null || objB == null) {
         return false;
     } else if (Array.isArray(objA) || Array.isArray(objB)) {
         return false;
+    } else {
+        return keys.every((key) => objA.hasOwnProperty(key) === objB.hasOwnProperty(key) && objA[key] === objB[key]);
     }
-    return keys
-        .map((key) => objA.hasOwnProperty(key) === objB.hasOwnProperty(key) && objA[key] === objB[key])
-        .every((isEqual) => isEqual);
-}
-
-function bothUndefined(objA: any, objB: any) {
-    return objA === undefined && objB === undefined;
-}
-
-function bothNull(objA: any, objB: any) {
-    return objA === null && objB === null;
 }

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -199,16 +199,24 @@ export const Utils = {
         return value;
     },
 
+    shallowCompareKeys,
+
     /**
-     * Partial shallow comparison between objects using the given list of keys.
+     * Returns true if the keys are the same between the two objects and the values for each key are
+     * shallowly equal.
      */
-    shallowCompareKeys(objA: any, objB: any, keys: string[]) {
-        for (const key of keys) {
-            if (objA[key] !== objB[key]) {
-                return false;
-            }
+    shallowCompare(objA: any, objB: any) {
+        if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
+            return true;
+        } else if (objA == null || objB == null) {
+            return false;
+        } else if (Array.isArray(objA) !== Array.isArray(objB)) {
+            return false;
         }
-        return true;
+        const keysA = Object.keys(objA);
+        const keysB = Object.keys(objB);
+        return shallowCompareKeys(objA, objB, keysA)
+            && shallowCompareKeys(objA, objB, keysB);
     },
 
     /**
@@ -334,3 +342,27 @@ export const Utils = {
         return event.button === 0;
     },
 };
+
+/**
+ * Partial shallow comparison between objects using the given list of keys.
+ */
+function shallowCompareKeys(objA: any, objB: any, keys: string[]) {
+    if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
+        return true;
+    } else if (objA == null || objB == null) {
+        return false;
+    } else if (Array.isArray(objA) !== Array.isArray(objB)) {
+        return false;
+    }
+    return keys
+        .map((key) => objA.hasOwnProperty(key) === objB.hasOwnProperty(key) && objA[key] === objB[key])
+        .every((isEqual) => isEqual);
+}
+
+function bothUndefined(objA: any, objB: any) {
+    return objA === undefined && objB === undefined;
+}
+
+function bothNull(objA: any, objB: any) {
+    return objA === null && objB === null;
+}

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -349,9 +349,9 @@ export const Utils = {
      * will be compared using the custom `compare` function if one is provided.
      */
     arraysEqual(arrA: any[], arrB: any[], compare?: (a: any, b: any) => boolean) {
-        if (arrA === undefined || arrB === undefined) {
+        if (arrA === undefined && arrB === undefined) {
             return true;
-        } else if (arrA === null || arrB === null) {
+        } else if (arrA === null && arrB === null) {
             return true;
         } else if (arrA == null || arrB == null || arrA.length !== arrB.length) {
             return false;

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -349,9 +349,7 @@ export const Utils = {
      * will be compared using the custom `compare` function if one is provided.
      */
     arraysEqual(arrA: any[], arrB: any[], compare?: (a: any, b: any) => boolean) {
-        if (arrA === undefined && arrB === undefined) {
-            return true;
-        } else if (arrA === null && arrB === null) {
+        if (bothUndefined(arrA, arrB) || bothNull(arrA, arrB)) {
             return true;
         } else if (arrA == null || arrB == null || arrA.length !== arrB.length) {
             return false;

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -199,24 +199,27 @@ export const Utils = {
         return value;
     },
 
-    shallowCompareKeys,
-
     /**
-     * Returns true if the keys are the same between the two objects and the values for each key are
-     * shallowly equal.
+     * Returns `true` if the mapped values for each of the specified keys are shallowly equal
+     * between the two objects. If `keys` is not provided, returns `true` if all keys and mapped
+     * values are shallowly equal between the two objects.
      */
-    shallowCompare(objA: any, objB: any) {
-        if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
-            return true;
-        } else if (objA == null || objB == null) {
-            return false;
-        } else if (Array.isArray(objA) !== Array.isArray(objB)) {
-            return false;
+    shallowCompareKeys(objA: any, objB: any, keys?: string[]) {
+        if (keys != null) {
+            return shallowCompareKeys(objA, objB, keys);
+        } else {
+            if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
+                return true;
+            } else if (objA == null || objB == null) {
+                return false;
+            } else if (Array.isArray(objA) !== Array.isArray(objB)) {
+                return false;
+            }
+            const keysA = Object.keys(objA);
+            const keysB = Object.keys(objB);
+            return shallowCompareKeys(objA, objB, keysA)
+                && shallowCompareKeys(objA, objB, keysB);
         }
-        const keysA = Object.keys(objA);
-        const keysB = Object.keys(objB);
-        return shallowCompareKeys(objA, objB, keysA)
-            && shallowCompareKeys(objA, objB, keysB);
     },
 
     /**
@@ -346,7 +349,7 @@ export const Utils = {
 /**
  * Partial shallow comparison between objects using the given list of keys.
  */
-function shallowCompareKeys(objA: any, objB: any, keys: string[]) {
+function shallowCompareKeys(objA: any, objB: any, keys?: string[]) {
     if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
         return true;
     } else if (objA == null || objB == null) {

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -344,6 +344,22 @@ export const Utils = {
     isLeftClick(event: MouseEvent) {
         return event.button === 0;
     },
+
+    /**
+     * Returns true if the arrays are equal based on the provided compare function. If no compare
+     * function is provided, each element will be shallowly compared to determine equality.
+     */
+    arraysEqual(arrA: any[], arrB: any[], compare?: (a: any, b: any) => boolean) {
+        if (arrA === undefined || arrB === undefined) {
+            return true;
+        } else if (arrA === null || arrB === null) {
+            return true;
+        } else if (arrA == null || arrB == null || arrA.length !== arrB.length) {
+            return false;
+        } else {
+            return arrA.every((a, i) => compare == null ? a === arrB[i] : compare(a, arrB[i]));
+        }
+    },
 };
 
 /**

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -200,9 +200,8 @@ export const Utils = {
     },
 
     /**
-     * Returns `true` if the mapped values for each of the specified keys are shallowly equal
-     * between the two objects. If `keys` is not provided, returns `true` if all keys and mapped
-     * values are shallowly equal between the two objects.
+     * Shallow comparison between objects. If `keys` is provided, just that subset of keys will be
+     * compared; otherwise, all keys will be compared.
      */
     shallowCompareKeys(objA: any, objB: any, keys?: string[]) {
         if (keys != null) {
@@ -346,8 +345,8 @@ export const Utils = {
     },
 
     /**
-     * Returns true if the arrays are equal based on the provided compare function. If no compare
-     * function is provided, each element will be shallowly compared to determine equality.
+     * Returns true if the arrays are equal. Elements will be shallowly compared by default, or they
+     * will be compared using the custom `compare` function if one is provided.
      */
     arraysEqual(arrA: any[], arrB: any[], compare?: (a: any, b: any) => boolean) {
         if (arrA === undefined || arrB === undefined) {
@@ -365,7 +364,7 @@ export const Utils = {
 /**
  * Partial shallow comparison between objects using the given list of keys.
  */
-function shallowCompareKeys(objA: any, objB: any, keys?: string[]) {
+function shallowCompareKeys(objA: any, objB: any, keys: string[]) {
     if (bothUndefined(objA, objB) || bothNull(objA, objB)) {
         return true;
     } else if (objA == null || objB == null) {

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -7,6 +7,7 @@
 
 import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as Classes from "../common/classes";
 
@@ -37,6 +38,7 @@ export interface IEditableNameProps extends IIntentProps, IProps {
     onConfirm?: (value: string) => void;
 }
 
+@PureRender
 export class EditableName extends React.Component<IEditableNameProps, {}> {
     public render() {
         const { className, intent, name, onCancel, onChange, onConfirm } = this.props;

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Classes as CoreClasses, ContextMenuTarget, IProps } from "@blueprintjs/core";
@@ -67,6 +68,7 @@ export interface IRowHeaderState {
 }
 
 @ContextMenuTarget
+@PureRender
 export class RowHeaderCell extends React.Component<IRowHeaderCellProps, IRowHeaderState> {
     public state = {
         isActive: false,

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -6,6 +6,7 @@
  */
 
 import { IMenuItemProps, MenuItem } from "@blueprintjs/core";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Clipboard } from "../../common/clipboard";
@@ -37,6 +38,7 @@ export interface ICopyCellsMenuItemProps extends IMenuItemProps {
     onCopy?: (success: boolean) => void;
 }
 
+@PureRender
 export class CopyCellsMenuItem extends React.Component<ICopyCellsMenuItemProps, {}> {
     public render() {
         return <MenuItem {...this.props} onClick={this.handleClick} />;

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -7,6 +7,7 @@
 
 import { IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../common/classes";
@@ -57,6 +58,7 @@ export interface IResizeHandleState {
     isDragging: boolean;
 }
 
+@PureRender
 export class ResizeHandle extends React.Component<IResizeHandleProps, IResizeHandleState> {
     public state: IResizeHandleState = {
         isDragging: false,

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -24,6 +24,17 @@ export interface IGuideLayerProps extends IProps {
 }
 
 export class GuideLayer extends React.Component<IGuideLayerProps, {}> {
+    public shouldComponentUpdate(nextProps: IGuideLayerProps) {
+        if (this.props.className !== nextProps.className) {
+            return false;
+        }
+        // shallow-comparing guide arrays leads to tons of unnecessary re-renders, so we check the
+        // array contents explicitly.
+        const verticalGuidesEqual = this.guidesArraysEqual(this.props.verticalGuides, nextProps.verticalGuides);
+        const horizontalGuidesEqual = this.guidesArraysEqual(this.props.horizontalGuides, nextProps.horizontalGuides);
+        return !verticalGuidesEqual || !horizontalGuidesEqual;
+    }
+
     public render() {
         const { verticalGuides, horizontalGuides, className } = this.props;
         const verticals = (verticalGuides == null) ? undefined : verticalGuides.map(this.renderVerticalGuide);
@@ -58,5 +69,17 @@ export class GuideLayer extends React.Component<IGuideLayerProps, {}> {
         return (
             <div className={className} key={index} style={style} />
         );
+    }
+
+    private guidesArraysEqual(arrA: number[], arrB: number[]) {
+        if (arrA === undefined && arrB === undefined) {
+            return true;
+        } else if (arrA === null && arrB === null) {
+            return true;
+        } else if (arrA == null || arrB == null || arrA.length !== arrB.length) {
+            return false;
+        } else {
+            return arrA.every((valA, i) => valA === arrB[i]);
+        }
     }
 }

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -27,7 +27,7 @@ export interface IGuideLayerProps extends IProps {
 export class GuideLayer extends React.Component<IGuideLayerProps, {}> {
     public shouldComponentUpdate(nextProps: IGuideLayerProps) {
         if (this.props.className !== nextProps.className) {
-            return false;
+            return true;
         }
         // shallow-comparing guide arrays leads to tons of unnecessary re-renders, so we check the
         // array contents explicitly.

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -10,6 +10,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../common/classes";
+import { Utils } from "../common/utils";
 
 export interface IGuideLayerProps extends IProps {
     /**
@@ -30,8 +31,8 @@ export class GuideLayer extends React.Component<IGuideLayerProps, {}> {
         }
         // shallow-comparing guide arrays leads to tons of unnecessary re-renders, so we check the
         // array contents explicitly.
-        const verticalGuidesEqual = this.guidesArraysEqual(this.props.verticalGuides, nextProps.verticalGuides);
-        const horizontalGuidesEqual = this.guidesArraysEqual(this.props.horizontalGuides, nextProps.horizontalGuides);
+        const verticalGuidesEqual = Utils.arraysEqual(this.props.verticalGuides, nextProps.verticalGuides);
+        const horizontalGuidesEqual = Utils.arraysEqual(this.props.horizontalGuides, nextProps.horizontalGuides);
         return !verticalGuidesEqual || !horizontalGuidesEqual;
     }
 
@@ -69,17 +70,5 @@ export class GuideLayer extends React.Component<IGuideLayerProps, {}> {
         return (
             <div className={className} key={index} style={style} />
         );
-    }
-
-    private guidesArraysEqual(arrA: number[], arrB: number[]) {
-        if (arrA === undefined && arrB === undefined) {
-            return true;
-        } else if (arrA === null && arrB === null) {
-            return true;
-        } else if (arrA == null || arrB == null || arrA.length !== arrB.length) {
-            return false;
-        } else {
-            return arrA.every((valA, i) => valA === arrB[i]);
-        }
     }
 }

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -31,9 +31,8 @@ export class GuideLayer extends React.Component<IGuideLayerProps, {}> {
         }
         // shallow-comparing guide arrays leads to tons of unnecessary re-renders, so we check the
         // array contents explicitly.
-        const verticalGuidesEqual = Utils.arraysEqual(this.props.verticalGuides, nextProps.verticalGuides);
-        const horizontalGuidesEqual = Utils.arraysEqual(this.props.horizontalGuides, nextProps.horizontalGuides);
-        return !verticalGuidesEqual || !horizontalGuidesEqual;
+        return !Utils.arraysEqual(this.props.verticalGuides, nextProps.verticalGuides)
+            || !Utils.arraysEqual(this.props.horizontalGuides, nextProps.horizontalGuides);
     }
 
     public render() {

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -21,7 +21,7 @@ export interface IRegionLayerProps extends IProps {
     regions?: IRegion[];
 
     /**
-     * The array of CSS styles to apply to each corresponding region.
+     * The array of CSS styles to apply to each region.
      */
     regionStyles?: React.CSSProperties[];
 }

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -21,7 +21,8 @@ export interface IRegionLayerProps extends IProps {
     regions?: IRegion[];
 
     /**
-     * The array of CSS styles to apply to each region.
+     * The array of CSS styles to apply to each region. The ith style object in this array will be
+     * applied to the ith region in `regions`.
      */
     regionStyles?: React.CSSProperties[];
 }

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -528,6 +528,11 @@ export class Regions {
         return regionGroups;
     }
 
+    public static regionsEqual(regionA: IRegion, regionB: IRegion) {
+        return Regions.intervalsEqual(regionA.rows, regionB.rows)
+            && Regions.intervalsEqual(regionA.cols, regionB.cols);
+    }
+
     /**
      * Iterates over the cells within an `IRegion`, invoking the callback with
      * each cell's coordinates.
@@ -571,11 +576,6 @@ export class Regions {
             default:
                 break;
         }
-    }
-
-    private static regionsEqual(regionA: IRegion, regionB: IRegion) {
-        return Regions.intervalsEqual(regionA.rows, regionB.rows)
-            && Regions.intervalsEqual(regionA.cols, regionB.cols);
     }
 
     private static regionContains(regionA: IRegion, regionB: IRegion) {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -579,7 +579,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 ref={this.setMenuRef}
                 onClick={this.selectAll}
             >
-                {this.maybeRenderMenuRegions()}
+                {this.maybeRenderRegions(this.styleMenuRegion)}
             </div>
         );
     }
@@ -663,7 +663,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     onFocus={this.handleFocus}
                     onLayoutLock={this.handleLayoutLock}
                     onReordered={this.handleColumnsReordered}
-                    onReordering={this.handleColumnReorderPreview}
+                    onReordering={this.handleColumnsReordering}
                     onResizeGuide={this.handleColumnResizeGuide}
                     onSelection={this.getEnabledSelectionHandler(RegionCardinality.FULL_COLUMNS)}
                     selectedRegions={selectedRegions}
@@ -674,7 +674,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     {this.props.children}
                 </ColumnHeader>
 
-                {this.maybeRenderColumnHeaderRegions()}
+                {this.maybeRenderRegions(this.styleColumnHeaderRegion)}
             </div>
         );
     }
@@ -715,7 +715,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     onLayoutLock={this.handleLayoutLock}
                     onResizeGuide={this.handleRowResizeGuide}
                     onReordered={this.handleRowsReordered}
-                    onReordering={this.handleRowReordering}
+                    onReordering={this.handleRowsReordering}
                     onRowHeightChanged={this.handleRowHeightChanged}
                     onSelection={this.getEnabledSelectionHandler(RegionCardinality.FULL_ROWS)}
                     renderRowHeader={renderRowHeader}
@@ -725,7 +725,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     {...rowIndices}
                 />
 
-                {this.maybeRenderRowHeaderRegions()}
+                {this.maybeRenderRegions(this.styleRowHeaderRegion)}
             </div>
         );
     }
@@ -794,7 +794,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                         {...columnIndices}
                     />
 
-                    {this.maybeRenderBodyRegions()}
+                    {this.maybeRenderRegions(this.styleBodyRegion)}
 
                     <GuideLayer
                         className={Classes.TABLE_RESIZE_GUIDES}
@@ -865,12 +865,13 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         );
 
         return regionGroups.map((regionGroup, index) => {
+            const regionStyles = regionGroup.regions.map(getRegionStyle);
             return (
                 <RegionLayer
                     className={classNames(regionGroup.className)}
                     key={index}
                     regions={regionGroup.regions}
-                    getRegionStyle={getRegionStyle}
+                    regionStyles={regionStyles}
                 />
             );
         });
@@ -952,116 +953,104 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    private maybeRenderBodyRegions() {
-        const styler = (region: IRegion): React.CSSProperties => {
-            const cardinality = Regions.getRegionCardinality(region);
-            const style = this.grid.getRegionStyle(region);
-            switch (cardinality) {
-                case RegionCardinality.CELLS:
-                    return style;
+    private styleBodyRegion = (region: IRegion): React.CSSProperties => {
+        const cardinality = Regions.getRegionCardinality(region);
+        const style = this.grid.getRegionStyle(region);
+        switch (cardinality) {
+            case RegionCardinality.CELLS:
+                return style;
 
-                case RegionCardinality.FULL_COLUMNS:
-                    style.top = "-1px";
-                    return style;
+            case RegionCardinality.FULL_COLUMNS:
+                style.top = "-1px";
+                return style;
 
-                case RegionCardinality.FULL_ROWS:
-                    style.left = "-1px";
-                    return style;
+            case RegionCardinality.FULL_ROWS:
+                style.left = "-1px";
+                return style;
 
-                case RegionCardinality.FULL_TABLE:
-                    style.left = "-1px";
-                    style.top = "-1px";
-                    return style;
+            case RegionCardinality.FULL_TABLE:
+                style.left = "-1px";
+                style.top = "-1px";
+                return style;
 
-                default:
-                    return { display: "none" };
-            }
-        };
-        return this.maybeRenderRegions(styler);
+            default:
+                return { display: "none" };
+        }
     }
 
-    private maybeRenderMenuRegions() {
-        const styler = (region: IRegion): React.CSSProperties => {
-            const { grid } = this;
-            const { viewportRect } = this.state;
-            if (viewportRect == null) {
-                return {};
-            }
-            const cardinality = Regions.getRegionCardinality(region);
-            const style = grid.getRegionStyle(region);
+    private styleMenuRegion = (region: IRegion): React.CSSProperties => {
+        const { grid } = this;
+        const { viewportRect } = this.state;
+        if (viewportRect == null) {
+            return {};
+        }
+        const cardinality = Regions.getRegionCardinality(region);
+        const style = grid.getRegionStyle(region);
 
-            switch (cardinality) {
-                case RegionCardinality.FULL_TABLE:
-                    style.right = "0px";
-                    style.bottom = "0px";
-                    style.top = "0px";
-                    style.left = "0px";
-                    style.borderBottom = "none";
-                    style.borderRight = "none";
-                    return style;
+        switch (cardinality) {
+            case RegionCardinality.FULL_TABLE:
+                style.right = "0px";
+                style.bottom = "0px";
+                style.top = "0px";
+                style.left = "0px";
+                style.borderBottom = "none";
+                style.borderRight = "none";
+                return style;
 
-                default:
-                    return { display: "none" };
-            }
-        };
-        return this.maybeRenderRegions(styler);
+            default:
+                return { display: "none" };
+        }
     }
 
-    private maybeRenderColumnHeaderRegions() {
-        const styler = (region: IRegion): React.CSSProperties => {
-            const { grid } = this;
-            const { viewportRect } = this.state;
-            if (viewportRect == null) {
-                return {};
-            }
-            const cardinality = Regions.getRegionCardinality(region);
-            const style = grid.getRegionStyle(region);
+    private styleColumnHeaderRegion = (region: IRegion): React.CSSProperties => {
+        const { grid } = this;
+        const { viewportRect } = this.state;
+        if (viewportRect == null) {
+            return {};
+        }
+        const cardinality = Regions.getRegionCardinality(region);
+        const style = grid.getRegionStyle(region);
 
-            switch (cardinality) {
-                case RegionCardinality.FULL_TABLE:
-                    style.left = "-1px";
-                    style.borderLeft = "none";
-                    style.bottom = "-1px";
-                    style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
-                    return style;
-                case RegionCardinality.FULL_COLUMNS:
-                    style.bottom = "-1px";
-                    style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
-                    return style;
+        switch (cardinality) {
+            case RegionCardinality.FULL_TABLE:
+                style.left = "-1px";
+                style.borderLeft = "none";
+                style.bottom = "-1px";
+                style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
+                return style;
+            case RegionCardinality.FULL_COLUMNS:
+                style.bottom = "-1px";
+                style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
+                return style;
 
-                default:
-                    return { display: "none" };
-            }
-        };
-        return this.maybeRenderRegions(styler);
+            default:
+                return { display: "none" };
+        }
     }
 
-    private maybeRenderRowHeaderRegions() {
-        const styler = (region: IRegion): React.CSSProperties => {
-            const { grid } = this;
-            const { viewportRect } = this.state;
-            if (viewportRect == null) {
-                return {};
-            }
-            const cardinality = Regions.getRegionCardinality(region);
-            const style = grid.getRegionStyle(region);
-            switch (cardinality) {
-                case RegionCardinality.FULL_TABLE:
-                    style.top = "-1px";
-                    style.borderTop = "none";
-                    style.right = "-1px";
-                    style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
-                    return style;
-                case RegionCardinality.FULL_ROWS:
-                    style.right = "-1px";
-                    style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
-                    return style;
+    private styleRowHeaderRegion = (region: IRegion): React.CSSProperties => {
+        const { grid } = this;
+        const { viewportRect } = this.state;
+        if (viewportRect == null) {
+            return {};
+        }
+        const cardinality = Regions.getRegionCardinality(region);
+        const style = grid.getRegionStyle(region);
+        switch (cardinality) {
+            case RegionCardinality.FULL_TABLE:
+                style.top = "-1px";
+                style.borderTop = "none";
+                style.right = "-1px";
+                style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
+                return style;
+            case RegionCardinality.FULL_ROWS:
+                style.right = "-1px";
+                style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
+                return style;
 
-                default:
-                    return { display: "none" };
-            }
-        };
-        return this.maybeRenderRegions(styler);
+            default:
+                return { display: "none" };
+        }
     }
 
     private handleColumnWidthChanged = (columnIndex: number, width: number) => {
@@ -1215,7 +1204,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    private handleColumnReorderPreview = (oldIndex: number, newIndex: number, length: number) => {
+    private handleColumnsReordering = (oldIndex: number, newIndex: number, length: number) => {
         const guideIndex = Utils.reorderedIndexToGuideIndex(oldIndex, newIndex, length);
         const leftOffset = this.grid.getCumulativeWidthBefore(guideIndex);
         this.setState({ isReordering: true, verticalGuides: [leftOffset] } as ITableState);
@@ -1226,7 +1215,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         BlueprintUtils.safeInvoke(this.props.onColumnsReordered, oldIndex, newIndex, length);
     }
 
-    private handleRowReordering = (oldIndex: number, newIndex: number, length: number) => {
+    private handleRowsReordering = (oldIndex: number, newIndex: number, length: number) => {
         const guideIndex = Utils.reorderedIndexToGuideIndex(oldIndex, newIndex, length);
         const topOffset = this.grid.getCumulativeHeightBefore(guideIndex);
         this.setState({ isReordering: true, horizontalGuides: [topOffset] } as ITableState);

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -303,7 +303,7 @@ describe("Utils", () => {
         }
     });
 
-    describe.only("shallowCompareKeys", () => {
+    describe("shallowCompareKeys", () => {
         describe("with `keys` defined", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
                 runTest(true, { a: 1 }, { a: 1 }, ["a"]);

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -334,6 +334,7 @@ describe("Utils", () => {
                 runTest(false, undefined, null, []);
                 runTest(false, null, {}, []);
                 runTest(false, {}, [], []);
+                runTest(false, [], [], []);
             });
 
             function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -303,7 +303,7 @@ describe("Utils", () => {
         }
     });
 
-    describe("shallowCompareKeys", () => {
+    describe.only("shallowCompareKeys", () => {
         describe("with `keys` defined", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
                 runTest(true, { a: 1 }, { a: 1 }, ["a"]);
@@ -323,6 +323,7 @@ describe("Utils", () => {
 
             describe("edge cases that return true", () => {
                 runTest(true, undefined, undefined, []);
+                runTest(true, undefined, null, []);
                 runTest(true, undefined, undefined, ["a"]);
                 runTest(true, null, null, []);
                 runTest(true, null, null, ["a"]);
@@ -331,7 +332,7 @@ describe("Utils", () => {
             });
 
             describe("edge cases that return false", () => {
-                runTest(false, undefined, null, []);
+                runTest(false, {}, undefined, []);
                 runTest(false, null, {}, []);
                 runTest(false, {}, [], []);
                 runTest(false, [], [], []);
@@ -350,10 +351,11 @@ describe("Utils", () => {
                 runTest(true, {}, {});
                 runTest(true, null, null);
                 runTest(true, undefined, undefined);
+                runTest(true, null, undefined);
             });
 
             describe("returns false if values are not shallowly equal", () => {
-                runTest(false, undefined, null);
+                runTest(false, undefined, {});
                 runTest(false, null, {});
                 runTest(false, {}, []);
                 runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] });
@@ -390,14 +392,14 @@ describe("Utils", () => {
             describe("should return true if the arrays are shallowly equal", () => {
                 runTest(true, undefined, undefined);
                 runTest(true, null, null);
+                runTest(true, undefined, null);
                 runTest(true, [], []);
                 runTest(true, [3], [3]);
                 runTest(true, [3, "1", true], [3, "1", true]);
             });
 
             describe("should return false if the arrays are not shallowly equal", () => {
-                runTest(false, undefined, null);
-                runTest(false, null, []);
+                runTest(false, undefined, []);
                 runTest(false, null, [3]);
                 runTest(false, [3], []);
                 runTest(false, [3, 1, 2], [3, 1]);
@@ -412,14 +414,14 @@ describe("Utils", () => {
             describe("should return true if the arrays are equal using a custom compare function", () => {
                 runTest(true, undefined, undefined, COMPARE_FN);
                 runTest(true, null, null, COMPARE_FN);
+                runTest(true, undefined, null, COMPARE_FN);
                 runTest(true, [], [], COMPARE_FN);
                 runTest(true, [{}, {}], [{}, {}], COMPARE_FN);
                 runTest(true, [{ x: 1 }, { x: 2 }], [{ x: 1 }, { x: 2 }], COMPARE_FN);
             });
 
             describe("should return false if the arrays are not equal using custom compare function", () => {
-                runTest(false, undefined, null);
-                runTest(false, null, []);
+                runTest(false, null, [], COMPARE_FN);
                 runTest(false, [{ x: 1 }, {}], [{ x: 1 }, { x: 2 }], COMPARE_FN);
             });
         });

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -383,4 +383,49 @@ describe("Utils", () => {
             }
         });
     });
+
+    describe("arraysEqual", () => {
+        describe("no compare function provided", () => {
+            it("should return true if the arrays are shallowly equal", () => {
+                runTest(true, undefined, undefined);
+                runTest(true, null, null);
+                runTest(true, [], []);
+                runTest(true, [3], [3]);
+                runTest(true, [3, "1", true], [3, "1", true]);
+            });
+
+            it("should return false if the arrays are not shallowly equal", () => {
+                runTest(false, undefined, null);
+                runTest(false, null, []);
+                runTest(false, [3], []);
+                runTest(false, [3, 1, 2], [3, 1]);
+                runTest(false, [{}], [{}]);
+                runTest(false, [{ x: 1 }], [{ x: 1 }]);
+            });
+        });
+
+        describe("compare function provided", () => {
+            const COMPARE_FN = (a: any, b: any) => a.x === b.x;
+
+            it("should return true if the arrays are equal using a custom compare function", () => {
+                runTest(true, undefined, undefined, COMPARE_FN);
+                runTest(true, null, null, COMPARE_FN);
+                runTest(true, [], [], COMPARE_FN);
+                runTest(true, [{}, {}], [{}, {}], COMPARE_FN);
+                runTest(true, [{ x: 1 }, { x: 2 }], [{ x: 1 }, { x: 2 }], COMPARE_FN);
+            });
+
+            it("should return false if the arrays are not equal using custom compare function", () => {
+                runTest(false, undefined, null);
+                runTest(false, null, []);
+                runTest(false, [{ x: 1 }, {}], [{ x: 1 }, { x: 2 }], COMPARE_FN);
+            });
+        });
+
+        function runTest(expectedResult: boolean, a: any, b: any, compareFn?: (a: any, b: any) => boolean) {
+            it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
+                expect(Utils.arraysEqual(a, b, compareFn)).to.equal(expectedResult);
+            });
+        }
+    });
 });

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -303,7 +303,7 @@ describe("Utils", () => {
         }
     });
 
-    describe.only("shallowCompareKeys", () => {
+    describe("shallowCompareKeys", () => {
         describe("with `keys` defined", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
                 runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -303,82 +303,84 @@ describe("Utils", () => {
         }
     });
 
-    describe("shallowCompareKeys", () => {
-        describe("returns true if only the specified values are shallowly equal", () => {
-            runTest(true, { a: 1 }, { a: 1 }, ["a"]);
-            runTest(true, { a: 1, b: true }, { a: 1, b: false }, ["a"]);
-            runTest(true, { a: 1, b: true }, { a: 1, b: false }, []);
-            runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
-            runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["a", "c"]);
-            runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b"]);
-        });
-
-        describe("returns false if any specified values are not shallowly equal", () => {
-            runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, ["a"]);
-            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
-            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
-            runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b", "c"]);
-        });
-
-        describe("edge cases that return true", () => {
-            runTest(true, undefined, undefined, []);
-            runTest(true, undefined, undefined, ["a"]);
-            runTest(true, null, null, []);
-            runTest(true, null, null, ["a"]);
-            runTest(true, {}, {}, []);
-            runTest(true, {}, {}, ["a"]);
-        });
-
-        describe("edge cases that return false", () => {
-            runTest(false, undefined, null, []);
-            runTest(false, null, {}, []);
-            runTest(false, {}, [], []);
-        });
-
-        function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
-            it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
-                expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
+    describe.only("shallowCompareKeys", () => {
+        describe("with `keys` defined", () => {
+            describe("returns true if only the specified values are shallowly equal", () => {
+                runTest(true, { a: 1 }, { a: 1 }, ["a"]);
+                runTest(true, { a: 1, b: true }, { a: 1, b: false }, ["a"]);
+                runTest(true, { a: 1, b: true }, { a: 1, b: false }, []);
+                runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
+                runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["a", "c"]);
+                runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b"]);
             });
-        }
-    });
 
-    describe("shallowCompare", () => {
-        describe("returns true if values are shallowly equal", () => {
-            runTest(true, { a: 1, b: "2", c: true}, { a: 1, b: "2", c: true});
-            runTest(true, {}, {});
-            runTest(true, null, null);
-            runTest(true, undefined, undefined);
-        });
-
-        describe("returns false if values are not shallowly equal", () => {
-            runTest(false, undefined, null);
-            runTest(false, null, {});
-            runTest(false, {}, []);
-            runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] });
-            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
-            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
-            runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }});
-        });
-
-        describe("returns false if keys are different", () => {
-            runTest(false, {}, { a: 1 });
-            runTest(false, { a: 1 }, {});
-            runTest(false, { a: 1, b: "2" }, { b: "2" });
-            runTest(false, { b: "2" }, { a: 1, b: "2" });
-            runTest(false, { a: 1, b: "2", c: true}, { b: "2", c: true, d: 3 });
-        });
-
-        describe("returns true if same deeply-comparable instance is reused in both objects", () => {
-            const deeplyComparableThing1 = { a: 1 };
-            const deeplyComparableThing2 = [1, "2", true];
-            runTest(true, { a: 1, b: deeplyComparableThing1 }, { a: 1, b: deeplyComparableThing1 });
-            runTest(true, { a: 1, b: deeplyComparableThing2 }, { a: 1, b: deeplyComparableThing2 });
-        });
-
-        function runTest(expectedResult: boolean, a: any, b: any) {
-            it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
-                expect(Utils.shallowCompare(a, b)).to.equal(expectedResult);
+            describe("returns false if any specified values are not shallowly equal", () => {
+                runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, ["a"]);
+                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
+                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
+                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b", "c"]);
             });
-        }
+
+            describe("edge cases that return true", () => {
+                runTest(true, undefined, undefined, []);
+                runTest(true, undefined, undefined, ["a"]);
+                runTest(true, null, null, []);
+                runTest(true, null, null, ["a"]);
+                runTest(true, {}, {}, []);
+                runTest(true, {}, {}, ["a"]);
+            });
+
+            describe("edge cases that return false", () => {
+                runTest(false, undefined, null, []);
+                runTest(false, null, {}, []);
+                runTest(false, {}, [], []);
+            });
+
+            function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
+                it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
+                    expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
+                });
+            }
+        });
+
+        describe("with `keys` not defined", () => {
+            describe("returns true if values are shallowly equal", () => {
+                runTest(true, { a: 1, b: "2", c: true}, { a: 1, b: "2", c: true});
+                runTest(true, {}, {});
+                runTest(true, null, null);
+                runTest(true, undefined, undefined);
+            });
+
+            describe("returns false if values are not shallowly equal", () => {
+                runTest(false, undefined, null);
+                runTest(false, null, {});
+                runTest(false, {}, []);
+                runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] });
+                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
+                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
+                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }});
+            });
+
+            describe("returns false if keys are different", () => {
+                runTest(false, {}, { a: 1 });
+                runTest(false, { a: 1 }, {});
+                runTest(false, { a: 1, b: "2" }, { b: "2" });
+                runTest(false, { b: "2" }, { a: 1, b: "2" });
+                runTest(false, { a: 1, b: "2", c: true}, { b: "2", c: true, d: 3 });
+            });
+
+            describe("returns true if same deeply-comparable instance is reused in both objects", () => {
+                const deeplyComparableThing1 = { a: 1 };
+                const deeplyComparableThing2 = [1, "2", true];
+                runTest(true, { a: 1, b: deeplyComparableThing1 }, { a: 1, b: deeplyComparableThing1 });
+                runTest(true, { a: 1, b: deeplyComparableThing2 }, { a: 1, b: deeplyComparableThing2 });
+            });
+
+            function runTest(expectedResult: boolean, a: any, b: any) {
+                it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
+                    expect(Utils.shallowCompareKeys(a, b)).to.equal(expectedResult);
+                });
+            }
+        });
     });
 });

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -225,7 +225,6 @@ describe("Utils", () => {
     });
 
     describe("reorderArray", () => {
-
         const ARRAY_STRING = "ABCDEFG";
         const ARRAY = ARRAY_STRING.split("");
         const ARRAY_LENGTH = ARRAY.length;
@@ -301,6 +300,85 @@ describe("Utils", () => {
         function assertArraysEqual(result: string[], expected: string) {
             // use .eql to deeply compare arrays
             expect(result).to.eql(expected.split(""));
+        }
+    });
+
+    describe("shallowCompareKeys", () => {
+        describe("returns true if only the specified values are shallowly equal", () => {
+            runTest(true, { a: 1 }, { a: 1 }, ["a"]);
+            runTest(true, { a: 1, b: true }, { a: 1, b: false }, ["a"]);
+            runTest(true, { a: 1, b: true }, { a: 1, b: false }, []);
+            runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
+            runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["a", "c"]);
+            runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b"]);
+        });
+
+        describe("returns false if any specified values are not shallowly equal", () => {
+            runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, ["a"]);
+            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
+            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
+            runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b", "c"]);
+        });
+
+        describe("edge cases that return true", () => {
+            runTest(true, undefined, undefined, []);
+            runTest(true, undefined, undefined, ["a"]);
+            runTest(true, null, null, []);
+            runTest(true, null, null, ["a"]);
+            runTest(true, {}, {}, []);
+            runTest(true, {}, {}, ["a"]);
+        });
+
+        describe("edge cases that return false", () => {
+            runTest(false, undefined, null, []);
+            runTest(false, null, {}, []);
+            runTest(false, {}, [], []);
+        });
+
+        function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
+            it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
+                expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
+            });
+        }
+    });
+
+    describe("shallowCompare", () => {
+        describe("returns true if values are shallowly equal", () => {
+            runTest(true, { a: 1, b: "2", c: true}, { a: 1, b: "2", c: true});
+            runTest(true, {}, {});
+            runTest(true, null, null);
+            runTest(true, undefined, undefined);
+        });
+
+        describe("returns false if values are not shallowly equal", () => {
+            runTest(false, undefined, null);
+            runTest(false, null, {});
+            runTest(false, {}, []);
+            runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] });
+            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
+            runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
+            runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }});
+        });
+
+        describe("returns false if keys are different", () => {
+            runTest(false, {}, { a: 1 });
+            runTest(false, { a: 1 }, {});
+            runTest(false, { a: 1, b: "2" }, { b: "2" });
+            runTest(false, { b: "2" }, { a: 1, b: "2" });
+            runTest(false, { a: 1, b: "2", c: true}, { b: "2", c: true, d: 3 });
+        });
+
+        describe("returns true if same deeply-comparable instance is reused in both objects", () => {
+            const deeplyComparableThing1 = { a: 1 };
+            const deeplyComparableThing2 = [1, "2", true];
+            runTest(true, { a: 1, b: deeplyComparableThing1 }, { a: 1, b: deeplyComparableThing1 });
+            runTest(true, { a: 1, b: deeplyComparableThing2 }, { a: 1, b: deeplyComparableThing2 });
+        });
+
+        function runTest(expectedResult: boolean, a: any, b: any) {
+            it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
+                expect(Utils.shallowCompare(a, b)).to.equal(expectedResult);
+            });
         }
     });
 });

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -306,9 +306,6 @@ describe("Utils", () => {
     describe.only("shallowCompareKeys", () => {
         describe("with `keys` defined", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
-                runTest(true, { a: 1 }, { a: 1 }, ["a"]);
-                runTest(true, { a: 1, b: true }, { a: 1, b: false }, ["a"]);
-                runTest(true, { a: 1, b: true }, { a: 1, b: false }, []);
                 runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
                 runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["a", "c"]);
                 runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b"]);
@@ -316,24 +313,18 @@ describe("Utils", () => {
 
             describe("returns false if any specified values are not shallowly equal", () => {
                 runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, ["a"]);
-                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
-                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}}, ["a", "b", "c"]);
                 runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b", "c"]);
             });
 
             describe("edge cases that return true", () => {
-                runTest(true, undefined, undefined, []);
                 runTest(true, undefined, null, []);
                 runTest(true, undefined, undefined, ["a"]);
-                runTest(true, null, null, []);
                 runTest(true, null, null, ["a"]);
-                runTest(true, {}, {}, []);
                 runTest(true, {}, {}, ["a"]);
             });
 
             describe("edge cases that return false", () => {
                 runTest(false, {}, undefined, []);
-                runTest(false, null, {}, []);
                 runTest(false, {}, [], []);
                 runTest(false, [], [], []);
             });
@@ -348,8 +339,6 @@ describe("Utils", () => {
         describe("with `keys` not defined", () => {
             describe("returns true if values are shallowly equal", () => {
                 runTest(true, { a: 1, b: "2", c: true}, { a: 1, b: "2", c: true});
-                runTest(true, {}, {});
-                runTest(true, null, null);
                 runTest(true, undefined, undefined);
                 runTest(true, null, undefined);
             });
@@ -358,17 +347,12 @@ describe("Utils", () => {
                 runTest(false, undefined, {});
                 runTest(false, null, {});
                 runTest(false, {}, []);
-                runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] });
-                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
-                runTest(false, { a: 1, b: "2", c: {}}, { a: 1, b: "2", c: {}});
                 runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }});
             });
 
             describe("returns false if keys are different", () => {
                 runTest(false, {}, { a: 1 });
-                runTest(false, { a: 1 }, {});
                 runTest(false, { a: 1, b: "2" }, { b: "2" });
-                runTest(false, { b: "2" }, { a: 1, b: "2" });
                 runTest(false, { a: 1, b: "2", c: true}, { b: "2", c: true, d: 3 });
             });
 
@@ -391,19 +375,13 @@ describe("Utils", () => {
         describe("no compare function provided", () => {
             describe("should return true if the arrays are shallowly equal", () => {
                 runTest(true, undefined, undefined);
-                runTest(true, null, null);
                 runTest(true, undefined, null);
-                runTest(true, [], []);
-                runTest(true, [3], [3]);
                 runTest(true, [3, "1", true], [3, "1", true]);
             });
 
             describe("should return false if the arrays are not shallowly equal", () => {
-                runTest(false, undefined, []);
                 runTest(false, null, [3]);
-                runTest(false, [3], []);
                 runTest(false, [3, 1, 2], [3, 1]);
-                runTest(false, [{}], [{}]);
                 runTest(false, [{ x: 1 }], [{ x: 1 }]);
             });
         });
@@ -413,10 +391,7 @@ describe("Utils", () => {
 
             describe("should return true if the arrays are equal using a custom compare function", () => {
                 runTest(true, undefined, undefined, COMPARE_FN);
-                runTest(true, null, null, COMPARE_FN);
                 runTest(true, undefined, null, COMPARE_FN);
-                runTest(true, [], [], COMPARE_FN);
-                runTest(true, [{}, {}], [{}, {}], COMPARE_FN);
                 runTest(true, [{ x: 1 }, { x: 2 }], [{ x: 1 }, { x: 2 }], COMPARE_FN);
             });
 

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -386,7 +386,7 @@ describe("Utils", () => {
 
     describe("arraysEqual", () => {
         describe("no compare function provided", () => {
-            it("should return true if the arrays are shallowly equal", () => {
+            describe("should return true if the arrays are shallowly equal", () => {
                 runTest(true, undefined, undefined);
                 runTest(true, null, null);
                 runTest(true, [], []);
@@ -394,9 +394,10 @@ describe("Utils", () => {
                 runTest(true, [3, "1", true], [3, "1", true]);
             });
 
-            it("should return false if the arrays are not shallowly equal", () => {
+            describe("should return false if the arrays are not shallowly equal", () => {
                 runTest(false, undefined, null);
                 runTest(false, null, []);
+                runTest(false, null, [3]);
                 runTest(false, [3], []);
                 runTest(false, [3, 1, 2], [3, 1]);
                 runTest(false, [{}], [{}]);
@@ -407,7 +408,7 @@ describe("Utils", () => {
         describe("compare function provided", () => {
             const COMPARE_FN = (a: any, b: any) => a.x === b.x;
 
-            it("should return true if the arrays are equal using a custom compare function", () => {
+            describe("should return true if the arrays are equal using a custom compare function", () => {
                 runTest(true, undefined, undefined, COMPARE_FN);
                 runTest(true, null, null, COMPARE_FN);
                 runTest(true, [], [], COMPARE_FN);
@@ -415,7 +416,7 @@ describe("Utils", () => {
                 runTest(true, [{ x: 1 }, { x: 2 }], [{ x: 1 }, { x: 2 }], COMPARE_FN);
             });
 
-            it("should return false if the arrays are not equal using custom compare function", () => {
+            describe("should return false if the arrays are not equal using custom compare function", () => {
                 runTest(false, undefined, null);
                 runTest(false, null, []);
                 runTest(false, [{ x: 1 }, {}], [{ x: 1 }, { x: 2 }], COMPARE_FN);


### PR DESCRIPTION
#### Checklist
Redux of #988 that fixes some of the nefarious bugs that popped up.

- [x] Include tests

#### Changes proposed in this pull request:

Goal: Improve table perf by eliminating unnecessary re-renders, particularly when clicking+dragging.

- Add `@PureRender` decorator throughout `packages/table`.
- Add custom `shouldComponentUpdate` to `GuideLayer` to avoid unnecessary re-renders.
- Add custom `shouldComponentUpdate` to `RegionLayer` to avoid unnecessary re-renders.
    - 🔥 Also, change `RegionLayer` props to accept pre-computed `regionStyles` instead of `getRegionStyle` function. Before, we were creating this styling function inline in `table.tsx` on each render, causing shallow comparison between `this.props.getRegionStyle === nextProps.regionStyle` to always return `false` in `RegionLayer.shouldComponentUpdate`. Ultimately, this led to tons of unnecessary re-renders of the region layer (e.g. as you were clicking + dragging). LMK if you want to know more.
- Extend `Utils.shallowCompareKeys` (+ tests) to compare entire objects, not just subset of keys.
- Add `Utils.arraysEqual` (+ tests) to compare arrays using an optional `compare` callback.

#### Reviewers should focus on:

- Does perf improve noticeably enough?
- Any weird bugs lingering with selected regions or guides? `shouldComponentUpdate` is tricky to get right.


