### PR TITLE
[Table] Fix shouldComponentUpdate issues in *Header's

### DIFF
--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../common/classes";
@@ -15,9 +14,9 @@ import { Utils } from "../common/index";
 import { IClientCoordinates } from "../interactions/draggable";
 import { IIndexedResizeCallback } from "../interactions/resizable";
 import { Orientation } from "../interactions/resizeHandle";
-import { RegionCardinality, Regions } from "../regions";
+import { IRegion, RegionCardinality, Regions } from "../regions";
 import { ColumnHeaderCell, IColumnHeaderCellProps } from "./columnHeaderCell";
-import { Header, IHeaderProps } from "./header";
+import { Header, IHeaderProps, shouldHeaderComponentUpdate } from "./header";
 
 export type IColumnHeaderRenderer = (columnIndex: number) => React.ReactElement<IColumnHeaderCellProps>;
 
@@ -42,13 +41,16 @@ export interface IColumnHeaderProps extends IHeaderProps, IColumnWidths, IColumn
     onColumnWidthChanged: IIndexedResizeCallback;
 }
 
-@PureRender
 export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
     public static defaultProps = {
         isReorderable: false,
         isResizable: true,
         loading: false,
     };
+
+    public shouldComponentUpdate(nextProps: IColumnHeaderProps) {
+        return shouldHeaderComponentUpdate(this.props, nextProps, this.isSelectedRegionRelevant);
+    }
 
     public render() {
         const {
@@ -191,5 +193,9 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
 
     private toRegion = (index1: number, index2?: number) => {
         return Regions.column(index1, index2);
+    }
+
+    private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
+        return Regions.getRegionCardinality(selectedRegion) === RegionCardinality.FULL_COLUMNS;
     }
 }

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -383,6 +383,9 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
  * temporary solution, we at least want to avoid writing the same code in two places, so we expose
  * this utility for each higher-level component to leverage in their own respective
  * shouldComponentUpdate functions.
+ *
+ * (See: https://github.com/palantir/blueprint/issues/1214)
+ *
  * @param props - the current props
  * @param nextProps - the next props
  */

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -9,7 +9,7 @@ import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
-import { Grid, Rect, Utils } from "../common";
+import { Grid, Rect } from "../common";
 import * as Classes from "../common/classes";
 import { IClientCoordinates, ICoordinateData } from "../interactions/draggable";
 import { DragReorderable, IReorderableProps } from "../interactions/reorderable";
@@ -19,6 +19,7 @@ import { DragSelectable, ISelectableProps } from "../interactions/selectable";
 import { ILocator } from "../locator";
 import { IRegion, RegionCardinality, Regions } from "../regions";
 import { IHeaderCellProps } from "./headerCell";
+import { Utils } from "../index";
 
 export type IHeaderCellRenderer = (index: number) => React.ReactElement<IHeaderCellProps>;
 
@@ -225,23 +226,6 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
         super(props, context);
     }
 
-    public shouldComponentUpdate(nextProps: IInternalHeaderProps) {
-        if (!Utils.shallowCompareKeys(this.props, nextProps, { exclude: ["selectedRegions"] })) {
-            return true;
-        }
-
-        const relevantSelectedRegions = this.props.selectedRegions.filter(this.isSelectedRegionRelevant);
-        const nextRelevantSelectedRegions = nextProps.selectedRegions.filter(this.isSelectedRegionRelevant);
-
-        // ignore selection changes that didn't involve any relevant selected regions (FULL_COLUMNS
-        // for column headers, or FULL_ROWS for row headers)
-        if (relevantSelectedRegions.length > 0 || nextRelevantSelectedRegions.length > 0) {
-            return !Utils.deepCompareKeys(relevantSelectedRegions, nextRelevantSelectedRegions);
-        }
-
-        return false;
-    }
-
     public componentDidMount() {
         if (this.props.selectedRegions != null && this.props.selectedRegions.length > 0) {
             // we already have a selection defined, so we'll want to enable reordering interactions
@@ -390,8 +374,33 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             // both selection and reordering behavior.
             && selectedRegions.length === 1;
     }
+}
 
-    private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
-        return Regions.getRegionCardinality(selectedRegion) === this.props.fullRegionCardinality;
+/**
+ * Due to reasons we're still investigating, our tests fail if we put a common, custom
+ * shouldComponentUpdate function on the lower-level Header component. Rather, the ColumnHeaderCell
+ * and RowHeaderCell each need to include this same shouldComponentUpdate code at their level. As a
+ * temporary solution, we at least want to avoid writing the same code in two places, so we expose
+ * this utility for each higher-level component to leverage in their own respective
+ * shouldComponentUpdate functions.
+ * @param props - the current props
+ * @param nextProps - the next props
+ */
+export function shouldHeaderComponentUpdate<T extends IHeaderProps>(
+    props: T, nextProps: T, isSelectedRegionRelevant: (selectedRegion: IRegion) => boolean) {
+
+    if (!Utils.shallowCompareKeys(props, nextProps, { exclude: ["selectedRegions"] })) {
+        return true;
     }
+
+    const relevantSelectedRegions = props.selectedRegions.filter(isSelectedRegionRelevant);
+    const nextRelevantSelectedRegions = nextProps.selectedRegions.filter(isSelectedRegionRelevant);
+
+    // ignore selection changes that didn't involve any relevant selected regions (FULL_COLUMNS
+    // for column headers, or FULL_ROWS for row headers)
+    if (relevantSelectedRegions.length > 0 || nextRelevantSelectedRegions.length > 0) {
+        return !Utils.deepCompareKeys(relevantSelectedRegions, nextRelevantSelectedRegions);
+    }
+
+    return false;
 }

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -377,11 +377,9 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 }
 
 /**
- * Due to reasons we're still investigating, our tests fail if we put a common, custom
- * shouldComponentUpdate function on the lower-level Header component. Rather, the ColumnHeaderCell
- * and RowHeaderCell each need to include this same shouldComponentUpdate code at their level. As a
- * temporary solution, we at least want to avoid writing the same code in two places, so we expose
- * this utility for each higher-level component to leverage in their own respective
+ * In the current architecture, ColumnHeaderCell and RowHeaderCell each need to include this same
+ * shouldComponentUpdate code at their level. To avoid writing the same code in two places, we
+ * expose this utility for each higher-level component to leverage in their own respective
  * shouldComponentUpdate functions.
  *
  * (See: https://github.com/palantir/blueprint/issues/1214)

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 
 import { Grid, Rect } from "../common";
 import * as Classes from "../common/classes";
+import { Utils } from "../index";
 import { IClientCoordinates, ICoordinateData } from "../interactions/draggable";
 import { DragReorderable, IReorderableProps } from "../interactions/reorderable";
 import { Resizable } from "../interactions/resizable";
@@ -19,7 +20,6 @@ import { DragSelectable, ISelectableProps } from "../interactions/selectable";
 import { ILocator } from "../locator";
 import { IRegion, RegionCardinality, Regions } from "../regions";
 import { IHeaderCellProps } from "./headerCell";
-import { Utils } from "../index";
 
 export type IHeaderCellRenderer = (index: number) => React.ReactElement<IHeaderCellProps>;
 

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -6,7 +6,6 @@
  */
 
 import * as classNames from "classnames";
-import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../common/classes";
@@ -15,8 +14,8 @@ import { RoundSize } from "../common/roundSize";
 import { IClientCoordinates } from "../interactions/draggable";
 import { IIndexedResizeCallback } from "../interactions/resizable";
 import { Orientation } from "../interactions/resizeHandle";
-import { RegionCardinality, Regions } from "../regions";
-import { Header, IHeaderProps } from "./header";
+import { IRegion, RegionCardinality, Regions } from "../regions";
+import { Header, IHeaderProps, shouldHeaderComponentUpdate } from "./header";
 import { IRowHeaderCellProps, RowHeaderCell } from "./rowHeaderCell";
 
 export type IRowHeaderRenderer = (rowIndex: number) => React.ReactElement<IRowHeaderCellProps>;
@@ -39,11 +38,14 @@ export interface IRowHeaderProps extends IHeaderProps, IRowHeights, IRowIndices 
     renderRowHeader?: IRowHeaderRenderer;
 }
 
-@PureRender
 export class RowHeader extends React.Component<IRowHeaderProps, {}> {
     public defaultProps = {
         renderRowHeader: renderDefaultRowHeader,
     };
+
+    public shouldComponentUpdate(nextProps: IRowHeaderProps) {
+        return shouldHeaderComponentUpdate(this.props, nextProps, this.isSelectedRegionRelevant);
+    }
 
     public render() {
         const {
@@ -175,6 +177,10 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
     private toRegion = (index1: number, index2?: number) => {
         // the `this` value is messed up for Regions.row, so we have to have a wrapper function here
         return Regions.row(index1, index2);
+    }
+
+    private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
+        return Regions.getRegionCardinality(selectedRegion) === RegionCardinality.FULL_ROWS;
     }
 }
 


### PR DESCRIPTION
#### Fixes issue from PR #1212

#### Changes proposed in this pull request:

In #1206, I added a custom `shouldComponentUpdate` to the `Header` component, but I accidentally left a `@PureRender` decorator on it as well, which leads to a runtime warning that we didn't catch before merging that PR. Unfortunately, while `pure-render-decorator` warns you that it can't add its default `shouldComponentUpdate` because a `shouldComponentUpdate` is already defined, _it overwrites yours anyway_. Removing the decorator to get rid of this warning caused tests to fail.

This PR fixes those tests by moving the `Header`'s custom `shouldComponentUpdate` code a level up into `ColumnHeader` and `RowHeader`. I'm still not clear why that fixes things, but I opened an issue (#1214) to track.

#### Reviewers should focus on:

Exporting a custom function like this is awkward, but is it reasonable for now? I want to unblock @themadcreator so that we can merge his batching PR (#1201).