### PR TITLE
[Table] Delete @PureRenders on TruncatedFormat and JSONFormat

### DIFF
--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { ITruncatedFormatProps, TruncatedFormat, TruncatedPopoverMode } from "./truncatedFormat";
@@ -30,7 +29,6 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     stringify?: (obj: any) => string;
 }
 
-@PureRender
 export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
     public static defaultProps: IJSONFormatProps = {
         detectTruncation: true,

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -8,7 +8,6 @@
 import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/core";
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
@@ -67,7 +66,6 @@ export interface ITruncatedFormatState {
     isTruncated: boolean;
 }
 
-@PureRender
 export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITruncatedFormatState> {
     public static defaultProps: ITruncatedFormatProps = {
         detectTruncation: true,


### PR DESCRIPTION
#### Fixes #1022 

#### Checklist

- [ ] Include tests

#### Changes proposed in this pull request:

Delete @PureRender on `TruncatedFormat` and `JSONFormat` so that cell content updates properly when cells are resized.

#### Reviewers should focus on:

This is a quick fix that may increase the number of unnecessary re-renders. Would be better to think of a not-weird way to inform cell content that a cell parent's width has updated.

Some weird ways that come to mind:
- Passing a callback that a parent fires for a child to respond to is backward and weird.
- Passing a prop value like `shouldUpdate`/`didCellSizeChange` is goofy and weird.
- `context`? Have never done much with that, but from what I've read, even this use case seems ill-fitted for that.
- Or, keeping the API more straightforward (but bloated): `cellWidth`/`cellHeight` props.

#### Screenshot

![2017-04-24 08 14 15](https://cloud.githubusercontent.com/assets/443450/25344536/3d7de07c-28c7-11e7-80e1-8841e2c68ff5.gif)
