### PR TITLE
[Table] Add new utils: getShallowUnequalKeyValues and getDeepUnequalKeyValues

### DIFF
--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -263,10 +263,14 @@ export const Utils = {
      * provided objects. Useful for debugging shouldComponentUpdate.
      */
     getShallowUnequalKeyValues<T extends object>(objA: T, objB: T, keys?: IKeyBlacklist<T> | IKeyWhitelist<T>) {
-        const filteredKeys = _filterKeys(objA, objB, keys == null ? { exclude: [] } : keys);
+        // default param values let null values pass through, so we have to take this more thorough approach
+        const definedObjA = (objA == null) ? {} : objA;
+        const definedObjB = (objB == null) ? {} : objB;
+
+        const filteredKeys = _filterKeys(definedObjA, definedObjB, keys == null ? { exclude: [] } : keys);
         return _getUnequalKeyValues(
-            objA,
-            objB,
+            definedObjA,
+            definedObjB,
             filteredKeys,
             (a, b, key) => Utils.shallowCompareKeys(a, b, { include: [key] }));
     },
@@ -276,10 +280,13 @@ export const Utils = {
      * provided objects. Useful for debugging shouldComponentUpdate.
      */
     getDeepUnequalKeyValues<T extends object>(objA: T, objB: T, keys?: Array<keyof T>) {
-        const filteredKeys = (keys == null) ? _unionKeys(objA, objB) : keys;
+        const definedObjA = (objA == null) ? {} as T : objA;
+        const definedObjB = (objB == null) ? {} as T : objB;
+
+        const filteredKeys = (keys == null) ? _unionKeys(definedObjA, definedObjB) : keys;
         return _getUnequalKeyValues(
-            objA,
-            objB,
+            definedObjA,
+            definedObjB,
             filteredKeys,
             (a, b, key) => Utils.deepCompareKeys(a, b, [key]));
     },
@@ -482,7 +489,7 @@ function _getUnequalKeyValues<T extends object>(
     objA: T,
     objB: T,
     keys: Array<keyof T>,
-    compareFn: (objA: any, objB: any, key: keyof T) => boolean
+    compareFn: (objA: any, objB: any, key: keyof T) => boolean,
 ) {
     const unequalKeys = keys.filter((key) => !compareFn(objA, objB, key));
     const unequalKeyValues = unequalKeys.map((key) => ({

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -303,103 +303,6 @@ describe("Utils", () => {
         }
     });
 
-    describe("deepCompareKeys", () => {
-        // tslint:disable:max-classes-per-file
-        class DVD {
-            public constructor() { /* Empty */ }
-        }
-
-        class VHSTape {
-            public constructor() { /* Empty */ }
-        }
-        // tslint:enable:max-classes-per-file
-
-        describe("with `keys` defined", () => {
-            describe("returns true if only the specified values are deeply equal", () => {
-                const customInstance1 = new DVD();
-                const customInstance2 = new DVD();
-
-                runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
-                runTest(true, { a: customInstance1 }, { a: customInstance2 }, ["a"]);
-                runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["b", "c"]);
-                runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["b", "c"]);
-            });
-
-            describe("returns false if any specified values are not deeply equal", () => {
-                const customInstance1 = new DVD();
-                const customInstance2 = new VHSTape();
-
-                runTest(false, { a: [1, "2", true] }, { a: [1, "2", false] }, ["a"]);
-                runTest(false, { a: customInstance1 }, { a: customInstance2 }, ["a"]);
-                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 2 }}, ["a", "b", "c"]);
-            });
-
-            describe("edge cases that return true", () => {
-                runTest(true, undefined, null, []);
-                runTest(true, undefined, undefined, ["a"]);
-                runTest(true, null, null, ["a"]);
-                runTest(true, {}, {}, ["a"]);
-            });
-
-            describe("edge cases that return false", () => {
-                runTest(false, {}, undefined, []);
-                runTest(false, {}, [], []);
-            });
-
-            function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
-                it(getCompareTestDescription(a, b), () => {
-                    expect(Utils.deepCompareKeys(a, b, keys)).to.equal(expectedResult);
-                });
-            }
-        });
-
-        describe("with `keys` not defined", () => {
-            describe("returns true if values are deeply equal", () => {
-                const customInstance1 = new DVD();
-                const customInstance2 = new DVD();
-
-                runTest(true, { a: 1, b: "2", c: true }, { a: 1, b: "2", c: true });
-                runTest(true, { a: 1, b: "2", c: { a: 1, b: "2" } }, { a: 1, b: "2", c: { a: 1, b: "2" } });
-                runTest(true, [1, "2", true], [1, "2", true]);
-                runTest(true, 1, 1);
-                runTest(true, customInstance1, customInstance2);
-                runTest(true, "2", "2");
-                runTest(true, undefined, undefined);
-                runTest(true, null, undefined);
-            });
-
-            describe("returns false if values are not deeply equal", () => {
-                const customInstance1 = new DVD();
-                const customInstance2 = new VHSTape();
-
-                runTest(false, undefined, {});
-                runTest(false, null, {});
-                runTest(false, {}, []);
-                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: "1" }});
-                runTest(false, customInstance1, customInstance2);
-            });
-
-            describe("returns false if keys are different", () => {
-                runTest(false, {}, { a: 1 });
-                runTest(false, { a: 1, b: "2" }, { b: "2" });
-                runTest(false, { a: 1, b: "2", c: true}, { b: "2", c: true, d: 3 });
-            });
-
-            describe("returns true if same deeply-comparable instance is reused in both objects", () => {
-                const deeplyComparableThing1 = { a: 1 };
-                const deeplyComparableThing2 = [1, "2", true];
-                runTest(true, { a: 1, b: deeplyComparableThing1 }, { a: 1, b: deeplyComparableThing1 });
-                runTest(true, { a: 1, b: deeplyComparableThing2 }, { a: 1, b: deeplyComparableThing2 });
-            });
-
-            function runTest(expectedResult: boolean, a: any, b: any) {
-                it(getCompareTestDescription(a, b), () => {
-                    expect(Utils.deepCompareKeys(a, b)).to.equal(expectedResult);
-                });
-            }
-        });
-    });
-
     describe("shallowCompareKeys", () => {
         describe("with `keys` defined as whitelist", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
@@ -503,6 +406,103 @@ describe("Utils", () => {
             function runTest(expectedResult: boolean, a: any, b: any) {
                 it(getCompareTestDescription(a, b), () => {
                     expect(Utils.shallowCompareKeys(a, b)).to.equal(expectedResult);
+                });
+            }
+        });
+    });
+
+    describe("deepCompareKeys", () => {
+        // tslint:disable:max-classes-per-file
+        class DVD {
+            public constructor() { /* Empty */ }
+        }
+
+        class VHSTape {
+            public constructor() { /* Empty */ }
+        }
+        // tslint:enable:max-classes-per-file
+
+        describe("with `keys` defined", () => {
+            describe("returns true if only the specified values are deeply equal", () => {
+                const customInstance1 = new DVD();
+                const customInstance2 = new DVD();
+
+                runTest(true, { a: 1 }, { a: 1 }, ["a", "b", "c", "d"]);
+                runTest(true, { a: customInstance1 }, { a: customInstance2 }, ["a"]);
+                runTest(true, { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["b", "c"]);
+                runTest(true, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 1 }}, ["b", "c"]);
+            });
+
+            describe("returns false if any specified values are not deeply equal", () => {
+                const customInstance1 = new DVD();
+                const customInstance2 = new VHSTape();
+
+                runTest(false, { a: [1, "2", true] }, { a: [1, "2", false] }, ["a"]);
+                runTest(false, { a: customInstance1 }, { a: customInstance2 }, ["a"]);
+                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: 2 }}, ["a", "b", "c"]);
+            });
+
+            describe("edge cases that return true", () => {
+                runTest(true, undefined, null, []);
+                runTest(true, undefined, undefined, ["a"]);
+                runTest(true, null, null, ["a"]);
+                runTest(true, {}, {}, ["a"]);
+            });
+
+            describe("edge cases that return false", () => {
+                runTest(false, {}, undefined, []);
+                runTest(false, {}, [], []);
+            });
+
+            function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
+                it(getCompareTestDescription(a, b), () => {
+                    expect(Utils.deepCompareKeys(a, b, keys)).to.equal(expectedResult);
+                });
+            }
+        });
+
+        describe("with `keys` not defined", () => {
+            describe("returns true if values are deeply equal", () => {
+                const customInstance1 = new DVD();
+                const customInstance2 = new DVD();
+
+                runTest(true, { a: 1, b: "2", c: true }, { a: 1, b: "2", c: true });
+                runTest(true, { a: 1, b: "2", c: { a: 1, b: "2" } }, { a: 1, b: "2", c: { a: 1, b: "2" } });
+                runTest(true, [1, "2", true], [1, "2", true]);
+                runTest(true, 1, 1);
+                runTest(true, customInstance1, customInstance2);
+                runTest(true, "2", "2");
+                runTest(true, undefined, undefined);
+                runTest(true, null, undefined);
+            });
+
+            describe("returns false if values are not deeply equal", () => {
+                const customInstance1 = new DVD();
+                const customInstance2 = new VHSTape();
+
+                runTest(false, undefined, {});
+                runTest(false, null, {});
+                runTest(false, {}, []);
+                runTest(false, { a: 1, b: "2", c: { a: 1 }}, { a: 1, b: "2", c: { a: "1" }});
+                runTest(false, customInstance1, customInstance2);
+            });
+
+            describe("returns false if keys are different", () => {
+                runTest(false, {}, { a: 1 });
+                runTest(false, { a: 1, b: "2" }, { b: "2" });
+                runTest(false, { a: 1, b: "2", c: true}, { b: "2", c: true, d: 3 });
+            });
+
+            describe("returns true if same deeply-comparable instance is reused in both objects", () => {
+                const deeplyComparableThing1 = { a: 1 };
+                const deeplyComparableThing2 = [1, "2", true];
+                runTest(true, { a: 1, b: deeplyComparableThing1 }, { a: 1, b: deeplyComparableThing1 });
+                runTest(true, { a: 1, b: deeplyComparableThing2 }, { a: 1, b: deeplyComparableThing2 });
+            });
+
+            function runTest(expectedResult: boolean, a: any, b: any) {
+                it(getCompareTestDescription(a, b), () => {
+                    expect(Utils.deepCompareKeys(a, b)).to.equal(expectedResult);
                 });
             }
         });

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -565,7 +565,7 @@ describe("Utils", () => {
             expectedResult: any[],
             a: any,
             b: any,
-            keys?: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>
+            keys?: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>,
         ) {
             it(getCompareTestDescription(a, b, keys), () => {
                 expect(Utils.getShallowUnequalKeyValues(a, b, keys)).to.deep.equal(expectedResult);

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -508,6 +508,71 @@ describe("Utils", () => {
         });
     });
 
+    describe("getShallowUnequalKeyValues" , () => {
+        describe("with `keys` defined as whitelist", () => {
+            describe("returns empty array if the specified values are shallowly equal", () => {
+                runTest([], { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, wl(["a", "c"]));
+            });
+
+            describe("returns unequal key/values if any specified values are not shallowly equal", () => {
+                // identical objects, but different instances
+                runTest(
+                    [{ key: "a", valueA: [1, "2", true], valueB: [1, "2", true] }],
+                    { a: [1, "2", true] },
+                    { a: [1, "2", true] },
+                    wl(["a"]));
+                // different primitive-type values
+                runTest(
+                    [{ key: "a", valueA: 1, valueB: 2 }],
+                    { a: 1 },
+                    { a: 2 },
+                    wl(["a"]));
+            });
+        });
+
+        describe("with `keys` defined as blacklist", () => {
+            describe("returns empty array if the specified values are shallowly equal", () => {
+                runTest([], { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, bl(["b"]));
+            });
+
+            describe("returns unequal keys/values if any specified values are not shallowly equal", () => {
+                runTest(
+                    [{ key: "a", valueA: [1, "2", true], valueB: [1, "2", true] }],
+                    { a: [1, "2", true] },
+                    { a: [1, "2", true] },
+                    bl(["b", "c"]));
+                runTest(
+                    [{ key: "a", valueA: 1, valueB: 2 }],
+                    { a: 1 },
+                    { a: 2 },
+                    bl(["b"]));
+            });
+        });
+
+        describe("with `keys` not defined", () => {
+            describe("returns empty array if values are shallowly equal", () => {
+                runTest([], { a: 1, b: "2", c: true}, { a: 1, b: "2", c: true});
+                runTest([], undefined, undefined);
+                runTest([], null, undefined);
+            });
+
+            describe("returns unequal key/values if any specified values are not shallowly equal", () => {
+                runTest([{ key: "a", valueA: 1, valueB: 2 }], { a: 1 }, { a: 2 });
+            });
+        });
+
+        function runTest(
+            expectedResult: any[],
+            a: any,
+            b: any,
+            keys?: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>
+        ) {
+            it(getCompareTestDescription(a, b, keys), () => {
+                expect(Utils.getShallowUnequalKeyValues(a, b, keys)).to.deep.equal(expectedResult);
+            });
+        }
+    });
+
     describe("arraysEqual", () => {
         describe("no compare function provided", () => {
             describe("should return true if the arrays are shallowly equal", () => {

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -573,6 +573,49 @@ describe("Utils", () => {
         }
     });
 
+    describe("getDeepUnequalKeyValues", () => {
+        describe("with `keys` defined", () => {
+            describe("returns empty array if only the specified values are deeply equal", () => {
+                runTest([], { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, ["b", "c"]);
+            });
+
+            describe("returns unequal key/values if any specified values are not deeply equal", () => {
+                runTest(
+                    [
+                        { key: "a", valueA: 2, valueB: 1 },
+                        { key: "b", valueA: [2, 3, 4], valueB: [1, 2, 3] },
+                    ],
+                    { a: 2, b: [2, 3, 4], c: "3" },
+                    { b: [1, 2, 3], a: 1, c: "3" },
+                    ["a", "b"]);
+            });
+        });
+
+        describe("with `keys` not defined", () => {
+            describe("returns empty arrau if values are deeply equal", () => {
+                runTest([], { a: 1, b: "2", c: { a: 1, b: "2" } }, { a: 1, b: "2", c: { a: 1, b: "2" } });
+            });
+
+            describe("returns unequal key/values if values are not deeply equal", () => {
+                runTest(
+                    [{ key: "a", valueA: [1, "2", true], valueB: [1, "2", false] }],
+                    { a: [1, "2", true] },
+                    { a: [1, "2", false] });
+            });
+        });
+
+        function runTest(
+            expectedResult: any[],
+            a: any,
+            b: any,
+            keys?: string[],
+        ) {
+            it(getCompareTestDescription(a, b, keys), () => {
+                expect(Utils.getDeepUnequalKeyValues(a, b, keys)).to.deep.equal(expectedResult);
+            });
+        }
+    });
+
     describe("arraysEqual", () => {
         describe("no compare function provided", () => {
             describe("should return true if the arrays are shallowly equal", () => {

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -347,7 +347,7 @@ describe("Utils", () => {
             });
 
             function runTest(expectedResult: boolean, a: any, b: any, keys: string[]) {
-                it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
+                it(getCompareTestDescription(a, b), () => {
                     expect(Utils.deepCompareKeys(a, b, keys)).to.equal(expectedResult);
                 });
             }
@@ -393,7 +393,7 @@ describe("Utils", () => {
             });
 
             function runTest(expectedResult: boolean, a: any, b: any) {
-                it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
+                it(getCompareTestDescription(a, b), () => {
                     expect(Utils.deepCompareKeys(a, b)).to.equal(expectedResult);
                 });
             }
@@ -401,13 +401,6 @@ describe("Utils", () => {
     });
 
     describe("shallowCompareKeys", () => {
-        interface IKeys {
-            a?: any;
-            b?: any;
-            c?: any;
-            d?: any;
-        }
-
         describe("with `keys` defined as whitelist", () => {
             describe("returns true if only the specified values are shallowly equal", () => {
                 runTest(true, { a: 1 }, { a: 1 }, wl(["a", "b", "c", "d"]));
@@ -438,7 +431,7 @@ describe("Utils", () => {
                              a: any,
                              b: any,
                              keys: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
-                it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
+                it(getCompareTestDescription(a, b), () => {
                     expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
                 });
             }
@@ -474,7 +467,7 @@ describe("Utils", () => {
                              a: any,
                              b: any,
                              keys: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
-                it(`${JSON.stringify(a)} and ${JSON.stringify(b)} (keys: ${JSON.stringify(keys)})`, () => {
+                it(getCompareTestDescription(a, b), () => {
                     expect(Utils.shallowCompareKeys(a, b, keys)).to.equal(expectedResult);
                 });
             }
@@ -508,25 +501,11 @@ describe("Utils", () => {
             });
 
             function runTest(expectedResult: boolean, a: any, b: any) {
-                it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
+                it(getCompareTestDescription(a, b), () => {
                     expect(Utils.shallowCompareKeys(a, b)).to.equal(expectedResult);
                 });
             }
         });
-
-        /**
-         * A compactly named function for converting a string array to a key blacklist.
-         */
-        function bl(keys: string[]) {
-            return { exclude: keys } as IKeyBlacklist<IKeys>;
-        }
-
-        /**
-         * A compactly named function for converting a string array to a key whitelist.
-         */
-        function wl(keys: string[]) {
-            return { include: keys } as IKeyWhitelist<IKeys>;
-        }
     });
 
     describe("arraysEqual", () => {
@@ -560,9 +539,37 @@ describe("Utils", () => {
         });
 
         function runTest(expectedResult: boolean, a: any, b: any, compareFn?: (a: any, b: any) => boolean) {
-            it(`${JSON.stringify(a)} and ${JSON.stringify(b)}`, () => {
+            it(getCompareTestDescription(a, b), () => {
                 expect(Utils.arraysEqual(a, b, compareFn)).to.equal(expectedResult);
             });
         }
     });
 });
+
+function getCompareTestDescription(a?: any, b?: any, keys?: any) {
+    const baseResult = `${JSON.stringify(a)} and ${JSON.stringify(b)}`;
+    return (keys != null)
+        ? baseResult + ` (keys: ${JSON.stringify(keys)})`
+        : baseResult;
+}
+
+interface IKeys {
+    a?: any;
+    b?: any;
+    c?: any;
+    d?: any;
+}
+
+/**
+ * A compactly named function for converting a string array to a key blacklist.
+ */
+function bl(keys: string[]) {
+    return { exclude: keys } as IKeyBlacklist<IKeys>;
+}
+
+/**
+ * A compactly named function for converting a string array to a key whitelist.
+ */
+function wl(keys: string[]) {
+    return { include: keys } as IKeyWhitelist<IKeys>;
+}


### PR DESCRIPTION
#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Proposing to add `getShallowUnequalKeyValues` and `getDeepUnequalKeyValues` to our `Table` utils. These functions are useful primarily for debugging `shouldComponentUpdate`; I kept reimplementing the same helpers to do just this, so I figured I'd open a PR to add them to the codebase permanently.

#### Reviewers should focus on:

- Is it worth having these around permanently? I think so.
- If you agree, then I'll add tests. Not before. :)