### PR TITLE
Portal context class

### DIFF
--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -24,3 +24,10 @@ application.
 </div>
 
 @interface IPortalProps
+
+@### React context
+
+`Portal` supports the following options on its [React context](https://facebook.github.io/react/docs/context.html).
+To use them, supply a child context to a subtree that contains the Portals you want to customize.
+
+@interface IPortalContext

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -47,10 +47,10 @@ const REACT_CONTEXT_TYPES: React.ValidationMap<IPortalContext> = {
  */
 export class Portal extends React.Component<IPortalProps, {}> {
     public static displayName = "Blueprint.Portal";
-    private targetElement: HTMLElement;
-
     public static contextTypes = REACT_CONTEXT_TYPES;
     public context: IPortalContext;
+
+    private targetElement: HTMLElement;
 
     public render() {
         return null as JSX.Element;

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -26,6 +26,20 @@ export interface IPortalProps extends IProps, React.HTMLProps<HTMLDivElement> {
     onChildrenMount?: () => void;
 }
 
+export interface IPortalContext {
+    /** Additional class to add to portal element */
+    blueprintPortalClass?: string;
+}
+
+const REACT_CONTEXT_TYPES: React.ValidationMap<IPortalContext> = {
+    blueprintPortalClass: (obj: IPortalContext, key: keyof IPortalContext) => {
+        if (obj[key] != null && typeof obj[key] !== "string") {
+            return new Error("[Blueprint] Portal context blueprintPortalClass must be string");
+        }
+        return undefined;
+    },
+};
+
 /**
  * This component detaches its contents and re-attaches them to document.body.
  * Use it when you need to circumvent DOM z-stacking (for dialogs, popovers, etc.).
@@ -35,6 +49,9 @@ export class Portal extends React.Component<IPortalProps, {}> {
     public static displayName = "Blueprint.Portal";
     private targetElement: HTMLElement;
 
+    public static contextTypes = REACT_CONTEXT_TYPES;
+    public context: IPortalContext;
+
     public render() {
         return null as JSX.Element;
     }
@@ -42,6 +59,11 @@ export class Portal extends React.Component<IPortalProps, {}> {
     public componentDidMount() {
         const targetElement = document.createElement("div");
         targetElement.classList.add(Classes.PORTAL);
+
+        if (this.context.blueprintPortalClass != null) {
+            targetElement.classList.add(this.context.blueprintPortalClass);
+        }
+
         document.body.appendChild(targetElement);
         this.targetElement = targetElement;
         this.componentDidUpdate();

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -45,4 +45,18 @@ describe("<Portal>", () => {
         const portalChild = document.querySelector(`.${CLASS_TO_TEST}`);
         assert.strictEqual(portalChild.parentElement.className, Classes.PORTAL);
     });
+
+    it("respects blueprintPortalClass on context", () => {
+        const CLASS_TO_TEST = "bp-test-klass";
+        portal = mount(
+            <Portal>
+                <p>test</p>
+            </Portal>,
+        );
+
+        portal.setContext({blueprintPortalClass: CLASS_TO_TEST});
+
+        const portalChild = document.querySelector(`.${CLASS_TO_TEST}`);
+        assert.strictEqual(portalChild.parentElement.className, Classes.PORTAL);
+    });
 });

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -48,15 +48,20 @@ describe("<Portal>", () => {
 
     it("respects blueprintPortalClass on context", () => {
         const CLASS_TO_TEST = "bp-test-klass";
+        const CLASS_TO_TEST_2 = "bp-test-klass-2";
         portal = mount(
             <Portal>
                 <p>test</p>
             </Portal>,
+            {context: {blueprintPortalClass: CLASS_TO_TEST}},
         );
-
-        portal.setContext({blueprintPortalClass: CLASS_TO_TEST});
 
         const portalElement = document.querySelector(Classes.PORTAL);
         assert.include(portalElement.className, CLASS_TO_TEST);
+
+        portal.setContext({blueprintPortalClass: CLASS_TO_TEST_2});
+
+        const portalElement2 = document.querySelector(Classes.PORTAL);
+        assert.include(portalElement2.className, CLASS_TO_TEST_2);
     });
 });

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -56,7 +56,7 @@ describe("<Portal>", () => {
 
         portal.setContext({blueprintPortalClass: CLASS_TO_TEST});
 
-        const portalChild = document.querySelector(`.${CLASS_TO_TEST}`);
-        assert.strictEqual(portalChild.parentElement.className, Classes.PORTAL);
+        const portalElement = document.querySelector(Classes.PORTAL);
+        assert.include(portalElement.className, CLASS_TO_TEST);
     });
 });

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -48,7 +48,6 @@ describe("<Portal>", () => {
 
     it("respects blueprintPortalClass on context", () => {
         const CLASS_TO_TEST = "bp-test-klass";
-        const CLASS_TO_TEST_2 = "bp-test-klass-2";
         portal = mount(
             <Portal>
                 <p>test</p>
@@ -56,12 +55,7 @@ describe("<Portal>", () => {
             {context: {blueprintPortalClass: CLASS_TO_TEST}},
         );
 
-        const portalElement = document.querySelector(Classes.PORTAL);
-        assert.include(portalElement.className, CLASS_TO_TEST);
-
-        portal.setContext({blueprintPortalClass: CLASS_TO_TEST_2});
-
-        const portalElement2 = document.querySelector(Classes.PORTAL);
-        assert.include(portalElement2.className, CLASS_TO_TEST_2);
+        const portalElement = document.querySelector(`.${CLASS_TO_TEST}`);
+        assert.isTrue(portalElement.classList.contains(Classes.PORTAL));
     });
 });


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [X] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [X] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Add a context property called `blueprintPortalClass` that all Blueprint Portals respect.  This is very beneficial if you are displaying dialogs within a shared component/larger plugin and want to scope your styles.  You _could_ go through to every instance of Popover/Dialog/Tooltip and add the class yourself, but you're likely to forget to do it the next time you add something.

Not sure how to update documentation on this one.  Also open to suggestions on the context prop name.

Side note: writing the tests for this was confusing/tricky because the tests started with 3 Portals in wherever enzyme puts them.  I would have expected to start with an empty space to test.  Is there a chance something isn't cleaning up properly?