### PR TITLE
Only use table cells for resizeByTallest, not header cells

### DIFF
--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -83,7 +83,8 @@ export class Locator implements ILocator {
     }
 
     public getTallestVisibleCellInColumn(columnIndex: number): number {
-        const cells = this.tableElement.getElementsByClassName(Classes.columnCellIndexClass(columnIndex));
+        const cells = this.tableElement
+            .getElementsByClassName(`${Classes.columnCellIndexClass(columnIndex)} ${Classes.TABLE_CELL}`);
         let max = 0;
         for (let i = 0; i < cells.length; i++) {
             const cellValue = cells.item(i).querySelector(`.${Classes.TABLE_TRUNCATED_VALUE}`);

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -106,7 +106,7 @@ describe("<Table>", () => {
     });
 
     it("Gets and sets the tallest cell by columns correctly", () => {
-        const DEFAULT_RESIZE_HEIGHT = 30;
+        const DEFAULT_RESIZE_HEIGHT = 20;
         const MAX_HEIGHT = 40;
         const renderCellLong = () => <Cell wrapText={true}>my cell value with lots and lots of words</Cell>;
         const renderCellShort = () => <Cell wrapText={false}>short value</Cell>;


### PR DESCRIPTION
#### Fixes #1194

#### Changes proposed in this pull request:

Modify the selector to only include table cells
