### PR TITLE
[Table] Provide index to RowHeaderCell in index.tsx

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -256,6 +256,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     private renderRowHeader = (rowIndex: number) => {
         return <RowHeaderCell
+            index={rowIndex}
             name={`${rowIndex + 1}`}
             renderMenu={this.renderRowMenu}
         />;


### PR DESCRIPTION
One final cleanup: provide `index` prop to `RowHeaderCell` in `index.tsx` (for use in the `renderMenu` callback). Only affects the table preview page.