### PR TITLE
[Form group] Better pt-control support

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -412,7 +412,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     color: $pt-dark-text-color;
 
     &.pt-disabled {
-      color: $pt-text-color-disabled;
+      color: $pt-dark-text-color-disabled;
     }
 
     .pt-control-indicator {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -27,7 +27,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   margin-bottom: $pt-grid-size;
   cursor: pointer;
   // controls sometimes don't have text in their <label>, so we set a minimum height
-  min-height: $pt-grid-size * 2;
+  min-height: $control-indicator-size;
   padding-left: $control-indicator-size + $pt-grid-size;
   text-transform: none;
   line-height: $control-indicator-size;
@@ -363,6 +363,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   &.pt-large {
+    min-height: $control-indicator-size-large;
     padding-left: $control-indicator-size-large + $pt-grid-size;
     line-height: $control-indicator-size-large;
     font-size: $pt-font-size-large;

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -34,42 +34,67 @@ Markup:
   </div>
 </div>
 <div class="pt-form-group">
-  <label class="pt-label" for="example-form-group-switch-a">
-    Label A
+  <label class="pt-label" for="example-form-group-switch-c">
+    Label C
     <span class="pt-text-muted">(required)</span>
   </label>
   <div class="pt-form-content">
     <label class="pt-control pt-switch">
-      <input id="example-form-group-switch-a" type="checkbox" />
+      <input id="example-form-group-switch-c" type="checkbox" />
       <span class="pt-control-indicator"></span>
-      Switch A
+      Switch C
     </label>
     <div class="pt-form-helper-text">Helper text with details / user feedback</div>
   </div>
 </div>
-<div class="pt-form-group pt-inline pt-large pt-disabled">
-  <label class="pt-label" for="example-form-group-input-c">
-    Label C
+<div class="pt-form-group pt-inline">
+  <label class="pt-label" for="example-form-group-input-d">
+    Label D
     <span class="pt-text-muted">(optional)</span>
   </label>
   <div class="pt-form-content">
-    <div class="pt-input-group pt-large pt-disabled">
+    <div class="pt-input-group">
       <span class="pt-icon pt-icon-calendar"></span>
-      <input id="example-form-group-input-c" class="pt-input" disabled style="width: 200px;" type="text" placeholder="Placeholder text" dir="auto" />
+      <input id="example-form-group-input-d" class="pt-input" style="width: 200px;" type="text" placeholder="Placeholder text" dir="auto" />
     </div>
     <div class="pt-form-helper-text">Helper text with details / user feedback</div>
   </div>
 </div>
 <div class="pt-form-group pt-inline pt-large pt-disabled">
-  <label class="pt-label" for="example-form-group-switch-b">
-    Label B
-    <span class="pt-text-muted">(required)</span>
+  <label class="pt-label" for="example-form-group-input-e">
+    Label E
+    <span class="pt-text-muted">(optional)</span>
+  </label>
+  <div class="pt-form-content">
+    <div class="pt-input-group pt-large pt-disabled">
+      <span class="pt-icon pt-icon-calendar"></span>
+      <input id="example-form-group-input-e" class="pt-input" disabled style="width: 200px;" type="text" placeholder="Placeholder text" dir="auto" />
+    </div>
+    <div class="pt-form-helper-text">Helper text with details / user feedback</div>
+  </div>
+</div>
+<div class="pt-form-group pt-inline">
+  <label class="pt-label" for="example-form-group-switch-f">
+    Label F
   </label>
   <div class="pt-form-content">
     <label class="pt-control pt-switch">
-      <input id="example-form-group-switch-b" type="checkbox" />
+      <input id="example-form-group-switch-f" type="checkbox" />
       <span class="pt-control-indicator"></span>
-      Switch B
+      Switch F
+    </label>
+    <div class="pt-form-helper-text">Helper text with details / user feedback</div>
+  </div>
+</div>
+<div class="pt-form-group pt-inline pt-large pt-disabled">
+  <label class="pt-label" for="example-form-group-switch-g">
+    Label G
+  </label>
+  <div class="pt-form-content">
+    <label class="pt-control pt-switch pt-large pt-disabled">
+      <input id="example-form-group-switch-g" type="checkbox" disabled />
+      <span class="pt-control-indicator"></span>
+      Switch G
     </label>
     <div class="pt-form-helper-text">Helper text with details / user feedback</div>
   </div>

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -106,7 +106,7 @@ Styleguide pt-form-group
 .pt-form-group {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: baseline;
   margin: 0 0 ($pt-grid-size * 1.5);
 
   label.pt-label {
@@ -143,12 +143,6 @@ Styleguide pt-form-group
     label.pt-label {
       margin: 0 $pt-grid-size 0 0;
       line-height: $pt-input-height;
-    }
-
-    // not ideal but baseline doesn't align text perfectly
-    // so we have to align it to the label manually
-    .pt-control {
-      margin-top: $pt-grid-size * 1.2;
     }
   }
 

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -60,6 +60,10 @@ Styleguide pt-form-group
     margin-bottom: $pt-grid-size / 2;
   }
 
+  .pt-control {
+    margin: ($pt-grid-size / 2) 0 $pt-grid-size;
+  }
+
   .pt-form-helper-text {
     margin-top: $pt-grid-size / 2;
     color: $pt-text-color-muted;

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -81,7 +81,7 @@ Styleguide pt-form-group
 .pt-form-group {
   display: flex;
   flex-direction: column;
-  align-items: baseline;
+  align-items: flex-start;
   margin: 0 0 ($pt-grid-size * 1.5);
 
   label.pt-label {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -119,6 +119,12 @@ Styleguide pt-form-group
       margin: 0 $pt-grid-size 0 0;
       line-height: $pt-input-height;
     }
+
+    // not ideal but baseline doesn't align text perfectly
+    // so we have to align it to the label manually
+    .pt-control {
+      margin-top: $pt-grid-size * 1.2;
+    }
   }
 
   &.pt-disabled {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -33,6 +33,20 @@ Markup:
     <div class="pt-form-helper-text">Please enter a value</div>
   </div>
 </div>
+<div class="pt-form-group">
+  <label class="pt-label" for="example-form-group-switch-a">
+    Label A
+    <span class="pt-text-muted">(required)</span>
+  </label>
+  <div class="pt-form-content">
+    <label class="pt-control pt-switch">
+      <input id="example-form-group-switch-a" type="checkbox" />
+      <span class="pt-control-indicator"></span>
+      Switch A
+    </label>
+    <div class="pt-form-helper-text">Helper text with details / user feedback</div>
+  </div>
+</div>
 <div class="pt-form-group pt-inline pt-large pt-disabled">
   <label class="pt-label" for="example-form-group-input-c">
     Label C
@@ -43,6 +57,20 @@ Markup:
       <span class="pt-icon pt-icon-calendar"></span>
       <input id="example-form-group-input-c" class="pt-input" disabled style="width: 200px;" type="text" placeholder="Placeholder text" dir="auto" />
     </div>
+    <div class="pt-form-helper-text">Helper text with details / user feedback</div>
+  </div>
+</div>
+<div class="pt-form-group pt-inline pt-large pt-disabled">
+  <label class="pt-label" for="example-form-group-switch-b">
+    Label B
+    <span class="pt-text-muted">(required)</span>
+  </label>
+  <div class="pt-form-content">
+    <label class="pt-control pt-switch">
+      <input id="example-form-group-switch-b" type="checkbox" />
+      <span class="pt-control-indicator"></span>
+      Switch B
+    </label>
     <div class="pt-form-helper-text">Helper text with details / user feedback</div>
   </div>
 </div>

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -53,6 +53,7 @@ Styleguide pt-form-group
 .pt-form-group {
   display: flex;
   flex-direction: column;
+  align-items: baseline;
   margin: 0 0 ($pt-grid-size * 1.5);
 
   label.pt-label {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -114,7 +114,7 @@ Styleguide pt-form-group
   }
 
   .pt-control {
-    margin: ($pt-grid-size / 2) 0 $pt-grid-size;
+    margin-top: $pt-grid-size / 2;
   }
 
   .pt-form-helper-text {


### PR DESCRIPTION
#### Fixes #1305

#### Changes proposed in this pull request:

- Proper `min-height` for `.pt-control` (16px normal, 20px large)
- Align `.pt-form-group` items to their baseline
- Tweak `.pt-control` vertical margin within `.pt-form-group`

#### Screenshot

Before:
![screen shot 2017-07-11 at 4 15 18 pm](https://user-images.githubusercontent.com/199754/28095098-6df22d0a-6655-11e7-9949-8adf69f6a955.png)

After:
![screen shot 2017-07-11 at 4 15 26 pm](https://user-images.githubusercontent.com/199754/28095103-70fca340-6655-11e7-841b-de0d87635ce8.png)
