### PR TITLE
move icons font before keyword in $pt-font-family

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -20,8 +20,8 @@ $pt-font-family: -apple-system,
                  "Cantarell",
                  "Open Sans",
                  "Helvetica Neue",
-                 sans-serif,
-                 "Icons16" !default; // support inline Palantir icons
+                 "Icons16", // support inline Palantir icons
+                 sans-serif !default;
 
 $pt-font-family-monospace: monospace !default;
 


### PR DESCRIPTION
#### Fixes #1060, Fixes #1107

#### Changes proposed in this pull request:

- move `"Icons16"` font before keyword in `$pt-font-family`