### PR TITLE
[Table] Add more checks to componentWillReceiveProps

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -549,7 +549,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    public componentDidUpdate(prevProps: ITableProps, prevState: ITableState) {
+    public componentDidUpdate() {
         const { locator } = this.state;
 
         if (locator != null) {
@@ -558,7 +558,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
 
         this.syncMenuWidth();
-        this.syncScrollPosition(prevProps, prevState);
+        this.syncScrollPosition();
     }
 
     protected validateProps(props: ITableProps & { children: React.ReactNode }) {
@@ -622,29 +622,23 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    private syncScrollPosition(_prevProps: ITableProps, prevState: ITableState) {
-        // need to be a little cute to infer how many rows and columns there were before.
-        const prevNumCols = prevState.columnWidths.length;
-        const prevNumRows = prevState.rowHeights.length;
-
-        const { numCols, numRows } = this.grid;
+    private syncScrollPosition() {
         const { viewportRect } = this.state;
 
-        const maxRowIndex = numRows - 1;
-        const maxColIndex = numCols - 1;
+        const maxRowIndex = this.grid.numRows - 1;
+        const maxColIndex = this.grid.numCols - 1;
 
-        if (numRows < prevNumRows) {
+        const tableBottom = this.grid.getCumulativeHeightAt(maxRowIndex);
+        const tableRight = this.grid.getCumulativeWidthAt(maxColIndex);
+
+        if (tableBottom < viewportRect.top + viewportRect.height) {
             // scroll the last row into view
-            const tableBottom = this.grid.getCumulativeHeightAt(maxRowIndex);
-            const tableTop = Math.max(0, tableBottom - viewportRect.height);
-            this.bodyElement.scrollTop = tableTop;
+            this.bodyElement.scrollTop = Math.max(0, tableBottom - viewportRect.height);
         }
 
-        if (numCols < prevNumCols) {
+        if (tableRight < viewportRect.left + viewportRect.width) {
             // scroll the last column into view
-            const tableRight = this.grid.getCumulativeWidthAt(maxColIndex);
-            const tableLeft = Math.max(0, tableRight - viewportRect.width);
-            this.bodyElement.scrollLeft = tableLeft;
+            this.bodyElement.scrollLeft = Math.max(0, tableRight - viewportRect.width);
         }
     }
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -558,7 +558,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
 
         this.syncMenuWidth();
-        this.syncScrollPosition();
+        this.maybeScrollTableIntoView();
     }
 
     protected validateProps(props: ITableProps & { children: React.ReactNode }) {
@@ -622,7 +622,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    private syncScrollPosition() {
+    private maybeScrollTableIntoView() {
         const { viewportRect } = this.state;
 
         const maxRowIndex = this.grid.numRows - 1;
@@ -631,15 +631,20 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const tableBottom = this.grid.getCumulativeHeightAt(maxRowIndex);
         const tableRight = this.grid.getCumulativeWidthAt(maxColIndex);
 
+        let nextScrollLeft = viewportRect.left;
+        let nextScrollTop = viewportRect.top;
+
         if (tableBottom < viewportRect.top + viewportRect.height) {
             // scroll the last row into view
-            this.bodyElement.scrollTop = Math.max(0, tableBottom - viewportRect.height);
+            nextScrollTop = Math.max(0, tableBottom - viewportRect.height);
         }
 
         if (tableRight < viewportRect.left + viewportRect.width) {
             // scroll the last column into view
-            this.bodyElement.scrollLeft = Math.max(0, tableRight - viewportRect.width);
+            nextScrollLeft = Math.max(0, tableRight - viewportRect.width);
         }
+
+        this.syncViewportPosition(nextScrollLeft, nextScrollTop);
     }
 
     private selectAll = () => {
@@ -1286,6 +1291,12 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             const scrollDelta = focusedCellBounds.right - viewportBounds.right;
             nextScrollLeft = viewportBounds.left + scrollDelta;
         }
+
+        this.syncViewportPosition(nextScrollLeft, nextScrollTop);
+    }
+
+    private syncViewportPosition(nextScrollLeft: number, nextScrollTop: number) {
+        const { viewportRect } = this.state;
 
         const didScrollTopChange = nextScrollTop !== viewportRect.top;
         const didScrollLeftChange = nextScrollLeft !== viewportRect.left;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -625,24 +625,18 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private maybeScrollTableIntoView() {
         const { viewportRect } = this.state;
 
-        const maxRowIndex = this.grid.numRows - 1;
-        const maxColIndex = this.grid.numCols - 1;
+        const tableBottom = this.grid.getCumulativeHeightAt(this.grid.numRows - 1);
+        const tableRight = this.grid.getCumulativeWidthAt(this.grid.numCols - 1);
 
-        const tableBottom = this.grid.getCumulativeHeightAt(maxRowIndex);
-        const tableRight = this.grid.getCumulativeWidthAt(maxColIndex);
-
-        let nextScrollLeft = viewportRect.left;
-        let nextScrollTop = viewportRect.top;
-
-        if (tableBottom < viewportRect.top + viewportRect.height) {
+        const nextScrollTop = (tableBottom < viewportRect.top + viewportRect.height)
             // scroll the last row into view
-            nextScrollTop = Math.max(0, tableBottom - viewportRect.height);
-        }
+            ? Math.max(0, tableBottom - viewportRect.height)
+            : viewportRect.top;
 
-        if (tableRight < viewportRect.left + viewportRect.width) {
+        const nextScrollLeft = (tableRight < viewportRect.left + viewportRect.width)
             // scroll the last column into view
-            nextScrollLeft = Math.max(0, tableRight - viewportRect.width);
-        }
+            ? Math.max(0, tableRight - viewportRect.width)
+            : viewportRect.left;
 
         this.syncViewportPosition(nextScrollLeft, nextScrollTop);
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -549,14 +549,16 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    public componentDidUpdate() {
+    public componentDidUpdate(prevProps: ITableProps, prevState: ITableState) {
         const { locator } = this.state;
+
         if (locator != null) {
             this.validateGrid();
             locator.setGrid(this.grid);
         }
 
         this.syncMenuWidth();
+        this.syncScrollPosition(prevProps, prevState);
     }
 
     protected validateProps(props: ITableProps & { children: React.ReactNode }) {
@@ -617,6 +619,32 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         if (menuElement != null && rowHeaderElement != null) {
             const width = rowHeaderElement.getBoundingClientRect().width;
             menuElement.style.width = `${width}px`;
+        }
+    }
+
+    private syncScrollPosition(_prevProps: ITableProps, prevState: ITableState) {
+        // need to be a little cute to infer how many rows and columns there were before.
+        const prevNumCols = prevState.columnWidths.length;
+        const prevNumRows = prevState.rowHeights.length;
+
+        const { numCols, numRows } = this.grid;
+        const { viewportRect } = this.state;
+
+        const maxRowIndex = numRows - 1;
+        const maxColIndex = numCols - 1;
+
+        if (numRows < prevNumRows) {
+            // scroll the last row into view
+            const tableBottom = this.grid.getCumulativeHeightAt(maxRowIndex);
+            const tableTop = Math.max(0, tableBottom - viewportRect.height);
+            this.bodyElement.scrollTop = tableTop;
+        }
+
+        if (numCols < prevNumCols) {
+            // scroll the last column into view
+            const tableRight = this.grid.getCumulativeWidthAt(maxColIndex);
+            const tableLeft = Math.max(0, tableRight - viewportRect.width);
+            this.bodyElement.scrollLeft = tableLeft;
         }
     }
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -399,6 +399,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             defaultRowHeight,
             defaultColumnWidth,
             columnWidths,
+            enableFocus,
             focusedCell,
             rowHeights,
             children,
@@ -446,7 +447,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.invalidateGrid();
         this.setState({
             columnWidths: newColumnWidths,
-            focusedCell: newFocusedCellCoordinates,
+            focusedCell: enableFocus ? newFocusedCellCoordinates : undefined,
             rowHeights: newRowHeights,
             selectedRegions: newSelectedRegions,
         });

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -405,7 +405,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             children,
             numRows,
             selectedRegions,
+            selectionModes,
         } = nextProps;
+
         const newChildArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
 
         // Try to maintain widths of columns by looking up the width of the
@@ -435,7 +437,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             // if we're in uncontrolled mode, filter out all selected regions that don't
             // fit in the current new table dimensions
             newSelectedRegions = this.state.selectedRegions.filter((region) => {
-                return Regions.isRegionValidForTable(region, numRows, numCols);
+                const regionCardinality = Regions.getRegionCardinality(region);
+                const isSelectionModeEnabled = selectionModes.indexOf(regionCardinality) >= 0;
+                return isSelectionModeEnabled && Regions.isRegionValidForTable(region, numRows, numCols);
             });
         }
         const newFocusedCellCoordinates = (focusedCell == null)

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -740,7 +740,7 @@ describe("<Table>", () => {
         }
 
         function scrollTable(table: ReactWrapper<any, {}>, scrollLeft: number, scrollTop: number) {
-            // make the viewport large enough to fit a single cell in view
+            // make the viewport small enough to fit only one cell
             updateLocatorBodyElement(table,
                 scrollLeft,
                 scrollTop,
@@ -859,17 +859,17 @@ describe("<Table>", () => {
     }
 
     function updateLocatorBodyElement(table: ReactWrapper<any, {}>,
-                                      left: number,
-                                      top: number,
-                                      width: number,
-                                      height: number) {
+                                      scrollLeft: number,
+                                      scrollTop: number,
+                                      clientWidth: number,
+                                      clientHeight: number) {
         // bodyElement is private, so we need to cast as `any` to access it
         (table.state("locator") as any).bodyElement = {
-            clientHeight: height,
-            clientWidth: width,
+            clientHeight,
+            clientWidth,
             getBoundingClientRect: () => ({ left: 0, top: 0 }),
-            scrollLeft: left,
-            scrollTop: top,
+            scrollLeft,
+            scrollTop,
         };
     }
 });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -664,72 +664,60 @@ describe("<Table>", () => {
     });
 
     describe("Autoscrolling when rows/columns decrease in count or size", () => {
-        const ROW_HEIGHT = 60;
         const COL_WIDTH = 400;
+        const ROW_HEIGHT = 60;
 
-        it.only("when column count decreases", () => {
-            const NUM_COLS = 10;
-            const NUM_ROWS = 1; // we're testing only one dimension at a time
-            const LAST_COL_INDEX = NUM_COLS - 1;
+        const NUM_COLS = 10;
+        const NUM_ROWS = 10;
 
-            const table = mountTable(NUM_COLS, NUM_ROWS);
-            scrollTable(table, LAST_COL_INDEX * COL_WIDTH, 0);
+        const UPDATED_NUM_COLS = NUM_COLS - 1;
+        const UPDATED_NUM_ROWS = NUM_ROWS - 1;
 
-            const NEW_NUM_COLS = NUM_COLS - 1;
-            const newColumns = renderColumns(NEW_NUM_COLS);
+        // small, 1px tweaks that keep the entire table larger than the viewport but that also
+        // require autoscrolling
+        const UPDATED_COL_WIDTH = COL_WIDTH - 1;
+        const UPDATED_ROW_HEIGHT = ROW_HEIGHT - 1;
+
+        it("when column count decreases", () => {
+            const table = mountTable(NUM_COLS, 1);
+            scrollTable(table, (NUM_COLS - 1) * COL_WIDTH, 0);
+
+            const newColumns = renderColumns(UPDATED_NUM_COLS);
             table.setProps({ children: newColumns });
 
             // the viewport should have auto-scrolled to fit the last column in view
             const viewportRect = table.state("viewportRect");
-            expect(viewportRect.left).to.equal((NEW_NUM_COLS * COL_WIDTH) - viewportRect.width);
+            expect(viewportRect.left).to.equal((UPDATED_NUM_COLS * COL_WIDTH) - viewportRect.width);
         });
 
-        it.only("when row count decreases", () => {
-            const NUM_COLS = 1;
-            const NUM_ROWS = 10;
-            const LAST_ROW_INDEX = NUM_ROWS - 1;
+        it("when row count decreases", () => {
+            const table = mountTable(1, NUM_ROWS);
+            scrollTable(table, 0, (NUM_ROWS - 1) * ROW_HEIGHT);
 
-            const table = mountTable(NUM_COLS, NUM_ROWS);
-            scrollTable(table, 0, LAST_ROW_INDEX * ROW_HEIGHT);
+            table.setProps({ numRows: UPDATED_NUM_ROWS });
 
-            const NEW_NUM_ROWS = NUM_ROWS - 1;
-            table.setProps({ numRows: NEW_NUM_ROWS });
-
-            // the viewport should have auto-scrolled to fit the last row in view
             const viewportRect = table.state("viewportRect");
-            expect(viewportRect.top).to.equal((NEW_NUM_ROWS * ROW_HEIGHT) - viewportRect.height);
+            expect(viewportRect.top).to.equal((UPDATED_NUM_ROWS * ROW_HEIGHT) - viewportRect.height);
         });
 
-        it.only("when column widths decrease", () => {
-            const NUM_COLS = 10;
-            const NUM_ROWS = 1;
-            const LAST_COL_INDEX = NUM_COLS - 1;
+        it("when column widths decrease", () => {
+            const table = mountTable(NUM_COLS, 1);
+            scrollTable(table, (NUM_COLS - 1) * COL_WIDTH, 0);
 
-            const table = mountTable(NUM_COLS, NUM_ROWS);
-            scrollTable(table, LAST_COL_INDEX * COL_WIDTH, 0);
-
-            // a small tweak that keeps the table wider than the viewport but also requires autoscrolling
-            const NEW_COL_WIDTH = COL_WIDTH - 1;
-            table.setProps({ columnWidths: Array(NUM_COLS).fill(NEW_COL_WIDTH) });
+            table.setProps({ columnWidths: Array(NUM_COLS).fill(UPDATED_COL_WIDTH) });
 
             const viewportRect = table.state("viewportRect");
-            expect(viewportRect.left).to.equal((NUM_COLS * NEW_COL_WIDTH) - viewportRect.width);
+            expect(viewportRect.left).to.equal((NUM_COLS * UPDATED_COL_WIDTH) - viewportRect.width);
         });
 
-        it.only("when row heights decrease", () => {
-            const NUM_COLS = 1;
-            const NUM_ROWS = 10;
-            const LAST_ROW_INDEX = NUM_ROWS - 1;
+        it("when row heights decrease", () => {
+            const table = mountTable(1, NUM_ROWS);
+            scrollTable(table, 0, (NUM_ROWS - 1) * ROW_HEIGHT);
 
-            const table = mountTable(NUM_COLS, NUM_ROWS);
-            scrollTable(table, 0, LAST_ROW_INDEX * ROW_HEIGHT);
-
-            // again, a small tweak
-            const NEW_ROW_HEIGHT = ROW_HEIGHT - 1;
-            table.setProps({ rowHeights: Array(NUM_ROWS).fill(NEW_ROW_HEIGHT) });
+            table.setProps({ rowHeights: Array(NUM_ROWS).fill(UPDATED_ROW_HEIGHT) });
 
             const viewportRect = table.state("viewportRect");
-            expect(viewportRect.top).to.equal((NUM_ROWS * NEW_ROW_HEIGHT) - viewportRect.height);
+            expect(viewportRect.top).to.equal((NUM_ROWS * UPDATED_ROW_HEIGHT) - viewportRect.height);
         });
 
         function mountTable(numCols: number, numRows: number) {
@@ -752,6 +740,7 @@ describe("<Table>", () => {
         }
 
         function scrollTable(table: ReactWrapper<any, {}>, scrollLeft: number, scrollTop: number) {
+            // make the viewport large enough to fit a single cell in view
             updateLocatorBodyElement(table,
                 scrollLeft,
                 scrollTop,

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -170,10 +170,14 @@ describe("<Table>", () => {
     });
 
     it("Leaves controlled selected region if selectionModes change to make it invalid", () => {
-        const table = mount(<Table
-            selectionModes={[RegionCardinality.FULL_COLUMNS]}
-            selectedRegions={[Regions.column(0)]}
-        ><Column /></Table>);
+        const table = mount(
+            <Table
+                selectionModes={[RegionCardinality.FULL_COLUMNS]}
+                selectedRegions={[Regions.column(0)]}
+            >
+                <Column />
+            </Table>,
+        );
         table.setProps({ selectionModes: [] });
         expect(table.state("selectedRegions").length).to.equal(1);
     });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -433,6 +433,14 @@ describe("<Table>", () => {
             onFocus = sinon.spy();
         });
 
+        it("removes the focused cell if enableFocus is reset to false", () => {
+            const { component } = mountTable();
+            const focusCellSelector = `.${Classes.TABLE_FOCUS_REGION}`;
+            expect(component.find(focusCellSelector).exists()).to.be.true;
+            component.setProps({ enableFocus: false });
+            expect(component.find(focusCellSelector).exists()).to.be.false;
+        });
+
         describe("moves a focus cell with arrow keys", () => {
             runFocusCellMoveTest("up", Keys.ARROW_UP, { row: 0, col: 1 });
             runFocusCellMoveTest("down", Keys.ARROW_DOWN, { row: 2, col: 1 });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -17,9 +17,9 @@ import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import { Rect } from "../src/common/rect";
 import { Regions } from "../src/regions";
+import { TableBody } from "../src/tableBody";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 import { ElementHarness, ReactHarness } from "./harness";
-import { TableBody } from "../src/tableBody";
 
 describe("<Table>", () => {
     const harness = new ReactHarness();

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import { Keys } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/core/test/common/utils";
-import { Cell, Column, Grid, ITableProps, Table, TableLoadingOption, Utils } from "../src";
+import { Cell, Column, Grid, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import { Rect } from "../src/common/rect";
@@ -160,6 +160,22 @@ describe("<Table>", () => {
         const menu = table.find(`.${Classes.TABLE_MENU}`);
         menu.mouse("click");
         expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
+    });
+
+    it("Removes uncontrolled selected region if selectionModes change to make it invalid", () => {
+        const table = mount(<Table selectionModes={[RegionCardinality.FULL_COLUMNS]}><Column /></Table>);
+        table.setState({ selectedRegions: [Regions.column(0)] });
+        table.setProps({ selectionModes: [] });
+        expect(table.state("selectedRegions").length).to.equal(0);
+    });
+
+    it("Leaves controlled selected region if selectionModes change to make it invalid", () => {
+        const table = mount(<Table
+            selectionModes={[RegionCardinality.FULL_COLUMNS]}
+            selectedRegions={[Regions.column(0)]}
+        ><Column /></Table>);
+        table.setProps({ selectionModes: [] });
+        expect(table.state("selectedRegions").length).to.equal(1);
     });
 
     describe("Resizing", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -667,7 +667,7 @@ describe("<Table>", () => {
         const ROW_HEIGHT = 60;
         const COL_WIDTH = 400;
 
-        it.only("when number of columns decreases such that they are now out of view", () => {
+        it.only("when column count decreases", () => {
             const NUM_COLS = 10;
             const NUM_ROWS = 1; // we're testing only one dimension at a time
             const LAST_COL_INDEX = NUM_COLS - 1;
@@ -675,27 +675,61 @@ describe("<Table>", () => {
             const table = mountTable(NUM_COLS, NUM_ROWS);
             scrollTable(table, LAST_COL_INDEX * COL_WIDTH, 0);
 
-            const newColumns = renderColumns(NUM_COLS - 1);
-            const NEW_LAST_COL_INDEX = newColumns.length - 1;
+            const NEW_NUM_COLS = NUM_COLS - 1;
+            const newColumns = renderColumns(NEW_NUM_COLS);
             table.setProps({ children: newColumns });
 
-            // the viewport should have auto-scrolled to fit the last column in view.
-            expect(table.state("viewportRect").left).to.equal(NEW_LAST_COL_INDEX * COL_WIDTH);
+            // the viewport should have auto-scrolled to fit the last column in view
+            const viewportRect = table.state("viewportRect");
+            expect(viewportRect.left).to.equal((NEW_NUM_COLS * COL_WIDTH) - viewportRect.width);
         });
 
-        it.only("when number of rows decreases such that they are now out of view", () => {
-            const NUM_COLS = 1; // we're testing only one dimension at a time
+        it.only("when row count decreases", () => {
+            const NUM_COLS = 1;
             const NUM_ROWS = 10;
             const LAST_ROW_INDEX = NUM_ROWS - 1;
 
             const table = mountTable(NUM_COLS, NUM_ROWS);
             scrollTable(table, 0, LAST_ROW_INDEX * ROW_HEIGHT);
 
-            table.setProps({ numRows: NUM_ROWS - 1 });
-            const NEW_LAST_ROW_INDEX = LAST_ROW_INDEX - 1;
+            const NEW_NUM_ROWS = NUM_ROWS - 1;
+            table.setProps({ numRows: NEW_NUM_ROWS });
 
-            // the viewport should have auto-scrolled to fit the last row in view.
-            expect(table.state("viewportRect").top).to.equal(NEW_LAST_ROW_INDEX * ROW_HEIGHT);
+            // the viewport should have auto-scrolled to fit the last row in view
+            const viewportRect = table.state("viewportRect");
+            expect(viewportRect.top).to.equal((NEW_NUM_ROWS * ROW_HEIGHT) - viewportRect.height);
+        });
+
+        it.only("when column widths decrease", () => {
+            const NUM_COLS = 10;
+            const NUM_ROWS = 1;
+            const LAST_COL_INDEX = NUM_COLS - 1;
+
+            const table = mountTable(NUM_COLS, NUM_ROWS);
+            scrollTable(table, LAST_COL_INDEX * COL_WIDTH, 0);
+
+            // a small tweak that keeps the table wider than the viewport but also requires autoscrolling
+            const NEW_COL_WIDTH = COL_WIDTH - 1;
+            table.setProps({ columnWidths: Array(NUM_COLS).fill(NEW_COL_WIDTH) });
+
+            const viewportRect = table.state("viewportRect");
+            expect(viewportRect.left).to.equal((NUM_COLS * NEW_COL_WIDTH) - viewportRect.width);
+        });
+
+        it.only("when row heights decrease", () => {
+            const NUM_COLS = 1;
+            const NUM_ROWS = 10;
+            const LAST_ROW_INDEX = NUM_ROWS - 1;
+
+            const table = mountTable(NUM_COLS, NUM_ROWS);
+            scrollTable(table, 0, LAST_ROW_INDEX * ROW_HEIGHT);
+
+            // again, a small tweak
+            const NEW_ROW_HEIGHT = ROW_HEIGHT - 1;
+            table.setProps({ rowHeights: Array(NUM_ROWS).fill(NEW_ROW_HEIGHT) });
+
+            const viewportRect = table.state("viewportRect");
+            expect(viewportRect.top).to.equal((NUM_ROWS * NEW_ROW_HEIGHT) - viewportRect.height);
         });
 
         function mountTable(numCols: number, numRows: number) {


### PR DESCRIPTION
#### Fixes #533

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Added a few checks to `componentWillReceiveProps` to leave the table in a good state post-update: 
- If `enableFocus` toggles from `true` to `false`, clear the focused cell.
- If `selectionModes` changes, clear selected regions having cardinalities that are no longer selectable.
- If the number of rows or columns decreases, auto-scroll to the last row/column to keep it visible.
- If the number of row widths or column heights decrease, auto-scroll to the last row/column to keep it visible.

#### Reviewers should focus on:

- I can add more checks later.