### PR TITLE
Set autoComplete='off' in all InputGroups

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -224,6 +224,7 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
 
         const inputGroup = (
             <InputGroup
+                autoComplete="off"
                 {...inputGroupHtmlProps}
                 className={classNames({ [Classes.LARGE]: large })}
                 intent={this.props.intent}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -213,6 +213,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 popoverClassName={classNames("pt-dateinput-popover", popoverProps.popoverClassName)}
             >
                 <InputGroup
+                    autoComplete="off"
                     placeholder={this.props.format}
                     rightElement={this.props.rightElement}
                     {...htmlInputProps}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -355,6 +355,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
         return (
             <InputGroup
+                autoComplete="off"
                 {...htmlProps}
                 className={classes}
                 disabled={this.props.disabled}

--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -100,6 +100,7 @@ export class Navigator extends React.PureComponent<INavigatorProps, INavigatorSt
                 position={Position.BOTTOM_LEFT}
             >
                 <InputGroup
+                    autoComplete="off"
                     autoFocus={true}
                     inputRef={this.refHandlers.input}
                     leftIconName="search"


### PR DESCRIPTION
#### Fixes #1131

#### Changes proposed in this pull request:

- Add `autoComplete="off"` to:
    - `DateInput`
    - `DateRangeInput`
    - `NumericInput`
    - `Navigator` (docs-only component)

#### Reviewers should focus on:

- Do we need to include this on `Navigator`?
- Should `autoComplete="off"` go before the `html(Input)Props` spreads?
- Not really sure how to test this; the original autocomplete behavior isn't happening for me on IE.
