### PR TITLE
disable empty Popover

### DIFF
--- a/packages/core/examples/popoverExample.tsx
+++ b/packages/core/examples/popoverExample.tsx
@@ -147,6 +147,7 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                             <option value="2">Slider</option>
                             <option value="3">Menu</option>
                             <option value="4">Popover Example</option>
+                            <option value="5">Empty</option>
                         </select>
                     </div>
                 </label>,

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -49,6 +49,7 @@ export const POPOVER_WARN_DOUBLE_CONTENT =
     `${ns} <Popover> with two children ignores content prop; use either prop or children.`;
 export const POPOVER_WARN_DOUBLE_TARGET =
     `${ns} <Popover> with children ignores target prop; use either prop or children.`;
+export const POPOVER_WARN_EMPTY_CONTENT = `${ns} Disabling <Popover> with empty/whitespace content...`;
 export const POPOVER_WARN_MODAL_INLINE = `${ns} <Popover inline={true}> ignores isModal`;
 export const POPOVER_WARN_DEPRECATED_CONSTRAINTS =
     `${deprec} <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.`;
@@ -70,8 +71,6 @@ export const TABS_WARN_DEPRECATED = `${deprec} <Tabs> is deprecated since v1.11.
 
 export const TOASTER_WARN_INLINE = `${ns} Toaster.create() ignores inline prop as it always creates a new element.`;
 export const TOASTER_WARN_LEFT_RIGHT = `${ns} Toaster does not support LEFT or RIGHT positions.`;
-
-export const TOOLTIP_WARN_EMPTY_CONTENT = `${ns} Disabling <Tooltip> with empty content...`;
 
 export const DIALOG_WARN_NO_HEADER_ICON = `${ns} <Dialog> iconName is ignored if title is omitted.`;
 export const DIALOG_WARN_NO_HEADER_CLOSE_BUTTON =

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -21,10 +21,6 @@ export function isFunction(value: any): value is Function {
     return typeof value === "function";
 }
 
-export function isReactText(child: React.ReactChild): child is React.ReactText {
-    return typeof child === "string" || typeof child === "number";
-}
-
 /** Safely invoke the function with the given arguments, if it is indeed a function, and return its value. */
 export function safeInvoke<R>(func: (() => R) | undefined): R;
 export function safeInvoke<A, R>(func: ((arg1: A) => R) | undefined, arg1: A): R;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -462,6 +462,8 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
         );
     }
 
+    // content and target can be specified as props or as children.
+    // this method normalizes the two approaches, preferring child over prop.
     private understandChildren() {
         const { children, content: contentProp, target: targetProp } = this.props;
         // #validateProps asserts that 1 <= children.length <= 2 so content is optional
@@ -656,7 +658,11 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 }
 
-function ensureElement(child: React.ReactChild) {
+/**
+ * Converts a react child to an element: non-empty strings or numbers are wrapped in `<span>`;
+ * empty strings are discarded.
+ */
+function ensureElement(child: React.ReactChild | undefined) {
     // wrap text in a <span> so children are always elements
     if (typeof child === "string") {
         // cull whitespace strings

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -10,11 +10,9 @@ import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { TOOLTIP_WARN_EMPTY_CONTENT } from "../../common/errors";
 import { Position } from "../../common/position";
 import { IIntentProps, IProps } from "../../common/props";
 import { ITetherConstraint } from "../../common/tetherUtils";
-import { isNodeEnv } from "../../common/utils";
 
 import { Popover, PopoverInteractionKind } from "../popover/popover";
 
@@ -162,13 +160,8 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
     public static displayName = "Blueprint.Tooltip";
 
     public render(): JSX.Element {
-        const { content, children, intent, isDisabled, isOpen, openOnTargetFocus, tooltipClassName } = this.props;
+        const { children, intent, openOnTargetFocus, tooltipClassName } = this.props;
         const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
-
-        const isEmpty = content == null || (typeof content === "string" && content.trim() === "");
-        if (isEmpty && !isDisabled && isOpen !== false && !isNodeEnv("production")) {
-            console.warn(TOOLTIP_WARN_EMPTY_CONTENT);
-        }
 
         return (
             <Popover
@@ -176,7 +169,6 @@ export class Tooltip extends React.Component<ITooltipProps, {}> {
                 arrowSize={22}
                 autoFocus={false}
                 canEscapeKeyClose={false}
-                isDisabled={isDisabled || isEmpty}
                 enforceFocus={false}
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../src/index";
 import { dispatchMouseEvent } from "../common/utils";
 
-describe.only("<Popover>", () => {
+describe("<Popover>", () => {
     let testsContainerElement: HTMLElement;
     let wrapper: IPopoverWrapper;
 

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../src/index";
 import { dispatchMouseEvent } from "../common/utils";
 
-describe("<Popover>", () => {
+describe.only("<Popover>", () => {
     let testsContainerElement: HTMLElement;
     let wrapper: IPopoverWrapper;
 
@@ -42,29 +42,30 @@ describe("<Popover>", () => {
     });
 
     describe("validation:", () => {
-        let warnSpy: Sinon.SinonSpy;
-
-        before(() => warnSpy = sinon.spy(console, "warn"));
-        after(() => warnSpy.restore());
-        afterEach(() => warnSpy.reset());
 
         it("throws error if given no target", () => {
             assert.throws(() => shallow(<Popover />), Errors.POPOVER_REQUIRES_TARGET);
         });
 
         it("warns if given > 2 target elements", () => {
+            const warnSpy = sinon.spy(console, "warn");
             shallow(<Popover><h1 /><h2 />{"h3"}</Popover>);
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_TOO_MANY_CHILDREN));
+            warnSpy.restore();
         });
 
         it("warns if given children and target prop", () => {
+            const warnSpy = sinon.spy(console, "warn");
             shallow(<Popover target="boom">pow</Popover>);
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_TARGET));
+            warnSpy.restore();
         });
 
         it("warns if given two children and content prop", () => {
+            const warnSpy = sinon.spy(console, "warn");
             shallow(<Popover content="boom">{"pow"}{"jab"}</Popover>);
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_CONTENT));
+            warnSpy.restore();
         });
     });
 
@@ -93,6 +94,18 @@ describe("<Popover>", () => {
     it("does not render inside target container when inline=false", () => {
         wrapper = renderPopover({ inline: false, isOpen: true });
         assert.lengthOf(wrapper.find(`.${Classes.POPOVER_TARGET} .${Classes.POPOVER}`), 0);
+    });
+
+    it("empty content disables it and warns", () => {
+        const warnSpy = sinon.spy(console, "warn");
+        const popover = mount(<Popover content={undefined} isOpen><button /></Popover>);
+        assert.isFalse(popover.find(Overlay).prop("isOpen"));
+
+        popover.setProps({ content: "    " });
+        assert.isFalse(popover.find(Overlay).prop("isOpen"));
+
+        assert.equal(warnSpy.callCount, 2);
+        warnSpy.restore();
     });
 
     it("lifecycle methods are called appropriately", () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -9,11 +9,11 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { Classes, ITooltipProps, Popover, SVGTooltip, Tooltip } from "../../src/index";
+import { Classes, ITooltipProps, Overlay, Popover, SVGTooltip, Tooltip } from "../../src/index";
 
 const TOOLTIP_SELECTOR = `.${Classes.TOOLTIP}`;
 
-describe("<Tooltip>", () => {
+describe.only("<Tooltip>", () => {
     describe("in uncontrolled mode", () => {
         it("defaultIsOpen determines initial open state", () => {
             assert.lengthOf(renderTooltip({ defaultIsOpen: true }).find(TOOLTIP_SELECTOR), 1);
@@ -55,12 +55,12 @@ describe("<Tooltip>", () => {
 
         it("empty content disables Popover and warns", () => {
             const warnSpy = sinon.spy(console, "warn");
-            const tooltip = renderTooltip({ content: "" });
+            const tooltip = renderTooltip({ isOpen: true });
 
             function assertDisabledPopover(content?: string) {
                 tooltip.setProps({ content });
-                assert.isTrue(tooltip.find(Popover).prop("isDisabled"), `"${content}"`);
-                assert.isTrue(warnSpy.calledOnce);
+                assert.isFalse(tooltip.find(Overlay).prop("isOpen"), `"${content}"`);
+                assert.isTrue(warnSpy.calledOnce, "spy not called once");
                 warnSpy.reset();
             }
 
@@ -91,7 +91,7 @@ describe("<Tooltip>", () => {
         it("empty content disables Popover and warns", () => {
             const warnSpy = sinon.spy(console, "warn");
             const tooltip = renderTooltip({ content: "", isOpen: true });
-            assert.isTrue(tooltip.find(Popover).prop("isDisabled"));
+            assert.isFalse(tooltip.find(Overlay).prop("isOpen"));
             assert.isTrue(warnSpy.calledOnce);
             warnSpy.restore();
         });

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -13,7 +13,7 @@ import { Classes, ITooltipProps, Overlay, Popover, SVGTooltip, Tooltip } from ".
 
 const TOOLTIP_SELECTOR = `.${Classes.TOOLTIP}`;
 
-describe.only("<Tooltip>", () => {
+describe("<Tooltip>", () => {
     describe("in uncontrolled mode", () => {
         it("defaultIsOpen determines initial open state", () => {
             assert.lengthOf(renderTooltip({ defaultIsOpen: true }).find(TOOLTIP_SELECTOR), 1);


### PR DESCRIPTION
#### Fixes #1094

#### Changes proposed in this pull request:

- move empty content check from Tooltip to Popover
- remove now-unused `Utils.isReactText`
- add empty content option to Popover example so you can see warning in console (though not in prod mode)