### PR TITLE
Add delete key code

### DIFF
--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -15,3 +15,4 @@ export const ARROW_LEFT = 37;
 export const ARROW_UP = 38;
 export const ARROW_RIGHT = 39;
 export const ARROW_DOWN = 40;
+export const DELETE = 46;


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode for browser compatibility, 46 is used on all browsers.