### PR TITLE
[Table] Add resizeRowsByTallestCells to handle multi-column resize

### DIFF
--- a/packages/table/preview/index.html
+++ b/packages/table/preview/index.html
@@ -66,6 +66,8 @@
   <div class="resize-default pt-button pt-intent-success">Resize Default</div>
   <div class="resize-wrapped pt-button pt-intent-success">Resize Wrapped Text</div>
   <div class="resize-json-wrapped pt-button pt-intent-success">Resize Json Wrapped Text</div>
+  <div class="resize-wrapped-and-json pt-button pt-intent-success">Resize Wrapped and Json Text</div>
+  <div class="resize-viewport pt-button pt-intent-success">Resize Viewport</div>
   <br /><br />
 
   <h4>Editable Column Names and Cells</h4>

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -139,6 +139,12 @@ class FormatsTable extends React.Component<{}, {}> {
         document.querySelector(".resize-json-wrapped").addEventListener("click", () => {
             this.formatsTable.resizeRowsByTallestCell(3);
         });
+        document.querySelector(".resize-wrapped-and-json").addEventListener("click", () => {
+            this.formatsTable.resizeRowsByTallestCells([1, 3]);
+        });
+        document.querySelector(".resize-viewport").addEventListener("click", () => {
+            this.formatsTable.resizeRowsByTallestCells();
+        });
     }
 
     private renderDefaultCell = (row: number) => <Cell>{this.strings[row]}</Cell>;

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -140,10 +140,10 @@ class FormatsTable extends React.Component<{}, {}> {
             this.formatsTable.resizeRowsByTallestCell(3);
         });
         document.querySelector(".resize-wrapped-and-json").addEventListener("click", () => {
-            this.formatsTable.resizeRowsByTallestCells([1, 3]);
+            this.formatsTable.resizeRowsByTallestCell([1, 3]);
         });
         document.querySelector(".resize-viewport").addEventListener("click", () => {
-            this.formatsTable.resizeRowsByTallestCells();
+            this.formatsTable.resizeRowsByTallestCell();
         });
     }
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -513,6 +513,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.invalidateGrid();
         this.setState({ rowHeights });
     }
+
     /**
      * When the component mounts, the HTML Element refs will be available, so
      * we constructor the Locator, which queries the elements' bounding

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -490,33 +490,29 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     /**
-     * Resize rows based on a given set of column indices.
-     * If no indices are provided, default to using the columns that are currently in the viewport.
+     * Resize all rows in the table to the height of the tallest visible cell in the specified columns.
+     * If no indices are provided, default to using the tallest cell from all columns currently in view.
      */
-    public resizeRowsByTallestCells(columnIndices?: number[]) {
+    public resizeRowsByTallestCell(columnIndices?: number | number[]) {
         const { locator } = this.state;
         let tallest = 0;
-        if (columnIndices != null) {
-            const tallestByColumns = columnIndices.map((col) => locator.getTallestVisibleCellInColumn(col));
-            tallest = Math.max(...tallestByColumns);
-        } else {
-            // Use viewport columns
+        if (columnIndices == null) {
+            // Consider all columns currently in viewport
             const { grid } = this;
             const { viewportRect } = this.state;
             const viewportColumnIndices = grid.getColumnIndicesInRect(viewportRect);
             for (let col = viewportColumnIndices.columnIndexStart; col <= viewportColumnIndices.columnIndexEnd; col++) {
                 tallest = Math.max(tallest, locator.getTallestVisibleCellInColumn(col));
             }
+        } else {
+            const columnIndicesArray = Array.isArray(columnIndices) ? columnIndices : [columnIndices];
+            const tallestByColumns = columnIndicesArray.map((col) => locator.getTallestVisibleCellInColumn(col));
+            tallest = Math.max(...tallestByColumns);
         }
         const rowHeights = Array(this.state.rowHeights.length).fill(tallest);
         this.invalidateGrid();
         this.setState({ rowHeights });
     }
-
-    public resizeRowsByTallestCell(columnIndex: number) {
-        this.resizeRowsByTallestCells([columnIndex]);
-    }
-
     /**
      * When the component mounts, the HTML Element refs will be available, so
      * we constructor the Locator, which queries the elements' bounding

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -491,7 +491,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
     /**
      * Resize all rows in the table to the height of the tallest visible cell in the specified columns.
-     * If no indices are provided, default to using the tallest cell from all columns currently in view.
+     * If no indices are provided, default to using the tallest visible cell from all columns in view.
      */
     public resizeRowsByTallestCell(columnIndices?: number | number[]) {
         const { locator } = this.state;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -489,13 +489,32 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         );
     }
 
-    public resizeRowsByTallestCell(columnIndex: number) {
+    /**
+     * Resize rows based on a given set of column indices.
+     * If no indices are provided, default to using the columns that are currently in the viewport.
+     */
+    public resizeRowsByTallestCells(columnIndices?: number[]) {
         const { locator } = this.state;
-
-        const tallest = locator.getTallestVisibleCellInColumn(columnIndex);
+        let tallest = 0;
+        if (columnIndices != null) {
+            const tallestByColumns = columnIndices.map((col) => locator.getTallestVisibleCellInColumn(col));
+            tallest = Math.max(...tallestByColumns);
+        } else {
+            // Use viewport columns
+            const { grid } = this;
+            const { viewportRect } = this.state;
+            const viewportColumnIndices = grid.getColumnIndicesInRect(viewportRect);
+            for (let col = viewportColumnIndices.columnIndexStart; col <= viewportColumnIndices.columnIndexEnd; col++) {
+                tallest = Math.max(tallest, locator.getTallestVisibleCellInColumn(col));
+            }
+        }
         const rowHeights = Array(this.state.rowHeights.length).fill(tallest);
         this.invalidateGrid();
         this.setState({ rowHeights });
+    }
+
+    public resizeRowsByTallestCell(columnIndex: number) {
+        this.resizeRowsByTallestCells([columnIndex]);
     }
 
     /**

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -103,8 +103,11 @@ describe("<Table>", () => {
         rowHeaders.forEach((rowHeader) => expectCellLoading(rowHeader, CellType.ROW_HEADER));
     });
 
-    it("Gets and sets the tallest cell height in the table", () => {
-        const renderCell = () => <Cell wrapText={true}>my cell value with lots and lots of words</Cell>;
+    it("Gets and sets the tallest cell by columns correctly", () => {
+        const DEFAULT_RESIZE_HEIGHT = 30;
+        const MAX_HEIGHT = 40;
+        const renderCellLong = () => <Cell wrapText={true}>my cell value with lots and lots of words</Cell>;
+        const renderCellShort = () => <Cell wrapText={false}>short value</Cell>;
 
         let table: Table;
 
@@ -112,13 +115,30 @@ describe("<Table>", () => {
 
         harness.mount(
             <Table ref={saveTable} numRows={4}>
-                <Column name="Column0" renderCell={renderCell} />
-                <Column name="Column1" renderCell={renderCell} />
+                <Column name="Column0" renderCell={renderCellLong} />
+                <Column name="Column1" renderCell={renderCellShort} />
             </Table>,
         );
 
+        // Resize by first column
         table.resizeRowsByTallestCell(0);
-        expect(table.state.rowHeights[0]).to.equal(40);
+        expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
+
+        // Resize by second column
+        table.resizeRowsByTallestCell(1);
+        expect(table.state.rowHeights[0]).to.equal(DEFAULT_RESIZE_HEIGHT);
+
+        // Resize by both columns
+        table.resizeRowsByTallestCells([0, 1]);
+        expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
+
+        // Resize by second column via array
+        table.resizeRowsByTallestCells([1]);
+        expect(table.state.rowHeights[0]).to.equal(DEFAULT_RESIZE_HEIGHT);
+
+        // Resize by visible columns
+        table.resizeRowsByTallestCells();
+        expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
     });
 
     it("Selects all on click of upper-left corner", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -129,15 +129,15 @@ describe("<Table>", () => {
         expect(table.state.rowHeights[0]).to.equal(DEFAULT_RESIZE_HEIGHT);
 
         // Resize by both columns
-        table.resizeRowsByTallestCells([0, 1]);
+        table.resizeRowsByTallestCell([0, 1]);
         expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
 
         // Resize by second column via array
-        table.resizeRowsByTallestCells([1]);
+        table.resizeRowsByTallestCell([1]);
         expect(table.state.rowHeights[0]).to.equal(DEFAULT_RESIZE_HEIGHT);
 
         // Resize by visible columns
-        table.resizeRowsByTallestCells();
+        table.resizeRowsByTallestCell();
         expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
     });
 


### PR DESCRIPTION
#### Fixes #1070

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Add a method called `resizeRowsByTallestCells` that takes in an array of column indices to resize by a set of columns. If no array is provided, the method uses the columns in the viewport.

#### Screenshot

![table-resize](https://cloud.githubusercontent.com/assets/1463597/25906521/eb041222-3572-11e7-91fb-264acbc70836.gif)
