### PR TITLE
[Table] Add menu to change cell content in Table playground

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -653,13 +653,11 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     }
 
     private generateRandomAlphanumericString(minLength = 5, maxLength = 40) {
-        const chars = [];
         const randomLength = Math.floor(minLength + (Math.random() * (maxLength - minLength)));
-        for (let i = 0; i < randomLength; i++) {
+        return Utils.times(randomLength, () => {
             const randomIndex = Math.floor(Math.random() * maxLength);
-            chars.push(ALPHANUMERIC_CHARS[randomIndex]);
-        }
-        return chars.join("");
+            return ALPHANUMERIC_CHARS[randomIndex];
+        }).join("");
     }
 }
 

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -46,7 +46,7 @@ enum FocusStyle {
     TAB_OR_CLICK,
 };
 
-type CellContent = "Empty" | "CellNames";
+type CellContent = "Empty" | "CellNames" | "LongText";
 
 type IMutableStateUpdateCallback =
     (stateKey: keyof IMutableTableState) => ((event: React.FormEvent<HTMLElement>) => void);
@@ -103,10 +103,13 @@ const ROW_COUNTS = [
 const CELL_CONTENTS = [
     "Empty",
     "CellNames",
+    "LongText",
 ] as CellContent[];
 
 const COLUMN_COUNT_DEFAULT_INDEX = 2;
 const ROW_COUNT_DEFAULT_INDEX = 3;
+
+const ALPHANUMERIC_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 interface ICellContentGeneratorDictionary {
     [key: string]: (rowIndex?: number, columnIndex?: number) => string;
@@ -118,6 +121,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private contentGenerators = {
         CellNames: (row: number, col: number) => Utils.toBase26Alpha(col) + (row + 1),
         Empty: () => "",
+        LongText: () => this.generateRandomAlphanumericString(),
     } as ICellContentGeneratorDictionary;
 
     public constructor(props: any, context?: any) {
@@ -347,7 +351,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             "Cell content",
             "cellContent",
             CELL_CONTENTS,
-            this.generateCellContentLabel,
+            this.toCellContentLabel,
             this.handleStringStateChange,
         );
         return (
@@ -437,7 +441,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             label,
             stateKey,
             values,
-            this.generateValueString,
+            this.toValueLabel,
             this.handleNumberStateChange,
         );
     }
@@ -473,13 +477,14 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     // Select menu - label generators
     // ==============================
 
-    private generateCellContentLabel(cellContent: CellContent) {
+    private toCellContentLabel(cellContent: CellContent) {
         if (cellContent === "CellNames") { return "Cell names"; }
         if (cellContent === "Empty") { return "Empty"; }
+        if (cellContent === "LongText") { return "Long text"; }
         return "";
     }
 
-    private generateValueString(value: any) {
+    private toValueLabel(value: any) {
         return value.toString();
     }
 
@@ -656,6 +661,16 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 regions: [Regions.cell(5, 3, 7, 7)],
             },
         ] as IStyledRegionGroup[];
+    }
+
+    private generateRandomAlphanumericString(minLength = 5, maxLength = 40) {
+        const chars = [];
+        const randomLength = Math.floor(minLength + (Math.random() * (maxLength - minLength)));
+        for (let i = 0; i < randomLength; i++) {
+            const randomIndex = Math.floor(Math.random() * maxLength);
+            chars.push(ALPHANUMERIC_CHARS[randomIndex]);
+        }
+        return chars.join("");
     }
 }
 

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -113,16 +113,24 @@ const CELL_CONTENTS = [
 const COLUMN_COUNT_DEFAULT_INDEX = 2;
 const ROW_COUNT_DEFAULT_INDEX = 3;
 
+const LONG_TEXT_MIN_LENGTH = 5;
+const LONG_TEXT_MAX_LENGTH = 40;
 const ALPHANUMERIC_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+const CELL_CONTENT_GENERATORS = {
+    [CellContent.CELL_NAMES]: (row: number, col: number) => Utils.toBase26Alpha(col) + (row + 1),
+    [CellContent.EMPTY]: () => "",
+    [CellContent.LONG_TEXT]: () => {
+        const randomLength = getRandomInteger(LONG_TEXT_MIN_LENGTH, LONG_TEXT_MAX_LENGTH);
+        return Utils.times(randomLength, () => {
+            const randomIndex = getRandomInteger(0, ALPHANUMERIC_CHARS.length - 1);
+            return ALPHANUMERIC_CHARS[randomIndex];
+        }).join("");
+    },
+};
 
 class MutableTable extends React.Component<{}, IMutableTableState> {
     private store = new SparseGridMutableStore<string>();
-
-    private contentGenerators = {
-        [CellContent.CELL_NAMES]: (row: number, col: number) => Utils.toBase26Alpha(col) + (row + 1),
-        [CellContent.EMPTY]: () => "",
-        [CellContent.LONG_TEXT]: () => this.generateRandomAlphanumericString(),
-    };
 
     public constructor(props: any, context?: any) {
         super(props, context);
@@ -541,7 +549,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
 
     // designed to be called from componentWillMount and componentWillUpdate, hence it expects nextProps
     private syncCellContent = (nextState = this.state) => {
-        const generator = this.contentGenerators[nextState.cellContent];
+        const generator = CELL_CONTENT_GENERATORS[nextState.cellContent];
         Utils.times(nextState.numRows, (rowIndex) => {
             Utils.times(nextState.numCols, (columnIndex) => {
                 this.store.set(rowIndex, columnIndex, generator(rowIndex, columnIndex));
@@ -637,14 +645,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             },
         ] as IStyledRegionGroup[];
     }
-
-    private generateRandomAlphanumericString(minLength = 5, maxLength = 40) {
-        const randomLength = Math.floor(minLength + (Math.random() * (maxLength - minLength)));
-        return Utils.times(randomLength, () => {
-            const randomIndex = Math.floor(Math.random() * ALPHANUMERIC_CHARS.length);
-            return ALPHANUMERIC_CHARS[randomIndex];
-        }).join("");
-    }
 }
 
 ReactDOM.render(
@@ -667,4 +667,9 @@ function handleStringChange(handler: (value: string) => void) {
 /** Event handler that exposes the target element's value as a number. */
 function handleNumberChange(handler: (value: number) => void) {
     return handleStringChange((value) => handler(+value));
+}
+
+function getRandomInteger(min: number, max: number) {
+    // min and max are inclusive
+    return Math.floor(min + (Math.random() * (max - min + 1)));
 }

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -270,17 +270,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 }}
                 text="Remove column"
             />
-            <MenuItem
-                iconName="new-text-box"
-                onClick={() => {
-                    Utils.times(this.state.numRows, (i) => {
-                        const str = Math.random().toString(36).substring(7);
-                        this.store.set(i, columnIndex, str);
-                    });
-                    this.forceUpdate();
-                }}
-                text="Fill with random text"
-            />
         </Menu>;
 
         return this.state.showColumnMenus ? menu : undefined;


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add `<select>` menu to change cell content in the entire table in one fell swoop.
    - Empty
    - Cell names (A1, J17, etc.)
    - Long text (random alphanumeric strings between 5 and 40 chars long) 
- Delete the old "Fill with random text" menu items in column headers.

#### Reviewers should focus on:

- This only affects the table preview page. 
- We really need some way to force update all cells in the `Table`, without requiring scrolling (this goes for any `Table`, not just our preview). This constraint is why you have to scroll before seeing the cell content change.

#### Screenshot

<img src="https://user-images.githubusercontent.com/443450/27101141-5ba03bbe-5035-11e7-86d4-ce0fbbef4867.png" width="296" />

![2017-06-13 12 40 58](https://user-images.githubusercontent.com/443450/27101205-a5889e38-5035-11e7-804f-d82635ba71d8.gif)
