### PR TITLE
[Portal] Move new Portal error message to errors.ts

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -57,6 +57,8 @@ export const POPOVER_WARN_INLINE_NO_TETHER =
     `${ns} <Popover inline={true}> ignores tetherOptions, constraints, and useSmartPositioning.`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = `${ns} <Popover> onInteraction is ignored when uncontrolled.`;
 
+export const PORTAL_CONTEXT_CLASS_NAME_STRING = `${ns} <Portal> context blueprintPortalClassName must be string`;
+
 export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
     `${ns} <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;
 

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import * as Classes from "../../common/classes";
+import * as Errors from "../../common/errors";
 import { IProps, removeNonHTMLProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 
@@ -34,7 +35,7 @@ export interface IPortalContext {
 const REACT_CONTEXT_TYPES: React.ValidationMap<IPortalContext> = {
     blueprintPortalClassName: (obj: IPortalContext, key: keyof IPortalContext) => {
         if (obj[key] != null && typeof obj[key] !== "string") {
-            return new Error("[Blueprint] Portal context blueprintPortalClassName must be string");
+            return new Error(Errors.PORTAL_CONTEXT_CLASS_NAME_STRING);
         }
         return undefined;
     },


### PR DESCRIPTION
#### Addresses my comment in #1245

Move the new error message from #1245 into `errors.ts` with the rest of its friends.
