### PR TITLE
[Table] Add locator to table component for use in functions

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -263,13 +263,6 @@ export interface ITableState {
     columnWidths?: number[];
 
     /**
-     * An ILocator object used for locating cells, rows, or columns given
-     * client coordinates as well as determining cell bounds given their
-     * indices.
-     */
-    locator?: Locator;
-
-    /**
      * If `true`, will disable updates that will cause re-renders of children
      * components. This is used, for example, to disable layout updates while
      * the user is dragging a resize handle.
@@ -357,11 +350,12 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         return columnIdToIndex;
     }
 
+    public grid: Grid;
+    public locator: Locator;
+
     private bodyElement: HTMLElement;
     private childrenArray: Array<React.ReactElement<IColumnProps>>;
     private columnIdToIndex: {[key: string]: number};
-    private grid: Grid;
-    private locator: Locator;
     private menuElement: HTMLElement;
     private resizeSensorDetach: () => void;
     private rootTableElement: HTMLElement;
@@ -542,19 +536,16 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
      */
     public componentDidMount() {
         this.validateGrid();
-        const locator = new Locator(
+        this.locator = new Locator(
             this.rootTableElement,
             this.bodyElement,
             this.grid,
         );
-        this.locator = locator;
-
-        const viewportRect = locator.getViewportRect();
-        this.setState({ locator, viewportRect });
+        this.setState({ viewportRect: this.locator.getViewportRect() });
 
         this.resizeSensorDetach = ResizeSensor.attach(this.rootTableElement, () => {
             if (!this.state.isLayoutLocked) {
-                this.setState({ viewportRect: locator.getViewportRect() });
+                this.setState({ viewportRect: this.locator.getViewportRect() });
             }
         });
 
@@ -569,11 +560,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     public componentDidUpdate() {
-        const { locator } = this.state;
-
-        if (locator != null) {
+        if (this.locator != null) {
             this.validateGrid();
-            locator.setGrid(this.grid);
+            this.locator.setGrid(this.grid);
         }
 
         this.syncMenuWidth();
@@ -720,8 +709,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private renderColumnHeader() {
-        const { grid } = this;
-        const { locator, selectedRegions, viewportRect } = this.state;
+        const { grid, locator } = this;
+        const { selectedRegions, viewportRect } = this.state;
         const {
             allowMultipleSelection,
             fillBodyWithGhostCells,
@@ -770,8 +759,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private renderRowHeader() {
-        const { grid } = this;
-        const { locator, selectedRegions, viewportRect } = this.state;
+        const { grid, locator } = this;
+        const { selectedRegions, viewportRect } = this.state;
         const {
             allowMultipleSelection,
             fillBodyWithGhostCells,
@@ -833,7 +822,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private renderBody() {
-        const { grid } = this;
+        const { grid, locator } = this;
         const {
             allowMultipleSelection,
             fillBodyWithGhostCells,
@@ -841,7 +830,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             renderBodyContextMenu,
             selectedRegionTransform,
         } = this.props;
-        const { locator, selectedRegions, viewportRect, verticalGuides, horizontalGuides } = this.state;
+        const { selectedRegions, viewportRect, verticalGuides, horizontalGuides } = this.state;
 
         const style = grid.getRect().sizeStyle();
         const rowIndices = grid.getRowIndicesInRect(viewportRect, fillBodyWithGhostCells);
@@ -1211,9 +1200,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         // resize sensor.
         event.stopPropagation();
 
-        const { locator, isLayoutLocked } = this.state;
-        if (locator != null && !isLayoutLocked) {
-            const viewportRect = locator.getViewportRect();
+        if (this.locator != null && !this.state.isLayoutLocked) {
+            const viewportRect = this.locator.getViewportRect();
             this.setState({ viewportRect });
         }
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -518,17 +518,16 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
      * If no indices are provided, default to using the tallest visible cell from all columns in view.
      */
     public resizeRowsByTallestCell(columnIndices?: number | number[]) {
-        const locator = this.locator;
         let tallest = 0;
         if (columnIndices == null) {
             // Consider all columns currently in viewport
             const viewportColumnIndices = this.grid.getColumnIndicesInRect(this.state.viewportRect);
             for (let col = viewportColumnIndices.columnIndexStart; col <= viewportColumnIndices.columnIndexEnd; col++) {
-                tallest = Math.max(tallest, locator.getTallestVisibleCellInColumn(col));
+                tallest = Math.max(tallest, this.locator.getTallestVisibleCellInColumn(col));
             }
         } else {
             const columnIndicesArray = Array.isArray(columnIndices) ? columnIndices : [columnIndices];
-            const tallestByColumns = columnIndicesArray.map((col) => locator.getTallestVisibleCellInColumn(col));
+            const tallestByColumns = columnIndicesArray.map((col) => this.locator.getTallestVisibleCellInColumn(col));
             tallest = Math.max(...tallestByColumns);
         }
         const rowHeights = Array(this.state.rowHeights.length).fill(tallest);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -361,6 +361,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private childrenArray: Array<React.ReactElement<IColumnProps>>;
     private columnIdToIndex: {[key: string]: number};
     private grid: Grid;
+    private locator: Locator;
     private menuElement: HTMLElement;
     private resizeSensorDetach: () => void;
     private rootTableElement: HTMLElement;
@@ -517,7 +518,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
      * If no indices are provided, default to using the tallest visible cell from all columns in view.
      */
     public resizeRowsByTallestCell(columnIndices?: number | number[]) {
-        const { locator } = this.state;
+        const locator = this.locator;
         let tallest = 0;
         if (columnIndices == null) {
             // Consider all columns currently in viewport
@@ -547,6 +548,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             this.bodyElement,
             this.grid,
         );
+        this.locator = locator;
 
         const viewportRect = locator.getViewportRect();
         this.setState({ locator, viewportRect });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import { Keys } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/core/test/common/utils";
-import { Cell, Column, Grid, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
+import { Cell, Column, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import { Rect } from "../src/common/rect";
@@ -659,8 +659,8 @@ describe("<Table>", () => {
         function assertActivationCellUnaffected(nextCellCoords: ICellCoordinates) {
             // setup
             const table = mountTable();
-            const grid = (table.instance() as any).grid as Grid;
-            const prevViewportRect = table.state("locator").getViewportRect();
+            const { grid, locator } = table.instance() as Table;
+            const prevViewportRect = locator.getViewportRect();
 
             // get native DOM nodes
             const tableNode = ReactDOM.findDOMNode(table.instance());

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -930,7 +930,7 @@ describe("<Table>", () => {
                                       clientWidth: number,
                                       clientHeight: number) {
         // bodyElement is private, so we need to cast as `any` to access it
-        (table.state("locator") as any).bodyElement = {
+        (table.instance() as any).locator.bodyElement = {
             clientHeight,
             clientWidth,
             getBoundingClientRect: () => ({ left: 0, top: 0 }),


### PR DESCRIPTION
#### Fixes #1186

#### Changes proposed in this pull request:

Add a locator to the table component as a private attribute, and use _that_ in resizeByTallest.

#### Reviewers should focus on:

This is just adding the variable, no refactor. I'm not sure this is the best way, but I'm also not sure what a good refactor here would be, given the way we use the locator. Does anyone have a better idea? I'd almost like to pass the children a _reference_ to the locator (an object that just contains one thing, which is the locator) and do this with an added level of indirection -- but that just seems silly. 
