### PR TITLE
fix Popover deprecation warning in Table

### DIFF
--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -50,7 +50,6 @@ export class PopoverExample extends React.Component<{}, {}> {
                 interactionKind={PopoverInteractionKind.CLICK}
                 popoverClassName="pt-popover-content-sizing"
                 position={Position.RIGHT}
-                useSmartPositioning={false}
             >
                 <button className="pt-button pt-intent-primary">Popover target</button>
             </Popover>
@@ -101,7 +100,6 @@ export class ControlledPopoverExample extends React.Component<{}, { isOpen: bool
                 isOpen={this.state.isOpen}
                 onInteraction={(state) => this.handleInteraction(state)}
                 position={Position.RIGHT}
-                useSmartPositioning={false}
             >
                 <button className="pt-button pt-intent-primary">Popover target</button>
             </Popover>

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -99,7 +99,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             const className = classNames(this.props.className, Classes.TABLE_TRUNCATED_FORMAT);
             const constraints = [{
                 attachment: "together",
-                pin: true,
                 to: "window",
             }];
 
@@ -117,7 +116,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
                         content={popoverContent}
                         position={Position.BOTTOM}
                         useSmartArrowPositioning
-                        useSmartPositioning
                     >
                         <span className={iconClasses}/>
                     </Popover>


### PR DESCRIPTION
#### Fixes #1012 

#### Changes proposed in this pull request:

- we were already setting `tetherOptions`, and then overriding it with `useSmartPositioning` 😱 
- had to update constraints to preserve prior behavior.
