### PR TITLE
[EditableText] only sets defaultValue on initial render

### DIFF
--- a/packages/core/examples/editableTextExample.tsx
+++ b/packages/core/examples/editableTextExample.tsx
@@ -5,6 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import * as classNames from "classnames";
 import * as React from "react";
 
 import { Classes, EditableText, Intent, NumericInput, Switch } from "@blueprintjs/core";
@@ -65,7 +66,7 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                     <label className={Classes.LABEL} htmlFor={INPUT_ID}>Max length</label>
                     <NumericInput
                         id={INPUT_ID}
-                        className={Classes.FORM_CONTENT}
+                        className={classNames(Classes.FORM_CONTENT, Classes.FILL)}
                         min={0}
                         max={300}
                         onValueChange={this.handleMaxLengthChange}
@@ -73,8 +74,7 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                         value={this.state.maxLength || ""}
                     />
                 </div>,
-            ],
-            [
+            ], [
                 <Switch
                     checked={this.state.selectAllOnFocus}
                     label="Select all on focus"
@@ -87,7 +87,6 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                     key="swap"
                     onChange={this.toggleSwap}
                 />,
-                <small key="note">Title field is uncontrolled; report is controlled.</small>,
             ],
         ];
     }

--- a/packages/core/examples/editableTextExample.tsx
+++ b/packages/core/examples/editableTextExample.tsx
@@ -7,9 +7,11 @@
 
 import * as React from "react";
 
-import { Classes, EditableText, Intent, Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, handleNumberChange, handleStringChange } from "@blueprintjs/docs";
+import { Classes, EditableText, Intent, NumericInput, Switch } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs";
 import { IntentSelect } from "./common/intentSelect";
+
+const INPUT_ID = "EditableTextExample-max-length";
 
 export interface IEditableTextExampleState {
     confirmOnEnterKey?: boolean;
@@ -17,7 +19,6 @@ export interface IEditableTextExampleState {
     maxLength?: number;
     report?: string;
     selectAllOnFocus?: boolean;
-    title?: string;
 }
 
 export class EditableTextExample extends BaseExample<IEditableTextExampleState> {
@@ -25,25 +26,9 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
         confirmOnEnterKey: false,
         report: "",
         selectAllOnFocus: false,
-        title: "",
     };
 
     private handleIntentChange = handleNumberChange((intent: Intent) => this.setState({ intent }));
-    private handleMaxLengthChange = handleStringChange((maxLengthInput: string) => {
-        const invalidMaxLength = (+maxLengthInput === 0 || isNaN(+maxLengthInput)) && (maxLengthInput.length !== 0);
-        if (invalidMaxLength) {
-            return;
-        }
-
-        if (maxLengthInput.length === 0) {
-            this.setState({ maxLength: undefined });
-        } else {
-            const maxLength = +maxLengthInput;
-            const report = this.state.report.slice(0, maxLength);
-            const title = this.state.title.slice(0, maxLength);
-            this.setState({ maxLength, report, title });
-        }
-    });
     private toggleSelectAll = handleBooleanChange((selectAllOnFocus) => this.setState({ selectAllOnFocus }));
     private toggleSwap = handleBooleanChange((confirmOnEnterKey) => this.setState({ confirmOnEnterKey }));
 
@@ -55,8 +40,6 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                     maxLength={this.state.maxLength}
                     placeholder="Edit title..."
                     selectAllOnFocus={this.state.selectAllOnFocus}
-                    value={this.state.title}
-                    onChange={this.handleTitleChange}
                 />
             </h1>
             <EditableText
@@ -65,7 +48,7 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                 maxLines={12}
                 minLines={3}
                 multiline
-                placeholder="Edit report..."
+                placeholder="Edit report... (controlled)"
                 selectAllOnFocus={this.state.selectAllOnFocus}
                 confirmOnEnterKey={this.state.confirmOnEnterKey}
                 value={this.state.report}
@@ -78,15 +61,20 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
         return [
             [
                 <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
-                <label className={Classes.LABEL} key="maxlength">
-                    Max length
-                    <input
-                        className={Classes.INPUT}
+                <div className={Classes.FORM_GROUP} key="maxlength">
+                    <label className={Classes.LABEL} htmlFor={INPUT_ID}>Max length</label>
+                    <NumericInput
+                        id={INPUT_ID}
+                        className={Classes.FORM_CONTENT}
+                        min={0}
+                        max={300}
+                        onValueChange={this.handleMaxLengthChange}
                         placeholder="Unlimited"
-                        onChange={this.handleMaxLengthChange}
-                        value={this.state.maxLength !== undefined ? this.state.maxLength.toString() : ""}
+                        value={this.state.maxLength || ""}
                     />
-                </label>,
+                </div>,
+            ],
+            [
                 <Switch
                     checked={this.state.selectAllOnFocus}
                     label="Select all on focus"
@@ -99,11 +87,18 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
                     key="swap"
                     onChange={this.toggleSwap}
                 />,
+                <small key="note">Title field is uncontrolled; report is controlled.</small>,
             ],
         ];
     }
 
     private handleReportChange = (report: string) => this.setState({ report });
-    private handleTitleChange = (title: string) => this.setState({ title });
-
+    private handleMaxLengthChange = (maxLength: number) => {
+        if (maxLength === 0) {
+            this.setState({ maxLength: undefined });
+        } else {
+            const report = this.state.report.slice(0, maxLength);
+            this.setState({ maxLength, report });
+        }
+    }
 }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -136,12 +136,13 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
     public constructor(props?: IEditableTextProps, context?: any) {
         super(props, context);
 
+        const value = (props.value == null) ? props.defaultValue : props.value;
         this.state = {
             inputHeight: 0,
             inputWidth: 0,
             isEditing: props.isEditing === true && props.disabled === false,
-            lastValue: getValue(props),
-            value: getValue(props),
+            lastValue: value,
+            value,
         };
     }
 
@@ -201,7 +202,10 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
     }
 
     public componentWillReceiveProps(nextProps: IEditableTextProps) {
-        const state: IEditableTextState = { value: getValue(nextProps) };
+        const state: IEditableTextState = {};
+        if (nextProps.value != null) {
+            state.value = nextProps.value;
+        }
         if (nextProps.isEditing != null)  {
             state.isEditing = nextProps.isEditing;
         }
@@ -327,10 +331,6 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
             }
         }
     }
-}
-
-function getValue(props: IEditableTextProps) {
-    return props.value == null ? props.defaultValue : props.value;
 }
 
 function getFontSize(element: HTMLElement) {

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -31,7 +31,7 @@ describe("<EditableText>", () => {
         assert.isFalse(editable.state("isEditing"));
     });
 
-    describe.only("when editing", () => {
+    describe("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");
             assert.lengthOf(input, 1);

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -31,7 +31,7 @@ describe("<EditableText>", () => {
         assert.isFalse(editable.state("isEditing"));
     });
 
-    describe("when editing", () => {
+    describe.only("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");
             assert.lengthOf(input, 1);
@@ -129,6 +129,15 @@ describe("<EditableText>", () => {
             expected = "hello world";
             wrapper.setProps({ value: expected });
             assert.strictEqual(inputElement.value, expected, "controlled mode should be changeable via props");
+        });
+
+        it("applies defaultValue only on initial render", () => {
+            const wrapper = mount(<EditableText isEditing defaultValue="default" placeholder="placeholder" />);
+            assert.strictEqual(wrapper.state("value"), "default");
+            // type new value, then change a prop to cause re-render
+            wrapper.find("input").simulate("change", { target: { value: "hello" } });
+            wrapper.setProps({ placeholder: "new placeholder" });
+            assert.strictEqual(wrapper.state("value"), "hello");
         });
 
         // TODO: does not work in Phantom, only in Chrome (input.selectionStart is also equal to 8)


### PR DESCRIPTION
#### Fixes #987

#### Changes proposed in this pull request:

- turns out uncontrolled usage _never worked in a big way_
- so i refactored the example such that Title is uncontrolled. now we have an example to test differences between the two modes.

#### Reviewers should focus on:

- note that `maxLength` affects the two inputs differently because there's some logic that trims the controlled state. try setting max length to something less than the length of both fields.

cc @dskiff