### PR TITLE
[Table] Adds focus cell tab and enter microinteraction behavior

### DIFF
--- a/packages/table/src/common/cell.ts
+++ b/packages/table/src/common/cell.ts
@@ -10,8 +10,6 @@ export interface ICellCoordinates {
     row: number;
 }
 
-/* tslint:disable:no-empty-interface */
 export interface IFocusedCellCoordinates extends ICellCoordinates {
-    // more to come here
+    focusSelectionIndex: number;
 }
-/* tslint:enable:no-empty-interface */

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -122,8 +122,6 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         } = this.props;
 
         const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(region);
-        this.props.onFocus(focusCellCoordinates);
-
         if (selectedRegionTransform != null) {
             region = selectedRegionTransform(region, event);
         }
@@ -140,17 +138,38 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
             } else {
                 onSelection([]);
             }
+            const fullFocusCellCoordinates: IFocusedCellCoordinates = {
+                col: focusCellCoordinates.col,
+                focusSelectionIndex: null,
+                row: focusCellCoordinates.row,
+            };
+            this.props.onFocus(fullFocusCellCoordinates);
+
             return false;
         }
 
+        let focusSelectionIndex = null;
         if (event.shiftKey && selectedRegions.length > 0) {
             this.didExpandSelectionOnActivate = true;
             onSelection(expandSelectedRegions(selectedRegions, region));
+            focusSelectionIndex = 0;
         } else if (DragEvents.isAdditive(event) && this.props.allowMultipleSelection) {
             onSelection(Regions.add(selectedRegions, region));
+            // the focus should be in the newly created region,
+            // which is at index of the current list of regions plus one,
+            // which is the length of the current list of regions
+            focusSelectionIndex = selectedRegions.length;
         } else {
             onSelection([region]);
+            focusSelectionIndex = 0;
         }
+
+        const fullFocusCellCoordinates: IFocusedCellCoordinates = {
+            col: focusCellCoordinates.col,
+            focusSelectionIndex,
+            row: focusCellCoordinates.row,
+        };
+        this.props.onFocus(fullFocusCellCoordinates);
 
         return true;
     }
@@ -166,7 +185,12 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
             // have the focused cell follow the selected region
             const mostRecentRegion = nextSelectedRegions[nextSelectedRegions.length - 1];
             const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(mostRecentRegion);
-            this.props.onFocus(focusCellCoordinates);
+            const fullFocusCellCoordinates: IFocusedCellCoordinates = {
+                col: focusCellCoordinates.col,
+                focusSelectionIndex: nextSelectedRegions.length - 1,
+                row: focusCellCoordinates.row,
+            };
+            this.props.onFocus(fullFocusCellCoordinates);
         }
     }
 

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -447,6 +447,27 @@ export class Regions {
     }
 
     /**
+     * Using the supplied region, returns an "equivalent" region of
+     * type CELLS that define the bounds of the given region
+     */
+    public static getCellRegionFromRegion(region: IRegion, numRows: number, numCols: number) {
+        const regionCardinality = Regions.getRegionCardinality(region);
+
+        switch (regionCardinality) {
+            case RegionCardinality.FULL_TABLE:
+                return Regions.cell(0, 0, numRows - 1, numCols - 1);
+            case RegionCardinality.FULL_COLUMNS:
+                return Regions.cell(0, region.cols[0], numRows - 1, region.cols[1]);
+            case RegionCardinality.FULL_ROWS:
+                return Regions.cell(region.rows[0], 0, region.rows[1], numCols - 1);
+            case RegionCardinality.CELLS:
+                return Regions.cell(region.rows[0], region.cols[0], region.rows[1], region.cols[1]);
+            default:
+                return null;
+        }
+    }
+
+    /**
      * Maps a dense array of cell coordinates to a sparse 2-dimensional array
      * of cell values.
      *

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -52,7 +52,7 @@ describe("DragSelectable", () => {
         expect(onSelection.called).to.be.true;
         expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0)]);
         expect(onFocus.called).to.be.true;
-        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0});
+        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0, focusSelectionIndex: 0});
     });
 
     it("restricts to single selection when allowMultipleSelection={false}", () => {
@@ -116,10 +116,10 @@ describe("DragSelectable", () => {
         selectable.find(".selectable", 2).mouse("mousemove").mouse("mouseup");
 
         expect(onFocus.callCount).to.equal(4);
-        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0});
-        expect(onFocus.args[1][0]).to.deep.equal({col: 1, row: 0});
-        expect(onFocus.args[2][0]).to.deep.equal({col: 2, row: 0});
-        expect(onFocus.args[3][0]).to.deep.equal({col: 2, row: 0});
+        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0, focusSelectionIndex: 0});
+        expect(onFocus.args[1][0]).to.deep.equal({col: 1, row: 0, focusSelectionIndex: 0});
+        expect(onFocus.args[2][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
+        expect(onFocus.args[3][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
     });
 
     it("does drag selection", () => {
@@ -154,7 +154,7 @@ describe("DragSelectable", () => {
         expect(onSelection.args[1][0]).to.deep.equal([Regions.column(0, 1)]);
         expect(onSelection.args[2][0]).to.deep.equal([Regions.column(0, 2)]);
         expect(onFocus.callCount).to.equal(1);
-        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0});
+        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0, focusSelectionIndex: 0});
     });
 
     it("expands the selection on shift+click", () => {
@@ -183,7 +183,7 @@ describe("DragSelectable", () => {
         expect(onFocus.called).to.be.true;
         // this isn't proper behavior in the long run, but we'll address focus-cell stuff later
         // (see: https://github.com/palantir/blueprint/issues/823)
-        expect(onFocus.args[0][0]).to.deep.equal({col: 2, row: 0});
+        expect(onFocus.args[0][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
     });
 
     it("re-select clears region", () => {

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -38,7 +38,7 @@ describe("Selection", () => {
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
         expect(onFocus.called).to.equal(true);
-        expect(onFocus.lastCall.args).to.deep.equal([{col: 0, row: 0}]);
+        expect(onFocus.lastCall.args).to.deep.equal([{col: 0, row: 0, focusSelectionIndex: 0}]);
     });
 
     // TODO: Fix

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -158,7 +158,7 @@ describe("<Table>", () => {
             selectFullTable(table);
 
             expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
-            expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0 });
+            expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0, focusSelectionIndex: 0 });
         });
 
         it("selects and deselects column/row headers when selecting and deselecting the full table", () => {
@@ -498,10 +498,10 @@ describe("<Table>", () => {
         });
 
         describe("moves a focus cell with arrow keys", () => {
-            runFocusCellMoveTest("up", Keys.ARROW_UP, { row: 0, col: 1 });
-            runFocusCellMoveTest("down", Keys.ARROW_DOWN, { row: 2, col: 1 });
-            runFocusCellMoveTest("left", Keys.ARROW_LEFT, { row: 1, col: 0 });
-            runFocusCellMoveTest("right", Keys.ARROW_RIGHT, { row: 1, col: 2 });
+            runFocusCellMoveTest("up", Keys.ARROW_UP, { row: 0, col: 1, focusSelectionIndex: 0 });
+            runFocusCellMoveTest("down", Keys.ARROW_DOWN, { row: 2, col: 1, focusSelectionIndex: 0 });
+            runFocusCellMoveTest("left", Keys.ARROW_LEFT, { row: 1, col: 0, focusSelectionIndex: 0 });
+            runFocusCellMoveTest("right", Keys.ARROW_RIGHT, { row: 1, col: 2, focusSelectionIndex: 0 });
 
             it("doesn't move a focus cell if modifier key is pressed", () => {
                 const { component } = mountTable();

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -16,7 +16,7 @@ import { Cell, Column, ITableProps, RegionCardinality, Table, TableLoadingOption
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import { Rect } from "../src/common/rect";
-import { Regions } from "../src/regions";
+import { IRegion, Regions } from "../src/regions";
 import { TableBody } from "../src/tableBody";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 import { ElementHarness, ReactHarness } from "./harness";
@@ -517,6 +517,65 @@ describe("<Table>", () => {
                     expect(onFocus.getCall(0).args[0]).to.deep.equal(expectedCoords);
                 });
             }
+        });
+
+        describe("moves a focus cell internally with tab and enter", () => {
+            function runFocusCellMoveInternalTest(
+                name: string,
+                key: string,
+                keyCode: number,
+                shiftKey: boolean,
+                focusCellCoords: IFocusedCellCoordinates,
+                expectedCoords: IFocusedCellCoordinates,
+            ) {
+                it(name, () => {
+                    const selectedRegions: IRegion[] = [{cols: [0, 1], rows: [0, 1]}, {cols: [2, 2], rows: [2, 2]}];
+                    const tableHarness = mount(
+                        <Table
+                            numRows={5}
+                            enableFocus={true}
+                            focusedCell={focusCellCoords}
+                            onFocus={onFocus}
+                            selectedRegions={selectedRegions}
+                        >
+                            <Column name="Column0" renderCell={renderCell} />
+                            <Column name="Column1" renderCell={renderCell} />
+                            <Column name="Column2" renderCell={renderCell} />
+                            <Column name="Column3" renderCell={renderCell} />
+                            <Column name="Column4" renderCell={renderCell} />
+                        </Table>,
+                    );
+                    tableHarness.simulate("keyDown", createKeyEventConfig(tableHarness, key, keyCode, shiftKey));
+                    expect(onFocus.args[0][0]).to.deep.equal(expectedCoords);
+                });
+            }
+            runFocusCellMoveInternalTest("moves a focus cell on tab", "tab", Keys.TAB, false,
+                { row: 0, col: 0, focusSelectionIndex: 0 }, { row: 0, col: 1, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("wraps a focus cell around with tab", "tab", Keys.TAB, false,
+                { row: 0, col: 1, focusSelectionIndex: 0 }, { row: 1, col: 0, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("moves a focus cell to next region with tab", "tab", Keys.TAB, false,
+                { row: 1, col: 1, focusSelectionIndex: 0 }, { row: 2, col: 2, focusSelectionIndex: 1 });
+
+            runFocusCellMoveInternalTest("moves a focus cell on enter", "enter", Keys.ENTER, false,
+                { row: 0, col: 0, focusSelectionIndex: 0 }, { row: 1, col: 0, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("wraps a focus cell around with enter", "enter", Keys.ENTER, false,
+                { row: 1, col: 0, focusSelectionIndex: 0 }, { row: 0, col: 1, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("moves a focus cell to next region with enter", "enter", Keys.ENTER, false,
+                { row: 1, col: 1, focusSelectionIndex: 0 }, { row: 2, col: 2, focusSelectionIndex: 1 });
+
+            runFocusCellMoveInternalTest("moves a focus cell on shift+tab", "tab", Keys.TAB, true,
+                { row: 0, col: 1, focusSelectionIndex: 0 }, { row: 0, col: 0, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("wraps a focus cell around with shift+tab", "tab", Keys.TAB, true,
+                { row: 1, col: 0, focusSelectionIndex: 0 }, { row: 0, col: 1, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("moves a focus cell to prev region with shift+tab", "tab", Keys.TAB, true,
+                { row: 0, col: 0, focusSelectionIndex: 0 }, { row: 2, col: 2, focusSelectionIndex: 1 });
+
+            runFocusCellMoveInternalTest("moves a focus cell on shift+enter", "enter", Keys.ENTER, true,
+                { row: 1, col: 0, focusSelectionIndex: 0 }, { row: 0, col: 0, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("wraps a focus cell around with shift+enter", "enter", Keys.ENTER, true,
+                { row: 0, col: 1, focusSelectionIndex: 0 }, { row: 1, col: 0, focusSelectionIndex: 0 });
+            runFocusCellMoveInternalTest("moves a focus cell to next region with shift+enter", "enter", Keys.ENTER,
+                true, { row: 0, col: 0, focusSelectionIndex: 0 }, { row: 2, col: 2, focusSelectionIndex: 1 });
         });
 
         describe("scrolls viewport to fit focused cell after moving it", () => {


### PR DESCRIPTION
#### Fixes half of #1080

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Include tests

#### Changes proposed in this pull request:
Focus cells now track what region they belong to.

Pressing enter/tab and their shift-ed counterparts move the cell inside the selected region

#### Reviewers should focus on:
There's a... large block of code in this code that's duplicated a bunch, with minor changes. There really should be a way to simplify it. I'm not sure what that is. Help, please?

Also, all of my names for functions are pretty mediocre here. 

#### Screenshot

![jun-19-2017 17-13-53](https://user-images.githubusercontent.com/2463526/27306208-c9188002-5512-11e7-9da6-12bc3aa7ec34.gif)

