### PR TITLE
[Table] Refactor Utils.shallowCompareKeys to accept whitelist OR blacklist

### DIFF
--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -65,7 +65,7 @@ export class Cell extends React.Component<ICellProps, {}> {
 
     public shouldComponentUpdate(nextProps: ICellProps) {
         // deeply compare "style," because a new but identical object might have been provided.
-        return !Utils.shallowCompareKeys<ICellProps>(this.props, nextProps, { exclude: ["style"] })
+        return !Utils.shallowCompareKeys(this.props, nextProps, { exclude: ["style"] })
             || !Utils.deepCompareKeys(this.props.style, nextProps.style);
     }
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -53,19 +53,6 @@ export interface ICellProps extends IIntentProps, IProps {
     wrapText?: boolean;
 }
 
-// don't include "style" in here because it can't be shallowly compared
-// ordered with children and className first, since these are most likely to change
-const UPDATE_PROPS_KEYS = [
-    "children",
-    "className",
-    "intent",
-    "interactive",
-    "loading",
-    "tooltip",
-    "truncated",
-    "wrapText",
-];
-
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
 
 export const emptyCellRenderer = () => <Cell />;
@@ -77,7 +64,8 @@ export class Cell extends React.Component<ICellProps, {}> {
     };
 
     public shouldComponentUpdate(nextProps: ICellProps) {
-        return !Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS)
+        // deeply compare "style," because a new but identical object might have been provided.
+        return !Utils.shallowCompareKeys<ICellProps>(this.props, nextProps, { exclude: ["style"] })
             || !Utils.deepCompareKeys(this.props.style, nextProps.style);
     }
 

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -12,7 +12,7 @@ import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
-import { HeaderCell, IHeaderCellProps } from "./headerCell";
+import { HeaderCell, IHeaderCellProps, IInternalHeaderCellProps } from "./headerCell";
 
 export interface IColumnNameProps {
     /**
@@ -90,17 +90,17 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
     private static SHALLOWLY_COMPARABLE_PROP_KEYS = [
         "children",
         "className",
-        "name",
-        "renderName",
-        "useInteractionBar",
         "isActive",
-        "isColumnReorderable",
-        "isColumnSelected",
+        "isReorderable",
+        "isSelected",
         "loading",
         "menu",
         "menuIconName",
+        "name",
+        "renderName",
         "resizeHandle",
-    ];
+        "useInteractionBar",
+    ] as Array<keyof IInternalHeaderCellProps>;
 
     public render() {
         const {

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -87,19 +87,8 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
             || target.classList.contains(Classes.TABLE_HEADER_CONTENT);
     }
 
-    private static SHALLOWLY_COMPARABLE_PROP_KEYS = [
-        "children",
-        "className",
-        "isActive",
-        "isReorderable",
-        "isSelected",
-        "loading",
-        "menu",
-        "menuIconName",
-        "name",
-        "renderName",
-        "resizeHandle",
-        "useInteractionBar",
+    private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
+        "style",
     ] as Array<keyof IInternalHeaderCellProps>;
 
     public render() {
@@ -118,11 +107,13 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
             ...spreadableProps,
         } = this.props;
 
+        const propKeysBlacklist = { exclude: ColumnHeaderCell.SHALLOW_COMPARE_PROP_KEYS_BLACKLIST };
+
         return (
             <HeaderCell
                 isReorderable={this.props.isColumnReorderable}
                 isSelected={this.props.isColumnSelected}
-                shallowlyComparablePropKeys={ColumnHeaderCell.SHALLOWLY_COMPARABLE_PROP_KEYS}
+                shallowlyComparablePropKeysList={propKeysBlacklist}
                 {...spreadableProps}
             >
                 {this.renderName()}

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 
 import { Classes as CoreClasses, ContextMenuTarget, IProps } from "@blueprintjs/core";
 import * as Classes from "../common/classes";
-import { Utils } from "../common/utils";
+import { IKeyBlacklist, IKeyWhitelist, Utils } from "../common/utils";
 import { ResizeHandle } from "../interactions/resizeHandle";
 
 export interface IHeaderCellProps extends IProps {
@@ -65,7 +65,7 @@ export interface IInternalHeaderCellProps extends IHeaderCellProps {
     /**
      * Props that should be shallowly compared in shouldComponentUpdate.
      */
-    shallowlyComparablePropKeys?: Array<keyof IInternalHeaderCellProps>;
+    shallowlyComparablePropKeysList?: IKeyBlacklist<IInternalHeaderCellProps> | IKeyWhitelist<IInternalHeaderCellProps>;
 }
 
 export interface IHeaderCellState {
@@ -79,8 +79,8 @@ export class HeaderCell extends React.Component<IInternalHeaderCellProps, IHeade
     };
 
     public shouldComponentUpdate(nextProps: IHeaderCellProps) {
-        const propKeysWhitelist = { include: this.props.shallowlyComparablePropKeys };
-        return !Utils.shallowCompareKeys<IInternalHeaderCellProps>(this.props, nextProps, propKeysWhitelist)
+        const propKeysList = this.props.shallowlyComparablePropKeysList;
+        return !Utils.shallowCompareKeys(this.props, nextProps, propKeysList)
             || !Utils.deepCompareKeys(this.props.style, nextProps.style);
     }
 

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -65,7 +65,7 @@ export interface IInternalHeaderCellProps extends IHeaderCellProps {
     /**
      * Props that should be shallowly compared in shouldComponentUpdate.
      */
-    shallowlyComparablePropKeys?: string[];
+    shallowlyComparablePropKeys?: Array<keyof IInternalHeaderCellProps>;
 }
 
 export interface IHeaderCellState {
@@ -73,13 +73,14 @@ export interface IHeaderCellState {
 }
 
 @ContextMenuTarget
-export class HeaderCell  extends React.Component<IInternalHeaderCellProps, IHeaderCellState> {
+export class HeaderCell extends React.Component<IInternalHeaderCellProps, IHeaderCellState> {
     public state: IHeaderCellState = {
         isActive: false,
     };
 
     public shouldComponentUpdate(nextProps: IHeaderCellProps) {
-        return !Utils.shallowCompareKeys(this.props, nextProps, this.props.shallowlyComparablePropKeys)
+        const propKeysWhitelist = { include: this.props.shallowlyComparablePropKeys };
+        return !Utils.shallowCompareKeys<IInternalHeaderCellProps>(this.props, nextProps, propKeysWhitelist)
             || !Utils.deepCompareKeys(this.props.style, nextProps.style);
     }
 

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -27,16 +27,8 @@ export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
 }
 
 export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
-    private static SHALLOWLY_COMPARABLE_PROP_KEYS = [
-        "children",
-        "className",
-        "isActive",
-        "isReorderable",
-        "isSelected",
-        "loading",
-        "menu",
-        "name",
-        "resizeHandle",
+    private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
+        "style",
     ] as Array<keyof IInternalHeaderCellProps>;
 
     public render() {
@@ -53,11 +45,13 @@ export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
             ...spreadableProps,
         } = this.props;
 
+        const propKeysBlacklist = { exclude: RowHeaderCell.SHALLOW_COMPARE_PROP_KEYS_BLACKLIST };
+
         return (
             <HeaderCell
                 isReorderable={this.props.isRowReorderable}
                 isSelected={this.props.isRowSelected}
-                shallowlyComparablePropKeys={RowHeaderCell.SHALLOWLY_COMPARABLE_PROP_KEYS}
+                shallowlyComparablePropKeysList={propKeysBlacklist}
                 {...spreadableProps}
             >
                 <div className={Classes.TABLE_ROW_NAME}>

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -12,7 +12,7 @@ import { IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
-import { HeaderCell, IHeaderCellProps } from "./headerCell";
+import { HeaderCell, IHeaderCellProps, IInternalHeaderCellProps } from "./headerCell";
 
 export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
     /**
@@ -31,13 +31,13 @@ export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
         "children",
         "className",
         "isActive",
-        "isRowReorderable",
-        "isRowSelected",
-        "name",
+        "isReorderable",
+        "isSelected",
         "loading",
         "menu",
+        "name",
         "resizeHandle",
-    ];
+    ] as Array<keyof IInternalHeaderCellProps>;
 
     public render() {
         const loadableContentDivClasses = classNames(

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -149,7 +149,7 @@ export class Draggable extends React.Component<IDraggableProps, {}> {
 
     public componentWillReceiveProps(nextProps: IDraggableProps) {
         const propsWhitelist = { include: REATTACH_PROPS_KEYS };
-        if (this.events && !Utils.shallowCompareKeys<IDraggableProps>(this.props, nextProps, propsWhitelist)) {
+        if (this.events && !Utils.shallowCompareKeys(this.props, nextProps, propsWhitelist)) {
             this.events.attach(ReactDOM.findDOMNode(this) as HTMLElement, nextProps);
         }
     }

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -107,7 +107,7 @@ export interface IDraggableProps extends IProps, IDragHandler {
 const REATTACH_PROPS_KEYS = [
     "stopPropagation",
     "preventDefault",
-];
+] as Array<keyof IDraggableProps>;
 
 /**
  * This component provides a simple interface for combined drag and/or click
@@ -148,7 +148,8 @@ export class Draggable extends React.Component<IDraggableProps, {}> {
     }
 
     public componentWillReceiveProps(nextProps: IDraggableProps) {
-        if (this.events && !Utils.shallowCompareKeys(this.props, nextProps, REATTACH_PROPS_KEYS)) {
+        const propsWhitelist = { include: REATTACH_PROPS_KEYS };
+        if (this.events && !Utils.shallowCompareKeys<IDraggableProps>(this.props, nextProps, propsWhitelist)) {
             this.events.attach(ReactDOM.findDOMNode(this) as HTMLElement, nextProps);
         }
     }

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -30,7 +30,7 @@ export interface IRegionLayerProps extends IProps {
 // don't include "regions" or "regionStyles" in here, because they can't be shallowly compared
 const UPDATE_PROPS_KEYS = [
     "className",
-];
+] as Array<keyof IRegionLayerProps>;
 
 export class RegionLayer extends React.Component<IRegionLayerProps, {}> {
     public shouldComponentUpdate(nextProps: IRegionLayerProps) {
@@ -39,7 +39,7 @@ export class RegionLayer extends React.Component<IRegionLayerProps, {}> {
         // altogether.
         return !Utils.arraysEqual(this.props.regions, nextProps.regions, Regions.regionsEqual)
             || !Utils.arraysEqual(this.props.regionStyles, nextProps.regionStyles, Utils.shallowCompareKeys)
-            || !Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS);
+            || !Utils.shallowCompareKeys<IRegionLayerProps>(this.props, nextProps, { include: UPDATE_PROPS_KEYS });
     }
 
     public render() {

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -39,7 +39,7 @@ export class RegionLayer extends React.Component<IRegionLayerProps, {}> {
         // altogether.
         return !Utils.arraysEqual(this.props.regions, nextProps.regions, Regions.regionsEqual)
             || !Utils.arraysEqual(this.props.regionStyles, nextProps.regionStyles, Utils.shallowCompareKeys)
-            || !Utils.shallowCompareKeys<IRegionLayerProps>(this.props, nextProps, { include: UPDATE_PROPS_KEYS });
+            || !Utils.shallowCompareKeys(this.props, nextProps, { include: UPDATE_PROPS_KEYS });
     }
 
     public render() {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -365,7 +365,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         "selectedRegionTransform",
         "selectionModes",
         "styledRegionGroups",
-    ];
+    ] as Array<keyof ITableProps>;
 
     private static SHALLOWLY_COMPARABLE_STATE_KEYS = [
         "columnWidths",
@@ -378,7 +378,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         "rowHeights",
         // "selectedRegions" (intentionally omitted; can be deeply compared to save on re-renders in uncontrolled mode)
         "focusedCell",
-    ];
+    ] as Array<keyof ITableState>;
 
     private static createColumnIdIndex(children: Array<React.ReactElement<any>>) {
         const columnIdToIndex: {[key: string]: number} = {};
@@ -437,8 +437,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     public shouldComponentUpdate(nextProps: ITableProps, nextState: ITableState) {
-        return !Utils.shallowCompareKeys(this.props, nextProps, Table.SHALLOWLY_COMPARABLE_PROP_KEYS)
-            || !Utils.shallowCompareKeys(this.state, nextState, Table.SHALLOWLY_COMPARABLE_STATE_KEYS)
+        const propKeysWhitelist = { include: Table.SHALLOWLY_COMPARABLE_PROP_KEYS };
+        const stateKeysWhitelist = { include: Table.SHALLOWLY_COMPARABLE_STATE_KEYS };
+
+        return !Utils.shallowCompareKeys<ITableProps>(this.props, nextProps, propKeysWhitelist)
+            || !Utils.shallowCompareKeys<ITableState>(this.state, nextState, stateKeysWhitelist)
             || !Utils.deepCompareKeys(this.props, nextProps, ["selectedRegions"])
             || !Utils.deepCompareKeys(this.state, nextState, ["selectedRegions"]);
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -336,48 +336,12 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         selectionModes: SelectionModes.ALL,
     };
 
-    private static SHALLOWLY_COMPARABLE_PROP_KEYS = [
-        "enableFocus",
-        "allowMultipleSelection",
-        "children",
-        "fillBodyWithGhostCells",
-        "getCellClipboardData",
-        "isColumnReorderable",
-        "isColumnResizable",
-        "loadingOptions",
-        "onColumnWidthChanged",
-        "columnWidths",
-        "onColumnsReordered",
-        "isRowReorderable",
-        "isRowResizable",
-        "onRowHeightChanged",
-        "rowHeights",
-        "isRowHeaderShown",
-        "onRowsReordered",
-        "onSelection",
-        "onFocus",
-        "onCopy",
-        "renderRowHeader",
-        "renderBodyContextMenu",
-        "numRows",
-        "focusedCell",
-        // "selectedRegions" (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
-        "selectedRegionTransform",
-        "selectionModes",
-        "styledRegionGroups",
+    private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
+        "selectedRegions" // (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
     ] as Array<keyof ITableProps>;
 
-    private static SHALLOWLY_COMPARABLE_STATE_KEYS = [
-        "columnWidths",
-        "locator",
-        "isLayoutLocked",
-        "isReordering",
-        "viewportRect",
-        "verticalGuides",
-        "horizontalGuides",
-        "rowHeights",
-        // "selectedRegions" (intentionally omitted; can be deeply compared to save on re-renders in uncontrolled mode)
-        "focusedCell",
+    private static SHALLOW_COMPARE_STATE_KEYS_BLACKLIST = [
+        "selectedRegions", // (intentionally omitted; can be deeply compared to save on re-renders in uncontrolled mode)
     ] as Array<keyof ITableState>;
 
     private static createColumnIdIndex(children: Array<React.ReactElement<any>>) {
@@ -437,11 +401,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     public shouldComponentUpdate(nextProps: ITableProps, nextState: ITableState) {
-        const propKeysWhitelist = { include: Table.SHALLOWLY_COMPARABLE_PROP_KEYS };
-        const stateKeysWhitelist = { include: Table.SHALLOWLY_COMPARABLE_STATE_KEYS };
+        const propKeysBlacklist = { exclude: Table.SHALLOW_COMPARE_PROP_KEYS_BLACKLIST };
+        const stateKeysBlacklist = { exclude: Table.SHALLOW_COMPARE_STATE_KEYS_BLACKLIST };
 
-        return !Utils.shallowCompareKeys<ITableProps>(this.props, nextProps, propKeysWhitelist)
-            || !Utils.shallowCompareKeys<ITableState>(this.state, nextState, stateKeysWhitelist)
+        return !Utils.shallowCompareKeys<ITableProps>(this.props, nextProps, propKeysBlacklist)
+            || !Utils.shallowCompareKeys<ITableState>(this.state, nextState, stateKeysBlacklist)
             || !Utils.deepCompareKeys(this.props, nextProps, ["selectedRegions"])
             || !Utils.deepCompareKeys(this.state, nextState, ["selectedRegions"]);
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -337,7 +337,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     };
 
     private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
-        "selectedRegions" // (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
+        "selectedRegions", // (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
     ] as Array<keyof ITableProps>;
 
     private static SHALLOW_COMPARE_STATE_KEYS_BLACKLIST = [

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -336,6 +336,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         selectionModes: SelectionModes.ALL,
     };
 
+    // these blacklists are identical, but we still need two definitions due to the different typings
+
     private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
         "selectedRegions", // (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
     ] as Array<keyof ITableProps>;
@@ -404,8 +406,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const propKeysBlacklist = { exclude: Table.SHALLOW_COMPARE_PROP_KEYS_BLACKLIST };
         const stateKeysBlacklist = { exclude: Table.SHALLOW_COMPARE_STATE_KEYS_BLACKLIST };
 
-        return !Utils.shallowCompareKeys<ITableProps>(this.props, nextProps, propKeysBlacklist)
-            || !Utils.shallowCompareKeys<ITableState>(this.state, nextState, stateKeysBlacklist)
+        return !Utils.shallowCompareKeys(this.props, nextProps, propKeysBlacklist)
+            || !Utils.shallowCompareKeys(this.state, nextState, stateKeysBlacklist)
             || !Utils.deepCompareKeys(this.props, nextProps, ["selectedRegions"])
             || !Utils.deepCompareKeys(this.state, nextState, ["selectedRegions"]);
     }

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -98,7 +98,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
 
     public shouldComponentUpdate(nextProps: ITableBodyProps) {
         const propKeysWhitelist = { include: UPDATE_PROPS_KEYS };
-        const shallowEqual = Utils.shallowCompareKeys<ITableBodyProps>(this.props, nextProps, propKeysWhitelist);
+        const shallowEqual = Utils.shallowCompareKeys(this.props, nextProps, propKeysWhitelist);
         return !shallowEqual;
     }
 

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -72,7 +72,7 @@ const UPDATE_PROPS_KEYS = [
     "columnIndexStart",
     "columnIndexEnd",
     "selectedRegions",
-];
+] as Array<keyof ITableBodyProps>;
 
 export class TableBody extends React.Component<ITableBodyProps, {}> {
     public static defaultProps = {
@@ -97,7 +97,8 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
     private activationCell: ICellCoordinates;
 
     public shouldComponentUpdate(nextProps: ITableBodyProps) {
-        const shallowEqual = Utils.shallowCompareKeys(this.props, nextProps, UPDATE_PROPS_KEYS);
+        const propKeysWhitelist = { include: UPDATE_PROPS_KEYS };
+        const shallowEqual = Utils.shallowCompareKeys<ITableBodyProps>(this.props, nextProps, propKeysWhitelist);
         return !shallowEqual;
     }
 

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -402,10 +402,10 @@ describe("Utils", () => {
 
     describe("shallowCompareKeys", () => {
         interface IKeys {
-            a?: string;
-            b?: string;
-            c?: string;
-            d?: string;
+            a?: any;
+            b?: any;
+            c?: any;
+            d?: any;
         }
 
         describe("with `keys` defined as whitelist", () => {
@@ -439,7 +439,7 @@ describe("Utils", () => {
                              b: any,
                              keys: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
                 it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
-                    expect(Utils.shallowCompareKeys<IKeys>(a, b, keys)).to.equal(expectedResult);
+                    expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
                 });
             }
         });
@@ -475,7 +475,7 @@ describe("Utils", () => {
                              b: any,
                              keys: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
                 it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
-                    expect(Utils.shallowCompareKeys<IKeys>(a, b, keys)).to.equal(expectedResult);
+                    expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
                 });
             }
         });
@@ -509,7 +509,7 @@ describe("Utils", () => {
 
             function runTest(expectedResult: boolean, a: any, b: any) {
                 it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
-                    expect(Utils.shallowCompareKeys<IKeys>(a, b)).to.equal(expectedResult);
+                    expect(Utils.shallowCompareKeys(a, b)).to.equal(expectedResult);
                 });
             }
         });

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from "chai";
-import { Utils } from "../src/common/utils";
+import { IKeyBlacklist, IKeyWhitelist, Utils } from "../src/common/utils";
 
 describe("Utils", () => {
     describe("toBase26Alpha", () => {
@@ -401,34 +401,81 @@ describe("Utils", () => {
     });
 
     describe("shallowCompareKeys", () => {
-        describe("with `keys` defined", () => {
+        interface IKeys {
+            a?: string;
+            b?: string;
+            c?: string;
+            d?: string;
+        }
+
+        describe("with `keys` defined as whitelist", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
-                runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
-                runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["a", "c"]);
-                runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b"]);
+                runTest(true, { a: 1 }, { a: 1 }, wl(["a", "b", "c", "d"]));
+                runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, wl(["a", "c"]));
+                runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, wl(["a", "b"]));
             });
 
             describe("returns false if any specified values are not shallowly equal", () => {
-                runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, ["a"]);
-                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["a", "b", "c"]);
+                runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, wl(["a"]));
+                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, wl(["a", "b", "c"]));
+                runTest(false, { a: 1, c: { a: 1 }}, { a: 1, b: "2" }, wl(["a", "b"]));
             });
 
             describe("edge cases that return true", () => {
-                runTest(true, undefined, null, []);
-                runTest(true, undefined, undefined, ["a"]);
-                runTest(true, null, null, ["a"]);
-                runTest(true, {}, {}, ["a"]);
+                runTest(true, undefined, null, wl([]));
+                runTest(true, undefined, undefined, wl(["a"]));
+                runTest(true, null, null, wl(["a"]));
+                runTest(true, {}, {}, wl(["a"]));
             });
 
             describe("edge cases that return false", () => {
-                runTest(false, {}, undefined, []);
-                runTest(false, {}, [], []);
-                runTest(false, [], [], []);
+                runTest(false, {}, undefined, wl([]));
+                runTest(false, {}, [], wl([]));
+                runTest(false, [], [], wl([]));
             });
 
-            function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
+            function runTest(expectedResult: boolean,
+                             a: any,
+                             b: any,
+                             keys: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
                 it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
-                    expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
+                    expect(Utils.shallowCompareKeys<IKeys>(a, b, keys)).to.equal(expectedResult);
+                });
+            }
+        });
+
+        describe("with `keys` defined as blacklist", () => {
+            describe("returns true if only the specified values are shallowly equal", () => {
+                runTest(true, { a: 1 }, { a: 1 }, bl(["b", "c", "d"]));
+                runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, bl(["b"]));
+                runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, bl(["c"]));
+            });
+
+            describe("returns false if any specified values are not shallowly equal", () => {
+                runTest(false, { a: [1, "2", true] }, { a: [1, "2", true] }, bl(["b, c"]));
+                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, bl(["a", "b", "d"]));
+                runTest(false, { a: 1, c: { a: 1 }}, { a: 1, b: "2" }, bl(["c"]));
+            });
+
+            describe("edge cases that return true", () => {
+                runTest(true, undefined, null, bl([]));
+                runTest(true, undefined, undefined, bl(["a"]));
+                runTest(true, null, null, bl(["a"]));
+                runTest(true, {}, {}, bl(["a"]));
+            });
+
+            describe("edge cases that return false", () => {
+                runTest(false, {}, undefined, bl([]));
+                runTest(false, {}, [], bl([]));
+                runTest(false, [], [], bl([]));
+            });
+
+            function runTest(expectedResult: boolean,
+                             a: any,
+                             b: any,
+                             keys: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
+                it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
+                    expect(Utils.shallowCompareKeys<IKeys>(a, b, keys)).to.equal(expectedResult);
                 });
             }
         });
@@ -462,10 +509,24 @@ describe("Utils", () => {
 
             function runTest(expectedResult: boolean, a: any, b: any) {
                 it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
-                    expect(Utils.shallowCompareKeys(a, b)).to.equal(expectedResult);
+                    expect(Utils.shallowCompareKeys<IKeys>(a, b)).to.equal(expectedResult);
                 });
             }
         });
+
+        /**
+         * A compactly named function for converting a string array to a key blacklist.
+         */
+        function bl(keys: string[]) {
+            return { exclude: keys } as IKeyBlacklist<IKeys>;
+        }
+
+        /**
+         * A compactly named function for converting a string array to a key whitelist.
+         */
+        function wl(keys: string[]) {
+            return { include: keys } as IKeyWhitelist<IKeys>;
+        }
     });
 
     describe("arraysEqual", () => {


### PR DESCRIPTION
#### Followup to #1162 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Refactor `shallowCompareKeys` to accept a type-checked blacklist or whitelist.
- Fix resultant breakages all over the `Table` codebase.

#### Reviewers should focus on:

- Does the typing stuff look sane?
- Any keys I didn't convert properly into the new scheme?
