### PR TITLE
[TruncatedFormat] Fix popover size issues leading to infinite loops

### DIFF
--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -157,12 +157,15 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
     }
 
     private setTruncationState() {
-        if (!this.props.detectTruncation) {
+        if (!this.props.detectTruncation || this.props.showPopover !== TruncatedPopoverMode.WHEN_TRUNCATED) {
             return;
         }
 
         // if the popover handle exists, take it into account
-        const popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
+        let popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
+        // add a slight bit of buffer space where we don't show the popover, to deal with cases
+        // where everything isn't pixel perfect
+        popoverHandleAdjustmentFactor += .5;
 
         const isTruncated = this.contentDiv !== undefined &&
             (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||


### PR DESCRIPTION
#### Fixes #1335 

#### Changes proposed in this pull request:

Add a bit of buffer space to the calculation -- if there's a fractional amount of pixels off, we err on the side of not showing the popover, to deal with inconsistencies when at different zoom levels. 

Also only change the popover visibility when set to WHEN_TRUNCATED. 
