### PR TITLE
[Portal] portalClassName prop attaches directly to portal container

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -107,6 +107,9 @@ export interface IOverlayProps extends IOverlayableProps, IBackdropProps, IProps
      */
     isOpen: boolean;
 
+    /** CSS class name to add to the detached container root element (if not `inline`). */
+    portalClassName?: string;
+
     /**
      * Name of the transition for internal `CSSTransitionGroup`.
      * Providing your own name here will require defining new CSS transition properties.
@@ -200,6 +203,7 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
                     {...elementProps}
                     containerRef={this.refHandlers.container}
                     onChildrenMount={this.handleContentMount}
+                    portalClassName={this.props.portalClassName}
                 >
                     {transitionGroup}
                 </Portal>

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -34,7 +34,29 @@ describe("<Portal>", () => {
         assert.lengthOf(document.getElementsByClassName(CLASS_TO_TEST), 1);
     });
 
-    it("propagates class names", () => {
+    it("invokes onChildrenMount after mounting", () => {
+        const onChildrenMount = sinon.spy();
+        portal = mount(
+            <Portal onChildrenMount={onChildrenMount}>
+                <p>test</p>
+            </Portal>,
+        );
+        assert.isTrue(onChildrenMount.calledOnce);
+    });
+
+    it("propagates portalClassName to detached container root", () => {
+        const CLASS_TO_TEST = "bp-test-klass";
+        portal = mount(
+            <Portal portalClassName={CLASS_TO_TEST}>
+                <p>test</p>
+            </Portal>,
+        );
+
+        const portalChild = document.querySelector(`.${CLASS_TO_TEST}`);
+        assert.isTrue(portalChild.classList.contains(Classes.PORTAL), "expected to find .pt-portal");
+    });
+
+    it("propagates className to subtree parent", () => {
         const CLASS_TO_TEST = "bp-test-klass";
         portal = mount(
             <Portal className={CLASS_TO_TEST}>
@@ -52,7 +74,7 @@ describe("<Portal>", () => {
             <Portal>
                 <p>test</p>
             </Portal>,
-            {context: {blueprintPortalClassName: CLASS_TO_TEST}},
+            { context: { blueprintPortalClassName: CLASS_TO_TEST } },
         );
 
         const portalElement = document.querySelector(`.${CLASS_TO_TEST}`);


### PR DESCRIPTION
#### Part of popper.js conversion #1202 

#### Changes proposed in this pull request:

- `<Portal className>` attaches to rendered div inside, which is decidedly less useful, so gotta add a new prop to avoid breaking.
- `<Portal portalClassName>` is applied directly to root `.pt-portal` div, alongside context prop from #1244 
- add same prop to `Overlay` directly.
  - note that `Popover` and `Tooltip` define their own `portalClassName` but semantics are different: theirs is equivalent to `<Portal className>`, not `<Portal portalClassName>`. changing this would be an API break, so I have opted to not expose `portalClassName` on those two components

#### Why?

Popper.js exhibited some weird behavior where non-inline popovers would jump to the top of the screen. This is trivially resolved by removing `position: absolute` from `.pt-portal` in devtools, but this is straight up impossible in code, so I had to add this prop 😢.

In fact, removing `position: absolute` from `.pt-portal` seems like a completely safe change for all of our overlaid components (Dialog, Popover, Tooltip, Overlay example, Toast all work just fine without that property cuz they explicitly position themselves in their own CSS), but it's probably not safe to "just remove" due to the [glaring code comment](https://github.com/palantir/blueprint/blob/master/packages/core/src/components/portal/_portal.scss#L7-L10):

> take the portal out of the document flow to prevent browsers from autoscrolling to the bottom
