### PR TITLE
[Table] Add custom shouldComponentUpdates in Header and HeaderCell

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -5,13 +5,13 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { EditableText, Utils } from "@blueprintjs/core";
+import { EditableText, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
+import { Utils } from "../index";
 import { Draggable } from "../interactions/draggable";
 import { Cell, ICellProps } from "./cell";
 
@@ -46,11 +46,16 @@ export interface IEditableCellState {
     isEditing: boolean;
 }
 
-@PureRender
 export class EditableCell extends React.Component<IEditableCellProps, IEditableCellState> {
     public state = {
         isEditing: false,
     };
+
+    public shouldComponentUpdate(nextProps: IEditableCellProps, nextState: IEditableCellState) {
+        return !Utils.shallowCompareKeys(this.props, nextProps, { exclude: ["style"] })
+            || !Utils.shallowCompareKeys(this.state, nextState)
+            || !Utils.deepCompareKeys(this.props, nextProps, ["style"]);
+    }
 
     public render() {
         const { intent, onChange, value } = this.props;
@@ -88,12 +93,12 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
 
     private handleCancel = (value: string) => {
         this.setState({ isEditing: false });
-        Utils.safeInvoke(this.props.onCancel, value);
+        CoreUtils.safeInvoke(this.props.onCancel, value);
     }
 
     private handleConfirm = (value: string) => {
         this.setState({ isEditing: false });
-        Utils.safeInvoke(this.props.onConfirm, value);
+        CoreUtils.safeInvoke(this.props.onConfirm, value);
     }
 
     private handleCellActivate = (_event: MouseEvent) => {

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -12,7 +12,7 @@ import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
-import { HeaderCell, IHeaderCellProps, IInternalHeaderCellProps } from "./headerCell";
+import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
 export interface IColumnNameProps {
     /**
@@ -87,10 +87,6 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
             || target.classList.contains(Classes.TABLE_HEADER_CONTENT);
     }
 
-    private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
-        "style",
-    ] as Array<keyof IInternalHeaderCellProps>;
-
     public render() {
         const {
             // from IColumnHeaderCellProps
@@ -107,13 +103,10 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
             ...spreadableProps,
         } = this.props;
 
-        const propKeysBlacklist = { exclude: ColumnHeaderCell.SHALLOW_COMPARE_PROP_KEYS_BLACKLIST };
-
         return (
             <HeaderCell
                 isReorderable={this.props.isColumnReorderable}
                 isSelected={this.props.isColumnSelected}
-                shallowlyComparablePropKeysList={propKeysBlacklist}
                 {...spreadableProps}
             >
                 {this.renderName()}

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -10,7 +10,7 @@ import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../common/classes";
-import { Grid, Rect } from "../index";
+import { Grid, Rect, Utils } from "../index";
 import { IClientCoordinates, ICoordinateData } from "../interactions/draggable";
 import { DragReorderable, IReorderableProps } from "../interactions/reorderable";
 import { Resizable } from "../interactions/resizable";
@@ -225,6 +225,23 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
         super(props, context);
     }
 
+    public shouldComponentUpdate(nextProps: IInternalHeaderProps) {
+        if (!Utils.shallowCompareKeys(this.props, nextProps, { exclude: ["selectedRegions"] })) {
+            return true;
+        }
+
+        const relevantSelectedRegions = this.props.selectedRegions.filter(this.isSelectedRegionRelevant);
+        const nextRelevantSelectedRegions = nextProps.selectedRegions.filter(this.isSelectedRegionRelevant);
+
+        // ignore selection changes that didn't involve any relevant selected regions (FULL_COLUMNS
+        // for column headers, or FULL_ROWS for row headers)
+        if (relevantSelectedRegions.length > 0 || nextRelevantSelectedRegions.length > 0) {
+            return !Utils.deepCompareKeys(relevantSelectedRegions, nextRelevantSelectedRegions);
+        }
+
+        return false;
+    }
+
     public componentDidMount() {
         if (this.props.selectedRegions != null && this.props.selectedRegions.length > 0) {
             // we already have a selection defined, so we'll want to enable reordering interactions
@@ -372,5 +389,9 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             // interaction is complete. this prevents one click+drag interaction from triggering
             // both selection and reordering behavior.
             && selectedRegions.length === 1;
+    }
+
+    private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
+        return Regions.getRegionCardinality(selectedRegion) === this.props.fullRegionCardinality;
     }
 }

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 
 import { Classes as CoreClasses, ContextMenuTarget, IProps } from "@blueprintjs/core";
 import * as Classes from "../common/classes";
-import { IKeyBlacklist, IKeyWhitelist, Utils } from "../common/utils";
+import { Utils } from "../common/utils";
 import { ResizeHandle } from "../interactions/resizeHandle";
 
 export interface IHeaderCellProps extends IProps {
@@ -61,11 +61,6 @@ export interface IInternalHeaderCellProps extends IHeaderCellProps {
      * Specifies if the cell is selected.
      */
     isSelected?: boolean;
-
-    /**
-     * Props that should be shallowly compared in shouldComponentUpdate.
-     */
-    shallowlyComparablePropKeysList?: IKeyBlacklist<IInternalHeaderCellProps> | IKeyWhitelist<IInternalHeaderCellProps>;
 }
 
 export interface IHeaderCellState {
@@ -79,9 +74,8 @@ export class HeaderCell extends React.Component<IInternalHeaderCellProps, IHeade
     };
 
     public shouldComponentUpdate(nextProps: IHeaderCellProps) {
-        const propKeysList = this.props.shallowlyComparablePropKeysList;
-        return !Utils.shallowCompareKeys(this.props, nextProps, propKeysList)
-            || !Utils.deepCompareKeys(this.props.style, nextProps.style);
+        return !Utils.shallowCompareKeys(this.props, nextProps, { exclude: ["style"] })
+            || !Utils.deepCompareKeys(this.props, nextProps, ["style"]);
     }
 
     public renderContextMenu(_event: React.MouseEvent<HTMLElement>) {

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../common/classes";
@@ -38,6 +39,7 @@ export interface IRowHeaderProps extends IHeaderProps, IRowHeights, IRowIndices 
     renderRowHeader?: IRowHeaderRenderer;
 }
 
+@PureRender
 export class RowHeader extends React.Component<IRowHeaderProps, {}> {
     public defaultProps = {
         renderRowHeader: renderDefaultRowHeader,

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -12,7 +12,7 @@ import { IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
-import { HeaderCell, IHeaderCellProps, IInternalHeaderCellProps } from "./headerCell";
+import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
 export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
     /**
@@ -27,10 +27,6 @@ export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
 }
 
 export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
-    private static SHALLOW_COMPARE_PROP_KEYS_BLACKLIST = [
-        "style",
-    ] as Array<keyof IInternalHeaderCellProps>;
-
     public render() {
         const loadableContentDivClasses = classNames(
             Classes.TABLE_ROW_NAME_TEXT,
@@ -45,13 +41,10 @@ export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
             ...spreadableProps,
         } = this.props;
 
-        const propKeysBlacklist = { exclude: RowHeaderCell.SHALLOW_COMPARE_PROP_KEYS_BLACKLIST };
-
         return (
             <HeaderCell
                 isReorderable={this.props.isRowReorderable}
                 isSelected={this.props.isRowSelected}
-                shallowlyComparablePropKeysList={propKeysBlacklist}
                 {...spreadableProps}
             >
                 <div className={Classes.TABLE_ROW_NAME}>


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add more specific `shouldComponentUpdate`s in `*Header`s and `*HeaderCell`s.
- Delete `HeaderCell`'s wonky internal `shallowlyComparablePropKeys` prop

#### Reviewers should focus on:

This is part of constellation of upcoming perf-related PRs; it doesn't have much effect on its own, but it will in concert with other changes (which are all implemented on `cl/table-perf` if you want to peek at that).