### PR TITLE
[DateInput] Remove mentions of calendar button

### DIFF
--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -28,4 +28,4 @@ export const DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID =
 export const DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION =
     `${ns} DEPRECATION: <DateInput> popoverProps is deprecated. Use popoverProps.position.`;
 export const DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS =
-    `${ns} DEPRECATION: <DateInput> openOnFocus is deprecated.`;
+    `${ns} DEPRECATION: <DateInput> openOnFocus is deprecated. This feature will be removed in the next major version.`;

--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -27,3 +27,5 @@ export const DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID =
 
 export const DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION =
     `${ns} DEPRECATION: <DateInput> popoverProps is deprecated. Use popoverProps.position.`;
+export const DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS =
+    `${ns} DEPRECATION: <DateInput> openOnFocus is deprecated.`;

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -26,7 +26,7 @@ import {
     isMomentNull,
     isMomentValidAndInRange,
 } from "./common/dateUtils";
-import { DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION } from "./common/errors";
+import { DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS, DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION } from "./common/errors";
 import { DatePicker } from "./datePicker";
 import {
     getDefaultMaxDate,
@@ -87,8 +87,8 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     onError?: (errorDate: Date) => void;
 
     /**
-     * If `true`, the popover will open when the user clicks on the input. If `false`, the popover will only
-     * open when the calendar icon is clicked.
+     * If `true`, the popover will open when the user clicks on the input.
+     * @deprecated since 1.13.0.
      * @default true
      */
     openOnFocus?: boolean;
@@ -228,6 +228,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     public validateProps(props: IDateInputProps) {
         if (props.popoverPosition !== DateInput.defaultProps.popoverPosition) {
             console.warn(DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION);
+        }
+        if (props.openOnFocus !== DateInput.defaultProps.openOnFocus) {
+            console.warn(DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS);
         }
     }
 

--- a/packages/datetime/src/dateinput.md
+++ b/packages/datetime/src/dateinput.md
@@ -1,7 +1,6 @@
 @# Date input
 
-The `DateInput` component is an [input group](#core/components/forms/input-group) with a calendar button
-that shows a [`DatePicker`](#datetime/datepicker) in a [`Popover`](#core/components/popover).
+The `DateInput` component is an [input group](#core/components/forms/input-group) that shows a [`DatePicker`](#datetime/datepicker) in a [`Popover`](#core/components/popover) on focus.
 
 Use the `onChange` function to listen for changes to the selected date. Use `onError` to listen for
 invalid entered dates.


### PR DESCRIPTION
#### Fixes #966

#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

- Deprecate `openOnFocus` (on the road to #867)
- Remove mention of calendar button in `DateInput` docs (we deleted it in `datetime` `v1.11.0`)
