### PR TITLE
[DateRangeInput] Fix display value when controlled value is [undefined, undefined]

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -148,7 +148,11 @@ export function isMomentInRange(momentDate: moment.Moment, minDate: Date, maxDat
  * This is a no-op unless moment-timezone's setDefault has been called.
  */
 export function fromDateToMoment(date: Date) {
-    if (date == null || typeof date === "string") {
+    if (date == null) {
+        // moment(undefined) is equivalent to moment(), which returns the current date and time when
+        // invoked. thus, we need to explicitly return moment(null).
+        return moment(null);
+    } else if (typeof date === "string") {
         return moment(date);
     } else {
         return moment([

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -1992,7 +1992,7 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, END_STR);
         });
 
-        it.only("Setting value to [undefined, undefined] shows empty fields", () => {
+        it("Setting value to [undefined, undefined] shows empty fields", () => {
             const { root } = wrap(<DateRangeInput value={[undefined, undefined]} />);
             assertInputTextsEqual(root, "", "");
         });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -1992,6 +1992,11 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, END_STR);
         });
 
+        it.only("Setting value to [undefined, undefined] shows empty fields", () => {
+            const { root } = wrap(<DateRangeInput value={[undefined, undefined]} />);
+            assertInputTextsEqual(root, "", "");
+        });
+
         it("Setting value to [null, null] shows empty fields", () => {
             const { root } = wrap(<DateRangeInput value={[null, null]} />);
             assertInputTextsEqual(root, "", "");


### PR DESCRIPTION
#### Fixes #1254 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

This PR fixes bug in `fromDateToMoment` with `undefined` values. Before, if the provided `date` shallowly equaled `null` (i.e. if `date === undefined || date === null`), then we returned `moment(date)`. This effectively returned `moment()` when `date` was `undefined`, which returns the current date and time.

Now, we explicitly return `moment(null)` in either case, which creates an invalid or "empty" moment object as expected. 