### PR TITLE
[Table] Create a playground where you can toggle all features in one place

### DIFF
--- a/packages/table/preview/nav.tsx
+++ b/packages/table/preview/nav.tsx
@@ -21,17 +21,24 @@ export interface INavProps {
 
 export class Nav extends React.Component<INavProps, {}> {
     public render() {
-        return <nav className="pt-navbar pt-dark pt-fixed-top">
-            <div className="pt-navbar-group pt-align-left">
-                <div className="pt-navbar-heading">Blueprint Table preview</div>
-            </div>
-            <div className="pt-navbar-group pt-align-right">
-                <a href="index.html" className="pt-button pt-minimal pt-icon-home">Feature gallery</a>
-                <a href="perf.html" className="pt-button pt-minimal pt-icon-document">Spreadsheet</a>
-                <span className="pt-navbar-divider" />
-                <Switch style={{marginBottom: "0"}} label="Dark theme" onChange={this.handleToggleDarkTheme} />
-            </div>
-        </nav>;
+        const darkThemeToggleStyles = {
+            marginBottom: 0,
+            marginTop: "3px",
+        };
+
+        return (
+            <nav className="pt-navbar pt-dark pt-fixed-top">
+                <div className="pt-navbar-group pt-align-left">
+                    <div className="pt-navbar-heading">Blueprint Table</div>
+                </div>
+                <div className="pt-navbar-group pt-align-right">
+                    <a href="index.html" className="pt-button pt-minimal">Features</a>
+                    <a href="perf.html" className="pt-button pt-minimal">Example</a>
+                    <span className="pt-navbar-divider" />
+                    <Switch style={darkThemeToggleStyles} label="Dark theme" onChange={this.handleToggleDarkTheme} />
+                </div>
+            </nav>
+        );
     }
 
     private handleToggleDarkTheme() {

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -14,6 +14,8 @@
 
       margin: 0;
       padding: 0;
+
+      background-color: #F5F8FA;
     }
 
     body.pt-dark {
@@ -29,7 +31,6 @@
     }
 
     .container {
-      background: #F5F8FA;
       display: flex;
       overflow: hidden;
       height: 100%;
@@ -38,7 +39,7 @@
     .table {
       flex: 1;
       order: 2;
-      z-index: 1;
+      z-index: 2;
     }
 
     .table.is-inline {
@@ -54,11 +55,52 @@
       height: 100%;
       order: 1;
       overflow-y: auto;
-      padding: 20px;
-      z-index: 2;
+      padding: 0 15px 15px;
+      z-index: 3;
+    }
+
+    .pt-dark .sidebar {
+      background-color: #202B33;
+      box-shadow: 0 0 0 1px #182026; /* override pt-elevation-0 styles */
+      z-index: 1;
+    }
+
+    .sidebar h4 {
+      border-top: 1px solid #BFCCD6;
+      font-size: 14px;
+      margin: 15px -15px 0;
+      padding: 20px 15px 12px;
+      text-transform: uppercase;
+    }
+
+    .sidebar h4:first-child {
+      border-top: none;
+      margin-top: 0;
+    }
+
+    .sidebar h6 {
+      color: #5C7080;
+      font-size: 14px;
+      font-weight: normal;
+      line-height: 12px;
+      padding: 10px 0 3px;
+    }
+
+    .pt-dark .sidebar h4 {
+      border-top-color:#182026;
+      color: #A7B6C2;
+    }
+
+    .pt-dark .sidebar h6 {
+      color: #A7B6C2;
+    }
+
+    .sidebar label:last-child {
+      margin-bottom: 0;
     }
 
     label.tbl-select-label {
+      margin-top: -3px;
       margin-bottom: 7px;
     }
 

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -55,6 +55,14 @@
       padding: 20px;
       z-index: 2;
     }
+
+    label.tbl-select-label {
+      margin-bottom: 7px;
+    }
+
+    .tbl-select-label .pt-select {
+      float: right;
+    }
   </style>
 </head>
 <body>

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -65,6 +65,10 @@
     .tbl-select-label .pt-select {
       float: right;
     }
+
+    .tbl-zebra-stripe {
+      background: #F5F8FA;
+    }
   </style>
 </head>
 <body>

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -29,6 +29,7 @@
     }
 
     .container {
+      background: #F5F8FA;
       display: flex;
       overflow: hidden;
       height: 100%;
@@ -37,12 +38,22 @@
     .table {
       flex: 1;
       order: 2;
+      z-index: 1;
+    }
+
+    .table.is-inline {
+      margin-left: -12.5%;
+      max-height: 50%;
+      max-width: 50%;
+      transform: translateX(50%) translateY(50%);
     }
 
     .sidebar {
-      background-color: gray;
+      background-color: #EBF1F5;
       flex-basis: 300px;
       order: 1;
+      padding: 20px;
+      z-index: 2;
     }
   </style>
 </head>

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -51,7 +51,9 @@
     .sidebar {
       background-color: #EBF1F5;
       flex-basis: 300px;
+      height: 100%;
       order: 1;
+      overflow-y: auto;
       padding: 20px;
       z-index: 2;
     }

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -69,6 +69,21 @@
     .tbl-zebra-stripe {
       background: #F5F8FA;
     }
+
+    .tbl-styled-region-success {
+      border: 1px solid #0F9960;
+      background-color: rgba(15, 153, 96, 0.1);
+    }
+
+    .tbl-styled-region-warning {
+      border: 1px solid #D9822B;
+      background-color: rgba(217, 130, 43, 0.1);
+    }
+
+    .tbl-styled-region-danger {
+      border: 1px solid #DB3737;
+      background-color: rgba(219, 55, 55, 0.1);
+    }
   </style>
 </head>
 <body>

--- a/packages/table/preview/perf.html
+++ b/packages/table/preview/perf.html
@@ -6,25 +6,49 @@
   <link rel="stylesheet" type="text/css" href="dist/perf.css">
   <style>
     body {
-      padding: 20px 20px;
+      position: absolute;
+      top: 0;
+      right: 0;
+      left: 0;
+      bottom: 0;
+
+      margin: 0;
+      padding: 0;
     }
 
     body.pt-dark {
       background-color: #293742;
     }
 
+    #page-content {
+      position: absolute;
+      top: 50px;
+      left: 0;
+      bottom: 0;
+      right: 0;
+    }
+
+    .container {
+      display: flex;
+      overflow: hidden;
+      height: 100%;
+    }
+
     .table {
-        position: absolute;
-        top: 50px;
-        left: 0;
-        bottom: 0;
-        right: 0;
+      flex: 1;
+      order: 2;
+    }
+
+    .sidebar {
+      background-color: gray;
+      flex-basis: 300px;
+      order: 1;
     }
   </style>
 </head>
 <body>
   <div id="nav"></div>
-  <div class="table"></div>
+  <div id="page-content"></div>
   <script src="dist/perf.bundle.js"></script>
 </body>
 </html>

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -34,9 +34,11 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
+    enableColumnSelection?: boolean;
     enableContextMenu?: boolean;
     enableFullTableSelection?: boolean;
     enableMultipleSelections?: boolean;
+    enableRowSelection?: boolean;
     numCols?: number;
     numRows?: number;
     showFocusCell?: boolean;
@@ -204,6 +206,16 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Enable context menu", "enableContextMenu")}
                 {this.renderSwitch("Enable full-table selection", "enableFullTableSelection")}
                 {this.renderSwitch("Enable multiple selections", "enableMultipleSelections")}
+
+                <h4>Columns</h4>
+                <h6>Display</h6>
+                <h6>Interactions</h6>
+                {this.renderSwitch("Enable selection", "enableColumnSelection")}
+
+                <h4>Row</h4>
+                <h6>Display</h6>
+                <h6>Interactions</h6>
+                {this.renderSwitch("Enable selection", "enableRowSelection")}
             </div>
         );
     }
@@ -250,6 +262,12 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         const selectionModes: RegionCardinality[] = [];
         if (this.state.enableFullTableSelection) {
             selectionModes.push(RegionCardinality.FULL_TABLE);
+        }
+        if (this.state.enableColumnSelection) {
+            selectionModes.push(RegionCardinality.FULL_COLUMNS);
+        }
+        if (this.state.enableRowSelection) {
+            selectionModes.push(RegionCardinality.FULL_ROWS);
         }
         return selectionModes;
     }

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -7,6 +7,7 @@
  * Demonstrates sample usage of the table component.
  */
 
+import * as classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
@@ -50,6 +51,7 @@ interface IMutableTableState {
     showColumnMenus?: boolean;
     showFocusCell?: boolean;
     showGhostCells?: boolean;
+    showInline?: boolean;
 }
 
 class MutableTable extends React.Component<{}, IMutableTableState> {
@@ -73,7 +75,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             <div className="container">
                 <Table
                     allowMultipleSelection={this.state.enableMultipleSelections}
-                    className="table"
+                    className={classNames("table", { "is-inline": this.state.showInline })}
                     enableFocus={this.state.showFocusCell}
                     fillBodyWithGhostCells={this.state.showGhostCells}
                     isColumnResizable={this.state.enableColumnResizing}
@@ -211,9 +213,10 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     private renderSidebar() {
         return (
-            <div className="sidebar">
+            <div className="sidebar pt-elevation-2">
                 <h4>Table</h4>
                 <h6>Display</h6>
+                {this.renderSwitch("Show inline", "showInline")}
                 {this.renderSwitch("Show focus cell", "showFocusCell")}
                 {this.renderSwitch("Show ghost cells", "showGhostCells")}
                 <h6>Interactions</h6>

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -36,6 +36,7 @@ import { SparseGridMutableStore } from "./store";
 interface IMutableTableState {
     enableContextMenu?: boolean;
     enableFullTableSelection?: boolean;
+    enableMultipleSelections?: boolean;
     numCols?: number;
     numRows?: number;
     showFocusCell?: boolean;
@@ -62,6 +63,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         return (
             <div className="container">
                 <Table
+                    allowMultipleSelection={this.state.enableMultipleSelections}
                     className="table"
                     enableFocus={this.state.showFocusCell}
                     selectionModes={this.getEnabledSelectionModes()}
@@ -201,6 +203,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h6>Interactions</h6>
                 {this.renderSwitch("Enable context menu", "enableContextMenu")}
                 {this.renderSwitch("Enable full-table selection", "enableFullTableSelection")}
+                {this.renderSwitch("Enable multiple selections", "enableMultipleSelections")}
             </div>
         );
     }

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -34,11 +34,13 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
+    enableColumnReordering?: boolean;
     enableColumnResizing?: boolean;
     enableColumnSelection?: boolean;
     enableContextMenu?: boolean;
     enableFullTableSelection?: boolean;
     enableMultipleSelections?: boolean;
+    enableRowReordering?: boolean;
     enableRowResizing?: boolean;
     enableRowSelection?: boolean;
     numCols?: number;
@@ -72,6 +74,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     enableFocus={this.state.showFocusCell}
                     fillBodyWithGhostCells={this.state.showGhostCells}
                     isColumnResizable={this.state.enableColumnResizing}
+                    isColumnReorderable={this.state.enableColumnReordering}
+                    isRowReorderable={this.state.enableRowReordering}
                     isRowResizable={this.state.enableRowResizing}
                     numRows={this.state.numRows}
                     renderBodyContextMenu={this.renderBodyContextMenu}
@@ -214,12 +218,14 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h4>Columns</h4>
                 <h6>Display</h6>
                 <h6>Interactions</h6>
+                {this.renderSwitch("Enable drag-reordering", "enableColumnReordering")}
                 {this.renderSwitch("Enable drag-resizing", "enableColumnResizing")}
                 {this.renderSwitch("Enable selection", "enableColumnSelection")}
 
                 <h4>Row</h4>
                 <h6>Display</h6>
                 <h6>Interactions</h6>
+                {this.renderSwitch("Enable drag-reordering", "enableRowReordering")}
                 {this.renderSwitch("Enable drag-resizing", "enableRowResizing")}
                 {this.renderSwitch("Enable selection", "enableRowSelection")}
             </div>

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -78,7 +78,7 @@ const ROW_COUNTS = [
 ];
 
 const COLUMN_COUNT_DEFAULT_INDEX = 2;
-const ROW_COUNT_DEFAULT_INDEX = 2;
+const ROW_COUNT_DEFAULT_INDEX = 3;
 
 class MutableTable extends React.Component<{}, IMutableTableState> {
     private store = new SparseGridMutableStore<string>();

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -60,6 +60,7 @@ interface IMutableTableState {
     showInline?: boolean;
     showRowHeaders?: boolean;
     showRowHeadersLoading?: boolean;
+    showZebraStriping?: boolean;
 }
 
 const COLUMN_COUNTS = [
@@ -251,14 +252,19 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private renderCell(rowIndex: number, columnIndex: number) {
         const value = this.store.get(rowIndex, columnIndex);
         const valueAsString = value == null ? "" : value;
+
+        const isEvenRow = rowIndex % 2 === 0;
+        const classes = classNames({ "tbl-zebra-stripe": this.state.showZebraStriping && isEvenRow });
+
         return this.state.enableCellEditing ? (
             <EditableCell
+                className={classes}
                 loading={this.state.showCellsLoading}
                 value={valueAsString}
                 onConfirm={this.setCellValue.bind(this, rowIndex, columnIndex)}
             />
         ) : (
-            <Cell>
+            <Cell className={classes}>
                 {valueAsString}
             </Cell>
         );
@@ -296,6 +302,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {rowCountSelect}
                 {this.renderSwitch("Headers", "showRowHeaders")}
                 {this.renderSwitch("Loading state", "showRowHeadersLoading")}
+                {this.renderSwitch("Zebra striping", "showZebraStriping")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Reordering", "enableRowReordering")}
                 {this.renderSwitch("Resizing", "enableRowResizing")}
@@ -303,7 +310,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
                 <h4>Cells</h4>
                 <h6>Display</h6>
-                {this.renderSwitch("Show cells loading", "showCellsLoading")}
+                {this.renderSwitch("Loading state", "showCellsLoading")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Selection", "enableCellSelection")}
                 {this.renderSwitch("Editing", "enableCellEditing")}

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -247,6 +247,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         const value = this.store.get(rowIndex, columnIndex);
         return (
             <EditableCell
+                loading={this.state.showCellsLoading}
                 value={value == null ? "" : value}
                 onConfirm={this.setCellValue.bind(this, rowIndex, columnIndex)}
             />
@@ -289,6 +290,11 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Enable drag-reordering", "enableRowReordering")}
                 {this.renderSwitch("Enable drag-resizing", "enableRowResizing")}
                 {this.renderSwitch("Enable selection", "enableRowSelection")}
+
+                <h4>Cells</h4>
+                <h6>Display</h6>
+                {this.renderSwitch("Show cells loading", "showCellsLoading")}
+                <h6>Interactions</h6>
             </div>
         );
     }

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -24,7 +24,9 @@ import {
     ColumnHeaderCell,
     EditableCell,
     EditableName,
+    IStyledRegionGroup,
     RegionCardinality,
+    Regions,
     RowHeaderCell,
     Table,
     TableLoadingOption,
@@ -60,6 +62,7 @@ interface IMutableTableState {
     showInline?: boolean;
     showRowHeaders?: boolean;
     showRowHeadersLoading?: boolean;
+    showCustomRegions?: boolean;
     showZebraStriping?: boolean;
 }
 
@@ -108,6 +111,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             showColumnHeadersLoading: false,
             showColumnInteractionBar: true,
             showColumnMenus: true,
+            showCustomRegions: false,
             showFocusCell: true,
             showGhostCells: true,
             showInline: false,
@@ -134,6 +138,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     renderRowHeader={this.renderRowHeader.bind(this)}
                     selectionModes={this.getEnabledSelectionModes()}
                     isRowHeaderShown={this.state.showRowHeaders}
+                    styledRegionGroups={this.getStyledRegionGroups()}
                 >
                     {this.renderColumns()}
                 </Table>
@@ -311,6 +316,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h4>Cells</h4>
                 <h6>Display</h6>
                 {this.renderSwitch("Loading state", "showCellsLoading")}
+                {this.renderSwitch("Custom regions", "showCustomRegions")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Selection", "enableCellSelection")}
                 {this.renderSwitch("Editing", "enableCellEditing")}
@@ -413,6 +419,24 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             loadingOptions.push(TableLoadingOption.CELLS);
         }
         return loadingOptions;
+    }
+
+    private getStyledRegionGroups() {
+        // show 3 styled regions as samples
+        return !this.state.showCustomRegions ? [] : [
+            {
+                className: "tbl-styled-region-success",
+                regions: [Regions.cell(0, 0, 3, 3)],
+            },
+            {
+                className: "tbl-styled-region-warning",
+                regions: [Regions.cell(2, 1, 8, 1)],
+            },
+            {
+                className: "tbl-styled-region-danger",
+                regions: [Regions.cell(5, 3, 7, 7)],
+            },
+        ] as IStyledRegionGroup[];
     }
 }
 

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -45,6 +45,8 @@ interface IMutableTableState {
     enableRowSelection?: boolean;
     numCols?: number;
     numRows?: number;
+    showColumnInteractionBar?: boolean;
+    showColumnMenus?: boolean;
     showFocusCell?: boolean;
     showGhostCells?: boolean;
 }
@@ -111,13 +113,13 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         return (<ColumnHeaderCell
             menu={this.renderColumnMenu(columnIndex)}
             renderName={renderName}
-            useInteractionBar={true}
+            useInteractionBar={this.state.showColumnInteractionBar}
         />);
     }
 
     private renderColumnMenu(columnIndex: number) {
         // tslint:disable:jsx-no-multiline-js jsx-no-lambda
-        return <Menu>
+        const menu = <Menu>
             <MenuItem
                 iconName="insert"
                 onClick={() => {
@@ -154,6 +156,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 text="Fill with random text"
             />
         </Menu>;
+
+        return this.state.showColumnMenus ? menu : undefined;
     }
 
     private renderRowHeader(rowIndex: number) {
@@ -217,6 +221,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
                 <h4>Columns</h4>
                 <h6>Display</h6>
+                {this.renderSwitch("Show interaction bar", "showColumnInteractionBar")}
+                {this.renderSwitch("Show menus", "showColumnMenus")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Enable drag-reordering", "enableColumnReordering")}
                 {this.renderSwitch("Enable drag-resizing", "enableColumnResizing")}

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -13,6 +13,7 @@ import * as ReactDOM from "react-dom";
 import {
     Menu,
     MenuItem,
+    Switch,
 } from "@blueprintjs/core";
 
 import {
@@ -32,18 +33,27 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
-    numCols: number;
-    numRows: number;
+    numCols?: number;
+    numRows?: number;
+    showGhostCells?: boolean;
 }
 
 class MutableTable extends React.Component<{}, IMutableTableState> {
     private store = new SparseGridMutableStore<string>();
 
+    private callbacks = {
+        table: {
+            display: {
+                showGhostCells: this.toggleBoolean("showGhostCells"),
+            },
+        },
+    };
+
     public constructor(props: any, context?: any) {
         super(props, context);
         this.state = {
-            numCols : 100,
-            numRows : 100 * 1000,
+            numCols : 5, // 100,
+            numRows : 10, // 100 * 1000,
         };
 
         // Intialize column names
@@ -60,12 +70,11 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     selectionModes={SelectionModes.ALL}
                     numRows={this.state.numRows}
                     renderRowHeader={this.renderRowHeader.bind(this)}
+                    fillBodyWithGhostCells={this.state.showGhostCells}
                 >
                     {this.renderColumns()}
                 </Table>
-                <div className="sidebar">
-                    Hello world
-                </div>
+                {this.renderSidebar()}
             </div>
         );
     }
@@ -184,6 +193,18 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         );
     }
 
+    private renderSidebar() {
+        return (
+            <div className="sidebar">
+                <Switch
+                    className="pt-align-right"
+                    label="Show ghost cells"
+                    onChange={this.callbacks.table.display.showGhostCells}
+                />
+            </div>
+        );
+    }
+
     private setColumnName(columnIndex: number, value: string) {
         return this.store.set(-1, columnIndex, value);
     }
@@ -191,9 +212,33 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private setCellValue(rowIndex: number, columnIndex: number, value: string) {
         return this.store.set(rowIndex, columnIndex, value);
     }
+
+    private toggleBoolean(stateKey: keyof IMutableTableState) {
+        return handleBooleanChange((value: boolean) => {
+            this.setState({ [stateKey]: value });
+        });
+    }
 }
 
 ReactDOM.render(
     <MutableTable/>,
     document.querySelector("#page-content"),
 );
+
+
+// TODO: Pull these from @blueprintjs/docs
+
+/** Event handler that exposes the target element's value as a boolean. */
+function handleBooleanChange(handler: (checked: boolean) => void) {
+    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).checked);
+}
+
+// /** Event handler that exposes the target element's value as a string. */
+// function handleStringChange(handler: (value: string) => void) {
+//     return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
+// }
+
+// /** Event handler that exposes the target element's value as a number. */
+// function handleNumberChange(handler: (value: number) => void) {
+//     return handleStringChange((value) => handler(+value));
+// }

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -19,6 +19,7 @@ import {
 } from "@blueprintjs/core";
 
 import {
+    Cell,
     Column,
     ColumnHeaderCell,
     EditableCell,
@@ -36,9 +37,10 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
+    enableCellEditing?: boolean;
+    enableCellSelection?: boolean;
     enableColumnNameEditing?: boolean;
     enableColumnReordering?: boolean;
-    enableCellSelection?: boolean;
     enableColumnResizing?: boolean;
     enableColumnSelection?: boolean;
     enableContextMenu?: boolean;
@@ -87,6 +89,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     public constructor(props: any, context?: any) {
         super(props, context);
         this.state = {
+            enableCellEditing: true,
             enableCellSelection: true,
             enableColumnNameEditing: true,
             enableColumnReordering: true,
@@ -247,12 +250,17 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     private renderCell(rowIndex: number, columnIndex: number) {
         const value = this.store.get(rowIndex, columnIndex);
-        return (
+        const valueAsString = value == null ? "" : value;
+        return this.state.enableCellEditing ? (
             <EditableCell
                 loading={this.state.showCellsLoading}
-                value={value == null ? "" : value}
+                value={valueAsString}
                 onConfirm={this.setCellValue.bind(this, rowIndex, columnIndex)}
             />
+        ) : (
+            <Cell>
+                {valueAsString}
+            </Cell>
         );
     }
 
@@ -278,7 +286,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Interaction bar", "showColumnInteractionBar")}
                 {this.renderSwitch("Menus", "showColumnMenus")}
                 <h6>Interactions</h6>
-                {this.renderSwitch("Name editing", "enableColumnNameEditing")}
+                {this.renderSwitch("Editing", "enableColumnNameEditing")}
                 {this.renderSwitch("Reordering", "enableColumnReordering")}
                 {this.renderSwitch("Resizing", "enableColumnResizing")}
                 {this.renderSwitch("Selection", "enableColumnSelection")}
@@ -298,6 +306,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Show cells loading", "showCellsLoading")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Selection", "enableCellSelection")}
+                {this.renderSwitch("Editing", "enableCellEditing")}
             </div>
         );
     }

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -279,7 +279,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         const columnCountSelect = this.renderNumberSelectMenu("Number of columns", "numCols", COLUMN_COUNTS);
         const rowCountSelect = this.renderNumberSelectMenu("Number of rows", "numRows", ROW_COUNTS);
         return (
-            <div className="sidebar pt-elevation-2">
+            <div className="sidebar pt-elevation-0">
                 <h4>Table</h4>
                 <h6>Display</h6>
                 {this.renderSwitch("Inline", "showInline")}

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -34,6 +34,7 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
+    enableColumnNameEditing?: boolean;
     enableColumnReordering?: boolean;
     enableColumnResizing?: boolean;
     enableColumnSelection?: boolean;
@@ -102,8 +103,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     }
 
     private renderColumnHeader(columnIndex: number) {
+        const name = this.store.get(-1, columnIndex);
         const renderName = () => {
-            const name = this.store.get(-1, columnIndex);
             return (<EditableName
                 name={name == null ? "" : name}
                 onConfirm={this.setColumnName.bind(this, columnIndex)}
@@ -112,7 +113,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
         return (<ColumnHeaderCell
             menu={this.renderColumnMenu(columnIndex)}
-            renderName={renderName}
+            name={name}
+            renderName={this.state.enableColumnNameEditing ? renderName : undefined}
             useInteractionBar={this.state.showColumnInteractionBar}
         />);
     }
@@ -224,6 +226,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Show interaction bar", "showColumnInteractionBar")}
                 {this.renderSwitch("Show menus", "showColumnMenus")}
                 <h6>Interactions</h6>
+                {this.renderSwitch("Enable name editing", "enableColumnNameEditing")}
                 {this.renderSwitch("Enable drag-reordering", "enableColumnReordering")}
                 {this.renderSwitch("Enable drag-resizing", "enableColumnResizing")}
                 {this.renderSwitch("Enable selection", "enableColumnSelection")}

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -35,19 +35,12 @@ import { SparseGridMutableStore } from "./store";
 interface IMutableTableState {
     numCols?: number;
     numRows?: number;
+    showFocusCell?: boolean;
     showGhostCells?: boolean;
 }
 
 class MutableTable extends React.Component<{}, IMutableTableState> {
     private store = new SparseGridMutableStore<string>();
-
-    private callbacks = {
-        table: {
-            display: {
-                showGhostCells: this.toggleBoolean("showGhostCells"),
-            },
-        },
-    };
 
     public constructor(props: any, context?: any) {
         super(props, context);
@@ -67,6 +60,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             <div className="container">
                 <Table
                     className="table"
+                    enableFocus={this.state.showFocusCell}
                     selectionModes={SelectionModes.ALL}
                     numRows={this.state.numRows}
                     renderRowHeader={this.renderRowHeader.bind(this)}
@@ -196,12 +190,19 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private renderSidebar() {
         return (
             <div className="sidebar">
-                <Switch
-                    className="pt-align-right"
-                    label="Show ghost cells"
-                    onChange={this.callbacks.table.display.showGhostCells}
-                />
+                {this.renderSwitch("Show focus cell", "showFocusCell")}
+                {this.renderSwitch("Show ghost cells", "showGhostCells")}
             </div>
+        );
+    }
+
+    private renderSwitch(label: string, stateKey: keyof IMutableTableState) {
+        return (
+            <Switch
+                className="pt-align-right"
+                label={label}
+                onChange={this.toggleBoolean(stateKey)}
+            />
         );
     }
 

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -155,15 +155,12 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         );
     }
 
-    public componentDidUpdate() {
-        const { selectedFocusStyle } = this.state;
-        const isFocusStyleManagerActive = FocusStyleManager.isActive();
+    public componentDidMount() {
+        this.syncFocusStyle();
+    }
 
-        if (selectedFocusStyle === FocusStyle.TAB_OR_CLICK && isFocusStyleManagerActive) {
-            FocusStyleManager.alwaysShowFocus();
-        } else if (selectedFocusStyle === FocusStyle.TAB && !isFocusStyleManagerActive) {
-            FocusStyleManager.onlyShowFocusOnTabs();
-        }
+    public componentDidUpdate() {
+        this.syncFocusStyle();
     }
 
     public renderColumns() {
@@ -394,6 +391,17 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 </div>
             </label>
         );
+    }
+
+    private syncFocusStyle() {
+        const { selectedFocusStyle } = this.state;
+        const isFocusStyleManagerActive = FocusStyleManager.isActive();
+
+        if (selectedFocusStyle === FocusStyle.TAB_OR_CLICK && isFocusStyleManagerActive) {
+            FocusStyleManager.alwaysShowFocus();
+        } else if (selectedFocusStyle === FocusStyle.TAB && !isFocusStyleManagerActive) {
+            FocusStyleManager.onlyShowFocusOnTabs();
+        }
     }
 
     private setColumnName(columnIndex: number, value: string) {

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -34,10 +34,12 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
+    enableColumnResizing?: boolean;
     enableColumnSelection?: boolean;
     enableContextMenu?: boolean;
     enableFullTableSelection?: boolean;
     enableMultipleSelections?: boolean;
+    enableRowResizing?: boolean;
     enableRowSelection?: boolean;
     numCols?: number;
     numRows?: number;
@@ -68,11 +70,13 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     allowMultipleSelection={this.state.enableMultipleSelections}
                     className="table"
                     enableFocus={this.state.showFocusCell}
-                    selectionModes={this.getEnabledSelectionModes()}
-                    numRows={this.state.numRows}
-                    renderRowHeader={this.renderRowHeader.bind(this)}
                     fillBodyWithGhostCells={this.state.showGhostCells}
+                    isColumnResizable={this.state.enableColumnResizing}
+                    isRowResizable={this.state.enableRowResizing}
+                    numRows={this.state.numRows}
                     renderBodyContextMenu={this.renderBodyContextMenu}
+                    renderRowHeader={this.renderRowHeader.bind(this)}
+                    selectionModes={this.getEnabledSelectionModes()}
                 >
                     {this.renderColumns()}
                 </Table>
@@ -210,11 +214,13 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h4>Columns</h4>
                 <h6>Display</h6>
                 <h6>Interactions</h6>
+                {this.renderSwitch("Enable drag-resizing", "enableColumnResizing")}
                 {this.renderSwitch("Enable selection", "enableColumnSelection")}
 
                 <h4>Row</h4>
                 <h6>Display</h6>
                 <h6>Interactions</h6>
+                {this.renderSwitch("Enable drag-resizing", "enableRowResizing")}
                 {this.renderSwitch("Enable selection", "enableRowSelection")}
             </div>
         );

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -38,6 +38,7 @@ import { SparseGridMutableStore } from "./store";
 interface IMutableTableState {
     enableColumnNameEditing?: boolean;
     enableColumnReordering?: boolean;
+    enableCellSelection?: boolean;
     enableColumnResizing?: boolean;
     enableColumnSelection?: boolean;
     enableContextMenu?: boolean;
@@ -86,6 +87,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     public constructor(props: any, context?: any) {
         super(props, context);
         this.state = {
+            enableCellSelection: true,
             enableColumnNameEditing: true,
             enableColumnReordering: true,
             enableColumnResizing: true,
@@ -261,40 +263,41 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             <div className="sidebar pt-elevation-2">
                 <h4>Table</h4>
                 <h6>Display</h6>
-                {this.renderSwitch("Show inline", "showInline")}
-                {this.renderSwitch("Show focus cell", "showFocusCell")}
-                {this.renderSwitch("Show ghost cells", "showGhostCells")}
+                {this.renderSwitch("Inline", "showInline")}
+                {this.renderSwitch("Focus cell", "showFocusCell")}
+                {this.renderSwitch("Ghost cells", "showGhostCells")}
                 <h6>Interactions</h6>
-                {this.renderSwitch("Enable context menu", "enableContextMenu")}
-                {this.renderSwitch("Enable full-table selection", "enableFullTableSelection")}
-                {this.renderSwitch("Enable multiple selections", "enableMultipleSelections")}
+                {this.renderSwitch("Body context menu", "enableContextMenu")}
+                {this.renderSwitch("Full-table selection", "enableFullTableSelection")}
+                {this.renderSwitch("Multiple selections", "enableMultipleSelections")}
 
                 <h4>Columns</h4>
                 <h6>Display</h6>
                 {columnCountSelect}
-                {this.renderSwitch("Show headers loading", "showColumnHeadersLoading")}
-                {this.renderSwitch("Show interaction bar", "showColumnInteractionBar")}
-                {this.renderSwitch("Show menus", "showColumnMenus")}
+                {this.renderSwitch("Loading state", "showColumnHeadersLoading")}
+                {this.renderSwitch("Interaction bar", "showColumnInteractionBar")}
+                {this.renderSwitch("Menus", "showColumnMenus")}
                 <h6>Interactions</h6>
-                {this.renderSwitch("Enable name editing", "enableColumnNameEditing")}
-                {this.renderSwitch("Enable drag-reordering", "enableColumnReordering")}
-                {this.renderSwitch("Enable drag-resizing", "enableColumnResizing")}
-                {this.renderSwitch("Enable selection", "enableColumnSelection")}
+                {this.renderSwitch("Name editing", "enableColumnNameEditing")}
+                {this.renderSwitch("Reordering", "enableColumnReordering")}
+                {this.renderSwitch("Resizing", "enableColumnResizing")}
+                {this.renderSwitch("Selection", "enableColumnSelection")}
 
                 <h4>Row</h4>
                 <h6>Display</h6>
                 {rowCountSelect}
-                {this.renderSwitch("Show headers", "showRowHeaders")}
-                {this.renderSwitch("Show headers loading", "showRowHeadersLoading")}
+                {this.renderSwitch("Headers", "showRowHeaders")}
+                {this.renderSwitch("Loading state", "showRowHeadersLoading")}
                 <h6>Interactions</h6>
-                {this.renderSwitch("Enable drag-reordering", "enableRowReordering")}
-                {this.renderSwitch("Enable drag-resizing", "enableRowResizing")}
-                {this.renderSwitch("Enable selection", "enableRowSelection")}
+                {this.renderSwitch("Reordering", "enableRowReordering")}
+                {this.renderSwitch("Resizing", "enableRowResizing")}
+                {this.renderSwitch("Selection", "enableRowSelection")}
 
                 <h4>Cells</h4>
                 <h6>Display</h6>
                 {this.renderSwitch("Show cells loading", "showCellsLoading")}
                 <h6>Interactions</h6>
+                {this.renderSwitch("Selection", "enableCellSelection")}
             </div>
         );
     }
@@ -376,19 +379,22 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         if (this.state.enableRowSelection) {
             selectionModes.push(RegionCardinality.FULL_ROWS);
         }
+        if (this.state.enableCellSelection) {
+            selectionModes.push(RegionCardinality.CELLS);
+        }
         return selectionModes;
     }
 
     private getEnabledLoadingOptions() {
         const loadingOptions: TableLoadingOption[] = [];
-        if (this.state.showCellsLoading) {
-            loadingOptions.push(TableLoadingOption.CELLS);
-        }
         if (this.state.showColumnHeadersLoading) {
             loadingOptions.push(TableLoadingOption.COLUMN_HEADERS);
         }
         if (this.state.showRowHeadersLoading) {
             loadingOptions.push(TableLoadingOption.ROW_HEADERS);
+        }
+        if (this.state.showCellsLoading) {
+            loadingOptions.push(TableLoadingOption.CELLS);
         }
         return loadingOptions;
     }

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -55,6 +55,7 @@ interface IMutableTableState {
     showFocusCell?: boolean;
     showGhostCells?: boolean;
     showInline?: boolean;
+    showRowHeaders?: boolean;
     showRowHeadersLoading?: boolean;
 }
 
@@ -107,6 +108,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     renderBodyContextMenu={this.renderBodyContextMenu}
                     renderRowHeader={this.renderRowHeader.bind(this)}
                     selectionModes={this.getEnabledSelectionModes()}
+                    isRowHeaderShown={this.state.showRowHeaders}
                 >
                     {this.renderColumns()}
                 </Table>
@@ -262,6 +264,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h4>Row</h4>
                 <h6>Display</h6>
                 {rowCountSelect}
+                {this.renderSwitch("Show headers", "showRowHeaders")}
                 {this.renderSwitch("Show headers loading", "showRowHeadersLoading")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Enable drag-reordering", "enableRowReordering")}

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -53,13 +53,21 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     }
 
     public render() {
-        return <Table
-            selectionModes={SelectionModes.ALL}
-            numRows={this.state.numRows}
-            renderRowHeader={this.renderRowHeader.bind(this)}
-        >
-            {this.renderColumns()}
-        </Table>;
+        return (
+            <div className="container">
+                <Table
+                    className="table"
+                    selectionModes={SelectionModes.ALL}
+                    numRows={this.state.numRows}
+                    renderRowHeader={this.renderRowHeader.bind(this)}
+                >
+                    {this.renderColumns()}
+                </Table>
+                <div className="sidebar">
+                    Hello world
+                </div>
+            </div>
+        );
     }
 
     public renderColumns() {
@@ -187,5 +195,5 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
 ReactDOM.render(
     <MutableTable/>,
-    document.querySelector(".table"),
+    document.querySelector("#page-content"),
 );

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -12,6 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import {
     Menu,
+    MenuDivider,
     MenuItem,
     Switch,
 } from "@blueprintjs/core";
@@ -33,6 +34,7 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
+    enableContextMenu?: boolean;
     numCols?: number;
     numRows?: number;
     showFocusCell?: boolean;
@@ -65,6 +67,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     numRows={this.state.numRows}
                     renderRowHeader={this.renderRowHeader.bind(this)}
                     fillBodyWithGhostCells={this.state.showGhostCells}
+                    renderBodyContextMenu={this.renderBodyContextMenu}
                 >
                     {this.renderColumns()}
                 </Table>
@@ -190,8 +193,12 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private renderSidebar() {
         return (
             <div className="sidebar">
+                <h4>Table</h4>
+                <h6>Display</h6>
                 {this.renderSwitch("Show focus cell", "showFocusCell")}
                 {this.renderSwitch("Show ghost cells", "showGhostCells")}
+                <h6>Interactions</h6>
+                {this.renderSwitch("Enable context menu", "enableContextMenu")}
             </div>
         );
     }
@@ -218,6 +225,20 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         return handleBooleanChange((value: boolean) => {
             this.setState({ [stateKey]: value });
         });
+    }
+
+    private renderBodyContextMenu = () => {
+        const menu = (
+            <Menu>
+                <MenuItem iconName="search-around" text="Item 1" />
+                <MenuItem iconName="search" text="Item 2" />
+                <MenuItem iconName="graph-remove" text="Item 3" />
+                <MenuItem iconName="group-objects" text="Item 4" />
+                <MenuDivider />
+                <MenuItem disabled={true} text="Disabled item" />
+            </Menu>
+        );
+        return this.state.enableContextMenu ? menu : undefined;
     }
 }
 

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -26,6 +26,7 @@ import {
     RegionCardinality,
     RowHeaderCell,
     Table,
+    TableLoadingOption,
     Utils,
 } from "../src/index";
 
@@ -47,11 +48,14 @@ interface IMutableTableState {
     enableRowSelection?: boolean;
     numCols?: number;
     numRows?: number;
+    showCellsLoading?: boolean;
+    showColumnHeadersLoading?: boolean;
     showColumnInteractionBar?: boolean;
     showColumnMenus?: boolean;
     showFocusCell?: boolean;
     showGhostCells?: boolean;
     showInline?: boolean;
+    showRowHeadersLoading?: boolean;
 }
 
 const COLUMN_COUNTS = [
@@ -98,6 +102,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     isColumnReorderable={this.state.enableColumnReordering}
                     isRowReorderable={this.state.enableRowReordering}
                     isRowResizable={this.state.enableRowResizing}
+                    loadingOptions={this.getEnabledLoadingOptions()}
                     numRows={this.state.numRows}
                     renderBodyContextMenu={this.renderBodyContextMenu}
                     renderRowHeader={this.renderRowHeader.bind(this)}
@@ -245,6 +250,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h4>Columns</h4>
                 <h6>Display</h6>
                 {columnCountSelect}
+                {this.renderSwitch("Show headers loading", "showColumnHeadersLoading")}
                 {this.renderSwitch("Show interaction bar", "showColumnInteractionBar")}
                 {this.renderSwitch("Show menus", "showColumnMenus")}
                 <h6>Interactions</h6>
@@ -256,6 +262,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <h4>Row</h4>
                 <h6>Display</h6>
                 {rowCountSelect}
+                {this.renderSwitch("Show headers loading", "showRowHeadersLoading")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Enable drag-reordering", "enableRowReordering")}
                 {this.renderSwitch("Enable drag-resizing", "enableRowResizing")}
@@ -341,6 +348,20 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             selectionModes.push(RegionCardinality.FULL_ROWS);
         }
         return selectionModes;
+    }
+
+    private getEnabledLoadingOptions() {
+        const loadingOptions: TableLoadingOption[] = [];
+        if (this.state.showCellsLoading) {
+            loadingOptions.push(TableLoadingOption.CELLS);
+        }
+        if (this.state.showColumnHeadersLoading) {
+            loadingOptions.push(TableLoadingOption.COLUMN_HEADERS);
+        }
+        if (this.state.showRowHeadersLoading) {
+            loadingOptions.push(TableLoadingOption.ROW_HEADERS);
+        }
+        return loadingOptions;
     }
 }
 

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -86,8 +86,27 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     public constructor(props: any, context?: any) {
         super(props, context);
         this.state = {
-            numCols : COLUMN_COUNTS[COLUMN_COUNT_DEFAULT_INDEX],
-            numRows : ROW_COUNTS[ROW_COUNT_DEFAULT_INDEX],
+            enableColumnNameEditing: true,
+            enableColumnReordering: true,
+            enableColumnResizing: true,
+            enableColumnSelection: true,
+            enableContextMenu: true,
+            enableFullTableSelection: true,
+            enableMultipleSelections: true,
+            enableRowReordering: true,
+            enableRowResizing: true,
+            enableRowSelection: true,
+            numCols: COLUMN_COUNTS[COLUMN_COUNT_DEFAULT_INDEX],
+            numRows: ROW_COUNTS[ROW_COUNT_DEFAULT_INDEX],
+            showCellsLoading: false,
+            showColumnHeadersLoading: false,
+            showColumnInteractionBar: true,
+            showColumnMenus: true,
+            showFocusCell: true,
+            showGhostCells: true,
+            showInline: false,
+            showRowHeaders: true,
+            showRowHeadersLoading: false,
         };
     }
 
@@ -277,6 +296,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private renderSwitch(label: string, stateKey: keyof IMutableTableState) {
         return (
             <Switch
+                checked={this.state[stateKey] as boolean}
                 className="pt-align-right"
                 label={label}
                 onChange={this.updateBooleanState(stateKey)}

--- a/packages/table/preview/perf.tsx
+++ b/packages/table/preview/perf.tsx
@@ -22,8 +22,8 @@ import {
     ColumnHeaderCell,
     EditableCell,
     EditableName,
+    RegionCardinality,
     RowHeaderCell,
-    SelectionModes,
     Table,
     Utils,
 } from "../src/index";
@@ -35,6 +35,7 @@ import { SparseGridMutableStore } from "./store";
 
 interface IMutableTableState {
     enableContextMenu?: boolean;
+    enableFullTableSelection?: boolean;
     numCols?: number;
     numRows?: number;
     showFocusCell?: boolean;
@@ -63,7 +64,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <Table
                     className="table"
                     enableFocus={this.state.showFocusCell}
-                    selectionModes={SelectionModes.ALL}
+                    selectionModes={this.getEnabledSelectionModes()}
                     numRows={this.state.numRows}
                     renderRowHeader={this.renderRowHeader.bind(this)}
                     fillBodyWithGhostCells={this.state.showGhostCells}
@@ -199,6 +200,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Show ghost cells", "showGhostCells")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Enable context menu", "enableContextMenu")}
+                {this.renderSwitch("Enable full-table selection", "enableFullTableSelection")}
             </div>
         );
     }
@@ -239,6 +241,14 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             </Menu>
         );
         return this.state.enableContextMenu ? menu : undefined;
+    }
+
+    private getEnabledSelectionModes() {
+        const selectionModes: RegionCardinality[] = [];
+        if (this.state.enableFullTableSelection) {
+            selectionModes.push(RegionCardinality.FULL_TABLE);
+        }
+        return selectionModes;
     }
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Out with the old `perf.html` spreadsheet example.
- In with the new `Table` Playground. (The term "playground" is a little overloaded now; feel free to suggest something else, though note that string doesn't appear in this PR.)

#### Reviewers should focus on:

- I've discovered so many `Table` bugs and/or weirdnesses from this already!
- I want to merge this quickly and add to it iteratively in future PRs (TODO: text truncation, `resizeByTallest...`, reorganize the table preview pages).
- Play with it at `[table docs url]/perf.html`.
- Happy to polish styles in future PRs if we need to.

#### Screenshot

<img width="1440" alt="screen shot 2017-05-26 at 1 06 01 pm" src="https://cloud.githubusercontent.com/assets/443450/26510969/a59f074c-4214-11e7-965f-448239f44fb4.png">

![image](https://cloud.githubusercontent.com/assets/443450/26511064/11d6a5aa-4215-11e7-9ce1-d815d0e3f9b4.png)

<img width="1440" alt="screen shot 2017-05-26 at 1 06 09 pm" src="https://cloud.githubusercontent.com/assets/443450/26510973/aa0fdd56-4214-11e7-97c0-305103768d46.png">