### PR TITLE
fix wee dev bugs

### DIFF
--- a/gulp/typescript.js
+++ b/gulp/typescript.js
@@ -14,7 +14,7 @@ module.exports = (blueprint, gulp, plugins) => {
     }, (project, taskName) => {
         gulp.task(taskName, () => (
             gulp.src([
-                path.join(project.cwd, "!(dist|node_modules|typings)", "**", "*.{js,jsx,ts,tsx}"),
+                path.join(project.cwd, "!(coverage|dist|node_modules|typings)", "**", "*.{js,jsx,ts,tsx}"),
                 // exclude nested dist directories (ex: table/preview/dist)
                 "!" + path.join(project.cwd, "*", "dist", "**", "*.{js,jsx,ts,tsx}"),
             ])

--- a/packages/docs/src/components/interfaceTable.tsx
+++ b/packages/docs/src/components/interfaceTable.tsx
@@ -83,7 +83,7 @@ export interface IInterfaceTableProps {
     tagRenderers: ITagRendererMap;
 }
 
-export const InterfaceTable: React.SFC<IInterfaceTableProps> = ({iface, props, tagRenderers }) => {
+export const InterfaceTable: React.SFC<IInterfaceTableProps> = ({ iface, props, tagRenderers }) => {
     return (
         <div className="docs-modifiers">
             <div className="docs-interface-name">{iface.name}</div>

--- a/packages/docs/src/tags/interface.tsx
+++ b/packages/docs/src/tags/interface.tsx
@@ -21,6 +21,9 @@ export class InterfaceTagRenderer {
     public render: TagRenderer = ({ value: name }, key, tagRenderers) => {
         const iface = this.propsStore.getInterface(name);
         const props = this.propsStore.getProps(iface);
+        if (iface === undefined) {
+            throw new Error(`Unknown @interface ${name}`);
+        }
         return <InterfaceTable key={key} iface={iface} props={props} tagRenderers={tagRenderers}/>;
     }
 }


### PR DESCRIPTION
- ignore code coverage in linters (per @cmslewis)
- handle unknown `@interface` tags in renderer

these issues came up while working on #1159 but didn't make sense in that PR so here they are.