### PR TITLE
[Table] Anchor drag-selections to their original activation cell

### DIFF
--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -113,6 +113,8 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHea
         hasSelectionEnded: false,
     };
 
+    private activationCol: number;
+
     public componentDidMount() {
         if (this.props.selectedRegions != null && this.props.selectedRegions.length > 0) {
             // we already have a selection defined, so we'll want to enable reordering interactions
@@ -271,6 +273,7 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHea
     }
 
     private handleDragSelectableSelectionEnd = () => {
+        this.activationCol = null; // not strictly necessary, but good practice
         this.setState({ hasSelectionEnded: true });
     }
 
@@ -280,12 +283,12 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHea
         if (!ColumnHeaderCell.isHeaderMouseTarget(event.target as HTMLElement)) {
             return null;
         }
-        const col = this.props.locator.convertPointToColumn(event.clientX);
-        return Regions.column(col);
+        this.activationCol = this.props.locator.convertPointToColumn(event.clientX);
+        return Regions.column(this.activationCol);
     }
 
     private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData) => {
-        const colStart = this.props.locator.convertPointToColumn(coords.activation[0]);
+        const colStart = this.activationCol;
         const colEnd = this.props.locator.convertPointToColumn(coords.current[0]);
         return Regions.column(colStart, colEnd);
     }

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -113,6 +113,8 @@ export class RowHeader extends React.Component<IRowHeaderProps, IRowHeaderState>
         hasSelectionEnded: false,
     };
 
+    private activationRow: number;
+
     public componentDidMount() {
         if (this.props.selectedRegions != null && this.props.selectedRegions.length > 0) {
             // we already have a selection defined, so we'll want to enable reordering interactions
@@ -261,16 +263,17 @@ export class RowHeader extends React.Component<IRowHeaderProps, IRowHeaderState>
     }
 
     private handleDragSelectableSelectionEnd = () => {
+        this.activationRow = null; // not strictly required, but good practice
         this.setState({ hasSelectionEnded: true });
     }
 
     private locateClick = (event: MouseEvent) => {
-        const row = this.props.locator.convertPointToRow(event.clientY);
-        return Regions.row(row);
+        this.activationRow = this.props.locator.convertPointToRow(event.clientY);
+        return Regions.row(this.activationRow);
     }
 
     private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData) => {
-        const rowStart = this.props.locator.convertPointToRow(coords.activation[1]);
+        const rowStart = this.activationRow;
         const rowEnd = this.props.locator.convertPointToRow(coords.current[1]);
         return Regions.row(rowStart, rowEnd);
     }

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -108,9 +108,10 @@ export class Locator implements ILocator {
         if (!tableRect.containsX(clientX)) {
             return -1;
         }
+        const tableX = this.toTableRelativeX(clientX);
         const limit = useMidpoint ? this.grid.numCols : this.grid.numCols - 1;
         const lookupFn = useMidpoint ? this.convertCellMidpointToClientX : this.convertCellIndexToClientX;
-        return Utils.binarySearch(clientX, limit, lookupFn);
+        return Utils.binarySearch(tableX, limit, lookupFn);
     }
 
     public convertPointToRow(clientY: number, useMidpoint?: boolean): number {
@@ -118,14 +119,17 @@ export class Locator implements ILocator {
         if (!tableRect.containsY(clientY)) {
             return -1;
         }
+        const tableY = this.toTableRelativeY(clientY);
         const limit = useMidpoint ? this.grid.numRows : this.grid.numRows - 1;
         const lookupFn = useMidpoint ? this.convertCellMidpointToClientY : this.convertCellIndexToClientY;
-        return Utils.binarySearch(clientY, limit, lookupFn);
+        return Utils.binarySearch(tableY, limit, lookupFn);
     }
 
     public convertPointToCell(clientX: number, clientY: number) {
-        const col = Utils.binarySearch(clientX, this.grid.numCols - 1, this.convertCellIndexToClientX);
-        const row = Utils.binarySearch(clientY, this.grid.numRows - 1, this.convertCellIndexToClientY);
+        const tableX = this.toTableRelativeX(clientX);
+        const tableY = this.toTableRelativeY(clientY);
+        const col = Utils.binarySearch(tableX, this.grid.numCols - 1, this.convertCellIndexToClientX);
+        const row = Utils.binarySearch(tableY, this.grid.numRows - 1, this.convertCellIndexToClientY);
         return {col, row};
     }
 
@@ -133,41 +137,31 @@ export class Locator implements ILocator {
         return Rect.wrap(this.tableElement.getBoundingClientRect());
     }
 
-    private getBodyRect() {
-        return this.unscrollElementRect(this.bodyElement);
-    }
-
-    /**
-     * Subtracts the scroll offset from the element's bounding client rect.
-     */
-    private unscrollElementRect(element: HTMLElement) {
-        const rect = Rect.wrap(element.getBoundingClientRect());
-        rect.left -= element.scrollLeft;
-        rect.top -= element.scrollTop;
-        return rect;
-    }
-
     private convertCellIndexToClientX = (index: number) => {
-        const bodyRect = this.getBodyRect();
-        return bodyRect.left + this.grid.getCumulativeWidthAt(index);
+        return this.grid.getCumulativeWidthAt(index);
     }
 
     private convertCellMidpointToClientX = (index: number) => {
-        const bodyRect = this.getBodyRect();
-        const cumWidth = this.grid.getCumulativeWidthAt(index);
-        const prevCumWidth = (index > 0) ? this.grid.getCumulativeWidthAt(index - 1) : 0;
-        return bodyRect.left + ((cumWidth + prevCumWidth) / 2);
+        const cellLeft = this.grid.getCumulativeWidthBefore(index);
+        const cellRight = this.grid.getCumulativeWidthAt(index);
+        return (cellLeft + cellRight) / 2;
     }
 
     private convertCellIndexToClientY = (index: number) => {
-        const bodyRect = this.getBodyRect();
-        return bodyRect.top + this.grid.getCumulativeHeightAt(index);
+        return this.grid.getCumulativeHeightAt(index);
     }
 
     private convertCellMidpointToClientY = (index: number) => {
-        const bodyRect = this.getBodyRect();
-        const cumHeight = this.grid.getCumulativeHeightAt(index);
-        const prevCumHeight = (index > 0) ? this.grid.getCumulativeHeightAt(index - 1) : 0;
-        return bodyRect.top + ((cumHeight + prevCumHeight) / 2);
+        const cellTop = this.grid.getCumulativeHeightBefore(index);
+        const cellBottom = this.grid.getCumulativeHeightAt(index);
+        return (cellTop + cellBottom) / 2;
+    }
+
+    private toTableRelativeX = (clientX: number) => {
+        return this.bodyElement.scrollLeft + clientX - this.bodyElement.getBoundingClientRect().left;
+    }
+
+    private toTableRelativeY = (clientY: number) => {
+        return this.bodyElement.scrollTop + clientY - this.bodyElement.getBoundingClientRect().top;
     }
 }

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -9,6 +9,7 @@ import { IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 import { emptyCellRenderer, ICellProps, ICellRenderer } from "./cell/cell";
+import { ICellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
 import { ContextMenuTargetWrapper } from "./common/contextMenuTargetWrapper";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
@@ -93,7 +94,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         return `cell-${rowIndex}-${columnIndex}`;
     }
 
-    private activationCell: { "row": number, "col": number };
+    private activationCell: ICellCoordinates;
 
     public shouldComponentUpdate(nextProps: ITableBodyProps) {
         const shallowEqual = Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS);

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -93,6 +93,8 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         return `cell-${rowIndex}-${columnIndex}`;
     }
 
+    private activationCell: { "row": number, "col": number };
+
     public shouldComponentUpdate(nextProps: ITableBodyProps) {
         const shallowEqual = Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS);
         return !shallowEqual;
@@ -129,6 +131,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
                 locateDrag={this.locateDrag}
                 onFocus={onFocus}
                 onSelection={onSelection}
+                onSelectionEnd={this.handleSelectionEnd}
                 selectedRegions={selectedRegions}
                 selectedRegionTransform={selectedRegionTransform}
             >
@@ -175,13 +178,17 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         return React.cloneElement(baseCell, { className, key, loading: cellLoading, style } as ICellProps);
     }
 
+    private handleSelectionEnd = () => {
+        this.activationCell = null; // not strictly required, but good practice
+    }
+
     private locateClick = (event: MouseEvent) => {
-        const { col, row } = this.props.locator.convertPointToCell(event.clientX, event.clientY);
-        return Regions.cell(row, col);
+        this.activationCell = this.props.locator.convertPointToCell(event.clientX, event.clientY);
+        return Regions.cell(this.activationCell.row, this.activationCell.col);
     }
 
     private locateDrag = (_event: MouseEvent, coords: ICoordinateData) => {
-        const start = this.props.locator.convertPointToCell(coords.activation[0], coords.activation[1]);
+        const start = this.activationCell;
         const end = this.props.locator.convertPointToCell(coords.current[0], coords.current[1]);
         return Regions.cell(start.row, start.col, end.row, end.col);
     }

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -566,21 +566,28 @@ describe("<Table>", () => {
             onSelection = sinon.spy();
         });
 
-        it("should keep the same activation column when manually scrolling right", () => {
-            assertActivationCellUnaffected({ ...ACTIVATION_CELL_COORDS, col: ACTIVATION_CELL_COORDS.col + 1 });
-        });
+        runTest("up");
+        runTest("down");
+        runTest("left");
+        runTest("right");
 
-        it("should keep the same activation row when manually scrolling down", () => {
-            assertActivationCellUnaffected({ ...ACTIVATION_CELL_COORDS, row: ACTIVATION_CELL_COORDS.row + 1 });
-        });
+        function runTest(direction: "up" | "down" | "left" | "right") {
+            const nextCellCoords = ACTIVATION_CELL_COORDS;
 
-        it("should keep the same activation column when manually scrolling left", () => {
-            assertActivationCellUnaffected({ ...ACTIVATION_CELL_COORDS, col: ACTIVATION_CELL_COORDS.col - 1 });
-        });
+            if (direction === "up") {
+                nextCellCoords.col -= 1;
+            } else if (direction === "down") {
+                nextCellCoords.col += 1;
+            } else if (direction === "left") {
+                nextCellCoords.row -= 1;
+            } else { // if direction === "right"
+                nextCellCoords.row += 1;
+            }
 
-        it("should keep the same activation row when manually scrolling up", () => {
-            assertActivationCellUnaffected({ ...ACTIVATION_CELL_COORDS, row: ACTIVATION_CELL_COORDS.row - 1 });
-        });
+            it(`should keep the same activation row when manually scrolling ${direction}`, () => {
+                assertActivationCellUnaffected(nextCellCoords);
+            });
+        }
 
         function assertActivationCellUnaffected(nextCellCoords: ICellCoordinates) {
             // setup

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -584,7 +584,7 @@ describe("<Table>", () => {
                 nextCellCoords.row += 1;
             }
 
-            it(`should keep the same activation row when manually scrolling ${direction}`, () => {
+            it(`should keep the same activation coordinates when manually scrolling ${direction}`, () => {
                 assertActivationCellUnaffected(nextCellCoords);
             });
         }


### PR DESCRIPTION
#### Fixes #950

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

This PR contains only the changes from #1066 that directly fix #950. It does not anything related to _auto-scrolling_ while drag-selecting, because that behavior still needs more attention from me.

Fix issues with manual scrolling while a drag-selection is in progress:
- Mousing down on a **row** header and scrolling anchors the selection to that original row.
- Mousing down on a **column** header and scrolling anchors the selection to that original column.
- Mousing down on a **cell** and scrolling anchors the selection that original cell.

_NOTE:_ This PR still suffers from an existing issue where after a while, the drag selection on column/row headers stops growing all of a sudden. That's not a new issue; still, we should investigate further. Tracking in #1113.

#### Reviewers should focus on:

Does it work as expected?

#### Screenshot

Selecting a CELLS region:
![2017-05-17 16 37 13](https://cloud.githubusercontent.com/assets/443450/26180573/1ee17e98-3b1f-11e7-897a-c670da7faf99.gif)

Selecting a FULL_COLUMNS region:
![2017-05-17 16 37 37](https://cloud.githubusercontent.com/assets/443450/26180586/366cbcda-3b1f-11e7-9d86-c81101ce3cf1.gif)

Selecting a FULL_ROWS region:
![2017-05-17 16 38 43](https://cloud.githubusercontent.com/assets/443450/26180604/556c050a-3b1f-11e7-9a5e-b5a8ab50fbf0.gif)