### PR TITLE
[Docs] Navigator scrolls selected item into viewport

### DIFF
--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -33,11 +33,12 @@ export interface INavigatorProps {
 }
 
 export interface INavigatorState {
+    matches: INavigationSection[];
     query: string;
     selectedIndex: number;
 }
 
-interface INavigationSection {
+export interface INavigationSection {
     filterKey: string;
     path: string[];
     route: string;
@@ -47,6 +48,7 @@ interface INavigationSection {
 @HotkeysTarget
 export class Navigator extends React.PureComponent<INavigatorProps, INavigatorState> {
     public state: INavigatorState = {
+        matches: [],
         query: "",
         selectedIndex: 0,
     };
@@ -61,7 +63,7 @@ export class Navigator extends React.PureComponent<INavigatorProps, INavigatorSt
     // this guy must be defined before he's used in handleQueryChange
     // and it just makes sense to be up here with state init
     // tslint:disable:member-ordering
-    private resetState = (query = "") => this.setState({ query, selectedIndex: 0 });
+    private resetState = (query = "") => this.setState({ matches: this.getMatches(query), query, selectedIndex: 0 });
     private sections: INavigationSection[];
 
     /**
@@ -147,15 +149,12 @@ export class Navigator extends React.PureComponent<INavigatorProps, INavigatorSt
         }
     }
 
-    private getMatches() {
-        return filter(this.sections, this.state.query, {
-            key: "filterKey",
-        });
+    private getMatches(query: string) {
+        return filter(this.sections, query, { key: "filterKey" });
     }
 
     private renderPopover() {
-        const matches = this.getMatches();
-        const selectedIndex = Math.min(matches.length - 1, this.state.selectedIndex);
+        const { matches, selectedIndex } = this.state;
         let items = matches.map((section, index) => {
             const isSelected = index === selectedIndex;
             const classes = classNames(Classes.MENU_ITEM, Classes.POPOVER_DISMISS, {
@@ -213,9 +212,10 @@ export class Navigator extends React.PureComponent<INavigatorProps, INavigatorSt
             // indicate that the selected item may need to be scrolled into view after update.
             // this is not possible with mouse hover cuz you can't hover on something off screen.
             this.shouldCheckSelectedInViewport = true;
+            const { matches, selectedIndex } = this.state;
             this.setState({
                 ...this.state,
-                selectedIndex: Utils.clamp(this.state.selectedIndex + direction, 0, this.sections.length - 1),
+                selectedIndex: Utils.clamp(selectedIndex + direction, 0, matches.length - 1),
             });
         };
     }

--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -45,6 +45,8 @@ export interface INavigationSection {
     title: string;
 }
 
+const MENU_PADDING = 5; // $pt-grid-size / 2;
+
 @HotkeysTarget
 export class Navigator extends React.PureComponent<INavigatorProps, INavigatorState> {
     public state: INavigatorState = {
@@ -136,13 +138,13 @@ export class Navigator extends React.PureComponent<INavigatorProps, INavigatorSt
         if (this.shouldCheckSelectedInViewport && this.menuRef != null) {
             const selectedElement = this.menuRef.querySelector(`.${Classes.INTENT_PRIMARY}`) as HTMLElement;
             const { offsetTop: selectedTop, offsetHeight: selectedHeight } = selectedElement;
-            const { scrollTop: menuScrollTop, clientHeight: menuHeight} = this.menuRef;
+            const { scrollTop: menuScrollTop, clientHeight: menuHeight } = this.menuRef;
             if (selectedTop + selectedHeight  > menuScrollTop + menuHeight) {
                 // offscreen bottom: scroll such that one full item is visible above + menu padding
-                this.menuRef.scrollTop = selectedTop - selectedHeight - 5;
+                this.menuRef.scrollTop = selectedTop - selectedHeight - MENU_PADDING;
             } else if (selectedTop < menuScrollTop) {
                 // offscreen top: scroll such that one full item is visible below + menu padding
-                this.menuRef.scrollTop = selectedTop - menuHeight + selectedHeight * 2 + 5;
+                this.menuRef.scrollTop = selectedTop - menuHeight + selectedHeight * 2 + MENU_PADDING;
             }
             // reset the flag
             this.shouldCheckSelectedInViewport = false;

--- a/packages/docs/src/styles/_navigator.scss
+++ b/packages/docs/src/styles/_navigator.scss
@@ -3,7 +3,7 @@
 // of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
 // and https://github.com/palantir/blueprint/blob/master/PATENTS
 
-$navigator-height: $pt-grid-size * 24;
+$navigator-height: $pt-grid-size * 24.5;
 $navigator-min-width: $pt-grid-size * 22;
 
 .docs-navigator {


### PR DESCRIPTION
#### Fixes #335

#### Changes proposed in this pull request:

- adjust scroll position of menu when using keyboard to select items
  - leaves previously selected item visible above/below new selection. nice!
- track matches in state for a few good reasons:
  - only compute it once when query changes instead of in every render
  - can reliably clamp arrow key movement to ensure user can't slide off the end

#### Screenshot

![navigator-key-scroll](https://cloud.githubusercontent.com/assets/464822/25509437/e4b8b224-2b6d-11e7-8faa-da869374b26d.gif)