### PR TITLE
Add a default fallback for tallest cell calculations

### DIFF
--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -89,13 +89,17 @@ export class Locator implements ILocator {
         for (let i = 0; i < cells.length; i++) {
             const cellValue = cells.item(i).querySelector(`.${Classes.TABLE_TRUNCATED_VALUE}`);
             const cellTruncatedFormatText = cells.item(i).querySelector(`.${Classes.TABLE_TRUNCATED_FORMAT_TEXT}`);
+            const cellTruncatedText = cells.item(i).querySelector(`.${Classes.TABLE_TRUNCATED_TEXT}`);
             let height = 0;
             if (cellValue != null) {
                 height = cellValue.scrollHeight;
             } else if (cellTruncatedFormatText != null) {
                 height = cellTruncatedFormatText.scrollHeight;
+            } else if (cellTruncatedText != null) {
+                height = cellTruncatedText.scrollHeight;
             } else {
-                height = cells.item(i).querySelector(`.${Classes.TABLE_TRUNCATED_TEXT}`).scrollHeight;
+                // it's not anything we recognize, just use the current height of the cell
+                height = cells.item(i).scrollHeight;
             }
             if (height > max) {
                 max = height;


### PR DESCRIPTION
#### Fixes #1200

#### Changes proposed in this pull request:

Modify resize-by-tallest so it won't error out -- if we don't recognize anything inside the cell, use the current cell height. 

It doesn't make sense to special-case loading cells here, and covering cases where users have defined their own cell renderers to have sane defaults is good. 

