### PR TITLE
[Table] Have focused cell follow selection if allowMultipleSelection=false

### DIFF
--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -178,6 +178,13 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
             return;
         }
         this.props.onSelection(nextSelectedRegions);
+
+        if (!this.props.allowMultipleSelection) {
+            // have the focused cell follow the selected region
+            const mostRecentRegion = nextSelectedRegions[nextSelectedRegions.length - 1];
+            const focusCellCoordinates = DragSelectable.getFocusCellCoordinatesFromRegion(mostRecentRegion);
+            this.props.onFocus(focusCellCoordinates);
+        }
     }
 
     private handleDragEnd = (event: MouseEvent, coords: ICoordinateData) => {

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -156,6 +156,39 @@ describe("DragSelectable", () => {
         expect(onFocus.args[0][0]).to.deep.equal({col: 2, row: 0});
     });
 
+    it("moves focus cell with dragging selection when allowMultipleSelection=false", () => {
+        const onFocus = sinon.spy();
+        const locateClick = sinon.stub();
+
+        locateClick.onCall(0).returns(Regions.column(0));
+        locateClick.onCall(1).returns(Regions.column(1));
+        locateClick.onCall(2).returns(Regions.column(2));
+        locateClick.onCall(3).returns(Regions.column(2));
+
+        const selectable = harness.mount(
+            <DragSelectable
+                allowMultipleSelection={false}
+                selectedRegions={[]}
+                onFocus={onFocus}
+                onSelection={sinon.stub()}
+                locateClick={locateClick}
+                locateDrag={sinon.stub()}
+            >
+                {children}
+            </DragSelectable>,
+        );
+
+        selectable.find(".selectable", 0).mouse("mousedown");
+        selectable.find(".selectable", 1).mouse("mousemove");
+        selectable.find(".selectable", 2).mouse("mousemove").mouse("mouseup");
+
+        expect(onFocus.callCount).to.equal(4);
+        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0});
+        expect(onFocus.args[1][0]).to.deep.equal({col: 1, row: 0});
+        expect(onFocus.args[2][0]).to.deep.equal({col: 2, row: 0});
+        expect(onFocus.args[3][0]).to.deep.equal({col: 2, row: 0});
+    });
+
     it("re-select clears region", () => {
         const onSelection = sinon.spy();
         const onFocus = sinon.spy();


### PR DESCRIPTION
#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

If `allowMultipleSelection={false}`, then drag-selecting will simply move a single-cell/single-row/single-column selection around to follow your cursor. Now assume `enableFocus={true}` when you do that.

_Before:_
The focus cell stays put on drag in spite of your moving selection.

![2017-05-31 09 10 17](https://cloud.githubusercontent.com/assets/443450/26641967/ff6d8ac6-45e0-11e7-8409-38d78955b9df.gif)

_After:_
The focus cell moves with the selection on drag (except when you select the `FULL_TABLE` on click, in which case the existing code does not move the focus cell - which is a separate bug!).

![2017-05-31 09 02 21](https://cloud.githubusercontent.com/assets/443450/26641682/3968c818-45e0-11e7-8b6e-abc22807b127.gif)

#### Reviewers should focus on:

- Does this behavior feel more correct that the previous behavior?
