### PR TITLE
Expose click event in Tabs2 onChange handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@types/assertion-error": "1.0.30",
-    "@types/chai": "3.4.34",
+    "@types/chai": "3.5.2",
     "@types/classnames": "0.0.31",
     "@types/dom4": "1.5.20",
     "@types/enzyme": "2.8.0",
@@ -30,7 +30,7 @@
     "@types/tether": "1.1.27",
     "autoprefixer": "6.5.2",
     "better-handlebars": "github:wmeldon/better-handlebars",
-    "chai": "3.5.0",
+    "chai": "4.0.0",
     "del": "2.2.2",
     "documentalist": "0.0.6",
     "enzyme": "2.8.2",

--- a/packages/core/src/components/tabs2/tabTitle.tsx
+++ b/packages/core/src/components/tabs2/tabTitle.tsx
@@ -14,7 +14,7 @@ import { ITab2Props, TabId } from "./tab2";
 
 export interface ITabTitleProps extends ITab2Props {
     /** Handler invoked when this tab is clicked. */
-    onClick: (id: TabId, e: React.MouseEvent<HTMLElement>) => void;
+    onClick: (id: TabId, event: React.MouseEvent<HTMLElement>) => void;
 
     /** ID of the parent `Tabs` to which this tab belongs. Used to generate ID for ARIA attributes. */
     parentId: TabId;

--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -69,7 +69,7 @@ export interface ITabs2Props extends IProps {
     /**
      * A callback function that is invoked when a tab in the tab list is clicked.
      */
-    onChange?(newTabId: TabId, prevTabId: TabId): void;
+    onChange?(newTabId: TabId, prevTabId: TabId, event: React.MouseEvent<HTMLElement>): void;
 }
 
 export interface ITabs2State {
@@ -220,8 +220,8 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
         }
     }
 
-    private handleTabClick = (newTabId: TabId) => {
-        safeInvoke(this.props.onChange, newTabId, this.state.selectedTabId);
+    private handleTabClick = (newTabId: TabId, event: React.MouseEvent<HTMLElement>) => {
+        safeInvoke(this.props.onChange, newTabId, this.state.selectedTabId, event);
         if (this.props.selectedTabId === undefined) {
             this.setState({ selectedTabId: newTabId });
         }

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -82,14 +82,6 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             checkClickTriggeredOnKeyUp(done, {}, { which: Keys.SPACE });
         });
 
-        it("elementRef receives reference to HTML element", () => {
-            const elementRef = sinon.spy();
-            // full DOM rendering here so the ref handler is invoked
-            button({ elementRef }, true);
-            assert.isTrue(elementRef.calledOnce);
-            assert.instanceOf(elementRef.args[0][0], HTMLElement);
-        });
-
         function button(props: IButtonProps, useMount = false, ...children: React.ReactNode[]) {
             const element = React.createElement(component, props, ...children);
             return useMount ? mount(element) : shallow(element);

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -55,13 +55,6 @@ describe("Controls:", () => {
                 assert.equal(control.text(), "Label Text");
             });
 
-            it("inputRef receives reference to HTMLInputElement", () => {
-                const inputRef = sinon.spy();
-                mount(React.createElement(classType, { inputRef }));
-                assert.isTrue(inputRef.calledOnce);
-                assert.instanceOf(inputRef.args[0][0], HTMLInputElement);
-            });
-
             if (moreTests != null) {
                 moreTests();
             }

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -41,11 +41,4 @@ describe("<InputGroup>", () => {
         group.setProps({ type: "password" });
         assert.strictEqual(group.find("input").prop("type"), "password");
     });
-
-    it("inputRef receives reference to HTMLInputElement", () => {
-        const inputRef = sinon.spy();
-        mount(<InputGroup inputRef={inputRef} />);
-        assert.isTrue(inputRef.calledOnce);
-        assert.instanceOf(inputRef.args[0][0], HTMLInputElement);
-    });
 });

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -164,10 +164,8 @@ describe("<Tabs2>", () => {
         tabList.simulate("keypress", { target: tabElements[2], which: Keys.SPACE });
 
         assert.equal(changeSpy.callCount, 2);
-        assert.deepEqual(changeSpy.args, [
-            [TAB_IDS[1], TAB_IDS[0]],
-            [TAB_IDS[2], TAB_IDS[1]],
-        ]);
+        assert.includeDeepMembers(changeSpy.args[0], [TAB_IDS[1], TAB_IDS[0]]);
+        assert.includeDeepMembers(changeSpy.args[1], [TAB_IDS[2], TAB_IDS[1]]);
     });
 
     it("animate=false removes moving indicator element", () => {
@@ -263,7 +261,7 @@ describe("<Tabs2>", () => {
             findTabById(tabs, TAB_ID_TO_SELECT).simulate("click");
             assert.isTrue(onChangeSpy.calledOnce);
             // old selection is 0
-            assert.deepEqual(onChangeSpy.args[0], [TAB_ID_TO_SELECT, SELECTED_TAB_ID]);
+            assert.includeDeepMembers(onChangeSpy.args[0], [TAB_ID_TO_SELECT, SELECTED_TAB_ID]);
             assert.deepEqual(tabs.state("selectedTabId"), SELECTED_TAB_ID);
         });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -75,14 +75,6 @@ describe("<DateRangeInput>", () => {
         expect(picker.prop("contiguousCalendarMonths")).to.be.false;
     });
 
-    it("startInputProps.inputRef receives reference to HTML input element", () => {
-        const inputRef = sinon.spy();
-        // full DOM rendering here so the ref handler is invoked
-        mount(<DateRangeInput startInputProps={{ inputRef }} />);
-        expect(inputRef.calledOnce).to.be.true;
-        expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
-    });
-
     it("shows empty fields when no date range is selected", () => {
         const { root } = wrap(<DateRangeInput />);
         assertInputTextsEqual(root, "", "");
@@ -108,13 +100,6 @@ describe("<DateRangeInput>", () => {
 
         function runTestSuite(inputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
                               mountFn: (inputGroupProps: HTMLInputProps & IInputGroupProps) => any) {
-            it("inputRef receives reference to HTML input element", () => {
-                const inputRef = sinon.spy();
-                mountFn({ inputRef });
-                expect(inputRef.calledOnce).to.be.true;
-                expect(inputRef.firstCall.args[0]).to.be.an.instanceOf(HTMLInputElement);
-            });
-
             it("allows custom placeholder text", () => {
                 const { root } = mountFn({ placeholder: "Hello" });
                 expect(getInputPlaceholderText(inputGetterFn(root))).to.equal("Hello");


### PR DESCRIPTION
#### Fixes #1156

- Expose click event in Tabs2 onChange handler
- Upgrade to Chai 4.0, remove tests that were mostly tautological and relied on old lenient APIs