### PR TITLE
Fix example in pt-table documentation

### DIFF
--- a/packages/core/src/components/table/_table.scss
+++ b/packages/core/src/components/table/_table.scss
@@ -11,9 +11,11 @@ Tables
 Markup:
 <table class="pt-table {{.modifier}}">
   <thead>
-    <th>Project</th>
-    <th>Description</th>
-    <th>Technologies</th>
+    <tr>
+      <th>Project</th>
+      <th>Description</th>
+      <th>Technologies</th>
+    </tr>
   </thead>
   <tbody>
     <tr>


### PR DESCRIPTION
`<thead>` elements can only have `<tr>` elements as children: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead