### PR TITLE
react-transition-group becomes regular dependency of core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,20 +13,19 @@
     "dom4": "^1.8",
     "normalize.css": "4.1.1",
     "pure-render-decorator": "^1.1",
+    "react-transition-group": "^1.1.3",
     "tether": "^1.4",
     "tslib": "^1.5.0"
   },
   "peerDependencies": {
     "react": "^15.0.1 || ^0.14",
-    "react-dom": "^15.0.1 || ^0.14",
-    "react-transition-group": "^1.1.3"
+    "react-dom": "^15.0.1 || ^0.14"
   },
   "devDependencies": {
     "bourbon": "4.3.2",
     "react": "15.5.1",
     "react-addons-test-utils": "15.5.1",
-    "react-dom": "15.5.1",
-    "react-transition-group": "1.1.3"
+    "react-dom": "15.5.1"
   },
   "repository": {
     "type": "git",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,6 @@
     "fuzzaldrin-plus": "^0.3.1",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
-    "react-transition-group": "^1.1.3",
     "tslib": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/site-landing/package.json
+++ b/packages/site-landing/package.json
@@ -38,7 +38,6 @@
     "raw-loader": "0.5.1",
     "react": "15.5.1",
     "react-dom": "15.5.1",
-    "react-transition-group": "1.1.3",
     "sass-loader": "4.0.0",
     "style-loader": "0.13.1",
     "svgo": "0.7.1",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -36,7 +36,6 @@
     "react": "15.5.1",
     "react-addons-test-utils": "15.5.1",
     "react-dom": "15.5.1",
-    "react-transition-group": "1.1.3",
     "style-loader": "0.13.1",
     "typescript": "2.1.5",
     "webpack": "1.13.3"


### PR DESCRIPTION
#### Fixes broken 1.17.0 release

@zerovox points out that changing a peer dependency like we did in #1063 is basically a breaking change as it _requires action from every user._

fortunately, un-breaking the API is pretty easy: we can take `react-transition-group` on as a regular dependency, rather than a peer dependency. this is legit because it is no longer a react-addon package and does not make awkward use of the `React` global variable. it also has its [own peer dependencies on react](https://github.com/reactjs/react-transition-group/blob/master/package.json#L40-L43).

⚠️ `react-transition-group` peer dependency on react is `^15.0.0` so it is no longer valid to install `react@0.14` alongside Blueprint (even though we technically support it). @adidahiya how acceptable is this?

I also removed `r-t-g` dev dependencies from packages that don't use it (which is most of them--it's only used once in `Overlay`).

#### Reviewers should focus on

@adidahiya @cmslewis we should ship a patch release 1.17.1 after this merges to unbreak future installers. i'll be on a plane from 8:30am PST, if one of you could please handle that?