### PR TITLE
[Hotkeys] Add allowInInput, disabled, preventDefault, stopPropagation props

### DIFF
--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -24,6 +24,12 @@ export interface IHotkeyProps {
     combo: string;
 
     /**
+     * Whether the hotkey can be triggered.
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
      * Human-friendly label for the hotkey.
      */
     label: string;
@@ -57,6 +63,7 @@ export interface IHotkeyProps {
 export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
     public static defaultProps = {
         allowInInput: false,
+        disabled: false,
         global: false,
     };
 
@@ -65,10 +72,10 @@ export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
     }
 
     public render() {
-        const { allowInInput, combo, label } = this.props;
+        const { allowInInput, combo, disabled, label } = this.props;
         return <div className="pt-hotkey">
             <div className="pt-hotkey-label">{label}</div>
-            <KeyCombo allowInInput={allowInInput} combo={combo} />
+            <KeyCombo allowInInput={allowInInput} combo={combo} disabled={disabled} />
         </div>;
     }
 

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -14,6 +14,7 @@ import { KeyCombo } from "./keyCombo";
 export interface IHotkeyProps {
     /**
      * Whether the hotkey should be triggerable when focused in a text input.
+     * @default false
      */
     allowInInput?: boolean;
 
@@ -55,6 +56,7 @@ export interface IHotkeyProps {
 
 export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
     public static defaultProps = {
+        allowInInput: false,
         global: false,
     };
 

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -50,6 +50,20 @@ export interface IHotkeyProps {
     group?: string;
 
     /**
+     * When true, invokes `event.preventDefault()` in response to `keydown` and `keyup` events
+     * before the respective `onKeyDown` and `onKeyUp` callbacks are invoked.
+     * @default false
+     */
+    preventDefault?: boolean;
+
+    /**
+     * When true, invokes `event.stopPropagation()` in response to `keydown` and `keyup` events
+     * before the respective `onKeyDown` and `onKeyUp` callbacks are invoked.
+     * @default false
+     */
+    stopPropagation?: boolean;
+
+    /**
      * `keydown` event handler.
      */
     onKeyDown?(e: KeyboardEvent): any;
@@ -72,10 +86,16 @@ export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
     }
 
     public render() {
-        const { allowInInput, combo, disabled, label } = this.props;
+        const { allowInInput, combo, disabled, label, preventDefault, stopPropagation } = this.props;
         return <div className="pt-hotkey">
             <div className="pt-hotkey-label">{label}</div>
-            <KeyCombo allowInInput={allowInInput} combo={combo} disabled={disabled} />
+            <KeyCombo
+                allowInInput={allowInInput}
+                combo={combo}
+                disabled={disabled}
+                preventDefault={preventDefault}
+                stopPropagation={stopPropagation}
+            />
         </div>;
     }
 

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -24,7 +24,7 @@ export interface IHotkeyProps {
     combo: string;
 
     /**
-     * Whether the hotkey can be triggered.
+     * Whether the hotkey cannot be triggered.
      * @default false
      */
     disabled?: boolean;
@@ -50,15 +50,15 @@ export interface IHotkeyProps {
     group?: string;
 
     /**
-     * When true, invokes `event.preventDefault()` in response to `keydown` and `keyup` events
-     * before the respective `onKeyDown` and `onKeyUp` callbacks are invoked.
+     * When `true`, invokes `event.preventDefault()` before the respective `onKeyDown` and
+     * `onKeyUp` callbacks are invoked. Enabling this can simplify handler implementations.
      * @default false
      */
     preventDefault?: boolean;
 
     /**
-     * When true, invokes `event.stopPropagation()` in response to `keydown` and `keyup` events
-     * before the respective `onKeyDown` and `onKeyUp` callbacks are invoked.
+     * When `true`, invokes `event.stopPropagation()` before the respective `onKeyDown` and
+     * `onKeyUp` callbacks are invoked. Enabling this can simplify handler implementations.
      * @default false
      */
     stopPropagation?: boolean;
@@ -79,6 +79,8 @@ export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
         allowInInput: false,
         disabled: false,
         global: false,
+        preventDefault: false,
+        stopPropagation: false,
     };
 
     public static isInstance(element: any): element is ReactElement<IHotkeyProps> {
@@ -86,16 +88,10 @@ export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
     }
 
     public render() {
-        const { allowInInput, combo, disabled, label, preventDefault, stopPropagation } = this.props;
+        const { label, ...spreadableProps } = this.props;
         return <div className="pt-hotkey">
             <div className="pt-hotkey-label">{label}</div>
-            <KeyCombo
-                allowInInput={allowInInput}
-                combo={combo}
-                disabled={disabled}
-                preventDefault={preventDefault}
-                stopPropagation={stopPropagation}
-            />
+            <KeyCombo {...spreadableProps} />
         </div>;
     }
 

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -13,6 +13,11 @@ import { KeyCombo } from "./keyCombo";
 
 export interface IHotkeyProps {
     /**
+     * Whether the hotkey should be triggerable when focused in a text input.
+     */
+    allowInInput?: boolean;
+
+    /**
      * Hotkey combination string, such as "space" or "cmd+n".
      */
     combo: string;
@@ -58,10 +63,10 @@ export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
     }
 
     public render() {
-        const { combo, label } = this.props;
+        const { allowInInput, combo, label } = this.props;
         return <div className="pt-hotkey">
             <div className="pt-hotkey-label">{label}</div>
-            <KeyCombo combo={combo} />
+            <KeyCombo allowInInput={allowInInput} combo={combo} />
         </div>;
     }
 

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -53,51 +53,44 @@ export class HotkeysEvents {
     }
 
     public handleKeyDown = (e: KeyboardEvent) => {
-        const isTextInput = this.isTextInput(e);
-
         if (isHotkeysDialogShowing()) {
             return;
         }
 
         const combo = getKeyCombo(e);
+        const isTextInput = this.isTextInput(e);
 
         if (!isTextInput && comboMatches(parseKeyCombo(SHOW_DIALOG_KEY), combo)) {
             showHotkeysDialog(this.actions.map((action) => action.props));
             return;
         }
 
-        for (const action of this.actions) {
-            const shouldIgnore = (isTextInput && !action.props.allowInInput) || action.props.disabled;
-            if (comboMatches(action.combo, combo) && !shouldIgnore) {
-                if (action.props.preventDefault) {
-                    e.preventDefault();
-                }
-                if (action.props.stopPropagation) {
-                    e.stopPropagation();
-                }
-                safeInvoke(action.props.onKeyDown, e);
-            }
-        }
+        this.invokeNamedCallbackIfComboRecognized(combo, "onKeyDown", e);
     }
 
     public handleKeyUp = (e: KeyboardEvent) => {
-        const isTextInput = this.isTextInput(e);
-
         if (isHotkeysDialogShowing()) {
             return;
         }
+        this.invokeNamedCallbackIfComboRecognized(getKeyCombo(e), "onKeyUp", e);
+    }
 
-        const combo = getKeyCombo(e);
+    private invokeNamedCallbackIfComboRecognized(
+        combo: IKeyCombo,
+        callbackName: "onKeyDown" | "onKeyUp",
+        e: KeyboardEvent,
+    ) {
+        const isTextInput = this.isTextInput(e);
         for (const action of this.actions) {
             const shouldIgnore = (isTextInput && !action.props.allowInInput) || action.props.disabled;
-            if (comboMatches(action.combo, combo) && !shouldIgnore) {
+            if (!shouldIgnore && comboMatches(action.combo, combo)) {
                 if (action.props.preventDefault) {
                     e.preventDefault();
                 }
                 if (action.props.stopPropagation) {
                     e.stopPropagation();
                 }
-                safeInvoke(action.props.onKeyUp, e);
+                safeInvoke(action.props[callbackName], e);
             }
         }
     }

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -69,6 +69,12 @@ export class HotkeysEvents {
         for (const action of this.actions) {
             const shouldIgnore = (isTextInput && !action.props.allowInInput) || action.props.disabled;
             if (comboMatches(action.combo, combo) && !shouldIgnore) {
+                if (action.props.preventDefault) {
+                    e.preventDefault();
+                }
+                if (action.props.stopPropagation) {
+                    e.stopPropagation();
+                }
                 safeInvoke(action.props.onKeyDown, e);
             }
         }
@@ -85,6 +91,12 @@ export class HotkeysEvents {
         for (const action of this.actions) {
             const shouldIgnore = (isTextInput && !action.props.allowInInput) || action.props.disabled;
             if (comboMatches(action.combo, combo) && !shouldIgnore) {
+                if (action.props.preventDefault) {
+                    e.preventDefault();
+                }
+                if (action.props.stopPropagation) {
+                    e.stopPropagation();
+                }
                 safeInvoke(action.props.onKeyUp, e);
             }
         }

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -67,7 +67,7 @@ export class HotkeysEvents {
         }
 
         for (const action of this.actions) {
-            const shouldIgnore = isTextInput && !action.props.allowInInput;
+            const shouldIgnore = (isTextInput && !action.props.allowInInput) || action.props.disabled;
             if (comboMatches(action.combo, combo) && !shouldIgnore) {
                 safeInvoke(action.props.onKeyDown, e);
             }
@@ -83,7 +83,7 @@ export class HotkeysEvents {
 
         const combo = getKeyCombo(e);
         for (const action of this.actions) {
-            const shouldIgnore = isTextInput && !action.props.allowInInput;
+            const shouldIgnore = (isTextInput && !action.props.allowInInput) || action.props.disabled;
             if (comboMatches(action.combo, combo) && !shouldIgnore) {
                 safeInvoke(action.props.onKeyUp, e);
             }

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -88,6 +88,8 @@ export class HotkeysEvents {
                     e.preventDefault();
                 }
                 if (action.props.stopPropagation) {
+                    // set a flag just for unit testing. not meant to be referenced in feature work.
+                    (e as any).isPropagationStopped = true;
                     e.stopPropagation();
                 }
                 safeInvoke(action.props[callbackName], e);

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -53,32 +53,38 @@ export class HotkeysEvents {
     }
 
     public handleKeyDown = (e: KeyboardEvent) => {
-        if (this.isTextInput(e) || isHotkeysDialogShowing()) {
+        const isTextInput = this.isTextInput(e);
+
+        if (isHotkeysDialogShowing()) {
             return;
         }
 
         const combo = getKeyCombo(e);
 
-        if (comboMatches(parseKeyCombo(SHOW_DIALOG_KEY), combo)) {
+        if (!isTextInput && comboMatches(parseKeyCombo(SHOW_DIALOG_KEY), combo)) {
             showHotkeysDialog(this.actions.map((action) => action.props));
             return;
         }
 
         for (const action of this.actions) {
-            if (comboMatches(action.combo, combo)) {
+            const shouldIgnore = isTextInput && !action.props.allowInInput;
+            if (comboMatches(action.combo, combo) && !shouldIgnore) {
                 safeInvoke(action.props.onKeyDown, e);
             }
         }
     }
 
     public handleKeyUp = (e: KeyboardEvent) => {
-        if (this.isTextInput(e) || isHotkeysDialogShowing()) {
+        const isTextInput = this.isTextInput(e);
+
+        if (isHotkeysDialogShowing()) {
             return;
         }
 
         const combo = getKeyCombo(e);
         for (const action of this.actions) {
-            if (comboMatches(action.combo, combo)) {
+            const shouldIgnore = isTextInput && !action.props.allowInInput;
+            if (comboMatches(action.combo, combo) && !shouldIgnore) {
                 safeInvoke(action.props.onKeyUp, e);
             }
         }

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -24,6 +24,7 @@ const KeyIcons = {
 export interface IKeyComboProps {
     allowInInput?: boolean;
     combo: string;
+    disabled?: boolean;
 }
 
 export class KeyCombo extends React.Component<IKeyComboProps, {}> {

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -25,6 +25,8 @@ export interface IKeyComboProps {
     allowInInput?: boolean;
     combo: string;
     disabled?: boolean;
+    preventDefault?: boolean;
+    stopPropagation?: boolean;
 }
 
 export class KeyCombo extends React.Component<IKeyComboProps, {}> {

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -22,6 +22,7 @@ const KeyIcons = {
 } as {[key: string]: string};
 
 export interface IKeyComboProps {
+    allowInInput?: boolean;
     combo: string;
 }
 

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -172,7 +172,7 @@ describe("Hotkeys", () => {
         });
 
         function runHotkeySuiteForKeyEvent(eventName: "keydown" | "keyup") {
-            it("triggers local and global hotkeys on keydown", () => {
+            it(`triggers local and global hotkeys on ${eventName}`, () => {
                 comp = mount(<TestComponent />, { attachTo });
                 const node = ReactDOM.findDOMNode(comp.instance());
 
@@ -181,17 +181,6 @@ describe("Hotkeys", () => {
 
                 dispatchTestKeyboardEvent(node, eventName, "2");
                 expect(getGlobalSpy(eventName).called).to.be.true;
-            });
-
-            it("triggers local and global hotkeys on keyup", () => {
-                comp = mount(<TestComponent />, { attachTo });
-                const node = ReactDOM.findDOMNode(comp.instance());
-
-                dispatchTestKeyboardEvent(node, "keyup", "1");
-                expect(localKeyUpSpy.called).to.be.true;
-
-                dispatchTestKeyboardEvent(node, "keyup", "2");
-                expect(globalKeyUpSpy.called).to.be.true;
             });
 
             it("triggers only global hotkey when not focused", () => {
@@ -289,21 +278,21 @@ describe("Hotkeys", () => {
                     assertInputAllowsKeys("radio", true, true);
                 });
             });
-        }
 
-        function assertInputAllowsKeys(type: string, allowsKeys: boolean, allowInInput: boolean = false) {
-            comp = mount(<TestComponent allowInInput={allowInInput} />, { attachTo });
+            function assertInputAllowsKeys(type: string, allowsKeys: boolean, allowInInput: boolean = false) {
+                comp = mount(<TestComponent allowInInput={allowInInput} />, { attachTo });
 
-            const selector = "input[type='" + type + "']";
-            const input = ReactDOM.findDOMNode(comp.instance()).querySelector(selector);
+                const selector = "input[type='" + type + "']";
+                const input = ReactDOM.findDOMNode(comp.instance()).querySelector(selector);
 
-            (input as HTMLElement).focus();
+                (input as HTMLElement).focus();
 
-            dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localKeyDownSpy.called).to.equal(allowsKeys);
+                dispatchTestKeyboardEvent(input, eventName, "1");
+                expect(getLocalSpy(eventName).called).to.equal(allowsKeys);
 
-            dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalKeyDownSpy.called).to.equal(allowsKeys);
+                dispatchTestKeyboardEvent(input, eventName, "2");
+                expect(getGlobalSpy(eventName).called).to.equal(allowsKeys);
+            }
         }
 
         function getLocalSpy(eventName: "keydown" | "keyup") {

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -44,6 +44,8 @@ describe("Hotkeys", () => {
         interface ITestComponentProps {
             allowInInput?: boolean;
             disabled?: boolean;
+            preventDefault?: boolean;
+            stopPropagation?: boolean;
         }
 
         @HotkeysTarget
@@ -53,8 +55,8 @@ describe("Hotkeys", () => {
             };
 
             public renderHotkeys() {
-                const { allowInInput, disabled } = this.props;
-                const baseProps = { allowInInput, disabled };
+                const { allowInInput, disabled, preventDefault, stopPropagation } = this.props;
+                const baseProps = { allowInInput, disabled, preventDefault, stopPropagation };
                 return <Hotkeys>
                     <Hotkey
                         {...baseProps}
@@ -132,6 +134,19 @@ describe("Hotkeys", () => {
 
             dispatchTestKeyboardEvent(node, "keydown", "2");
             expect(globalHotkeySpy.called).to.be.false;
+        });
+
+        it("prevents default if preventDefault={true}", () => {
+            comp = mount(<TestComponent preventDefault={true} />, { attachTo });
+            const node = ReactDOM.findDOMNode(comp.instance());
+
+            dispatchTestKeyboardEvent(node, "keydown", "1");
+            const localEvent = localHotkeySpy.lastCall.args[0] as KeyboardEvent;
+            expect(localEvent.defaultPrevented).to.be.true;
+
+            dispatchTestKeyboardEvent(node, "keydown", "2");
+            const globalEvent = globalHotkeySpy.lastCall.args[0] as KeyboardEvent;
+            expect(globalEvent.defaultPrevented).to.be.true;
         });
 
         describe("if allowInInput={false}", () => {

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -41,12 +41,33 @@ describe("Hotkeys", () => {
         let attachTo: HTMLElement = null;
         let comp: Enzyme.ReactWrapper<any, any> = null;
 
+        interface ITestComponentProps {
+            allowInInput?: boolean;
+        }
+
         @HotkeysTarget
-        class TestComponent extends React.Component<{}, {}> {
+        class TestComponent extends React.Component<ITestComponentProps, {}> {
+            public static defaultProps: ITestComponentProps = {
+                allowInInput: false,
+            };
+
             public renderHotkeys() {
+                const { allowInInput } = this.props;
                 return <Hotkeys>
-                    <Hotkey label="local hotkey" group="test" combo="1" onKeyDown={localHotkeySpy} />
-                    <Hotkey label="global hotkey" global combo="2" onKeyDown={globalHotkeySpy} />
+                    <Hotkey
+                        allowInInput={allowInInput}
+                        combo="1"
+                        group="test"
+                        label="local hotkey"
+                        onKeyDown={localHotkeySpy}
+                    />
+                    <Hotkey
+                        allowInInput={allowInInput}
+                        combo="2"
+                        global
+                        label="global hotkey"
+                        onKeyDown={globalHotkeySpy}
+                    />
                 </Hotkeys>;
             }
 
@@ -100,24 +121,48 @@ describe("Hotkeys", () => {
             expect(globalHotkeySpy.called).to.be.true;
         });
 
-        it("ignores hotkeys when inside text input", () => {
-            assertInputAllowsKeys("text", false);
+        describe("if allowInInput={false}", () => {
+            it("ignores hotkeys when inside text input", () => {
+                assertInputAllowsKeys("text", false);
+            });
+
+            it("ignores hotkeys when inside number input", () => {
+                assertInputAllowsKeys("number", false);
+            });
+
+            it("ignores hotkeys when inside password input", () => {
+                assertInputAllowsKeys("password", false);
+            });
+
+            it("triggers hotkeys when inside checkbox input", () => {
+                assertInputAllowsKeys("checkbox", true);
+            });
+
+            it("triggers hotkeys when inside radio input", () => {
+                assertInputAllowsKeys("radio", true);
+            });
         });
 
-        it("ignores hotkeys when inside number input", () => {
-            assertInputAllowsKeys("number", false);
-        });
+        describe("if allowInInput={true}", () => {
+            it("triggers hotkeys when inside text input", () => {
+                assertInputAllowsKeys("text", true, true);
+            });
 
-        it("ignores hotkeys when inside password input", () => {
-            assertInputAllowsKeys("password", false);
-        });
+            it("triggers hotkeys when inside number input", () => {
+                assertInputAllowsKeys("number", true, true);
+            });
 
-        it("triggers hotkeys when inside checkbox input", () => {
-            assertInputAllowsKeys("checkbox", true);
-        });
+            it("triggers hotkeys when inside password input", () => {
+                assertInputAllowsKeys("password", true, true);
+            });
 
-        it("triggers hotkeys when inside radio input", () => {
-            assertInputAllowsKeys("radio", true);
+            it("triggers hotkeys when inside checkbox input", () => {
+                assertInputAllowsKeys("checkbox", true, true);
+            });
+
+            it("triggers hotkeys when inside radio input", () => {
+                assertInputAllowsKeys("radio", true, true);
+            });
         });
 
         it("triggers non-inline hotkey dialog with \"?\"", (done) => {
@@ -167,8 +212,8 @@ describe("Hotkeys", () => {
             expect(testCombo).to.equal(combo);
         });
 
-        function assertInputAllowsKeys(type: string, allowsKeys: boolean) {
-            comp = mount(<TestComponent />, { attachTo });
+        function assertInputAllowsKeys(type: string, allowsKeys: boolean, allowInInput: boolean = false) {
+            comp = mount(<TestComponent allowInInput={allowInInput} />, { attachTo });
 
             const selector = "input[type='" + type + "']";
             const input = ReactDOM.findDOMNode(comp.instance()).querySelector(selector);

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -36,8 +36,15 @@ describe("Hotkeys", () => {
 
     describe("Local/Global @HotkeysTarget", () => {
 
-        let localHotkeySpy: Sinon.SinonSpy = null;
-        let globalHotkeySpy: Sinon.SinonSpy = null;
+        let localKeyDownSpy: Sinon.SinonSpy = null;
+        let localKeyUpSpy: Sinon.SinonSpy = null;
+
+        let globalKeyDownSpy: Sinon.SinonSpy = null;
+        let globalKeyUpSpy: Sinon.SinonSpy = null;
+
+        let wrappingKeyDownSpy: Sinon.SinonSpy = null;
+        let wrappingKeyUpSpy: Sinon.SinonSpy = null;
+
         let attachTo: HTMLElement = null;
         let comp: Enzyme.ReactWrapper<any, any> = null;
 
@@ -55,22 +62,22 @@ describe("Hotkeys", () => {
             };
 
             public renderHotkeys() {
-                const { allowInInput, disabled, preventDefault, stopPropagation } = this.props;
-                const baseProps = { allowInInput, disabled, preventDefault, stopPropagation };
                 return <Hotkeys>
                     <Hotkey
-                        {...baseProps}
+                        {...this.props}
                         combo="1"
                         group="test"
                         label="local hotkey"
-                        onKeyDown={localHotkeySpy}
+                        onKeyDown={localKeyDownSpy}
+                        onKeyUp={localKeyUpSpy}
                     />
                     <Hotkey
-                        {...baseProps}
+                        {...this.props}
                         combo="2"
                         global
                         label="global hotkey"
-                        onKeyDown={globalHotkeySpy}
+                        onKeyDown={globalKeyDownSpy}
+                        onKeyUp={globalKeyUpSpy}
                     />
                 </Hotkeys>;
             }
@@ -90,8 +97,14 @@ describe("Hotkeys", () => {
         }
 
         beforeEach(() => {
-            localHotkeySpy = sinon.spy();
-            globalHotkeySpy = sinon.spy();
+            localKeyDownSpy = sinon.spy();
+            localKeyUpSpy = sinon.spy();
+
+            globalKeyDownSpy = sinon.spy();
+            globalKeyUpSpy = sinon.spy();
+
+            wrappingKeyDownSpy = sinon.spy();
+            wrappingKeyUpSpy = sinon.spy();
 
             attachTo = document.createElement("div");
             document.documentElement.appendChild(attachTo);
@@ -102,97 +115,15 @@ describe("Hotkeys", () => {
             attachTo.remove();
         });
 
-        it("triggers local and global hotkey", () => {
-            comp = mount(<TestComponent />, { attachTo });
-            const node = ReactDOM.findDOMNode(comp.instance());
-
-            dispatchTestKeyboardEvent(node, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.true;
-
-            dispatchTestKeyboardEvent(node, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.true;
+        describe("on keydown", () => {
+            runHotkeySuiteForKeyEvent("keydown");
         });
 
-        it("triggers only global hotkey when not focused", () => {
-            comp = mount(<div><TestComponent /><div className="unhotkeyed" tabIndex={2} /></div>, { attachTo });
-            const unhotkeyed = ReactDOM.findDOMNode(comp.instance()).querySelector(".unhotkeyed");
-            (unhotkeyed as HTMLElement).focus();
-
-            dispatchTestKeyboardEvent(unhotkeyed, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.false;
-
-            dispatchTestKeyboardEvent(unhotkeyed, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.true;
+        describe("on keyup", () => {
+            runHotkeySuiteForKeyEvent("keyup");
         });
 
-        it("ignores hotkeys when disabled={true}", () => {
-            comp = mount(<TestComponent disabled={true} />, { attachTo });
-            const node = ReactDOM.findDOMNode(comp.instance());
-
-            dispatchTestKeyboardEvent(node, "keydown", "1");
-            expect(localHotkeySpy.called).to.be.false;
-
-            dispatchTestKeyboardEvent(node, "keydown", "2");
-            expect(globalHotkeySpy.called).to.be.false;
-        });
-
-        it("prevents default if preventDefault={true}", () => {
-            comp = mount(<TestComponent preventDefault={true} />, { attachTo });
-            const node = ReactDOM.findDOMNode(comp.instance());
-
-            dispatchTestKeyboardEvent(node, "keydown", "1");
-            const localEvent = localHotkeySpy.lastCall.args[0] as KeyboardEvent;
-            expect(localEvent.defaultPrevented).to.be.true;
-
-            dispatchTestKeyboardEvent(node, "keydown", "2");
-            const globalEvent = globalHotkeySpy.lastCall.args[0] as KeyboardEvent;
-            expect(globalEvent.defaultPrevented).to.be.true;
-        });
-
-        describe("if allowInInput={false}", () => {
-            it("ignores hotkeys when inside text input", () => {
-                assertInputAllowsKeys("text", false);
-            });
-
-            it("ignores hotkeys when inside number input", () => {
-                assertInputAllowsKeys("number", false);
-            });
-
-            it("ignores hotkeys when inside password input", () => {
-                assertInputAllowsKeys("password", false);
-            });
-
-            it("triggers hotkeys when inside checkbox input", () => {
-                assertInputAllowsKeys("checkbox", true);
-            });
-
-            it("triggers hotkeys when inside radio input", () => {
-                assertInputAllowsKeys("radio", true);
-            });
-        });
-
-        describe("if allowInInput={true}", () => {
-            it("triggers hotkeys when inside text input", () => {
-                assertInputAllowsKeys("text", true, true);
-            });
-
-            it("triggers hotkeys when inside number input", () => {
-                assertInputAllowsKeys("number", true, true);
-            });
-
-            it("triggers hotkeys when inside password input", () => {
-                assertInputAllowsKeys("password", true, true);
-            });
-
-            it("triggers hotkeys when inside checkbox input", () => {
-                assertInputAllowsKeys("checkbox", true, true);
-            });
-
-            it("triggers hotkeys when inside radio input", () => {
-                assertInputAllowsKeys("radio", true, true);
-            });
-        });
-
+        // this works only on keydown, so don't put it in the test suite
         it("triggers non-inline hotkey dialog with \"?\"", (done) => {
             const TEST_TIMEOUT_DURATION = 30;
 
@@ -240,6 +171,126 @@ describe("Hotkeys", () => {
             expect(testCombo).to.equal(combo);
         });
 
+        function runHotkeySuiteForKeyEvent(eventName: "keydown" | "keyup") {
+            it("triggers local and global hotkeys on keydown", () => {
+                comp = mount(<TestComponent />, { attachTo });
+                const node = ReactDOM.findDOMNode(comp.instance());
+
+                dispatchTestKeyboardEvent(node, eventName, "1");
+                expect(getLocalSpy(eventName).called).to.be.true;
+
+                dispatchTestKeyboardEvent(node, eventName, "2");
+                expect(getGlobalSpy(eventName).called).to.be.true;
+            });
+
+            it("triggers local and global hotkeys on keyup", () => {
+                comp = mount(<TestComponent />, { attachTo });
+                const node = ReactDOM.findDOMNode(comp.instance());
+
+                dispatchTestKeyboardEvent(node, "keyup", "1");
+                expect(localKeyUpSpy.called).to.be.true;
+
+                dispatchTestKeyboardEvent(node, "keyup", "2");
+                expect(globalKeyUpSpy.called).to.be.true;
+            });
+
+            it("triggers only global hotkey when not focused", () => {
+                comp = mount(<div><TestComponent /><div className="unhotkeyed" tabIndex={2} /></div>, { attachTo });
+                const unhotkeyed = ReactDOM.findDOMNode(comp.instance()).querySelector(".unhotkeyed");
+                (unhotkeyed as HTMLElement).focus();
+
+                dispatchTestKeyboardEvent(unhotkeyed, eventName, "1");
+                expect(getLocalSpy(eventName).called).to.be.false;
+
+                dispatchTestKeyboardEvent(unhotkeyed, eventName, "2");
+                expect(getGlobalSpy(eventName).called).to.be.true;
+            });
+
+            it("ignores hotkeys when disabled={true}", () => {
+                comp = mount(<TestComponent disabled={true} />, { attachTo });
+                const node = ReactDOM.findDOMNode(comp.instance());
+
+                dispatchTestKeyboardEvent(node, eventName, "1");
+                expect(getLocalSpy(eventName).called).to.be.false;
+
+                dispatchTestKeyboardEvent(node, eventName, "2");
+                expect(getGlobalSpy(eventName).called).to.be.false;
+            });
+
+            it("prevents default if preventDefault={true}", () => {
+                comp = mount(<TestComponent preventDefault={true} />, { attachTo });
+                const node = ReactDOM.findDOMNode(comp.instance());
+
+                dispatchTestKeyboardEvent(node, eventName, "1");
+                const localEvent = getLocalSpy(eventName).lastCall.args[0] as KeyboardEvent;
+                expect(localEvent.defaultPrevented).to.be.true;
+
+                dispatchTestKeyboardEvent(node, eventName, "2");
+                const globalEvent = getGlobalSpy(eventName).lastCall.args[0] as KeyboardEvent;
+                expect(globalEvent.defaultPrevented).to.be.true;
+            });
+
+            // TODO (clewis): we need to get the following test working to actually verify the
+            // stopPropagation behavior, but it's proving difficult.
+            it.skip("stops propagation if stopPropagation={true}", () => {
+                comp = mount(
+                    <div onKeyDown={wrappingKeyDownSpy} onKeyUp={wrappingKeyUpSpy}>
+                        <TestComponent stopPropagation={true} />
+                    </div>
+                , { attachTo });
+                const node = ReactDOM.findDOMNode(comp.instance()).children[0];
+
+                dispatchTestKeyboardEvent(node, eventName, "1");
+                dispatchTestKeyboardEvent(node, eventName, "2");
+
+                expect(getWrappingSpy(eventName).called).to.be.false;
+            });
+
+            describe("if allowInInput={false}", () => {
+                it("ignores hotkeys when inside text input", () => {
+                    assertInputAllowsKeys("text", false);
+                });
+
+                it("ignores hotkeys when inside number input", () => {
+                    assertInputAllowsKeys("number", false);
+                });
+
+                it("ignores hotkeys when inside password input", () => {
+                    assertInputAllowsKeys("password", false);
+                });
+
+                it("triggers hotkeys when inside checkbox input", () => {
+                    assertInputAllowsKeys("checkbox", true);
+                });
+
+                it("triggers hotkeys when inside radio input", () => {
+                    assertInputAllowsKeys("radio", true);
+                });
+            });
+
+            describe("if allowInInput={true}", () => {
+                it("triggers hotkeys when inside text input", () => {
+                    assertInputAllowsKeys("text", true, true);
+                });
+
+                it("triggers hotkeys when inside number input", () => {
+                    assertInputAllowsKeys("number", true, true);
+                });
+
+                it("triggers hotkeys when inside password input", () => {
+                    assertInputAllowsKeys("password", true, true);
+                });
+
+                it("triggers hotkeys when inside checkbox input", () => {
+                    assertInputAllowsKeys("checkbox", true, true);
+                });
+
+                it("triggers hotkeys when inside radio input", () => {
+                    assertInputAllowsKeys("radio", true, true);
+                });
+            });
+        }
+
         function assertInputAllowsKeys(type: string, allowsKeys: boolean, allowInInput: boolean = false) {
             comp = mount(<TestComponent allowInInput={allowInInput} />, { attachTo });
 
@@ -249,10 +300,22 @@ describe("Hotkeys", () => {
             (input as HTMLElement).focus();
 
             dispatchTestKeyboardEvent(input, "keydown", "1");
-            expect(localHotkeySpy.called).to.equal(allowsKeys);
+            expect(localKeyDownSpy.called).to.equal(allowsKeys);
 
             dispatchTestKeyboardEvent(input, "keydown", "2");
-            expect(globalHotkeySpy.called).to.equal(allowsKeys);
+            expect(globalKeyDownSpy.called).to.equal(allowsKeys);
+        }
+
+        function getLocalSpy(eventName: "keydown" | "keyup") {
+            return eventName === "keydown" ? localKeyDownSpy : localKeyUpSpy;
+        }
+
+        function getGlobalSpy(eventName: "keydown" | "keyup") {
+            return eventName === "keydown" ? globalKeyDownSpy : globalKeyUpSpy;
+        }
+
+        function getWrappingSpy(eventName: "keydown" | "keyup") {
+            return eventName === "keydown" ? wrappingKeyDownSpy : wrappingKeyUpSpy;
         }
     });
 

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -43,6 +43,7 @@ describe("Hotkeys", () => {
 
         interface ITestComponentProps {
             allowInInput?: boolean;
+            disabled?: boolean;
         }
 
         @HotkeysTarget
@@ -52,17 +53,18 @@ describe("Hotkeys", () => {
             };
 
             public renderHotkeys() {
-                const { allowInInput } = this.props;
+                const { allowInInput, disabled } = this.props;
+                const baseProps = { allowInInput, disabled };
                 return <Hotkeys>
                     <Hotkey
-                        allowInInput={allowInInput}
+                        {...baseProps}
                         combo="1"
                         group="test"
                         label="local hotkey"
                         onKeyDown={localHotkeySpy}
                     />
                     <Hotkey
-                        allowInInput={allowInInput}
+                        {...baseProps}
                         combo="2"
                         global
                         label="global hotkey"
@@ -119,6 +121,17 @@ describe("Hotkeys", () => {
 
             dispatchTestKeyboardEvent(unhotkeyed, "keydown", "2");
             expect(globalHotkeySpy.called).to.be.true;
+        });
+
+        it("ignores hotkeys when disabled={true}", () => {
+            comp = mount(<TestComponent disabled={true} />, { attachTo });
+            const node = ReactDOM.findDOMNode(comp.instance());
+
+            dispatchTestKeyboardEvent(node, "keydown", "1");
+            expect(localHotkeySpy.called).to.be.false;
+
+            dispatchTestKeyboardEvent(node, "keydown", "2");
+            expect(globalHotkeySpy.called).to.be.false;
         });
 
         describe("if allowInInput={false}", () => {


### PR DESCRIPTION
#### Fixes #1216, Fixes #825, Fixes #824

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add `allowInInput?: boolean` prop to `Hotkey`, which defaults to `false`.
    - With `allowInInput={true}`, a hotkey can be triggered when a `"text"`, `"password"`, or `[contenteditable=true]` input is focused. This is currently not possible.
- Add `disabled?: boolean` prop to `Hotkey`, which defaults to `false`.
    - With `disabled={true}`, a hotkey will not be triggered.
- Add `preventDefault?: boolean` prop to `Hotkey`, which defaults to `false`.
    - With `preventDefault={true}`, `event.preventDefault()` will be invoked in response to `keydown` and `keyup` events before the respective `onKeyDown` and `onKeyUp` callbacks are invoked.
- Add `stopPropagation?: boolean` prop to `Hotkey`, which defaults to `false`.
    - With `stopPropagation={true}`, `event.stopPropagation()` will be invoked in response to `keydown` and `keyup` events before the respective `onKeyDown` and `onKeyUp` callbacks are invoked.