### PR TITLE
add ?examples to hide all that crufty text

### DIFF
--- a/packages/docs/src/components/documentation.tsx
+++ b/packages/docs/src/components/documentation.tsx
@@ -92,8 +92,9 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
     public render() {
         const { activePageId, activeSectionId } = this.state;
         const { nav, pages } = this.props.docs;
+        const examplesOnly = location.search === "?examples";
         return (
-            <div className={classNames("docs-root", this.props.className)}>
+            <div className={classNames("docs-root", { "docs-examples-only": examplesOnly }, this.props.className)}>
                 <div className="docs-app">
                     <div className="pt-navbar docs-navbar docs-flex-row">
                         <div className="pt-navbar-group">

--- a/packages/docs/src/styles/_layout.scss
+++ b/packages/docs/src/styles/_layout.scss
@@ -121,3 +121,14 @@ Lefthand navigation menu
     }
   }
 }
+
+// hides all documentation content, to focus on live examples
+// trigger this behavior by adding ?examples to URL immediately after the path (before #route):
+// http://blueprintjs.com/docs/?examples
+.docs-examples-only {
+  .docs-markup,
+  .docs-modifiers,
+  .docs-section {
+    display: none;
+  }
+}


### PR DESCRIPTION
#### Addresses #125 

#### Changes proposed in this pull request:

- add `?examples` query string to URL to hide all that crufty text so you can focus on the _examples_

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/464822/25246283/02356b92-25bc-11e7-81df-0afe42a65482.png)

