### PR TITLE
[Table] Bugfix: Have column headers and row headers respond to FULL_TABLE selections too

### DIFF
--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -196,6 +196,8 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
     }
 
     private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
-        return Regions.getRegionCardinality(selectedRegion) === RegionCardinality.FULL_COLUMNS;
+        const regionCardinality = Regions.getRegionCardinality(selectedRegion);
+        return regionCardinality === RegionCardinality.FULL_COLUMNS
+            || regionCardinality === RegionCardinality.FULL_TABLE;
     }
 }

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -180,7 +180,9 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
     }
 
     private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
-        return Regions.getRegionCardinality(selectedRegion) === RegionCardinality.FULL_ROWS;
+        const regionCardinality = Regions.getRegionCardinality(selectedRegion);
+        return regionCardinality === RegionCardinality.FULL_ROWS
+            || regionCardinality === RegionCardinality.FULL_TABLE;
     }
 }
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -171,7 +171,7 @@ describe("<Table>", () => {
             expect(rowHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.true;
 
             // deselect the full table
-            table.setProps({ selectedRegions: [] })
+            table.setProps({ selectedRegions: [] });
             expect(columnHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.false;
             expect(rowHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.false;
         });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -160,11 +160,24 @@ describe("<Table>", () => {
             expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
         });
 
-        it.skip("selects column headers and row headers when selecting the full table");
-        it.skip("deselects column headers and row headers when deselecting the full table");
+        it("selects and deselects column/row headers when selecting and deselecting the full table", () => {
+            const table = mountTable();
+            const columnHeader = table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`).at(0);
+            const rowHeader = table.find(`.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`).at(0);
+
+            // select the full table
+            selectFullTable(table);
+            expect(columnHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.true;
+            expect(rowHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.true;
+
+            // deselect the full table
+            table.setProps({ selectedRegions: [] })
+            expect(columnHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.false;
+            expect(rowHeader.hasClass(Classes.TABLE_HEADER_SELECTED)).to.be.false;
+        });
 
         function mountTable() {
-            return harness.mount(
+            return mount(
                 <Table
                     enableFocus={true}
                     onFocus={onFocus}
@@ -178,9 +191,9 @@ describe("<Table>", () => {
             );
         }
 
-        function selectFullTable(table: ElementHarness) {
+        function selectFullTable(table: ReactWrapper<any, {}>) {
             const menu = table.find(`.${Classes.TABLE_MENU}`);
-            menu.mouse("click");
+            menu.simulate("click");
         }
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -167,6 +167,9 @@ describe("<Table>", () => {
             expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
             expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
         });
+
+        it.skip("selects column headers and row headers when selecting the full table");
+        it.skip("deselects column headers and row headers when deselecting the full table");
     });
 
     describe("Resizing", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -144,11 +144,27 @@ describe("<Table>", () => {
     });
 
     describe("Full-table selection", () => {
-        it("Selects all and moves focus cell to (0, 0) on click of upper-left corner", () => {
-            const onFocus = sinon.spy();
-            const onSelection = sinon.spy();
+        const onFocus = sinon.spy();
+        const onSelection = sinon.spy();
 
-            const table = harness.mount(
+        afterEach(() => {
+            onFocus.reset();
+            onSelection.reset();
+        });
+
+        it("Selects all and moves focus cell to (0, 0) on click of upper-left corner", () => {
+            const table = mountTable();
+            selectFullTable(table);
+
+            expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
+            expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
+        });
+
+        it.skip("selects column headers and row headers when selecting the full table");
+        it.skip("deselects column headers and row headers when deselecting the full table");
+
+        function mountTable() {
+            return harness.mount(
                 <Table
                     enableFocus={true}
                     onFocus={onFocus}
@@ -160,16 +176,12 @@ describe("<Table>", () => {
                     <Column renderCell={renderCell}/>
                 </Table>,
             );
+        }
 
+        function selectFullTable(table: ElementHarness) {
             const menu = table.find(`.${Classes.TABLE_MENU}`);
             menu.mouse("click");
-
-            expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
-            expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
-        });
-
-        it.skip("selects column headers and row headers when selecting the full table");
-        it.skip("deselects column headers and row headers when deselecting the full table");
+        }
     });
 
     describe("Resizing", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -143,28 +143,30 @@ describe("<Table>", () => {
         expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
     });
 
-    it("Selects all and moves focus cell to (0, 0) on click of upper-left corner", () => {
-        const onFocus = sinon.spy();
-        const onSelection = sinon.spy();
+    describe("Full-table selection", () => {
+        it("Selects all and moves focus cell to (0, 0) on click of upper-left corner", () => {
+            const onFocus = sinon.spy();
+            const onSelection = sinon.spy();
 
-        const table = harness.mount(
-            <Table
-                enableFocus={true}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                numRows={10}
-            >
-                <Column renderCell={renderCell}/>
-                <Column renderCell={renderCell}/>
-                <Column renderCell={renderCell}/>
-            </Table>,
-        );
+            const table = harness.mount(
+                <Table
+                    enableFocus={true}
+                    onFocus={onFocus}
+                    onSelection={onSelection}
+                    numRows={10}
+                >
+                    <Column renderCell={renderCell}/>
+                    <Column renderCell={renderCell}/>
+                    <Column renderCell={renderCell}/>
+                </Table>,
+            );
 
-        const menu = table.find(`.${Classes.TABLE_MENU}`);
-        menu.mouse("click");
+            const menu = table.find(`.${Classes.TABLE_MENU}`);
+            menu.mouse("click");
 
-        expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
-        expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
+            expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
+            expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
+        });
     });
 
     describe("Resizing", () => {


### PR DESCRIPTION
#### Fixes bug introduced in #1215

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Have `ColumnHeader`s and `RowHeader`s respond to `FULL_TABLE` updates too.

#### Screenshot

_After:_

![2017-06-09 15 00 32](https://user-images.githubusercontent.com/443450/26995958-81c4fcda-4d24-11e7-8937-4d28d37ca093.gif)
