### PR TITLE
[Table] Fixed the row resize for truncated non-word-wrapped

### DIFF
--- a/packages/table/preview/index.html
+++ b/packages/table/preview/index.html
@@ -65,6 +65,7 @@
   <div id="table-formats" class="fixed-size-table"></div>
   <div class="resize-default pt-button pt-intent-success">Resize Default</div>
   <div class="resize-wrapped pt-button pt-intent-success">Resize Wrapped Text</div>
+  <div class="resize-json pt-button pt-intent-success">Resize JSON</div>
   <div class="resize-json-wrapped pt-button pt-intent-success">Resize Json Wrapped Text</div>
   <div class="resize-wrapped-and-json pt-button pt-intent-success">Resize Wrapped and Json Text</div>
   <div class="resize-viewport pt-button pt-intent-success">Resize Viewport</div>

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -136,6 +136,9 @@ class FormatsTable extends React.Component<{}, {}> {
         document.querySelector(".resize-wrapped").addEventListener("click", () => {
             this.formatsTable.resizeRowsByTallestCell(1);
         });
+        document.querySelector(".resize-json").addEventListener("click", () => {
+            this.formatsTable.resizeRowsByTallestCell(2);
+        });
         document.querySelector(".resize-json-wrapped").addEventListener("click", () => {
             this.formatsTable.resizeRowsByTallestCell(3);
         });

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -11,8 +11,8 @@
   position: absolute;
   top: 0;
   right: $pt-grid-size * 3.5;
-  bottom: 0;
   left: $pt-grid-size;
+  max-height: 100%;
 
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
#### Changes proposed in this pull request

The truncated non-word-wrapped cells were taking up the
whole cell and so the size calculation wasn't working properly.

Now it should work properly.

#### Reviewers should focus on:

This is pretty straightforward :) 
