### PR TITLE
[NumericInput] Fix pt-fill example in docs

### DIFF
--- a/packages/core/examples/numericInputBasicExample.tsx
+++ b/packages/core/examples/numericInputBasicExample.tsx
@@ -145,28 +145,26 @@ export class NumericInputBasicExample extends BaseExample<INumericInputBasicExam
 
     protected renderExample() {
         return (
-            <div className="docs-react-numeric-input-example">
-                <NumericInput
-                    allowNumericCharactersOnly={this.state.numericCharsOnly}
-                    buttonPosition={BUTTON_POSITIONS[this.state.buttonPositionIndex].value}
-                    className={classNames({ [Classes.FILL]: this.state.showFullWidth })}
-                    intent={this.state.intent}
+            <NumericInput
+                allowNumericCharactersOnly={this.state.numericCharsOnly}
+                buttonPosition={BUTTON_POSITIONS[this.state.buttonPositionIndex].value}
+                className={classNames({ [Classes.FILL]: this.state.showFullWidth })}
+                intent={this.state.intent}
 
-                    min={MIN_VALUES[this.state.minValueIndex].value}
-                    max={MAX_VALUES[this.state.maxValueIndex].value}
+                min={MIN_VALUES[this.state.minValueIndex].value}
+                max={MAX_VALUES[this.state.maxValueIndex].value}
 
-                    disabled={this.state.showDisabled}
-                    readOnly={this.state.showReadOnly}
-                    leftIconName={this.state.showLeftIcon ? "dollar" : null}
-                    placeholder="Enter a number..."
+                disabled={this.state.showDisabled}
+                readOnly={this.state.showReadOnly}
+                leftIconName={this.state.showLeftIcon ? "dollar" : null}
+                placeholder="Enter a number..."
 
-                    selectAllOnFocus={this.state.selectAllOnFocus}
-                    selectAllOnIncrement={this.state.selectAllOnIncrement}
+                selectAllOnFocus={this.state.selectAllOnFocus}
+                selectAllOnIncrement={this.state.selectAllOnIncrement}
 
-                    onValueChange={this.handleValueChange}
-                    value={this.state.value}
-                />
-            </div>
+                onValueChange={this.handleValueChange}
+                value={this.state.value}
+            />
         );
     }
 

--- a/packages/docs/src/styles/_examples.scss
+++ b/packages/docs/src/styles/_examples.scss
@@ -52,3 +52,10 @@
     margin-right: 0;
   }
 }
+
+#{example("NumericInputBasicExample")} {
+  .docs-react-example {
+    // abandon display:flex to ensure pt-fill displays properly
+    display: block;
+  }
+}

--- a/packages/site-docs/src/styles/_sections.scss
+++ b/packages/site-docs/src/styles/_sections.scss
@@ -245,13 +245,6 @@
   display: inline-block;
 }
 
-#{example("NumericInputBasicExample")} {
-  .docs-react-numeric-input-example {
-    // to ensure pt-fill displays properly
-    width: 100%;
-  }
-}
-
 #{example("NumericInputExtendedExample")} {
   .docs-react-example input {
     width: $pt-grid-size * 23;

--- a/packages/site-docs/src/styles/_sections.scss
+++ b/packages/site-docs/src/styles/_sections.scss
@@ -245,6 +245,13 @@
   display: inline-block;
 }
 
+#{example("NumericInputBasicExample")} {
+  .docs-react-example {
+    // abandon display:flex to ensure pt-fill displays properly
+    display: block;
+  }
+}
+
 #{example("NumericInputExtendedExample")} {
   .docs-react-example input {
     width: $pt-grid-size * 23;

--- a/packages/site-docs/src/styles/_sections.scss
+++ b/packages/site-docs/src/styles/_sections.scss
@@ -245,6 +245,13 @@
   display: inline-block;
 }
 
+#{example("NumericInputBasicExample")} {
+  .docs-react-numeric-input-example {
+    // to ensure pt-fill displays properly
+    width: 100%;
+  }
+}
+
 #{example("NumericInputExtendedExample")} {
   .docs-react-example input {
     width: $pt-grid-size * 23;


### PR DESCRIPTION
#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

Style the `NumericInput` basic example container to `width: 100%` to fix the `Full width` switch.

#### Screenshot

![2017-04-26 16 46 54](https://cloud.githubusercontent.com/assets/443450/25461816/0332b48a-2aa0-11e7-9376-86d13c1d05c0.gif)