### PR TITLE
[Menu] Flexify menu items

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -94,6 +94,7 @@ export const FORM_HELPER_TEXT = "pt-form-helper-text";
 
 export const MENU = "pt-menu";
 export const MENU_ITEM = "pt-menu-item";
+export const MENU_ITEM_TEXT = "pt-menu-item-text";
 export const MENU_ITEM_LABEL = "pt-menu-item-label";
 export const MENU_SUBMENU = "pt-submenu";
 export const MENU_DIVIDER = "pt-menu-divider";

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -22,8 +22,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
 // customize modifier classes with params.
 // setting modifier to "" will generally apply it as default styles due to & selectors
 @mixin menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
-  @include overflow-ellipsis();
-  display: block;
+  display: flex;
   border-radius: $menu-item-border-radius;
   padding: $menu-item-padding;
   line-height: $pt-icon-size-standard;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -16,17 +16,17 @@ Menus
 Markup:
 <ul class="pt-menu {{.modifier}} pt-elevation-1">
   <li>
-    <a class="pt-menu-item pt-icon-people" tabindex="0">Share...</a>
+    <a class="pt-menu-item pt-icon-people" tabindex="0"><span class="pt-menu-item-text">Share...</span></a>
   </li>
   <li>
-    <a class="pt-menu-item pt-icon-circle-arrow-right" tabindex="0">Move...</a>
+    <a class="pt-menu-item pt-icon-circle-arrow-right" tabindex="0"><span class="pt-menu-item-text">Move...</span></a>
   </li>
   <li>
-    <a class="pt-menu-item pt-icon-edit" tabindex="0">Rename</a>
+    <a class="pt-menu-item pt-icon-edit" tabindex="0"><span class="pt-menu-item-text">Rename</span></a>
   </li>
   <li class="pt-menu-divider"></li>
   <li>
-    <a class="pt-menu-item pt-icon-trash pt-intent-danger" tabindex="0">Delete</a>
+    <a class="pt-menu-item pt-icon-trash pt-intent-danger" tabindex="0"><span class="pt-menu-item-text">Delete</span></a>
   </li>
 </ul>
 
@@ -63,10 +63,18 @@ Styleguide pt-menu
 
   &::before,
   &::after {
+    flex: 0 0 $pt-icon-size-standard;
     color: $pt-icon-color;
   }
 
+  .pt-menu-item-text {
+    @include overflow-ellipsis();
+    flex: 1 1 100%;
+  }
+
   .pt-menu-item-label {
+    flex: 1 0 auto;
+    margin-left: $menu-item-padding;
     color: $pt-text-color-muted;
   }
 
@@ -101,6 +109,7 @@ Styleguide pt-menu
 
     &::before {
       @include pt-icon($pt-icon-size-large);
+      flex-basis: $pt-icon-size-large;
       margin-right: $menu-item-padding-large;
     }
   }
@@ -118,11 +127,6 @@ button.pt-menu-item {
   background: none;
   width: 100%;
   text-align: left;
-}
-
-.pt-menu-item-label {
-  float: right;
-  margin-left: $menu-item-padding;
 }
 
 /*

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -150,8 +150,9 @@ as they abstract away the tedious parts of implementing a menu.
 
 - Make menu items non-interactive with the class `pt-disabled`.
 
-- Wrap menu item text in a `<span>` element for proper alignment. (Note that React automatically
-does this.)
+- Wrap menu item text in a `span.pt-menu-item-text` element for proper alignment. Text will
+automatically be truncated if longer than the menu width. If you'd like the text to wrap,
+simply remove the `.pt-menu-item-text` class.
 
 - Add a right-aligned label to a menu item by adding a `span.pt-menu-item-label` inside the
 `.pt-menu-item`, after the content. Add an icon to the label by adding icon classes to the label

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -114,7 +114,7 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
                 target={this.props.target}
             >
                 <span className={Classes.MENU_ITEM_TEXT}>{this.props.text}</span>
-                {label != null && <span className={Classes.MENU_ITEM_LABEL}>{label}</span>}
+                {label != null ? <span className={Classes.MENU_ITEM_LABEL}>{label}</span> : undefined}
             </a>
         );
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -105,11 +105,6 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
             [Classes.POPOVER_DISMISS]: this.props.shouldDismissPopover && !disabled && !hasSubmenu,
         }, Classes.iconClass(this.props.iconName), this.props.className);
 
-        let labelElement: JSX.Element;
-        if (label != null) {
-            labelElement = <span className="pt-menu-item-label">{label}</span>;
-        }
-
         let content = (
             <a
                 className={anchorClasses}
@@ -118,8 +113,8 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
                 tabIndex={disabled ? undefined : 0}
                 target={this.props.target}
             >
-                {labelElement}
-                {this.props.text}
+                <span className="pt-menu-item-text">{this.props.text}</span>
+                {label != null && <span className="pt-menu-item-label">{label}</span>}
             </a>
         );
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -113,8 +113,8 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
                 tabIndex={disabled ? undefined : 0}
                 target={this.props.target}
             >
-                <span className="pt-menu-item-text">{this.props.text}</span>
-                {label != null && <span className="pt-menu-item-label">{label}</span>}
+                <span className={Classes.MENU_ITEM_TEXT}>{this.props.text}</span>
+                {label != null && <span className={Classes.MENU_ITEM_LABEL}>{label}</span>}
             </a>
         );
 

--- a/packages/docs/src/components/navigator.tsx
+++ b/packages/docs/src/components/navigator.tsx
@@ -174,8 +174,10 @@ export class Navigator extends React.PureComponent<INavigatorProps, INavigatorSt
                     key={section.route}
                     onMouseEnter={this.handleResultHover}
                 >
-                    <small className="docs-result-path pt-text-muted" dangerouslySetInnerHTML={pathHtml} />
-                    <div dangerouslySetInnerHTML={headerHtml} />
+                    <span className="pt-menu-item-text">
+                        <small className="docs-result-path pt-text-muted" dangerouslySetInnerHTML={pathHtml} />
+                        <div dangerouslySetInnerHTML={headerHtml} />
+                    </span>
                 </a>
             );
         });


### PR DESCRIPTION
#### Fixes #984 

#### Changes proposed in this pull request:

Use flex for menu items for better truncation.

- Should menu items truncate or wrap by default?

#### Screenshots

Menu items no longer truncate by default:
![image](https://cloud.githubusercontent.com/assets/199754/26369968/2c3d65f8-3fab-11e7-8f9f-e16cbcf5210b.png)

Menu items with buttons still work but no longer truncate:
![image](https://cloud.githubusercontent.com/assets/199754/26369881/e989b36a-3faa-11e7-94bf-b539670b7e55.png)

For perfectly truncated one-liner menu items, a new class is now required for the menu item text itself (`span.pt-menu-item-text`):
![image](https://cloud.githubusercontent.com/assets/199754/26370058/7cc8f3c0-3fab-11e7-8c97-9e1bf2835d51.png)
