### PR TITLE
[Table] Final cleanups from perf work

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -150,7 +150,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     loadingOptions={this.getEnabledLoadingOptions()}
                     numRows={this.state.numRows}
                     renderBodyContextMenu={this.renderBodyContextMenu}
-                    renderRowHeader={this.renderRowHeader.bind(this)}
+                    renderRowHeader={this.renderRowHeader}
                     selectionModes={this.getEnabledSelectionModes()}
                     isRowHeaderShown={this.state.showRowHeaders}
                     styledRegionGroups={this.getStyledRegionGroups()}
@@ -185,13 +185,13 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         return Utils.times(this.state.numCols, (index) => {
             return <Column
                 key={index}
-                renderColumnHeader={this.renderColumnHeader.bind(this)}
+                renderColumnHeader={this.renderColumnHeader}
                 renderCell={this.renderCell}
             />;
         });
     }
 
-    private renderColumnHeader(columnIndex: number) {
+    private renderColumnHeader = (columnIndex: number) => {
         const name = `Column ${Utils.toBase26Alpha(columnIndex)}`;
         return (<ColumnHeaderCell
             index={columnIndex}
@@ -254,7 +254,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         return this.state.showColumnMenus ? menu : undefined;
     }
 
-    private renderRowHeader(rowIndex: number) {
+    private renderRowHeader = (rowIndex: number) => {
         return <RowHeaderCell
             name={`${rowIndex + 1}`}
             renderMenu={this.renderRowMenu}

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -181,7 +181,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     // Renderers
     // =========
 
-    public renderColumns() {
+    private renderColumns() {
         return Utils.times(this.state.numCols, (index) => {
             return <Column
                 key={index}
@@ -308,7 +308,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 value={valueAsString}
             />
         ) : (
-            <Cell className={classes}>
+            <Cell className={classes} columnIndex={columnIndex} rowIndex={rowIndex}>
                 {valueAsString}
             </Cell>
         );

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -209,8 +209,8 @@ export class ColumnHeaderCell extends AbstractComponent<IColumnHeaderCellProps, 
                     content={content}
                     position={Position.BOTTOM}
                     className={Classes.TABLE_TH_MENU}
-                    popoverDidOpen={this.getPopoverStateChangeHandler(true)}
-                    popoverWillClose={this.getPopoverStateChangeHandler(false)}
+                    popoverDidOpen={this.handlePopoverDidOpen}
+                    popoverWillClose={this.handlePopoverWillClose}
                     useSmartArrowPositioning={true}
                 >
                     <span className={popoverTargetClasses}/>
@@ -219,7 +219,11 @@ export class ColumnHeaderCell extends AbstractComponent<IColumnHeaderCellProps, 
         );
     }
 
-    private getPopoverStateChangeHandler = (isActive: boolean) => () => {
-        this.setState({ isActive });
+    private handlePopoverDidOpen = () => {
+        this.setState({ isActive: true });
+    }
+
+    private handlePopoverWillClose = () => {
+        this.setState({ isActive: false });
     }
 }


### PR DESCRIPTION
Some final, tiny cleanups from last week's `Table` perf work:
- Move from anonymous functions to private functions in `ColumnHeaderCell`.
- Use fat arrow instead of `.bind(this)` in `index.tsx`
- Provide indices to cells when editing is disabled on Table preview.