### PR TITLE
Fix build!

### DIFF
--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -165,7 +165,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         if (!this.props.allowMultipleSelection) {
             // have the focused cell follow the selected region
             const mostRecentRegion = nextSelectedRegions[nextSelectedRegions.length - 1];
-            const focusCellCoordinates = DragSelectable.getFocusCellCoordinatesFromRegion(mostRecentRegion);
+            const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(mostRecentRegion);
             this.props.onFocus(focusCellCoordinates);
         }
     }


### PR DESCRIPTION
Two PRs recently merged (#1171, #1172), one that moved a function to a different file, one that referenced the function in its old position. Neither failed the build by itself, but together, they've broken the build on `master`.

This fixes that.