### PR TITLE
[DateInput] add inputProps just like DRI

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -70,9 +70,9 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     format?: string;
 
     /**
-     * Props to pass to the input group.
+     * Props to pass to the [input group](#core/components/forms/input-group.javascript-api).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
-     * Note that `ref` will also be ignored; use `inputRef` instead.
+     * `type` is fixed to "text" and `ref` is not supported; use `inputRef` instead.
      */
     inputProps?: HTMLInputProps & IInputGroupProps;
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -11,6 +11,8 @@ import * as React from "react";
 
 import {
     AbstractComponent,
+    HTMLInputProps,
+    IInputGroupProps,
     InputGroup,
     IPopoverProps,
     IProps,
@@ -66,6 +68,13 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
      * @default "YYYY-MM-DD"
      */
     format?: string;
+
+    /**
+     * Props to pass to the input group.
+     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
+     * Note that `ref` will also be ignored; use `inputRef` instead.
+     */
+    inputProps?: HTMLInputProps & IInputGroupProps;
 
     /**
      * The error message to display when the date selected is invalid.
@@ -183,11 +192,13 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 timePickerProps={{ precision: this.props.timePrecision }}
             />;
         // assign default empty object here to prevent mutation
-        const { popoverProps = {} } = this.props;
+        const { inputProps = {}, popoverProps = {} } = this.props;
+        // exclude ref (comes from HTMLInputProps typings, not InputGroup)
+        const { ref, ...htmlInputProps } = inputProps;
 
         const inputClasses = classNames({
             "pt-intent-danger": !(this.isMomentValidAndInRange(date) || isMomentNull(date) || dateString === ""),
-        });
+        }, inputProps.className);
 
         return (
             <Popover
@@ -202,6 +213,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 popoverClassName={classNames("pt-dateinput-popover", popoverProps.popoverClassName)}
             >
                 <InputGroup
+                    placeholder={this.props.format}
+                    rightElement={this.props.rightElement}
+                    {...htmlInputProps}
                     className={inputClasses}
                     disabled={this.props.disabled}
                     inputRef={this.setInputRef}
@@ -210,8 +224,6 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                     onChange={this.handleInputChange}
                     onClick={this.handleInputClick}
                     onFocus={this.handleInputFocus}
-                    placeholder={this.props.format}
-                    rightElement={this.props.rightElement}
                     value={dateString}
                 />
             </Popover>
@@ -275,7 +287,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         Utils.safeInvoke(this.props.onChange, date === null ? null : fromMomentToDate(momentDate));
     }
 
-    private handleInputFocus = () => {
+    private handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
         const valueString = isMomentNull(this.state.value) ? "" : this.state.value.format(this.props.format);
 
         if (this.props.openOnFocus) {
@@ -283,12 +295,14 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         } else {
             this.setState({ isInputFocused: true, valueString });
         }
+        this.safeInvokeInputProp("onFocus", e);
     }
 
     private handleInputClick = (e: React.SyntheticEvent<HTMLInputElement>) => {
         if (this.props.openOnFocus) {
             e.stopPropagation();
         }
+        this.safeInvokeInputProp("onClick", e);
     }
 
     private handleInputChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
@@ -308,9 +322,10 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             }
             this.setState({ valueString });
         }
+        this.safeInvokeInputProp("onChange", e);
     }
 
-    private handleInputBlur = () => {
+    private handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         const valueString = this.state.valueString;
         const value = moment(valueString, this.props.format);
         if (valueString.length > 0
@@ -337,9 +352,18 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 this.setState({ isInputFocused: false });
             }
         }
+        this.safeInvokeInputProp("onBlur", e);
     }
 
     private setInputRef = (el: HTMLElement) => {
         this.inputRef = el;
+        const { inputProps = {} } = this.props;
+        Utils.safeInvoke(inputProps.inputRef, el);
+    }
+
+    /** safe wrapper around invoking input props event handler (prop defaults to undefined) */
+    private safeInvokeInputProp(name: keyof HTMLInputProps, e: React.SyntheticEvent<HTMLElement>) {
+        const { inputProps = {} } = this.props;
+        Utils.safeInvoke(inputProps[name], e);
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -78,8 +78,9 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     disabled?: boolean;
 
     /**
-     * Props to pass to the end-date input.
+     * Props to pass to the end-date [input group](#core/components/forms/input-group.javascript-api).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
+     * `ref` is not supported; use `inputRef` instead.
      */
     endInputProps?: HTMLInputProps & IInputGroupProps;
 
@@ -148,8 +149,9 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
-     * Props to pass to the start-date input.
+     * Props to pass to the start-date [input group](#core/components/forms/input-group.javascript-api).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
+     * `ref` is not supported; use `inputRef` instead.
      */
     startInputProps?: HTMLInputProps & IInputGroupProps;
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -82,8 +82,8 @@ describe("<DateInput>", () => {
         assert.strictEqual(input.prop("leftIconName"), "star");
         assert.isTrue(input.prop("required"));
         assert.isTrue(inputRef.calledOnce, "inputRef not invoked");
-        assert.isTrue(onFocus.calledOnce, "onFocus not invoked")
-    })
+        assert.isTrue(onFocus.calledOnce, "onFocus not invoked");
+    });
 
     it("popoverProps are passed to Popover", () => {
         const popoverWillOpen = sinon.spy();

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -67,6 +67,24 @@ describe("<DateInput>", () => {
         });
     });
 
+    it("inputProps are passed to InputGroup", () => {
+        const inputRef = sinon.spy();
+        const onFocus = sinon.spy();
+        const wrapper = mount(<DateInput
+            disabled={false}
+            inputProps={{ disabled: true, inputRef, leftIconName: "star", onFocus, required: true, value: "fail" }}
+        />);
+        wrapper.find("input").simulate("focus");
+
+        const input = wrapper.find(InputGroup);
+        assert.isFalse(input.prop("disabled"), "disabled comes from DateInput props");
+        assert.notStrictEqual(input.prop("value"), "fail", "value cannot be changed");
+        assert.strictEqual(input.prop("leftIconName"), "star");
+        assert.isTrue(input.prop("required"));
+        assert.isTrue(inputRef.calledOnce, "inputRef not invoked");
+        assert.isTrue(onFocus.calledOnce, "onFocus not invoked")
+    })
+
     it("popoverProps are passed to Popover", () => {
         const popoverWillOpen = sinon.spy();
         const wrapper = mount(<DateInput
@@ -132,15 +150,18 @@ describe("<DateInput>", () => {
             assert.equal(wrapper.find(InputGroup).prop("value"), "2016-03-27");
         });
 
-        it("Typing in a valid date runs the onChange callback", () => {
+        it("Typing in a valid date invokes onChange and inputProps.onChange", () => {
             const date = "2015-02-10";
             const onChange = sinon.spy();
-            const wrapper = mount(<DateInput onChange={onChange} />);
+            const onInputChange = sinon.spy();
+            const wrapper = mount(<DateInput inputProps={{ onChange: onInputChange }} onChange={onChange} />);
             wrapper.find("input")
                 .simulate("change", { target: { value: date }});
 
             assert.isTrue(onChange.calledOnce);
             assertDateEquals(onChange.args[0][0], date);
+            assert.isTrue(onInputChange.calledOnce);
+            assert.strictEqual(onInputChange.args[0][0].type, "change", "inputProps.onChange expects change event");
         });
 
         it("Typing in a date out of range displays the error message and calls onError with invalid date", () => {
@@ -217,12 +238,19 @@ describe("<DateInput>", () => {
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_STR);
         });
 
-        it("Typing in a date runs the onChange callback", () => {
+        it("Typing in a date invokes onChange and inputProps.onChange", () => {
             const onChange = sinon.spy();
-            const wrapper = mount(<DateInput onChange={onChange} value={DATE} />);
+            const onInputChange = sinon.spy();
+            const wrapper = mount(<DateInput
+                inputProps={{ onChange: onInputChange }}
+                onChange={onChange}
+                value={DATE}
+            />);
             wrapper.find("input").simulate("change", { target: { value: DATE2 }});
             assert.isTrue(onChange.calledOnce);
             assertDateEquals(onChange.args[0][0], DATE2_STR);
+            assert.isTrue(onInputChange.calledOnce);
+            assert.strictEqual(onInputChange.args[0][0].type, "change", "inputProps.onChange expects change event");
         });
 
         it("Clearing the date in the input invokes onChange with null", () => {


### PR DESCRIPTION
#### Fixes #387, #1010 

#### Changes proposed in this pull request:

- add `DateInput` `inputProps` exactly like we did for `DateRangeInput` in #945 
- turns out this wasn't the least bit breaking, nor did it require any deprecations!