### PR TITLE
Prepare Release 1.21.0

### DIFF
--- a/docs/blueprint-landing.css
+++ b/docs/blueprint-landing.css
@@ -6220,6 +6220,10 @@ table.pt-table {
     color: #182026; }
   .pt-tag.pt-tag-removable {
     padding-right: 20px; }
+  .pt-tag.pt-active {
+    outline: rgba(19, 124, 189, 0.5) auto 2px;
+    outline-offset: 0;
+    -moz-outline-radius: 6px; }
   .pt-tag.pt-large,
   .pt-large .pt-tag {
     min-width: 30px;

--- a/docs/blueprint-landing.js
+++ b/docs/blueprint-landing.js
@@ -5032,6 +5032,7 @@
 	exports.POPOVER_WARN_DEPRECATED_CONSTRAINTS = deprec + " <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.";
 	exports.POPOVER_WARN_INLINE_NO_TETHER = ns + " <Popover inline={true}> ignores tetherOptions, constraints, and useSmartPositioning.";
 	exports.POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + " <Popover> onInteraction is ignored when uncontrolled.";
+	exports.PORTAL_CONTEXT_CLASS_NAME_STRING = ns + " <Portal> context blueprintPortalClassName must be string";
 	exports.RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX = ns + " <RadioGroup> children and options prop are mutually exclusive, with options taking priority.";
 	exports.SLIDER_ZERO_STEP = ns + " <Slider> stepSize must be greater than zero.";
 	exports.SLIDER_ZERO_LABEL_STEP = ns + " <Slider> labelStepSize must be greater than zero.";
@@ -5552,6 +5553,7 @@
 	 */
 	"use strict";
 	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.BACKSPACE = 8;
 	exports.TAB = 9;
 	exports.ENTER = 13;
 	exports.SHIFT = 16;
@@ -28937,8 +28939,17 @@
 	var React = __webpack_require__(24);
 	var ReactDOM = __webpack_require__(71);
 	var Classes = __webpack_require__(66);
+	var Errors = __webpack_require__(60);
 	var props_1 = __webpack_require__(64);
 	var utils_1 = __webpack_require__(59);
+	var REACT_CONTEXT_TYPES = {
+	    blueprintPortalClassName: function (obj, key) {
+	        if (obj[key] != null && typeof obj[key] !== "string") {
+	            return new Error(Errors.PORTAL_CONTEXT_CLASS_NAME_STRING);
+	        }
+	        return undefined;
+	    },
+	};
 	/**
 	 * This component detaches its contents and re-attaches them to document.body.
 	 * Use it when you need to circumvent DOM z-stacking (for dialogs, popovers, etc.).
@@ -28955,6 +28966,9 @@
 	    Portal.prototype.componentDidMount = function () {
 	        var targetElement = document.createElement("div");
 	        targetElement.classList.add(Classes.PORTAL);
+	        if (this.context.blueprintPortalClassName != null) {
+	            targetElement.classList.add(this.context.blueprintPortalClassName);
+	        }
 	        document.body.appendChild(targetElement);
 	        this.targetElement = targetElement;
 	        this.componentDidUpdate();
@@ -28972,6 +28986,7 @@
 	    return Portal;
 	}(React.Component));
 	Portal.displayName = "Blueprint.Portal";
+	Portal.contextTypes = REACT_CONTEXT_TYPES;
 	exports.Portal = Portal;
 
 	//# sourceMappingURL=portal.js.map
@@ -33305,20 +33320,27 @@
 	var classNames = __webpack_require__(218);
 	var PureRender = __webpack_require__(219);
 	var React = __webpack_require__(24);
+	var common_1 = __webpack_require__(21);
 	var props_1 = __webpack_require__(64);
-	var utils_1 = __webpack_require__(59);
 	var Classes = __webpack_require__(66);
 	var Tag = (function (_super) {
 	    tslib_1.__extends(Tag, _super);
 	    function Tag() {
-	        return _super !== null && _super.apply(this, arguments) || this;
+	        var _this = _super !== null && _super.apply(this, arguments) || this;
+	        _this.onRemoveClick = function (e) {
+	            common_1.Utils.safeInvoke(_this.props.onRemove, e, _this.props);
+	        };
+	        return _this;
 	    }
 	    Tag.prototype.render = function () {
-	        var _a = this.props, className = _a.className, intent = _a.intent, onRemove = _a.onRemove;
+	        var _a = this.props, active = _a.active, className = _a.className, intent = _a.intent, onRemove = _a.onRemove;
 	        var tagClasses = classNames(Classes.TAG, Classes.intentClass(intent), (_b = {},
 	            _b[Classes.TAG_REMOVABLE] = onRemove != null,
+	            _b[Classes.ACTIVE] = active,
 	            _b), className);
-	        var button = utils_1.isFunction(onRemove) ? React.createElement("button", { type: "button", className: Classes.TAG_REMOVE, onClick: onRemove }) : undefined;
+	        var button = common_1.Utils.isFunction(onRemove)
+	            ? React.createElement("button", { type: "button", className: Classes.TAG_REMOVE, onClick: this.onRemoveClick })
+	            : undefined;
 	        return (React.createElement("span", tslib_1.__assign({}, props_1.removeNonHTMLProps(this.props), { className: tagClasses }),
 	            this.props.children,
 	            button));

--- a/docs/docs/site-docs.css
+++ b/docs/docs/site-docs.css
@@ -5925,6 +5925,10 @@ table.pt-table.pt-interactive tbody tr:hover td {
     color: #182026; }
 .pt-tag.pt-tag-removable {
     padding-right: 20px; }
+.pt-tag.pt-active {
+    outline: rgba(19, 124, 189, 0.5) auto 2px;
+    outline-offset: 0;
+    -moz-outline-radius: 6px; }
 .pt-tag.pt-large,
   .pt-large .pt-tag {
     min-width: 30px;
@@ -6773,6 +6777,37 @@ table.pt-table.pt-interactive tbody tr:hover td {
   padding: 0; }
 .pt-select-popover .pt-menu:not(:first-child) {
     padding-top: 5px; }
+.pt-tag-input {
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+          flex-wrap: wrap;
+  cursor: text;
+  height: auto;
+  padding: 5px 0 0 5px; }
+.pt-tag-input .pt-tag {
+    margin: 0 5px 5px 0;
+    overflow-wrap: break-word; }
+.pt-tag-input .pt-input-ghost {
+    -webkit-flex: 1 1 auto;
+            flex: 1 1 auto;
+    margin-bottom: 5px;
+    width: 100px;
+    line-height: 20px; }
+.pt-tag-input.pt-large {
+    height: auto; }
+.pt-tag-input.pt-large .pt-input-ghost {
+      line-height: 30px; }
+.pt-tag-input.pt-active {
+    box-shadow: 0 0 0 1px #137cbd, 0 0 0 3px rgba(19, 124, 189, 0.3), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+    background-color: #ffffff; }
+.pt-input-ghost {
+  border: none;
+  box-shadow: none;
+  background: none;
+  padding: 0; }
+.pt-input-ghost:focus {
+    outline: none !important; }
 @-webkit-keyframes skeleton-fade-in {
   0% {
     opacity: 0; }
@@ -7251,6 +7286,25 @@ table.pt-table.pt-interactive tbody tr:hover td {
 .bp-table-selection-enabled .pt-editable-text::before,
 .bp-table-selection-enabled .pt-editable-content {
   cursor: cell; }
+.bp-table-reorder-handle-target {
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+  position: absolute;
+  top: 0;
+  left: 0;
+  color: #8a9ba8; }
+.bp-table-reorder-handle-target:active {
+    cursor: -webkit-grabbing;
+    cursor: -moz-grabbing;
+    cursor: grabbing; }
+.bp-table-reorder-handle-target:hover {
+    color: #5c7080; }
+.bp-table-reorder-handle-target:active {
+    color: #182026; }
+.bp-table-reorder-handle-target .bp-table-reorder-handle {
+    padding: 3px 6px 3px 1px;
+    line-height: 14px; }
 .bp-table-resize-handle-target {
   position: absolute;
   opacity: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprint",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Core styles & components",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/labs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Incubator for unstable and in-development Blueprint components",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/site-docs/package.json
+++ b/packages/site-docs/package.json
@@ -1,14 +1,14 @@
 {
   "name": "blueprintjs.com/docs",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Blueprint Docs",
   "private": true,
   "dependencies": {
-    "@blueprintjs/core": "^1.20.0",
+    "@blueprintjs/core": "^1.21.0",
     "@blueprintjs/datetime": "^1.17.0",
     "@blueprintjs/docs": "^1.1.1",
-    "@blueprintjs/labs": "^0.1.0",
-    "@blueprintjs/table": "^1.17.0",
+    "@blueprintjs/labs": "^0.2.0",
+    "@blueprintjs/table": "^1.18.0",
     "bourbon": "4.2.2",
     "chroma-js": "1.1.1",
     "classnames": "2.2.5",

--- a/packages/table/examples/index.ts
+++ b/packages/table/examples/index.ts
@@ -11,4 +11,5 @@ export * from "./tableDollarExample";
 export * from "./tableEditableExample";
 export * from "./tableFormatsExample";
 export * from "./tableLoadingExample";
+export * from "./tableReorderableExample";
 export * from "./tableSortableExample";

--- a/packages/table/examples/tableReorderableExample.tsx
+++ b/packages/table/examples/tableReorderableExample.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import * as React from "react";
+
+import { Switch } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange } from "@blueprintjs/docs";
+
+import {
+    Cell,
+    Column,
+    Table,
+    Utils,
+} from "../src";
+
+export interface ITableReorderableExampleState {
+    columns?: JSX.Element[];
+    data?: any[];
+    useInteractionBar?: boolean;
+}
+
+const REORDERABLE_TABLE_DATA = [
+    ["A", "Apple", "Ape", "Albania", "Anchorage"],
+    ["B", "Banana", "Boa", "Brazil", "Boston"],
+    ["C", "Cranberry", "Cougar", "Croatia", "Chicago"],
+    ["D", "Dragonfruit", "Deer", "Denmark", "Denver"],
+    ["E", "Eggplant", "Elk", "Eritrea", "El Paso"],
+].map(([letter, fruit, animal, country, city]) => ({ letter, fruit, animal, country, city }));
+
+export class TableReorderableExample extends BaseExample<ITableReorderableExampleState> {
+    public state: ITableReorderableExampleState = {
+        data: REORDERABLE_TABLE_DATA,
+        useInteractionBar: false,
+    };
+
+    private toggleUseInteractionBar = handleBooleanChange((useInteractionBar) => this.setState({ useInteractionBar }));
+
+    public componentDidMount() {
+        const { useInteractionBar } = this.state;
+        const columns = [
+            <Column key="1" name="Letter" renderCell={this.renderLetterCell} useInteractionBar={useInteractionBar} />,
+            <Column key="2" name="Fruit" renderCell={this.renderFruitCell} useInteractionBar={useInteractionBar} />,
+            <Column key="3" name="Animal" renderCell={this.renderAnimalCell} useInteractionBar={useInteractionBar} />,
+            <Column key="4" name="Country" renderCell={this.renderCountryCell} useInteractionBar={useInteractionBar} />,
+            <Column key="5" name="City" renderCell={this.renderCityCell} useInteractionBar={useInteractionBar} />,
+        ];
+        this.setState({ columns });
+    }
+
+    public componentDidUpdate(_nextProps: {}, nextState: ITableReorderableExampleState) {
+        const { useInteractionBar } = this.state;
+        if (nextState.useInteractionBar !== useInteractionBar) {
+            const nextColumns = React.Children.map(this.state.columns, (column: JSX.Element) => {
+                return React.cloneElement(column, { useInteractionBar });
+            });
+            this.setState({ columns: nextColumns });
+        }
+    }
+
+    public renderExample() {
+        return (
+            <Table
+                isColumnReorderable={true}
+                isColumnResizable={false}
+                isRowReorderable={true}
+                isRowResizable={false}
+                numRows={this.state.data.length}
+                onColumnsReordered={this.handleColumnsReordered}
+                onRowsReordered={this.handleRowsReordered}
+            >
+                {this.state.columns}
+            </Table>
+        );
+    }
+
+    protected renderOptions() {
+        return (
+            <Switch
+                checked={this.state.useInteractionBar}
+                label="Interaction bar"
+                onChange={this.toggleUseInteractionBar}
+            />
+        );
+    }
+
+    private renderLetterCell = (row: number) => <Cell>{this.state.data[row].letter}</Cell>;
+    private renderFruitCell = (row: number) => <Cell>{this.state.data[row].fruit}</Cell>;
+    private renderAnimalCell = (row: number) => <Cell>{this.state.data[row].animal}</Cell>;
+    private renderCountryCell = (row: number) => <Cell>{this.state.data[row].country}</Cell>;
+    private renderCityCell = (row: number) => <Cell>{this.state.data[row].city}</Cell>;
+
+    private handleColumnsReordered = (oldIndex: number, newIndex: number, length: number) => {
+        if (oldIndex === newIndex) { return; }
+        const nextChildren = Utils.reorderArray(this.state.columns, oldIndex, newIndex, length);
+        this.setState({ columns: nextChildren });
+    }
+
+    private handleRowsReordered = (oldIndex: number, newIndex: number, length: number) => {
+        if (oldIndex === newIndex) { return; }
+        this.setState({ data: Utils.reorderArray(this.state.data, oldIndex, newIndex, length) });
+    }
+}

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/table/src/docs.md
+++ b/packages/table/src/docs.md
@@ -92,6 +92,26 @@ regular expression (`[a-zA-Z]`). If the content is invalid, a
 
 @reactExample TableEditableExample
 
+@## Reorderable content
+
+The table supports column and row reordering via the `isColumnReorderable` and `isRowReorderable`
+props, respectively. The table also requires the `FULL_COLUMNS` selection mode to be enabled for
+column reordering and the `FULL_ROWS` selection mode to be enabled for row reordering; these can be
+set via the `selectionModes` prop.
+
+To reorder a single row or column, first click its header cell to select it, then click and drag the
+header cell again to move it elsewhere. Likewise, to reorder multiple consecutive rows or columns at
+once, click and drag across multiple header cells to select the range, then click and drag anywhere in
+the selected header cells to move them as a group.
+
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    <h5>Column reordering with interaction bar enabled</h5>
+    When the interaction bar is enabled, the table will show handle icons in the interaction bar that
+    you can drag directly without having to make a selection first.
+</div>
+
+@reactExample TableReorderableExample
+
 @## Loading states
 
 When fetching or updating data, it may be desirable to show a loading state. The table components


### PR DESCRIPTION
:fireworks: **Highlights**: `TagInput` component, `Table` column reorder handles, Tab/Enter to navigate `Table` focus cell

:book: **Latest docs**: [blueprintjs.com/docs](http://blueprintjs.com/docs)

## `@blueprintjs/core 1.21.0`
- __NEW__ `Tag` `onRemove` callback now receives full tag props as second argument (#1267)
- __NEW__ `Portal` now receives `blueprintPortalClassName` context property (#1244, #1245) (🎩 @jrafidi)
    - This is beneficial if you are displaying dialogs within a shared component/larger plugin and want to scope your styles.

## `@blueprintjs/labs 0.2.0`
- 🌟 __NEW__ `TagInput` component (#1232)
    - Renders `Tag`s inside an input, followed by an actual (ghosted) text input.
    - On `Enter`, the inputted text is displayed in a new tag.
    - This component is fully controlled, and all tags are individually customizable via `tagProps`.

![taginput](https://user-images.githubusercontent.com/443450/27459805-dd30df9a-5764-11e7-94e3-a46408260766.gif)

- __Fixed__ `QueryList` (formerly `InputList`) no longer invokes `onActiveItemChange` if list is empty or `activeItem` is `undefined` (#1256) (🎩 @k-simons)
- __Changed__ `InputList` is now `QueryList` and has a new directory structure for consistency with other packages (#1243)

## `@blueprintjs/table 1.18.0`
- 🌟 __NEW__ `Column` now has reorder handles when interaction bar enabled (#1250)
![reorder-handle](https://user-images.githubusercontent.com/443450/27306011-e134cc32-54f8-11e7-80a9-311d6ef59c3c.gif)
- 🌟 __NEW__ `Table` now supports focus-cell `Tab` and `Enter` microinteraction behavior (#1251)
    - `Tab` moves the focus cell to the right (`Shift + Tab` moves it to the left)
    - `Enter` moves the focus cell down (`Shift + Enter` moves it up)
    - The focus cell is constrained within selected regions if one or more are present.
![jun-19-2017 17-13-53](https://user-images.githubusercontent.com/2463526/27306208-c9188002-5512-11e7-9da6-12bc3aa7ec34.gif)
- __Fixed__ `EditableCell` now updates text in response to controlled `value` prop change (#1239)

## Documentation
- __NEW__ `Table` docs now have a section about reorderable content (#1271)
- __NEW__ Added additional `Table` functionality to the dev preview page
    - Add menu to change cell content (#1229)
    - Add content truncation controls (#1253)
    - Make reordering work (#1263)
- __Changed__ `pt-table` docs example code now includes `<tr>` (#1265) (🎩 @tomshen)
