### PR TITLE
[DateRangePicker] Ensure hovered range displays when contiguousCalendarMonths=false

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -254,6 +254,8 @@ export class DateRangePicker
                         localeUtils={localeUtils}
                         modifiers={modifiers}
                         onDayClick={this.handleDayClick}
+                        onDayMouseEnter={this.handleDayMouseEnter}
+                        onDayMouseLeave={this.handleDayMouseLeave}
                         onMonthChange={this.handleLeftMonthChange}
                         selectedDays={selectedDays}
                         toMonth={DateUtils.getDatePreviousMonth(maxDate)}
@@ -268,6 +270,8 @@ export class DateRangePicker
                         localeUtils={localeUtils}
                         modifiers={modifiers}
                         onDayClick={this.handleDayClick}
+                        onDayMouseEnter={this.handleDayMouseEnter}
+                        onDayMouseLeave={this.handleDayMouseLeave}
                         onMonthChange={this.handleRightMonthChange}
                         selectedDays={selectedDays}
                         toMonth={maxDate}

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -213,6 +213,17 @@ export class DateRangePicker
         const { leftView, rightView } = this.state;
         const { disabledDays, selectedDays } = this.states;
 
+        const dayPickerBaseProps: ReactDayPicker.Props = {
+            disabledDays,
+            locale,
+            localeUtils,
+            modifiers,
+            onDayClick: this.handleDayClick,
+            onDayMouseEnter: this.handleDayMouseEnter,
+            onDayMouseLeave: this.handleDayMouseLeave,
+            selectedDays,
+        };
+
         if (contiguousCalendarMonths || isShowingOneMonth) {
             const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
                 [DateClasses.DATERANGEPICKER_CONTIGUOUS]: contiguousCalendarMonths,
@@ -223,19 +234,12 @@ export class DateRangePicker
                 <div className={classes}>
                     {this.maybeRenderShortcuts()}
                     <DayPicker
+                        {...dayPickerBaseProps}
                         captionElement={this.renderSingleCaption()}
-                        disabledDays={disabledDays}
                         fromMonth={minDate}
                         initialMonth={leftView.getFullDate()}
-                        locale={locale}
-                        localeUtils={localeUtils}
-                        modifiers={modifiers}
                         numberOfMonths={isShowingOneMonth ? 1 : 2}
-                        onDayClick={this.handleDayClick}
-                        onDayMouseEnter={this.handleDayMouseEnter}
-                        onDayMouseLeave={this.handleDayMouseLeave}
                         onMonthChange={this.handleLeftMonthChange}
-                        selectedDays={selectedDays}
                         toMonth={maxDate}
                     />
                 </div>
@@ -245,35 +249,21 @@ export class DateRangePicker
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
                     {this.maybeRenderShortcuts()}
                     <DayPicker
+                        {...dayPickerBaseProps}
                         canChangeMonth={true}
                         captionElement={this.renderLeftCaption()}
-                        disabledDays={disabledDays}
                         fromMonth={minDate}
                         initialMonth={leftView.getFullDate()}
-                        locale={locale}
-                        localeUtils={localeUtils}
-                        modifiers={modifiers}
-                        onDayClick={this.handleDayClick}
-                        onDayMouseEnter={this.handleDayMouseEnter}
-                        onDayMouseLeave={this.handleDayMouseLeave}
                         onMonthChange={this.handleLeftMonthChange}
-                        selectedDays={selectedDays}
                         toMonth={DateUtils.getDatePreviousMonth(maxDate)}
                     />
                     <DayPicker
+                        {...dayPickerBaseProps}
                         canChangeMonth={true}
                         captionElement={this.renderRightCaption()}
-                        disabledDays={disabledDays}
                         fromMonth={DateUtils.getDateNextMonth(minDate)}
                         initialMonth={rightView.getFullDate()}
-                        locale={locale}
-                        localeUtils={localeUtils}
-                        modifiers={modifiers}
-                        onDayClick={this.handleDayClick}
-                        onDayMouseEnter={this.handleDayMouseEnter}
-                        onDayMouseLeave={this.handleDayMouseLeave}
                         onMonthChange={this.handleRightMonthChange}
-                        selectedDays={selectedDays}
                         toMonth={maxDate}
                     />
                 </div>

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -550,7 +550,7 @@ describe("<DateRangePicker>", () => {
         });
 
         // verifies the fix for https://github.com/palantir/blueprint/issues/1048
-        it.only("hovering when contiguousCalendarMonths=false shows a hovered range", () => {
+        it("hovering when contiguousCalendarMonths=false shows a hovered range", () => {
             renderDateRangePicker({ contiguousCalendarMonths: false });
             clickDay(14);
             // hover on right month

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -548,6 +548,16 @@ describe("<DateRangePicker>", () => {
             mouseEnterDay(14, false);
             assert.equal(dateRangePicker.state.leftView.getMonth(), MONTH_OUT_OF_VIEW);
         });
+
+        // verifies the fix for https://github.com/palantir/blueprint/issues/1048
+        it.only("hovering when contiguousCalendarMonths=false shows a hovered range", () => {
+            renderDateRangePicker({ contiguousCalendarMonths: false });
+            clickDay(14);
+            // hover on right month
+            mouseEnterDay(18, false);
+            assert.equal(getHoveredRangeStartDayElement().textContent, "14");
+            assert.equal(getHoveredRangeEndDayElement().textContent, "18");
+        });
     });
 
     describe("when controlled", () => {


### PR DESCRIPTION
#### Fixes #1048 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Herp derp. Wasn't include the `mouseenter` and `mouseleave` listeners in the split `DayPicker`s before. Fixed here. Also pulled out the common base props into a shared object and added a unit test to prevent this from happening again.

#### Reviewers should focus on:

Worth mentioning the issue in a comment above the new unit test?