### PR TITLE
[Table] Use width of popover dots when calculating whether to show it

### DIFF
--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -39,6 +39,8 @@
   border-radius: 3px;
   cursor: pointer;
 
+  // note: modifying this value, or anything that affects the width of the popover target
+  // may affect the calculation of when to draw the popover target
   padding: 0 $pt-grid-size / 2;
   text-align: center;
 

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -10,6 +10,7 @@
 .bp-table-truncated-value {
   position: absolute;
   top: 0;
+  // note: changing this value can throw off the width calculation in truncated popover
   right: $pt-grid-size * 3.5;
   left: $pt-grid-size;
   max-height: 100%;
@@ -21,6 +22,7 @@
 .bp-table-truncated-format-text {
   position: absolute;
   top: 0;
+  // note: changing this value can throw off the width calculation in truncated popover
   right: $pt-grid-size;
   left: $pt-grid-size;
   max-height: 100%;

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -39,8 +39,6 @@
   border-radius: 3px;
   cursor: pointer;
 
-  // note: modifying this value, or anything that affects the width of the popover target
-  // may affect the calculation of when to draw the popover target
   padding: 0 $pt-grid-size / 2;
   text-align: center;
 

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -12,6 +12,10 @@ import * as React from "react";
 
 import * as Classes from "../../common/classes";
 
+// amount in pixels that the content div width changes when truncated vs when
+// not truncated. Note: could be modified by styles
+const CONTENT_DIV_WIDTH_DELTA = 25;
+
 export enum TruncatedPopoverMode {
     ALWAYS,
     NEVER,
@@ -78,7 +82,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
     public state: ITruncatedFormatState = { isTruncated: false };
 
     private contentDiv: HTMLDivElement;
-    private popoverComponent: Popover;
 
     public render() {
         const { children, detectTruncation, preformatted, truncateLength, truncationSuffix } = this.props;
@@ -110,7 +113,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
                 <div className={className}>
                     <div className={Classes.TABLE_TRUNCATED_VALUE} ref={this.handleContentDivRef}>{cellContent}</div>
                     <Popover
-                        ref={this.handlePopoverComponentRef}
                         className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
                         tetherOptions={{ constraints }}
                         content={popoverContent}
@@ -137,8 +139,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
 
     private handleContentDivRef = (ref: HTMLDivElement) => this.contentDiv = ref;
 
-    private handlePopoverComponentRef = (ref: Popover) => this.popoverComponent = ref;
-
     private shouldShowPopover(content: string) {
         const { detectTruncation, showPopover, truncateLength } = this.props;
 
@@ -162,7 +162,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
 
         // if the popover handle exists, take it into account
-        const popoverHandleAdjustmentFactor = this.state.isTruncated ? this.popoverComponent.state.targetWidth : 0;
+        const popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
 
         const isTruncated = this.contentDiv !== undefined &&
             (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -5,7 +5,9 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-const POPOVER_HANDLE_WIDTH = 25;
+// assumed because this is dependent on styles -- changing the padding width or
+// otherwise can cause this to behave differently
+const ASSUMED_POPOVER_HANDLE_WIDTH = 25;
 
 import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/core";
 
@@ -160,7 +162,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
 
         // if the popover handle exists, take it into account
-        const popoverHandleAdjustmentFactor = this.state.isTruncated ? POPOVER_HANDLE_WIDTH : 0;
+        const popoverHandleAdjustmentFactor = this.state.isTruncated ? ASSUMED_POPOVER_HANDLE_WIDTH : 0;
 
         const isTruncated = this.contentDiv !== undefined &&
             (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -5,6 +5,8 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+const POPOVER_HANDLE_WIDTH = 25;
+
 import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/core";
 
 import * as classNames from "classnames";
@@ -157,8 +159,11 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             return;
         }
 
+        // if the popover handle exists, take it into account
+        const popoverHandleAdjustmentFactor = this.state.isTruncated ? POPOVER_HANDLE_WIDTH : 0;
+
         const isTruncated = this.contentDiv !== undefined &&
-            (this.contentDiv.scrollWidth > this.contentDiv.clientWidth ||
+            (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||
             this.contentDiv.scrollHeight > this.contentDiv.clientHeight);
         if (this.state.isTruncated !== isTruncated) {
             this.setState({ isTruncated });

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -5,10 +5,6 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-// assumed because this is dependent on styles -- changing the padding width or
-// otherwise can cause this to behave differently
-const ASSUMED_POPOVER_HANDLE_WIDTH = 25;
-
 import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/core";
 
 import * as classNames from "classnames";
@@ -82,6 +78,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
     public state: ITruncatedFormatState = { isTruncated: false };
 
     private contentDiv: HTMLDivElement;
+    private popoverComponent: Popover;
 
     public render() {
         const { children, detectTruncation, preformatted, truncateLength, truncationSuffix } = this.props;
@@ -113,6 +110,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
                 <div className={className}>
                     <div className={Classes.TABLE_TRUNCATED_VALUE} ref={this.handleContentDivRef}>{cellContent}</div>
                     <Popover
+                        ref={this.handlePopoverComponentRef}
                         className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
                         tetherOptions={{ constraints }}
                         content={popoverContent}
@@ -139,6 +137,8 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
 
     private handleContentDivRef = (ref: HTMLDivElement) => this.contentDiv = ref;
 
+    private handlePopoverComponentRef = (ref: Popover) => this.popoverComponent = ref;
+
     private shouldShowPopover(content: string) {
         const { detectTruncation, showPopover, truncateLength } = this.props;
 
@@ -162,7 +162,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
 
         // if the popover handle exists, take it into account
-        const popoverHandleAdjustmentFactor = this.state.isTruncated ? ASSUMED_POPOVER_HANDLE_WIDTH : 0;
+        const popoverHandleAdjustmentFactor = this.state.isTruncated ? this.popoverComponent.state.targetWidth : 0;
 
         const isTruncated = this.contentDiv !== undefined &&
             (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||


### PR DESCRIPTION
#### Fixes #953 

#### Changes proposed in this pull request:

Take the width into account when measuring if we should show or hide the popover handle

#### Reviewers should focus on:
This is... pretty straightforward. I had a much more complicated way of doing this, but realized we might as well just do it the easy way first.

#### Screenshot
![may-16-2017 11-23-45](https://cloud.githubusercontent.com/assets/2463526/26113994/25c4290e-3a2a-11e7-97a2-6e3e7f7b0aee.gif)

