### PR TITLE
[DateRangeInput] Add openPopover() and closePopover() instance methods

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -257,16 +257,16 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     /**
-     * A convenience method for opening the popover while otherwise deferring to default,
-     * uncontrolled popover behavior.
+     * A convenience method for opening the popover while otherwise deferring to uncontrolled
+     * popover behavior.
      */
     public openPopover() {
         this.setState({ isOpen: true });
     }
 
     /**
-     * A convenience method for closing the popover while otherwise deferring to default,
-     * uncontrolled popover behavior.
+     * A convenience method for closing the popover while otherwise deferring to uncontrolled
+     * popover behavior.
      */
     public closePopover() {
         this.setState({ isOpen: false });

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -256,6 +256,22 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         };
     }
 
+    /**
+     * A convenience method for opening the popover while otherwise deferring to default,
+     * uncontrolled popover behavior.
+     */
+    public openPopover() {
+        this.setState({ isOpen: true });
+    }
+
+    /**
+     * A convenience method for closing the popover while otherwise deferring to default,
+     * uncontrolled popover behavior.
+     */
+    public closePopover() {
+        this.setState({ isOpen: false });
+    }
+
     public componentDidUpdate() {
         const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -1996,6 +1996,18 @@ describe("<DateRangeInput>", () => {
             assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
             assertInputTextsEqual(root, "", "");
         });
+
+        it("Invoking openPopover opens the popover", () => {
+            const { root } = wrap(<DateRangeInput />);
+            (root.instance() as DateRangeInput).openPopover();
+            expect(root.state("isOpen")).to.be.true;
+        });
+
+        it("Invoking closePopover closes the popover", () => {
+            const { root } = wrap(<DateRangeInput />);
+            (root.instance() as DateRangeInput).closePopover();
+            expect(root.state("isOpen")).to.be.false;
+        });
     });
 
     describe("when controlled", () => {


### PR DESCRIPTION
#### Fixes #1053

#### Checklist

- [x] Include tests
- [ ] Update documentation (how best to document the instance methods?)

#### Changes proposed in this pull request:

Added `openPopover()` and `closePopover()` instance methods to `DateRangeInput`. Goal is to let devs defer to uncontrolled popover logic for the most part, while also being able to explicitly open and close the popover on occasion via these new instance methods.

Also added unit tests.

#### Reviewers should focus on:

I still think we should fix our controlled-popover issues as proposed in #1046. This PR is just providing additional conveniences for those wishing to operate the popover in uncontrolled mode. 