### PR TITLE
Disable the `<RoundSize>` component wrapper

### DIFF
--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -10,7 +10,6 @@ import * as React from "react";
 
 import * as Classes from "../common/classes";
 import { IRowIndices } from "../common/grid";
-import { RoundSize } from "../common/roundSize";
 import { IClientCoordinates } from "../interactions/draggable";
 import { IIndexedResizeCallback } from "../interactions/resizable";
 import { Orientation } from "../interactions/resizeHandle";
@@ -112,11 +111,9 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
         }
 
         return (
-            <RoundSize>
-                <div style={style}>
-                    {cells}
-                </div>
-            </RoundSize>
+            <div style={style}>
+                {cells}
+            </div>
         );
     }
 


### PR DESCRIPTION
Previously, a bug in chrome broke scrolling in the table.

As demonstrated in this fiddle, the bug has been fixed.
https://jsfiddle.net/2rmz7p1d/5/

The RoundSize workaround has non-zero performance impact,
so we should disable it now that chrome is fixed.
