### PR TITLE
Missing parenthesis in popover doc

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -192,7 +192,7 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
      * enough room in the viewport. This is equivalent to:
      * ```
      * const tetherOptions = {
-     *     constraints: { attachment: "together", to: "scrollParent" },
+     *     constraints: [{ attachment: "together", to: "scrollParent" }]
      * };
      * ```
      * @default false


### PR DESCRIPTION
Because of depreciation of smart positioning option, looking at the doc and just copypaste the example could throw an error.


#### Checklist
- [x] Update documentation

#### Changes proposed in this pull request:

Add missing parenthesis in the tethering conf example


