### PR TITLE
Fix collapse.tsx for TS 2.4

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -124,7 +124,7 @@ export class Collapse extends AbstractComponent<ICollapseProps, ICollapseState> 
 
         const containerStyle = {
             height: showContents ? this.state.height : undefined,
-            overflowY: isAutoHeight ? "visible" : undefined,
+            overflowY: (isAutoHeight ? "visible" : undefined) as "visible" | undefined,
             transition: isAutoHeight ? "none" : undefined,
         };
 


### PR DESCRIPTION
React.HTMLAttributes requires `overflowY` to be a member of a string union: `"initial" | "inherit" | "unset" | "auto" | "hidden" | "scroll" | "visible" | undefined`. In Collapse.render, the `overflowY` needs to be given the explicit type `"visible" | undefined` in order to be assignable to HTMLAttributes. Otherwise, it gets the type `string`, which is too general.

#### Fixes #1237

See also DefinitelyTyped/DefinitelyTyped#17581, which this change depends on.
See also discussion at Microsoft/TypeScript#16047.