### PR TITLE
Convert Table children to union type for ts 2.3 support

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -61,7 +61,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * The children of a `Table` component, which must be React elements
      * that use `IColumnProps`.
      */
-    children?: React.ReactElement<IColumnProps>;
+    children?: React.ReactElement<IColumnProps> | React.ReactElement<IColumnProps>[];
 
     /**
      * If `true`, empty space in the table container will be filled with empty


### PR DESCRIPTION
#### Fixes #1143

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Allows Typescript 2.3 to be used which changed some of the behaviour of children with React: https://github.com/Microsoft/TypeScript/issues/13618


#### Reviewers should focus on:

Whether this breaks anything in Typescript 2.2

#### Screenshot
