### PR TITLE
.pt-intent-* by itself sets text color

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -367,6 +367,10 @@ Markup:
 .pt-text-muted - Changes text color to a gentler gray.
 .pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
   container.
+.pt-intent-primary - Primary text color
+.pt-intent-danger - Danger text color
+.pt-intent-warning - Warning text color
+.pt-intent-success - Success text color
 
 Styleguide utilities
 */
@@ -381,6 +385,12 @@ Styleguide utilities
 
 .pt-text-overflow-ellipsis {
   @include overflow-ellipsis();
+}
+
+@each $name, $color in $pt-intent-colors {
+  .pt-intent-#{$name} {
+    color: $color;
+  }
 }
 
 /*

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -30,6 +30,7 @@ Styleguide pt-callout
   border-radius: $pt-border-radius;
   background-color: rgba($gray3, 0.15);
   padding: $pt-grid-size ($pt-grid-size * 1.2) ($pt-grid-size * 0.9);
+  color: inherit;
 
   &[class*="pt-icon-"] {
     padding-left: ($pt-grid-size * 2) + $pt-icon-size-large;


### PR DESCRIPTION
#### Fixes #1019

#### Changes proposed in this pull request:

- this allows coloring icons, and any other arbitrary text!
- i audited all the examples and found only one actual issue (callouts).

#### Reviewers should focus on:

Go try adding `pt-intent-primary` to random elements! It works really nicely on icons, cards, table headers, etc.

The following components have minor visual changes as a result of this change. Are you ok with this or must we go in and cancel these color changes?

- input group icons are now colored according to group intent:
![input-group-intent](https://cloud.githubusercontent.com/assets/464822/25246329/2908172e-25bc-11e7-907f-f59aa75b04e5.png)
(this makes me wonder if we should drop the [nasty] selector that cancels colors on input group icons when unfocused)

- form group label text is now colored according to group intent:
![form-group-intent](https://cloud.githubusercontent.com/assets/464822/25246384/5320436a-25bc-11e7-97b7-f43be9a056e9.png)
