### PR TITLE
Add cell class to row/column headers so auto-resize works properly

### DIFF
--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -209,9 +209,9 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHea
         };
 
         const cell = cellRenderer(columnIndex);
-        const className = classNames(cell.props.className, extremaClasses, {
+        const className = classNames(extremaClasses, {
             [Classes.TABLE_DRAGGABLE]: (onSelection != null),
-        }, Classes.columnCellIndexClass(columnIndex));
+        }, Classes.columnCellIndexClass(columnIndex), cell.props.className);
         const cellLoading = cell.props.loading != null ? cell.props.loading : loading;
         const isColumnSelected = Regions.hasFullColumn(selectedRegions, columnIndex);
         const isColumnCurrentlyReorderable = this.isColumnCurrentlyReorderable(isColumnSelected);

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -211,7 +211,7 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHea
         const cell = cellRenderer(columnIndex);
         const className = classNames(cell.props.className, extremaClasses, {
             [Classes.TABLE_DRAGGABLE]: (onSelection != null),
-        });
+        }, Classes.columnCellIndexClass(columnIndex));
         const cellLoading = cell.props.loading != null ? cell.props.loading : loading;
         const isColumnSelected = Regions.hasFullColumn(selectedRegions, columnIndex);
         const isColumnCurrentlyReorderable = this.isColumnCurrentlyReorderable(isColumnSelected);

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -201,9 +201,9 @@ export class RowHeader extends React.Component<IRowHeaderProps, IRowHeaderState>
         };
 
         const cell = renderRowHeader(rowIndex);
-        const className = classNames(cell.props.className, extremaClasses, {
+        const className = classNames(extremaClasses, {
             [Classes.TABLE_DRAGGABLE]: onSelection != null,
-        }, Classes.rowCellIndexClass(rowIndex));
+        }, Classes.rowCellIndexClass(rowIndex), cell.props.className);
         const cellLoading = cell.props.loading != null ? cell.props.loading : loading;
         const isRowSelected = Regions.hasFullRow(selectedRegions, rowIndex);
         const isRowCurrentlyReorderable = this.isRowCurrentlyReorderable(isRowSelected);

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -203,7 +203,7 @@ export class RowHeader extends React.Component<IRowHeaderProps, IRowHeaderState>
         const cell = renderRowHeader(rowIndex);
         const className = classNames(cell.props.className, extremaClasses, {
             [Classes.TABLE_DRAGGABLE]: onSelection != null,
-        });
+        }, Classes.rowCellIndexClass(rowIndex));
         const cellLoading = cell.props.loading != null ? cell.props.loading : loading;
         const isRowSelected = Regions.hasFullRow(selectedRegions, rowIndex);
         const isRowCurrentlyReorderable = this.isRowCurrentlyReorderable(isRowSelected);

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -70,11 +70,7 @@ export class Locator implements ILocator {
     }
 
     public getWidestVisibleCellInColumn(columnIndex: number): number {
-        const cellClasses = [
-            `.${Classes.columnCellIndexClass(columnIndex)}`,
-            `.${Classes.TABLE_COLUMN_NAME}`,
-        ];
-        const cells = this.tableElement.querySelectorAll(cellClasses.join(", "));
+        const cells = this.tableElement.querySelectorAll(`.${Classes.columnCellIndexClass(columnIndex)}`);
         let max = 0;
         for (let i = 0; i < cells.length; i++) {
             const contentWidth = Utils.measureElementTextContent(cells.item(i)).width;

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -70,7 +70,7 @@ export class Locator implements ILocator {
     }
 
     public getWidestVisibleCellInColumn(columnIndex: number): number {
-        const cells = this.tableElement.querySelectorAll(`.${Classes.columnCellIndexClass(columnIndex)}`);
+        const cells = this.tableElement.getElementsByClassName(Classes.columnCellIndexClass(columnIndex));
         let max = 0;
         for (let i = 0; i < cells.length; i++) {
             const contentWidth = Utils.measureElementTextContent(cells.item(i)).width;

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -83,7 +83,7 @@ export class Locator implements ILocator {
     }
 
     public getTallestVisibleCellInColumn(columnIndex: number): number {
-        const cells = this.tableElement.querySelectorAll(`.${Classes.columnCellIndexClass(columnIndex)}`);
+        const cells = this.tableElement.getElementsByClassName(Classes.columnCellIndexClass(columnIndex));
         let max = 0;
         for (let i = 0; i < cells.length; i++) {
             const cellValue = cells.item(i).querySelector(`.${Classes.TABLE_TRUNCATED_VALUE}`);

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -7,6 +7,7 @@
  */
 
 import { expect } from "chai";
+import * as classNames from "classnames";
 import * as React from "react";
 
 import { Cell, Column, ColumnLoadingOption, Table } from "../src";
@@ -75,13 +76,16 @@ describe("Column", () => {
         expectCellLoading(columnHeaders[1], CellType.COLUMN_HEADER);
         expectCellLoading(columnHeaders[2], CellType.COLUMN_HEADER, false);
 
-        const col0cells = table.element.queryAll(`.${Classes.columnCellIndexClass(0)}`);
+        const col0CellsClass = classNames(Classes.columnCellIndexClass(0), Classes.TABLE_CELL);
+        const col0cells = table.element.queryAll(col0CellsClass);
         col0cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
 
-        const col1cells = table.element.queryAll(`.${Classes.columnCellIndexClass(1)}`);
+        const col1CellsClass = classNames(Classes.columnCellIndexClass(1), Classes.TABLE_CELL);
+        const col1cells = table.element.queryAll(col1CellsClass);
         col1cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
 
-        const col2cells = table.element.queryAll(`.${Classes.columnCellIndexClass(2)}`);
+        const col2CellsClass = classNames(Classes.columnCellIndexClass(2), Classes.TABLE_CELL);
+        const col2cells = table.element.queryAll(col2CellsClass);
         col2cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL, false));
     });
 

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -76,17 +76,20 @@ describe("Column", () => {
         expectCellLoading(columnHeaders[1], CellType.COLUMN_HEADER);
         expectCellLoading(columnHeaders[2], CellType.COLUMN_HEADER, false);
 
-        const col0CellsClass = classNames(Classes.columnCellIndexClass(0), Classes.TABLE_CELL);
-        const col0cells = table.element.queryAll(col0CellsClass);
+        const col0CellsSelector = `.${Classes.columnCellIndexClass(0)}.${Classes.TABLE_CELL}`;
+        const col0cells = table.element.queryAll(col0CellsSelector);
         col0cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
+        expect(col0cells.length).to.equal(4);
 
-        const col1CellsClass = classNames(Classes.columnCellIndexClass(1), Classes.TABLE_CELL);
-        const col1cells = table.element.queryAll(col1CellsClass);
+        const col1CellsSelector = `.${Classes.columnCellIndexClass(1)}.${Classes.TABLE_CELL}`;
+        const col1cells = table.element.queryAll(col1CellsSelector);
         col1cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
+        expect(col1cells.length).to.equal(4);
 
-        const col2CellsClass = classNames(Classes.columnCellIndexClass(2), Classes.TABLE_CELL);
-        const col2cells = table.element.queryAll(col2CellsClass);
+        const col2CellsSelector = `.${Classes.columnCellIndexClass(2)}.${Classes.TABLE_CELL}`;
+        const col2cells = table.element.queryAll(col2CellsSelector);
         col2cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL, false));
+        expect(col2cells.length).to.equal(4);
     });
 
     it("passes custom class name to renderer", () => {


### PR DESCRIPTION
#### Fixes #952 

#### Changes proposed in this pull request:

Added the relevant classes to the column and row headers, so they'll be included if you try to select all the cells in a given column/row. 
Modified the resize logic to only grab cells with that one class, instead of also grabbing all the headers in the entire table. 
