### PR TITLE
Don't render Collapse unless a tree node has children

### DIFF
--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -107,9 +107,7 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
                     <span className={Classes.TREE_NODE_LABEL}>{label}</span>
                     {this.maybeRenderSecondaryLabel()}
                 </div>
-                <Collapse isOpen={isExpanded}>
-                    {children}
-                </Collapse>
+                {this.maybeRenderChildren()}
             </li>
         );
     }
@@ -127,6 +125,18 @@ export class TreeNode extends React.Component<ITreeNodeProps, {}> {
     private maybeRenderSecondaryLabel() {
         if (this.props.secondaryLabel != null) {
             return <span className={Classes.TREE_NODE_SECONDARY_LABEL}>{this.props.secondaryLabel}</span>;
+        } else {
+            return undefined;
+        }
+    }
+
+    private maybeRenderChildren() {
+        if (React.Children.count(this.props.children) > 0) {
+            return (
+                <Collapse isOpen={this.props.isExpanded}>
+                    {this.props.children}
+                </Collapse>
+            );
         } else {
             return undefined;
         }


### PR DESCRIPTION
#### Changes proposed in this pull request:

Don't render Collapse unless a tree node has children.

Previously always `<Collapse />` was rendered regardless of children. [`Collapse` triggers layout](https://github.com/palantir/blueprint/blob/master/packages/core/src/components/collapse/collapse.tsx#L169), so it make tree with many nodes slower.

#### Reviewers should focus on:

With this change, it changes markup by not rendering `<div class="pt-collapse"><div class="pt-collapse-body" style="transform: translateY(0px);"></div></div>`. This could be a breaking change if somebody relied on that markup.