### PR TITLE
[site-docs] fix theme switcher inheritance

### DIFF
--- a/packages/core/examples/alertExample.tsx
+++ b/packages/core/examples/alertExample.tsx
@@ -33,7 +33,7 @@ export class AlertExample extends BaseExample<{}> {
             <div>
                 <Button onClick={this.handleOpenError} text="Open file error alert" />
                 <Alert
-                    className={this.props.getTheme()}
+                    className={this.props.themeName}
                     isOpen={this.state.isOpenError}
                     confirmButtonText="Okay"
                     onConfirm={this.handleCloseError}
@@ -45,7 +45,7 @@ export class AlertExample extends BaseExample<{}> {
                 </Alert>
                 <Button onClick={this.handleOpen} text="Open file deletion alert" />
                 <Alert
-                    className={this.props.getTheme()}
+                    className={this.props.themeName}
                     intent={Intent.PRIMARY}
                     isOpen={this.state.isOpen}
                     confirmButtonText="Move to Trash"
@@ -68,7 +68,7 @@ export class AlertExample extends BaseExample<{}> {
     private handleMoveClose = () => {
         this.setState({ isOpen: false });
         this.toaster.show({
-            className: this.props.getTheme(),
+            className: this.props.themeName,
             message: this.message,
         });
     }

--- a/packages/core/examples/dialogExample.tsx
+++ b/packages/core/examples/dialogExample.tsx
@@ -16,7 +16,7 @@ export class DialogExample extends OverlayExample {
             <div className="docs-dialog-example">
                 <Button onClick={this.handleOpen}>Show dialog</Button>
                 <Dialog
-                    className={this.props.getTheme()}
+                    className={this.props.themeName}
                     iconName="inbox"
                     onClose={this.handleClose}
                     title="Dialog header"

--- a/packages/core/examples/overlayExample.tsx
+++ b/packages/core/examples/overlayExample.tsx
@@ -53,7 +53,7 @@ export class OverlayExample extends BaseExample<IOverlayExampleState> {
             Classes.CARD,
             Classes.ELEVATION_4,
             OVERLAY_EXAMPLE_CLASS,
-            this.props.getTheme(),
+            this.props.themeName,
         );
 
         return (

--- a/packages/core/examples/toastExample.tsx
+++ b/packages/core/examples/toastExample.tsx
@@ -131,7 +131,7 @@ export class ToastExample extends BaseExample<IToasterProps> {
 
     private renderProgress(amount: number): IToastProps {
         return {
-            className: this.props.getTheme(),
+            className: this.props.themeName,
             iconName: "cloud-upload",
             message: (
                 <ProgressBar
@@ -145,7 +145,7 @@ export class ToastExample extends BaseExample<IToasterProps> {
     }
 
     private addToast(toast: IToastProps) {
-        toast.className = this.props.getTheme();
+        toast.className = this.props.themeName;
         toast.timeout = 5000;
         this.toaster.show(toast);
     }

--- a/packages/core/examples/tooltipExample.tsx
+++ b/packages/core/examples/tooltipExample.tsx
@@ -16,11 +16,14 @@ export class TooltipExample extends BaseExample<{ isOpen: boolean }> {
      };
 
     protected renderExample() {
-        const lotsOfText = `
-            In facilisis scelerisque dui vel dignissim.
-            Sed nunc orci, ultricies congue vehicula quis, facilisis a orci.
-        `;
-
+        // using JSX instead of strings for all content so the Tooltips will re-render
+        // with every update for dark theme inheritance.
+        const lotsOfText = (
+            <span>
+                In facilisis scelerisque dui vel dignissim.
+                Sed nunc orci, ultricies congue vehicula quis, facilisis a orci.
+            </span>
+        );
         return (
             <div>
                 <p>
@@ -39,13 +42,21 @@ export class TooltipExample extends BaseExample<{ isOpen: boolean }> {
                 </p>
                 <p>
                     This line's tooltip&nbsp;
-                    <Tooltip className="pt-tooltip-indicator" content="disabled" isDisabled={true}>
+                    <Tooltip
+                        className="pt-tooltip-indicator"
+                        content={<span>disabled</span>}
+                        isDisabled={true}
+                    >
                         is disabled.
                     </Tooltip>
                 </p>
                 <p>
                     This line's tooltip&nbsp;
-                    <Tooltip className="pt-tooltip-indicator" content="BRRAAAIINS" isOpen={this.state.isOpen}>
+                    <Tooltip
+                        className="pt-tooltip-indicator"
+                        content={<span>BRRAAAIINS</span>}
+                        isOpen={this.state.isOpen}
+                    >
                         is controlled by external state.
                     </Tooltip>
                     <Switch
@@ -100,7 +111,7 @@ export class TooltipExample extends BaseExample<{ isOpen: boolean }> {
                     position={Position.RIGHT}
                 >
                     <Tooltip
-                        content="This button also has a popover!"
+                        content={<span>This button also has a popover!</span>}
                         inline={true}
                         position={Position.RIGHT}
                     >

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -381,10 +381,13 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
         if (props.isModal && props.interactionKind !== PopoverInteractionKind.CLICK) {
             throw new Error(Errors.POPOVER_MODAL_INTERACTION);
         }
-        try {
-            React.Children.only(props.children);
-        } catch (e) {
-            throw new Error(Errors.POPOVER_ONE_CHILD);
+        if (typeof props.children === "object") {
+            try {
+                React.Children.only(props.children);
+            } catch (e) {
+                console.error(props);
+                throw new Error(Errors.POPOVER_ONE_CHILD);
+            }
         }
     }
 

--- a/packages/site-docs/src/components/blueprintDocs.tsx
+++ b/packages/site-docs/src/components/blueprintDocs.tsx
@@ -59,8 +59,8 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
 
     private handleToggleDark = (useDark: boolean) => {
         const themeName = useDark ? DARK_THEME : LIGHT_THEME;
-        this.setState({ themeName });
         setTheme(themeName);
         setHotkeysDialogProps({ className: this.state.themeName });
+        this.setState({ themeName });
     }
 }

--- a/packages/site-docs/src/tags/reactExamples.ts
+++ b/packages/site-docs/src/tags/reactExamples.ts
@@ -19,7 +19,7 @@ function addPackageExamples(
         const example = packageExamples[exampleName];
         const fileName = exampleName.charAt(0).toLowerCase() + exampleName.slice(1) + ".tsx";
         reactExamples[exampleName] = {
-            render: (props) => React.createElement(example, { ...props, getTheme }),
+            render: (props) => React.createElement(example, { ...props, themeName: getTheme() }),
             sourceUrl: [SRC_HREF_BASE, packageName, "examples", fileName].join("/"),
         };
     }


### PR DESCRIPTION
#### Fixes #163 

#### Changes proposed in this pull request:

- the actual fix for the issue was ensuring that we call `this.setState()` _after_ updating local storage with new theme state so that the examples are seeing the latest state when they re-render.
- refactor BaseExample `getTheme` callback prop to string `themeName`, for simplicity.

#### Focus on

- Popover and Tooltip examples should respond to theme switching every time.

Here's a cool thing:
![toasts-dark-inheritance](https://cloud.githubusercontent.com/assets/464822/25151410/56164016-243a-11e7-8cfb-a9788e2e6510.gif)
