### PR TITLE
[DateInput] Clear selected date on deselect when time precision specified

### DIFF
--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -101,6 +101,9 @@ export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDat
                 dateValue: nextProps.value,
                 timeValue: nextProps.value,
             });
+        } else {
+            // clear only the date to remove the selected-date style in the calendar
+            this.setState({ dateValue: null });
         }
     }
 

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -88,6 +88,16 @@ describe("<DateTimePicker>", () => {
         assert.equal(root.state("timeValue").getMilliseconds(), defaultValue.getMilliseconds());
     });
 
+    describe("when controlled", () => {
+        it("passing a null value clears the selected date in the calendar", () => {
+            const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
+            const { root, getSelectedDay } = wrap(<DateTimePicker value={defaultValue} />);
+            assert.isTrue(getSelectedDay().exists());
+            root.setProps({ value: undefined });
+            assert.isFalse(getSelectedDay().exists());
+        });
+    });
+
     function wrap(dtp: JSX.Element) {
         const root = mount(dtp);
         return {
@@ -97,6 +107,7 @@ describe("<DateTimePicker>", () => {
                     .filterWhere((day) => day.text() === "" + dayNumber &&
                         !day.hasClass(Classes.DATEPICKER_DAY_OUTSIDE));
             },
+            getSelectedDay: () => root.find(`.${Classes.DATEPICKER_DAY_SELECTED}`),
             root,
         };
     }


### PR DESCRIPTION
#### Fixes #1246 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

On deselect in `DateInput` with time precision specified, this PR now properly clears the selected date in the calendar. The bug was specifically with controlled usage of the `DateTimePicker`: when `nextProps.value == null`, we weren't setting `this.state.dateValue` to `null` for some reason.

#### Reviewers should focus on:

Give it a try in the dev preview.

#### Screenshot

![dateinput-1246](https://user-images.githubusercontent.com/443450/27701609-446a352a-5cb6-11e7-9dde-145b3b47e58e.gif)
