### PR TITLE
[Table] Correct pureRender logic on Cell as style object is reconstructed each render

### DIFF
--- a/packages/table/preview/index.html
+++ b/packages/table/preview/index.html
@@ -14,8 +14,8 @@
     }
 
     #table-big {
-      width: 600px;
-      height: 400px;
+      width: 1800px;
+      height: 1200px;
     }
 
     #table-1 {

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -6,9 +6,9 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as Classes from "../common/classes";
+import { Utils } from "../common/utils";
 
 import { Classes as CoreClasses, IIntentProps, IProps } from "@blueprintjs/core";
 
@@ -53,16 +53,34 @@ export interface ICellProps extends IIntentProps, IProps {
     wrapText?: boolean;
 }
 
+// don't include "style" in here because it can't be shallowly compared
+const UPDATE_PROPS_KEYS = [
+    "className",
+    "intent",
+    "interactive",
+    "loading",
+    "tooltip",
+    "truncated",
+    "wrapText"
+];
+
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
 
 export const emptyCellRenderer = () => <Cell />;
 
-@PureRender
 export class Cell extends React.Component<ICellProps, {}> {
     public static defaultProps = {
         truncated: true,
         wrapText: false,
     };
+
+    public shouldComponentUpdate(nextProps: ICellProps) {
+        // shallowly comparable props like "className" tend not to change in the default table
+        // implementation, so do that check last with hope that we return earlier and avoid it
+        // altogether.
+        return !Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS)
+            || !Utils.deepCompareKeys(this.props.style, nextProps.style);
+    }
 
     public render() {
         const { style, intent, interactive, loading, tooltip, truncated, className, wrapText } = this.props;

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -54,14 +54,16 @@ export interface ICellProps extends IIntentProps, IProps {
 }
 
 // don't include "style" in here because it can't be shallowly compared
+// ordered with children and className first, since these are most likely to change
 const UPDATE_PROPS_KEYS = [
+    "children",
     "className",
     "intent",
     "interactive",
     "loading",
     "tooltip",
     "truncated",
-    "wrapText"
+    "wrapText",
 ];
 
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
@@ -75,9 +77,6 @@ export class Cell extends React.Component<ICellProps, {}> {
     };
 
     public shouldComponentUpdate(nextProps: ICellProps) {
-        // shallowly comparable props like "className" tend not to change in the default table
-        // implementation, so do that check last with hope that we return earlier and avoid it
-        // altogether.
         return !Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS)
             || !Utils.deepCompareKeys(this.props.style, nextProps.style);
     }

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -229,17 +229,26 @@ export const Utils = {
         // treat `null` and `undefined` as the same
         if (objA === objB) {
             return true;
-        } else if (objA == null && objB == null) {
+        } else if (objA == objB) {
             return true;
         } else if (objA == null || objB == null) {
             return false;
         } else if (Array.isArray(objA) || Array.isArray(objB)) {
             return Utils.arraysEqual(objA, objB);
+        } else if (typeof objA === "string" || typeof objB === "string" ) {
+            return objA === objB;
+        } else if (typeof objA === "number" || typeof objB === "number" ) {
+            return objA === objB;
         } else if (keys != null) {
             return _deepCompareKeys(objA, objB, keys);
+        } else if (objA.constructor !== objB.constructor) {
+            return false;
         } else {
             const keysA = Object.keys(objA);
             const keysB = Object.keys(objB);
+            if (keysA == null || keysB == null) {
+                return false;
+            }
             if (keysA.length === 0 && keysB.length === 0) {
                 return true;
             }
@@ -397,7 +406,7 @@ function _shallowCompareKeys(objA: any, objB: any, keys: string[]) {
 }
 
 /**
- * Partial shallow comparison between objects using the given list of keys.
+ * Partial deep comparison between objects using the given list of keys.
  */
 function _deepCompareKeys(objA: any, objB: any, keys: string[]): boolean {
     return keys.every((key) => {

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -405,4 +405,3 @@ function _deepCompareKeys(objA: any, objB: any, keys: string[]): boolean {
             && Utils.deepCompareKeys(objA[key], objB[key]);
     });
 }
-

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -222,6 +222,32 @@ export const Utils = {
     },
 
     /**
+     * Deep comparison between objects. If `keys` is provided, just that subset of keys will be
+     * compared; otherwise, all keys will be compared.
+     */
+    deepCompareKeys(objA: any, objB: any, keys?: string[]) {
+        // treat `null` and `undefined` as the same
+        if (objA === objB) {
+            return true;
+        } else if (objA == null && objB == null) {
+            return true;
+        } else if (objA == null || objB == null) {
+            return false;
+        } else if (Array.isArray(objA) || Array.isArray(objB)) {
+            return Utils.arraysEqual(objA, objB);
+        } else if (keys != null) {
+            return _deepCompareKeys(objA, objB, keys);
+        } else {
+            const keysA = Object.keys(objA);
+            const keysB = Object.keys(objB);
+            if (keysA.length === 0 && keysB.length === 0) {
+                return true;
+            }
+            return Utils.arraysEqual(keysA, keysB) && _deepCompareKeys(objA, objB, keysA);
+        }
+    },
+
+    /**
      * When reordering a contiguous block of rows or columns to a new index, we show a preview guide
      * at the absolute index in the original ordering but emit the new index in the reordered list.
      * This function converts an absolute "guide" index to a relative "reordered" index.
@@ -369,3 +395,14 @@ function _shallowCompareKeys(objA: any, objB: any, keys: string[]) {
             && objA[key] === objB[key];
     });
 }
+
+/**
+ * Partial shallow comparison between objects using the given list of keys.
+ */
+function _deepCompareKeys(objA: any, objB: any, keys: string[]): boolean {
+    return keys.every((key) => {
+        return objA.hasOwnProperty(key) === objB.hasOwnProperty(key)
+            && Utils.deepCompareKeys(objA[key], objB[key]);
+    });
+}
+

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -6,13 +6,13 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Classes as CoreClasses, ContextMenuTarget, IProps, Popover, Position } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
+import { Utils } from "../common/utils";
 import { ResizeHandle } from "../interactions/resizeHandle";
 
 export type IColumnHeaderRenderer = (columnIndex: number) => React.ReactElement<IColumnHeaderCellProps>;
@@ -108,8 +108,24 @@ export function HorizontalCellDivider(): JSX.Element {
     return <div className={Classes.TABLE_HORIZONTAL_CELL_DIVIDER}/>;
 }
 
+// don't include "style" in here because it can't be shallowly compared
+// ordered with children and className first, since these are most likely to change
+const UPDATE_PROPS_KEYS = [
+    "children",
+    "className",
+    "name",
+    "renderName",
+    "useInteractionBar",
+    "isActive",
+    "isColumnReorderable",
+    "isColumnSelected",
+    "loading",
+    "menu",
+    "menuIconName",
+    "resizeHandle",
+];
+
 @ContextMenuTarget
-@PureRender
 export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IColumnHeaderState> {
     public static defaultProps: IColumnHeaderCellProps = {
         isActive: false,
@@ -134,6 +150,14 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, IC
     public state = {
         isActive: false,
     };
+
+    public shouldComponentUpdate(nextProps: IColumnHeaderCellProps) {
+        // shallowly comparable props like "className" tend not to change in the default table
+        // implementation, so do that check last with hope that we return earlier and avoid it
+        // altogether.
+        return !Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS)
+            || !Utils.deepCompareKeys(this.props.style, nextProps.style);
+    }
 
     public render() {
         const {

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -6,13 +6,13 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { Classes as CoreClasses, ContextMenuTarget, IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
+import { Utils } from "../common/utils";
 import { ResizeHandle } from "../interactions/resizeHandle";
 
 export interface IRowHeaderCellProps extends IProps {
@@ -67,12 +67,33 @@ export interface IRowHeaderState {
     isActive: boolean;
 }
 
+// don't include "style" in here because it can't be shallowly compared
+// ordered with children and className first, since these are most likely to change
+const UPDATE_PROPS_KEYS = [
+    "children",
+    "className",
+    "isActive",
+    "isRowReorderable",
+    "isRowSelected",
+    "name",
+    "loading",
+    "menu",
+    "resizeHandle",
+];
+
 @ContextMenuTarget
-@PureRender
 export class RowHeaderCell extends React.Component<IRowHeaderCellProps, IRowHeaderState> {
     public state = {
         isActive: false,
     };
+
+    public shouldComponentUpdate(nextProps: IRowHeaderCellProps) {
+        // shallowly comparable props like "className" tend not to change in the default table
+        // implementation, so do that check last with hope that we return earlier and avoid it
+        // altogether.
+        return !Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS)
+            || !Utils.deepCompareKeys(this.props.style, nextProps.style);
+    }
 
     public render() {
         const {

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -114,31 +114,32 @@ export class Resizable extends React.Component<IResizableProps, IResizeableState
     private renderResizeHandle() {
         const { onLayoutLock, onDoubleClick, orientation } = this.props;
 
-        const onResizeMove = (_offset: number, delta: number) => {
-            this.offsetSize(delta);
-            if (this.props.onSizeChanged != null) {
-                this.props.onSizeChanged(this.state.size);
-            }
-        };
-        const onResizeEnd = (_offset: number) => {
-            // reset "unclamped" size on end
-            this.setState({unclampedSize: this.state.size});
-
-            if (this.props.onResizeEnd != null) {
-                this.props.onResizeEnd(this.state.size);
-            }
-        };
-
         return (
             <ResizeHandle
                 key="resize-handle"
                 onDoubleClick={onDoubleClick}
                 onLayoutLock={onLayoutLock}
-                onResizeEnd={onResizeEnd}
-                onResizeMove={onResizeMove}
+                onResizeEnd={this.onResizeEnd}
+                onResizeMove={this.onResizeMove}
                 orientation={orientation}
             />
         );
+    }
+
+    private onResizeMove = (_offset: number, delta: number) => {
+        this.offsetSize(delta);
+        if (this.props.onSizeChanged != null) {
+            this.props.onSizeChanged(this.state.size);
+        }
+    }
+
+    private onResizeEnd = (_offset: number) => {
+        // reset "unclamped" size on end
+        this.setState({unclampedSize: this.state.size});
+
+        if (this.props.onResizeEnd != null) {
+            this.props.onResizeEnd(this.state.size);
+        }
     }
 
     /**

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -7,7 +7,6 @@
  */
 
 import { expect } from "chai";
-import * as classNames from "classnames";
 import * as React from "react";
 
 import { Cell, Column, ColumnLoadingOption, Table } from "../src";


### PR DESCRIPTION
@dcervelli This fixes the cell re-renders when only the style object has changed. 

Here's an after/before on this change in the profiler.

![screen shot 2017-05-16 at 16 22 18](https://cloud.githubusercontent.com/assets/933064/26132252/dfbfd82a-3a53-11e7-8ed3-abb2b03d8f42.png)

I have a commit locally that applies the same treatment to RowHeaderCell and ColumnHeaderCell, however it doesn't quite do the right thing. Both take a prop `resizeHandle` which is a React Component. This component, as with all components, is recreated each time, and as such it fails at a shallow equality check. I wonder if there's a react utility for checking ahead of time wether two elements will work out to be equal?
