### PR TITLE
[Labs] Propagate event correctly when handling empty list

### DIFF
--- a/packages/labs/src/query-list/queryList.tsx
+++ b/packages/labs/src/query-list/queryList.tsx
@@ -186,7 +186,9 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             this.shouldCheckActiveItemInViewport = false;
         }
         // reset active item (in the same step) if it's no longer valid
-        if (this.getActiveIndex() < 0) {
+        // Also don't fire the event if the active item is already undefined and there is nothing to pick
+        if (this.getActiveIndex() < 0 &&
+            (this.state.filteredItems.length !== 0 || this.props.activeItem !== undefined)) {
             Utils.safeInvoke(this.props.onActiveItemChange, this.state.filteredItems[0]);
         }
     }

--- a/packages/labs/test/queryListTests.tsx
+++ b/packages/labs/test/queryListTests.tsx
@@ -6,7 +6,7 @@
  */
 
 import { assert } from "chai";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import * as React from "react";
 
 import { Film, TOP_100_FILMS } from "../examples/data";
@@ -62,6 +62,26 @@ describe("<QueryList>", () => {
             />);
             assert.isTrue(listPredicate.called, "listPredicate should be invoked");
             assert.isFalse(predicate.called, "item predicate should not be invoked");
+        });
+
+        it("ensure onActiveItemChange is not called with undefined and empty list", () => {
+            const myItem = { title: "Toy Story 3", year: 2010, rank: 1 };
+            const listPredicate = (query: string, films: Film[]) => {
+                return films.filter((film) => film.title === query);
+            };
+            const onActiveItemChange = sinon.spy(() => {return; });
+            const filmQueryList = mount(<FilmQueryList
+                {...props}
+                items={[myItem]}
+                activeItem={myItem}
+                onActiveItemChange={onActiveItemChange}
+                itemListPredicate={listPredicate}
+                query=""
+            />);
+            filmQueryList.setProps({query: "FAKE_QUERY"});
+            filmQueryList.setProps({activeItem: undefined});
+            assert.isTrue(onActiveItemChange.returned(undefined));
+            assert.equal(onActiveItemChange.callCount, 1);
         });
     });
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Right now if you have a class that instantiates a raw queryList and passes in an empty filtered list and undefined as the active state, then on `componentDidUpdate` it will call update and pass an active item of undefined. If you have a parent class that listens to `onActiveItemChange` and then sets its state, the parent class will be re-rendered. Then the queryList will will be re-rendered, and so on and so forth. This will cause an infinite re-rendering loop and a stackover-flow error. You can emulate this behavior if you remove @pure-render from select.tsx and remove:

```
        if (filteredItems.length === 0) {
            return noResults;
        }
```

so the query list is always rendered.

Then if you filter to an empty list in select.tsx, you will get a stack-overflow error


<!-- fill this out -->

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->

@giladgray This fixes an edge case of propagating an incorrect change event
