### PR TITLE
[DateInput] [DateRangeInput] Add MM/DD/YYYY example and make it the default

### DIFF
--- a/packages/datetime/examples/common/formatSelect.tsx
+++ b/packages/datetime/examples/common/formatSelect.tsx
@@ -22,7 +22,6 @@ export interface IFormatSelectProps {
 
 export const FORMATS = [
     "MM/DD/YYYY",
-    "DD/MM/YYYY",
     "YYYY-MM-DD",
     "YYYY-MM-DD HH:mm:ss",
 ];

--- a/packages/datetime/examples/common/formatSelect.tsx
+++ b/packages/datetime/examples/common/formatSelect.tsx
@@ -21,8 +21,8 @@ export interface IFormatSelectProps {
 }
 
 export const FORMATS = [
+    "MM/DD/YYYY",
     "DD/MM/YYYY",
-    "MM-DD-YYYY",
     "YYYY-MM-DD",
     "YYYY-MM-DD HH:mm:ss",
 ];


### PR DESCRIPTION
#### Checklist

- [x] Update documentation (update `DateInput` and `DateRangeInput` examples.

#### Changes proposed in this pull request:

Got a comment that the `DateInput`/`DateRangeInput` examples are missing a pretty common date format for the US: `MM/DD/YYYY`. This PR adds that format and makes it the default for each example.

![image](https://cloud.githubusercontent.com/assets/443450/25460604/5e99568c-2a99-11e7-98a3-173884669da4.png)
