### PR TITLE
[DateRangeInput] Fix controlled-popover issues

### DIFF
--- a/packages/datetime/examples/dateRangeInputExample.tsx
+++ b/packages/datetime/examples/dateRangeInputExample.tsx
@@ -19,6 +19,7 @@ export interface IDateRangeInputExampleState {
     disabled?: boolean;
     format?: string;
     selectAllOnFocus?: boolean;
+    popoverIsOpen?: boolean;
 }
 
 export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleState> {
@@ -28,6 +29,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
         contiguousCalendarMonths: true,
         disabled: false,
         format: FORMATS[0],
+        popoverIsOpen: false,
         selectAllOnFocus: false,
     };
 
@@ -41,7 +43,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     private toggleSingleDay = handleBooleanChange((allowSingleDayRange) => this.setState({ allowSingleDayRange }));
 
     protected renderExample() {
-        return <DateRangeInput {...this.state} />;
+        const popoverProps = {
+            isOpen: this.state.popoverIsOpen,
+            onInteraction: this.handlePopoverInteraction,
+        };
+        const { popoverIsOpen, ...uncontrolledState } = this.state;
+        return <DateRangeInput {...uncontrolledState} popoverProps={popoverProps} />;
     }
 
     protected renderOptions() {
@@ -86,5 +93,9 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                 />,
             ],
         ];
+    }
+
+    private handlePopoverInteraction = (nextOpenState: boolean) => {
+        this.setState({ popoverIsOpen: nextOpenState });
     }
 }

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -376,7 +376,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private handleDateRangePickerChange = (selectedRange: DateRange) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
-        if (!this.state.isOpen) {
+        if (!this.isOpen()) {
             return;
         }
 
@@ -434,6 +434,12 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             this.setState({ ...baseStateChange, selectedEnd, selectedStart });
         }
 
+        // isOpen will remain true unless closeOnSelection deems the popover should close; we only
+        // need to invoke onInteraction if that's the case.
+        if (!isOpen) {
+            this.maybeInvokeOnInteractionCallback(isOpen);
+        }
+
         Utils.safeInvoke(this.props.onChange, selectedRange);
     }
 
@@ -441,7 +447,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                                                 _hoveredDay: Date,
                                                 hoveredBoundary: DateRangeBoundary) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
-        if (!this.state.isOpen) { return; }
+        if (!this.isOpen()) { return; }
 
         if (hoveredRange == null) {
             // undo whatever focus changes we made while hovering over various calendar dates
@@ -568,8 +574,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             ? this.state.boundaryToModify
             : boundary;
 
+        const isOpen = true;
+        this.maybeInvokeOnInteractionCallback(isOpen);
         this.setState({
-            isOpen: true,
+            isOpen,
             boundaryToModify,
             [keys.inputString]: inputString,
             [keys.isInputFocused]: true,
@@ -667,6 +675,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     // ===================
 
     private handlePopoverClose = () => {
+        // the popover invokes onInteraction immediately before onClose, so no need for us to invoke
+        // it again here.
         this.setState({ isOpen: false });
         Utils.safeInvoke(this.props.popoverProps.onClose);
     }
@@ -891,6 +901,20 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     private isInputEmpty = (inputString: string) => {
         return inputString == null || inputString.length === 0;
+    }
+
+    private isOpen = () => {
+        const { popoverProps } = this.props;
+        if (popoverProps != null && popoverProps.isOpen != null) {
+            return popoverProps.isOpen;
+        } else {
+            return this.state.isOpen;
+        }
+    }
+
+    private maybeInvokeOnInteractionCallback = (nextOpenState: boolean) => {
+        const { popoverProps = {} } = this.props;
+        Utils.safeInvoke(popoverProps.onInteraction, nextOpenState);
     }
 
     private isInputInErrorState = (boundary: DateRangeBoundary) => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2305,6 +2305,97 @@ describe("<DateRangeInput>", () => {
             startInput.simulate("blur");
             assertInputTextsEqual(root, START_STR, "");
         });
+
+        describe("when popover controlled", () => {
+            it("Invokes popoverProps.onInteraction with true when popover closed and start input focuses", () => {
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: false };
+                const { root } = wrap(<DateRangeInput popoverProps={popoverProps} value={DATE_RANGE} />);
+
+                getStartInput(root).simulate("focus");
+                expect(onInteraction.calledOnce).to.be.true;
+                expect(onInteraction.calledWith(true)).to.be.true;
+            });
+
+            it("Invokes popoverProps.onInteraction with true when popover closed and end input focuses", () => {
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: false };
+                const { root } = wrap(<DateRangeInput popoverProps={popoverProps} value={DATE_RANGE} />);
+
+                getEndInput(root).simulate("focus");
+                expect(onInteraction.calledOnce).to.be.true;
+                expect(onInteraction.calledWith(true)).to.be.true;
+            });
+
+            it("Invokes popoverProps.onInteraction with true when popover already open and end input focuses", () => {
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: true };
+                const { root } = wrap(<DateRangeInput popoverProps={popoverProps} value={DATE_RANGE} />);
+
+                getEndInput(root).simulate("focus");
+                expect(onInteraction.calledOnce).to.be.true;
+                expect(onInteraction.calledWith(true)).to.be.true;
+            });
+
+            it("Invokes popoverProps.onInteraction with false when date range is fully selected", () => {
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: true };
+                const { root, getDayElement } = wrap(
+                    <DateRangeInput popoverProps={popoverProps} value={[START_DATE, null]} />);
+
+                getEndInput(root).simulate("focus"); // calls onInteraction once
+                getDayElement(END_DAY).simulate("click");
+                expect(onInteraction.callCount).to.equal(2);
+                expect(onInteraction.getCall(1).calledWith(false)).to.be.true; // 2nd call, 0-indexed
+            });
+
+            it(`Does not invoke popoverProps.onInteraction when date range is fully selected but\
+                closeOnSelection=false`, () => {
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: true };
+                const { root, getDayElement } = wrap(
+                    <DateRangeInput
+                        closeOnSelection={false}
+                        popoverProps={popoverProps}
+                        value={[START_DATE, null]}
+                    />);
+
+                getEndInput(root).simulate("focus"); // calls onInteraction once
+                getDayElement(END_DAY).simulate("click");
+                expect(onInteraction.callCount).to.equal(1);
+            });
+
+            it("Popover renders as open right away if popoverProps.isOpen={true}", () => {
+                // try focusing the start field, which would normally open the popover
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: true };
+                const { root } = wrap(
+                    <DateRangeInput popoverProps={popoverProps} value={DATE_RANGE} />);
+                expect(root.find(DateRangePicker).isEmpty()).to.be.false;
+            });
+
+            it("Popover never opens if popoverProps.isOpen={false}", () => {
+                // try focusing the start field, which would normally open the popover
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: false };
+                const { root } = wrap(
+                    <DateRangeInput popoverProps={popoverProps} value={DATE_RANGE} />);
+
+                getStartInput(root).simulate("focus");
+                expect(root.find(DateRangePicker).isEmpty()).to.be.true;
+            });
+
+            it("Popover never closes if popoverProps.isOpen={true}", () => {
+                // try focusing the start field, which would normally open the popover
+                const onInteraction = sinon.spy();
+                const popoverProps = { onInteraction, isOpen: true };
+                const { root } = wrap(
+                    <DateRangeInput popoverProps={popoverProps} value={DATE_RANGE} />);
+
+                getStartInput(root).simulate("blur");
+                expect(root.find(DateRangePicker).isEmpty()).to.be.false;
+            });
+        });
     });
 
     function getStartInput(root: WrappedComponentRoot): WrappedComponentInput {


### PR DESCRIPTION
#### Checklist

- [x] Include tests
  - [x] Invokes `popoverProps.onInteraction` when start input focuses (maybe we should set `isOpen=true` and invoke `onInteraction` only if popover is not yet open?)
  - [x] Invokes `popoverProps.onInteraction` when end input focuses (same question as above)
  - [x] Invokes `popoverProps.onInteraction` when date range is fully selected
  - [x] Does not invoke `popoverProps.onInteraction` when date range is fully selected but `closeOnSelection={false}`
  - [x] Popover opens right away if `popoverProps.isOpen={true}` (should we also auto-focus in the start field, or just let that happen automatically as soon as the user hovers over a date?)
  - [x] Popover never closes if `popoverProps.isOpen={true}`
  - [x] Popover never opens if `popoverProps.isOpen={false}`
- [ ] Revert example changes once we've tested new behavior

#### Changes proposed in this pull request:

- Explicitly invoke `popoverProps.onInteraction` whenever we update `isOpen` in `dRI.tsx`.
- Add an `isOpen()` helper that returns `popoverProps.isOpen` if it exists (instead of this.state.isOpen`).

#### Reviewers should focus on:

- Should we bother updating `this.state.isOpen` at all if the `popoverProps.isOpen` is defined? Currently, I'm updating state but simply ignoring it if the popover is controlled.
- I'll revert my `DateRangeInputExample` changes before merging. 
