### PR TITLE
[Dialog] Reduce top position

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -53,7 +53,7 @@ $dialog-padding: $pt-grid-size * 2 !default;
   display: flex;
   flex-direction: column;
   position: absolute;
-  top: 25%;
+  top: 10%;
   right: 50%;
   z-index: $pt-z-index-overlay;
   // add bottom margin for overflow scrolling scenarios


### PR DESCRIPTION
- Going from 25% to 10%
- Doesn't impact short dialogs, but makes tall dialogs better
- Decent compromise until we fix `Overlay` and backdrop woes (centering, scrolling, etc...)
