### PR TITLE
[DateRangeInput] Fix various bugs

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -5,11 +5,11 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Switch } from "@blueprintjs/core";
+import { Classes, Switch } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange, handleStringChange } from "@blueprintjs/docs";
 import * as React from "react";
 
-import { DateRangeInput } from "../src";
+import { DateRange, DateRangeInput } from "../src";
 import { FORMATS, FormatSelect } from "./common/formatSelect";
 
 export interface IDateRangeInputExampleState {
@@ -19,6 +19,8 @@ export interface IDateRangeInputExampleState {
     disabled?: boolean;
     format?: string;
     selectAllOnFocus?: boolean;
+    useControlledMode?: boolean;
+    value?: DateRange;
 }
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
@@ -29,11 +31,14 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
         disabled: false,
         format: FORMATS[0],
         selectAllOnFocus: false,
+        useControlledMode: false,
+        value: undefined,
     };
 
     private toggleContiguous = handleBooleanChange((contiguous) => {
         this.setState({ contiguousCalendarMonths: contiguous });
     });
+    private toggleControlledMode = handleBooleanChange((useControlledMode) => this.setState({ useControlledMode }));
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
@@ -41,7 +46,16 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
 
     protected renderExample() {
-        return <DateRangeInput {...this.state} />;
+        const { value, useControlledMode, ...uncontrolledModeProps } = this.state;
+        return (
+            <div>
+                <DateRangeInput
+                    {...uncontrolledModeProps}
+                    onChange={this.handleChange}
+                    value={useControlledMode ? value : undefined}
+                />
+            </div>
+        );
     }
 
     protected renderOptions() {
@@ -53,6 +67,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     selectedValue={this.state.format}
                 />,
             ], [
+                <label className={Classes.LABEL} key="modifierslabel">Modifiers</label>,
                 <Switch
                     checked={this.state.allowSingleDayRange}
                     label="Allow single day range"
@@ -83,7 +98,17 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     key="Select all on focus"
                     onChange={this.toggleSelectAllOnFocus}
                 />,
+            ], [
+                <label className={Classes.LABEL} key="modelabel">Mode</label>,
+                <Switch
+                    checked={this.state.useControlledMode}
+                    label="Use controlled mode"
+                    key="Use controlled mode"
+                    onChange={this.toggleControlledMode}
+                />,
             ],
         ];
     }
+
+    private handleChange = (value: DateRange) => this.setState({ value });
 }

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -9,7 +9,7 @@ import { Classes, Switch } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange, handleStringChange } from "@blueprintjs/docs";
 import * as React from "react";
 
-import { DateRange, DateRangeInput } from "../src";
+import { DateRangeInput } from "../src";
 import { FORMATS, FormatSelect } from "./common/formatSelect";
 
 export interface IDateRangeInputExampleState {
@@ -19,8 +19,6 @@ export interface IDateRangeInputExampleState {
     disabled?: boolean;
     format?: string;
     selectAllOnFocus?: boolean;
-    useControlledMode?: boolean;
-    value?: DateRange;
 }
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
@@ -31,8 +29,6 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
         disabled: false,
         format: FORMATS[0],
         selectAllOnFocus: false,
-        useControlledMode: false,
-        value: undefined,
     };
 
     private toggleContiguous = handleBooleanChange((contiguous) => {
@@ -44,24 +40,8 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     private toggleSelectAllOnFocus = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
 
-    private toggleControlledMode = handleBooleanChange((useControlledMode) => {
-        if (this.state.value === undefined) {
-            // switch to a controlled version of an empty value
-            this.setState({ useControlledMode, value: [null, null] });
-        } else {
-            this.setState({ useControlledMode });
-        }
-    });
-
     protected renderExample() {
-        const { value, useControlledMode, ...uncontrolledModeProps } = this.state;
-        return (
-            <DateRangeInput
-                {...uncontrolledModeProps}
-                onChange={this.handleChange}
-                value={useControlledMode ? value : undefined}
-            />
-        );
+        return <DateRangeInput {...this.state} />;
     }
 
     protected renderOptions() {
@@ -104,17 +84,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     key="Select all on focus"
                     onChange={this.toggleSelectAllOnFocus}
                 />,
-            ], [
-                <label className={Classes.LABEL} key="modelabel">Mode</label>,
-                <Switch
-                    checked={this.state.useControlledMode}
-                    label="Use controlled mode"
-                    key="Use controlled mode"
-                    onChange={this.toggleControlledMode}
-                />,
             ],
         ];
     }
-
-    private handleChange = (value: DateRange) => this.setState({ value });
 }

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -56,13 +56,11 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     protected renderExample() {
         const { value, useControlledMode, ...uncontrolledModeProps } = this.state;
         return (
-            <div>
-                <DateRangeInput
-                    {...uncontrolledModeProps}
-                    onChange={this.handleChange}
-                    value={useControlledMode ? value : undefined}
-                />
-            </div>
+            <DateRangeInput
+                {...uncontrolledModeProps}
+                onChange={this.handleChange}
+                value={useControlledMode ? value : undefined}
+            />
         );
     }
 

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -53,7 +53,6 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
         }
     });
 
-
     protected renderExample() {
         const { value, useControlledMode, ...uncontrolledModeProps } = this.state;
         return (

--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -38,12 +38,21 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     private toggleContiguous = handleBooleanChange((contiguous) => {
         this.setState({ contiguousCalendarMonths: contiguous });
     });
-    private toggleControlledMode = handleBooleanChange((useControlledMode) => this.setState({ useControlledMode }));
     private toggleDisabled = handleBooleanChange((disabled) => this.setState({ disabled }));
     private toggleFormat = handleStringChange((format) => this.setState({ format }));
     private toggleSelection = handleBooleanChange((closeOnSelection) => this.setState({ closeOnSelection }));
     private toggleSelectAllOnFocus = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
+
+    private toggleControlledMode = handleBooleanChange((useControlledMode) => {
+        if (this.state.value === undefined) {
+            // switch to a controlled version of an empty value
+            this.setState({ useControlledMode, value: [null, null] });
+        } else {
+            this.setState({ useControlledMode });
+        }
+    });
+
 
     protected renderExample() {
         const { value, useControlledMode, ...uncontrolledModeProps } = this.state;

--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -29,3 +29,7 @@ export const DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION =
     `${ns} DEPRECATION: <DateInput> popoverProps is deprecated. Use popoverProps.position.`;
 export const DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS =
     `${ns} DEPRECATION: <DateInput> openOnFocus is deprecated. This feature will be removed in the next major version.`;
+
+export const DATERANGEINPUT_NULL_VALUE =
+    `${ns} <DateRangeInput> value cannot be null. Pass undefined to clear the value and operate in ` +
+    "uncontrolled mode, or pass [null, null] to clear the value and continue operating in controlled mode.";

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -332,7 +332,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         this.setState(nextState);
     }
 
-    protected validateProps(props: IDateRangeInputProps & { children?: React.ReactNode }) {
+    protected validateProps(props: IDateRangeInputProps) {
         if (props.value === null) {
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
         }
@@ -634,14 +634,13 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             if (isValueControlled) {
                 nextState = baseState;
             } else {
-                nextState = { ...nextState, [keys.selectedValue]: moment(null) };
+                nextState = { ...baseState, [keys.selectedValue]: moment(null) };
             }
             Utils.safeInvoke(this.props.onChange, this.getDateRangeForCallback(moment(null), boundary));
         } else if (this.isMomentValidAndInRange(maybeNextValue)) {
             // note that error cases that depend on both fields (e.g. overlapping dates) should fall
             // through into this block so that the UI can update immediately, possibly with an error
             // message on the other field.
-            //
             // also, clear the hover string to ensure the most recent keystroke appears.
             const baseState: IDateRangeInputState = {
                 ...nextState,

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -27,6 +27,7 @@ import {
     DateRange,
     DateRangeBoundary,
     fromDateRangeToMomentDateRange,
+    fromDateToMoment,
     fromMomentToDate,
     isMomentInRange,
     isMomentNull,
@@ -379,57 +380,60 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             return;
         }
 
-        if (this.props.value === undefined) {
-            const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
+        const [selectedStart, selectedEnd] = fromDateRangeToMomentDateRange(selectedRange);
 
-            let isOpen = true;
+        let isOpen = true;
 
-            let isStartInputFocused: boolean;
-            let isEndInputFocused: boolean;
+        let isStartInputFocused: boolean;
+        let isEndInputFocused: boolean;
 
-            let startHoverString: string;
-            let endHoverString: string;
+        let startHoverString: string;
+        let endHoverString: string;
 
-            if (isMomentNull(selectedStart)) {
-                // focus the start field by default or if only an end date is specified
-                isStartInputFocused = true;
-                isEndInputFocused = false;
+        if (isMomentNull(selectedStart)) {
+            // focus the start field by default or if only an end date is specified
+            isStartInputFocused = true;
+            isEndInputFocused = false;
 
-                // for clarity, hide the hover string until the mouse moves over a different date
-                startHoverString = null;
-            } else if (isMomentNull(selectedEnd)) {
-                // focus the end field if a start date is specified
-                isStartInputFocused = false;
-                isEndInputFocused = true;
+            // for clarity, hide the hover string until the mouse moves over a different date
+            startHoverString = null;
+        } else if (isMomentNull(selectedEnd)) {
+            // focus the end field if a start date is specified
+            isStartInputFocused = false;
+            isEndInputFocused = true;
 
-                endHoverString = null;
-            } else if (this.props.closeOnSelection) {
-                isOpen = false;
-                isStartInputFocused = false;
-                isEndInputFocused = false;
-            } else if (this.state.lastFocusedField === DateRangeBoundary.START) {
-                // keep the start field focused
-                isStartInputFocused = true;
-                isEndInputFocused = false;
-            } else {
-                // keep the end field focused
-                isStartInputFocused = false;
-                isEndInputFocused = true;
-            }
-
-            this.setState({
-                isOpen,
-                selectedEnd,
-                selectedStart,
-                isEndInputFocused,
-                isStartInputFocused,
-                startHoverString,
-                endHoverString,
-                endInputString: this.getFormattedDateString(selectedEnd),
-                startInputString: this.getFormattedDateString(selectedStart),
-                wasLastFocusChangeDueToHover: false,
-            });
+            endHoverString = null;
+        } else if (this.props.closeOnSelection) {
+            isOpen = false;
+            isStartInputFocused = false;
+            isEndInputFocused = false;
+        } else if (this.state.lastFocusedField === DateRangeBoundary.START) {
+            // keep the start field focused
+            isStartInputFocused = true;
+            isEndInputFocused = false;
+        } else {
+            // keep the end field focused
+            isStartInputFocused = false;
+            isEndInputFocused = true;
         }
+
+        const baseStateChange = {
+            isOpen,
+            isEndInputFocused,
+            isStartInputFocused,
+            startHoverString,
+            endHoverString,
+            endInputString: this.getFormattedDateString(selectedEnd),
+            startInputString: this.getFormattedDateString(selectedStart),
+            wasLastFocusChangeDueToHover: false,
+        };
+
+        if (this.isControlled()) {
+            this.setState(baseStateChange);
+        } else {
+            this.setState({ ...baseStateChange, selectedEnd, selectedStart });
+        }
+
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
@@ -452,7 +456,6 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             });
         } else {
             const [hoveredStart, hoveredEnd] = fromDateRangeToMomentDateRange(hoveredRange);
-
             const isStartInputFocused = (hoveredBoundary != null)
                 ? hoveredBoundary === DateRangeBoundary.START
                 : this.state.isStartInputFocused;
@@ -687,7 +690,15 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     private getSelectedRange = () => {
-        const { selectedStart, selectedEnd } = this.state;
+        let selectedStart: moment.Moment;
+        let selectedEnd: moment.Moment;
+
+        if (this.isControlled()) {
+            [selectedStart, selectedEnd] = this.props.value.map(fromDateToMoment);
+        } else {
+            selectedStart = this.state.selectedStart;
+            selectedEnd = this.state.selectedEnd;
+        }
 
         // this helper function checks if the provided boundary date *would* overlap the selected
         // other boundary date. providing the already-selected start date simply tells us if we're
@@ -720,8 +731,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const { values } = this.getStateKeysAndValuesForBoundary(boundary);
         const { isInputFocused, inputString, selectedValue, hoverString } = values;
 
-        if (hoverString != null && !this.isControlled()) {
-            // we don't want to overwrite the inputStrings in controlled mode
+        if (hoverString != null) {
             return hoverString;
         } else if (isInputFocused) {
             return (inputString == null) ? "" : inputString;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -33,6 +33,7 @@ import {
     isMomentValidAndInRange,
     MomentDateRange,
 } from "./common/dateUtils";
+import * as Errors from "./common/errors";
 import {
     getDefaultMaxDate,
     getDefaultMinDate,
@@ -157,8 +158,9 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
 
     /**
      * The currently selected date range.
-     * If this prop is present, the component acts in a controlled manner.
-     * To display no date range in the input fields, pass `[null, null]` to the value prop.
+     * If the prop is strictly `undefined`, the component acts in an uncontrolled manner.
+     * If this prop is anything else, the component acts in a controlled manner.
+     * To display an empty value in the input fields in a controlled manner, pass `[null, null]`.
      * To display an invalid date error in either input field, pass `new Date(undefined)`
      * for the appropriate date in the value prop.
      */
@@ -327,6 +329,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         }
 
         this.setState(nextState);
+    }
+
+    protected validateProps(props: IDateRangeInputProps & { children?: React.ReactNode }) {
+        if (props.value === null) {
+            throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
+        }
     }
 
     private renderInputGroup = (boundary: DateRangeBoundary) => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2084,7 +2084,6 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR_2, "");
         });
 
-
         describe("Typing an out-of-range date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -1967,28 +1967,30 @@ describe("<DateRangeInput>", () => {
             const defaultValue = [START_DATE, null] as DateRange;
 
             const { root, getDayElement } = wrap(<DateRangeInput defaultValue={defaultValue} onChange={onChange} />);
-            root.setState({ isOpen: true });
 
+            getStartInput(root).simulate("focus");
             getDayElement(START_DAY).simulate("click");
             assertInputTextsEqual(root, "", "");
             expect(onChange.called).to.be.true;
             expect(onChange.calledWith([null, null])).to.be.true;
         });
 
-        it(`Clearing only the start input (e.g.) invokes onChange with [null, <endDate>]`, () => {
+        it("Clearing only the start input (e.g.) invokes onChange with [null, <endDate>]", () => {
             const onChange = sinon.spy();
             const { root } = wrap(<DateRangeInput onChange={onChange} defaultValue={DATE_RANGE} />);
 
-            changeStartInputText(root, "");
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+            changeInputText(startInput, "");
             expect(onChange.called).to.be.true;
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
             assertInputTextsEqual(root, "", END_STR);
         });
 
-        it(`Clearing the dates in both inputs invokes onChange with [null, null] and leaves the inputs empty`, () => {
+        it("Clearing the dates in both inputs invokes onChange with [null, null] and leaves the inputs empty", () => {
             const onChange = sinon.spy();
             const { root } = wrap(<DateRangeInput onChange={onChange} defaultValue={[START_DATE, null]} />);
-
+            getStartInput(root).simulate("focus");
             changeStartInputText(root, "");
             expect(onChange.called).to.be.true;
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
@@ -2070,7 +2072,7 @@ describe("<DateRangeInput>", () => {
             assertEndInputFocused(controlledRoot);
         });
 
-        it(`Typing in a field while hovering over a date shows the typed date, not the hovered date`, () => {
+        it("Typing in a field while hovering over a date shows the typed date, not the hovered date", () => {
             let controlledRoot: WrappedComponentRoot;
 
             const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2032,14 +2032,13 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR_2, END_STR_2);
         });
 
-        it("Clicking a date invokes onChange with the new date range, but doesn't change the UI", () => {
+        it("Clicking a date invokes onChange with the new date range and updates the input field text", () => {
             const onChange = sinon.spy();
             const { root, getDayElement } = wrap(<DateRangeInput value={DATE_RANGE} onChange={onChange} />);
-
             getStartInput(root).simulate("focus"); // to open popover
             getDayElement(START_DAY).simulate("click");
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
-            assertInputTextsEqual(root, START_STR, END_STR);
+            assertInputTextsEqual(root, "", END_STR);
             expect(onChange.callCount).to.equal(1);
         });
 
@@ -2066,9 +2065,9 @@ describe("<DateRangeInput>", () => {
             const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} value={[null, null]} />);
             controlledRoot = root;
 
-            getStartInput(root).simulate("focus");
+            getStartInput(controlledRoot).simulate("focus");
             getDayElement(1).simulate("click"); // triggers a controlled value change
-            assertEndInputFocused(root);
+            assertEndInputFocused(controlledRoot);
         });
 
         it(`Typing in a field while hovering over a date shows the typed date, not the hovered date`, () => {
@@ -2251,7 +2250,7 @@ describe("<DateRangeInput>", () => {
             });
         });
 
-        it("Clearing the dates in the picker invokes onChange with [null, null], but doesn't change the UI", () => {
+        it("Clearing the dates in the picker invokes onChange with [null, null] and updates input fields", () => {
             const onChange = sinon.spy();
             const value = [START_DATE, null] as DateRange;
 
@@ -2262,7 +2261,7 @@ describe("<DateRangeInput>", () => {
             getDayElement(START_DAY).simulate("click");
 
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
-            assertInputTextsEqual(root, START_STR, "");
+            assertInputTextsEqual(root, "", "");
         });
 
         it(`Clearing only the start input (e.g.) invokes onChange with [null, <endDate>], doesn't clear the\

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2045,6 +2045,18 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, END_STR);
         });
 
+        it("Clicking a start date causes focus to move to end field", () => {
+            let controlledRoot: WrappedComponentRoot;
+
+            const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });
+            const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} value={[null, null]} />);
+            controlledRoot = root;
+
+            getStartInput(root).simulate("focus");
+            getDayElement(1).simulate("click"); // triggers a controlled value change
+            assertEndInputFocused(root);
+        });
+
         describe("Typing an out-of-range date", () => {
             let onChange: Sinon.SinonSpy;
             let onError: Sinon.SinonSpy;

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -88,6 +88,10 @@ describe("<DateRangeInput>", () => {
         assertInputTextsEqual(root, "", "");
     });
 
+    it("throws error if value === null", () => {
+        expect(() => mount(<DateRangeInput value={null} />)).to.throw;
+    });
+
     describe("startInputProps and endInputProps", () => {
 
         describe("startInputProps", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -415,6 +415,16 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR_2, END_STR_2);
         });
 
+        it(`Typing in a field while hovering over a date shows the typed date, not the hovered date`, () => {
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} defaultValue={DATE_RANGE} />);
+
+            getStartInput(root).simulate("focus");
+            getDayElement(1).simulate("mouseenter");
+            changeStartInputText(root, START_STR_2);
+            assertInputTextsEqual(root, START_STR_2, END_STR);
+        });
+
         describe("Typing an out-of-range date", () => {
             // we run the same four tests for each of several cases. putting
             // setup logic in beforeEach lets us express our it(...) tests as
@@ -2056,6 +2066,20 @@ describe("<DateRangeInput>", () => {
             getDayElement(1).simulate("click"); // triggers a controlled value change
             assertEndInputFocused(root);
         });
+
+        it(`Typing in a field while hovering over a date shows the typed date, not the hovered date`, () => {
+            let controlledRoot: WrappedComponentRoot;
+
+            const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });
+            const { root, getDayElement } = wrap(<DateRangeInput onChange={onChange} value={[null, null]} />);
+            controlledRoot = root;
+
+            getStartInput(root).simulate("focus");
+            getDayElement(1).simulate("mouseenter");
+            changeStartInputText(root, START_STR_2);
+            assertInputTextsEqual(root, START_STR_2, "");
+        });
+
 
         describe("Typing an out-of-range date", () => {
             let onChange: Sinon.SinonSpy;


### PR DESCRIPTION
#### Fixes #971, Fixes #1040, Fixes other uncatalogued issues

#### Checklist

- [x] Include tests
- [x] Update documentation (updated example to add "Use controlled mode" prop)

#### Changes proposed in this pull request:

- Controlled mode now has the same UX as uncontrolled mode.
    - In particular, clicking a start date in controlled mode moves the focus to the end-date field and vice versa.
- If you hover over a date and then use the keyboard to edit it, the keyboard-edited date will be displayed (before, we were simply displaying the hovered date, which didn't show the effects of your keystrokes.)
    - In general, any time the value changes, we now clear the `{start,end}HoverString` value in state, showing the `{start,end}InputString` instead.
- After typing an invalid date into a field, hovering over a valid date will hide the error state for the duration of the hover. The error state will return if you mouse out of the calendar without clicking a date.
- Throw a descriptive error if `value === null` (`undefined` triggers uncontrolled mode and `[null, null]` empties the fields in a controlled fashion, but a strictly `null` value doesn't have clear semantics).
- Added unit tests verifying these changes.

#### Reviewers should focus on:

- Make sure everything looks and feels good in both uncontrolled and controlled modes!
- I've included a "Use controlled mode" prop to help you test the dev preview. Should I nix that toggle before merging this PR?

