### PR TITLE
[Non-ideal state] Fix title centering

### DIFF
--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -48,6 +48,7 @@ Styleguide pt-non-ideal-state
   }
 }
 
+.pt-non-ideal-state-title,
 .pt-non-ideal-state-description {
   text-align: center;
 }


### PR DESCRIPTION
Useful for multiline cases.

Before:
<img width="465" alt="screen shot 2017-07-07 at 2 49 32 pm" src="https://user-images.githubusercontent.com/199754/27978948-5b1c1bea-6327-11e7-9783-775dd765b85a.png">

After:
<img width="501" alt="screen shot 2017-07-07 at 2 49 15 pm" src="https://user-images.githubusercontent.com/199754/27978949-60909de4-6327-11e7-85e5-c5f7ee762446.png">
