### PR TITLE
Prepare Release v1.17.0

### DIFF
--- a/docs/blueprint-landing.css
+++ b/docs/blueprint-landing.css
@@ -7013,7 +7013,6 @@ header {
     margin-bottom: 100px;
     box-shadow: inset 0 -1px 0 rgba(16, 22, 26, 0.1);
     background: #ffffff;
-    background-image: -webkit-linear-gradient(left, #ffffff, #ebf1f5);
     background-image: linear-gradient(to right, #ffffff, #ebf1f5);
     overflow: hidden;
     padding: 90px 0; }
@@ -7067,7 +7066,6 @@ header {
 .pt-getting-started {
   position: relative;
   box-shadow: 0 1px 0 rgba(16, 22, 26, 0.8);
-  background-image: -webkit-radial-gradient(ellipse farthest-side at center -300px, rgba(32, 43, 51, 0) 0%, #202b33 100%);
   background-image: radial-gradient(ellipse farthest-side at center -300px, rgba(32, 43, 51, 0) 0%, #202b33 100%);
   padding: 90px 0; }
   .pt-getting-started::before, .pt-getting-started::after {
@@ -7121,7 +7119,6 @@ header {
 
 .pt-about {
   background-color: #182026;
-  background-image: -webkit-radial-gradient(ellipse farthest-side at center 700px, #182026 0%, #10161a 100%);
   background-image: radial-gradient(ellipse farthest-side at center 700px, #182026 0%, #10161a 100%);
   padding: 90px 0 0;
   text-align: center; }
@@ -7154,7 +7151,6 @@ header {
   text-align: left; }
   .pt-copyright::before {
     display: block;
-    background-image: -webkit-linear-gradient(left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.3) 50%, rgba(255, 255, 255, 0) 100%);
     background-image: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.3) 50%, rgba(255, 255, 255, 0) 100%);
     height: 1px;
     content: ""; }
@@ -7182,7 +7178,6 @@ header {
     padding-bottom: 80px; }
     .pt-info .pt-description {
       margin-bottom: 80px;
-      background-image: -webkit-linear-gradient(top, #ffffff, #ebf1f5);
       background-image: linear-gradient(to bottom, #ffffff, #ebf1f5);
       padding-top: 50px;
       padding-bottom: 250px; }

--- a/docs/blueprint-landing.css
+++ b/docs/blueprint-landing.css
@@ -4824,38 +4824,48 @@ label.pt-label {
   .pt-disabled.pt-select::after {
     color: rgba(92, 112, 128, 0.5); }
 
-.pt-numeric-input .pt-button-group.pt-vertical > .pt-button {
-  min-width: 30px;
-  min-height: 30px;
-  line-height: 30px;
-  display: block;
-  min-height: 15px;
-  line-height: 15px; }
-  .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
-    border-radius: 0 3px 0 0;
-    height: 16px; }
-  .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
-    border-radius: 0 0 3px 0;
-    height: 15px; }
-  .pt-numeric-input .pt-button-group.pt-vertical > .pt-button[class*="pt-icon-"]::before {
-    display: block;
-    height: 14px;
-    overflow: hidden;
-    line-height: 14px; }
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
+  min-height: 16px; }
 
-.pt-numeric-input .pt-button-group:first-child.pt-vertical > .pt-button:first-child {
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
+  min-height: 15px; }
+
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
+  border-radius: 0 3px 0 0; }
+
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
+  border-radius: 0 0 3px 0; }
+
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button[class*="pt-icon-"]::before {
+  display: block;
+  height: 14px;
+  overflow: hidden;
+  line-height: 14px; }
+
+.pt-numeric-input .pt-button-group.pt-vertical:first-child > .pt-button:first-child {
   border-radius: 3px 0 0 0; }
 
-.pt-numeric-input .pt-button-group:first-child.pt-vertical > .pt-button:last-child {
+.pt-numeric-input .pt-button-group.pt-vertical:first-child > .pt-button:last-child {
   border-radius: 0 0 0 3px; }
 
+.pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:first-child {
+  min-height: 21px; }
+
+.pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:last-child {
+  min-height: 20px; }
+
 .pt-dark .pt-numeric-input .pt-button-group.pt-vertical > .pt-button {
-  min-height: 14px;
   line-height: 14px; }
   .pt-dark .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
-    height: 15px; }
+    min-height: 15px; }
   .pt-dark .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
-    height: 14px; }
+    min-height: 14px; }
+
+.pt-dark .pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:first-child {
+  min-height: 20px; }
+
+.pt-dark .pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:last-child {
+  min-height: 19px; }
 
 form {
   display: block; }

--- a/docs/blueprint-landing.js
+++ b/docs/blueprint-landing.js
@@ -29663,12 +29663,13 @@
 	        }
 	    };
 	    NumericInput.prototype.render = function () {
-	        var _a = this.props, buttonPosition = _a.buttonPosition, className = _a.className;
+	        var _a = this.props, buttonPosition = _a.buttonPosition, className = _a.className, large = _a.large;
 	        var inputGroupHtmlProps = common_1.removeNonHTMLProps(this.props, [
 	            "allowNumericCharactersOnly",
 	            "buttonPosition",
 	            "clampValueOnBlur",
 	            "className",
+	            "large",
 	            "majorStepSize",
 	            "minorStepSize",
 	            "onValueChange",
@@ -29676,7 +29677,7 @@
 	            "selectAllOnIncrement",
 	            "stepSize",
 	        ], true);
-	        var inputGroup = (React.createElement(inputGroup_1.InputGroup, tslib_1.__assign({}, inputGroupHtmlProps, { intent: this.props.intent, inputRef: this.inputRef, key: "input-group", leftIconName: this.props.leftIconName, onFocus: this.handleInputFocus, onBlur: this.handleInputBlur, onChange: this.handleInputChange, onKeyDown: this.handleInputKeyDown, onKeyPress: this.handleInputKeyPress, onPaste: this.handleInputPaste, value: this.state.value })));
+	        var inputGroup = (React.createElement(inputGroup_1.InputGroup, tslib_1.__assign({}, inputGroupHtmlProps, { className: classNames((_b = {}, _b[common_1.Classes.LARGE] = large, _b)), intent: this.props.intent, inputRef: this.inputRef, key: "input-group", leftIconName: this.props.leftIconName, onFocus: this.handleInputFocus, onBlur: this.handleInputBlur, onChange: this.handleInputChange, onKeyDown: this.handleInputKeyDown, onKeyPress: this.handleInputKeyPress, onPaste: this.handleInputPaste, value: this.state.value })));
 	        // the strict null check here is intentional; an undefined value should
 	        // fall back to the default button position on the right side.
 	        if (buttonPosition === "none" || buttonPosition === null) {
@@ -29695,8 +29696,12 @@
 	            var inputElems = (buttonPosition === common_1.Position.LEFT)
 	                ? [buttonGroup, inputGroup]
 	                : [inputGroup, buttonGroup];
-	            return (React.createElement("div", { className: classNames(common_1.Classes.NUMERIC_INPUT, common_1.Classes.CONTROL_GROUP, className) }, inputElems));
+	            var classes = classNames(common_1.Classes.NUMERIC_INPUT, common_1.Classes.CONTROL_GROUP, (_c = {},
+	                _c[common_1.Classes.LARGE] = large,
+	                _c), className);
+	            return (React.createElement("div", { className: classes }, inputElems));
 	        }
+	        var _b, _c;
 	    };
 	    NumericInput.prototype.componentDidUpdate = function () {
 	        if (this.shouldSelectAfterUpdate) {
@@ -29843,6 +29848,7 @@
 	    allowNumericCharactersOnly: true,
 	    buttonPosition: common_1.Position.RIGHT,
 	    clampValueOnBlur: false,
+	    large: false,
 	    majorStepSize: 10,
 	    minorStepSize: 0.1,
 	    selectAllOnFocus: false,

--- a/docs/blueprint-landing.js
+++ b/docs/blueprint-landing.js
@@ -94,9 +94,9 @@
 	"use strict";
 	var core_1 = __webpack_require__(17);
 	core_1.FocusStyleManager.onlyShowFocusOnTabs();
-	var Logo = __webpack_require__(288);
+	var Logo = __webpack_require__(290);
 	Logo.init(document.querySelector("header canvas.pt-logo"), document.querySelector("header canvas.pt-logo-background"));
-	var SVGs = __webpack_require__(289);
+	var SVGs = __webpack_require__(291);
 	SVGs.init(document.querySelector(".pt-wireframes"));
 	var copyright = ".pt-copyright .pt-container > div:first-child";
 	document.querySelector(copyright).innerHTML = "\u00A9 2014\u2013" + new Date().getFullYear() + " Palantir Technologies";
@@ -120,9 +120,9 @@
 	__export(__webpack_require__(18));
 	__export(__webpack_require__(21));
 	__export(__webpack_require__(68));
-	var iconClasses_1 = __webpack_require__(286);
+	var iconClasses_1 = __webpack_require__(288);
 	exports.IconClasses = iconClasses_1.IconClasses;
-	var iconStrings_1 = __webpack_require__(287);
+	var iconStrings_1 = __webpack_require__(289);
 	exports.IconContents = iconStrings_1.IconContents;
 
 	//# sourceMappingURL=index.js.map
@@ -390,6 +390,7 @@
 	var __values;
 	var __read;
 	var __spread;
+	var __await;
 	var __asyncGenerator;
 	var __asyncDelegator;
 	var __asyncValues;
@@ -527,24 +528,26 @@
 	        return ar;
 	    };
 
+	    __await = function (v) {
+	        return this instanceof __await ? (this.v = v, this) : new __await(v);
+	    };
+
 	    __asyncGenerator = function (thisArg, _arguments, generator) {
 	        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
-	        var g = generator.apply(thisArg, _arguments || []), q = [], c, i;
-	        return i = { next: verb("next"), "throw": verb("throw"), "return": verb("return") }, i[Symbol.asyncIterator] = function () { return this; }, i;
-	        function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
-	        function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
-	        function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-	        function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
-	        function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+	        var g = generator.apply(thisArg, _arguments || []), i, q = [];
+	        return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+	        function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+	        function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+	        function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
 	        function fulfill(value) { resume("next", value); }
 	        function reject(value) { resume("throw", value); }
-	        function settle(f, v) { c = void 0, f(v), next(); }
+	        function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
 	    };
 
 	    __asyncDelegator = function (o) {
-	        var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
-	        return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-	        function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+	        var i, p;
+	        return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+	        function verb(n) { if (o[n]) i[n] = function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : v; }; }
 	    };
 
 	    __asyncValues = function (o) {
@@ -565,6 +568,7 @@
 	    exporter("__values", __values);
 	    exporter("__read", __read);
 	    exporter("__spread", __spread);
+	    exporter("__await", __await);
 	    exporter("__asyncGenerator", __asyncGenerator);
 	    exporter("__asyncDelegator", __asyncDelegator);
 	    exporter("__asyncValues", __asyncValues);
@@ -863,6 +867,10 @@
 	process.removeListener = noop;
 	process.removeAllListeners = noop;
 	process.emit = noop;
+	process.prependListener = noop;
+	process.prependOnceListener = noop;
+
+	process.listeners = function (name) { return [] }
 
 	process.binding = function (name) {
 	    throw new Error('process.binding is not supported');
@@ -5541,46 +5549,46 @@
 	}
 	var contextMenu = __webpack_require__(70);
 	exports.ContextMenu = contextMenu;
-	__export(__webpack_require__(238));
-	__export(__webpack_require__(243));
-	__export(__webpack_require__(239));
-	__export(__webpack_require__(244));
+	__export(__webpack_require__(240));
 	__export(__webpack_require__(245));
-	__export(__webpack_require__(248));
-	__export(__webpack_require__(242));
-	__export(__webpack_require__(249));
-	__export(__webpack_require__(252));
-	__export(__webpack_require__(253));
+	__export(__webpack_require__(241));
+	__export(__webpack_require__(246));
+	__export(__webpack_require__(247));
+	__export(__webpack_require__(250));
+	__export(__webpack_require__(244));
+	__export(__webpack_require__(251));
 	__export(__webpack_require__(254));
 	__export(__webpack_require__(255));
 	__export(__webpack_require__(256));
-	__export(__webpack_require__(246));
-	__export(__webpack_require__(263));
-	__export(__webpack_require__(247));
-	__export(__webpack_require__(264));
-	__export(__webpack_require__(221));
+	__export(__webpack_require__(257));
+	__export(__webpack_require__(258));
+	__export(__webpack_require__(248));
 	__export(__webpack_require__(265));
-	__export(__webpack_require__(217));
+	__export(__webpack_require__(249));
 	__export(__webpack_require__(266));
-	__export(__webpack_require__(235));
+	__export(__webpack_require__(221));
 	__export(__webpack_require__(267));
+	__export(__webpack_require__(217));
 	__export(__webpack_require__(268));
+	__export(__webpack_require__(237));
 	__export(__webpack_require__(269));
-	__export(__webpack_require__(272));
-	__export(__webpack_require__(241));
-	__export(__webpack_require__(273));
+	__export(__webpack_require__(270));
+	__export(__webpack_require__(271));
 	__export(__webpack_require__(274));
+	__export(__webpack_require__(243));
 	__export(__webpack_require__(275));
 	__export(__webpack_require__(276));
 	__export(__webpack_require__(277));
 	__export(__webpack_require__(278));
 	__export(__webpack_require__(279));
+	__export(__webpack_require__(280));
 	__export(__webpack_require__(281));
-	__export(__webpack_require__(282));
 	__export(__webpack_require__(283));
-	__export(__webpack_require__(236));
 	__export(__webpack_require__(284));
 	__export(__webpack_require__(285));
+	__export(__webpack_require__(238));
+	__export(__webpack_require__(286));
+	__export(__webpack_require__(287));
 
 	//# sourceMappingURL=index.js.map
 
@@ -24145,8 +24153,8 @@
 	var TetherUtils = __webpack_require__(65);
 	var Utils = __webpack_require__(59);
 	var overlay_1 = __webpack_require__(221);
-	var tooltip_1 = __webpack_require__(236);
-	var Arrows = __webpack_require__(237);
+	var tooltip_1 = __webpack_require__(238);
+	var Arrows = __webpack_require__(239);
 	var SVG_SHADOW_PATH = "M8.11 6.302c1.015-.936 1.887-2.922 1.887-4.297v26c0-1.378" +
 	    "-.868-3.357-1.888-4.297L.925 17.09c-1.237-1.14-1.233-3.034 0-4.17L8.11 6.302z";
 	var SVG_ARROW_PATH = "M8.787 7.036c1.22-1.125 2.21-3.376 2.21-5.03V0v30-2.005" +
@@ -26487,7 +26495,7 @@
 	var Classes = __webpack_require__(66);
 	var Keys = __webpack_require__(67);
 	var utils_1 = __webpack_require__(59);
-	var portal_1 = __webpack_require__(235);
+	var portal_1 = __webpack_require__(237);
 	var Overlay = Overlay_1 = (function (_super) {
 	    tslib_1.__extends(Overlay, _super);
 	    function Overlay(props, context) {
@@ -26689,25 +26697,31 @@
 /* 222 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(223);
-
-/***/ },
-/* 223 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
 	'use strict';
 
-	var _assign = __webpack_require__(27);
+	exports.__esModule = true;
+
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+	var _react = __webpack_require__(24);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _propTypes = __webpack_require__(223);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _TransitionGroup = __webpack_require__(225);
+
+	var _TransitionGroup2 = _interopRequireDefault(_TransitionGroup);
+
+	var _CSSTransitionGroupChild = __webpack_require__(229);
+
+	var _CSSTransitionGroupChild2 = _interopRequireDefault(_CSSTransitionGroupChild);
+
+	var _PropTypes = __webpack_require__(236);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -26715,55 +26729,37 @@
 
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	var React = __webpack_require__(25);
-	var propTypesFactory = __webpack_require__(53);
-	var PropTypes = propTypesFactory(React.isValidElement);
+	var propTypes = {
+	  transitionName: _PropTypes.nameShape.isRequired,
 
-	var ReactTransitionGroup = __webpack_require__(224);
-	var ReactCSSTransitionGroupChild = __webpack_require__(227);
+	  transitionAppear: _propTypes2.default.bool,
+	  transitionEnter: _propTypes2.default.bool,
+	  transitionLeave: _propTypes2.default.bool,
+	  transitionAppearTimeout: (0, _PropTypes.transitionTimeout)('Appear'),
+	  transitionEnterTimeout: (0, _PropTypes.transitionTimeout)('Enter'),
+	  transitionLeaveTimeout: (0, _PropTypes.transitionTimeout)('Leave')
+	};
 
-	function createTransitionTimeoutPropValidator(transitionType) {
-	  var timeoutPropName = 'transition' + transitionType + 'Timeout';
-	  var enabledPropName = 'transition' + transitionType;
+	var defaultProps = {
+	  transitionAppear: false,
+	  transitionEnter: true,
+	  transitionLeave: true
+	};
 
-	  return function (props) {
-	    // If the transition is enabled
-	    if (props[enabledPropName]) {
-	      // If no timeout duration is provided
-	      if (props[timeoutPropName] == null) {
-	        return new Error(timeoutPropName + ' wasn\'t supplied to ReactCSSTransitionGroup: ' + 'this can cause unreliable animations and won\'t be supported in ' + 'a future version of React. See ' + 'https://fb.me/react-animation-transition-group-timeout for more ' + 'information.');
+	var CSSTransitionGroup = function (_React$Component) {
+	  _inherits(CSSTransitionGroup, _React$Component);
 
-	        // If the duration isn't a number
-	      } else if (typeof props[timeoutPropName] !== 'number') {
-	        return new Error(timeoutPropName + ' must be a number (in milliseconds)');
-	      }
-	    }
-	  };
-	}
-
-	/**
-	 * An easy way to perform CSS transitions and animations when a React component
-	 * enters or leaves the DOM.
-	 * See https://facebook.github.io/react/docs/animation.html#high-level-api-reactcsstransitiongroup
-	 */
-
-	var ReactCSSTransitionGroup = function (_React$Component) {
-	  _inherits(ReactCSSTransitionGroup, _React$Component);
-
-	  function ReactCSSTransitionGroup() {
+	  function CSSTransitionGroup() {
 	    var _temp, _this, _ret;
 
-	    _classCallCheck(this, ReactCSSTransitionGroup);
+	    _classCallCheck(this, CSSTransitionGroup);
 
 	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 	      args[_key] = arguments[_key];
 	    }
 
 	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this._wrapChild = function (child) {
-	      // We need to provide this childFactory so that
-	      // ReactCSSTransitionGroupChild can receive updates to name, enter, and
-	      // leave while it is leaving.
-	      return React.createElement(ReactCSSTransitionGroupChild, {
+	      return _react2.default.createElement(_CSSTransitionGroupChild2.default, {
 	        name: _this.props.transitionName,
 	        appear: _this.props.transitionAppear,
 	        enter: _this.props.transitionEnter,
@@ -26775,32 +26771,63 @@
 	    }, _temp), _possibleConstructorReturn(_this, _ret);
 	  }
 
-	  ReactCSSTransitionGroup.prototype.render = function render() {
-	    return React.createElement(ReactTransitionGroup, _assign({}, this.props, { childFactory: this._wrapChild }));
+	  // We need to provide this childFactory so that
+	  // ReactCSSTransitionGroupChild can receive updates to name, enter, and
+	  // leave while it is leaving.
+
+
+	  CSSTransitionGroup.prototype.render = function render() {
+	    return _react2.default.createElement(_TransitionGroup2.default, _extends({}, this.props, { childFactory: this._wrapChild }));
 	  };
 
-	  return ReactCSSTransitionGroup;
-	}(React.Component);
+	  return CSSTransitionGroup;
+	}(_react2.default.Component);
 
-	ReactCSSTransitionGroup.displayName = 'ReactCSSTransitionGroup';
-	ReactCSSTransitionGroup.propTypes = {
-	  transitionName: ReactCSSTransitionGroupChild.propTypes.name,
-
-	  transitionAppear: PropTypes.bool,
-	  transitionEnter: PropTypes.bool,
-	  transitionLeave: PropTypes.bool,
-	  transitionAppearTimeout: createTransitionTimeoutPropValidator('Appear'),
-	  transitionEnterTimeout: createTransitionTimeoutPropValidator('Enter'),
-	  transitionLeaveTimeout: createTransitionTimeoutPropValidator('Leave')
-	};
-	ReactCSSTransitionGroup.defaultProps = {
-	  transitionAppear: false,
-	  transitionEnter: true,
-	  transitionLeave: true
-	};
+	CSSTransitionGroup.displayName = 'CSSTransitionGroup';
 
 
-	module.exports = ReactCSSTransitionGroup;
+	CSSTransitionGroup.propTypes = propTypes;
+	CSSTransitionGroup.defaultProps = defaultProps;
+
+	exports.default = CSSTransitionGroup;
+	module.exports = exports['default'];
+
+/***/ },
+/* 223 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 */
+
+	if (process.env.NODE_ENV !== 'production') {
+	  var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
+	    Symbol.for &&
+	    Symbol.for('react.element')) ||
+	    0xeac7;
+
+	  var isValidElement = function(object) {
+	    return typeof object === 'object' &&
+	      object !== null &&
+	      object.$$typeof === REACT_ELEMENT_TYPE;
+	  };
+
+	  // By explicitly using `prop-types` you are opting into new development behavior.
+	  // http://fb.me/prop-types-in-prod
+	  var throwOnDirectAccess = true;
+	  module.exports = __webpack_require__(54)(isValidElement, throwOnDirectAccess);
+	} else {
+	  // By explicitly using `prop-types` you are opting into new production behavior.
+	  // http://fb.me/prop-types-in-prod
+	  module.exports = __webpack_require__(224)();
+	}
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
 
 /***/ },
 /* 224 */
@@ -26813,12 +26840,84 @@
 	 * This source code is licensed under the BSD-style license found in the
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
 	 */
 
 	'use strict';
 
-	var _assign = __webpack_require__(27);
+	var emptyFunction = __webpack_require__(35);
+	var invariant = __webpack_require__(31);
+
+	module.exports = function() {
+	  // Important!
+	  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
+	  function shim() {
+	    invariant(
+	      false,
+	      'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+	      'Use PropTypes.checkPropTypes() to call them. ' +
+	      'Read more at http://fb.me/use-check-prop-types'
+	    );
+	  };
+	  shim.isRequired = shim;
+	  function getShim() {
+	    return shim;
+	  };
+	  var ReactPropTypes = {
+	    array: shim,
+	    bool: shim,
+	    func: shim,
+	    number: shim,
+	    object: shim,
+	    string: shim,
+	    symbol: shim,
+
+	    any: shim,
+	    arrayOf: getShim,
+	    element: shim,
+	    instanceOf: getShim,
+	    node: shim,
+	    objectOf: getShim,
+	    oneOf: getShim,
+	    oneOfType: getShim,
+	    shape: getShim
+	  };
+
+	  ReactPropTypes.checkPropTypes = emptyFunction;
+	  ReactPropTypes.PropTypes = ReactPropTypes;
+
+	  return ReactPropTypes;
+	};
+
+
+/***/ },
+/* 225 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
+
+	exports.__esModule = true;
+
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+	var _chainFunction = __webpack_require__(226);
+
+	var _chainFunction2 = _interopRequireDefault(_chainFunction);
+
+	var _react = __webpack_require__(24);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _propTypes = __webpack_require__(223);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _warning = __webpack_require__(227);
+
+	var _warning2 = _interopRequireDefault(_warning);
+
+	var _ChildMapping = __webpack_require__(228);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -26826,87 +26925,87 @@
 
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	var React = __webpack_require__(25);
-	var ReactTransitionChildMapping = __webpack_require__(225);
+	var propTypes = {
+	  component: _propTypes2.default.any,
+	  childFactory: _propTypes2.default.func,
+	  children: _propTypes2.default.node
+	};
 
-	var propTypesFactory = __webpack_require__(53);
-	var PropTypes = propTypesFactory(React.isValidElement);
+	var defaultProps = {
+	  component: 'span',
+	  childFactory: function childFactory(child) {
+	    return child;
+	  }
+	};
 
-	var emptyFunction = __webpack_require__(35);
+	var TransitionGroup = function (_React$Component) {
+	  _inherits(TransitionGroup, _React$Component);
 
-	/**
-	 * A basis for animations. When children are declaratively added or removed,
-	 * special lifecycle hooks are called.
-	 * See https://facebook.github.io/react/docs/animation.html#low-level-api-reacttransitiongroup
-	 */
+	  function TransitionGroup(props, context) {
+	    _classCallCheck(this, TransitionGroup);
 
-	var ReactTransitionGroup = function (_React$Component) {
-	  _inherits(ReactTransitionGroup, _React$Component);
+	    var _this = _possibleConstructorReturn(this, _React$Component.call(this, props, context));
 
-	  function ReactTransitionGroup() {
-	    var _temp, _this, _ret;
-
-	    _classCallCheck(this, ReactTransitionGroup);
-
-	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-	      args[_key] = arguments[_key];
-	    }
-
-	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.state = {
-	      // TODO: can we get useful debug information to show at this point?
-	      children: ReactTransitionChildMapping.getChildMapping(_this.props.children)
-	    }, _this.performAppear = function (key) {
+	    _this.performAppear = function (key) {
 	      _this.currentlyTransitioningKeys[key] = true;
 
-	      var component = _this.refs[key];
+	      var component = _this.childRefs[key];
 
 	      if (component.componentWillAppear) {
 	        component.componentWillAppear(_this._handleDoneAppearing.bind(_this, key));
 	      } else {
 	        _this._handleDoneAppearing(key);
 	      }
-	    }, _this._handleDoneAppearing = function (key) {
-	      var component = _this.refs[key];
-	      if (component.componentDidAppear) {
+	    };
+
+	    _this._handleDoneAppearing = function (key) {
+	      var component = _this.childRefs[key];
+	      if (component && component.componentDidAppear) {
 	        component.componentDidAppear();
 	      }
 
 	      delete _this.currentlyTransitioningKeys[key];
 
-	      var currentChildMapping = ReactTransitionChildMapping.getChildMapping(_this.props.children);
+	      var currentChildMapping = (0, _ChildMapping.getChildMapping)(_this.props.children);
 
 	      if (!currentChildMapping || !currentChildMapping.hasOwnProperty(key)) {
 	        // This was removed before it had fully appeared. Remove it.
 	        _this.performLeave(key);
 	      }
-	    }, _this.performEnter = function (key) {
+	    };
+
+	    _this.performEnter = function (key) {
 	      _this.currentlyTransitioningKeys[key] = true;
 
-	      var component = _this.refs[key];
+	      var component = _this.childRefs[key];
 
 	      if (component.componentWillEnter) {
 	        component.componentWillEnter(_this._handleDoneEntering.bind(_this, key));
 	      } else {
 	        _this._handleDoneEntering(key);
 	      }
-	    }, _this._handleDoneEntering = function (key) {
-	      var component = _this.refs[key];
-	      if (component.componentDidEnter) {
+	    };
+
+	    _this._handleDoneEntering = function (key) {
+	      var component = _this.childRefs[key];
+	      if (component && component.componentDidEnter) {
 	        component.componentDidEnter();
 	      }
 
 	      delete _this.currentlyTransitioningKeys[key];
 
-	      var currentChildMapping = ReactTransitionChildMapping.getChildMapping(_this.props.children);
+	      var currentChildMapping = (0, _ChildMapping.getChildMapping)(_this.props.children);
 
 	      if (!currentChildMapping || !currentChildMapping.hasOwnProperty(key)) {
 	        // This was removed before it had fully entered. Remove it.
 	        _this.performLeave(key);
 	      }
-	    }, _this.performLeave = function (key) {
+	    };
+
+	    _this.performLeave = function (key) {
 	      _this.currentlyTransitioningKeys[key] = true;
 
-	      var component = _this.refs[key];
+	      var component = _this.childRefs[key];
 	      if (component.componentWillLeave) {
 	        component.componentWillLeave(_this._handleDoneLeaving.bind(_this, key));
 	      } else {
@@ -26915,37 +27014,46 @@
 	        // is done.
 	        _this._handleDoneLeaving(key);
 	      }
-	    }, _this._handleDoneLeaving = function (key) {
-	      var component = _this.refs[key];
+	    };
 
-	      if (component.componentDidLeave) {
+	    _this._handleDoneLeaving = function (key) {
+	      var component = _this.childRefs[key];
+
+	      if (component && component.componentDidLeave) {
 	        component.componentDidLeave();
 	      }
 
 	      delete _this.currentlyTransitioningKeys[key];
 
-	      var currentChildMapping = ReactTransitionChildMapping.getChildMapping(_this.props.children);
+	      var currentChildMapping = (0, _ChildMapping.getChildMapping)(_this.props.children);
 
 	      if (currentChildMapping && currentChildMapping.hasOwnProperty(key)) {
 	        // This entered again before it fully left. Add it again.
 	        _this.performEnter(key);
 	      } else {
 	        _this.setState(function (state) {
-	          var newChildren = _assign({}, state.children);
+	          var newChildren = _extends({}, state.children);
 	          delete newChildren[key];
 	          return { children: newChildren };
 	        });
 	      }
-	    }, _temp), _possibleConstructorReturn(_this, _ret);
+	    };
+
+	    _this.childRefs = Object.create(null);
+
+	    _this.state = {
+	      children: (0, _ChildMapping.getChildMapping)(props.children)
+	    };
+	    return _this;
 	  }
 
-	  ReactTransitionGroup.prototype.componentWillMount = function componentWillMount() {
+	  TransitionGroup.prototype.componentWillMount = function componentWillMount() {
 	    this.currentlyTransitioningKeys = {};
 	    this.keysToEnter = [];
 	    this.keysToLeave = [];
 	  };
 
-	  ReactTransitionGroup.prototype.componentDidMount = function componentDidMount() {
+	  TransitionGroup.prototype.componentDidMount = function componentDidMount() {
 	    var initialChildMapping = this.state.children;
 	    for (var key in initialChildMapping) {
 	      if (initialChildMapping[key]) {
@@ -26954,34 +27062,32 @@
 	    }
 	  };
 
-	  ReactTransitionGroup.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
-	    var nextChildMapping = ReactTransitionChildMapping.getChildMapping(nextProps.children);
+	  TransitionGroup.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
+	    var nextChildMapping = (0, _ChildMapping.getChildMapping)(nextProps.children);
 	    var prevChildMapping = this.state.children;
 
 	    this.setState({
-	      children: ReactTransitionChildMapping.mergeChildMappings(prevChildMapping, nextChildMapping)
+	      children: (0, _ChildMapping.mergeChildMappings)(prevChildMapping, nextChildMapping)
 	    });
 
-	    var key;
-
-	    for (key in nextChildMapping) {
+	    for (var key in nextChildMapping) {
 	      var hasPrev = prevChildMapping && prevChildMapping.hasOwnProperty(key);
 	      if (nextChildMapping[key] && !hasPrev && !this.currentlyTransitioningKeys[key]) {
 	        this.keysToEnter.push(key);
 	      }
 	    }
 
-	    for (key in prevChildMapping) {
-	      var hasNext = nextChildMapping && nextChildMapping.hasOwnProperty(key);
-	      if (prevChildMapping[key] && !hasNext && !this.currentlyTransitioningKeys[key]) {
-	        this.keysToLeave.push(key);
+	    for (var _key in prevChildMapping) {
+	      var hasNext = nextChildMapping && nextChildMapping.hasOwnProperty(_key);
+	      if (prevChildMapping[_key] && !hasNext && !this.currentlyTransitioningKeys[_key]) {
+	        this.keysToLeave.push(_key);
 	      }
 	    }
 
 	    // If we want to someday check for reordering, we could do it here.
 	  };
 
-	  ReactTransitionGroup.prototype.componentDidUpdate = function componentDidUpdate() {
+	  TransitionGroup.prototype.componentDidUpdate = function componentDidUpdate() {
 	    var keysToEnter = this.keysToEnter;
 	    this.keysToEnter = [];
 	    keysToEnter.forEach(this.performEnter);
@@ -26991,24 +27097,50 @@
 	    keysToLeave.forEach(this.performLeave);
 	  };
 
-	  ReactTransitionGroup.prototype.render = function render() {
+	  TransitionGroup.prototype.render = function render() {
+	    var _this2 = this;
+
 	    // TODO: we could get rid of the need for the wrapper node
 	    // by cloning a single child
 	    var childrenToRender = [];
-	    for (var key in this.state.children) {
-	      var child = this.state.children[key];
+
+	    var _loop = function _loop(key) {
+	      var child = _this2.state.children[key];
 	      if (child) {
+	        var isCallbackRef = typeof child.ref !== 'string';
+	        var factoryChild = _this2.props.childFactory(child);
+	        var ref = function ref(r) {
+	          _this2.childRefs[key] = r;
+	        };
+
+	        process.env.NODE_ENV !== 'production' ? (0, _warning2.default)(isCallbackRef, 'string refs are not supported on children of TransitionGroup and will be ignored. ' + 'Please use a callback ref instead: https://facebook.github.io/react/docs/refs-and-the-dom.html#the-ref-callback-attribute') : void 0;
+
+	        // Always chaining the refs leads to problems when the childFactory
+	        // wraps the child. The child ref callback gets called twice with the
+	        // wrapper and the child. So we only need to chain the ref if the
+	        // factoryChild is not different from child.
+	        if (factoryChild === child && isCallbackRef) {
+	          ref = (0, _chainFunction2.default)(child.ref, ref);
+	        }
+
 	        // You may need to apply reactive updates to a child as it is leaving.
 	        // The normal React way to do it won't work since the child will have
 	        // already been removed. In case you need this behavior you can provide
 	        // a childFactory function to wrap every child, even the ones that are
 	        // leaving.
-	        childrenToRender.push(React.cloneElement(this.props.childFactory(child), { ref: key, key: key }));
+	        childrenToRender.push(_react2.default.cloneElement(factoryChild, {
+	          key: key,
+	          ref: ref
+	        }));
 	      }
+	    };
+
+	    for (var key in this.state.children) {
+	      _loop(key);
 	    }
 
-	    // Do not forward ReactTransitionGroup props to primitive DOM nodes
-	    var props = _assign({}, this.props);
+	    // Do not forward TransitionGroup props to primitive DOM nodes
+	    var props = _extends({}, this.props);
 	    delete props.transitionLeave;
 	    delete props.transitionName;
 	    delete props.transitionAppear;
@@ -27019,229 +27151,248 @@
 	    delete props.transitionAppearTimeout;
 	    delete props.component;
 
-	    return React.createElement(this.props.component, props, childrenToRender);
+	    return _react2.default.createElement(this.props.component, props, childrenToRender);
 	  };
 
-	  return ReactTransitionGroup;
-	}(React.Component);
+	  return TransitionGroup;
+	}(_react2.default.Component);
 
-	ReactTransitionGroup.displayName = 'ReactTransitionGroup';
-	ReactTransitionGroup.propTypes = {
-	  component: PropTypes.any,
-	  childFactory: PropTypes.func
-	};
-	ReactTransitionGroup.defaultProps = {
-	  component: 'span',
-	  childFactory: emptyFunction.thatReturnsArgument
-	};
+	TransitionGroup.displayName = 'TransitionGroup';
 
 
-	module.exports = ReactTransitionGroup;
+	TransitionGroup.propTypes = propTypes;
+	TransitionGroup.defaultProps = defaultProps;
 
-/***/ },
-/* 225 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
-	'use strict';
-
-	var flattenChildren = __webpack_require__(226);
-
-	var ReactTransitionChildMapping = {
-	  /**
-	   * Given `this.props.children`, return an object mapping key to child. Just
-	   * simple syntactic sugar around flattenChildren().
-	   *
-	   * @param {*} children `this.props.children`
-	   * @param {number=} selfDebugID Optional debugID of the current internal instance.
-	   * @return {object} Mapping of key to child
-	   */
-	  getChildMapping: function (children, selfDebugID) {
-	    if (!children) {
-	      return children;
-	    }
-
-	    if (process.env.NODE_ENV !== 'production') {
-	      return flattenChildren(children, selfDebugID);
-	    }
-
-	    return flattenChildren(children);
-	  },
-
-	  /**
-	   * When you're adding or removing children some may be added or removed in the
-	   * same render pass. We want to show *both* since we want to simultaneously
-	   * animate elements in and out. This function takes a previous set of keys
-	   * and a new set of keys and merges them with its best guess of the correct
-	   * ordering. In the future we may expose some of the utilities in
-	   * ReactMultiChild to make this easy, but for now React itself does not
-	   * directly have this concept of the union of prevChildren and nextChildren
-	   * so we implement it here.
-	   *
-	   * @param {object} prev prev children as returned from
-	   * `ReactTransitionChildMapping.getChildMapping()`.
-	   * @param {object} next next children as returned from
-	   * `ReactTransitionChildMapping.getChildMapping()`.
-	   * @return {object} a key set that contains all keys in `prev` and all keys
-	   * in `next` in a reasonable order.
-	   */
-	  mergeChildMappings: function (prev, next) {
-	    prev = prev || {};
-	    next = next || {};
-
-	    function getValueForKey(key) {
-	      if (next.hasOwnProperty(key)) {
-	        return next[key];
-	      } else {
-	        return prev[key];
-	      }
-	    }
-
-	    // For each key of `next`, the list of keys to insert before that key in
-	    // the combined list
-	    var nextKeysPending = {};
-
-	    var pendingKeys = [];
-	    for (var prevKey in prev) {
-	      if (next.hasOwnProperty(prevKey)) {
-	        if (pendingKeys.length) {
-	          nextKeysPending[prevKey] = pendingKeys;
-	          pendingKeys = [];
-	        }
-	      } else {
-	        pendingKeys.push(prevKey);
-	      }
-	    }
-
-	    var i;
-	    var childMapping = {};
-	    for (var nextKey in next) {
-	      if (nextKeysPending.hasOwnProperty(nextKey)) {
-	        for (i = 0; i < nextKeysPending[nextKey].length; i++) {
-	          var pendingNextKey = nextKeysPending[nextKey][i];
-	          childMapping[nextKeysPending[nextKey][i]] = getValueForKey(pendingNextKey);
-	        }
-	      }
-	      childMapping[nextKey] = getValueForKey(nextKey);
-	    }
-
-	    // Finally, add the keys which didn't appear before any key in `next`
-	    for (i = 0; i < pendingKeys.length; i++) {
-	      childMapping[pendingKeys[i]] = getValueForKey(pendingKeys[i]);
-	    }
-
-	    return childMapping;
-	  }
-	};
-
-	module.exports = ReactTransitionChildMapping;
+	exports.default = TransitionGroup;
+	module.exports = exports['default'];
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
 
 /***/ },
 /* 226 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * 
-	 */
+	
+	module.exports = function chain(){
+	  var len = arguments.length
+	  var args = [];
 
-	'use strict';
+	  for (var i = 0; i < len; i++)
+	    args[i] = arguments[i]
 
-	var KeyEscapeUtils = __webpack_require__(40);
-	var traverseAllChildren = __webpack_require__(38);
-	var warning = __webpack_require__(34);
+	  args = args.filter(function(fn){ return fn != null })
 
-	var ReactComponentTreeHook;
+	  if (args.length === 0) return undefined
+	  if (args.length === 1) return args[0]
 
-	if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test') {
-	  // Temporary hack.
-	  // Inline requires don't work well with Jest:
-	  // https://github.com/facebook/react/issues/7240
-	  // Remove the inline requires when we don't need them anymore:
-	  // https://github.com/facebook/react/pull/7178
-	  ReactComponentTreeHook = __webpack_require__(49);
+	  return args.reduce(function(current, next){
+	    return function chainedFunction() {
+	      current.apply(this, arguments);
+	      next.apply(this, arguments);
+	    };
+	  })
 	}
 
-	/**
-	 * @param {function} traverseContext Context passed through traversal.
-	 * @param {?ReactComponent} child React child component.
-	 * @param {!string} name String name of key path to child.
-	 * @param {number=} selfDebugID Optional debugID of the current internal instance.
-	 */
-	function flattenSingleChildIntoContext(traverseContext, child, name, selfDebugID) {
-	  // We found a component instance.
-	  if (traverseContext && typeof traverseContext === 'object') {
-	    var result = traverseContext;
-	    var keyUnique = result[name] === undefined;
-	    if (process.env.NODE_ENV !== 'production') {
-	      if (!ReactComponentTreeHook) {
-	        ReactComponentTreeHook = __webpack_require__(49);
-	      }
-	      if (!keyUnique) {
-	        process.env.NODE_ENV !== 'production' ? warning(false, 'flattenChildren(...): Encountered two children with the same key, ' + '`%s`. Child keys must be unique; when two children share a key, only ' + 'the first child will be used.%s', KeyEscapeUtils.unescape(name), ReactComponentTreeHook.getStackAddendumByID(selfDebugID)) : void 0;
-	      }
-	    }
-	    if (keyUnique && child != null) {
-	      result[name] = child;
-	    }
-	  }
-	}
-
-	/**
-	 * Flattens children that are typically specified as `props.children`. Any null
-	 * children will not be included in the resulting object.
-	 * @return {!object} flattened children keyed by name.
-	 */
-	function flattenChildren(children, selfDebugID) {
-	  if (children == null) {
-	    return children;
-	  }
-	  var result = {};
-
-	  if (process.env.NODE_ENV !== 'production') {
-	    traverseAllChildren(children, function (traverseContext, child, name) {
-	      return flattenSingleChildIntoContext(traverseContext, child, name, selfDebugID);
-	    }, result);
-	  } else {
-	    traverseAllChildren(children, flattenSingleChildIntoContext, result);
-	  }
-	  return result;
-	}
-
-	module.exports = flattenChildren;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
 
 /***/ },
 /* 227 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
+	/* WEBPACK VAR INJECTION */(function(process) {/**
+	 * Copyright 2014-2015, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
 	 */
 
 	'use strict';
+
+	/**
+	 * Similar to invariant but only logs a warning if the condition is not met.
+	 * This can be used to log issues in development environments in critical
+	 * paths. Removing the logging code for production environments will keep the
+	 * same logic and follow the same code paths.
+	 */
+
+	var warning = function() {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  warning = function(condition, format, args) {
+	    var len = arguments.length;
+	    args = new Array(len > 2 ? len - 2 : 0);
+	    for (var key = 2; key < len; key++) {
+	      args[key - 2] = arguments[key];
+	    }
+	    if (format === undefined) {
+	      throw new Error(
+	        '`warning(condition, format, ...args)` requires a warning ' +
+	        'message argument'
+	      );
+	    }
+
+	    if (format.length < 10 || (/^[s\W]*$/).test(format)) {
+	      throw new Error(
+	        'The warning format should be able to uniquely identify this ' +
+	        'warning. Please, use a more descriptive format than: ' + format
+	      );
+	    }
+
+	    if (!condition) {
+	      var argIndex = 0;
+	      var message = 'Warning: ' +
+	        format.replace(/%s/g, function() {
+	          return args[argIndex++];
+	        });
+	      if (typeof console !== 'undefined') {
+	        console.error(message);
+	      }
+	      try {
+	        // This error was thrown as a convenience so that you can use this stack
+	        // to find the callsite that caused this warning to fire.
+	        throw new Error(message);
+	      } catch(x) {}
+	    }
+	  };
+	}
+
+	module.exports = warning;
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
+
+/***/ },
+/* 228 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	exports.__esModule = true;
+	exports.getChildMapping = getChildMapping;
+	exports.mergeChildMappings = mergeChildMappings;
+
+	var _react = __webpack_require__(24);
+
+	/**
+	 * Given `this.props.children`, return an object mapping key to child.
+	 *
+	 * @param {*} children `this.props.children`
+	 * @return {object} Mapping of key to child
+	 */
+	function getChildMapping(children) {
+	  if (!children) {
+	    return children;
+	  }
+	  var result = {};
+	  _react.Children.map(children, function (child) {
+	    return child;
+	  }).forEach(function (child) {
+	    result[child.key] = child;
+	  });
+	  return result;
+	}
+
+	/**
+	 * When you're adding or removing children some may be added or removed in the
+	 * same render pass. We want to show *both* since we want to simultaneously
+	 * animate elements in and out. This function takes a previous set of keys
+	 * and a new set of keys and merges them with its best guess of the correct
+	 * ordering. In the future we may expose some of the utilities in
+	 * ReactMultiChild to make this easy, but for now React itself does not
+	 * directly have this concept of the union of prevChildren and nextChildren
+	 * so we implement it here.
+	 *
+	 * @param {object} prev prev children as returned from
+	 * `ReactTransitionChildMapping.getChildMapping()`.
+	 * @param {object} next next children as returned from
+	 * `ReactTransitionChildMapping.getChildMapping()`.
+	 * @return {object} a key set that contains all keys in `prev` and all keys
+	 * in `next` in a reasonable order.
+	 */
+	function mergeChildMappings(prev, next) {
+	  prev = prev || {};
+	  next = next || {};
+
+	  function getValueForKey(key) {
+	    if (next.hasOwnProperty(key)) {
+	      return next[key];
+	    }
+
+	    return prev[key];
+	  }
+
+	  // For each key of `next`, the list of keys to insert before that key in
+	  // the combined list
+	  var nextKeysPending = {};
+
+	  var pendingKeys = [];
+	  for (var prevKey in prev) {
+	    if (next.hasOwnProperty(prevKey)) {
+	      if (pendingKeys.length) {
+	        nextKeysPending[prevKey] = pendingKeys;
+	        pendingKeys = [];
+	      }
+	    } else {
+	      pendingKeys.push(prevKey);
+	    }
+	  }
+
+	  var i = void 0;
+	  var childMapping = {};
+	  for (var nextKey in next) {
+	    if (nextKeysPending.hasOwnProperty(nextKey)) {
+	      for (i = 0; i < nextKeysPending[nextKey].length; i++) {
+	        var pendingNextKey = nextKeysPending[nextKey][i];
+	        childMapping[nextKeysPending[nextKey][i]] = getValueForKey(pendingNextKey);
+	      }
+	    }
+	    childMapping[nextKey] = getValueForKey(nextKey);
+	  }
+
+	  // Finally, add the keys which didn't appear before any key in `next`
+	  for (i = 0; i < pendingKeys.length; i++) {
+	    childMapping[pendingKeys[i]] = getValueForKey(pendingKeys[i]);
+	  }
+
+	  return childMapping;
+	}
+
+/***/ },
+/* 229 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	exports.__esModule = true;
+
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+	var _addClass = __webpack_require__(230);
+
+	var _addClass2 = _interopRequireDefault(_addClass);
+
+	var _removeClass = __webpack_require__(232);
+
+	var _removeClass2 = _interopRequireDefault(_removeClass);
+
+	var _requestAnimationFrame = __webpack_require__(233);
+
+	var _requestAnimationFrame2 = _interopRequireDefault(_requestAnimationFrame);
+
+	var _properties = __webpack_require__(235);
+
+	var _react = __webpack_require__(24);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _propTypes = __webpack_require__(223);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	var _reactDom = __webpack_require__(71);
+
+	var _PropTypes = __webpack_require__(236);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -27249,96 +27400,55 @@
 
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	var React = __webpack_require__(25);
-	var ReactAddonsDOMDependencies = __webpack_require__(228);
+	var events = [];
+	if (_properties.transitionEnd) events.push(_properties.transitionEnd);
+	if (_properties.animationEnd) events.push(_properties.animationEnd);
 
-	var propTypesFactory = __webpack_require__(53);
-	var PropTypes = propTypesFactory(React.isValidElement);
+	function addEndListener(node, listener) {
+	  if (events.length) {
+	    events.forEach(function (e) {
+	      return node.addEventListener(e, listener, false);
+	    });
+	  } else {
+	    setTimeout(listener, 0);
+	  }
 
-	var CSSCore = __webpack_require__(233);
-	var ReactTransitionEvents = __webpack_require__(234);
+	  return function () {
+	    if (!events.length) return;
+	    events.forEach(function (e) {
+	      return node.removeEventListener(e, listener, false);
+	    });
+	  };
+	}
 
-	var onlyChild = __webpack_require__(58);
+	var propTypes = {
+	  children: _propTypes2.default.node,
+	  name: _PropTypes.nameShape.isRequired,
 
-	var TICK = 17;
+	  // Once we require timeouts to be specified, we can remove the
+	  // boolean flags (appear etc.) and just accept a number
+	  // or a bool for the timeout flags (appearTimeout etc.)
+	  appear: _propTypes2.default.bool,
+	  enter: _propTypes2.default.bool,
+	  leave: _propTypes2.default.bool,
+	  appearTimeout: _propTypes2.default.number,
+	  enterTimeout: _propTypes2.default.number,
+	  leaveTimeout: _propTypes2.default.number
+	};
 
-	var ReactCSSTransitionGroupChild = function (_React$Component) {
-	  _inherits(ReactCSSTransitionGroupChild, _React$Component);
+	var CSSTransitionGroupChild = function (_React$Component) {
+	  _inherits(CSSTransitionGroupChild, _React$Component);
 
-	  function ReactCSSTransitionGroupChild() {
+	  function CSSTransitionGroupChild() {
 	    var _temp, _this, _ret;
 
-	    _classCallCheck(this, ReactCSSTransitionGroupChild);
+	    _classCallCheck(this, CSSTransitionGroupChild);
 
 	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 	      args[_key] = arguments[_key];
 	    }
 
-	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this._isMounted = false, _this.transition = function (animationType, finishCallback, userSpecifiedDelay) {
-	      var node = ReactAddonsDOMDependencies.getReactDOM().findDOMNode(_this);
-
-	      if (!node) {
-	        if (finishCallback) {
-	          finishCallback();
-	        }
-	        return;
-	      }
-
-	      var className = _this.props.name[animationType] || _this.props.name + '-' + animationType;
-	      var activeClassName = _this.props.name[animationType + 'Active'] || className + '-active';
-	      var timeout = null;
-
-	      var endListener = function (e) {
-	        if (e && e.target !== node) {
-	          return;
-	        }
-
-	        clearTimeout(timeout);
-
-	        CSSCore.removeClass(node, className);
-	        CSSCore.removeClass(node, activeClassName);
-
-	        ReactTransitionEvents.removeEndEventListener(node, endListener);
-
-	        // Usually this optional callback is used for informing an owner of
-	        // a leave animation and telling it to remove the child.
-	        if (finishCallback) {
-	          finishCallback();
-	        }
-	      };
-
-	      CSSCore.addClass(node, className);
-
-	      // Need to do this to actually trigger a transition.
-	      _this.queueClassAndNode(activeClassName, node);
-
-	      // If the user specified a timeout delay.
-	      if (userSpecifiedDelay) {
-	        // Clean-up the animation after the specified delay
-	        timeout = setTimeout(endListener, userSpecifiedDelay);
-	        _this.transitionTimeouts.push(timeout);
-	      } else {
-	        // DEPRECATED: this listener will be removed in a future version of react
-	        ReactTransitionEvents.addEndEventListener(node, endListener);
-	      }
-	    }, _this.queueClassAndNode = function (className, node) {
-	      _this.classNameAndNodeQueue.push({
-	        className: className,
-	        node: node
-	      });
-
-	      if (!_this.timeout) {
-	        _this.timeout = setTimeout(_this.flushClassNameAndNodeQueue, TICK);
-	      }
-	    }, _this.flushClassNameAndNodeQueue = function () {
-	      if (_this._isMounted) {
-	        _this.classNameAndNodeQueue.forEach(function (obj) {
-	          CSSCore.addClass(obj.node, obj.className);
-	        });
-	      }
-	      _this.classNameAndNodeQueue.length = 0;
-	      _this.timeout = null;
-	    }, _this.componentWillAppear = function (done) {
+	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _React$Component.call.apply(_React$Component, [this].concat(args))), _this), _this.componentWillAppear = function (done) {
 	      if (_this.props.appear) {
 	        _this.transition('appear', done, _this.props.appearTimeout);
 	      } else {
@@ -27359,17 +27469,13 @@
 	    }, _temp), _possibleConstructorReturn(_this, _ret);
 	  }
 
-	  ReactCSSTransitionGroupChild.prototype.componentWillMount = function componentWillMount() {
+	  CSSTransitionGroupChild.prototype.componentWillMount = function componentWillMount() {
 	    this.classNameAndNodeQueue = [];
 	    this.transitionTimeouts = [];
 	  };
 
-	  ReactCSSTransitionGroupChild.prototype.componentDidMount = function componentDidMount() {
-	    this._isMounted = true;
-	  };
-
-	  ReactCSSTransitionGroupChild.prototype.componentWillUnmount = function componentWillUnmount() {
-	    this._isMounted = false;
+	  CSSTransitionGroupChild.prototype.componentWillUnmount = function componentWillUnmount() {
+	    this.unmounted = true;
 
 	    if (this.timeout) {
 	      clearTimeout(this.timeout);
@@ -27381,1468 +27487,397 @@
 	    this.classNameAndNodeQueue.length = 0;
 	  };
 
-	  ReactCSSTransitionGroupChild.prototype.render = function render() {
-	    return onlyChild(this.props.children);
+	  CSSTransitionGroupChild.prototype.transition = function transition(animationType, finishCallback, timeout) {
+	    var node = (0, _reactDom.findDOMNode)(this);
+
+	    if (!node) {
+	      if (finishCallback) {
+	        finishCallback();
+	      }
+	      return;
+	    }
+
+	    var className = this.props.name[animationType] || this.props.name + '-' + animationType;
+	    var activeClassName = this.props.name[animationType + 'Active'] || className + '-active';
+	    var timer = null;
+	    var removeListeners = void 0;
+
+	    (0, _addClass2.default)(node, className);
+
+	    // Need to do this to actually trigger a transition.
+	    this.queueClassAndNode(activeClassName, node);
+
+	    // Clean-up the animation after the specified delay
+	    var finish = function finish(e) {
+	      if (e && e.target !== node) {
+	        return;
+	      }
+
+	      clearTimeout(timer);
+	      if (removeListeners) removeListeners();
+
+	      (0, _removeClass2.default)(node, className);
+	      (0, _removeClass2.default)(node, activeClassName);
+
+	      if (removeListeners) removeListeners();
+
+	      // Usually this optional callback is used for informing an owner of
+	      // a leave animation and telling it to remove the child.
+	      if (finishCallback) {
+	        finishCallback();
+	      }
+	    };
+
+	    if (timeout) {
+	      timer = setTimeout(finish, timeout);
+	      this.transitionTimeouts.push(timer);
+	    } else if (_properties.transitionEnd) {
+	      removeListeners = addEndListener(node, finish);
+	    }
 	  };
 
-	  return ReactCSSTransitionGroupChild;
-	}(React.Component);
+	  CSSTransitionGroupChild.prototype.queueClassAndNode = function queueClassAndNode(className, node) {
+	    var _this2 = this;
 
-	ReactCSSTransitionGroupChild.propTypes = {
-	  name: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({
-	    enter: PropTypes.string,
-	    leave: PropTypes.string,
-	    active: PropTypes.string
-	  }), PropTypes.shape({
-	    enter: PropTypes.string,
-	    enterActive: PropTypes.string,
-	    leave: PropTypes.string,
-	    leaveActive: PropTypes.string,
-	    appear: PropTypes.string,
-	    appearActive: PropTypes.string
-	  })]).isRequired,
+	    this.classNameAndNodeQueue.push({
+	      className: className,
+	      node: node
+	    });
 
-	  // Once we require timeouts to be specified, we can remove the
-	  // boolean flags (appear etc.) and just accept a number
-	  // or a bool for the timeout flags (appearTimeout etc.)
-	  appear: PropTypes.bool,
-	  enter: PropTypes.bool,
-	  leave: PropTypes.bool,
-	  appearTimeout: PropTypes.number,
-	  enterTimeout: PropTypes.number,
-	  leaveTimeout: PropTypes.number
-	};
-
-
-	module.exports = ReactCSSTransitionGroupChild;
-
-/***/ },
-/* 228 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
-	'use strict';
-
-	var ReactDOM = __webpack_require__(72);
-
-	exports.getReactDOM = function () {
-	  return ReactDOM;
-	};
-
-	if (process.env.NODE_ENV !== 'production') {
-	  var ReactPerf;
-	  var ReactTestUtils;
-
-	  exports.getReactPerf = function () {
-	    if (!ReactPerf) {
-	      ReactPerf = __webpack_require__(229);
+	    if (!this.rafHandle) {
+	      this.rafHandle = (0, _requestAnimationFrame2.default)(function () {
+	        return _this2.flushClassNameAndNodeQueue();
+	      });
 	    }
-	    return ReactPerf;
 	  };
 
-	  exports.getReactTestUtils = function () {
-	    if (!ReactTestUtils) {
-	      ReactTestUtils = __webpack_require__(230);
+	  CSSTransitionGroupChild.prototype.flushClassNameAndNodeQueue = function flushClassNameAndNodeQueue() {
+	    if (!this.unmounted) {
+	      this.classNameAndNodeQueue.forEach(function (obj) {
+	        // This is for to force a repaint,
+	        // which is necessary in order to transition styles when adding a class name.
+	        /* eslint-disable no-unused-expressions */
+	        obj.node.scrollTop;
+	        /* eslint-enable no-unused-expressions */
+	        (0, _addClass2.default)(obj.node, obj.className);
+	      });
 	    }
-	    return ReactTestUtils;
+	    this.classNameAndNodeQueue.length = 0;
+	    this.rafHandle = null;
 	  };
-	}
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
 
-/***/ },
-/* 229 */
-/***/ function(module, exports, __webpack_require__) {
+	  CSSTransitionGroupChild.prototype.render = function render() {
+	    var props = _extends({}, this.props);
+	    delete props.name;
+	    delete props.appear;
+	    delete props.enter;
+	    delete props.leave;
+	    delete props.appearTimeout;
+	    delete props.enterTimeout;
+	    delete props.leaveTimeout;
+	    delete props.children;
+	    return _react2.default.cloneElement(_react2.default.Children.only(this.props.children), props);
+	  };
 
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2016-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * 
-	 */
+	  return CSSTransitionGroupChild;
+	}(_react2.default.Component);
 
-	'use strict';
+	CSSTransitionGroupChild.displayName = 'CSSTransitionGroupChild';
 
-	var _assign = __webpack_require__(27);
 
-	var _extends = _assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+	CSSTransitionGroupChild.propTypes = propTypes;
 
-	var ReactDebugTool = __webpack_require__(102);
-	var warning = __webpack_require__(34);
-	var alreadyWarned = false;
-
-	function roundFloat(val) {
-	  var base = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
-
-	  var n = Math.pow(10, base);
-	  return Math.floor(val * n) / n;
-	}
-
-	// Flow type definition of console.table is too strict right now, see
-	// https://github.com/facebook/flow/pull/2353 for updates
-	function consoleTable(table) {
-	  console.table(table);
-	}
-
-	function warnInProduction() {
-	  if (alreadyWarned) {
-	    return;
-	  }
-	  alreadyWarned = true;
-	  if (typeof console !== 'undefined') {
-	    console.error('ReactPerf is not supported in the production builds of React. ' + 'To collect measurements, please use the development build of React instead.');
-	  }
-	}
-
-	function getLastMeasurements() {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return [];
-	  }
-
-	  return ReactDebugTool.getFlushHistory();
-	}
-
-	function getExclusive() {
-	  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
-
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return [];
-	  }
-
-	  var aggregatedStats = {};
-	  var affectedIDs = {};
-
-	  function updateAggregatedStats(treeSnapshot, instanceID, timerType, applyUpdate) {
-	    var displayName = treeSnapshot[instanceID].displayName;
-
-	    var key = displayName;
-	    var stats = aggregatedStats[key];
-	    if (!stats) {
-	      affectedIDs[key] = {};
-	      stats = aggregatedStats[key] = {
-	        key: key,
-	        instanceCount: 0,
-	        counts: {},
-	        durations: {},
-	        totalDuration: 0
-	      };
-	    }
-	    if (!stats.durations[timerType]) {
-	      stats.durations[timerType] = 0;
-	    }
-	    if (!stats.counts[timerType]) {
-	      stats.counts[timerType] = 0;
-	    }
-	    affectedIDs[key][instanceID] = true;
-	    applyUpdate(stats);
-	  }
-
-	  flushHistory.forEach(function (flush) {
-	    var measurements = flush.measurements,
-	        treeSnapshot = flush.treeSnapshot;
-
-	    measurements.forEach(function (measurement) {
-	      var duration = measurement.duration,
-	          instanceID = measurement.instanceID,
-	          timerType = measurement.timerType;
-
-	      updateAggregatedStats(treeSnapshot, instanceID, timerType, function (stats) {
-	        stats.totalDuration += duration;
-	        stats.durations[timerType] += duration;
-	        stats.counts[timerType]++;
-	      });
-	    });
-	  });
-
-	  return Object.keys(aggregatedStats).map(function (key) {
-	    return _extends({}, aggregatedStats[key], {
-	      instanceCount: Object.keys(affectedIDs[key]).length
-	    });
-	  }).sort(function (a, b) {
-	    return b.totalDuration - a.totalDuration;
-	  });
-	}
-
-	function getInclusive() {
-	  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
-
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return [];
-	  }
-
-	  var aggregatedStats = {};
-	  var affectedIDs = {};
-
-	  function updateAggregatedStats(treeSnapshot, instanceID, applyUpdate) {
-	    var _treeSnapshot$instanc = treeSnapshot[instanceID],
-	        displayName = _treeSnapshot$instanc.displayName,
-	        ownerID = _treeSnapshot$instanc.ownerID;
-
-	    var owner = treeSnapshot[ownerID];
-	    var key = (owner ? owner.displayName + ' > ' : '') + displayName;
-	    var stats = aggregatedStats[key];
-	    if (!stats) {
-	      affectedIDs[key] = {};
-	      stats = aggregatedStats[key] = {
-	        key: key,
-	        instanceCount: 0,
-	        inclusiveRenderDuration: 0,
-	        renderCount: 0
-	      };
-	    }
-	    affectedIDs[key][instanceID] = true;
-	    applyUpdate(stats);
-	  }
-
-	  var isCompositeByID = {};
-	  flushHistory.forEach(function (flush) {
-	    var measurements = flush.measurements;
-
-	    measurements.forEach(function (measurement) {
-	      var instanceID = measurement.instanceID,
-	          timerType = measurement.timerType;
-
-	      if (timerType !== 'render') {
-	        return;
-	      }
-	      isCompositeByID[instanceID] = true;
-	    });
-	  });
-
-	  flushHistory.forEach(function (flush) {
-	    var measurements = flush.measurements,
-	        treeSnapshot = flush.treeSnapshot;
-
-	    measurements.forEach(function (measurement) {
-	      var duration = measurement.duration,
-	          instanceID = measurement.instanceID,
-	          timerType = measurement.timerType;
-
-	      if (timerType !== 'render') {
-	        return;
-	      }
-	      updateAggregatedStats(treeSnapshot, instanceID, function (stats) {
-	        stats.renderCount++;
-	      });
-	      var nextParentID = instanceID;
-	      while (nextParentID) {
-	        // As we traverse parents, only count inclusive time towards composites.
-	        // We know something is a composite if its render() was called.
-	        if (isCompositeByID[nextParentID]) {
-	          updateAggregatedStats(treeSnapshot, nextParentID, function (stats) {
-	            stats.inclusiveRenderDuration += duration;
-	          });
-	        }
-	        nextParentID = treeSnapshot[nextParentID].parentID;
-	      }
-	    });
-	  });
-
-	  return Object.keys(aggregatedStats).map(function (key) {
-	    return _extends({}, aggregatedStats[key], {
-	      instanceCount: Object.keys(affectedIDs[key]).length
-	    });
-	  }).sort(function (a, b) {
-	    return b.inclusiveRenderDuration - a.inclusiveRenderDuration;
-	  });
-	}
-
-	function getWasted() {
-	  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
-
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return [];
-	  }
-
-	  var aggregatedStats = {};
-	  var affectedIDs = {};
-
-	  function updateAggregatedStats(treeSnapshot, instanceID, applyUpdate) {
-	    var _treeSnapshot$instanc2 = treeSnapshot[instanceID],
-	        displayName = _treeSnapshot$instanc2.displayName,
-	        ownerID = _treeSnapshot$instanc2.ownerID;
-
-	    var owner = treeSnapshot[ownerID];
-	    var key = (owner ? owner.displayName + ' > ' : '') + displayName;
-	    var stats = aggregatedStats[key];
-	    if (!stats) {
-	      affectedIDs[key] = {};
-	      stats = aggregatedStats[key] = {
-	        key: key,
-	        instanceCount: 0,
-	        inclusiveRenderDuration: 0,
-	        renderCount: 0
-	      };
-	    }
-	    affectedIDs[key][instanceID] = true;
-	    applyUpdate(stats);
-	  }
-
-	  flushHistory.forEach(function (flush) {
-	    var measurements = flush.measurements,
-	        treeSnapshot = flush.treeSnapshot,
-	        operations = flush.operations;
-
-	    var isDefinitelyNotWastedByID = {};
-
-	    // Find host components associated with an operation in this batch.
-	    // Mark all components in their parent tree as definitely not wasted.
-	    operations.forEach(function (operation) {
-	      var instanceID = operation.instanceID;
-
-	      var nextParentID = instanceID;
-	      while (nextParentID) {
-	        isDefinitelyNotWastedByID[nextParentID] = true;
-	        nextParentID = treeSnapshot[nextParentID].parentID;
-	      }
-	    });
-
-	    // Find composite components that rendered in this batch.
-	    // These are potential candidates for being wasted renders.
-	    var renderedCompositeIDs = {};
-	    measurements.forEach(function (measurement) {
-	      var instanceID = measurement.instanceID,
-	          timerType = measurement.timerType;
-
-	      if (timerType !== 'render') {
-	        return;
-	      }
-	      renderedCompositeIDs[instanceID] = true;
-	    });
-
-	    measurements.forEach(function (measurement) {
-	      var duration = measurement.duration,
-	          instanceID = measurement.instanceID,
-	          timerType = measurement.timerType;
-
-	      if (timerType !== 'render') {
-	        return;
-	      }
-
-	      // If there was a DOM update below this component, or it has just been
-	      // mounted, its render() is not considered wasted.
-	      var updateCount = treeSnapshot[instanceID].updateCount;
-
-	      if (isDefinitelyNotWastedByID[instanceID] || updateCount === 0) {
-	        return;
-	      }
-
-	      // We consider this render() wasted.
-	      updateAggregatedStats(treeSnapshot, instanceID, function (stats) {
-	        stats.renderCount++;
-	      });
-
-	      var nextParentID = instanceID;
-	      while (nextParentID) {
-	        // Any parents rendered during this batch are considered wasted
-	        // unless we previously marked them as dirty.
-	        var isWasted = renderedCompositeIDs[nextParentID] && !isDefinitelyNotWastedByID[nextParentID];
-	        if (isWasted) {
-	          updateAggregatedStats(treeSnapshot, nextParentID, function (stats) {
-	            stats.inclusiveRenderDuration += duration;
-	          });
-	        }
-	        nextParentID = treeSnapshot[nextParentID].parentID;
-	      }
-	    });
-	  });
-
-	  return Object.keys(aggregatedStats).map(function (key) {
-	    return _extends({}, aggregatedStats[key], {
-	      instanceCount: Object.keys(affectedIDs[key]).length
-	    });
-	  }).sort(function (a, b) {
-	    return b.inclusiveRenderDuration - a.inclusiveRenderDuration;
-	  });
-	}
-
-	function getOperations() {
-	  var flushHistory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getLastMeasurements();
-
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return [];
-	  }
-
-	  var stats = [];
-	  flushHistory.forEach(function (flush, flushIndex) {
-	    var operations = flush.operations,
-	        treeSnapshot = flush.treeSnapshot;
-
-	    operations.forEach(function (operation) {
-	      var instanceID = operation.instanceID,
-	          type = operation.type,
-	          payload = operation.payload;
-	      var _treeSnapshot$instanc3 = treeSnapshot[instanceID],
-	          displayName = _treeSnapshot$instanc3.displayName,
-	          ownerID = _treeSnapshot$instanc3.ownerID;
-
-	      var owner = treeSnapshot[ownerID];
-	      var key = (owner ? owner.displayName + ' > ' : '') + displayName;
-
-	      stats.push({
-	        flushIndex: flushIndex,
-	        instanceID: instanceID,
-	        key: key,
-	        type: type,
-	        ownerID: ownerID,
-	        payload: payload
-	      });
-	    });
-	  });
-	  return stats;
-	}
-
-	function printExclusive(flushHistory) {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return;
-	  }
-
-	  var stats = getExclusive(flushHistory);
-	  var table = stats.map(function (item) {
-	    var key = item.key,
-	        instanceCount = item.instanceCount,
-	        totalDuration = item.totalDuration;
-
-	    var renderCount = item.counts.render || 0;
-	    var renderDuration = item.durations.render || 0;
-	    return {
-	      'Component': key,
-	      'Total time (ms)': roundFloat(totalDuration),
-	      'Instance count': instanceCount,
-	      'Total render time (ms)': roundFloat(renderDuration),
-	      'Average render time (ms)': renderCount ? roundFloat(renderDuration / renderCount) : undefined,
-	      'Render count': renderCount,
-	      'Total lifecycle time (ms)': roundFloat(totalDuration - renderDuration)
-	    };
-	  });
-	  consoleTable(table);
-	}
-
-	function printInclusive(flushHistory) {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return;
-	  }
-
-	  var stats = getInclusive(flushHistory);
-	  var table = stats.map(function (item) {
-	    var key = item.key,
-	        instanceCount = item.instanceCount,
-	        inclusiveRenderDuration = item.inclusiveRenderDuration,
-	        renderCount = item.renderCount;
-
-	    return {
-	      'Owner > Component': key,
-	      'Inclusive render time (ms)': roundFloat(inclusiveRenderDuration),
-	      'Instance count': instanceCount,
-	      'Render count': renderCount
-	    };
-	  });
-	  consoleTable(table);
-	}
-
-	function printWasted(flushHistory) {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return;
-	  }
-
-	  var stats = getWasted(flushHistory);
-	  var table = stats.map(function (item) {
-	    var key = item.key,
-	        instanceCount = item.instanceCount,
-	        inclusiveRenderDuration = item.inclusiveRenderDuration,
-	        renderCount = item.renderCount;
-
-	    return {
-	      'Owner > Component': key,
-	      'Inclusive wasted time (ms)': roundFloat(inclusiveRenderDuration),
-	      'Instance count': instanceCount,
-	      'Render count': renderCount
-	    };
-	  });
-	  consoleTable(table);
-	}
-
-	function printOperations(flushHistory) {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return;
-	  }
-
-	  var stats = getOperations(flushHistory);
-	  var table = stats.map(function (stat) {
-	    return {
-	      'Owner > Node': stat.key,
-	      'Operation': stat.type,
-	      'Payload': typeof stat.payload === 'object' ? JSON.stringify(stat.payload) : stat.payload,
-	      'Flush index': stat.flushIndex,
-	      'Owner Component ID': stat.ownerID,
-	      'DOM Component ID': stat.instanceID
-	    };
-	  });
-	  consoleTable(table);
-	}
-
-	var warnedAboutPrintDOM = false;
-	function printDOM(measurements) {
-	  process.env.NODE_ENV !== 'production' ? warning(warnedAboutPrintDOM, '`ReactPerf.printDOM(...)` is deprecated. Use ' + '`ReactPerf.printOperations(...)` instead.') : void 0;
-	  warnedAboutPrintDOM = true;
-	  return printOperations(measurements);
-	}
-
-	var warnedAboutGetMeasurementsSummaryMap = false;
-	function getMeasurementsSummaryMap(measurements) {
-	  process.env.NODE_ENV !== 'production' ? warning(warnedAboutGetMeasurementsSummaryMap, '`ReactPerf.getMeasurementsSummaryMap(...)` is deprecated. Use ' + '`ReactPerf.getWasted(...)` instead.') : void 0;
-	  warnedAboutGetMeasurementsSummaryMap = true;
-	  return getWasted(measurements);
-	}
-
-	function start() {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return;
-	  }
-
-	  ReactDebugTool.beginProfiling();
-	}
-
-	function stop() {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return;
-	  }
-
-	  ReactDebugTool.endProfiling();
-	}
-
-	function isRunning() {
-	  if (!(process.env.NODE_ENV !== 'production')) {
-	    warnInProduction();
-	    return false;
-	  }
-
-	  return ReactDebugTool.isProfiling();
-	}
-
-	var ReactPerfAnalysis = {
-	  getLastMeasurements: getLastMeasurements,
-	  getExclusive: getExclusive,
-	  getInclusive: getInclusive,
-	  getWasted: getWasted,
-	  getOperations: getOperations,
-	  printExclusive: printExclusive,
-	  printInclusive: printInclusive,
-	  printWasted: printWasted,
-	  printOperations: printOperations,
-	  start: start,
-	  stop: stop,
-	  isRunning: isRunning,
-	  // Deprecated:
-	  printDOM: printDOM,
-	  getMeasurementsSummaryMap: getMeasurementsSummaryMap
-	};
-
-	module.exports = ReactPerfAnalysis;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
+	exports.default = CSSTransitionGroupChild;
+	module.exports = exports['default'];
 
 /***/ },
 /* 230 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(74),
-	    _assign = __webpack_require__(27);
-
-	var EventConstants = __webpack_require__(231);
-	var EventPluginHub = __webpack_require__(81);
-	var EventPluginRegistry = __webpack_require__(82);
-	var EventPropagators = __webpack_require__(80);
-	var React = __webpack_require__(25);
-	var ReactDOM = __webpack_require__(72);
-	var ReactDOMComponentTree = __webpack_require__(73);
-	var ReactBrowserEventEmitter = __webpack_require__(144);
-	var ReactInstanceMap = __webpack_require__(155);
-	var ReactUpdates = __webpack_require__(95);
-	var SyntheticEvent = __webpack_require__(92);
-	var ReactShallowRenderer = __webpack_require__(232);
-
-	var findDOMNode = __webpack_require__(211);
-	var invariant = __webpack_require__(31);
-	var warning = __webpack_require__(34);
-
-	var topLevelTypes = EventConstants.topLevelTypes;
-
-	function Event(suffix) {}
-
-	// In react 16+ shallowRenderer will not be accessible via ReactTestUtils.createRenderer()
-	// Instead it will be available via react-test-renderer/shallow
-	// Maintain backwards compat for 15.5.0 release, but warn about using the deprecated method
-	var hasWarnedAboutCreateRenderer = false;
-	function createRendererWithWarning() {
-	  process.env.NODE_ENV !== 'production' ? warning(hasWarnedAboutCreateRenderer, 'Shallow renderer has been moved to react-test-renderer/shallow. ' + 'Update references to remove this warning.') : void 0;
-	  hasWarnedAboutCreateRenderer = true;
-
-	  return new ReactShallowRenderer();
-	}
-
-	/**
-	 * @class ReactTestUtils
-	 */
-
-	function findAllInRenderedTreeInternal(inst, test) {
-	  if (!inst || !inst.getPublicInstance) {
-	    return [];
-	  }
-	  var publicInst = inst.getPublicInstance();
-	  var ret = test(publicInst) ? [publicInst] : [];
-	  var currentElement = inst._currentElement;
-	  if (ReactTestUtils.isDOMComponent(publicInst)) {
-	    var renderedChildren = inst._renderedChildren;
-	    var key;
-	    for (key in renderedChildren) {
-	      if (!renderedChildren.hasOwnProperty(key)) {
-	        continue;
-	      }
-	      ret = ret.concat(findAllInRenderedTreeInternal(renderedChildren[key], test));
-	    }
-	  } else if (React.isValidElement(currentElement) && typeof currentElement.type === 'function') {
-	    ret = ret.concat(findAllInRenderedTreeInternal(inst._renderedComponent, test));
-	  }
-	  return ret;
-	}
-
-	/**
-	 * Utilities for making it easy to test React components.
-	 *
-	 * See https://facebook.github.io/react/docs/test-utils.html
-	 *
-	 * Todo: Support the entire DOM.scry query syntax. For now, these simple
-	 * utilities will suffice for testing purposes.
-	 * @lends ReactTestUtils
-	 */
-	var ReactTestUtils = {
-	  renderIntoDocument: function (element) {
-	    var div = document.createElement('div');
-	    // None of our tests actually require attaching the container to the
-	    // DOM, and doing so creates a mess that we rely on test isolation to
-	    // clean up, so we're going to stop honoring the name of this method
-	    // (and probably rename it eventually) if no problems arise.
-	    // document.documentElement.appendChild(div);
-	    return ReactDOM.render(element, div);
-	  },
-
-	  isElement: function (element) {
-	    return React.isValidElement(element);
-	  },
-
-	  isElementOfType: function (inst, convenienceConstructor) {
-	    return React.isValidElement(inst) && inst.type === convenienceConstructor;
-	  },
-
-	  isDOMComponent: function (inst) {
-	    return !!(inst && inst.nodeType === 1 && inst.tagName);
-	  },
-
-	  isDOMComponentElement: function (inst) {
-	    return !!(inst && React.isValidElement(inst) && !!inst.tagName);
-	  },
-
-	  isCompositeComponent: function (inst) {
-	    if (ReactTestUtils.isDOMComponent(inst)) {
-	      // Accessing inst.setState warns; just return false as that'll be what
-	      // this returns when we have DOM nodes as refs directly
-	      return false;
-	    }
-	    return inst != null && typeof inst.render === 'function' && typeof inst.setState === 'function';
-	  },
-
-	  isCompositeComponentWithType: function (inst, type) {
-	    if (!ReactTestUtils.isCompositeComponent(inst)) {
-	      return false;
-	    }
-	    var internalInstance = ReactInstanceMap.get(inst);
-	    var constructor = internalInstance._currentElement.type;
-
-	    return constructor === type;
-	  },
-
-	  isCompositeComponentElement: function (inst) {
-	    if (!React.isValidElement(inst)) {
-	      return false;
-	    }
-	    // We check the prototype of the type that will get mounted, not the
-	    // instance itself. This is a future proof way of duck typing.
-	    var prototype = inst.type.prototype;
-	    return typeof prototype.render === 'function' && typeof prototype.setState === 'function';
-	  },
-
-	  isCompositeComponentElementWithType: function (inst, type) {
-	    var internalInstance = ReactInstanceMap.get(inst);
-	    var constructor = internalInstance._currentElement.type;
-
-	    return !!(ReactTestUtils.isCompositeComponentElement(inst) && constructor === type);
-	  },
-
-	  getRenderedChildOfCompositeComponent: function (inst) {
-	    if (!ReactTestUtils.isCompositeComponent(inst)) {
-	      return null;
-	    }
-	    var internalInstance = ReactInstanceMap.get(inst);
-	    return internalInstance._renderedComponent.getPublicInstance();
-	  },
-
-	  findAllInRenderedTree: function (inst, test) {
-	    if (!inst) {
-	      return [];
-	    }
-	    !ReactTestUtils.isCompositeComponent(inst) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'findAllInRenderedTree(...): instance must be a composite component') : _prodInvariant('10') : void 0;
-	    return findAllInRenderedTreeInternal(ReactInstanceMap.get(inst), test);
-	  },
-
-	  /**
-	   * Finds all instance of components in the rendered tree that are DOM
-	   * components with the class name matching `className`.
-	   * @return {array} an array of all the matches.
-	   */
-	  scryRenderedDOMComponentsWithClass: function (root, classNames) {
-	    return ReactTestUtils.findAllInRenderedTree(root, function (inst) {
-	      if (ReactTestUtils.isDOMComponent(inst)) {
-	        var className = inst.className;
-	        if (typeof className !== 'string') {
-	          // SVG, probably.
-	          className = inst.getAttribute('class') || '';
-	        }
-	        var classList = className.split(/\s+/);
-
-	        if (!Array.isArray(classNames)) {
-	          !(classNames !== undefined) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'TestUtils.scryRenderedDOMComponentsWithClass expects a className as a second argument.') : _prodInvariant('11') : void 0;
-	          classNames = classNames.split(/\s+/);
-	        }
-	        return classNames.every(function (name) {
-	          return classList.indexOf(name) !== -1;
-	        });
-	      }
-	      return false;
-	    });
-	  },
-
-	  /**
-	   * Like scryRenderedDOMComponentsWithClass but expects there to be one result,
-	   * and returns that one result, or throws exception if there is any other
-	   * number of matches besides one.
-	   * @return {!ReactDOMComponent} The one match.
-	   */
-	  findRenderedDOMComponentWithClass: function (root, className) {
-	    var all = ReactTestUtils.scryRenderedDOMComponentsWithClass(root, className);
-	    if (all.length !== 1) {
-	      throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for class:' + className);
-	    }
-	    return all[0];
-	  },
-
-	  /**
-	   * Finds all instance of components in the rendered tree that are DOM
-	   * components with the tag name matching `tagName`.
-	   * @return {array} an array of all the matches.
-	   */
-	  scryRenderedDOMComponentsWithTag: function (root, tagName) {
-	    return ReactTestUtils.findAllInRenderedTree(root, function (inst) {
-	      return ReactTestUtils.isDOMComponent(inst) && inst.tagName.toUpperCase() === tagName.toUpperCase();
-	    });
-	  },
-
-	  /**
-	   * Like scryRenderedDOMComponentsWithTag but expects there to be one result,
-	   * and returns that one result, or throws exception if there is any other
-	   * number of matches besides one.
-	   * @return {!ReactDOMComponent} The one match.
-	   */
-	  findRenderedDOMComponentWithTag: function (root, tagName) {
-	    var all = ReactTestUtils.scryRenderedDOMComponentsWithTag(root, tagName);
-	    if (all.length !== 1) {
-	      throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for tag:' + tagName);
-	    }
-	    return all[0];
-	  },
-
-	  /**
-	   * Finds all instances of components with type equal to `componentType`.
-	   * @return {array} an array of all the matches.
-	   */
-	  scryRenderedComponentsWithType: function (root, componentType) {
-	    return ReactTestUtils.findAllInRenderedTree(root, function (inst) {
-	      return ReactTestUtils.isCompositeComponentWithType(inst, componentType);
-	    });
-	  },
-
-	  /**
-	   * Same as `scryRenderedComponentsWithType` but expects there to be one result
-	   * and returns that one result, or throws exception if there is any other
-	   * number of matches besides one.
-	   * @return {!ReactComponent} The one match.
-	   */
-	  findRenderedComponentWithType: function (root, componentType) {
-	    var all = ReactTestUtils.scryRenderedComponentsWithType(root, componentType);
-	    if (all.length !== 1) {
-	      throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for componentType:' + componentType);
-	    }
-	    return all[0];
-	  },
-
-	  /**
-	   * Pass a mocked component module to this method to augment it with
-	   * useful methods that allow it to be used as a dummy React component.
-	   * Instead of rendering as usual, the component will become a simple
-	   * <div> containing any provided children.
-	   *
-	   * @param {object} module the mock function object exported from a
-	   *                        module that defines the component to be mocked
-	   * @param {?string} mockTagName optional dummy root tag name to return
-	   *                              from render method (overrides
-	   *                              module.mockTagName if provided)
-	   * @return {object} the ReactTestUtils object (for chaining)
-	   */
-	  mockComponent: function (module, mockTagName) {
-	    mockTagName = mockTagName || module.mockTagName || 'div';
-
-	    module.prototype.render.mockImplementation(function () {
-	      return React.createElement(mockTagName, null, this.props.children);
-	    });
-
-	    return this;
-	  },
-
-	  /**
-	   * Simulates a top level event being dispatched from a raw event that occurred
-	   * on an `Element` node.
-	   * @param {Object} topLevelType A type from `EventConstants.topLevelTypes`
-	   * @param {!Element} node The dom to simulate an event occurring on.
-	   * @param {?Event} fakeNativeEvent Fake native event to use in SyntheticEvent.
-	   */
-	  simulateNativeEventOnNode: function (topLevelType, node, fakeNativeEvent) {
-	    fakeNativeEvent.target = node;
-	    ReactBrowserEventEmitter.ReactEventListener.dispatchEvent(topLevelType, fakeNativeEvent);
-	  },
-
-	  /**
-	   * Simulates a top level event being dispatched from a raw event that occurred
-	   * on the `ReactDOMComponent` `comp`.
-	   * @param {Object} topLevelType A type from `EventConstants.topLevelTypes`.
-	   * @param {!ReactDOMComponent} comp
-	   * @param {?Event} fakeNativeEvent Fake native event to use in SyntheticEvent.
-	   */
-	  simulateNativeEventOnDOMComponent: function (topLevelType, comp, fakeNativeEvent) {
-	    ReactTestUtils.simulateNativeEventOnNode(topLevelType, findDOMNode(comp), fakeNativeEvent);
-	  },
-
-	  nativeTouchData: function (x, y) {
-	    return {
-	      touches: [{ pageX: x, pageY: y }]
-	    };
-	  },
-
-	  createRenderer: createRendererWithWarning,
-
-	  Simulate: null,
-	  SimulateNative: {}
-	};
-
-	/**
-	 * Exports:
-	 *
-	 * - `ReactTestUtils.Simulate.click(Element/ReactDOMComponent)`
-	 * - `ReactTestUtils.Simulate.mouseMove(Element/ReactDOMComponent)`
-	 * - `ReactTestUtils.Simulate.change(Element/ReactDOMComponent)`
-	 * - ... (All keys from event plugin `eventTypes` objects)
-	 */
-	function makeSimulator(eventType) {
-	  return function (domComponentOrNode, eventData) {
-	    var node;
-	    !!React.isValidElement(domComponentOrNode) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'TestUtils.Simulate expects a component instance and not a ReactElement.TestUtils.Simulate will not work if you are using shallow rendering.') : _prodInvariant('14') : void 0;
-	    if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
-	      node = findDOMNode(domComponentOrNode);
-	    } else if (domComponentOrNode.tagName) {
-	      node = domComponentOrNode;
-	    }
-
-	    var dispatchConfig = EventPluginRegistry.eventNameDispatchConfigs[eventType];
-
-	    var fakeNativeEvent = new Event();
-	    fakeNativeEvent.target = node;
-	    fakeNativeEvent.type = eventType.toLowerCase();
-
-	    // We don't use SyntheticEvent.getPooled in order to not have to worry about
-	    // properly destroying any properties assigned from `eventData` upon release
-	    var event = new SyntheticEvent(dispatchConfig, ReactDOMComponentTree.getInstanceFromNode(node), fakeNativeEvent, node);
-	    // Since we aren't using pooling, always persist the event. This will make
-	    // sure it's marked and won't warn when setting additional properties.
-	    event.persist();
-	    _assign(event, eventData);
-
-	    if (dispatchConfig.phasedRegistrationNames) {
-	      EventPropagators.accumulateTwoPhaseDispatches(event);
-	    } else {
-	      EventPropagators.accumulateDirectDispatches(event);
-	    }
-
-	    ReactUpdates.batchedUpdates(function () {
-	      EventPluginHub.enqueueEvents(event);
-	      EventPluginHub.processEventQueue(true);
-	    });
-	  };
-	}
-
-	function buildSimulators() {
-	  ReactTestUtils.Simulate = {};
-
-	  var eventType;
-	  for (eventType in EventPluginRegistry.eventNameDispatchConfigs) {
-	    /**
-	     * @param {!Element|ReactDOMComponent} domComponentOrNode
-	     * @param {?object} eventData Fake event data to use in SyntheticEvent.
-	     */
-	    ReactTestUtils.Simulate[eventType] = makeSimulator(eventType);
-	  }
-	}
-
-	// Rebuild ReactTestUtils.Simulate whenever event plugins are injected
-	var oldInjectEventPluginOrder = EventPluginHub.injection.injectEventPluginOrder;
-	EventPluginHub.injection.injectEventPluginOrder = function () {
-	  oldInjectEventPluginOrder.apply(this, arguments);
-	  buildSimulators();
-	};
-	var oldInjectEventPlugins = EventPluginHub.injection.injectEventPluginsByName;
-	EventPluginHub.injection.injectEventPluginsByName = function () {
-	  oldInjectEventPlugins.apply(this, arguments);
-	  buildSimulators();
-	};
-
-	buildSimulators();
-
-	/**
-	 * Exports:
-	 *
-	 * - `ReactTestUtils.SimulateNative.click(Element/ReactDOMComponent)`
-	 * - `ReactTestUtils.SimulateNative.mouseMove(Element/ReactDOMComponent)`
-	 * - `ReactTestUtils.SimulateNative.mouseIn/ReactDOMComponent)`
-	 * - `ReactTestUtils.SimulateNative.mouseOut(Element/ReactDOMComponent)`
-	 * - ... (All keys from `EventConstants.topLevelTypes`)
-	 *
-	 * Note: Top level event types are a subset of the entire set of handler types
-	 * (which include a broader set of "synthetic" events). For example, onDragDone
-	 * is a synthetic event. Except when testing an event plugin or React's event
-	 * handling code specifically, you probably want to use ReactTestUtils.Simulate
-	 * to dispatch synthetic events.
-	 */
-
-	function makeNativeSimulator(eventType) {
-	  return function (domComponentOrNode, nativeEventData) {
-	    var fakeNativeEvent = new Event(eventType);
-	    _assign(fakeNativeEvent, nativeEventData);
-	    if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
-	      ReactTestUtils.simulateNativeEventOnDOMComponent(eventType, domComponentOrNode, fakeNativeEvent);
-	    } else if (domComponentOrNode.tagName) {
-	      // Will allow on actual dom nodes.
-	      ReactTestUtils.simulateNativeEventOnNode(eventType, domComponentOrNode, fakeNativeEvent);
-	    }
-	  };
-	}
-
-	Object.keys(topLevelTypes).forEach(function (eventType) {
-	  // Event type is stored as 'topClick' - we transform that to 'click'
-	  var convenienceName = eventType.indexOf('top') === 0 ? eventType.charAt(3).toLowerCase() + eventType.substr(4) : eventType;
-	  /**
-	   * @param {!Element|ReactDOMComponent} domComponentOrNode
-	   * @param {?Event} nativeEventData Fake native event to use in SyntheticEvent.
-	   */
-	  ReactTestUtils.SimulateNative[convenienceName] = makeNativeSimulator(eventType);
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
 	});
+	exports.default = addClass;
 
-	module.exports = ReactTestUtils;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
+	var _hasClass = __webpack_require__(231);
+
+	var _hasClass2 = _interopRequireDefault(_hasClass);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function addClass(element, className) {
+	  if (element.classList) element.classList.add(className);else if (!(0, _hasClass2.default)(element)) element.className = element.className + ' ' + className;
+	}
+	module.exports = exports['default'];
 
 /***/ },
 /* 231 */
 /***/ function(module, exports) {
 
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
+	"use strict";
 
-	'use strict';
-
-	/**
-	 * Types of raw signals from the browser caught at the top level.
-	 */
-	var topLevelTypes = {
-	  topAbort: null,
-	  topAnimationEnd: null,
-	  topAnimationIteration: null,
-	  topAnimationStart: null,
-	  topBlur: null,
-	  topCanPlay: null,
-	  topCanPlayThrough: null,
-	  topChange: null,
-	  topClick: null,
-	  topCompositionEnd: null,
-	  topCompositionStart: null,
-	  topCompositionUpdate: null,
-	  topContextMenu: null,
-	  topCopy: null,
-	  topCut: null,
-	  topDoubleClick: null,
-	  topDrag: null,
-	  topDragEnd: null,
-	  topDragEnter: null,
-	  topDragExit: null,
-	  topDragLeave: null,
-	  topDragOver: null,
-	  topDragStart: null,
-	  topDrop: null,
-	  topDurationChange: null,
-	  topEmptied: null,
-	  topEncrypted: null,
-	  topEnded: null,
-	  topError: null,
-	  topFocus: null,
-	  topInput: null,
-	  topInvalid: null,
-	  topKeyDown: null,
-	  topKeyPress: null,
-	  topKeyUp: null,
-	  topLoad: null,
-	  topLoadedData: null,
-	  topLoadedMetadata: null,
-	  topLoadStart: null,
-	  topMouseDown: null,
-	  topMouseMove: null,
-	  topMouseOut: null,
-	  topMouseOver: null,
-	  topMouseUp: null,
-	  topPaste: null,
-	  topPause: null,
-	  topPlay: null,
-	  topPlaying: null,
-	  topProgress: null,
-	  topRateChange: null,
-	  topReset: null,
-	  topScroll: null,
-	  topSeeked: null,
-	  topSeeking: null,
-	  topSelectionChange: null,
-	  topStalled: null,
-	  topSubmit: null,
-	  topSuspend: null,
-	  topTextInput: null,
-	  topTimeUpdate: null,
-	  topTouchCancel: null,
-	  topTouchEnd: null,
-	  topTouchMove: null,
-	  topTouchStart: null,
-	  topTransitionEnd: null,
-	  topVolumeChange: null,
-	  topWaiting: null,
-	  topWheel: null
-	};
-
-	var EventConstants = {
-	  topLevelTypes: topLevelTypes
-	};
-
-	module.exports = EventConstants;
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = hasClass;
+	function hasClass(element, className) {
+	  if (element.classList) return !!className && element.classList.contains(className);else return (" " + element.className + " ").indexOf(" " + className + " ") !== -1;
+	}
+	module.exports = exports["default"];
 
 /***/ },
 /* 232 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
+/***/ function(module, exports) {
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(74),
-	    _assign = __webpack_require__(27);
-
-	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-	var React = __webpack_require__(25);
-	var ReactCompositeComponent = __webpack_require__(158);
-	var ReactDefaultBatchingStrategy = __webpack_require__(179);
-	var ReactReconciler = __webpack_require__(98);
-	var ReactReconcileTransaction = __webpack_require__(184);
-	var ReactUpdates = __webpack_require__(95);
-
-	var emptyObject = __webpack_require__(43);
-	var getNextDebugID = __webpack_require__(166);
-	var invariant = __webpack_require__(31);
-
-	function injectDefaults() {
-	  ReactUpdates.injection.injectReconcileTransaction(ReactReconcileTransaction);
-	  ReactUpdates.injection.injectBatchingStrategy(ReactDefaultBatchingStrategy);
-	}
-
-	var NoopInternalComponent = function () {
-	  function NoopInternalComponent(element) {
-	    _classCallCheck(this, NoopInternalComponent);
-
-	    this._renderedOutput = element;
-	    this._currentElement = element;
-
-	    if (process.env.NODE_ENV !== 'production') {
-	      this._debugID = getNextDebugID();
-	    }
-	  }
-
-	  NoopInternalComponent.prototype.mountComponent = function mountComponent() {};
-
-	  NoopInternalComponent.prototype.receiveComponent = function receiveComponent(element) {
-	    this._renderedOutput = element;
-	    this._currentElement = element;
-	  };
-
-	  NoopInternalComponent.prototype.unmountComponent = function unmountComponent() {};
-
-	  NoopInternalComponent.prototype.getHostNode = function getHostNode() {
-	    return undefined;
-	  };
-
-	  NoopInternalComponent.prototype.getPublicInstance = function getPublicInstance() {
-	    return null;
-	  };
-
-	  return NoopInternalComponent;
-	}();
-
-	var ShallowComponentWrapper = function (element) {
-	  // TODO: Consolidate with instantiateReactComponent
-	  if (process.env.NODE_ENV !== 'production') {
-	    this._debugID = getNextDebugID();
-	  }
-
-	  this.construct(element);
+	module.exports = function removeClass(element, className) {
+	  if (element.classList) element.classList.remove(className);else element.className = element.className.replace(new RegExp('(^|\\s)' + className + '(?:\\s|$)', 'g'), '$1').replace(/\s+/g, ' ').replace(/^\s*|\s*$/g, '');
 	};
-	_assign(ShallowComponentWrapper.prototype, ReactCompositeComponent, {
-	  _constructComponent: ReactCompositeComponent._constructComponentWithoutOwner,
-	  _instantiateReactComponent: function (element) {
-	    return new NoopInternalComponent(element);
-	  },
-	  _replaceNodeWithMarkup: function () {},
-	  _renderValidatedComponent: ReactCompositeComponent._renderValidatedComponentWithoutOwnerOrContext
-	});
-
-	function _batchedRender(renderer, element, context) {
-	  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
-	  renderer._render(element, transaction, context);
-	  ReactUpdates.ReactReconcileTransaction.release(transaction);
-	}
-
-	var ReactShallowRenderer = function () {
-	  function ReactShallowRenderer() {
-	    _classCallCheck(this, ReactShallowRenderer);
-
-	    this._instance = null;
-	  }
-
-	  ReactShallowRenderer.prototype.getMountedInstance = function getMountedInstance() {
-	    return this._instance ? this._instance._instance : null;
-	  };
-
-	  ReactShallowRenderer.prototype.render = function render(element, context) {
-	    // Ensure we've done the default injections. This might not be true in the
-	    // case of a simple test that only requires React and the TestUtils in
-	    // conjunction with an inline-requires transform.
-	    injectDefaults();
-
-	    !React.isValidElement(element) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'ReactShallowRenderer render(): Invalid component element.%s', typeof element === 'function' ? ' Instead of passing a component class, make sure to instantiate ' + 'it by passing it to React.createElement.' : '') : _prodInvariant('12', typeof element === 'function' ? ' Instead of passing a component class, make sure to instantiate ' + 'it by passing it to React.createElement.' : '') : void 0;
-	    !(typeof element.type !== 'string') ? process.env.NODE_ENV !== 'production' ? invariant(false, 'ReactShallowRenderer render(): Shallow rendering works only with custom components, not primitives (%s). Instead of calling `.render(el)` and inspecting the rendered output, look at `el.props` directly instead.', element.type) : _prodInvariant('13', element.type) : void 0;
-
-	    if (!context) {
-	      context = emptyObject;
-	    }
-	    ReactUpdates.batchedUpdates(_batchedRender, this, element, context);
-
-	    return this.getRenderOutput();
-	  };
-
-	  ReactShallowRenderer.prototype.getRenderOutput = function getRenderOutput() {
-	    return this._instance && this._instance._renderedComponent && this._instance._renderedComponent._renderedOutput || null;
-	  };
-
-	  ReactShallowRenderer.prototype.unmount = function unmount() {
-	    if (this._instance) {
-	      ReactReconciler.unmountComponent(this._instance, false);
-	    }
-	  };
-
-	  ReactShallowRenderer.prototype._render = function _render(element, transaction, context) {
-	    if (this._instance) {
-	      ReactReconciler.receiveComponent(this._instance, element, transaction, context);
-	    } else {
-	      var instance = new ShallowComponentWrapper(element);
-	      ReactReconciler.mountComponent(instance, transaction, null, null, context, 0);
-	      this._instance = instance;
-	    }
-	  };
-
-	  return ReactShallowRenderer;
-	}();
-
-	ReactShallowRenderer.createRenderer = function () {
-	  return new ReactShallowRenderer();
-	};
-
-	module.exports = ReactShallowRenderer;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
 
 /***/ },
 /* 233 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
+	'use strict';
 
-	/**
-	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @typechecks
-	 */
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
 
-	var invariant = __webpack_require__(31);
+	var _inDOM = __webpack_require__(234);
 
-	/**
-	 * The CSSCore module specifies the API (and implements most of the methods)
-	 * that should be used when dealing with the display of elements (via their
-	 * CSS classes and visibility on screen. It is an API focused on mutating the
-	 * display and not reading it as no logical state should be encoded in the
-	 * display of elements.
-	 */
+	var _inDOM2 = _interopRequireDefault(_inDOM);
 
-	/* Slow implementation for browsers that don't natively support .matches() */
-	function matchesSelector_SLOW(element, selector) {
-	  var root = element;
-	  while (root.parentNode) {
-	    root = root.parentNode;
-	  }
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	  var all = root.querySelectorAll(selector);
-	  return Array.prototype.indexOf.call(all, element) !== -1;
-	}
+	var vendors = ['', 'webkit', 'moz', 'o', 'ms'];
+	var cancel = 'clearTimeout';
+	var raf = fallback;
+	var compatRaf = void 0;
 
-	var CSSCore = {
-
-	  /**
-	   * Adds the class passed in to the element if it doesn't already have it.
-	   *
-	   * @param {DOMElement} element the element to set the class on
-	   * @param {string} className the CSS className
-	   * @return {DOMElement} the element passed in
-	   */
-	  addClass: function addClass(element, className) {
-	    !!/\s/.test(className) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'CSSCore.addClass takes only a single class name. "%s" contains ' + 'multiple classes.', className) : invariant(false) : void 0;
-
-	    if (className) {
-	      if (element.classList) {
-	        element.classList.add(className);
-	      } else if (!CSSCore.hasClass(element, className)) {
-	        element.className = element.className + ' ' + className;
-	      }
-	    }
-	    return element;
-	  },
-
-	  /**
-	   * Removes the class passed in from the element
-	   *
-	   * @param {DOMElement} element the element to set the class on
-	   * @param {string} className the CSS className
-	   * @return {DOMElement} the element passed in
-	   */
-	  removeClass: function removeClass(element, className) {
-	    !!/\s/.test(className) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'CSSCore.removeClass takes only a single class name. "%s" contains ' + 'multiple classes.', className) : invariant(false) : void 0;
-
-	    if (className) {
-	      if (element.classList) {
-	        element.classList.remove(className);
-	      } else if (CSSCore.hasClass(element, className)) {
-	        element.className = element.className.replace(new RegExp('(^|\\s)' + className + '(?:\\s|$)', 'g'), '$1').replace(/\s+/g, ' ') // multiple spaces to one
-	        .replace(/^\s*|\s*$/g, ''); // trim the ends
-	      }
-	    }
-	    return element;
-	  },
-
-	  /**
-	   * Helper to add or remove a class from an element based on a condition.
-	   *
-	   * @param {DOMElement} element the element to set the class on
-	   * @param {string} className the CSS className
-	   * @param {*} bool condition to whether to add or remove the class
-	   * @return {DOMElement} the element passed in
-	   */
-	  conditionClass: function conditionClass(element, className, bool) {
-	    return (bool ? CSSCore.addClass : CSSCore.removeClass)(element, className);
-	  },
-
-	  /**
-	   * Tests whether the element has the class specified.
-	   *
-	   * @param {DOMNode|DOMWindow} element the element to check the class on
-	   * @param {string} className the CSS className
-	   * @return {boolean} true if the element has the class, false if not
-	   */
-	  hasClass: function hasClass(element, className) {
-	    !!/\s/.test(className) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'CSS.hasClass takes only a single class name.') : invariant(false) : void 0;
-	    if (element.classList) {
-	      return !!className && element.classList.contains(className);
-	    }
-	    return (' ' + element.className + ' ').indexOf(' ' + className + ' ') > -1;
-	  },
-
-	  /**
-	   * Tests whether the element matches the selector specified
-	   *
-	   * @param {DOMNode|DOMWindow} element the element that we are querying
-	   * @param {string} selector the CSS selector
-	   * @return {boolean} true if the element matches the selector, false if not
-	   */
-	  matchesSelector: function matchesSelector(element, selector) {
-	    var matchesImpl = element.matches || element.webkitMatchesSelector || element.mozMatchesSelector || element.msMatchesSelector || function (s) {
-	      return matchesSelector_SLOW(element, s);
-	    };
-	    return matchesImpl.call(element, selector);
-	  }
-
+	var getKey = function getKey(vendor, k) {
+	  return vendor + (!vendor ? k : k[0].toUpperCase() + k.substr(1)) + 'AnimationFrame';
 	};
 
-	module.exports = CSSCore;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(26)))
+	if (_inDOM2.default) {
+	  vendors.some(function (vendor) {
+	    var rafKey = getKey(vendor, 'request');
+
+	    if (rafKey in window) {
+	      cancel = getKey(vendor, 'cancel');
+	      return raf = function raf(cb) {
+	        return window[rafKey](cb);
+	      };
+	    }
+	  });
+	}
+
+	/* https://github.com/component/raf */
+	var prev = new Date().getTime();
+	function fallback(fn) {
+	  var curr = new Date().getTime(),
+	      ms = Math.max(0, 16 - (curr - prev)),
+	      req = setTimeout(fn, ms);
+
+	  prev = curr;
+	  return req;
+	}
+
+	compatRaf = function compatRaf(cb) {
+	  return raf(cb);
+	};
+	compatRaf.cancel = function (id) {
+	  window[cancel] && typeof window[cancel] === 'function' && window[cancel](id);
+	};
+	exports.default = compatRaf;
+	module.exports = exports['default'];
 
 /***/ },
 /* 234 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
+/***/ function(module, exports) {
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(87);
-
-	var getVendorPrefixedEventName = __webpack_require__(146);
-
-	var endEvents = [];
-
-	function detectEvents() {
-	  var animEnd = getVendorPrefixedEventName('animationend');
-	  var transEnd = getVendorPrefixedEventName('transitionend');
-
-	  if (animEnd) {
-	    endEvents.push(animEnd);
-	  }
-
-	  if (transEnd) {
-	    endEvents.push(transEnd);
-	  }
-	}
-
-	if (ExecutionEnvironment.canUseDOM) {
-	  detectEvents();
-	}
-
-	// We use the raw {add|remove}EventListener() call because EventListener
-	// does not know how to remove event listeners and we really should
-	// clean up. Also, these events are not triggered in older browsers
-	// so we should be A-OK here.
-
-	function addEventListener(node, eventName, eventListener) {
-	  node.addEventListener(eventName, eventListener, false);
-	}
-
-	function removeEventListener(node, eventName, eventListener) {
-	  node.removeEventListener(eventName, eventListener, false);
-	}
-
-	var ReactTransitionEvents = {
-	  addEndEventListener: function (node, eventListener) {
-	    if (endEvents.length === 0) {
-	      // If CSS transitions are not supported, trigger an "end animation"
-	      // event immediately.
-	      window.setTimeout(eventListener, 0);
-	      return;
-	    }
-	    endEvents.forEach(function (endEvent) {
-	      addEventListener(node, endEvent, eventListener);
-	    });
-	  },
-
-	  removeEndEventListener: function (node, eventListener) {
-	    if (endEvents.length === 0) {
-	      return;
-	    }
-	    endEvents.forEach(function (endEvent) {
-	      removeEventListener(node, endEvent, eventListener);
-	    });
-	  }
-	};
-
-	module.exports = ReactTransitionEvents;
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+	module.exports = exports['default'];
 
 /***/ },
 /* 235 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.animationEnd = exports.animationDelay = exports.animationTiming = exports.animationDuration = exports.animationName = exports.transitionEnd = exports.transitionDuration = exports.transitionDelay = exports.transitionTiming = exports.transitionProperty = exports.transform = undefined;
+
+	var _inDOM = __webpack_require__(234);
+
+	var _inDOM2 = _interopRequireDefault(_inDOM);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var transform = 'transform';
+	var prefix = void 0,
+	    transitionEnd = void 0,
+	    animationEnd = void 0;
+	var transitionProperty = void 0,
+	    transitionDuration = void 0,
+	    transitionTiming = void 0,
+	    transitionDelay = void 0;
+	var animationName = void 0,
+	    animationDuration = void 0,
+	    animationTiming = void 0,
+	    animationDelay = void 0;
+
+	if (_inDOM2.default) {
+	  var _getTransitionPropert = getTransitionProperties();
+
+	  prefix = _getTransitionPropert.prefix;
+	  exports.transitionEnd = transitionEnd = _getTransitionPropert.transitionEnd;
+	  exports.animationEnd = animationEnd = _getTransitionPropert.animationEnd;
+
+
+	  exports.transform = transform = prefix + '-' + transform;
+	  exports.transitionProperty = transitionProperty = prefix + '-transition-property';
+	  exports.transitionDuration = transitionDuration = prefix + '-transition-duration';
+	  exports.transitionDelay = transitionDelay = prefix + '-transition-delay';
+	  exports.transitionTiming = transitionTiming = prefix + '-transition-timing-function';
+
+	  exports.animationName = animationName = prefix + '-animation-name';
+	  exports.animationDuration = animationDuration = prefix + '-animation-duration';
+	  exports.animationTiming = animationTiming = prefix + '-animation-delay';
+	  exports.animationDelay = animationDelay = prefix + '-animation-timing-function';
+	}
+
+	exports.transform = transform;
+	exports.transitionProperty = transitionProperty;
+	exports.transitionTiming = transitionTiming;
+	exports.transitionDelay = transitionDelay;
+	exports.transitionDuration = transitionDuration;
+	exports.transitionEnd = transitionEnd;
+	exports.animationName = animationName;
+	exports.animationDuration = animationDuration;
+	exports.animationTiming = animationTiming;
+	exports.animationDelay = animationDelay;
+	exports.animationEnd = animationEnd;
+	exports.default = {
+	  transform: transform,
+	  end: transitionEnd,
+	  property: transitionProperty,
+	  timing: transitionTiming,
+	  delay: transitionDelay,
+	  duration: transitionDuration
+	};
+
+
+	function getTransitionProperties() {
+	  var style = document.createElement('div').style;
+
+	  var vendorMap = {
+	    O: function O(e) {
+	      return 'o' + e.toLowerCase();
+	    },
+	    Moz: function Moz(e) {
+	      return e.toLowerCase();
+	    },
+	    Webkit: function Webkit(e) {
+	      return 'webkit' + e;
+	    },
+	    ms: function ms(e) {
+	      return 'MS' + e;
+	    }
+	  };
+
+	  var vendors = Object.keys(vendorMap);
+
+	  var transitionEnd = void 0,
+	      animationEnd = void 0;
+	  var prefix = '';
+
+	  for (var i = 0; i < vendors.length; i++) {
+	    var vendor = vendors[i];
+
+	    if (vendor + 'TransitionProperty' in style) {
+	      prefix = '-' + vendor.toLowerCase();
+	      transitionEnd = vendorMap[vendor]('TransitionEnd');
+	      animationEnd = vendorMap[vendor]('AnimationEnd');
+	      break;
+	    }
+	  }
+
+	  if (!transitionEnd && 'transitionProperty' in style) transitionEnd = 'transitionend';
+
+	  if (!animationEnd && 'animationName' in style) animationEnd = 'animationend';
+
+	  style = null;
+
+	  return { animationEnd: animationEnd, transitionEnd: transitionEnd, prefix: prefix };
+	}
+
+/***/ },
+/* 236 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	exports.__esModule = true;
+	exports.nameShape = undefined;
+	exports.transitionTimeout = transitionTimeout;
+
+	var _react = __webpack_require__(24);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _propTypes = __webpack_require__(223);
+
+	var _propTypes2 = _interopRequireDefault(_propTypes);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function transitionTimeout(transitionType) {
+	  var timeoutPropName = 'transition' + transitionType + 'Timeout';
+	  var enabledPropName = 'transition' + transitionType;
+
+	  return function (props) {
+	    // If the transition is enabled
+	    if (props[enabledPropName]) {
+	      // If no timeout duration is provided
+	      if (props[timeoutPropName] == null) {
+	        return new Error(timeoutPropName + ' wasn\'t supplied to CSSTransitionGroup: ' + 'this can cause unreliable animations and won\'t be supported in ' + 'a future version of React. See ' + 'https://fb.me/react-animation-transition-group-timeout for more ' + 'information.');
+
+	        // If the duration isn't a number
+	      } else if (typeof props[timeoutPropName] !== 'number') {
+	        return new Error(timeoutPropName + ' must be a number (in milliseconds)');
+	      }
+	    }
+
+	    return null;
+	  };
+	}
+
+	var nameShape = exports.nameShape = _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.shape({
+	  enter: _propTypes2.default.string,
+	  leave: _propTypes2.default.string,
+	  active: _propTypes2.default.string
+	}), _propTypes2.default.shape({
+	  enter: _propTypes2.default.string,
+	  enterActive: _propTypes2.default.string,
+	  leave: _propTypes2.default.string,
+	  leaveActive: _propTypes2.default.string,
+	  appear: _propTypes2.default.string,
+	  appearActive: _propTypes2.default.string
+	})]);
+
+/***/ },
+/* 237 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28898,7 +27933,7 @@
 
 
 /***/ },
-/* 236 */
+/* 238 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -28956,7 +27991,7 @@
 
 
 /***/ },
-/* 237 */
+/* 239 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -29038,7 +28073,7 @@
 
 
 /***/ },
-/* 238 */
+/* 240 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29054,8 +28089,8 @@
 	var React = __webpack_require__(24);
 	var common_1 = __webpack_require__(21);
 	var errors_1 = __webpack_require__(60);
-	var buttons_1 = __webpack_require__(239);
-	var dialog_1 = __webpack_require__(242);
+	var buttons_1 = __webpack_require__(241);
+	var dialog_1 = __webpack_require__(244);
 	var Alert = (function (_super) {
 	    tslib_1.__extends(Alert, _super);
 	    function Alert() {
@@ -29105,7 +28140,7 @@
 
 
 /***/ },
-/* 239 */
+/* 241 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29121,7 +28156,7 @@
 	// tslint:disable max-classes-per-file
 	var React = __webpack_require__(24);
 	var props_1 = __webpack_require__(64);
-	var abstractButton_1 = __webpack_require__(240);
+	var abstractButton_1 = __webpack_require__(242);
 	var Button = (function (_super) {
 	    tslib_1.__extends(Button, _super);
 	    function Button() {
@@ -29155,7 +28190,7 @@
 
 
 /***/ },
-/* 240 */
+/* 242 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29172,7 +28207,7 @@
 	var Classes = __webpack_require__(66);
 	var Keys = __webpack_require__(67);
 	var utils_1 = __webpack_require__(59);
-	var spinner_1 = __webpack_require__(241);
+	var spinner_1 = __webpack_require__(243);
 	var AbstractButton = (function (_super) {
 	    tslib_1.__extends(AbstractButton, _super);
 	    function AbstractButton() {
@@ -29256,7 +28291,7 @@
 
 
 /***/ },
-/* 241 */
+/* 243 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29324,7 +28359,7 @@
 
 
 /***/ },
-/* 242 */
+/* 244 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29401,7 +28436,7 @@
 
 
 /***/ },
-/* 243 */
+/* 245 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29427,7 +28462,7 @@
 
 
 /***/ },
-/* 244 */
+/* 246 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29586,7 +28621,7 @@
 
 
 /***/ },
-/* 245 */
+/* 247 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29603,8 +28638,8 @@
 	var Classes = __webpack_require__(66);
 	var Errors = __webpack_require__(60);
 	var position_1 = __webpack_require__(63);
-	var menu_1 = __webpack_require__(246);
-	var menuItem_1 = __webpack_require__(247);
+	var menu_1 = __webpack_require__(248);
+	var menuItem_1 = __webpack_require__(249);
 	var popover_1 = __webpack_require__(217);
 	var CollapseFrom;
 	(function (CollapseFrom) {
@@ -29678,7 +28713,7 @@
 
 
 /***/ },
-/* 246 */
+/* 248 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29711,7 +28746,7 @@
 
 
 /***/ },
-/* 247 */
+/* 249 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29731,7 +28766,7 @@
 	var Errors = __webpack_require__(60);
 	var position_1 = __webpack_require__(63);
 	var popover_1 = __webpack_require__(217);
-	var menu_1 = __webpack_require__(246);
+	var menu_1 = __webpack_require__(248);
 	var REACT_CONTEXT_TYPES = {
 	    alignLeft: function (obj, key) {
 	        if (obj[key] != null && typeof obj[key] !== "boolean") {
@@ -29884,7 +28919,7 @@
 
 
 /***/ },
-/* 248 */
+/* 250 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29940,7 +28975,7 @@
 
 
 /***/ },
-/* 249 */
+/* 251 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -29959,7 +28994,7 @@
 	var Classes = __webpack_require__(66);
 	var Keys = __webpack_require__(67);
 	var utils_1 = __webpack_require__(59);
-	var compatibility_1 = __webpack_require__(250);
+	var compatibility_1 = __webpack_require__(252);
 	var BUFFER_WIDTH_EDGE = 5;
 	var BUFFER_WIDTH_IE = 30;
 	var EditableText = (function (_super) {
@@ -30036,12 +29071,13 @@
 	                }
 	            }
 	        };
+	        var value = (props.value == null) ? props.defaultValue : props.value;
 	        _this.state = {
 	            inputHeight: 0,
 	            inputWidth: 0,
 	            isEditing: props.isEditing === true && props.disabled === false,
-	            lastValue: getValue(props),
-	            value: getValue(props),
+	            lastValue: value,
+	            value: value,
 	        };
 	        return _this;
 	    }
@@ -30087,7 +29123,10 @@
 	        this.updateInputDimensions();
 	    };
 	    EditableText.prototype.componentWillReceiveProps = function (nextProps) {
-	        var state = { value: getValue(nextProps) };
+	        var state = {};
+	        if (nextProps.value != null) {
+	            state.value = nextProps.value;
+	        }
 	        if (nextProps.isEditing != null) {
 	            state.isEditing = nextProps.isEditing;
 	        }
@@ -30168,9 +29207,6 @@
 	    PureRender
 	], EditableText);
 	exports.EditableText = EditableText;
-	function getValue(props) {
-	    return props.value == null ? props.defaultValue : props.value;
-	}
 	function getFontSize(element) {
 	    var fontSize = getComputedStyle(element).fontSize;
 	    return fontSize === "" ? 0 : parseInt(fontSize.slice(0, -2), 10);
@@ -30210,7 +29246,7 @@
 
 
 /***/ },
-/* 250 */
+/* 252 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30224,13 +29260,13 @@
 	    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 	}
 	Object.defineProperty(exports, "__esModule", { value: true });
-	__export(__webpack_require__(251));
+	__export(__webpack_require__(253));
 
 	//# sourceMappingURL=index.js.map
 
 
 /***/ },
-/* 251 */
+/* 253 */
 /***/ function(module, exports) {
 
 	/*
@@ -30257,7 +29293,7 @@
 
 
 /***/ },
-/* 252 */
+/* 254 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30369,7 +29405,7 @@
 
 
 /***/ },
-/* 253 */
+/* 255 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30456,7 +29492,7 @@
 
 
 /***/ },
-/* 254 */
+/* 256 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30473,8 +29509,8 @@
 	var React = __webpack_require__(24);
 	var common_1 = __webpack_require__(21);
 	var Errors = __webpack_require__(60);
-	var buttons_1 = __webpack_require__(239);
-	var inputGroup_1 = __webpack_require__(253);
+	var buttons_1 = __webpack_require__(241);
+	var inputGroup_1 = __webpack_require__(255);
 	var IncrementDirection;
 	(function (IncrementDirection) {
 	    IncrementDirection[IncrementDirection["DOWN"] = -1] = "DOWN";
@@ -30484,6 +29520,9 @@
 	    tslib_1.__extends(NumericInput, _super);
 	    function NumericInput(props, context) {
 	        var _this = _super.call(this, props, context) || this;
+	        // updating these flags need not trigger re-renders, so don't include them in this.state.
+	        _this.didPasteEventJustOccur = false;
+	        _this.shouldSelectAfterUpdate = false;
 	        _this.inputRef = function (input) {
 	            _this.inputElement = input;
 	        };
@@ -30522,13 +29561,26 @@
 	        // Callbacks - Input
 	        // =================
 	        _this.handleInputFocus = function (e) {
-	            _this.setState({ isInputGroupFocused: true, shouldSelectAfterUpdate: _this.props.selectAllOnFocus });
+	            _this.shouldSelectAfterUpdate = _this.props.selectAllOnFocus;
+	            _this.setState({ isInputGroupFocused: true });
 	            common_1.Utils.safeInvoke(_this.props.onFocus, e);
 	        };
 	        _this.handleInputBlur = function (e) {
 	            // explicitly set `shouldSelectAfterUpdate` to `false` to prevent focus
 	            // hoarding on IE11 (#704)
-	            _this.setState({ isInputGroupFocused: false, shouldSelectAfterUpdate: false });
+	            _this.shouldSelectAfterUpdate = false;
+	            var baseStateChange = { isInputGroupFocused: false };
+	            if (_this.props.clampValueOnBlur) {
+	                var value = e.target.value;
+	                var sanitizedValue = _this.getSanitizedValue(value);
+	                _this.setState(tslib_1.__assign({}, baseStateChange, { value: sanitizedValue }));
+	                if (value !== sanitizedValue) {
+	                    _this.invokeOnValueChangeCallback(sanitizedValue);
+	                }
+	            }
+	            else {
+	                _this.setState(baseStateChange);
+	            }
 	            common_1.Utils.safeInvoke(_this.props.onBlur, e);
 	        };
 	        _this.handleInputKeyDown = function (e) {
@@ -30580,11 +29632,11 @@
 	            else {
 	                nextValue = value;
 	            }
-	            _this.setState({ shouldSelectAfterUpdate: false, value: nextValue });
-	            _this.invokeOnChangeCallbacks(nextValue);
+	            _this.shouldSelectAfterUpdate = false;
+	            _this.setState({ value: nextValue });
+	            _this.invokeOnValueChangeCallback(nextValue);
 	        };
 	        _this.state = {
-	            shouldSelectAfterUpdate: false,
 	            stepMaxPrecision: _this.getStepMaxPrecision(props),
 	            value: _this.getValueOrEmptyValue(props.value),
 	        };
@@ -30604,7 +29656,7 @@
 	        // outside of the new bounds, then clamp the value to the new valid range.
 	        if (didBoundsChange && sanitizedValue !== this.state.value) {
 	            this.setState({ stepMaxPrecision: stepMaxPrecision, value: sanitizedValue });
-	            this.invokeOnChangeCallbacks(sanitizedValue);
+	            this.invokeOnValueChangeCallback(sanitizedValue);
 	        }
 	        else {
 	            this.setState({ stepMaxPrecision: stepMaxPrecision, value: value });
@@ -30615,6 +29667,7 @@
 	        var inputGroupHtmlProps = common_1.removeNonHTMLProps(this.props, [
 	            "allowNumericCharactersOnly",
 	            "buttonPosition",
+	            "clampValueOnBlur",
 	            "className",
 	            "majorStepSize",
 	            "minorStepSize",
@@ -30646,13 +29699,13 @@
 	        }
 	    };
 	    NumericInput.prototype.componentDidUpdate = function () {
-	        if (this.state.shouldSelectAfterUpdate) {
+	        if (this.shouldSelectAfterUpdate) {
 	            this.inputElement.setSelectionRange(0, this.state.value.length);
 	        }
 	    };
 	    NumericInput.prototype.validateProps = function (nextProps) {
 	        var majorStepSize = nextProps.majorStepSize, max = nextProps.max, min = nextProps.min, minorStepSize = nextProps.minorStepSize, stepSize = nextProps.stepSize;
-	        if (min && max && min >= max) {
+	        if (min != null && max != null && min >= max) {
 	            throw new Error(Errors.NUMERIC_INPUT_MIN_MAX);
 	        }
 	        if (stepSize == null) {
@@ -30686,7 +29739,7 @@
 	        };
 	        return (React.createElement(buttons_1.Button, { disabled: this.props.disabled || this.props.readOnly, iconName: iconName, intent: this.props.intent, key: key, onBlur: this.handleButtonBlur, onClick: onClick, onFocus: this.handleButtonFocus, onKeyUp: onKeyUp }));
 	    };
-	    NumericInput.prototype.invokeOnChangeCallbacks = function (value) {
+	    NumericInput.prototype.invokeOnValueChangeCallback = function (value) {
 	        var valueAsString = value;
 	        var valueAsNumber = +value; // coerces non-numeric strings to NaN
 	        common_1.Utils.safeInvoke(this.props.onValueChange, valueAsNumber, valueAsString);
@@ -30696,9 +29749,10 @@
 	    NumericInput.prototype.incrementValue = function (delta /*, e: React.FormEvent<HTMLInputElement>*/) {
 	        // pretend we're incrementing from 0 if currValue is empty
 	        var currValue = this.state.value || NumericInput_1.VALUE_ZERO;
-	        var nextValue = this.getSanitizedValue(currValue, delta, this.props.min, this.props.max);
-	        this.setState({ shouldSelectAfterUpdate: this.props.selectAllOnIncrement, value: nextValue });
-	        this.invokeOnChangeCallbacks(nextValue);
+	        var nextValue = this.getSanitizedValue(currValue, delta);
+	        this.shouldSelectAfterUpdate = this.props.selectAllOnIncrement;
+	        this.setState({ value: nextValue });
+	        this.invokeOnValueChangeCallback(nextValue);
 	    };
 	    NumericInput.prototype.getIncrementDelta = function (direction, isShiftKeyPressed, isAltKeyPressed) {
 	        var _a = this.props, majorStepSize = _a.majorStepSize, minorStepSize = _a.minorStepSize, stepSize = _a.stepSize;
@@ -30714,6 +29768,8 @@
 	    };
 	    NumericInput.prototype.getSanitizedValue = function (value, delta, min, max) {
 	        if (delta === void 0) { delta = 0; }
+	        if (min === void 0) { min = this.props.min; }
+	        if (max === void 0) { max = this.props.max; }
 	        if (!this.isValueNumeric(value)) {
 	            return NumericInput_1.VALUE_EMPTY;
 	        }
@@ -30786,6 +29842,7 @@
 	NumericInput.defaultProps = {
 	    allowNumericCharactersOnly: true,
 	    buttonPosition: common_1.Position.RIGHT,
+	    clampValueOnBlur: false,
 	    majorStepSize: 10,
 	    minorStepSize: 0.1,
 	    selectAllOnFocus: false,
@@ -30820,7 +29877,7 @@
 
 
 /***/ },
-/* 255 */
+/* 257 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30836,7 +29893,7 @@
 	var abstractComponent_1 = __webpack_require__(22);
 	var Classes = __webpack_require__(66);
 	var Errors = __webpack_require__(60);
-	var controls_1 = __webpack_require__(252);
+	var controls_1 = __webpack_require__(254);
 	var counter = 0;
 	function nextName() { return RadioGroup.displayName + "-" + counter++; }
 	var RadioGroup = (function (_super) {
@@ -30896,7 +29953,7 @@
 
 
 /***/ },
-/* 256 */
+/* 258 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30911,19 +29968,19 @@
 	var react_1 = __webpack_require__(24);
 	var React = __webpack_require__(24);
 	var common_1 = __webpack_require__(21);
-	var hotkey_1 = __webpack_require__(257);
-	var hotkey_2 = __webpack_require__(257);
+	var hotkey_1 = __webpack_require__(259);
+	var hotkey_2 = __webpack_require__(259);
 	exports.Hotkey = hotkey_2.Hotkey;
-	var keyCombo_1 = __webpack_require__(258);
+	var keyCombo_1 = __webpack_require__(260);
 	exports.KeyCombo = keyCombo_1.KeyCombo;
-	var hotkeysTarget_1 = __webpack_require__(260);
+	var hotkeysTarget_1 = __webpack_require__(262);
 	exports.HotkeysTarget = hotkeysTarget_1.HotkeysTarget;
-	var hotkeyParser_1 = __webpack_require__(259);
+	var hotkeyParser_1 = __webpack_require__(261);
 	exports.comboMatches = hotkeyParser_1.comboMatches;
 	exports.getKeyCombo = hotkeyParser_1.getKeyCombo;
 	exports.getKeyComboString = hotkeyParser_1.getKeyComboString;
 	exports.parseKeyCombo = hotkeyParser_1.parseKeyCombo;
-	var hotkeysDialog_1 = __webpack_require__(262);
+	var hotkeysDialog_1 = __webpack_require__(264);
 	exports.hideHotkeysDialog = hotkeysDialog_1.hideHotkeysDialog;
 	exports.setHotkeysDialogProps = hotkeysDialog_1.setHotkeysDialogProps;
 	var errors_1 = __webpack_require__(60);
@@ -30975,7 +30032,7 @@
 
 
 /***/ },
-/* 257 */
+/* 259 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -30989,7 +30046,7 @@
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
 	var common_1 = __webpack_require__(21);
-	var keyCombo_1 = __webpack_require__(258);
+	var keyCombo_1 = __webpack_require__(260);
 	var Hotkey = (function (_super) {
 	    tslib_1.__extends(Hotkey, _super);
 	    function Hotkey() {
@@ -31020,7 +30077,7 @@
 
 
 /***/ },
-/* 258 */
+/* 260 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -31033,7 +30090,7 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
-	var hotkeyParser_1 = __webpack_require__(259);
+	var hotkeyParser_1 = __webpack_require__(261);
 	var KeyIcons = {
 	    alt: "pt-icon-key-option",
 	    ctrl: "pt-icon-key-control",
@@ -31079,7 +30136,7 @@
 
 
 /***/ },
-/* 259 */
+/* 261 */
 /***/ function(module, exports) {
 
 	/*
@@ -31353,7 +30410,7 @@
 
 
 /***/ },
-/* 260 */
+/* 262 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31366,7 +30423,7 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var React = __webpack_require__(24);
 	var utils_1 = __webpack_require__(59);
-	var hotkeysEvents_1 = __webpack_require__(261);
+	var hotkeysEvents_1 = __webpack_require__(263);
 	function HotkeysTarget(constructor) {
 	    var _a = constructor.prototype, componentWillMount = _a.componentWillMount, componentDidMount = _a.componentDidMount, componentWillUnmount = _a.componentWillUnmount, render = _a.render, renderHotkeys = _a.renderHotkeys;
 	    if (!utils_1.isFunction(renderHotkeys)) {
@@ -31432,7 +30489,7 @@
 
 
 /***/ },
-/* 261 */
+/* 263 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31445,9 +30502,9 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var react_1 = __webpack_require__(24);
 	var utils_1 = __webpack_require__(59);
-	var hotkey_1 = __webpack_require__(257);
-	var hotkeyParser_1 = __webpack_require__(259);
-	var hotkeysDialog_1 = __webpack_require__(262);
+	var hotkey_1 = __webpack_require__(259);
+	var hotkeyParser_1 = __webpack_require__(261);
+	var hotkeysDialog_1 = __webpack_require__(264);
 	var SHOW_DIALOG_KEY = "?";
 	var HotkeyScope;
 	(function (HotkeyScope) {
@@ -31542,7 +30599,7 @@
 
 
 /***/ },
-/* 262 */
+/* 264 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31559,8 +30616,8 @@
 	var ReactDOM = __webpack_require__(71);
 	var common_1 = __webpack_require__(21);
 	var components_1 = __webpack_require__(68);
-	var hotkey_1 = __webpack_require__(257);
-	var hotkeys_1 = __webpack_require__(256);
+	var hotkey_1 = __webpack_require__(259);
+	var hotkeys_1 = __webpack_require__(258);
 	var HotkeysDialog = (function () {
 	    function HotkeysDialog() {
 	        var _this = this;
@@ -31666,7 +30723,7 @@
 
 
 /***/ },
-/* 263 */
+/* 265 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31708,7 +30765,7 @@
 
 
 /***/ },
-/* 264 */
+/* 266 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31779,7 +30836,7 @@
 
 
 /***/ },
-/* 265 */
+/* 267 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31839,7 +30896,7 @@
 
 
 /***/ },
-/* 266 */
+/* 268 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31870,7 +30927,7 @@
 
 
 /***/ },
-/* 267 */
+/* 269 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31913,7 +30970,7 @@
 
 
 /***/ },
-/* 268 */
+/* 270 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31926,7 +30983,7 @@
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var tslib_1 = __webpack_require__(23);
 	var React = __webpack_require__(24);
-	var tooltip_1 = __webpack_require__(236);
+	var tooltip_1 = __webpack_require__(238);
 	var SVGTooltip = (function (_super) {
 	    tslib_1.__extends(SVGTooltip, _super);
 	    function SVGTooltip() {
@@ -31944,7 +31001,7 @@
 
 
 /***/ },
-/* 269 */
+/* 271 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -31961,8 +31018,8 @@
 	var Classes = __webpack_require__(66);
 	var Errors = __webpack_require__(60);
 	var utils_1 = __webpack_require__(59);
-	var coreSlider_1 = __webpack_require__(270);
-	var handle_1 = __webpack_require__(271);
+	var coreSlider_1 = __webpack_require__(272);
+	var handle_1 = __webpack_require__(273);
 	var RangeEnd;
 	(function (RangeEnd) {
 	    RangeEnd[RangeEnd["LEFT"] = 0] = "LEFT";
@@ -32064,7 +31121,7 @@
 
 
 /***/ },
-/* 270 */
+/* 272 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32198,7 +31255,7 @@
 
 
 /***/ },
-/* 271 */
+/* 273 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32353,7 +31410,7 @@
 
 
 /***/ },
-/* 272 */
+/* 274 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32368,8 +31425,8 @@
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(66);
 	var utils_1 = __webpack_require__(59);
-	var coreSlider_1 = __webpack_require__(270);
-	var handle_1 = __webpack_require__(271);
+	var coreSlider_1 = __webpack_require__(272);
+	var handle_1 = __webpack_require__(273);
 	var Slider = (function (_super) {
 	    tslib_1.__extends(Slider, _super);
 	    function Slider() {
@@ -32422,7 +31479,7 @@
 
 
 /***/ },
-/* 273 */
+/* 275 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32438,7 +31495,7 @@
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(66);
 	// import * to avoid "cannot be named" error on factory
-	var spinner = __webpack_require__(241);
+	var spinner = __webpack_require__(243);
 	var SVGSpinner = (function (_super) {
 	    tslib_1.__extends(SVGSpinner, _super);
 	    function SVGSpinner() {
@@ -32457,7 +31514,7 @@
 
 
 /***/ },
-/* 274 */
+/* 276 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32498,7 +31555,7 @@
 
 
 /***/ },
-/* 275 */
+/* 277 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32519,9 +31576,9 @@
 	var Errors = __webpack_require__(60);
 	var Keys = __webpack_require__(67);
 	var Utils = __webpack_require__(59);
-	var tab_1 = __webpack_require__(274);
-	var tabList_1 = __webpack_require__(276);
-	var tabPanel_1 = __webpack_require__(277);
+	var tab_1 = __webpack_require__(276);
+	var tabList_1 = __webpack_require__(278);
+	var tabPanel_1 = __webpack_require__(279);
 	var TAB_CSS_SELECTOR = "li[role=tab]";
 	var Tabs = (function (_super) {
 	    tslib_1.__extends(Tabs, _super);
@@ -32808,7 +31865,7 @@
 
 
 /***/ },
-/* 276 */
+/* 278 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32859,7 +31916,7 @@
 
 
 /***/ },
-/* 277 */
+/* 279 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32896,7 +31953,7 @@
 
 
 /***/ },
-/* 278 */
+/* 280 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32940,7 +31997,7 @@
 
 
 /***/ },
-/* 279 */
+/* 281 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -32959,8 +32016,8 @@
 	var Classes = __webpack_require__(66);
 	var Keys = __webpack_require__(67);
 	var utils_1 = __webpack_require__(59);
-	var tab2_1 = __webpack_require__(278);
-	var tabTitle_1 = __webpack_require__(280);
+	var tab2_1 = __webpack_require__(280);
+	var tabTitle_1 = __webpack_require__(282);
 	exports.Expander = function () { return React.createElement("div", { className: "pt-flex-expander" }); };
 	var TAB_SELECTOR = "." + Classes.TAB;
 	var Tabs2 = (function (_super) {
@@ -32997,12 +32054,9 @@
 	            }
 	        };
 	        _this.handleTabClick = function (newTabId) {
-	            var selectedTabId = _this.state.selectedTabId;
-	            if (newTabId !== selectedTabId) {
-	                utils_1.safeInvoke(_this.props.onChange, newTabId, selectedTabId);
-	                if (_this.props.selectedTabId === undefined) {
-	                    _this.setState({ selectedTabId: newTabId });
-	                }
+	            utils_1.safeInvoke(_this.props.onChange, newTabId, _this.state.selectedTabId);
+	            if (_this.props.selectedTabId === undefined) {
+	                _this.setState({ selectedTabId: newTabId });
 	            }
 	        };
 	        _this.renderTabPanel = function (tab) {
@@ -33140,7 +32194,7 @@
 
 
 /***/ },
-/* 280 */
+/* 282 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -33189,7 +32243,7 @@
 
 
 /***/ },
-/* 281 */
+/* 283 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -33236,7 +32290,7 @@
 
 
 /***/ },
-/* 282 */
+/* 284 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -33254,7 +32308,7 @@
 	var abstractComponent_1 = __webpack_require__(22);
 	var Classes = __webpack_require__(66);
 	var utils_1 = __webpack_require__(59);
-	var buttons_1 = __webpack_require__(239);
+	var buttons_1 = __webpack_require__(241);
 	var Toast = (function (_super) {
 	    tslib_1.__extends(Toast, _super);
 	    function Toast() {
@@ -33334,7 +32388,7 @@
 
 
 /***/ },
-/* 283 */
+/* 285 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -33357,7 +32411,7 @@
 	var position_1 = __webpack_require__(63);
 	var utils_1 = __webpack_require__(59);
 	var overlay_1 = __webpack_require__(221);
-	var toast_1 = __webpack_require__(282);
+	var toast_1 = __webpack_require__(284);
 	var Toaster = Toaster_1 = (function (_super) {
 	    tslib_1.__extends(Toaster, _super);
 	    function Toaster() {
@@ -33467,7 +32521,7 @@
 
 
 /***/ },
-/* 284 */
+/* 286 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -33483,7 +32537,7 @@
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(66);
 	var utils_1 = __webpack_require__(59);
-	var treeNode_1 = __webpack_require__(285);
+	var treeNode_1 = __webpack_require__(287);
 	var Tree = (function (_super) {
 	    tslib_1.__extends(Tree, _super);
 	    function Tree() {
@@ -33560,7 +32614,7 @@
 
 
 /***/ },
-/* 285 */
+/* 287 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -33576,7 +32630,7 @@
 	var React = __webpack_require__(24);
 	var Classes = __webpack_require__(66);
 	var utils_1 = __webpack_require__(59);
-	var collapse_1 = __webpack_require__(244);
+	var collapse_1 = __webpack_require__(246);
 	var TreeNode = (function (_super) {
 	    tslib_1.__extends(TreeNode, _super);
 	    function TreeNode() {
@@ -33648,7 +32702,7 @@
 
 
 /***/ },
-/* 286 */
+/* 288 */
 /***/ function(module, exports) {
 
 	/*
@@ -34058,7 +33112,7 @@
 
 
 /***/ },
-/* 287 */
+/* 289 */
 /***/ function(module, exports) {
 
 	/*
@@ -34468,7 +33522,7 @@
 
 
 /***/ },
-/* 288 */
+/* 290 */
 /***/ function(module, exports) {
 
 	/**
@@ -35562,7 +34616,7 @@
 
 
 /***/ },
-/* 289 */
+/* 291 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -35574,20 +34628,20 @@
 	"use strict";
 	// tslint:disable no-var-requires
 	var HERO_SVGS = {
-	    "alert": __webpack_require__(290),
-	    "buttons": __webpack_require__(291),
-	    "calendar": __webpack_require__(292),
-	    "checkboxes": __webpack_require__(293),
-	    "file-upload": __webpack_require__(294),
-	    "input-groups": __webpack_require__(295),
-	    "inputs": __webpack_require__(296),
-	    "labels": __webpack_require__(297),
-	    "radios": __webpack_require__(298),
-	    "select-menus": __webpack_require__(299),
-	    "sliders": __webpack_require__(300),
-	    "switches": __webpack_require__(301),
-	    "time-selections": __webpack_require__(302),
-	    "toggles": __webpack_require__(303),
+	    "alert": __webpack_require__(292),
+	    "buttons": __webpack_require__(293),
+	    "calendar": __webpack_require__(294),
+	    "checkboxes": __webpack_require__(295),
+	    "file-upload": __webpack_require__(296),
+	    "input-groups": __webpack_require__(297),
+	    "inputs": __webpack_require__(298),
+	    "labels": __webpack_require__(299),
+	    "radios": __webpack_require__(300),
+	    "select-menus": __webpack_require__(301),
+	    "sliders": __webpack_require__(302),
+	    "switches": __webpack_require__(303),
+	    "time-selections": __webpack_require__(304),
+	    "toggles": __webpack_require__(305),
 	};
 	var injectSVG = function (elem, id) {
 	    var wrapper = document.createElement("div");
@@ -35604,85 +34658,85 @@
 
 
 /***/ },
-/* 290 */
+/* 292 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"406\" height=\"165\" viewBox=\"0 0 406 165\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        ALERT\n    </title>\n    <defs>\n        <rect id=\"alert-a\" x=\"16\" y=\"13\" width=\"371\" height=\"143\" rx=\"10\"/>\n        <mask id=\"alert-i\" x=\"0\" y=\"0\" width=\"371\" height=\"143\" fill=\"#fff\">\n            <use xlink:href=\"#alert-a\"/>\n        </mask>\n        <circle id=\"alert-b\" cx=\"17\" cy=\"14\" r=\"6\"/>\n        <mask id=\"alert-j\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-b\"/>\n        </mask>\n        <circle id=\"alert-c\" cx=\"17\" cy=\"155\" r=\"6\"/>\n        <mask id=\"alert-k\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-c\"/>\n        </mask>\n        <circle id=\"alert-d\" cx=\"386\" cy=\"155\" r=\"6\"/>\n        <mask id=\"alert-l\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-d\"/>\n        </mask>\n        <circle id=\"alert-e\" cx=\"386\" cy=\"14\" r=\"6\"/>\n        <mask id=\"alert-m\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#alert-e\"/>\n        </mask>\n        <path d=\"M57.72 38.98c-.36-.58-.98-.98-1.72-.98s-1.36.42-1.7 1L40.28 62.98c-.16.32-.28.64-.28 1.02 0 1.1.9 2 2 2h28c1.1 0 2-.9 2-2 0-.36-.12-.7-.3-1L57.72 38.98zM54 62v-4h4v4h-4zm0-6V46h4v10h-4z\" id=\"alert-f\"/>\n        <mask id=\"alert-n\" x=\"-2\" y=\"-2\" width=\"36\" height=\"32\">\n            <path fill=\"#fff\" d=\"M38 36h36v32H38z\"/>\n            <use xlink:href=\"#alert-f\"/>\n        </mask>\n        <path d=\"M195 102.994a3 3 0 0 1 3.004-2.994h54.992a3 3 0 0 1 3.004 2.994v23.012a3 3 0 0 1-3.004 2.994h-54.992a3 3 0 0 1-3.004-2.994v-23.012z\" id=\"alert-g\"/>\n        <mask id=\"alert-o\" x=\"0\" y=\"0\" width=\"61\" height=\"29\" fill=\"#fff\">\n            <use xlink:href=\"#alert-g\"/>\n        </mask>\n        <rect id=\"alert-h\" x=\"266\" y=\"100\" width=\"96\" height=\"29\" rx=\"3\"/>\n        <mask id=\"alert-p\" x=\"0\" y=\"0\" width=\"96\" height=\"29\" fill=\"#fff\">\n            <use xlink:href=\"#alert-h\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#alert-i)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#alert-a\"/>\n                        <path d=\"M.5 14h401M17 0v164.5M386 0v164.5M2.5 155h403\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#alert-j)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-b\"/>\n                        <use mask=\"url(#alert-k)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-c\"/>\n                        <use mask=\"url(#alert-l)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-d\"/>\n                        <use mask=\"url(#alert-m)\" stroke-width=\"2\" opacity=\".3\" xlink:href=\"#alert-e\"/>\n                        <use mask=\"url(#alert-n)\" stroke-width=\"4\" xlink:href=\"#alert-f\"/>\n                        <use mask=\"url(#alert-o)\" stroke-width=\"4\" xlink:href=\"#alert-g\"/>\n                        <use mask=\"url(#alert-p)\" stroke-width=\"4\" xlink:href=\"#alert-h\"/>\n                        <path d=\"M95 48.5h235M95 68.5h145\" stroke-width=\"5\" stroke-linecap=\"square\"/>\n                        <path d=\"M208 114.5h35M277.5 114.5H347\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 291 */
+/* 293 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"454\" height=\"115\" viewBox=\"0 0 454 115\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        BUTTONS\n    </title>\n    <defs>\n        <rect id=\"buttons-a\" x=\"6\" y=\"7\" width=\"111\" height=\"31\" rx=\"3\"/>\n        <mask id=\"buttons-I\" x=\"0\" y=\"0\" width=\"111\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-a\"/>\n        </mask>\n        <circle id=\"buttons-b\" cx=\"7\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-J\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-b\"/>\n        </mask>\n        <circle id=\"buttons-c\" cx=\"7\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-K\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-c\"/>\n        </mask>\n        <circle id=\"buttons-d\" cx=\"116\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-L\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-d\"/>\n        </mask>\n        <circle id=\"buttons-e\" cx=\"116\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-M\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-e\"/>\n        </mask>\n        <rect id=\"buttons-f\" x=\"9\" y=\"7\" width=\"111\" height=\"31\" rx=\"3\"/>\n        <mask id=\"buttons-N\" x=\"0\" y=\"0\" width=\"111\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-f\"/>\n        </mask>\n        <path d=\"M108 19c-.28 0-.53.11-.71.29L104 22.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 108 19z\" id=\"buttons-g\"/>\n        <mask id=\"buttons-O\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-g\"/>\n        </mask>\n        <circle id=\"buttons-h\" cx=\"10\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-h\"/>\n        </mask>\n        <circle id=\"buttons-i\" cx=\"10\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-i\"/>\n        </mask>\n        <circle id=\"buttons-j\" cx=\"119\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-R\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-j\"/>\n        </mask>\n        <circle id=\"buttons-k\" cx=\"119\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-S\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-k\"/>\n        </mask>\n        <rect id=\"buttons-l\" x=\"9\" y=\"7\" width=\"131\" height=\"31\" rx=\"3\"/>\n        <mask id=\"buttons-T\" x=\"0\" y=\"0\" width=\"131\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-l\"/>\n        </mask>\n        <circle id=\"buttons-m\" cx=\"10\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-U\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-m\"/>\n        </mask>\n        <circle id=\"buttons-n\" cx=\"10\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-V\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-n\"/>\n        </mask>\n        <circle id=\"buttons-o\" cx=\"139\" cy=\"37\" r=\"4\"/>\n        <mask id=\"buttons-W\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-o\"/>\n        </mask>\n        <circle id=\"buttons-p\" cx=\"139\" cy=\"8\" r=\"4\"/>\n        <mask id=\"buttons-X\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-p\"/>\n        </mask>\n        <path d=\"M30 21h-2v-2c0-.55-.45-1-1-1s-1 .45-1 1v2h-2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1zm-3-7c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6z\" id=\"buttons-q\"/>\n        <mask id=\"buttons-Y\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-q\"/>\n        </mask>\n        <rect id=\"buttons-r\" x=\"6\" y=\"7\" width=\"121\" height=\"41\" rx=\"3\"/>\n        <mask id=\"buttons-Z\" x=\"0\" y=\"0\" width=\"121\" height=\"41\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-r\"/>\n        </mask>\n        <circle id=\"buttons-s\" cx=\"7\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-aa\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-s\"/>\n        </mask>\n        <circle id=\"buttons-t\" cx=\"7\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ab\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-t\"/>\n        </mask>\n        <circle id=\"buttons-u\" cx=\"126\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ac\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-u\"/>\n        </mask>\n        <circle id=\"buttons-v\" cx=\"126\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-ad\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-v\"/>\n        </mask>\n        <rect id=\"buttons-w\" x=\"9\" y=\"7\" width=\"121\" height=\"41\" rx=\"3\"/>\n        <mask id=\"buttons-ae\" x=\"0\" y=\"0\" width=\"121\" height=\"41\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-w\"/>\n        </mask>\n        <path d=\"M113 24c-.28 0-.53.11-.71.29L109 27.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 113 24z\" id=\"buttons-x\"/>\n        <mask id=\"buttons-af\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-x\"/>\n        </mask>\n        <circle id=\"buttons-y\" cx=\"10\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-ag\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-y\"/>\n        </mask>\n        <circle id=\"buttons-z\" cx=\"10\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ah\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-z\"/>\n        </mask>\n        <circle id=\"buttons-A\" cx=\"129\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-ai\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-A\"/>\n        </mask>\n        <circle id=\"buttons-B\" cx=\"129\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-aj\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-B\"/>\n        </mask>\n        <rect id=\"buttons-C\" x=\"9\" y=\"7\" width=\"141\" height=\"41\" rx=\"3\"/>\n        <mask id=\"buttons-ak\" x=\"0\" y=\"0\" width=\"141\" height=\"41\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-C\"/>\n        </mask>\n        <circle id=\"buttons-D\" cx=\"10\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-al\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-D\"/>\n        </mask>\n        <circle id=\"buttons-E\" cx=\"10\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-am\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-E\"/>\n        </mask>\n        <circle id=\"buttons-F\" cx=\"149\" cy=\"47\" r=\"5\"/>\n        <mask id=\"buttons-an\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-F\"/>\n        </mask>\n        <circle id=\"buttons-G\" cx=\"149\" cy=\"8\" r=\"5\"/>\n        <mask id=\"buttons-ao\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-G\"/>\n        </mask>\n        <path d=\"M35 26h-2v-2c0-.55-.45-1-1-1s-1 .45-1 1v2h-2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1zm-3-7c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6z\" id=\"buttons-H\"/>\n        <mask id=\"buttons-ap\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#buttons-H\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <g>\n                            <use mask=\"url(#buttons-I)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-a\"/>\n                            <path d=\"M7 0v44M116 2v42M0 8h124M1 37h121\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-J)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-b\"/>\n                            <use mask=\"url(#buttons-K)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-c\"/>\n                            <use mask=\"url(#buttons-L)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-d\"/>\n                            <use mask=\"url(#buttons-M)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-e\"/>\n                            <path d=\"M20.5 22.5H103\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(147)\">\n                            <use mask=\"url(#buttons-N)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-f\"/>\n                            <path d=\"M10 0v44M119 2v42M90 2v42M0 8h124M0 37h124\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-O)\" stroke-width=\"4\" xlink:href=\"#buttons-g\"/>\n                            <use mask=\"url(#buttons-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-h\"/>\n                            <use mask=\"url(#buttons-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-i\"/>\n                            <use mask=\"url(#buttons-R)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-j\"/>\n                            <use mask=\"url(#buttons-S)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-k\"/>\n                            <path d=\"M21.5 22.5H74\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(297)\">\n                            <use mask=\"url(#buttons-T)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-l\"/>\n                            <path d=\"M10 0v44M139 2v42M0 8h144M2 37h141\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-U)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-m\"/>\n                            <use mask=\"url(#buttons-V)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-n\"/>\n                            <use mask=\"url(#buttons-W)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-o\"/>\n                            <use mask=\"url(#buttons-X)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-p\"/>\n                            <path d=\"M42.5 22.5H125\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#buttons-Y)\" stroke-width=\"4\" xlink:href=\"#buttons-q\"/>\n                        </g>\n                        <g transform=\"translate(0 61)\">\n                            <use mask=\"url(#buttons-Z)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-r\"/>\n                            <path d=\"M7 0v54M126 2v52M0 8h134M2 47h131\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-aa)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-s\"/>\n                            <use mask=\"url(#buttons-ab)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-t\"/>\n                            <use mask=\"url(#buttons-ac)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-u\"/>\n                            <use mask=\"url(#buttons-ad)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-v\"/>\n                            <path d=\"M20.5 27.5H111\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(147 61)\">\n                            <use mask=\"url(#buttons-ae)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-w\"/>\n                            <path d=\"M10 0v54M129 2v52M90 2v52M0 8h134\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-af)\" stroke-width=\"4\" xlink:href=\"#buttons-x\"/>\n                            <path d=\"M2 47h133\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-ag)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-y\"/>\n                            <use mask=\"url(#buttons-ah)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-z\"/>\n                            <use mask=\"url(#buttons-ai)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-A\"/>\n                            <use mask=\"url(#buttons-aj)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-B\"/>\n                            <path d=\"M21.5 27.5H74\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(297 61)\">\n                            <use mask=\"url(#buttons-ak)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#buttons-C\"/>\n                            <path d=\"M10 0v54M149 2v52M0 8h157M2 47h154\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#buttons-al)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-D\"/>\n                            <use mask=\"url(#buttons-am)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-E\"/>\n                            <use mask=\"url(#buttons-an)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-F\"/>\n                            <use mask=\"url(#buttons-ao)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#buttons-G\"/>\n                            <path d=\"M52 27.5h82\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#buttons-ap)\" stroke-width=\"4\" xlink:href=\"#buttons-H\"/>\n                        </g>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 292 */
+/* 294 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"475\" height=\"293\" viewBox=\"0 0 475 293\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        CALENDAR\n    </title>\n    <defs>\n        <path id=\"calendar-a\" d=\"M13 10h451v274H13z\"/>\n        <mask id=\"calendar-j\" x=\"0\" y=\"0\" width=\"451\" height=\"274\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-a\"/>\n        </mask>\n        <circle id=\"calendar-b\" cx=\"14\" cy=\"11\" r=\"6\"/>\n        <mask id=\"calendar-k\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-b\"/>\n        </mask>\n        <circle id=\"calendar-c\" cx=\"14\" cy=\"283\" r=\"6\"/>\n        <mask id=\"calendar-l\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-c\"/>\n        </mask>\n        <circle id=\"calendar-d\" cx=\"463\" cy=\"282\" r=\"6\"/>\n        <mask id=\"calendar-m\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-d\"/>\n        </mask>\n        <circle id=\"calendar-e\" cx=\"463\" cy=\"11\" r=\"6\"/>\n        <mask id=\"calendar-n\" x=\"0\" y=\"0\" width=\"12\" height=\"12\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-e\"/>\n        </mask>\n        <path d=\"M32.42 42l3.29-3.29a1.003 1.003 0 0 0-1.42-1.42l-4 4c-.18.18-.29.43-.29.71 0 .28.11.53.29.71l4 4a1.003 1.003 0 0 0 1.42-1.42L32.42 42z\" id=\"calendar-f\"/>\n        <mask id=\"calendar-o\" x=\"0\" y=\"0\" width=\"6\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-f\"/>\n        </mask>\n        <path d=\"M446.42 42l3.29-3.29a1.003 1.003 0 0 0-1.42-1.42l-4 4c-.18.18-.29.43-.29.71 0 .28.11.53.29.71l4 4a1.003 1.003 0 0 0 1.42-1.42L446.42 42z\" id=\"calendar-g\"/>\n        <mask id=\"calendar-p\" x=\"0\" y=\"0\" width=\"6\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-g\"/>\n        </mask>\n        <path d=\"M113 154c0-1.657 1.347-3 3-3h24c1.657 0 3 1.347 3 3v24c0 1.657-1.344 3-3.002 3H116c-1.657 0-3-1.347-3-3v-24z\" id=\"calendar-h\"/>\n        <mask id=\"calendar-q\" x=\"0\" y=\"0\" width=\"30\" height=\"30\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-h\"/>\n        </mask>\n        <path id=\"calendar-i\" d=\"M243 181h30v30h-30z\"/>\n        <mask id=\"calendar-r\" x=\"0\" y=\"0\" width=\"30\" height=\"30\" fill=\"#fff\">\n            <use xlink:href=\"#calendar-i\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#calendar-j)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#calendar-a\"/>\n                        <path d=\"M14 0v292.5M.5 11h473M.5 11h463M3.5 283h471M463 0v292.5\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#calendar-k)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-b\"/>\n                        <use mask=\"url(#calendar-l)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-c\"/>\n                        <use mask=\"url(#calendar-m)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-d\"/>\n                        <use mask=\"url(#calendar-n)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#calendar-e\"/>\n                        <path d=\"M99 41.5h64M317 41.5h64\" stroke-width=\"5\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#calendar-o)\" stroke-width=\"4\" xlink:href=\"#calendar-f\"/>\n                        <use mask=\"url(#calendar-p)\" stroke-width=\"4\" transform=\"rotate(-180 447 42)\" xlink:href=\"#calendar-g\"/>\n                        <g stroke-width=\"4\" stroke-linecap=\"square\">\n                            <path d=\"M44 76H32M74 76H62M104 76H92M134 76h-12M164 76h-12M194 76h-12M224 76h-12\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 106H33M73 106H63M103 106H93M133 106h-10M163 106h-10M193 106h-10M223 106h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 136H33M73 136H63M103 136H93M133 136h-10M163 136h-10M193 136h-10M223 136h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 166H33M73 166H63M103 166H93M133 166h-10M163 166h-10M193 166h-10M223 166h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 196H33M73 196H63M103 196H93M133 196h-10M163 196h-10M193 196h-10M223 196h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 226H33M73 226H63M103 226H93M133 226h-10M163 226h-10M193 226h-10M223 226h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M43 256H33M73 256H63M103 256H93M133 256h-10M163 256h-10M193 256h-10M223 256h-10\"/>\n                        </g>\n                        <g stroke-width=\"4\" stroke-linecap=\"square\">\n                            <path d=\"M264 76h-12M294 76h-12M324 76h-12M354 76h-12M384 76h-12M414 76h-12M444 76h-12\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 106h-10M293 106h-10M323 106h-10M353 106h-10M383 106h-10M413 106h-10M443 106h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 136h-10M293 136h-10M323 136h-10M353 136h-10M383 136h-10M413 136h-10M443 136h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 166h-10M293 166h-10M323 166h-10M353 166h-10M383 166h-10M413 166h-10M443 166h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 196h-10M293 196h-10M323 196h-10M353 196h-10M383 196h-10M413 196h-10M443 196h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 226h-10M293 226h-10M323 226h-10M353 226h-10M383 226h-10M413 226h-10M443 226h-10\"/>\n                        </g>\n                        <g stroke-width=\"2\" stroke-linecap=\"square\">\n                            <path d=\"M263 256h-10M293 256h-10M323 256h-10M353 256h-10M383 256h-10M413 256h-10M443 256h-10\"/>\n                        </g>\n                        <use mask=\"url(#calendar-q)\" stroke-width=\"4\" xlink:href=\"#calendar-h\"/>\n                        <use mask=\"url(#calendar-r)\" stroke-width=\"4\" xlink:href=\"#calendar-i\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 293 */
+/* 295 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"168\" height=\"77\" viewBox=\"0 0 168 77\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        CHECKBOXES\n    </title>\n    <defs>\n        <path id=\"checkboxes-a\" d=\"M0 .977h16v16H0z\"/>\n        <mask id=\"checkboxes-f\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-a\"/>\n        </mask>\n        <path id=\"checkboxes-b\" d=\"M0 30.977h16v16H0z\"/>\n        <mask id=\"checkboxes-g\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-b\"/>\n        </mask>\n        <path d=\"M12 36c-.28 0-.53.11-.71.29L7 40.58l-2.29-2.29a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 36z\" id=\"checkboxes-c\"/>\n        <mask id=\"checkboxes-h\" x=\"0\" y=\"0\" width=\"10\" height=\"7\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-c\"/>\n        </mask>\n        <path id=\"checkboxes-d\" d=\"M0 60.977h16v16H0z\"/>\n        <mask id=\"checkboxes-i\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-d\"/>\n        </mask>\n        <path d=\"M11 68H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z\" id=\"checkboxes-e\"/>\n        <mask id=\"checkboxes-j\" x=\"0\" y=\"0\" width=\"8\" height=\"2\" fill=\"#fff\">\n            <use xlink:href=\"#checkboxes-e\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <use mask=\"url(#checkboxes-f)\" stroke-width=\"4\" xlink:href=\"#checkboxes-a\"/>\n                    <path d=\"M26.5 8.5H76\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#checkboxes-g)\" stroke-width=\"4\" xlink:href=\"#checkboxes-b\"/>\n                    <use mask=\"url(#checkboxes-h)\" stroke-width=\"4\" xlink:href=\"#checkboxes-c\"/>\n                    <path d=\"M26.5 38.5H132\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#checkboxes-i)\" stroke-width=\"4\" xlink:href=\"#checkboxes-d\"/>\n                    <use mask=\"url(#checkboxes-j)\" stroke-width=\"4\" xlink:href=\"#checkboxes-e\"/>\n                    <path d=\"M26.5 68.5H166\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 294 */
+/* 296 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"446\" height=\"44\" viewBox=\"0 0 446 44\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        UPLOAD\n    </title>\n    <defs>\n        <rect id=\"file-upload-a\" x=\"9\" y=\"7\" width=\"431\" height=\"31\" rx=\"3\"/>\n        <mask id=\"file-upload-f\" x=\"0\" y=\"0\" width=\"431\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-a\"/>\n        </mask>\n        <circle id=\"file-upload-b\" cx=\"10\" cy=\"8\" r=\"4\"/>\n        <mask id=\"file-upload-g\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-b\"/>\n        </mask>\n        <circle id=\"file-upload-c\" cx=\"10\" cy=\"37\" r=\"4\"/>\n        <mask id=\"file-upload-h\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-c\"/>\n        </mask>\n        <circle id=\"file-upload-d\" cx=\"439\" cy=\"37\" r=\"4\"/>\n        <mask id=\"file-upload-i\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-d\"/>\n        </mask>\n        <circle id=\"file-upload-e\" cx=\"439\" cy=\"8\" r=\"4\"/>\n        <mask id=\"file-upload-j\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#file-upload-e\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <use mask=\"url(#file-upload-f)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#file-upload-a\"/>\n                    <path d=\"M10 0v44M439 2v42M340 2v42M0 8h446M0 37h444\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                    <use mask=\"url(#file-upload-g)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-b\"/>\n                    <use mask=\"url(#file-upload-h)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-c\"/>\n                    <use mask=\"url(#file-upload-i)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-d\"/>\n                    <use mask=\"url(#file-upload-j)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#file-upload-e\"/>\n                    <path d=\"M21.5 22.5H94M352.5 22.5H415\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 295 */
+/* 297 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"314\" height=\"194\" viewBox=\"0 0 314 194\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        INPUTS\n    </title>\n    <defs>\n        <rect id=\"input-groups-a\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-w\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-a\"/>\n        </mask>\n        <circle id=\"input-groups-b\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-x\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-b\"/>\n        </mask>\n        <circle id=\"input-groups-c\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-y\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-c\"/>\n        </mask>\n        <circle id=\"input-groups-d\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-z\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-d\"/>\n        </mask>\n        <circle id=\"input-groups-e\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-A\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-e\"/>\n        </mask>\n        <rect id=\"input-groups-f\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-B\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-f\"/>\n        </mask>\n        <mask id=\"input-groups-C\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M4 3h305v35H4z\"/>\n            <use xlink:href=\"#input-groups-f\"/>\n        </mask>\n        <circle id=\"input-groups-g\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-D\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-g\"/>\n        </mask>\n        <circle id=\"input-groups-h\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-E\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-h\"/>\n        </mask>\n        <circle id=\"input-groups-i\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-F\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-i\"/>\n        </mask>\n        <circle id=\"input-groups-j\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-G\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-j\"/>\n        </mask>\n        <rect id=\"input-groups-k\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-H\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-k\"/>\n        </mask>\n        <mask id=\"input-groups-I\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M4 3h305v35H4z\"/>\n            <use xlink:href=\"#input-groups-k\"/>\n        </mask>\n        <path d=\"M298.56 25.44l-2.67-2.68A6.94 6.94 0 0 0 297 19c0-3.87-3.13-7-7-7s-7 3.13-7 7 3.13 7 7 7c1.39 0 2.68-.42 3.76-1.11l2.68 2.67a1.498 1.498 0 1 0 2.12-2.12zM290 24c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\" id=\"input-groups-l\"/>\n        <mask id=\"input-groups-J\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-l\"/>\n        </mask>\n        <circle id=\"input-groups-m\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-K\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-m\"/>\n        </mask>\n        <circle id=\"input-groups-n\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-L\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-n\"/>\n        </mask>\n        <circle id=\"input-groups-o\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-M\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-o\"/>\n        </mask>\n        <circle id=\"input-groups-p\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-N\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-p\"/>\n        </mask>\n        <rect id=\"input-groups-q\" x=\"6\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"input-groups-O\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-q\"/>\n        </mask>\n        <circle id=\"input-groups-r\" cx=\"7\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-r\"/>\n        </mask>\n        <circle id=\"input-groups-s\" cx=\"7\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-s\"/>\n        </mask>\n        <circle id=\"input-groups-t\" cx=\"306\" cy=\"35\" r=\"4\"/>\n        <mask id=\"input-groups-R\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-t\"/>\n        </mask>\n        <circle id=\"input-groups-u\" cx=\"306\" cy=\"6\" r=\"4\"/>\n        <mask id=\"input-groups-S\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-u\"/>\n        </mask>\n        <path d=\"M292.42 20l3.29-3.29a1.003 1.003 0 0 0-1.42-1.42L291 18.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l3.29 3.29-3.29 3.29a1.003 1.003 0 0 0 1.42 1.42l3.29-3.29 3.29 3.29a1.003 1.003 0 0 0 1.42-1.42L292.42 20z\" id=\"input-groups-v\"/>\n        <mask id=\"input-groups-T\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#input-groups-v\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <g>\n                            <use mask=\"url(#input-groups-w)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#input-groups-a\"/>\n                            <path d=\"M7 0v42M306 0v42M0 6h314M0 6h314M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-x)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-b\"/>\n                            <use mask=\"url(#input-groups-y)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-c\"/>\n                            <use mask=\"url(#input-groups-z)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-d\"/>\n                            <use mask=\"url(#input-groups-A)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-e\"/>\n                            <path d=\"M18.5 20.5H71\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 50)\">\n                            <g opacity=\".4\" stroke-width=\"4\">\n                                <use mask=\"url(#input-groups-B)\" xlink:href=\"#input-groups-f\"/>\n                                <use mask=\"url(#input-groups-C)\" xlink:href=\"#input-groups-f\"/>\n                            </g>\n                            <path d=\"M7 0v42M306 0v42M0 6h314M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-D)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-g\"/>\n                            <use mask=\"url(#input-groups-E)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-h\"/>\n                            <use mask=\"url(#input-groups-F)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-i\"/>\n                            <use mask=\"url(#input-groups-G)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-j\"/>\n                            <path d=\"M18.5 20.5H71\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 101)\">\n                            <g opacity=\".4\" stroke-width=\"4\">\n                                <use mask=\"url(#input-groups-H)\" xlink:href=\"#input-groups-k\"/>\n                                <use mask=\"url(#input-groups-I)\" xlink:href=\"#input-groups-k\"/>\n                            </g>\n                            <path d=\"M306 0v42M7 0v42M0 6h314M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-J)\" stroke-width=\"4\" xlink:href=\"#input-groups-l\"/>\n                            <use mask=\"url(#input-groups-K)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-m\"/>\n                            <use mask=\"url(#input-groups-L)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-n\"/>\n                            <use mask=\"url(#input-groups-M)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-o\"/>\n                            <use mask=\"url(#input-groups-N)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-p\"/>\n                            <path d=\"M18.5 20.5H111\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 152)\">\n                            <use mask=\"url(#input-groups-O)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#input-groups-q\"/>\n                            <path d=\"M306 0v42M0 6h314M7 0v42M0 35h314\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#input-groups-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-r\"/>\n                            <use mask=\"url(#input-groups-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-s\"/>\n                            <use mask=\"url(#input-groups-R)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-t\"/>\n                            <use mask=\"url(#input-groups-S)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#input-groups-u\"/>\n                            <use mask=\"url(#input-groups-T)\" stroke-width=\"4\" xlink:href=\"#input-groups-v\"/>\n                            <path d=\"M18.5 20.5H111\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 296 */
+/* 298 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"317\" height=\"238\" viewBox=\"0 0 317 238\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        INPUTS\n    </title>\n    <defs>\n        <rect id=\"inputs-a\" x=\"7\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-x\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-a\"/>\n        </mask>\n        <circle id=\"inputs-b\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"inputs-y\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-b\"/>\n        </mask>\n        <circle id=\"inputs-c\" cx=\"8\" cy=\"35\" r=\"4\"/>\n        <mask id=\"inputs-z\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-c\"/>\n        </mask>\n        <circle id=\"inputs-d\" cx=\"307\" cy=\"35\" r=\"4\"/>\n        <mask id=\"inputs-A\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-d\"/>\n        </mask>\n        <circle id=\"inputs-e\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"inputs-B\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-e\"/>\n        </mask>\n        <rect id=\"inputs-f\" x=\"6\" y=\"6\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-C\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-f\"/>\n        </mask>\n        <circle id=\"inputs-g\" cx=\"7\" cy=\"7\" r=\"4\"/>\n        <mask id=\"inputs-D\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-g\"/>\n        </mask>\n        <circle id=\"inputs-h\" cx=\"7\" cy=\"36\" r=\"4\"/>\n        <mask id=\"inputs-E\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-h\"/>\n        </mask>\n        <circle id=\"inputs-i\" cx=\"306\" cy=\"36\" r=\"4\"/>\n        <mask id=\"inputs-F\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-i\"/>\n        </mask>\n        <circle id=\"inputs-j\" cx=\"306\" cy=\"7\" r=\"4\"/>\n        <mask id=\"inputs-G\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-j\"/>\n        </mask>\n        <rect id=\"inputs-k\" x=\"7\" y=\"7\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-H\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-k\"/>\n        </mask>\n        <mask id=\"inputs-I\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M5 5h305v35H5z\"/>\n            <use xlink:href=\"#inputs-k\"/>\n        </mask>\n        <circle id=\"inputs-l\" cx=\"8\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-J\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-l\"/>\n        </mask>\n        <circle id=\"inputs-m\" cx=\"8\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-K\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-m\"/>\n        </mask>\n        <circle id=\"inputs-n\" cx=\"307\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-L\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-n\"/>\n        </mask>\n        <circle id=\"inputs-o\" cx=\"307\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-M\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-o\"/>\n        </mask>\n        <rect id=\"inputs-p\" x=\"8\" y=\"7\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"inputs-N\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-p\"/>\n        </mask>\n        <circle id=\"inputs-q\" cx=\"9\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-O\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-q\"/>\n        </mask>\n        <circle id=\"inputs-r\" cx=\"9\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-r\"/>\n        </mask>\n        <circle id=\"inputs-s\" cx=\"308\" cy=\"37\" r=\"4\"/>\n        <mask id=\"inputs-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-s\"/>\n        </mask>\n        <circle id=\"inputs-t\" cx=\"308\" cy=\"8\" r=\"4\"/>\n        <mask id=\"inputs-R\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-t\"/>\n        </mask>\n        <path d=\"M26 18c.55 0 1-.45 1-1v-1c0-.55-.45-1-1-1s-1 .45-1 1v1c0 .55.45 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2v-1h-3v1c0 1.1-.9 2-2 2s-2-.9-2-2v-1h-1c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h13c.55 0 1-.45 1-1V17c0-.55-.45-1-1-1zm-9 12h-3v-3h3v3zm0-4h-3v-3h3v3zm4 4h-3v-3h3v3zm0-4h-3v-3h3v3zm4 4h-3v-3h3v3zm0-4h-3v-3h3v3zm-9-6c.55 0 1-.45 1-1v-1c0-.55-.45-1-1-1s-1 .45-1 1v1c0 .55.45 1 1 1z\" id=\"inputs-u\"/>\n        <mask id=\"inputs-S\" x=\"0\" y=\"0\" width=\"15\" height=\"15\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-u\"/>\n        </mask>\n        <rect id=\"inputs-v\" x=\"4\" width=\"301\" height=\"31\" rx=\"15\"/>\n        <mask id=\"inputs-T\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-v\"/>\n        </mask>\n        <path d=\"M26.56 20.44l-2.67-2.68A6.94 6.94 0 0 0 25 14c0-3.87-3.13-7-7-7s-7 3.13-7 7 3.13 7 7 7c1.39 0 2.68-.42 3.76-1.11l2.68 2.67a1.498 1.498 0 1 0 2.12-2.12zM18 19c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\" id=\"inputs-w\"/>\n        <mask id=\"inputs-U\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#inputs-w\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <g transform=\"translate(1)\">\n                            <use mask=\"url(#inputs-x)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-a\"/>\n                            <path d=\"M1 6h314M0 35h314M8 0v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-y)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-b\"/>\n                            <use mask=\"url(#inputs-z)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-c\"/>\n                            <use mask=\"url(#inputs-A)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-d\"/>\n                            <use mask=\"url(#inputs-B)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-e\"/>\n                            <path d=\"M20 20h31.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(2 49)\">\n                            <use mask=\"url(#inputs-C)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-f\"/>\n                            <path d=\"M0 7h314M0 36h314M7 1v42M306 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-D)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-g\"/>\n                            <use mask=\"url(#inputs-E)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-h\"/>\n                            <use mask=\"url(#inputs-F)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-i\"/>\n                            <use mask=\"url(#inputs-G)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-j\"/>\n                            <path d=\"M19 21h70.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(1 99)\">\n                            <g opacity=\".4\" stroke-width=\"4\">\n                                <use mask=\"url(#inputs-H)\" xlink:href=\"#inputs-k\"/>\n                                <use mask=\"url(#inputs-I)\" xlink:href=\"#inputs-k\"/>\n                            </g>\n                            <path d=\"M2 8h314M0 37h314M8 2v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-J)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-l\"/>\n                            <use mask=\"url(#inputs-K)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-m\"/>\n                            <use mask=\"url(#inputs-L)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-n\"/>\n                            <use mask=\"url(#inputs-M)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-o\"/>\n                            <path d=\"M20 22h81.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        </g>\n                        <g transform=\"translate(0 149)\">\n                            <use mask=\"url(#inputs-N)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-p\"/>\n                            <path d=\"M2 8h314M0 37h314M9 2v42M308 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <use mask=\"url(#inputs-O)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-q\"/>\n                            <use mask=\"url(#inputs-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-r\"/>\n                            <use mask=\"url(#inputs-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-s\"/>\n                            <use mask=\"url(#inputs-R)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#inputs-t\"/>\n                            <path d=\"M39 22h88.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#inputs-S)\" stroke-width=\"4\" xlink:href=\"#inputs-u\"/>\n                        </g>\n                        <g transform=\"translate(4 207)\">\n                            <use mask=\"url(#inputs-T)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#inputs-v\"/>\n                            <path d=\"M0 1h310M2 30h306\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                            <path d=\"M32 15h73.5\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                            <use mask=\"url(#inputs-U)\" stroke-width=\"4\" xlink:href=\"#inputs-w\"/>\n                        </g>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 297 */
+/* 299 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"315\" height=\"104\" viewBox=\"0 0 315 104\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        LABELS\n    </title>\n    <defs>\n        <rect id=\"labels-a\" x=\"7\" y=\"16\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"labels-k\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#labels-a\"/>\n        </mask>\n        <circle id=\"labels-b\" cx=\"8\" cy=\"17\" r=\"4\"/>\n        <mask id=\"labels-l\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-b\"/>\n        </mask>\n        <circle id=\"labels-c\" cx=\"8\" cy=\"46\" r=\"4\"/>\n        <mask id=\"labels-m\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-c\"/>\n        </mask>\n        <circle id=\"labels-d\" cx=\"307\" cy=\"46\" r=\"4\"/>\n        <mask id=\"labels-n\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-d\"/>\n        </mask>\n        <circle id=\"labels-e\" cx=\"307\" cy=\"17\" r=\"4\"/>\n        <mask id=\"labels-o\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-e\"/>\n        </mask>\n        <rect id=\"labels-f\" x=\"117\" y=\"5\" width=\"181\" height=\"31\" rx=\"3\"/>\n        <mask id=\"labels-p\" x=\"0\" y=\"0\" width=\"181\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#labels-f\"/>\n        </mask>\n        <circle id=\"labels-g\" cx=\"118\" cy=\"6\" r=\"4\"/>\n        <mask id=\"labels-q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-g\"/>\n        </mask>\n        <circle id=\"labels-h\" cx=\"118\" cy=\"35\" r=\"4\"/>\n        <mask id=\"labels-r\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-h\"/>\n        </mask>\n        <circle id=\"labels-i\" cx=\"297\" cy=\"35\" r=\"4\"/>\n        <mask id=\"labels-s\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-i\"/>\n        </mask>\n        <circle id=\"labels-j\" cx=\"297\" cy=\"6\" r=\"4\"/>\n        <mask id=\"labels-t\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#labels-j\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g transform=\"translate(0 1)\">\n                        <use mask=\"url(#labels-k)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#labels-a\"/>\n                        <path d=\"M1 17h314M0 46h314M8 11v42M307 11v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#labels-l)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-b\"/>\n                        <use mask=\"url(#labels-m)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-c\"/>\n                        <use mask=\"url(#labels-n)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-d\"/>\n                        <use mask=\"url(#labels-o)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-e\"/>\n                        <path d=\"M9 1h45M19 31h35\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    </g>\n                    <g transform=\"translate(10 62)\">\n                        <use mask=\"url(#labels-p)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#labels-f\"/>\n                        <path d=\"M111 6h194M110 35h194M118 0v42M297 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#labels-q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-g\"/>\n                        <use mask=\"url(#labels-r)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-h\"/>\n                        <use mask=\"url(#labels-s)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-i\"/>\n                        <use mask=\"url(#labels-t)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#labels-j\"/>\n                        <path d=\"M0 20h97M129 20h35\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 298 */
+/* 300 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"115\" height=\"46\" viewBox=\"0 0 115 46\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        RADIOS\n    </title>\n    <defs>\n        <circle id=\"radios-a\" cx=\"8\" cy=\"8\" r=\"8\"/>\n        <mask id=\"radios-d\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#radios-a\"/>\n        </mask>\n        <circle id=\"radios-b\" cx=\"8\" cy=\"38\" r=\"8\"/>\n        <mask id=\"radios-e\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#radios-b\"/>\n        </mask>\n        <circle id=\"radios-c\" cx=\"8\" cy=\"38\" r=\"3\"/>\n        <mask id=\"radios-f\" x=\"0\" y=\"0\" width=\"6\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#radios-c\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <path d=\"M23.5 7.5H53\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#radios-d)\" stroke-width=\"4\" xlink:href=\"#radios-a\"/>\n                    <use mask=\"url(#radios-e)\" stroke-width=\"4\" xlink:href=\"#radios-b\"/>\n                    <use mask=\"url(#radios-f)\" stroke-width=\"4\" xlink:href=\"#radios-c\"/>\n                    <path d=\"M23.5 37.5H113\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 299 */
+/* 301 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"315\" height=\"92\" viewBox=\"0 0 315 92\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        SELECT MENUS\n    </title>\n    <defs>\n        <rect id=\"select-menus-a\" x=\"7\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"select-menus-m\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-a\"/>\n        </mask>\n        <circle id=\"select-menus-b\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-n\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-b\"/>\n        </mask>\n        <circle id=\"select-menus-c\" cx=\"8\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-o\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-c\"/>\n        </mask>\n        <circle id=\"select-menus-d\" cx=\"307\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-p\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-d\"/>\n        </mask>\n        <circle id=\"select-menus-e\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-e\"/>\n        </mask>\n        <path d=\"M295 18h-6a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l3-3A1.003 1.003 0 0 0 295 18z\" id=\"select-menus-f\"/>\n        <mask id=\"select-menus-r\" x=\"0\" y=\"0\" width=\"8\" height=\"5\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-f\"/>\n        </mask>\n        <rect id=\"select-menus-g\" x=\"7\" y=\"5\" width=\"301\" height=\"31\" rx=\"3\"/>\n        <mask id=\"select-menus-s\" x=\"0\" y=\"0\" width=\"301\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-g\"/>\n        </mask>\n        <mask id=\"select-menus-t\" x=\"-2\" y=\"-2\" width=\"305\" height=\"35\">\n            <path fill=\"#fff\" d=\"M5 3h305v35H5z\"/>\n            <use xlink:href=\"#select-menus-g\"/>\n        </mask>\n        <circle id=\"select-menus-h\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-u\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-h\"/>\n        </mask>\n        <circle id=\"select-menus-i\" cx=\"8\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-v\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-i\"/>\n        </mask>\n        <circle id=\"select-menus-j\" cx=\"307\" cy=\"35\" r=\"4\"/>\n        <mask id=\"select-menus-w\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-j\"/>\n        </mask>\n        <circle id=\"select-menus-k\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"select-menus-x\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-k\"/>\n        </mask>\n        <path d=\"M295 18h-6a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l3-3A1.003 1.003 0 0 0 295 18z\" id=\"select-menus-l\"/>\n        <mask id=\"select-menus-y\" x=\"0\" y=\"0\" width=\"8\" height=\"5\" fill=\"#fff\">\n            <use xlink:href=\"#select-menus-l\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#select-menus-m)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#select-menus-a\"/>\n                        <path d=\"M1 6h314M0 35h314M8 0v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#select-menus-n)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-b\"/>\n                        <use mask=\"url(#select-menus-o)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-c\"/>\n                        <use mask=\"url(#select-menus-p)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-d\"/>\n                        <use mask=\"url(#select-menus-q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-e\"/>\n                        <path d=\"M20 20h85\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#select-menus-r)\" stroke-width=\"4\" xlink:href=\"#select-menus-f\"/>\n                    </g>\n                    <g transform=\"translate(0 50)\">\n                        <g opacity=\".4\" stroke-width=\"4\">\n                            <use mask=\"url(#select-menus-s)\" xlink:href=\"#select-menus-g\"/>\n                            <use mask=\"url(#select-menus-t)\" xlink:href=\"#select-menus-g\"/>\n                        </g>\n                        <path d=\"M1 6h314M0 35h314M8 0v42M307 0v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#select-menus-u)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-h\"/>\n                        <use mask=\"url(#select-menus-v)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-i\"/>\n                        <use mask=\"url(#select-menus-w)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-j\"/>\n                        <use mask=\"url(#select-menus-x)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#select-menus-k\"/>\n                        <path d=\"M20 20h85\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#select-menus-y)\" stroke-width=\"4\" xlink:href=\"#select-menus-l\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 300 */
+/* 302 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"317\" height=\"70\" viewBox=\"0 0 317 70\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        SLIDERS\n    </title>\n    <defs>\n        <rect id=\"sliders-a\" x=\"7\" y=\"6\" width=\"74\" height=\"9\" rx=\"4.5\"/>\n        <mask id=\"sliders-q\" x=\"0\" y=\"0\" width=\"74\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-a\"/>\n        </mask>\n        <path d=\"M148 6h156.505A4.5 4.5 0 0 1 309 10.5c0 2.485-2.006 4.5-4.495 4.5H148V6z\" id=\"sliders-b\"/>\n        <mask id=\"sliders-r\" x=\"0\" y=\"0\" width=\"161\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-b\"/>\n        </mask>\n        <circle id=\"sliders-c\" cx=\"8\" cy=\"7\" r=\"4\"/>\n        <mask id=\"sliders-s\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-c\"/>\n        </mask>\n        <circle id=\"sliders-d\" cx=\"8\" cy=\"14\" r=\"4\"/>\n        <mask id=\"sliders-t\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-d\"/>\n        </mask>\n        <circle id=\"sliders-e\" cx=\"307\" cy=\"14\" r=\"4\"/>\n        <mask id=\"sliders-u\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-e\"/>\n        </mask>\n        <circle id=\"sliders-f\" cx=\"307\" cy=\"7\" r=\"4\"/>\n        <mask id=\"sliders-v\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-f\"/>\n        </mask>\n        <path id=\"sliders-g\" d=\"M79 .977h19v19H79z\"/>\n        <mask id=\"sliders-w\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-g\"/>\n        </mask>\n        <path id=\"sliders-h\" d=\"M131 .977h19v19h-19z\"/>\n        <mask id=\"sliders-x\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-h\"/>\n        </mask>\n        <rect id=\"sliders-i\" x=\"7\" y=\"5\" width=\"73\" height=\"9\" rx=\"4.5\"/>\n        <mask id=\"sliders-y\" x=\"0\" y=\"0\" width=\"73\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-i\"/>\n        </mask>\n        <path d=\"M237 5h66.505A4.5 4.5 0 0 1 308 9.5c0 2.485-2.01 4.5-4.495 4.5H237V5z\" id=\"sliders-j\"/>\n        <mask id=\"sliders-z\" x=\"0\" y=\"0\" width=\"71\" height=\"9\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-j\"/>\n        </mask>\n        <circle id=\"sliders-k\" cx=\"8\" cy=\"6\" r=\"4\"/>\n        <mask id=\"sliders-A\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-k\"/>\n        </mask>\n        <circle id=\"sliders-l\" cx=\"8\" cy=\"13\" r=\"4\"/>\n        <mask id=\"sliders-B\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-l\"/>\n        </mask>\n        <circle id=\"sliders-m\" cx=\"307\" cy=\"14\" r=\"4\"/>\n        <mask id=\"sliders-C\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-m\"/>\n        </mask>\n        <circle id=\"sliders-n\" cx=\"307\" cy=\"6\" r=\"4\"/>\n        <mask id=\"sliders-D\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-n\"/>\n        </mask>\n        <path id=\"sliders-o\" d=\"M78 .977h19v19H78z\"/>\n        <mask id=\"sliders-E\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-o\"/>\n        </mask>\n        <path id=\"sliders-p\" d=\"M219 .977h19v19h-19z\"/>\n        <mask id=\"sliders-F\" x=\"0\" y=\"0\" width=\"19\" height=\"19\" fill=\"#fff\">\n            <use xlink:href=\"#sliders-p\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#sliders-q)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-a\"/>\n                        <use mask=\"url(#sliders-r)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-b\"/>\n                        <path d=\"M1 7h79M150 7h162M0 14h80M150 14h167M8 1v20M307 1v20\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#sliders-s)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-c\"/>\n                        <use mask=\"url(#sliders-t)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-d\"/>\n                        <use mask=\"url(#sliders-u)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-e\"/>\n                        <use mask=\"url(#sliders-v)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-f\"/>\n                        <use mask=\"url(#sliders-w)\" stroke-width=\"4\" xlink:href=\"#sliders-g\"/>\n                        <use mask=\"url(#sliders-x)\" stroke-width=\"4\" xlink:href=\"#sliders-h\"/>\n                        <path d=\"M98 7h32M98 13h32M97.661 11.839l2.679-3.679M102.661 11.839l2.679-3.679M107.661 11.839l2.679-3.679M112.661 11.839l2.679-3.679M117.661 11.839l2.679-3.679M122.661 11.839l2.679-3.679M127.661 11.839l2.679-3.679\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                    </g>\n                    <g transform=\"translate(0 41)\">\n                        <use mask=\"url(#sliders-y)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-i\"/>\n                        <use mask=\"url(#sliders-z)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#sliders-j\"/>\n                        <path d=\"M1 6h78M238 6h78M0 13h79M238 13h79M8 0v19M307 0v18\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#sliders-A)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-k\"/>\n                        <use mask=\"url(#sliders-B)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-l\"/>\n                        <use mask=\"url(#sliders-C)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-m\"/>\n                        <use mask=\"url(#sliders-D)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#sliders-n\"/>\n                        <use mask=\"url(#sliders-E)\" stroke-width=\"4\" xlink:href=\"#sliders-o\"/>\n                        <use mask=\"url(#sliders-F)\" stroke-width=\"4\" xlink:href=\"#sliders-p\"/>\n                        <path d=\"M23 28H13M93 28H83M163 28h-10M233 28h-10M303 28h-10M98 6h121M98 12h121M96.661 10.839L99.34 7.16M101.661 10.839l2.679-3.679M106.661 10.839l2.679-3.679M111.661 10.839l2.679-3.679M116.661 10.839l2.679-3.679M121.661 10.839l2.679-3.679M126.661 10.839l2.679-3.679M131.661 10.839l2.679-3.679M136.661 10.839l2.679-3.679M141.661 10.839l2.679-3.679M146.661 10.839l2.679-3.679M151.661 10.839l2.679-3.679M156.661 10.839l2.679-3.679M161.661 10.839l2.679-3.679M166.661 10.839l2.679-3.679M171.661 10.839l2.679-3.679M176.661 10.839l2.679-3.679M181.661 10.839l2.679-3.679M186.661 10.839l2.679-3.679M191.661 10.839l2.679-3.679M196.661 10.839l2.679-3.679M201.661 10.839l2.679-3.679M206.661 10.839l2.679-3.679M211.661 10.839l2.679-3.679M216.661 10.839l2.679-3.679\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 301 */
+/* 303 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"51\" height=\"46\" viewBox=\"0 0 51 46\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        SWITCHES\n    </title>\n    <defs>\n        <circle id=\"switches-a\" cx=\"9\" cy=\"8\" r=\"5\"/>\n        <mask id=\"switches-e\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#switches-a\"/>\n        </mask>\n        <path d=\"M0 8c0-4.418 3.588-8 7.995-8h10.01C22.42 0 26 3.59 26 8c0 4.418-3.588 8-7.995 8H7.995C3.58 16 0 12.41 0 8z\" id=\"switches-b\"/>\n        <mask id=\"switches-f\" x=\"0\" y=\"0\" width=\"26\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#switches-b\"/>\n        </mask>\n        <circle id=\"switches-c\" cx=\"18\" cy=\"38\" r=\"5\"/>\n        <mask id=\"switches-g\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#switches-c\"/>\n        </mask>\n        <path d=\"M0 38c0-4.418 3.588-8 7.995-8h10.01C22.42 30 26 33.59 26 38c0 4.418-3.588 8-7.995 8H7.995C3.58 46 0 42.41 0 38z\" id=\"switches-d\"/>\n        <mask id=\"switches-h\" x=\"0\" y=\"0\" width=\"26\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#switches-d\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <path d=\"M34.5 7.5H49\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                    <use mask=\"url(#switches-e)\" stroke-width=\"4\" xlink:href=\"#switches-a\"/>\n                    <use mask=\"url(#switches-f)\" stroke-width=\"4\" xlink:href=\"#switches-b\"/>\n                    <use mask=\"url(#switches-g)\" stroke-width=\"4\" xlink:href=\"#switches-c\"/>\n                    <use mask=\"url(#switches-h)\" stroke-width=\"4\" xlink:href=\"#switches-d\"/>\n                    <path d=\"M34.5 37.5H46\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 302 */
+/* 304 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"215\" height=\"154\" viewBox=\"0 0 215 154\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        TIME SELECTIONS\n    </title>\n    <defs>\n        <rect id=\"time-selections-a\" x=\"7\" y=\"16\" width=\"201\" height=\"31\" rx=\"3\"/>\n        <mask id=\"time-selections-M\" x=\"0\" y=\"0\" width=\"201\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-a\"/>\n        </mask>\n        <circle id=\"time-selections-b\" cx=\"8\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-N\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-b\"/>\n        </mask>\n        <circle id=\"time-selections-c\" cx=\"8\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-O\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-c\"/>\n        </mask>\n        <circle id=\"time-selections-d\" cx=\"207\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-P\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-d\"/>\n        </mask>\n        <circle id=\"time-selections-e\" cx=\"207\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-Q\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-e\"/>\n        </mask>\n        <path id=\"time-selections-f\" d=\"M46 28h3v3h-3z\"/>\n        <mask id=\"time-selections-R\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-f\"/>\n        </mask>\n        <path id=\"time-selections-g\" d=\"M46 34h3v3h-3z\"/>\n        <mask id=\"time-selections-S\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-g\"/>\n        </mask>\n        <path id=\"time-selections-h\" d=\"M83 28h3v3h-3z\"/>\n        <mask id=\"time-selections-T\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-h\"/>\n        </mask>\n        <path id=\"time-selections-i\" d=\"M83 34h3v3h-3z\"/>\n        <mask id=\"time-selections-U\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-i\"/>\n        </mask>\n        <path id=\"time-selections-j\" d=\"M121 28h3v3h-3z\"/>\n        <mask id=\"time-selections-V\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-j\"/>\n        </mask>\n        <path id=\"time-selections-k\" d=\"M121 34h3v3h-3z\"/>\n        <mask id=\"time-selections-W\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-k\"/>\n        </mask>\n        <path id=\"time-selections-l\" d=\"M159 28h3v3h-3z\"/>\n        <mask id=\"time-selections-X\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-l\"/>\n        </mask>\n        <path id=\"time-selections-m\" d=\"M159 34h3v3h-3z\"/>\n        <mask id=\"time-selections-Y\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-m\"/>\n        </mask>\n        <path d=\"M34 58c-.28 0-.53.11-.71.29L30 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 34 58z\" id=\"time-selections-n\"/>\n        <mask id=\"time-selections-Z\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-n\"/>\n        </mask>\n        <path d=\"M72 58c-.28 0-.53.11-.71.29L68 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 72 58z\" id=\"time-selections-o\"/>\n        <mask id=\"time-selections-aa\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-o\"/>\n        </mask>\n        <path d=\"M110 58c-.28 0-.53.11-.71.29L106 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 110 58z\" id=\"time-selections-p\"/>\n        <mask id=\"time-selections-ab\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-p\"/>\n        </mask>\n        <path d=\"M147 58c-.28 0-.53.11-.71.29L143 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 147 58z\" id=\"time-selections-q\"/>\n        <mask id=\"time-selections-ac\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-q\"/>\n        </mask>\n        <path d=\"M185 58c-.28 0-.53.11-.71.29L181 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 185 58z\" id=\"time-selections-r\"/>\n        <mask id=\"time-selections-ad\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-r\"/>\n        </mask>\n        <path d=\"M33.29.29L30 3.58 26.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 33.29.29z\" id=\"time-selections-s\"/>\n        <mask id=\"time-selections-ae\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-s\"/>\n        </mask>\n        <path d=\"M71.29.29L68 3.58 64.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 71.29.29z\" id=\"time-selections-t\"/>\n        <mask id=\"time-selections-af\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-t\"/>\n        </mask>\n        <path d=\"M109.29.29L106 3.58 102.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-u\"/>\n        <mask id=\"time-selections-ag\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-u\"/>\n        </mask>\n        <path d=\"M146.29.29L143 3.58 139.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-v\"/>\n        <mask id=\"time-selections-ah\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-v\"/>\n        </mask>\n        <path d=\"M184.29.29L181 3.58 177.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-w\"/>\n        <mask id=\"time-selections-ai\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-w\"/>\n        </mask>\n        <rect id=\"time-selections-x\" x=\"7\" y=\"16\" width=\"121\" height=\"31\" rx=\"3\"/>\n        <mask id=\"time-selections-aj\" x=\"0\" y=\"0\" width=\"121\" height=\"31\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-x\"/>\n        </mask>\n        <circle id=\"time-selections-y\" cx=\"8\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-ak\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-y\"/>\n        </mask>\n        <circle id=\"time-selections-z\" cx=\"8\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-al\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-z\"/>\n        </mask>\n        <circle id=\"time-selections-A\" cx=\"127\" cy=\"46\" r=\"4\"/>\n        <mask id=\"time-selections-am\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-A\"/>\n        </mask>\n        <circle id=\"time-selections-B\" cx=\"127\" cy=\"17\" r=\"4\"/>\n        <mask id=\"time-selections-an\" x=\"0\" y=\"0\" width=\"8\" height=\"8\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-B\"/>\n        </mask>\n        <path id=\"time-selections-C\" d=\"M46 28h3v3h-3z\"/>\n        <mask id=\"time-selections-ao\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-C\"/>\n        </mask>\n        <path id=\"time-selections-D\" d=\"M46 34h3v3h-3z\"/>\n        <mask id=\"time-selections-ap\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-D\"/>\n        </mask>\n        <path id=\"time-selections-E\" d=\"M83 28h3v3h-3z\"/>\n        <mask id=\"time-selections-aq\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-E\"/>\n        </mask>\n        <path id=\"time-selections-F\" d=\"M83 34h3v3h-3z\"/>\n        <mask id=\"time-selections-ar\" x=\"0\" y=\"0\" width=\"3\" height=\"3\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-F\"/>\n        </mask>\n        <path d=\"M34 58c-.28 0-.53.11-.71.29L30 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 34 58z\" id=\"time-selections-G\"/>\n        <mask id=\"time-selections-as\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-G\"/>\n        </mask>\n        <path d=\"M72 58c-.28 0-.53.11-.71.29L68 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 72 58z\" id=\"time-selections-H\"/>\n        <mask id=\"time-selections-at\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-H\"/>\n        </mask>\n        <path d=\"M110 58c-.28 0-.53.11-.71.29L106 61.58l-3.29-3.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 110 58z\" id=\"time-selections-I\"/>\n        <mask id=\"time-selections-au\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-I\"/>\n        </mask>\n        <path d=\"M33.29.29L30 3.58 26.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 33.29.29z\" id=\"time-selections-J\"/>\n        <mask id=\"time-selections-av\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-J\"/>\n        </mask>\n        <path d=\"M71.29.29L68 3.58 64.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4A1.003 1.003 0 0 0 71.29.29z\" id=\"time-selections-K\"/>\n        <mask id=\"time-selections-aw\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-K\"/>\n        </mask>\n        <path d=\"M109.29.29L106 3.58 102.71.29a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29.28 0 .53-.11.71-.29l4-4a1.003 1.003 0 0 0-1.42-1.42z\" id=\"time-selections-L\"/>\n        <mask id=\"time-selections-ax\" x=\"0\" y=\"0\" width=\"10\" height=\"6\" fill=\"#fff\">\n            <use xlink:href=\"#time-selections-L\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g opacity=\".8\">\n                    <g>\n                        <use mask=\"url(#time-selections-M)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#time-selections-a\"/>\n                        <path d=\"M1 17h214M0 46h214M8 11v42M207 11v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#time-selections-N)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-b\"/>\n                        <use mask=\"url(#time-selections-O)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-c\"/>\n                        <use mask=\"url(#time-selections-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-d\"/>\n                        <use mask=\"url(#time-selections-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-e\"/>\n                        <path d=\"M23 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-R)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-f\"/>\n                        <use mask=\"url(#time-selections-S)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-g\"/>\n                        <path d=\"M60 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-T)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-h\"/>\n                        <use mask=\"url(#time-selections-U)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-i\"/>\n                        <path d=\"M98 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-V)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-j\"/>\n                        <use mask=\"url(#time-selections-W)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-k\"/>\n                        <path d=\"M136 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-X)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-l\"/>\n                        <use mask=\"url(#time-selections-Y)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-m\"/>\n                        <path d=\"M174 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-Z)\" stroke-width=\"4\" xlink:href=\"#time-selections-n\"/>\n                        <use mask=\"url(#time-selections-aa)\" stroke-width=\"4\" xlink:href=\"#time-selections-o\"/>\n                        <use mask=\"url(#time-selections-ab)\" stroke-width=\"4\" xlink:href=\"#time-selections-p\"/>\n                        <use mask=\"url(#time-selections-ac)\" stroke-width=\"4\" xlink:href=\"#time-selections-q\"/>\n                        <use mask=\"url(#time-selections-ad)\" stroke-width=\"4\" xlink:href=\"#time-selections-r\"/>\n                        <use mask=\"url(#time-selections-ae)\" stroke-width=\"4\" transform=\"rotate(-180 30 3)\" xlink:href=\"#time-selections-s\"/>\n                        <use mask=\"url(#time-selections-af)\" stroke-width=\"4\" transform=\"rotate(-180 68 3)\" xlink:href=\"#time-selections-t\"/>\n                        <use mask=\"url(#time-selections-ag)\" stroke-width=\"4\" transform=\"rotate(-180 106 3)\" xlink:href=\"#time-selections-u\"/>\n                        <use mask=\"url(#time-selections-ah)\" stroke-width=\"4\" transform=\"rotate(-180 143 3)\" xlink:href=\"#time-selections-v\"/>\n                        <use mask=\"url(#time-selections-ai)\" stroke-width=\"4\" transform=\"rotate(-180 181 3)\" xlink:href=\"#time-selections-w\"/>\n                    </g>\n                    <g transform=\"translate(0 90)\">\n                        <use mask=\"url(#time-selections-aj)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#time-selections-x\"/>\n                        <path d=\"M1 17h134M0 46h134M8 11v42M127 11v42\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#time-selections-ak)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-y\"/>\n                        <use mask=\"url(#time-selections-al)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-z\"/>\n                        <use mask=\"url(#time-selections-am)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-A\"/>\n                        <use mask=\"url(#time-selections-an)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#time-selections-B\"/>\n                        <path d=\"M23 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-ao)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-C\"/>\n                        <use mask=\"url(#time-selections-ap)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-D\"/>\n                        <path d=\"M60 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-aq)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-E\"/>\n                        <use mask=\"url(#time-selections-ar)\" stroke-width=\"6\" stroke-linecap=\"square\" xlink:href=\"#time-selections-F\"/>\n                        <path d=\"M98 32h15\" stroke-width=\"2\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#time-selections-as)\" stroke-width=\"4\" xlink:href=\"#time-selections-G\"/>\n                        <use mask=\"url(#time-selections-at)\" stroke-width=\"4\" xlink:href=\"#time-selections-H\"/>\n                        <use mask=\"url(#time-selections-au)\" stroke-width=\"4\" xlink:href=\"#time-selections-I\"/>\n                        <use mask=\"url(#time-selections-av)\" stroke-width=\"4\" transform=\"rotate(-180 30 3)\" xlink:href=\"#time-selections-J\"/>\n                        <use mask=\"url(#time-selections-aw)\" stroke-width=\"4\" transform=\"rotate(-180 68 3)\" xlink:href=\"#time-selections-K\"/>\n                        <use mask=\"url(#time-selections-ax)\" stroke-width=\"4\" transform=\"rotate(-180 106 3)\" xlink:href=\"#time-selections-L\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"
 
 /***/ },
-/* 303 */
+/* 305 */
 /***/ function(module, exports) {
 
 	module.exports = "<svg width=\"450\" height=\"346\" viewBox=\"0 0 450 346\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n    <title>\n        TOGGLES\n    </title>\n    <defs>\n        <path d=\"M43.816 40h174.181A3.004 3.004 0 0 1 221 43v288.696c0 1.654-1.344 3-3.003 3H13.003a3.004 3.004 0 0 1-3.003-3V43.001C10 41.346 11.344 40 13.003 40h13.18c.051-.05.1-.1.145-.15l7.344-8.246c.733-.823 1.924-.822 2.656 0l7.344 8.245c.045.051.094.101.144.151z\" id=\"toggles-a\"/>\n        <mask id=\"toggles-M\" x=\"0\" y=\"0\" width=\"211\" height=\"303.71\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-a\"/>\n        </mask>\n        <circle id=\"toggles-b\" cx=\"11\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-N\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-b\"/>\n        </mask>\n        <circle id=\"toggles-c\" cx=\"220\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-O\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-c\"/>\n        </mask>\n        <circle id=\"toggles-d\" cx=\"220\" cy=\"334\" r=\"5\"/>\n        <mask id=\"toggles-P\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-d\"/>\n        </mask>\n        <circle id=\"toggles-e\" cx=\"10\" cy=\"334\" r=\"5\"/>\n        <mask id=\"toggles-Q\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-e\"/>\n        </mask>\n        <path id=\"toggles-f\" d=\"M192 60l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-R\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-f\"/>\n        </mask>\n        <path id=\"toggles-g\" d=\"M192 100l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-S\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-g\"/>\n        </mask>\n        <path id=\"toggles-h\" d=\"M192 140l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-T\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-h\"/>\n        </mask>\n        <path id=\"toggles-i\" d=\"M192 180l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-U\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-i\"/>\n        </mask>\n        <path id=\"toggles-j\" d=\"M192 220l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-V\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-j\"/>\n        </mask>\n        <path id=\"toggles-k\" d=\"M192 260l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-W\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-k\"/>\n        </mask>\n        <path id=\"toggles-l\" d=\"M192 300l2.47 5.27 5.53.85-4 4.1.94 5.78-4.94-2.73-4.94 2.73.94-5.78-4-4.1 5.53-.85z\"/>\n        <mask id=\"toggles-X\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-l\"/>\n        </mask>\n        <path d=\"M44 8h-2.31c-.14-.46-.33-.89-.56-1.3l1.7-1.7a.996.996 0 0 0 0-1.41l-1.41-1.41a.996.996 0 0 0-1.41 0l-1.7 1.7c-.41-.22-.84-.41-1.3-.55V1c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v2.33c-.48.14-.94.35-1.37.59l-1.63-1.63a.972.972 0 0 0-1.36 0l-1.36 1.36c-.37.38-.37.98 0 1.36l1.62 1.62c-.24.43-.45.89-.6 1.38H26c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1h2.31c.14.46.33.89.56 1.3l-1.7 1.7a.996.996 0 0 0 0 1.41l1.41 1.41c.39.39 1.02.39 1.41 0l1.7-1.7c.41.22.84.41 1.3.55v2.33c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.33c.48-.14.94-.35 1.37-.59l1.63 1.63c.37.37.98.37 1.36 0l1.36-1.36c.37-.38.37-.98 0-1.36l-1.62-1.62c.24-.43.45-.89.6-1.38H44c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-9 6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z\" id=\"toggles-m\"/>\n        <mask id=\"toggles-Y\" x=\"0\" y=\"0\" width=\"20\" height=\"20.01\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-m\"/>\n        </mask>\n        <path d=\"M43 70.99c-.53 0-1.01.21-1.37.55l-4.72-2.95c.06-.19.1-.39.1-.6 0-.21-.04-.41-.1-.6l4.72-2.95c.36.34.84.55 1.37.55 1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2c0 .21.04.41.1.6l-4.73 2.96c-.24-.23-.54-.4-.87-.48v-4.14c.86-.22 1.5-1 1.5-1.93 0-1.1-.9-2-2-2s-2 .9-2 2c0 .93.64 1.71 1.5 1.93v4.14c-.33.09-.63.26-.87.48l-4.73-2.96c.06-.19.1-.39.1-.6 0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2c.53 0 1.01-.21 1.37-.55l4.72 2.95c-.06.19-.1.39-.1.6 0 .21.04.41.1.6l-4.72 2.95c-.36-.34-.84-.55-1.37-.55-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2c0-.21-.04-.41-.1-.6l4.73-2.96c.24.23.54.4.87.48v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93v-4.14c.33-.09.63-.26.87-.48l4.73 2.96c-.06.19-.1.39-.1.6 0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2z\" id=\"toggles-n\"/>\n        <mask id=\"toggles-Z\" x=\"0\" y=\"0\" width=\"20\" height=\"19.98\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-n\"/>\n        </mask>\n        <path d=\"M43.3 106c-.2-.9-.6-1.7-1.1-2.5.2-.3.3-.7.3-1 0-1.1-.9-2-2-2-.4 0-.7.1-1 .3-.8-.5-1.6-.8-2.5-1.1-.1-1-1-1.7-2-1.7s-1.8.8-2 1.7c-.9.3-1.7.6-2.5 1.1-.3-.2-.7-.3-1-.3-1.1 0-2 .9-2 2 0 .4.1.7.3 1-.5.8-.8 1.6-1.1 2.5-.9.2-1.7 1-1.7 2s.8 1.8 1.7 2c.2.9.6 1.7 1.1 2.5-.2.3-.3.7-.3 1 0 1.1.9 2 2 2 .4 0 .7-.1 1-.3.8.5 1.6.8 2.5 1.1.1 1 1 1.7 2 1.7s1.8-.8 2-1.7c.9-.2 1.7-.6 2.5-1.1.3.2.7.3 1 .3 1.1 0 2-.9 2-2 0-.4-.1-.7-.3-1 .5-.8.8-1.6 1.1-2.5 1-.1 1.7-1 1.7-2s-.8-1.8-1.7-2zm-1.8 5.8c-.3-.2-.6-.3-1-.3-1.1 0-2 .9-2 2 0 .4.1.7.3 1-.6.3-1.2.6-1.9.8-.3-.7-1-1.3-1.9-1.3-.8 0-1.6.5-1.9 1.3-.7-.2-1.3-.4-1.9-.8.2-.3.3-.6.3-1 0-1.1-.9-2-2-2-.4 0-.7.1-1 .3-.3-.6-.6-1.2-.8-1.9.8-.3 1.3-1.1 1.3-1.9 0-.8-.5-1.6-1.2-1.8.2-.7.4-1.3.8-1.9.3.2.6.3 1 .3 1.1 0 2-.9 2-2 0-.4-.1-.7-.3-1 .6-.3 1.2-.6 1.9-.8.2.7 1 1.2 1.8 1.2s1.6-.5 1.9-1.3c.7.2 1.3.4 1.9.8-.2.3-.3.6-.3 1 0 1.1.9 2 2 2 .4 0 .7-.1 1-.3.3.6.6 1.2.8 1.9-.8.3-1.3 1.1-1.3 1.9 0 .8.5 1.6 1.2 1.8-.1.7-.4 1.4-.7 2z\" id=\"toggles-o\"/>\n        <mask id=\"toggles-aa\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-o\"/>\n        </mask>\n        <path d=\"M27 146c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16-12c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-16-4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm8 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm8 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-8-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z\" id=\"toggles-p\"/>\n        <mask id=\"toggles-ab\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-p\"/>\n        </mask>\n        <path d=\"M27 178c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16-12c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-16 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-8 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z\" id=\"toggles-q\"/>\n        <mask id=\"toggles-ac\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-q\"/>\n        </mask>\n        <path d=\"M43.5 234.07v-4.14c.86-.22 1.5-1 1.5-1.93 0-1.1-.9-2-2-2-.93 0-1.71.64-1.93 1.5h-4.14c-.18-.7-.73-1.25-1.43-1.43v-4.14c.86-.22 1.5-1 1.5-1.93 0-1.1-.9-2-2-2s-2 .9-2 2c0 .93.64 1.71 1.5 1.93v4.14c-.7.18-1.25.73-1.43 1.43h-4.14c-.22-.86-1-1.5-1.93-1.5-1.1 0-2 .9-2 2 0 .93.64 1.71 1.5 1.93v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93v-4.14c.7-.18 1.25-.73 1.43-1.43h4.14c.18.7.73 1.25 1.43 1.43v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93v-4.14c.7-.18 1.25-.73 1.43-1.43h4.14c.18.7.73 1.25 1.43 1.43v4.14c-.86.22-1.5 1-1.5 1.93 0 1.1.9 2 2 2s2-.9 2-2c0-.93-.64-1.71-1.5-1.93z\" id=\"toggles-r\"/>\n        <mask id=\"toggles-ad\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-r\"/>\n        </mask>\n        <path d=\"M27 272c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-12c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm16 2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-16 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm11 4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm5-4c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-5-12c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z\" id=\"toggles-s\"/>\n        <mask id=\"toggles-ae\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-s\"/>\n        </mask>\n        <path d=\"M42.5 306a2.5 2.5 0 0 0-2.45 2h-2.1a2.5 2.5 0 0 0-4.9 0h-2.1a2.5 2.5 0 1 0 0 1h2.1a2.5 2.5 0 0 0 4.9 0h2.1a2.5 2.5 0 1 0 2.45-3z\" id=\"toggles-t\"/>\n        <mask id=\"toggles-af\" x=\"0\" y=\"0\" width=\"19\" height=\"5\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-t\"/>\n        </mask>\n        <path d=\"M43.816 40H188.01A3.002 3.002 0 0 1 191 42.996v127.008a2.991 2.991 0 0 1-2.99 2.996H12.99a3.002 3.002 0 0 1-2.99-2.996V42.996A2.991 2.991 0 0 1 12.99 40h13.194c.05-.05.099-.1.144-.15l7.344-8.246c.733-.823 1.924-.822 2.656 0l7.344 8.245c.045.051.094.101.144.151z\" id=\"toggles-u\"/>\n        <mask id=\"toggles-ag\" x=\"0\" y=\"0\" width=\"181\" height=\"142.013\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-u\"/>\n        </mask>\n        <path id=\"toggles-v\" d=\"M25 54.977h20v20H25z\"/>\n        <mask id=\"toggles-ah\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-v\"/>\n        </mask>\n        <path id=\"toggles-w\" d=\"M25 94.977h20v20H25z\"/>\n        <mask id=\"toggles-ai\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-w\"/>\n        </mask>\n        <path id=\"toggles-x\" d=\"M25 134.977h20v20H25z\"/>\n        <mask id=\"toggles-aj\" x=\"0\" y=\"0\" width=\"20\" height=\"20\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-x\"/>\n        </mask>\n        <circle id=\"toggles-y\" cx=\"11\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-ak\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-y\"/>\n        </mask>\n        <circle id=\"toggles-z\" cx=\"190\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-al\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-z\"/>\n        </mask>\n        <circle id=\"toggles-A\" cx=\"190\" cy=\"172\" r=\"5\"/>\n        <mask id=\"toggles-am\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-A\"/>\n        </mask>\n        <circle id=\"toggles-B\" cx=\"10\" cy=\"172\" r=\"5\"/>\n        <mask id=\"toggles-an\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-B\"/>\n        </mask>\n        <path d=\"M44 8h-2.31c-.14-.46-.33-.89-.56-1.3l1.7-1.7a.996.996 0 0 0 0-1.41l-1.41-1.41a.996.996 0 0 0-1.41 0l-1.7 1.7c-.41-.22-.84-.41-1.3-.55V1c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v2.33c-.48.14-.94.35-1.37.59l-1.63-1.63a.972.972 0 0 0-1.36 0l-1.36 1.36c-.37.38-.37.98 0 1.36l1.62 1.62c-.24.43-.45.89-.6 1.38H26c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1h2.31c.14.46.33.89.56 1.3l-1.7 1.7a.996.996 0 0 0 0 1.41l1.41 1.41c.39.39 1.02.39 1.41 0l1.7-1.7c.41.22.84.41 1.3.55v2.33c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.33c.48-.14.94-.35 1.37-.59l1.63 1.63c.37.37.98.37 1.36 0l1.36-1.36c.37-.38.37-.98 0-1.36l-1.62-1.62c.24-.43.45-.89.6-1.38H44c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-9 6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z\" id=\"toggles-C\"/>\n        <mask id=\"toggles-ao\" x=\"0\" y=\"0\" width=\"20\" height=\"20.01\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-C\"/>\n        </mask>\n        <path d=\"M43.816 40H188.01A3.005 3.005 0 0 1 191 43v98.998a2.998 2.998 0 0 1-2.99 3H12.99a3.005 3.005 0 0 1-2.99-3V43A2.998 2.998 0 0 1 12.99 40h13.194c.05-.05.099-.1.144-.15l7.344-8.246c.733-.823 1.924-.822 2.656 0l7.344 8.245c.045.051.094.101.144.15z\" id=\"toggles-D\"/>\n        <mask id=\"toggles-ap\" x=\"0\" y=\"0\" width=\"181\" height=\"114.013\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-D\"/>\n        </mask>\n        <path id=\"toggles-E\" d=\"M25 54.977h16v16H25z\"/>\n        <mask id=\"toggles-aq\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-E\"/>\n        </mask>\n        <path id=\"toggles-F\" d=\"M25 84.977h16v16H25z\"/>\n        <mask id=\"toggles-ar\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-F\"/>\n        </mask>\n        <path id=\"toggles-G\" d=\"M25 114.977h16v16H25z\"/>\n        <mask id=\"toggles-as\" x=\"0\" y=\"0\" width=\"16\" height=\"16\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-G\"/>\n        </mask>\n        <circle id=\"toggles-H\" cx=\"11\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-at\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-H\"/>\n        </mask>\n        <circle id=\"toggles-I\" cx=\"190\" cy=\"41\" r=\"5\"/>\n        <mask id=\"toggles-au\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-I\"/>\n        </mask>\n        <circle id=\"toggles-J\" cx=\"190\" cy=\"144\" r=\"5\"/>\n        <mask id=\"toggles-av\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-J\"/>\n        </mask>\n        <circle id=\"toggles-K\" cx=\"11\" cy=\"144\" r=\"5\"/>\n        <mask id=\"toggles-aw\" x=\"0\" y=\"0\" width=\"10\" height=\"10\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-K\"/>\n        </mask>\n        <path d=\"M44 8h-2.31c-.14-.46-.33-.89-.56-1.3l1.7-1.7a.996.996 0 0 0 0-1.41l-1.41-1.41a.996.996 0 0 0-1.41 0l-1.7 1.7c-.41-.22-.84-.41-1.3-.55V1c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v2.33c-.48.14-.94.35-1.37.59l-1.63-1.63a.972.972 0 0 0-1.36 0l-1.36 1.36c-.37.38-.37.98 0 1.36l1.62 1.62c-.24.43-.45.89-.6 1.38H26c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1h2.31c.14.46.33.89.56 1.3l-1.7 1.7a.996.996 0 0 0 0 1.41l1.41 1.41c.39.39 1.02.39 1.41 0l1.7-1.7c.41.22.84.41 1.3.55v2.33c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.33c.48-.14.94-.35 1.37-.59l1.63 1.63c.37.37.98.37 1.36 0l1.36-1.36c.37-.38.37-.98 0-1.36l-1.62-1.62c.24-.43.45-.89.6-1.38H44c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zm-9 6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z\" id=\"toggles-L\"/>\n        <mask id=\"toggles-ax\" x=\"0\" y=\"0\" width=\"20\" height=\"20.01\" fill=\"#fff\">\n            <use xlink:href=\"#toggles-L\"/>\n        </mask>\n    </defs>\n    <g fill=\"none\" fill-rule=\"evenodd\" opacity=\".1\">\n        <g stroke=\"#FFF\">\n            <g>\n                <g>\n                    <g>\n                        <use mask=\"url(#toggles-M)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#toggles-a\"/>\n                        <path d=\"M11 34v312M220 34v312M0 334h230M0 41h230\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#toggles-N)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-b\"/>\n                        <use mask=\"url(#toggles-O)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-c\"/>\n                        <use mask=\"url(#toggles-P)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-d\"/>\n                        <use mask=\"url(#toggles-Q)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-e\"/>\n                        <use mask=\"url(#toggles-R)\" stroke-width=\"4\" xlink:href=\"#toggles-f\"/>\n                        <use mask=\"url(#toggles-S)\" stroke-width=\"4\" xlink:href=\"#toggles-g\"/>\n                        <use mask=\"url(#toggles-T)\" stroke-width=\"4\" xlink:href=\"#toggles-h\"/>\n                        <use mask=\"url(#toggles-U)\" stroke-width=\"4\" xlink:href=\"#toggles-i\"/>\n                        <use mask=\"url(#toggles-V)\" stroke-width=\"4\" xlink:href=\"#toggles-j\"/>\n                        <use mask=\"url(#toggles-W)\" stroke-width=\"4\" xlink:href=\"#toggles-k\"/>\n                        <use mask=\"url(#toggles-X)\" stroke-width=\"4\" xlink:href=\"#toggles-l\"/>\n                        <path d=\"M62.5 68.5H92M62.5 108.5H116M62.5 148.5H89M62.5 188.5H131M62.5 228.5H127M62.5 268.5H123M62.5 308.5H104\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#toggles-Y)\" stroke-width=\"4\" xlink:href=\"#toggles-m\"/>\n                        <use mask=\"url(#toggles-Z)\" stroke-width=\"4\" xlink:href=\"#toggles-n\"/>\n                        <use mask=\"url(#toggles-aa)\" stroke-width=\"4\" xlink:href=\"#toggles-o\"/>\n                        <use mask=\"url(#toggles-ab)\" stroke-width=\"4\" xlink:href=\"#toggles-p\"/>\n                        <use mask=\"url(#toggles-ac)\" stroke-width=\"4\" xlink:href=\"#toggles-q\"/>\n                        <use mask=\"url(#toggles-ad)\" stroke-width=\"4\" xlink:href=\"#toggles-r\"/>\n                        <use mask=\"url(#toggles-ae)\" stroke-width=\"4\" xlink:href=\"#toggles-s\"/>\n                        <use mask=\"url(#toggles-af)\" stroke-width=\"4\" xlink:href=\"#toggles-t\"/>\n                    </g>\n                    <g transform=\"translate(250)\">\n                        <use mask=\"url(#toggles-ag)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#toggles-u\"/>\n                        <use mask=\"url(#toggles-ah)\" stroke-width=\"4\" xlink:href=\"#toggles-v\"/>\n                        <use mask=\"url(#toggles-ai)\" stroke-width=\"4\" xlink:href=\"#toggles-w\"/>\n                        <use mask=\"url(#toggles-aj)\" stroke-width=\"4\" xlink:href=\"#toggles-x\"/>\n                        <path d=\"M11 34v146M190 34v146M0 172h200M0 41h200\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <path d=\"M56.5 64.5H86M56.5 104.5H86M56.5 144.5H86\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#toggles-ak)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-y\"/>\n                        <use mask=\"url(#toggles-al)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-z\"/>\n                        <use mask=\"url(#toggles-am)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-A\"/>\n                        <use mask=\"url(#toggles-an)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-B\"/>\n                        <use mask=\"url(#toggles-ao)\" stroke-width=\"4\" xlink:href=\"#toggles-C\"/>\n                    </g>\n                    <g transform=\"translate(250 190)\">\n                        <use mask=\"url(#toggles-ap)\" stroke-width=\"4\" opacity=\".4\" xlink:href=\"#toggles-D\"/>\n                        <use mask=\"url(#toggles-aq)\" stroke-width=\"4\" xlink:href=\"#toggles-E\"/>\n                        <use mask=\"url(#toggles-ar)\" stroke-width=\"4\" xlink:href=\"#toggles-F\"/>\n                        <use mask=\"url(#toggles-as)\" stroke-width=\"4\" xlink:href=\"#toggles-G\"/>\n                        <path d=\"M11 34v119M190 34v120M0 144h200M0 41h200\" stroke-opacity=\".5\" stroke-width=\"2\"/>\n                        <use mask=\"url(#toggles-at)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-H\"/>\n                        <use mask=\"url(#toggles-au)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-I\"/>\n                        <use mask=\"url(#toggles-av)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-J\"/>\n                        <use mask=\"url(#toggles-aw)\" stroke-width=\"2\" opacity=\".4\" xlink:href=\"#toggles-K\"/>\n                        <path d=\"M52.5 62.5H82M52.5 92.5H82M52.5 122.5H82\" stroke-width=\"3\" stroke-linecap=\"square\"/>\n                        <use mask=\"url(#toggles-ax)\" stroke-width=\"4\" xlink:href=\"#toggles-L\"/>\n                    </g>\n                </g>\n            </g>\n        </g>\n    </g>\n</svg>\n"

--- a/docs/docs/site-docs.css
+++ b/docs/docs/site-docs.css
@@ -6865,7 +6865,7 @@ table.pt-table.pt-interactive tbody tr:hover td {
 .bp-table-column-headers {
   box-shadow: 0 1px 0 0 rgba(16, 22, 26, 0.15); }
 .bp-table-row-headers {
-  box-shadow: 1px 0 0 rgba(16, 22, 26, 0.15), inset 0 1px 0 rgba(16, 22, 26, 0.15); }
+  box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.15); }
 .bp-table-cell {
   box-shadow: inset -1px 0 0 rgba(16, 22, 26, 0.15), inset 0 -1px 0 rgba(16, 22, 26, 0.15); }
 .bp-table-horizontal-cell-divider {
@@ -6881,12 +6881,12 @@ table.pt-table.pt-interactive tbody tr:hover td {
 .bp-table-column-headers .bp-table-header.bp-table-last-in-row::before {
       right: 0; }
 .bp-table-row-headers .bp-table-header {
-  box-shadow: inset 0 -1px 0 rgba(16, 22, 26, 0.15); }
+  box-shadow: inset 0 -1px 0 rgba(16, 22, 26, 0.15), 1px 0 0 rgba(16, 22, 26, 0.15); }
 .bp-table-row-headers .bp-table-header::before {
     right: 0;
     bottom: 1px; }
 .bp-table-row-headers .bp-table-header.bp-table-last-in-column {
-    box-shadow: 0 1px 0 rgba(16, 22, 26, 0.15); }
+    box-shadow: 1px 0 0 0 rgba(16, 22, 26, 0.15), 0 1px 0 0 rgba(16, 22, 26, 0.15); }
 .bp-table-row-headers .bp-table-header.bp-table-last-in-column::before {
       bottom: 0; }
 .bp-table-body .bp-table-last-in-row {
@@ -6906,7 +6906,7 @@ table.pt-table.pt-interactive tbody tr:hover td {
 .pt-dark .bp-table-column-headers {
   box-shadow: 0 1px 0 0 rgba(16, 22, 26, 0.4); }
 .pt-dark .bp-table-row-headers {
-  box-shadow: 1px 0 0 rgba(16, 22, 26, 0.4), inset 0 1px 0 rgba(16, 22, 26, 0.4); }
+  box-shadow: inset 0 1px 0 rgba(16, 22, 26, 0.4); }
 .pt-dark .bp-table-cell {
   box-shadow: inset -1px 0 0 rgba(16, 22, 26, 0.4), inset 0 -1px 0 rgba(16, 22, 26, 0.4); }
 .pt-dark .bp-table-horizontal-cell-divider {
@@ -6922,12 +6922,12 @@ table.pt-table.pt-interactive tbody tr:hover td {
 .pt-dark .bp-table-column-headers .bp-table-header.bp-table-last-in-row::before {
       right: 0; }
 .pt-dark .bp-table-row-headers .bp-table-header {
-  box-shadow: inset 0 -1px 0 rgba(16, 22, 26, 0.4); }
+  box-shadow: inset 0 -1px 0 rgba(16, 22, 26, 0.4), 1px 0 0 rgba(16, 22, 26, 0.4); }
 .pt-dark .bp-table-row-headers .bp-table-header::before {
     right: 0;
     bottom: 1px; }
 .pt-dark .bp-table-row-headers .bp-table-header.bp-table-last-in-column {
-    box-shadow: 0 1px 0 rgba(16, 22, 26, 0.4); }
+    box-shadow: 1px 0 0 0 rgba(16, 22, 26, 0.4), 0 1px 0 0 rgba(16, 22, 26, 0.4); }
 .pt-dark .bp-table-row-headers .bp-table-header.bp-table-last-in-column::before {
       bottom: 0; }
 .pt-dark .bp-table-body .bp-table-last-in-row {
@@ -7677,7 +7677,7 @@ and https://github.com/palantir/blueprint/blob/master/PATENTS
 .docs-navigator .pt-menu {
   min-width: 220px; }
 .docs-navigator .pt-menu {
-  max-height: 240px;
+  max-height: 245px;
   overflow: auto; }
 .docs-navigator .pt-menu-item:not(.pt-active) {
   background: inherit; }

--- a/docs/docs/site-docs.css
+++ b/docs/docs/site-docs.css
@@ -4648,35 +4648,37 @@ label.pt-label.pt-disabled,
   pointer-events: none; }
 .pt-disabled.pt-select::after {
     color: rgba(92, 112, 128, 0.5); }
-.pt-numeric-input .pt-button-group.pt-vertical > .pt-button {
-  min-width: 30px;
-  min-height: 30px;
-  line-height: 30px;
-  display: block;
-  min-height: 15px;
-  line-height: 15px; }
 .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
-    border-radius: 0 3px 0 0;
-    height: 16px; }
+  min-height: 16px; }
 .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
-    border-radius: 0 0 3px 0;
-    height: 15px; }
+  min-height: 15px; }
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
+  border-radius: 0 3px 0 0; }
+.pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
+  border-radius: 0 0 3px 0; }
 .pt-numeric-input .pt-button-group.pt-vertical > .pt-button[class*="pt-icon-"]::before {
-    display: block;
-    height: 14px;
-    overflow: hidden;
-    line-height: 14px; }
-.pt-numeric-input .pt-button-group:first-child.pt-vertical > .pt-button:first-child {
+  display: block;
+  height: 14px;
+  overflow: hidden;
+  line-height: 14px; }
+.pt-numeric-input .pt-button-group.pt-vertical:first-child > .pt-button:first-child {
   border-radius: 3px 0 0 0; }
-.pt-numeric-input .pt-button-group:first-child.pt-vertical > .pt-button:last-child {
+.pt-numeric-input .pt-button-group.pt-vertical:first-child > .pt-button:last-child {
   border-radius: 0 0 0 3px; }
+.pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:first-child {
+  min-height: 21px; }
+.pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:last-child {
+  min-height: 20px; }
 .pt-dark .pt-numeric-input .pt-button-group.pt-vertical > .pt-button {
-  min-height: 14px;
   line-height: 14px; }
 .pt-dark .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:first-child {
-    height: 15px; }
+    min-height: 15px; }
 .pt-dark .pt-numeric-input .pt-button-group.pt-vertical > .pt-button:last-child {
-    height: 14px; }
+    min-height: 14px; }
+.pt-dark .pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:first-child {
+  min-height: 20px; }
+.pt-dark .pt-numeric-input.pt-large .pt-button-group.pt-vertical > .pt-button:last-child {
+  min-height: 19px; }
 form {
   display: block; }
 .pt-key {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprint",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Core styles & components",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/datetime",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Components for interacting with dates and times",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/docs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Blueprint theme for documentalist",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/site-docs/package.json
+++ b/packages/site-docs/package.json
@@ -1,13 +1,13 @@
 {
   "name": "blueprintjs.com/docs",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Blueprint Docs",
   "private": true,
   "dependencies": {
-    "@blueprintjs/core": "^1.16.0",
-    "@blueprintjs/datetime": "^1.14.1",
-    "@blueprintjs/docs": "^1.0.0",
-    "@blueprintjs/table": "^1.13.0",
+    "@blueprintjs/core": "^1.17.0",
+    "@blueprintjs/datetime": "^1.15.0",
+    "@blueprintjs/docs": "^1.1.0",
+    "@blueprintjs/table": "^1.14.0",
     "bourbon": "4.2.2",
     "chroma-js": "1.1.1",
     "classnames": "2.2.5",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
:fireworks: **Highlights**: _TODO_

:book: **Latest docs**: [blueprintjs.com/docs](http://blueprintjs.com/docs)

## @blueprintjs/core `1.17.0`
- __NEW__ `NumericInput` `clampValueOnBlur` prop will restrict the value to between `min` and `max` when the input is blurred (default `false` for compatibility) #1044 
- __NEW__ `NumericInput` `large` prop applies `.pt-large` modifier to use larger inputs and buttons #907
  - this was not as simple as adding `.pt-large` once to the container element, so we opted for a prop to ensure the correct classes are added correctly, see #1038  
- __Fixed__ `EditableText` only sets `defaultValue` on initial render #987 
- __Fixed__ `Tabs2` clicking selected tab again fires `onChange` #1067 
- 📦  __Replaced__ deprecated package `react-addons-css-transition-group` with `react-transition-group` per https://github.com/facebook/react/issues/8125 (:tophat: @benhjames) #1051 
  - 💡 while the only code change here is in `core`, every package is affected by this change, through the magic of peer dependencies
  - yarn (or npm) should take care of this for you, but your `@types` are on you

## @blueprintjs/datetime `1.15.0`
- __Fixed__ `DateRangePicker` with `contiguousCalendarMonths=false` now shows hovered range #1048 
- 📦 __Updated__ `react-day-picker` dependency to latest `v5.3.0` #688 #1014 
  - `react-day-picker` NPM module now includes its own typings, so we were able to remove some interfaces that were redefined locally to avoid adding an `@types` dependency
  - nothing has changed in the `Date[Range]Picker` APIs, but they are no longer compatible with older versions of `react-day-picker`

## @blueprintjs/docs `1.1.0`
- __NEW__ `Navigator` scrolls selected item into viewport #335 
![navigator-key-scroll](https://cloud.githubusercontent.com/assets/464822/25509437/e4b8b224-2b6d-11e7-8faa-da869374b26d.gif)

## @blueprintjs/table `1.14.0`
- 🌟 __NEW__ `Table#resizeRowsByTallestCell` instance method now accepts an array of column indices to consider when computing tallest cell, or no arguments to consider all columns in the viewport (:tophat: @philcchen) #1070 
  - it still accepts a single column index (not an array) for the one-column case
- __Fixed__ divider appearance between headings and ghost cells #972 

## Documentation
- __Fixed__ link in tooltip docs (:tophat: @acolombi) #1058
- __Fixed__ missing braces in popover docs (:tophat: @maxdow) #1074