### PR TITLE
[NumericInput] Add clampValueOnBlur prop

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -23,6 +23,8 @@ export const HOTKEYS_HOTKEY_CHILDREN = `${ns} <Hotkeys> only accepts <Hotkey> ch
 export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
     `${ns} <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;
 
+export const NUMERIC_INPUT_CLAMP_VALUE_ON_BLUR =
+    `${ns} <NumericInput clampValueOnBlur={true}> requires one of min or max to be defined`;
 export const NUMERIC_INPUT_MIN_MAX =
     `${ns} <NumericInput> requires min to be strictly less than max if both are defined.`;
 export const NUMERIC_INPUT_MINOR_STEP_SIZE_BOUND =

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -23,8 +23,6 @@ export const HOTKEYS_HOTKEY_CHILDREN = `${ns} <Hotkeys> only accepts <Hotkey> ch
 export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
     `${ns} <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;
 
-export const NUMERIC_INPUT_CLAMP_VALUE_ON_BLUR =
-    `${ns} <NumericInput clampValueOnBlur={true}> requires one of min or max to be defined`;
 export const NUMERIC_INPUT_MIN_MAX =
     `${ns} <NumericInput> requires min to be strictly less than max if both are defined.`;
 export const NUMERIC_INPUT_MINOR_STEP_SIZE_BOUND =

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -194,7 +194,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
         // outside of the new bounds, then clamp the value to the new valid range.
         if (didBoundsChange && sanitizedValue !== this.state.value) {
             this.setState({ stepMaxPrecision, value: sanitizedValue });
-            this.invokeOnChangeCallbacks(sanitizedValue);
+            this.invokeOnValueChangeCallback(sanitizedValue);
         } else {
             this.setState({ stepMaxPrecision, value });
         }
@@ -393,7 +393,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
             const sanitizedValue = this.getSanitizedValue(value);
             this.setState({ ...baseStateChange, value: sanitizedValue });
             if (value !== sanitizedValue) {
-                this.invokeOnChangeCallbacks(sanitizedValue);
+                this.invokeOnValueChangeCallback(sanitizedValue);
             }
         } else {
             this.setState(baseStateChange);
@@ -464,10 +464,10 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
 
         this.shouldSelectAfterUpdate = false;
         this.setState({ value: nextValue });
-        this.invokeOnChangeCallbacks(nextValue);
+        this.invokeOnValueChangeCallback(nextValue);
     }
 
-    private invokeOnChangeCallbacks(value: string) {
+    private invokeOnValueChangeCallback(value: string) {
         const valueAsString = value;
         const valueAsNumber = +value; // coerces non-numeric strings to NaN
         Utils.safeInvoke(this.props.onValueChange, valueAsNumber, valueAsString);
@@ -483,7 +483,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
 
         this.shouldSelectAfterUpdate = this.props.selectAllOnIncrement;
         this.setState({ value: nextValue });
-        this.invokeOnChangeCallbacks(nextValue);
+        this.invokeOnValueChangeCallback(nextValue);
     }
 
     private getIncrementDelta(direction: IncrementDirection, isShiftKeyPressed: boolean, isAltKeyPressed: boolean) {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -148,14 +148,19 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
      */
     private static FLOATING_POINT_NUMBER_CHARACTER_REGEX = /^[Ee0-9\+\-\.]$/;
 
-    private didPasteEventJustOccur: boolean;
     private inputElement: HTMLInputElement;
+
+    /**
+     * Updating these flags need not trigger re-renders, so don't include them in this.state.
+     */
+    private didPasteEventJustOccur: boolean;
+    private shouldSelectAfterUpdate: boolean;
 
     public constructor(props?: HTMLInputProps & INumericInputProps, context?: any) {
         super(props, context);
 
+        this.shouldSelectAfterUpdate = false;
         this.state = {
-            shouldSelectAfterUpdate: false,
             stepMaxPrecision: this.getStepMaxPrecision(props),
             value: this.getValueOrEmptyValue(props.value),
         };
@@ -256,7 +261,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
     }
 
     public componentDidUpdate() {
-        if (this.state.shouldSelectAfterUpdate) {
+        if (this.shouldSelectAfterUpdate) {
             this.inputElement.setSelectionRange(0, this.state.value.length);
         }
     }
@@ -359,14 +364,16 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
     // =================
 
     private handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-        this.setState({ isInputGroupFocused: true, shouldSelectAfterUpdate: this.props.selectAllOnFocus });
+        this.shouldSelectAfterUpdate = this.props.selectAllOnFocus;
+        this.setState({ isInputGroupFocused: true });
         Utils.safeInvoke(this.props.onFocus, e);
     }
 
     private handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         // explicitly set `shouldSelectAfterUpdate` to `false` to prevent focus
         // hoarding on IE11 (#704)
-        this.setState({ isInputGroupFocused: false, shouldSelectAfterUpdate: false });
+        this.shouldSelectAfterUpdate = false;
+        this.setState({ isInputGroupFocused: false });
         Utils.safeInvoke(this.props.onBlur, e);
     }
 
@@ -430,7 +437,8 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
             nextValue = value;
         }
 
-        this.setState({ shouldSelectAfterUpdate : false, value: nextValue });
+        this.shouldSelectAfterUpdate = false;
+        this.setState({ value: nextValue });
         this.invokeOnChangeCallbacks(nextValue);
     }
 
@@ -448,7 +456,8 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
         const currValue = this.state.value || NumericInput.VALUE_ZERO;
         const nextValue = this.getSanitizedValue(currValue, delta, this.props.min, this.props.max);
 
-        this.setState({ shouldSelectAfterUpdate : this.props.selectAllOnIncrement, value: nextValue });
+        this.shouldSelectAfterUpdate = this.props.selectAllOnIncrement;
+        this.setState({ value: nextValue });
         this.invokeOnChangeCallbacks(nextValue);
     }
 

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -159,7 +159,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
 
     private inputElement: HTMLInputElement;
 
-    // updating these flags need not trigger re-renders, so don't include them // in this.state.
+    // updating these flags need not trigger re-renders, so don't include them in this.state.
     private didPasteEventJustOccur = false;
     private shouldSelectAfterUpdate = false;
 

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -277,9 +277,12 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
     }
 
     protected validateProps(nextProps: HTMLInputProps & INumericInputProps) {
-        const { majorStepSize, max, min, minorStepSize, stepSize } = nextProps;
-        if (min && max && min >= max) {
+        const { clampValueOnBlur, majorStepSize, max, min, minorStepSize, stepSize } = nextProps;
+        if (min != null && max != null && min >= max) {
             throw new Error(Errors.NUMERIC_INPUT_MIN_MAX);
+        }
+        if (clampValueOnBlur && min == null && max == null) {
+            throw new Error(Errors.NUMERIC_INPUT_CLAMP_VALUE_ON_BLUR);
         }
         if (stepSize == null) {
             throw new Error(Errors.NUMERIC_INPUT_STEP_SIZE_NULL);

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -159,16 +159,12 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
 
     private inputElement: HTMLInputElement;
 
-    /**
-     * Updating these flags need not trigger re-renders, so don't include them in this.state.
-     */
-    private didPasteEventJustOccur: boolean;
-    private shouldSelectAfterUpdate: boolean;
+    // updating these flags need not trigger re-renders, so don't include them // in this.state.
+    private didPasteEventJustOccur = false;
+    private shouldSelectAfterUpdate = false;
 
     public constructor(props?: HTMLInputProps & INumericInputProps, context?: any) {
         super(props, context);
-
-        this.shouldSelectAfterUpdate = false;
         this.state = {
             stepMaxPrecision: this.getStepMaxPrecision(props),
             value: this.getValueOrEmptyValue(props.value),
@@ -277,12 +273,9 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
     }
 
     protected validateProps(nextProps: HTMLInputProps & INumericInputProps) {
-        const { clampValueOnBlur, majorStepSize, max, min, minorStepSize, stepSize } = nextProps;
+        const { majorStepSize, max, min, minorStepSize, stepSize } = nextProps;
         if (min != null && max != null && min >= max) {
             throw new Error(Errors.NUMERIC_INPUT_MIN_MAX);
-        }
-        if (clampValueOnBlur && min == null && max == null) {
-            throw new Error(Errors.NUMERIC_INPUT_CLAMP_VALUE_ON_BLUR);
         }
         if (stepSize == null) {
             throw new Error(Errors.NUMERIC_INPUT_STEP_SIZE_NULL);

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -736,12 +736,6 @@ describe("<NumericInput>", () => {
                 expect(onValueChange.calledOnce).to.be.true;
             });
 
-            it("throws an error if clampValueOnBlur=true but both min and max are not defined", () => {
-                // null and undefined should be treated identically when considering the error case
-                const mountFn = () => mount(<NumericInput clampValueOnBlur={true} max={null} />);
-                expect(mountFn).to.throw(Errors.NUMERIC_INPUT_CLAMP_VALUE_ON_BLUR);
-            });
-
             it("clamps an out-of-bounds value to min", () => {
                 const MIN = 0;
                 const component = mount(<NumericInput clampValueOnBlur={true} min={MIN} />);


### PR DESCRIPTION
#### Fixes #1044 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add `clampValueOnBlur: boolean` prop that defaults to `false` so as to not affect current `NumericInput` users.
- Invoke `onValueChange` with the clamped value if the value was clamped on blur.
- Throw error if `clampValueOnBlur={true}` but `min` and `max` are `null/undefined`.
- Add unit tests.
- Fix a few other suboptimalities in the `NumericInput` code.

#### Reviewers should focus on:

- The prop description. How does it look?
- Should this just be default behavior out of the box? Would prefer not, so that the basic `NumericInput` mimics `input[type="number"]` as closely as possible.
- Should we add a switch for `clampValueOnBlur` in the Basic Example in the docs?

#### Screenshot

Here's an example of clamping on blur when `min=0` and `max=10`:
![2017-05-02 14 15 26](https://cloud.githubusercontent.com/assets/443450/25639758/e8af0ad6-2f41-11e7-80c7-db788e57a9fe.gif)
_(Ignore the weird colors; they're an artifact of Gifox)_