### PR TITLE
[DateInput] Don't closeOnSelection when the time changes 

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -278,10 +278,13 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         const prevMomentDate = this.state.value;
         const momentDate = fromDateToMoment(date);
 
-        const isOpen = !(this.props.closeOnSelection
-            && hasUserManuallySelectedDate
-            && !this.hasMonthChanged(prevMomentDate, momentDate)
-            && !this.hasTimeChanged(prevMomentDate, momentDate));
+        // this change handler was triggered by a change in month, day, or (if enabled) time. for UX
+        // purposes, we want to close the popover only if the user explicitly clicked a day within
+        // the current month.
+        const isOpen = (!hasUserManuallySelectedDate
+            || this.hasMonthChanged(prevMomentDate, momentDate)
+            || this.hasTimeChanged(prevMomentDate, momentDate)
+            || !this.props.closeOnSelection);
 
         if (this.props.value === undefined) {
             this.setState({ isInputFocused: false, isOpen, value: momentDate });

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -295,7 +295,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private shouldCheckForDateChanges(prevMomentDate: moment.Moment, nextMomentDate: moment.Moment) {
-        return nextMomentDate !== null && !isMomentNull(prevMomentDate) && prevMomentDate.isValid();
+        return nextMomentDate != null && !isMomentNull(prevMomentDate) && prevMomentDate.isValid();
     }
 
     private hasMonthChanged(prevMomentDate: moment.Moment, nextMomentDate: moment.Moment) {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -301,11 +301,14 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private hasTimeChanged(prevMomentDate: moment.Moment, nextMomentDate: moment.Moment) {
-        return this.shouldCheckForDateChanges(prevMomentDate, nextMomentDate) && (
-            nextMomentDate.hours() !== prevMomentDate.hours()
-            || nextMomentDate.minutes() !== prevMomentDate.minutes()
-            || nextMomentDate.seconds() !== prevMomentDate.seconds()
-            || nextMomentDate.milliseconds() !== prevMomentDate.milliseconds());
+        return this.shouldCheckForDateChanges(prevMomentDate, nextMomentDate)
+            && this.props.timePrecision != null
+            && (
+                nextMomentDate.hours() !== prevMomentDate.hours()
+                || nextMomentDate.minutes() !== prevMomentDate.minutes()
+                || nextMomentDate.seconds() !== prevMomentDate.seconds()
+                || nextMomentDate.milliseconds() !== prevMomentDate.milliseconds()
+            );
     }
 
     private handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -275,16 +275,30 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     }
 
     private handleDateChange = (date: Date, hasUserManuallySelectedDate: boolean) => {
+        const prevMomentDate = this.state.value;
         const momentDate = fromDateToMoment(date);
-        const hasMonthChanged = date !== null && !isMomentNull(this.state.value) && this.state.value.isValid() &&
-            momentDate.month() !== this.state.value.month();
-        const isOpen = !(this.props.closeOnSelection && hasUserManuallySelectedDate && !hasMonthChanged);
+
+        // the popover should close only in response to the user explicitly clicking a date
+        const hasMonthChanged = this.hasDateChanged(prevMomentDate, momentDate, "months");
+        const hasTimeChanged = this.hasDateChanged(prevMomentDate, momentDate);
+
+        const isOpen = !(this.props.closeOnSelection
+            && hasUserManuallySelectedDate
+            && !hasMonthChanged
+            && !hasTimeChanged);
         if (this.props.value === undefined) {
             this.setState({ isInputFocused: false, isOpen, value: momentDate });
         } else {
             this.setState({ isInputFocused: false, isOpen });
         }
         Utils.safeInvoke(this.props.onChange, date === null ? null : fromMomentToDate(momentDate));
+    }
+
+    private hasDateChanged(prevDate: moment.Moment, nextDate: moment.Moment, precision?: "months") {
+        return nextDate !== null
+            && !isMomentNull(prevDate)
+            && prevDate.isValid()
+            && nextDate.diff(prevDate, precision) !== 0; // if precision is undefined, returns diff in milliseconds
     }
 
     private handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -278,14 +278,11 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         const prevMomentDate = this.state.value;
         const momentDate = fromDateToMoment(date);
 
-        // the popover should close only in response to the user explicitly clicking a date
-        const hasMonthChanged = this.hasDateChanged(prevMomentDate, momentDate, "months");
-        const hasTimeChanged = this.hasDateChanged(prevMomentDate, momentDate);
-
         const isOpen = !(this.props.closeOnSelection
             && hasUserManuallySelectedDate
-            && !hasMonthChanged
-            && !hasTimeChanged);
+            && !this.hasMonthChanged(prevMomentDate, momentDate)
+            && !this.hasTimeChanged(prevMomentDate, momentDate));
+
         if (this.props.value === undefined) {
             this.setState({ isInputFocused: false, isOpen, value: momentDate });
         } else {
@@ -294,11 +291,21 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         Utils.safeInvoke(this.props.onChange, date === null ? null : fromMomentToDate(momentDate));
     }
 
-    private hasDateChanged(prevDate: moment.Moment, nextDate: moment.Moment, precision?: "months") {
-        return nextDate !== null
-            && !isMomentNull(prevDate)
-            && prevDate.isValid()
-            && nextDate.diff(prevDate, precision) !== 0; // if precision is undefined, returns diff in milliseconds
+    private shouldCheckForDateChanges(prevMomentDate: moment.Moment, nextMomentDate: moment.Moment) {
+        return nextMomentDate !== null && !isMomentNull(prevMomentDate) && prevMomentDate.isValid();
+    }
+
+    private hasMonthChanged(prevMomentDate: moment.Moment, nextMomentDate: moment.Moment) {
+        return this.shouldCheckForDateChanges(prevMomentDate, nextMomentDate)
+            && nextMomentDate.month() !== prevMomentDate.month();
+    }
+
+    private hasTimeChanged(prevMomentDate: moment.Moment, nextMomentDate: moment.Moment) {
+        return this.shouldCheckForDateChanges(prevMomentDate, nextMomentDate) && (
+            nextMomentDate.hours() !== prevMomentDate.hours()
+            || nextMomentDate.minutes() !== prevMomentDate.minutes()
+            || nextMomentDate.seconds() !== prevMomentDate.seconds()
+            || nextMomentDate.milliseconds() !== prevMomentDate.milliseconds());
     }
 
     private handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { InputGroup, Popover, Position } from "@blueprintjs/core";
+import { InputGroup, Keys, Popover, Position } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes, DateInput, TimePicker, TimePickerPrecision } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -131,10 +131,36 @@ describe("<DateInput>", () => {
             assert.isTrue(onChange.calledWith(null));
         });
 
-        it("The popover stays open on date click if closeOnSelection=false", () => {
+        it("Popover stays open on date click if closeOnSelection=false", () => {
             const wrapper = mount(<DateInput closeOnSelection={false} />).setState({ isOpen: true });
             wrapper.find(`.${Classes.DATEPICKER_DAY}`).first().simulate("click");
             assert.isTrue(wrapper.state("isOpen"));
+        });
+
+        it("Popover doesn't close when month changes if closeOnSelection=true", () => {
+            const defaultValue = new Date(2017, Months.JANUARY, 1);
+            const wrapper = mount(<DateInput closeOnSelection={true} defaultValue={defaultValue} />);
+            wrapper.setState({ isOpen: true });
+            wrapper.find(".pt-datepicker-month-select").simulate("change", { value: Months.FEBRUARY.toString() });
+            assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+        });
+
+        it("Popover doesn't close when time changes if closeOnSelection=true", () => {
+            const defaultValue = new Date(2017, Months.JANUARY, 1, 0, 0, 0, 0);
+            const wrapper = mount(<DateInput
+                closeOnSelection={true}
+                defaultValue={defaultValue}
+                timePrecision={TimePickerPrecision.MILLISECOND}
+            />);
+            wrapper.setState({ isOpen: true });
+
+            // try typing a new time
+            wrapper.find(".pt-timepicker-millisecond").simulate("change", { target: { value: "1" } });
+            assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+
+            // try keyboard-incrementing to a new time
+            wrapper.find(".pt-timepicker-millisecond").simulate("keydown", { which: Keys.ARROW_UP });
+            assert.isTrue(wrapper.find(Popover).prop("isOpen"));
         });
 
         it("Clicking a date in a different month sets input value but keeps popover open", () => {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -14,7 +14,7 @@ import { Months } from "../src/common/months";
 import { Classes, DateInput, TimePicker, TimePickerPrecision } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
 
-describe.only("<DateInput>", () => {
+describe("<DateInput>", () => {
     it("handles null inputs without crashing", () => {
         assert.doesNotThrow(() => mount(<DateInput value={null} />));
     });

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -109,6 +109,15 @@ describe("<DateInput>", () => {
             assert.notEqual(wrapper.find(InputGroup).prop("value"), "");
         });
 
+        it("Clicking a date in the same month closes the popover when there is already a default value", () => {
+            const DAY = 15;
+            const PREV_DAY = DAY - 1;
+            const defaultValue = new Date(2017, Months.JANUARY, DAY, 15, 0, 0, 0); // include an arbitrary non-zero hour
+            const wrapper = mount(<DateInput defaultValue={defaultValue} />).setState({ isOpen: true });
+            wrapper.find(`.${Classes.DATEPICKER_DAY}`).at(PREV_DAY - 1).simulate("click");
+            assert.isFalse(wrapper.state("isOpen"));
+        });
+
         it("Clearing the date in the DatePicker clears the input, and invokes onChange with null", () => {
             const onChange = sinon.spy();
             const { root, getDay } = wrap(

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -14,7 +14,7 @@ import { Months } from "../src/common/months";
 import { Classes, DateInput, TimePicker, TimePickerPrecision } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
 
-describe("<DateInput>", () => {
+describe.only("<DateInput>", () => {
     it("handles null inputs without crashing", () => {
         assert.doesNotThrow(() => mount(<DateInput value={null} />));
     });
@@ -137,18 +137,17 @@ describe("<DateInput>", () => {
             assert.isTrue(wrapper.state("isOpen"));
         });
 
-        it("Popover doesn't close when month changes if closeOnSelection=true", () => {
+        it("Popover doesn't close when month changes", () => {
             const defaultValue = new Date(2017, Months.JANUARY, 1);
-            const wrapper = mount(<DateInput closeOnSelection={true} defaultValue={defaultValue} />);
+            const wrapper = mount(<DateInput defaultValue={defaultValue} />);
             wrapper.setState({ isOpen: true });
             wrapper.find(".pt-datepicker-month-select").simulate("change", { value: Months.FEBRUARY.toString() });
             assert.isTrue(wrapper.find(Popover).prop("isOpen"));
         });
 
-        it("Popover doesn't close when time changes if closeOnSelection=true", () => {
+        it("Popover doesn't close when time changes", () => {
             const defaultValue = new Date(2017, Months.JANUARY, 1, 0, 0, 0, 0);
             const wrapper = mount(<DateInput
-                closeOnSelection={true}
                 defaultValue={defaultValue}
                 timePrecision={TimePickerPrecision.MILLISECOND}
             />);


### PR DESCRIPTION
#### Related to #1089 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

**Before:** incrementing or otherwise changing the time would immediately close the popover if `closeOnSelection=true`.
**After:** Stop doing that. Popover now closes only after clicking a date in the calendar, not after changing the time (or the month, but that was already implemented).

#### Screenshot

![2017-05-11 23 18 03](https://cloud.githubusercontent.com/assets/443450/25985595/2874dadc-36a0-11e7-9dcd-1e91739dae47.gif)
