### PR TITLE
[DateTime] Add disabled prop to TimePicker

### DIFF
--- a/packages/datetime/examples/timePickerExample.tsx
+++ b/packages/datetime/examples/timePickerExample.tsx
@@ -16,10 +16,12 @@ export interface ITimePickerExampleState {
     precision?: TimePickerPrecision;
     selectAllOnFocus?: boolean;
     showArrowButtons?: boolean;
+    disabled?: boolean;
 }
 
 export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     public state = {
+        disabled: false,
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
@@ -51,6 +53,12 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                     key="arrows"
                     onChange={this.toggleShowArrowButtons}
                 />,
+                <Switch
+                    checked={this.state.disabled}
+                    label="Disabled"
+                    key="disabled"
+                    onChange={this.toggleDisabled}
+                />,
             ],
         ];
     }
@@ -61,5 +69,9 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
 
     private toggleSelectAllOnFocus = () => {
         this.setState({ selectAllOnFocus: !this.state.selectAllOnFocus });
+    }
+
+    private toggleDisabled = () => {
+        this.setState({ disabled: !this.state.disabled });
     }
 }

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -73,6 +73,23 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
       box-shadow: input-transition-shadow($input-shadow-color-focus, true);
     }
   }
+
+  &.pt-disabled {
+    .pt-timepicker-input-row {
+      @include pt-input-disabled();
+    }
+
+    .pt-timepicker-input,
+    .pt-timepicker-divider-text {
+      color: $input-color-disabled;
+    }
+
+    .pt-timepicker-arrow-button,
+    .pt-timepicker-arrow-button:hover {
+      cursor: not-allowed;
+      color: $input-color-disabled;
+    }
+  }
 }
 
 .pt-dark .pt-timepicker {

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { IProps, Keys, Utils as BlueprintUtils } from "@blueprintjs/core";
+import { Classes as CoreClasses, IProps, Keys, Utils as BlueprintUtils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 
@@ -25,6 +25,12 @@ export interface ITimePickerProps extends IProps {
     * This should not be set if `value` is set.
     */
     defaultValue?: Date;
+
+   /**
+    * Whether the time picker is non-interactive.
+    * @default false
+    */
+    disabled?: boolean;
 
    /**
     * Callback invoked when the user changes the time.
@@ -66,6 +72,7 @@ export interface ITimePickerState {
 
 export class TimePicker extends React.Component<ITimePickerProps, ITimePickerState> {
     public static defaultProps: ITimePickerProps = {
+        disabled: false,
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
@@ -88,10 +95,13 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     public render() {
         const shouldRenderSeconds = this.props.precision >= TimePickerPrecision.SECOND;
         const shouldRenderMilliseconds = this.props.precision >= TimePickerPrecision.MILLISECOND;
+        const classes = classNames(Classes.TIMEPICKER, this.props.className, {
+            [CoreClasses.DISABLED]: this.props.disabled,
+        });
 
         /* tslint:disable:max-line-length */
         return (
-            <div className={classNames(Classes.TIMEPICKER, this.props.className)}>
+            <div className={classes}>
                 <div className={Classes.TIMEPICKER_ARROW_ROW}>
                     {this.maybeRenderArrowButton(true, Classes.TIMEPICKER_HOUR, () => this.incrementTime(TimeUnit.HOUR))}
                     {this.maybeRenderArrowButton(true, Classes.TIMEPICKER_MINUTE, () => this.incrementTime(TimeUnit.MINUTE))}
@@ -151,6 +161,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 onFocus={this.handleFocus}
                 onKeyDown={this.getInputKeyDownHandler(unit)}
                 value={value}
+                disabled={this.props.disabled}
             />
         );
     }
@@ -226,11 +237,17 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     }
 
     private incrementTime(unit: TimeUnit) {
+        if (this.props.disabled) {
+            return;
+        }
         const newTime = getTimeUnit(this.state.value, unit) + 1;
         this.updateTime(loopTime(newTime, unit), unit);
     }
 
     private decrementTime(unit: TimeUnit) {
+        if (this.props.disabled) {
+            return;
+        }
         const newTime = getTimeUnit(this.state.value, unit) - 1;
         this.updateTime(loopTime(newTime, unit), unit);
     }

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -163,6 +163,52 @@ describe("<TimePicker>", () => {
         assert.equal(window.getSelection().toString(), "00");
     });
 
+    it("value doesn't change when disabled", () => {
+        renderTimePicker({ disabled: true, precision: TimePickerPrecision.MILLISECOND, showArrowButtons: true });
+
+        const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
+        assert.isTrue(hourInput.disabled);
+        const minuteInput = findInputElement(Classes.TIMEPICKER_MINUTE);
+        assert.isTrue(minuteInput.disabled);
+
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickIncrementBtn(Classes.TIMEPICKER_HOUR);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickIncrementBtn(Classes.TIMEPICKER_MINUTE);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickIncrementBtn(Classes.TIMEPICKER_SECOND);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickIncrementBtn(Classes.TIMEPICKER_MILLISECOND);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+
+        clickDecrementBtn(Classes.TIMEPICKER_HOUR);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickDecrementBtn(Classes.TIMEPICKER_MINUTE);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickDecrementBtn(Classes.TIMEPICKER_SECOND);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        clickDecrementBtn(Classes.TIMEPICKER_MILLISECOND);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+
+        keyDownOnInput(Classes.TIMEPICKER_HOUR, Keys.ARROW_UP);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        keyDownOnInput(Classes.TIMEPICKER_MINUTE, Keys.ARROW_UP);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        keyDownOnInput(Classes.TIMEPICKER_SECOND, Keys.ARROW_UP);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        keyDownOnInput(Classes.TIMEPICKER_MILLISECOND, Keys.ARROW_UP);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+
+        keyDownOnInput(Classes.TIMEPICKER_HOUR, Keys.ARROW_DOWN);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        keyDownOnInput(Classes.TIMEPICKER_MINUTE, Keys.ARROW_DOWN);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        keyDownOnInput(Classes.TIMEPICKER_SECOND, Keys.ARROW_DOWN);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+        keyDownOnInput(Classes.TIMEPICKER_MILLISECOND, Keys.ARROW_DOWN);
+        assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+    });
+
     describe("when uncontrolled", () => {
         it("defaultValue sets the initialTime", () => {
             renderTimePicker({


### PR DESCRIPTION
#### Feature #672

##### Changes

- "Disabled" optional property added to TimePiker component. False for default
- Styling was reused from `core/src/components/forms/common`, as for InputGroup component
- Changes pass linter checks
- Covered with tests

##### Screenshot

<img width="114" alt="screenshot at jun 11 01-35-47" src="https://user-images.githubusercontent.com/10484318/27006785-57bf64fc-4e46-11e7-9fc0-cc890f7370fb.png">

