### PR TITLE
[Table] Don't show regions that aren't in the table

### DIFF
--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -312,8 +312,7 @@ export class Grid {
                 const [colStart, colEnd] = region.cols;
 
                 // if the region is outside the bounds of the table, don't display it
-                if (this.isGhostIndex(rowStart, colStart)
-                    || this.isGhostIndex(rowEnd, colEnd)) {
+                if (this.isGhostIndex(rowStart, colStart) || this.isGhostIndex(rowEnd, colEnd)) {
                     return { display: "none" };
                 }
                 const cellRect0 = this.getCellRect(rowStart, colStart);
@@ -332,8 +331,7 @@ export class Grid {
                 const [colStart, colEnd] = region.cols;
 
                 // if the region is outside the bounds of the table, don't display it
-                if (this.isGhostIndex(0, colStart)
-                    || this.isGhostIndex(0, colEnd)) {
+                if (this.isGhostIndex(0, colStart) || this.isGhostIndex(0, colEnd)) {
                     return { display: "none" };
                 }
                 const cellRect0 = this.getCellRect(0, colStart);
@@ -353,8 +351,7 @@ export class Grid {
                 const [rowStart, rowEnd] = region.rows;
 
                 // if the region is outside the bounds of the table, don't display it
-                if (this.isGhostIndex(rowStart, 0)
-                    || this.isGhostIndex(rowEnd, 0)) {
+                if (this.isGhostIndex(rowStart, 0) || this.isGhostIndex(rowEnd, 0)) {
                     return { display: "none" };
                 }
                 const cellRect0 = this.getCellRect(rowStart, 0);

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -308,15 +308,18 @@ export class Grid {
         const cardinality = Regions.getRegionCardinality(region);
         switch (cardinality) {
             case RegionCardinality.CELLS: {
+                const [rowStart, rowEnd] = region.rows;
+                const [colStart, colEnd] = region.cols;
+
                 // if the region is outside the bounds of the table, don't display it
-                if (this.isGhostIndex(region.rows[0], region.cols[0])
-                 || this.isGhostIndex(region.rows[1], region.cols[1])) {
+                if (this.isGhostIndex(rowStart, colStart)
+                 || this.isGhostIndex(rowEnd, colEnd)) {
                     return { display: "none" };
                 }
-                const cellRect0 = this.getCellRect(region.rows[0], region.cols[0]);
-                const cellRect1 = this.getCellRect(region.rows[1], region.cols[1]);
-                const offsetLeft = region.cols[0] === 0 ? 0 : 1;
-                const offsetTop = region.rows[0] === 0 ? 0 : 1;
+                const cellRect0 = this.getCellRect(rowStart, colStart);
+                const cellRect1 = this.getCellRect(rowEnd, colEnd);
+                const offsetLeft = colStart === 0 ? 0 : 1;
+                const offsetTop = rowStart === 0 ? 0 : 1;
                 const rect = cellRect0.union(cellRect1);
                 rect.height += offsetTop;
                 rect.left -= offsetLeft;
@@ -326,15 +329,17 @@ export class Grid {
             }
 
             case RegionCardinality.FULL_COLUMNS: {
+                const [colStart, colEnd] = region.cols;
+
                 // if the region is outside the bounds of the table, don't display it
-                if (this.isGhostIndex(0, region.cols[0])
-                 || this.isGhostIndex(0, region.cols[1])) {
+                if (this.isGhostIndex(0, colStart)
+                 || this.isGhostIndex(0, colEnd)) {
                     return { display: "none" };
                 }
-                const cellRect0 = this.getCellRect(0, region.cols[0]);
-                const cellRect1 = this.getCellRect(0, region.cols[1]);
+                const cellRect0 = this.getCellRect(0, colStart);
+                const cellRect1 = this.getCellRect(0, colEnd);
                 const rect = cellRect0.union(cellRect1);
-                const offsetLeft = region.cols[0] === 0 ? 0 : 1;
+                const offsetLeft = colStart === 0 ? 0 : 1;
                 return {
                     bottom: 0,
                     display: "block",
@@ -345,15 +350,17 @@ export class Grid {
               }
 
             case RegionCardinality.FULL_ROWS: {
+                const [rowStart, rowEnd] = region.rows;
+
                 // if the region is outside the bounds of the table, don't display it
-                if (this.isGhostIndex(region.rows[0], 0)
-                 || this.isGhostIndex(region.rows[1], 0)) {
+                if (this.isGhostIndex(rowStart, 0)
+                 || this.isGhostIndex(rowEnd, 0)) {
                     return { display: "none" };
                 }
-                const cellRect0 = this.getCellRect(region.rows[0], 0);
-                const cellRect1 = this.getCellRect(region.rows[1], 0);
+                const cellRect0 = this.getCellRect(rowStart, 0);
+                const cellRect1 = this.getCellRect(rowEnd, 0);
                 const rect = cellRect0.union(cellRect1);
-                const offsetTop = region.rows[0] === 0 ? 0 : 1;
+                const offsetTop = rowStart === 0 ? 0 : 1;
                 return {
                     display: "block",
                     height: rect.height + offsetTop,

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -313,7 +313,7 @@ export class Grid {
 
                 // if the region is outside the bounds of the table, don't display it
                 if (this.isGhostIndex(rowStart, colStart)
-                 || this.isGhostIndex(rowEnd, colEnd)) {
+                    || this.isGhostIndex(rowEnd, colEnd)) {
                     return { display: "none" };
                 }
                 const cellRect0 = this.getCellRect(rowStart, colStart);
@@ -333,7 +333,7 @@ export class Grid {
 
                 // if the region is outside the bounds of the table, don't display it
                 if (this.isGhostIndex(0, colStart)
-                 || this.isGhostIndex(0, colEnd)) {
+                    || this.isGhostIndex(0, colEnd)) {
                     return { display: "none" };
                 }
                 const cellRect0 = this.getCellRect(0, colStart);
@@ -354,7 +354,7 @@ export class Grid {
 
                 // if the region is outside the bounds of the table, don't display it
                 if (this.isGhostIndex(rowStart, 0)
-                 || this.isGhostIndex(rowEnd, 0)) {
+                    || this.isGhostIndex(rowEnd, 0)) {
                     return { display: "none" };
                 }
                 const cellRect0 = this.getCellRect(rowStart, 0);

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -308,6 +308,11 @@ export class Grid {
         const cardinality = Regions.getRegionCardinality(region);
         switch (cardinality) {
             case RegionCardinality.CELLS: {
+                // if the region is outside the bounds of the table, don't display it
+                if (this.isGhostIndex(region.rows[0], region.cols[0])
+                 || this.isGhostIndex(region.rows[1], region.cols[1])) {
+                    return { display: "none" };
+                }
                 const cellRect0 = this.getCellRect(region.rows[0], region.cols[0]);
                 const cellRect1 = this.getCellRect(region.rows[1], region.cols[1]);
                 const offsetLeft = region.cols[0] === 0 ? 0 : 1;
@@ -321,6 +326,11 @@ export class Grid {
             }
 
             case RegionCardinality.FULL_COLUMNS: {
+                // if the region is outside the bounds of the table, don't display it
+                if (this.isGhostIndex(0, region.cols[0])
+                 || this.isGhostIndex(0, region.cols[1])) {
+                    return { display: "none" };
+                }
                 const cellRect0 = this.getCellRect(0, region.cols[0]);
                 const cellRect1 = this.getCellRect(0, region.cols[1]);
                 const rect = cellRect0.union(cellRect1);
@@ -335,6 +345,11 @@ export class Grid {
               }
 
             case RegionCardinality.FULL_ROWS: {
+                // if the region is outside the bounds of the table, don't display it
+                if (this.isGhostIndex(region.rows[0], 0)
+                 || this.isGhostIndex(region.rows[1], 0)) {
+                    return { display: "none" };
+                }
                 const cellRect0 = this.getCellRect(region.rows[0], 0);
                 const cellRect1 = this.getCellRect(region.rows[1], 0);
                 const rect = cellRect0.union(cellRect1);

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -9,6 +9,7 @@ import { expect } from "chai";
 import { Grid } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
 import { Utils } from "../src/common/utils";
+import { Regions } from "../src/regions";
 
 const test7s = Utils.times(10, () => 7);
 const test13s = Utils.times(10, () => 13);
@@ -155,6 +156,15 @@ describe("Grid", () => {
             const {columnIndexStart, columnIndexEnd} = grid.getColumnIndicesInRect(rect);
             expect(columnIndexStart).to.equal(0);
             expect(columnIndexEnd).to.equal(9);
+        });
+    });
+
+    describe("style", () => {
+        it("returns display: none if region not inside grid", () => {
+            const grid = new Grid(test7s, test13s);
+            const region = Regions.cell(5, 5, 10, 10);
+            const regionStyle = grid.getRegionStyle(region);
+            expect(regionStyle.display).to.equal("none");
         });
     });
 

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -160,9 +160,23 @@ describe("Grid", () => {
     });
 
     describe("style", () => {
-        it("returns display: none if region not inside grid", () => {
+        it("returns display: none if region not inside grid for cells", () => {
             const grid = new Grid(test7s, test13s);
             const region = Regions.cell(5, 5, 10, 10);
+            const regionStyle = grid.getRegionStyle(region);
+            expect(regionStyle.display).to.equal("none");
+        });
+
+        it("returns display: none if region not inside grid for columns", () => {
+            const grid = new Grid(test7s, test13s);
+            const region = Regions.column(8, 16);
+            const regionStyle = grid.getRegionStyle(region);
+            expect(regionStyle.display).to.equal("none");
+        });
+
+        it("returns display: none if region not inside grid for rows", () => {
+            const grid = new Grid(test7s, test13s);
+            const region = Regions.row(8, 16);
             const regionStyle = grid.getRegionStyle(region);
             expect(regionStyle.display).to.equal("none");
         });


### PR DESCRIPTION
#### Fixes #1077 

#### Changes proposed in this pull request:

Check whether or not a region is fully contained in the table before styling it; if it turns out it isn't, style it with `display: none`
