### PR TITLE
[Table] Add missing + sign to multiline log statement

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -649,7 +649,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     private onVisibleCellsChange = (rowIndices: IRowIndices, columnIndices: IColumnIndices) => {
         const { rowIndexStart, rowIndexEnd } = rowIndices;
         const { columnIndexStart, columnIndexEnd } = columnIndices;
-        this.maybeLogCallback(`[onVisibleCellsChange] rowIndexStart=${rowIndexStart} rowIndexEnd=${rowIndexEnd} `
+        this.maybeLogCallback(`[onVisibleCellsChange] rowIndexStart=${rowIndexStart} rowIndexEnd=${rowIndexEnd} ` +
             `columnIndexStart=${columnIndexStart} columnIndexEnd=${columnIndexEnd}`);
     }
 


### PR DESCRIPTION
Fixes a syntax issue with the log statement introduced in #1268