### PR TITLE
[DateInput] No longer defaults to Today with time precision enabled

### DIFF
--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -69,7 +69,7 @@ export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDat
     public constructor(props?: IDateTimePickerProps, context?: any) {
         super(props, context);
 
-        const initialValue = (this.props.value != null) ? this.props.value : this.props.defaultValue;
+        const initialValue = (this.props.value !== undefined) ? this.props.value : this.props.defaultValue;
         this.state = {
             dateValue: initialValue,
             timeValue: initialValue,

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -94,11 +94,12 @@ describe("<DateTimePicker>", () => {
 
         function runValuNotDefinedTest(value: null | undefined) {
             it(`passing value={${value}} clears the selected date in the calendar`, () => {
-            const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
-            const { root, getSelectedDay } = wrap(<DateTimePicker value={defaultValue} />);
-            assert.isTrue(getSelectedDay().exists());
-            root.setProps({ value });
-            assert.isFalse(getSelectedDay().exists());
+                const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
+                const { root, getSelectedDay } = wrap(<DateTimePicker value={defaultValue} />);
+                assert.isTrue(getSelectedDay().exists());
+                root.setProps({ value });
+                assert.isFalse(getSelectedDay().exists());
+            });
         }
     });
 

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -89,13 +89,17 @@ describe("<DateTimePicker>", () => {
     });
 
     describe("when controlled", () => {
-        it("passing a null value clears the selected date in the calendar", () => {
+        runValuNotDefinedTest(undefined);
+        runValuNotDefinedTest(null);
+
+        function runValuNotDefinedTest(value: null | undefined) {
+            it(`passing value={${value}} clears the selected date in the calendar`, () => {
             const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
             const { root, getSelectedDay } = wrap(<DateTimePicker value={defaultValue} />);
             assert.isTrue(getSelectedDay().exists());
-            root.setProps({ value: undefined });
+            root.setProps({ value });
             assert.isFalse(getSelectedDay().exists());
-        });
+        }
     });
 
     function wrap(dtp: JSX.Element) {


### PR DESCRIPTION
#### Fixes #1246 (again)

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- __Fixed__ `DateInput` with time precision enabled no longer defaults to Today when popover re-opens with controlled `value === null` 
    - Note: If you deselect a date and then close the popover, the time fields will be cleared as well on re-open.

#### Reviewers should focus on:

Fixing the time fields (to not clear on popover re-open) would require more plumbing work, and I wasn't sure what the best UX was. @llorca? I also wanted to bias toward getting this quick fix submitted.

#### Screenshot

![2017-07-14 09 14 17](https://user-images.githubusercontent.com/443450/28220590-eaf7ccbc-6874-11e7-9dee-fd0438d0c375.gif)
