### PR TITLE
[Tabs2] clicking selected tab again fires onChange

### DIFF
--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -221,12 +221,9 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
     }
 
     private handleTabClick = (newTabId: TabId) => {
-        const { selectedTabId } = this.state;
-        if (newTabId !== selectedTabId) {
-            safeInvoke(this.props.onChange, newTabId, selectedTabId);
-            if (this.props.selectedTabId === undefined) {
-                this.setState({ selectedTabId: newTabId });
-            }
+        safeInvoke(this.props.onChange, newTabId, this.state.selectedTabId);
+        if (this.props.selectedTabId === undefined) {
+            this.setState({ selectedTabId: newTabId });
         }
     }
 

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -97,6 +97,17 @@ describe("<Tabs2>", () => {
         });
     });
 
+    it("clicking selected tab still fires onChange", () => {
+        const tabId = TAB_IDS[0];
+        const changeSpy = sinon.spy();
+        const wrapper = mount(
+            <Tabs2 defaultSelectedTabId={tabId} id={ID} onChange={changeSpy}>{getTabsContents()}</Tabs2>,
+            { attachTo: testsContainerElement },
+        );
+        findTabById(wrapper, tabId).simulate("click");
+        assert.isTrue(changeSpy.calledWith(tabId, tabId));
+    });
+
     it("clicking nested tab should not affect parent", () => {
         const changeSpy = sinon.spy();
         const wrapper = mount(


### PR DESCRIPTION
#### Fixes #1067 

cc @JKillian 

As easy as removing an `if` statement!