### PR TITLE
[Table] Eliminate excessive selection re-renders

### DIFF
--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -235,11 +235,7 @@ export const Utils = {
             return false;
         } else if (Array.isArray(objA) || Array.isArray(objB)) {
             return Utils.arraysEqual(objA, objB, Utils.deepCompareKeys);
-        } else if (typeof objA === "string" || typeof objB === "string" ) {
-            return objA === objB;
-        } else if (typeof objA === "number" || typeof objB === "number" ) {
-            return objA === objB;
-        } else if (typeof objA === "boolean" || typeof objB === "boolean" ) {
+        } else if (_isSimplePrimitiveType(objA) || _isSimplePrimitiveType(objB)) {
             return objA === objB;
         } else if (keys != null) {
             return _deepCompareKeys(objA, objB, keys);
@@ -415,4 +411,10 @@ function _deepCompareKeys(objA: any, objB: any, keys: string[]): boolean {
         return objA.hasOwnProperty(key) === objB.hasOwnProperty(key)
             && Utils.deepCompareKeys(objA[key], objB[key]);
     });
+}
+
+function _isSimplePrimitiveType(value: any) {
+    return typeof value === "number"
+        || typeof value === "string"
+        || typeof value === "boolean";
 }

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -225,7 +225,7 @@ export const Utils = {
      * Deep comparison between objects. If `keys` is provided, just that subset of keys will be
      * compared; otherwise, all keys will be compared.
      */
-    deepCompareKeys(objA: any, objB: any, keys?: string[]) {
+    deepCompareKeys(objA: any, objB: any, keys?: string[]): boolean {
         if (objA === objB) {
             return true;
         } else if (objA == null && objB == null) {
@@ -234,10 +234,12 @@ export const Utils = {
         } else if (objA == null || objB == null) {
             return false;
         } else if (Array.isArray(objA) || Array.isArray(objB)) {
-            return Utils.arraysEqual(objA, objB);
+            return Utils.arraysEqual(objA, objB, Utils.deepCompareKeys);
         } else if (typeof objA === "string" || typeof objB === "string" ) {
             return objA === objB;
         } else if (typeof objA === "number" || typeof objB === "number" ) {
+            return objA === objB;
+        } else if (typeof objA === "boolean" || typeof objB === "boolean" ) {
             return objA === objB;
         } else if (keys != null) {
             return _deepCompareKeys(objA, objB, keys);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -8,7 +8,6 @@
 import { AbstractComponent, IProps, Utils as BlueprintUtils } from "@blueprintjs/core";
 import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import { ICellProps } from "./cell/cell";
@@ -320,7 +319,6 @@ export interface ITableState {
     focusedCell?: IFocusedCellCoordinates;
 }
 
-@PureRender
 @HotkeysTarget
 export class Table extends AbstractComponent<ITableProps, ITableState> {
     public static defaultProps: ITableProps = {
@@ -337,6 +335,50 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         renderRowHeader: renderDefaultRowHeader,
         selectionModes: SelectionModes.ALL,
     };
+
+    private static SHALLOWLY_COMPARABLE_PROP_KEYS = [
+        "enableFocus",
+        "allowMultipleSelection",
+        "children",
+        "fillBodyWithGhostCells",
+        "getCellClipboardData",
+        "isColumnReorderable",
+        "isColumnResizable",
+        "loadingOptions",
+        "onColumnWidthChanged",
+        "columnWidths",
+        "onColumnsReordered",
+        "isRowReorderable",
+        "isRowResizable",
+        "onRowHeightChanged",
+        "rowHeights",
+        "isRowHeaderShown",
+        "onRowsReordered",
+        "onSelection",
+        "onFocus",
+        "onCopy",
+        "renderRowHeader",
+        "renderBodyContextMenu",
+        "numRows",
+        "focusedCell",
+        // "selectedRegions" (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
+        "selectedRegionTransform",
+        "selectionModes",
+        "styledRegionGroups",
+    ];
+
+    private static SHALLOWLY_COMPARABLE_STATE_KEYS = [
+        "columnWidths",
+        "locator",
+        "isLayoutLocked",
+        "isReordering",
+        "viewportRect",
+        "verticalGuides",
+        "horizontalGuides",
+        "rowHeights",
+        // "selectedRegions" (intentionally omitted; can be deeply compared to save on re-renders in uncontrolled mode)
+        "focusedCell",
+    ];
 
     private static createColumnIdIndex(children: Array<React.ReactElement<any>>) {
         const columnIdToIndex: {[key: string]: number} = {};
@@ -392,6 +434,12 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             rowHeights: newRowHeights,
             selectedRegions,
         };
+    }
+
+    public shouldComponentUpdate(nextProps: ITableProps, nextState: ITableState) {
+        return !Utils.shallowCompareKeys(this.props, nextProps, Table.SHALLOWLY_COMPARABLE_PROP_KEYS)
+            || !Utils.shallowCompareKeys(this.state, nextState, Table.SHALLOWLY_COMPARABLE_STATE_KEYS)
+            || !Utils.deepCompareKeys(this.state, nextState, ["selectedRegions"]);
     }
 
     public componentWillReceiveProps(nextProps: ITableProps) {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -439,6 +439,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     public shouldComponentUpdate(nextProps: ITableProps, nextState: ITableState) {
         return !Utils.shallowCompareKeys(this.props, nextProps, Table.SHALLOWLY_COMPARABLE_PROP_KEYS)
             || !Utils.shallowCompareKeys(this.state, nextState, Table.SHALLOWLY_COMPARABLE_STATE_KEYS)
+            || !Utils.deepCompareKeys(this.props, nextProps, ["selectedRegions"])
             || !Utils.deepCompareKeys(this.state, nextState, ["selectedRegions"]);
     }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Fix bugs with boolean-checking and array deep-comparison in `Utils.deepCompareKeys`
- Add a custom `shouldComponentUpdate` to `Table` to deeply compare `state.selectedRegions`
    - Eliminates unnecessary re-renders when selection is disabled (before: every `mouseup` and `mousedown` with selection disabled would trigger a re-render of every cell in view, because `selectedRegions` was being continually overwritten with a new empty-array instance). 
    - Eliminates re-render on `mouseup` if one just happened on `mousedown`.
- Continues to shallowly compare every other key in `props` and `state`
