### PR TITLE
[Table] Have EditableCell fully control value in child EditableText

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -55,8 +55,6 @@ export interface IEditableCellState {
 }
 
 export class EditableCell extends React.Component<IEditableCellProps, IEditableCellState> {
-    public state: IEditableCellState;
-
     public constructor(props: IEditableCellProps, context?: any) {
         super(props, context);
         this.state = {

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -6,6 +6,7 @@
  */
 
 import { expect } from "chai";
+import { mount } from "enzyme";
 import * as React from "react";
 
 import { EditableCell } from "../src/index";
@@ -31,6 +32,17 @@ describe("<EditableCell>", () => {
     it("renders loading state", () => {
         const editableCellHarness = harness.mount(<EditableCell loading={true} value="test-value-5000" />);
         expectCellLoading(editableCellHarness.element.children[0], CellType.BODY_CELL);
+    });
+
+    it("renders new value if props.value changes", () => {
+        const VALUE_1 = "foo";
+        const VALUE_2 = "bar";
+
+        const elem = mount(<EditableCell value={VALUE_1} />);
+        expect(elem.find(".pt-editable-content").text()).to.equal(VALUE_1);
+
+        elem.setProps({ value: VALUE_2 });
+        expect(elem.find(".pt-editable-content").text()).to.equal(VALUE_2);
     });
 
     it("edits", () => {


### PR DESCRIPTION
#### Fixes #1234 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Have `EditableCell` fully control the value that it passes to its child `EditableText` component. (At preset, it's simply passing down the value as a `defaultValue`, so only the initial render is "controlled," as it were.) 

#### Reviewers should focus on:

This approach fixes the issue as far as I can tell. Does everything feel right? @seansfkelley, would especially appreciate a pass from you.