### PR TITLE
[Table] Introduce HeaderCell#renderMenu prop, deprecate HeaderCell#menu prop

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -195,8 +195,8 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         const name = `Column ${Utils.toBase26Alpha(columnIndex)}`;
         return (<ColumnHeaderCell
             index={columnIndex}
-            menu={this.renderColumnMenu(columnIndex)}
             name={name}
+            renderMenu={this.state.showColumnMenus ? this.renderColumnMenu : undefined}
             renderName={this.state.enableColumnNameEditing ? this.renderEditableColumnName : undefined}
             useInteractionBar={this.state.showColumnInteractionBar}
         />);
@@ -211,7 +211,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         );
     }
 
-    private renderColumnMenu(columnIndex: number) {
+    private renderColumnMenu = (columnIndex: number) => {
         // tslint:disable:jsx-no-multiline-js jsx-no-lambda
         const menu = <Menu>
             <MenuItem
@@ -257,7 +257,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private renderRowHeader(rowIndex: number) {
         return <RowHeaderCell
             name={`${rowIndex + 1}`}
-            menu={this.renderRowMenu(rowIndex)}
+            renderMenu={this.renderRowMenu}
         />;
     }
 

--- a/packages/table/src/common/errors.ts
+++ b/packages/table/src/common/errors.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+const ns = "[Blueprint Table]";
+const deprec = `${ns} DEPRECATION:`;
+
+export const COLUMN_HEADER_CELL_MENU_DEPRECATED =
+    `${deprec} <ColumnHeaderCell> menu is deprecated. Use renderMenu instead.`;
+
+export const ROW_HEADER_CELL_MENU_DEPRECATED =
+    `${deprec} <RowHeaderCell> menu is deprecated. Use renderMenu instead.`;

--- a/packages/table/src/common/index.ts
+++ b/packages/table/src/common/index.ts
@@ -10,3 +10,4 @@ export { Grid } from "./grid";
 export { Rect, AnyRect } from "./rect";
 export { RoundSize } from "./roundSize";
 export { Utils } from "./utils";
+// NOTE: Errors is not exported in public API

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -8,9 +8,17 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, IProps, Popover, Position, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    AbstractComponent,
+    Classes as CoreClasses,
+    IProps,
+    Popover,
+    Position,
+    Utils as CoreUtils,
+} from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
+import * as Errors from "../common/errors";
 import { LoadableContent } from "../common/loadableContent";
 import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
@@ -69,7 +77,7 @@ export function HorizontalCellDivider(): JSX.Element {
     return <div className={Classes.TABLE_HORIZONTAL_CELL_DIVIDER}/>;
 }
 
-export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}> {
+export class ColumnHeaderCell extends AbstractComponent<IColumnHeaderCellProps, {}> {
     public static defaultProps: IColumnHeaderCellProps = {
         isActive: false,
         menuIconName: "chevron-down",
@@ -117,6 +125,15 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
                 {this.props.loading ? undefined : this.props.resizeHandle}
             </HeaderCell>
         );
+    }
+
+    protected validateProps(nextProps: IColumnHeaderCellProps) {
+        if (nextProps.menu != null) {
+            // throw this warning from the publicly exported, higher-order *HeaderCell components
+            // rather than HeaderCell, so consumers know exactly which components are receiving the
+            // offending prop
+            console.warn(Errors.COLUMN_HEADER_CELL_MENU_DEPRECATED);
+        }
     }
 
     private renderName() {

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -8,7 +8,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, IProps, Popover, Position } from "@blueprintjs/core";
+import { Classes as CoreClasses, IProps, Popover, Position, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
@@ -162,9 +162,9 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
     }
 
     private maybeRenderDropdownMenu() {
-        const { menu, menuIconName } = this.props;
+        const { index, menu, menuIconName, renderMenu } = this.props;
 
-        if (menu == null) {
+        if (renderMenu == null && menu == null) {
             return undefined;
         }
 
@@ -179,12 +179,17 @@ export class ColumnHeaderCell extends React.Component<IColumnHeaderCellProps, {}
             to: "window",
         }];
 
+        // prefer renderMenu if it's defined
+        const content = CoreUtils.isFunction(renderMenu)
+            ? renderMenu(index)
+            : menu;
+
         return (
             <div className={Classes.TABLE_TH_MENU_CONTAINER}>
                 <div className={Classes.TABLE_TH_MENU_CONTAINER_BACKGROUND} />
                 <Popover
                     tetherOptions={{ constraints }}
-                    content={menu}
+                    content={content}
                     position={Position.BOTTOM}
                     className={Classes.TABLE_TH_MENU}
                     popoverDidOpen={this.getPopoverStateChangeHandler(true)}

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -8,7 +8,12 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, ContextMenuTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    Classes as CoreClasses,
+    ContextMenuTarget,
+    IProps,
+    Utils as CoreUtils,
+} from "@blueprintjs/core";
 import * as Classes from "../common/classes";
 import { Utils } from "../common/utils";
 import { ResizeHandle } from "../interactions/resizeHandle";

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -8,7 +8,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, ContextMenuTarget, IProps } from "@blueprintjs/core";
+import { Classes as CoreClasses, ContextMenuTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
 import * as Classes from "../common/classes";
 import { Utils } from "../common/utils";
 import { ResizeHandle } from "../interactions/resizeHandle";
@@ -37,6 +37,7 @@ export interface IHeaderCellProps extends IProps {
     /**
      * An element, like a `<Menu>`, this is displayed by right-clicking
      * anywhere in the header.
+     * @deprecated since v1.20.0; use `renderMenu` instead
      */
     menu?: JSX.Element;
 
@@ -44,6 +45,13 @@ export interface IHeaderCellProps extends IProps {
      * The name displayed in the header of the row/column.
      */
     name?: string;
+
+    /**
+     * A callback that returns an element, like a `<Menu>`, which is displayed by right-clicking
+     * anywhere in the header. The callback will receive the cell index if it was provided via
+     * props.
+     */
+    renderMenu?: (index?: number) => JSX.Element;
 
     /**
      * A `ResizeHandle` React component that allows users to drag-resize the
@@ -85,7 +93,17 @@ export class HeaderCell extends React.Component<IInternalHeaderCellProps, IHeade
     }
 
     public renderContextMenu(_event: React.MouseEvent<HTMLElement>) {
-        return this.props.menu;
+        const { renderMenu } = this.props;
+
+        if (CoreUtils.isFunction(renderMenu)) {
+            // the preferred way (a consistent function instance that won't cause as many re-renders)
+            return renderMenu(this.props.index);
+        } else {
+            // the deprecated way (leads to lots of unnecessary re-renders because of menu-item
+            // callbacks needing access to the index of the right-clicked cell, which demands that
+            // new callback functions and JSX elements be recreated on each render of the parent)
+            return this.props.menu;
+        }
     }
 
     public render() {

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -8,9 +8,10 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { AbstractComponent, IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
+import * as Errors from "../common/errors";
 import { LoadableContent } from "../common/loadableContent";
 import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
@@ -26,7 +27,7 @@ export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
     isRowSelected?: boolean;
 }
 
-export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
+export class RowHeaderCell extends AbstractComponent<IRowHeaderCellProps, {}> {
     public render() {
         const loadableContentDivClasses = classNames(
             Classes.TABLE_ROW_NAME_TEXT,
@@ -58,5 +59,14 @@ export class RowHeaderCell extends React.Component<IRowHeaderCellProps, {}> {
                 {spreadableProps.loading ? undefined : spreadableProps.resizeHandle}
             </HeaderCell>
         );
+    }
+
+    protected validateProps(nextProps: IRowHeaderCellProps) {
+        if (nextProps.menu != null) {
+            // throw this warning from the publicly exported, higher-order *HeaderCell components
+            // rather than HeaderCell, so consumers know exactly which components are receiving the
+            // offending prop
+            console.warn(Errors.ROW_HEADER_CELL_MENU_DEPRECATED);
+        }
     }
 }

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -76,7 +76,44 @@ describe("<ColumnHeaderCell>", () => {
 
         it("renders custom menu items", () => {
             const menuClickSpy = sinon.spy();
-            const menu = (
+            const menu = getMenuComponent(menuClickSpy);
+
+            const renderColumnHeader = (columnIndex: number) => {
+                return (
+                    <ColumnHeaderCell name={`COL-${columnIndex}`} menu={menu} />
+                );
+            };
+            const table = harness.mount(createTableOfSize(3, 2, {renderColumnHeader}));
+            expectMenuToOpen(table, menuClickSpy);
+        });
+
+        it("renders custom menu items with a renderMenu callback", () => {
+            const menuClickSpy = sinon.spy();
+            const menu = getMenuComponent(menuClickSpy);
+            const renderMenu = sinon.stub().returns(menu);
+
+            const renderColumnHeader = (columnIndex: number) => (
+                <ColumnHeaderCell
+                    name={`COL-${columnIndex}`}
+                    renderMenu={renderMenu}
+                />
+            );
+            const table = harness.mount(createTableOfSize(3, 2, { renderColumnHeader }));
+            expectMenuToOpen(table, menuClickSpy);
+        });
+
+        it("renders loading state properly", () => {
+            const renderColumnHeader = (columnIndex: number) => {
+                return <ColumnHeaderCell loading={columnIndex === 0} name="Column Header" />;
+            };
+            const table = harness.mount(createTableOfSize(2, 1, { renderColumnHeader }));
+            expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 0).text()).to.equal("");
+            expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 1).text())
+                .to.equal("Column Header");
+        });
+
+        function getMenuComponent(menuClickSpy: Sinon.SinonSpy) {
+            return (
                 <Menu>
                     <MenuItem
                         iconName="export"
@@ -95,28 +132,13 @@ describe("<ColumnHeaderCell>", () => {
                     />
                 </Menu>
             );
+        }
 
-            const renderColumnHeader = (columnIndex: number) => {
-                return (
-                    <ColumnHeaderCell name={`COL-${columnIndex}`} menu={menu} />
-                );
-            };
-            const table = harness.mount(createTableOfSize(3, 2, {renderColumnHeader}));
-
+        function expectMenuToOpen(table: ElementHarness, menuClickSpy: Sinon.SinonSpy) {
             table.find(`.${Classes.TABLE_COLUMN_HEADERS}`).mouse("mousemove");
             table.find(`.${Classes.TABLE_TH_MENU}`).mouse("mousemove").mouse("click");
             ElementHarness.document().find(".pt-icon-export").mouse("click");
             expect(menuClickSpy.called).to.be.true;
-        });
-
-        it("renders loading state properly", () => {
-            const renderColumnHeader = (columnIndex: number) => {
-                return <ColumnHeaderCell loading={columnIndex === 0} name="Column Header" />;
-            };
-            const table = harness.mount(createTableOfSize(2, 1, { renderColumnHeader }));
-            expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 0).text()).to.equal("");
-            expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 1).text())
-                .to.equal("Column Header");
-        });
+        }
     });
 });


### PR DESCRIPTION
#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

The `HeaderCell#menu` prop we have now is bad, because `<MenuItem>`s typically require callbacks that are instantiated as inline anonymous functions so that they can have access to a row/column index.

This PR deprecates `HeaderCell#menu` and introduces `HeaderCell#renderMenu` instead, a callback that receives a row/column index parameter and expects a JSX element in return. This works in concert with the `HeaderCell#index` props introduced in #1210.

The major benefit here is that `shouldComponentUpdate` checks pass, because `renderMenu` can be a single, persistent function instance; whereas `menu` was typically reinstantiated on each re-render.

#### Reviewers should focus on:

Does this API change sound good?
