### PR TITLE
[Table] Introduce Cell/HeaderCell index props and pass them to callbacks

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -421,7 +421,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     // =========
 
     // allow console.log for these callbacks so devs can see exactly when they fire
-    // tslint:disable no-console
     private onSelection = (selectedRegions: IRegion[]) => {
         this.maybeLogCallback(`[onSelection] selectedRegions =`, ...selectedRegions);
     }
@@ -452,10 +451,10 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     private maybeLogCallback = (message?: any, ...optionalParams: any[]) => {
         if (this.state.showCallbackLogs) {
+            // tslint:disable-next-line no-console
             console.log(message, ...optionalParams);
         }
     }
-    // tslint:enable no-console
 
     private handleEditableBodyCellConfirm = (value: string, rowIndex?: number, columnIndex?: number) => {
         this.store.set(rowIndex, columnIndex, value);

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -193,19 +193,22 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     private renderColumnHeader(columnIndex: number) {
         const name = `Column ${Utils.toBase26Alpha(columnIndex)}`;
-        const renderName = () => {
-            return (<EditableName
-                name={name == null ? "" : name}
-                onConfirm={this.setColumnName.bind(this, columnIndex)}
-            />);
-        };
-
         return (<ColumnHeaderCell
+            index={columnIndex}
             menu={this.renderColumnMenu(columnIndex)}
             name={name}
-            renderName={this.state.enableColumnNameEditing ? renderName : undefined}
+            renderName={this.state.enableColumnNameEditing ? this.renderEditableColumnName : undefined}
             useInteractionBar={this.state.showColumnInteractionBar}
         />);
+    }
+
+    private renderEditableColumnName = (name: string) => {
+        return (
+            <EditableName
+                name={name == null ? "" : name}
+                onConfirm={this.handleEditableColumnCellConfirm}
+            />
+        );
     }
 
     private renderColumnMenu(columnIndex: number) {
@@ -452,6 +455,11 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     }
     // tslint:enable no-console
 
+    private handleEditableColumnCellConfirm = (value: string, columnIndex?: number) => {
+        // set column name
+        this.store.set(-1, columnIndex, value);
+    }
+
     // State updates
     // =============
 
@@ -464,10 +472,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         } else if (selectedFocusStyle === FocusStyle.TAB && !isFocusStyleManagerActive) {
             FocusStyleManager.onlyShowFocusOnTabs();
         }
-    }
-
-    private setColumnName(columnIndex: number, value: string) {
-        return this.store.set(-1, columnIndex, value);
     }
 
     private setCellValue(rowIndex: number, columnIndex: number, value: string) {

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -186,7 +186,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             return <Column
                 key={index}
                 renderColumnHeader={this.renderColumnHeader.bind(this)}
-                renderCell={this.renderCell.bind(this)}
+                renderCell={this.renderCell}
             />;
         });
     }
@@ -291,7 +291,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         // tslint:enable:jsx-no-multiline-js jsx-no-lambda
     }
 
-    private renderCell(rowIndex: number, columnIndex: number) {
+    private renderCell = (rowIndex: number, columnIndex: number) => {
         const value = this.store.get(rowIndex, columnIndex);
         const valueAsString = value == null ? "" : value;
 

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -301,9 +301,11 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         return this.state.enableCellEditing ? (
             <EditableCell
                 className={classes}
+                columnIndex={columnIndex}
                 loading={this.state.showCellsLoading}
+                onConfirm={this.handleEditableBodyCellConfirm}
+                rowIndex={rowIndex}
                 value={valueAsString}
-                onConfirm={this.setCellValue.bind(this, rowIndex, columnIndex)}
             />
         ) : (
             <Cell className={classes}>
@@ -455,6 +457,10 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     }
     // tslint:enable no-console
 
+    private handleEditableBodyCellConfirm = (value: string, rowIndex?: number, columnIndex?: number) => {
+        this.store.set(rowIndex, columnIndex, value);
+    }
+
     private handleEditableColumnCellConfirm = (value: string, columnIndex?: number) => {
         // set column name
         this.store.set(-1, columnIndex, value);
@@ -472,10 +478,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         } else if (selectedFocusStyle === FocusStyle.TAB && !isFocusStyleManagerActive) {
             FocusStyleManager.onlyShowFocusOnTabs();
         }
-    }
-
-    private setCellValue(rowIndex: number, columnIndex: number, value: string) {
-        return this.store.set(rowIndex, columnIndex, value);
     }
 
     private updateBooleanState(stateKey: keyof IMutableTableState) {

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -20,6 +20,12 @@ export interface ICellProps extends IIntentProps, IProps {
     style?: React.CSSProperties;
 
     /**
+     * The column index of the cell. If provided, this will be passed as an argument to any callbacks
+     * when they are invoked.
+     */
+    columnIndex?: number;
+
+    /**
      * If `true`, the cell will be rendered above overlay layers to enable mouse
      * interactions within the cell.
      * @default false
@@ -32,6 +38,12 @@ export interface ICellProps extends IIntentProps, IProps {
      * @default false
      */
     loading?: boolean;
+
+    /**
+     * The row index of the cell. If provided, this will be passed as an argument to any callbacks
+     * when they are invoked.
+     */
+    rowIndex?: number;
 
     /**
      * An optional native tooltip that is displayed on hover.

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -25,21 +25,27 @@ export interface IEditableCellProps extends ICellProps {
     /**
      * A listener that is triggered if the user cancels the edit. This is
      * important to listen to if you are doing anything with `onChange` events,
-     * since you'll likely want to revert whatever changes you made.
+     * since you'll likely want to revert whatever changes you made. The
+     * callback will also receive the row index and column index if they were
+     * originally provided via props.
      */
-    onCancel?: (value: string) => void;
+    onCancel?: (value: string, rowIndex?: number, columnIndex?: number) => void;
 
     /**
      * A listener that is triggered as soon as the editable name is modified.
-     * This can be due, for example, to keyboard input or the clipboard.
+     * This can be due, for example, to keyboard input or the clipboard. The
+     * callback will also receive the row index and column index if they were
+     * originally provided via props.
      */
-    onChange?: (value: string) => void;
+    onChange?: (value: string, rowIndex?: number, columnIndex?: number) => void;
 
     /**
      * A listener that is triggered once the editing is confirmed. This is
      * usually due to the <code>return</code> (or <code>enter</code>) key press.
+     * The callback will also receive the row index and column index if they
+     * were originally provided via props.
      */
-    onConfirm?: (value: string) => void;
+    onConfirm?: (value: string, rowIndex?: number, columnIndex?: number) => void;
 }
 
 export interface IEditableCellState {
@@ -83,7 +89,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
                         intent={spreadableProps.intent}
                         minWidth={null}
                         onCancel={this.handleCancel}
-                        onChange={onChange}
+                        onChange={this.handleChange}
                         onConfirm={this.handleConfirm}
                         onEdit={this.handleEdit}
                         placeholder=""
@@ -100,12 +106,22 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
 
     private handleCancel = (value: string) => {
         this.setState({ isEditing: false });
-        CoreUtils.safeInvoke(this.props.onCancel, value);
+        this.invokeCallback(this.props.onCancel, value);
+    }
+
+    private handleChange = (value: string) => {
+        this.invokeCallback(this.props.onChange, value);
     }
 
     private handleConfirm = (value: string) => {
         this.setState({ isEditing: false });
-        CoreUtils.safeInvoke(this.props.onConfirm, value);
+        this.invokeCallback(this.props.onConfirm, value);
+    }
+
+    private invokeCallback(callback: (value: string, rowIndex?: number, columnIndex?: number) => void, value: string) {
+        // pass through the row and column indices if they were provided as props by the consumer
+        const { rowIndex, columnIndex } = this.props;
+        CoreUtils.safeInvoke(callback, value, rowIndex, columnIndex);
     }
 
     private handleCellActivate = (_event: MouseEvent) => {

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -182,8 +182,9 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
         };
         return (
             <ColumnHeaderCell
-                key={Classes.columnIndexClass(index)}
                 className={classNames(extremaClasses)}
+                index={index}
+                key={Classes.columnIndexClass(index)}
                 loading={loading}
                 style={style}
             />);

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -71,7 +71,6 @@ export function HorizontalCellDivider(): JSX.Element {
 
 export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
     public static defaultProps: IColumnHeaderCellProps = {
-        index: undefined,
         isActive: false,
         menuIconName: "chevron-down",
         useInteractionBar: false,

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -29,8 +29,11 @@ export interface IColumnNameProps {
      *
      * If you define this callback, we recommend you also set
      * `useInteractionBar` to `true`, to avoid issues with menus or selection.
+     *
+     * The callback will also receive the column index if an `index` was originally
+     * provided via props.
      */
-    renderName?: (name: string) => React.ReactElement<IProps>;
+    renderName?: (name: string, index?: number) => React.ReactElement<IProps>;
 
     /**
      * If `true`, adds an interaction bar on top of the column header cell and
@@ -68,6 +71,7 @@ export function HorizontalCellDivider(): JSX.Element {
 
 export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
     public static defaultProps: IColumnHeaderCellProps = {
+        index: undefined,
         isActive: false,
         menuIconName: "chevron-down",
         useInteractionBar: false,
@@ -117,14 +121,17 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
     }
 
     private renderName() {
-        const { loading, name, renderName, useInteractionBar } = this.props;
+        const { index, loading, name, renderName, useInteractionBar } = this.props;
+
         const dropdownMenu = this.maybeRenderDropdownMenu();
         const defaultName = <div className={Classes.TABLE_TRUNCATED_TEXT}>{name}</div>;
+
         const nameComponent = (
             <LoadableContent loading={loading} variableLength={true}>
-                {renderName == null ? defaultName : renderName(name)}
+                {renderName == null ? defaultName : renderName(name, index)}
             </LoadableContent>
         );
+
         if (useInteractionBar) {
             return (
                 <div className={Classes.TABLE_COLUMN_NAME} title={name}>

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -311,6 +311,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
         const cellProps: IHeaderCellProps = {
             className,
+            index,
             [this.props.headerCellIsSelectedPropName]: isSelected,
             [this.props.headerCellIsReorderablePropName]: isCurrentlyReorderable,
             loading: isLoading,

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -15,15 +15,16 @@ import { ResizeHandle } from "../interactions/resizeHandle";
 
 export interface IHeaderCellProps extends IProps {
     /**
+     * The index of the cell in the header. If provided, this will be passed as an argument to any
+     * callbacks when they are invoked.
+     */
+    index?: number;
+
+    /**
      * If `true`, will apply the active class to the header to indicate it is
      * part of an external operation.
      */
     isActive?: boolean;
-
-    /**
-     * The name displayed in the header of the row/column.
-     */
-    name?: string;
 
     /**
      * If `true`, the row/column `name` will be replaced with a fixed-height skeleton, and the
@@ -38,6 +39,11 @@ export interface IHeaderCellProps extends IProps {
      * anywhere in the header.
      */
     menu?: JSX.Element;
+
+    /**
+     * The name displayed in the header of the row/column.
+     */
+    name?: string;
 
     /**
      * A `ResizeHandle` React component that allows users to drag-resize the

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -184,5 +184,5 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
  * numbers for each row.
  */
 export function renderDefaultRowHeader(rowIndex: number) {
-    return <RowHeaderCell index={index} name={`${rowIndex + 1}`}/>;
+    return <RowHeaderCell index={rowIndex} name={`${rowIndex + 1}`}/>;
 }

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -165,8 +165,9 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
         const rect = this.props.grid.getGhostCellRect(index, 0);
         return (
             <RowHeaderCell
-                key={Classes.rowIndexClass(index)}
                 className={classNames(extremaClasses)}
+                index={index}
+                key={Classes.rowIndexClass(index)}
                 loading={this.props.loading}
                 style={{ height: `${rect.height}px` }}
             />);
@@ -183,5 +184,5 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
  * numbers for each row.
  */
 export function renderDefaultRowHeader(rowIndex: number) {
-    return <RowHeaderCell name={`${rowIndex + 1}`}/>;
+    return <RowHeaderCell index={index} name={`${rowIndex + 1}`}/>;
 }

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -9,6 +9,7 @@ import "es6-shim";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 import { expect } from "chai";
+import { shallow } from "enzyme";
 import * as React from "react";
 
 import * as Classes from "../src/common/classes";
@@ -38,6 +39,14 @@ describe("<ColumnHeaderCell>", () => {
         const table = harness.mount(<ColumnHeaderCell className={CLASS_NAME} />);
         const hasCustomClass = table.find(`.${Classes.TABLE_HEADER}`, 0).hasClass(CLASS_NAME);
         expect(hasCustomClass).to.be.true;
+    });
+
+    it("passes index prop to renderName callback if index was provided", () => {
+        const renderNameSpy = sinon.spy();
+        const NAME = "my-name";
+        const INDEX = 17;
+        shallow(<ColumnHeaderCell index={INDEX} name={NAME} renderName={renderNameSpy} />);
+        expect(renderNameSpy.firstCall.args).to.deep.equal([NAME, INDEX]);
     });
 
     describe("Custom renderer", () => {

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 
 import { EditableCell } from "../src/index";
 import { CellType, expectCellLoading } from "./cellTestUtils";
-import { ReactHarness } from "./harness";
+import { ElementHarness, ReactHarness } from "./harness";
 
 describe("<EditableCell>", () => {
     const harness = new ReactHarness();
@@ -45,12 +45,8 @@ describe("<EditableCell>", () => {
         />);
 
         // double click to edit
-        elem.find(".pt-editable-content")
-            .mouse("mousedown")
-            .mouse("mouseup")
-            .mouse("mousedown")
-            .mouse("mouseup");
-        const input = elem.find(".pt-editable-input");
+        doubleClickToEdit(elem);
+        const input = getInput(elem);
         expect(input.element).to.equal(document.activeElement);
 
         // edit
@@ -65,4 +61,45 @@ describe("<EditableCell>", () => {
         expect(onCancel.called).to.be.false;
         expect(onConfirm.called).to.be.true;
     });
+
+    it("passes index prop to callbacks if index was provided", () => {
+        const onCancelSpy = sinon.spy();
+        const onChangeSpy = sinon.spy();
+        const onConfirmSpy = sinon.spy();
+
+        const CHANGED_VALUE = "my-changed-value";
+        const ROW_INDEX = 17;
+        const COLUMN_INDEX = 44;
+
+        const elem = harness.mount(<EditableCell
+            rowIndex={ROW_INDEX}
+            columnIndex={COLUMN_INDEX}
+            onCancel={onCancelSpy}
+            onChange={onChangeSpy}
+            onConfirm={onConfirmSpy}
+        />);
+
+        doubleClickToEdit(elem);
+
+        // edit
+        const input = getInput(elem);
+        input.change(CHANGED_VALUE);
+        expect(onChangeSpy.firstCall.args).to.deep.equal([CHANGED_VALUE, ROW_INDEX, COLUMN_INDEX]);
+
+        // confirm
+        input.blur();
+        expect(onConfirmSpy.firstCall.args).to.deep.equal([CHANGED_VALUE, ROW_INDEX, COLUMN_INDEX]);
+    });
+
+    function doubleClickToEdit(elem: ElementHarness) {
+        elem.find(".pt-editable-content")
+            .mouse("mousedown")
+            .mouse("mouseup")
+            .mouse("mousedown")
+            .mouse("mouseup");
+    }
+
+    function getInput(elem: ElementHarness) {
+        return elem.find(".pt-editable-input");
+    }
 });


### PR DESCRIPTION
#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add optional new `index` prop to `HeaderCell` (can be passed to callbacks to avoid having to re-instantiate anonymous functions in parent components on each re-render).
- Add optional new `rowIndex` and `columnIndex` props to `Cell` (same reasoning).
- Pass `index` callback to `ColumnHeaderCell`'s `renderName` callback.
- Pass `rowIndex` and `columnIndex` to `EditableCell` callbacks.
- Refactor `preview/index.tsx` to take advantage of these new `*index` props

#### Reviewers should focus on

Perf gains! This approach lets you provide a persistent function instance as a callback to the various `*Cell` components, causing shallow equality checks on that function instance to pass now. This avoids lots of unnecessary re-renders.