### PR TITLE
[Table] Fire onSelection only when the selection actually changes

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -61,6 +61,7 @@ interface IMutableTableState {
     enableRowSelection?: boolean;
     numCols?: number;
     numRows?: number;
+    showCallbackLogs?: boolean;
     showCellsLoading?: boolean;
     showColumnHeadersLoading?: boolean;
     showColumnInteractionBar?: boolean;
@@ -117,6 +118,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             numCols: COLUMN_COUNTS[COLUMN_COUNT_DEFAULT_INDEX],
             numRows: ROW_COUNTS[ROW_COUNT_DEFAULT_INDEX],
             selectedFocusStyle: FocusStyle.TAB,
+            showCallbackLogs: false,
             showCellsLoading: false,
             showColumnHeadersLoading: false,
             showColumnInteractionBar: true,
@@ -317,6 +319,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Ghost cells", "showGhostCells")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Body context menu", "enableContextMenu")}
+                {this.renderSwitch("Callback logs", "showCallbackLogs")}
                 {this.renderSwitch("Full-table selection", "enableFullTableSelection")}
                 {this.renderSwitch("Multi-selection", "enableMultiSelection")}
 
@@ -414,32 +417,38 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     // allow console.log for these callbacks so devs can see exactly when they fire
     // tslint:disable no-console
-    private onSelection(selectedRegions: IRegion[]) {
-        console.log(`[onSelection] selectedRegions =`, ...selectedRegions);
+    private onSelection = (selectedRegions: IRegion[]) => {
+        this.maybeLogCallback(`[onSelection] selectedRegions =`, ...selectedRegions);
     }
 
-    private onColumnsReordered(oldIndex: number, newIndex: number, length: number) {
-        console.log(`[onColumnsReordered] oldIndex = ${oldIndex} newIndex = ${newIndex} length = ${length}`);
+    private onColumnsReordered = (oldIndex: number, newIndex: number, length: number) => {
+        this.maybeLogCallback(`[onColumnsReordered] oldIndex = ${oldIndex} newIndex = ${newIndex} length = ${length}`);
     }
 
-    private onRowsReordered(oldIndex: number, newIndex: number, length: number) {
-        console.log(`[onRowsReordered] oldIndex = ${oldIndex} newIndex = ${newIndex} length = ${length}`);
+    private onRowsReordered = (oldIndex: number, newIndex: number, length: number) => {
+        this.maybeLogCallback(`[onRowsReordered] oldIndex = ${oldIndex} newIndex = ${newIndex} length = ${length}`);
     }
 
-    private onColumnWidthChanged(index: number, size: number) {
-        console.log(`[onColumnWidthChanged] index = ${index} size = ${size}`);
+    private onColumnWidthChanged = (index: number, size: number) => {
+        this.maybeLogCallback(`[onColumnWidthChanged] index = ${index} size = ${size}`);
     }
 
-    private onRowHeightChanged(index: number, size: number) {
-        console.log(`[onRowHeightChanged] index = ${index} size = ${size}`);
+    private onRowHeightChanged = (index: number, size: number) => {
+        this.maybeLogCallback(`[onRowHeightChanged] index = ${index} size = ${size}`);
     }
 
-    private onFocus(focusedCell: IFocusedCellCoordinates) {
-        console.log("[onFocus] focusedCell =", focusedCell);
+    private onFocus = (focusedCell: IFocusedCellCoordinates) => {
+        this.maybeLogCallback("[onFocus] focusedCell =", focusedCell);
     }
 
-    private onCopy(success: boolean) {
-        console.log(`[onCopy] success = ${success}`);
+    private onCopy = (success: boolean) => {
+        this.maybeLogCallback(`[onCopy] success = ${success}`);
+    }
+
+    private maybeLogCallback = (message?: any, ...optionalParams: any[]) => {
+        if (this.state.showCallbackLogs) {
+            console.log(message, ...optionalParams);
+        }
     }
     // tslint:enable no-console
 

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -37,9 +37,9 @@ import {
 import { Nav } from "./nav";
 ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 
-import { SparseGridMutableStore } from "./store";
-import { IRegion } from "../src/regions";
 import { IFocusedCellCoordinates } from "../src/common/cell";
+import { IRegion } from "../src/regions";
+import { SparseGridMutableStore } from "./store";
 
 enum FocusStyle {
     TAB,
@@ -412,6 +412,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     // Callbacks
     // =========
 
+    // allow console.log for these callbacks so devs can see exactly when they fire
+    // tslint:disable no-console
     private onSelection(selectedRegions: IRegion[]) {
         console.log(`[onSelection] selectedRegions =`, ...selectedRegions);
     }
@@ -439,6 +441,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private onCopy(success: boolean) {
         console.log(`[onCopy] success = ${success}`);
     }
+    // tslint:enable no-console
 
     // State updates
     // =============

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -38,6 +38,8 @@ import { Nav } from "./nav";
 ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 
 import { SparseGridMutableStore } from "./store";
+import { IRegion } from "../src/regions";
+import { IFocusedCellCoordinates } from "../src/common/cell";
 
 enum FocusStyle {
     TAB,
@@ -128,6 +130,9 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         };
     }
 
+    // React Lifecycle
+    // ===============
+
     public render() {
         return (
             <div className="container">
@@ -147,6 +152,14 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     selectionModes={this.getEnabledSelectionModes()}
                     isRowHeaderShown={this.state.showRowHeaders}
                     styledRegionGroups={this.getStyledRegionGroups()}
+
+                    onSelection={this.onSelection}
+                    onColumnsReordered={this.onColumnsReordered}
+                    onColumnWidthChanged={this.onColumnWidthChanged}
+                    onCopy={this.onCopy}
+                    onFocus={this.onFocus}
+                    onRowHeightChanged={this.onRowHeightChanged}
+                    onRowsReordered={this.onRowsReordered}
                 >
                     {this.renderColumns()}
                 </Table>
@@ -162,6 +175,9 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     public componentDidUpdate() {
         this.syncFocusStyle();
     }
+
+    // Renderers
+    // =========
 
     public renderColumns() {
         return Utils.times(this.state.numCols, (index) => {
@@ -392,6 +408,40 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             </label>
         );
     }
+
+    // Callbacks
+    // =========
+
+    private onSelection(selectedRegions: IRegion[]) {
+        console.log(`[onSelection] selectedRegions =`, ...selectedRegions);
+    }
+
+    private onColumnsReordered(oldIndex: number, newIndex: number, length: number) {
+        console.log(`[onColumnsReordered] oldIndex = ${oldIndex} newIndex = ${newIndex} length = ${length}`);
+    }
+
+    private onRowsReordered(oldIndex: number, newIndex: number, length: number) {
+        console.log(`[onRowsReordered] oldIndex = ${oldIndex} newIndex = ${newIndex} length = ${length}`);
+    }
+
+    private onColumnWidthChanged(index: number, size: number) {
+        console.log(`[onColumnWidthChanged] index = ${index} size = ${size}`);
+    }
+
+    private onRowHeightChanged(index: number, size: number) {
+        console.log(`[onRowHeightChanged] index = ${index} size = ${size}`);
+    }
+
+    private onFocus(focusedCell: IFocusedCellCoordinates) {
+        console.log("[onFocus] focusedCell =", focusedCell);
+    }
+
+    private onCopy(success: boolean) {
+        console.log(`[onCopy] success = ${success}`);
+    }
+
+    // State updates
+    // =============
 
     private syncFocusStyle() {
         const { selectedFocusStyle } = this.state;

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -160,7 +160,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         if (nextSelectedRegions == null) {
             return;
         }
-        this.props.onSelection(nextSelectedRegions);
+        this.maybeInvokeSelectionCallback(nextSelectedRegions);
 
         if (!this.props.allowMultipleSelection) {
             // have the focused cell follow the selected region
@@ -175,7 +175,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         if (nextSelectedRegions == null) {
             return;
         }
-        this.props.onSelection(nextSelectedRegions);
+        this.maybeInvokeSelectionCallback(nextSelectedRegions);
         BlueprintUtils.safeInvoke(this.props.onSelectionEnd, nextSelectedRegions);
         this.finishInteraction();
     }
@@ -189,7 +189,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         const { selectedRegions } = this.props;
 
         if (!Regions.isValid(region)) {
-            this.props.onSelection([]);
+            this.maybeInvokeSelectionCallback([]);
             BlueprintUtils.safeInvoke(this.props.onSelectionEnd, []);
             return false;
         }
@@ -209,7 +209,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
             nextSelectedRegions = [region];
         }
 
-        this.props.onSelection(nextSelectedRegions);
+        this.maybeInvokeSelectionCallback(nextSelectedRegions);
         BlueprintUtils.safeInvoke(this.props.onSelectionEnd, nextSelectedRegions);
         this.finishInteraction();
         return false;
@@ -241,6 +241,14 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         return this.didExpandSelectionOnActivate
             ? expandSelectedRegions(selectedRegions, region)
             : Regions.update(selectedRegions, region);
+    }
+
+    private maybeInvokeSelectionCallback(nextSelectedRegions: IRegion[]) {
+        const { selectedRegions } = this.props;
+        // invoke only if the selection changed
+        if (!Utils.deepCompareKeys(selectedRegions, nextSelectedRegions)) {
+            this.props.onSelection(nextSelectedRegions);
+        }
     }
 }
 

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -260,9 +260,8 @@ describe("DragSelectable", () => {
             );
 
             selectable.find(".selectable", 0).mouse("mousedown").mouse("mouseup");
-            expect(onSelection.callCount).to.equal(2);
+            expect(onSelection.callCount).to.equal(1);
             expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0)]);
-            expect(onSelection.args[1][0]).to.deep.equal([]);
         });
 
         it("ignores invalid drag", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -578,7 +578,9 @@ describe("<Table>", () => {
         runTest("right");
 
         function runTest(direction: "up" | "down" | "left" | "right") {
-            const nextCellCoords = ACTIVATION_CELL_COORDS;
+            // create a new object so that tests don't keep mutating the same object instance.
+            const { row, col } = ACTIVATION_CELL_COORDS;
+            const nextCellCoords = { row, col };
 
             if (direction === "up") {
                 nextCellCoords.col -= 1;


### PR DESCRIPTION
#### Fixes #997 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Log to the console whenever callbacks are fired in Table Playground
- Currently, we fire `onSelection` every time a drag event is triggered (`onActivation`, `onDragMove`, `onDragEnd`). This fires `onSelection` SO many times. Now, we fire `onSelection` only when the selection changes. See GIFs below for a demo.

#### Reviewers should focus on:

- This requires a deep comparison between the old selected-regions array and the new one, but that's a relatively inexpensive check, since most of the time we'll only have one selected region in play.

#### Screenshot

_Before:_
![2017-06-02 10 01 59](https://cloud.githubusercontent.com/assets/443450/26736493/22d5e698-477b-11e7-91d2-b341174d26e9.gif)

_After:_
![2017-06-02 09 56 11](https://cloud.githubusercontent.com/assets/443450/26736498/29ea811e-477b-11e7-83e1-c3be4d9d2dc4.gif)
