### PR TITLE
[Table] Improve Utils.times(...) to work with huge numbers 

### DIFF
--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -53,7 +53,11 @@ export const Utils = {
      * is the return value. Similar to _.times
      */
     times<T>(n: number, callback: (i: number) => T): T[] {
-        return Array.apply(null, Array(n)).map((_none: any, index: number) => callback(index));
+        const result: T[] = Array(n);
+        for (let index = 0; index < n; index++) {
+            result[index] = callback(index);
+        }
+        return result;
     },
 
     /**

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -67,7 +67,7 @@ describe("Utils", () => {
         });
     });
 
-    describe("times", () => {
+    describe.only("times", () => {
         it("returns empty array for 0", () => {
             const arr = Utils.times(0, () => "test");
             expect(arr).to.deep.equal([]);
@@ -76,6 +76,11 @@ describe("Utils", () => {
         it("returns array of correct length", () => {
             const arr = Utils.times(4, () => "test");
             expect(arr).to.deep.equal(["test", "test", "test", "test"]);
+        });
+
+        it("works for high numbers of elements without throwing an error", () => {
+            const HUGE_NUMBER = 3e6;
+            expect(() => Utils.times(HUGE_NUMBER, () => "test")).to.not.throw();
         });
 
         it("uses argument length", () => {

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -67,7 +67,7 @@ describe("Utils", () => {
         });
     });
 
-    describe.only("times", () => {
+    describe("times", () => {
         it("returns empty array for 0", () => {
             const arr = Utils.times(0, () => "test");
             expect(arr).to.deep.equal([]);


### PR DESCRIPTION
#### Fixes #1279 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Use a basic for loop in `Utils.times(...)` instead of a `.map(...)`. This lets the function handle much bigger numbers without filling up the call stack.

#### Reviewers should focus on:

Poke around the table example to make sure everything still works.