### PR TITLE
[Labs] Listen to query on select components

### DIFF
--- a/packages/labs/src/components/omnibox/omnibox.tsx
+++ b/packages/labs/src/components/omnibox/omnibox.tsx
@@ -99,9 +99,17 @@ export class Omnibox<T> extends React.Component<IOmniboxProps<T>, IOmniboxState<
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { isOpen, itemRenderer, inputProps, noResults, overlayProps, ...props } = this.props;
+        const {
+            isOpen,
+            itemRenderer,
+            inputProps,
+            noResults,
+            overlayProps,
+            ...restProps,
+        } = this.props;
+
         return <this.TypedQueryList
-            {...props}
+            {...restProps}
             activeItem={this.state.activeItem}
             onActiveItemChange={this.handleActiveItemChange}
             onItemSelect={this.handleItemSelect}

--- a/packages/labs/src/components/omnibox/omnibox.tsx
+++ b/packages/labs/src/components/omnibox/omnibox.tsx
@@ -17,6 +17,7 @@ import {
     InputGroup,
     IOverlayableProps,
     IOverlayProps,
+    Menu,
     Overlay,
     Utils,
 } from "@blueprintjs/core";
@@ -145,10 +146,10 @@ export class Omnibox<T> extends React.Component<IOmniboxProps<T>, IOmniboxState<
                         autoFocus={true}
                         className={CoreClasses.LARGE}
                         leftIconName="search"
-                        onChange={this.handleQueryChange}
                         placeholder="Search..."
                         value={listProps.query}
                         {...htmlInputProps}
+                        onChange={this.handleQueryChange}
                     />
                     {this.maybeRenderMenu(listProps)}
                 </div>
@@ -172,9 +173,9 @@ export class Omnibox<T> extends React.Component<IOmniboxProps<T>, IOmniboxState<
     private maybeRenderMenu(listProps: IQueryListRendererProps<T>) {
         if (this.state.query.length > 0) {
             return (
-                <ul className={CoreClasses.MENU} ref={listProps.itemsParentRef}>
+                <Menu ulRef={listProps.itemsParentRef}>
                     {this.renderItems(listProps)}
-                </ul>
+                </Menu>
             );
         }
         return undefined;
@@ -190,6 +191,7 @@ export class Omnibox<T> extends React.Component<IOmniboxProps<T>, IOmniboxState<
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
         this.setState({ query: event.currentTarget.value });
+        Utils.safeInvoke(this.props.inputProps.onChange, event);
     }
 
     private handleOverlayClose = (event: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/labs/src/components/omnibox/omnibox.tsx
+++ b/packages/labs/src/components/omnibox/omnibox.tsx
@@ -198,8 +198,9 @@ export class Omnibox<T> extends React.Component<IOmniboxProps<T>, IOmniboxState<
     }
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
+        const { inputProps = {} } = this.props;
         this.setState({ query: event.currentTarget.value });
-        Utils.safeInvoke(this.props.inputProps.onChange, event);
+        Utils.safeInvoke(inputProps.onChange, event);
     }
 
     private handleOverlayClose = (event: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/labs/src/components/select/multiSelect.tsx
+++ b/packages/labs/src/components/select/multiSelect.tsx
@@ -147,8 +147,8 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                 >
                     <TagInput
-                        inputProps={defaultInputProps}
                         {...tagInputProps}
+                        inputProps={defaultInputProps}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         values={this.props.selectedItems.map(this.props.tagRenderer)}
                     />
@@ -176,8 +176,10 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
     }
 
     private handleQueryChange = (e: React.FormEvent<HTMLInputElement>) => {
+        const { tagInputProps = {}, openOnKeyDown } = this.props;
         const query = e.currentTarget.value;
-        this.setState({ query, isOpen: !(query.length === 0 && this.props.openOnKeyDown) });
+        this.setState({ query, isOpen: !(query.length === 0 && openOnKeyDown) });
+        Utils.safeInvoke(tagInputProps.inputProps.onChange, e);
     }
 
     private handleItemSelect = (item: T, e: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/labs/src/components/select/multiSelect.tsx
+++ b/packages/labs/src/components/select/multiSelect.tsx
@@ -147,8 +147,8 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                 >
                     <TagInput
-                        {...tagInputProps}
                         inputProps={defaultInputProps}
+                        {...tagInputProps}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         values={this.props.selectedItems.map(this.props.tagRenderer)}
                     />
@@ -179,7 +179,10 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
         const { tagInputProps = {}, openOnKeyDown } = this.props;
         const query = e.currentTarget.value;
         this.setState({ query, isOpen: query.length > 0 || !openOnKeyDown });
-        Utils.safeInvoke(tagInputProps.inputProps.onChange, e);
+
+        if (tagInputProps.inputProps != null) {
+            Utils.safeInvoke(tagInputProps.inputProps.onChange, e);
+        }
     }
 
     private handleItemSelect = (item: T, e: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/labs/src/components/select/multiSelect.tsx
+++ b/packages/labs/src/components/select/multiSelect.tsx
@@ -178,7 +178,7 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
     private handleQueryChange = (e: React.FormEvent<HTMLInputElement>) => {
         const { tagInputProps = {}, openOnKeyDown } = this.props;
         const query = e.currentTarget.value;
-        this.setState({ query, isOpen: !(query.length === 0 && openOnKeyDown) });
+        this.setState({ query, isOpen: query.length > 0 || !openOnKeyDown });
         Utils.safeInvoke(tagInputProps.inputProps.onChange, e);
     }
 

--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -107,9 +107,17 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, itemRenderer, inputProps, noResults, popoverProps, ...props } = this.props;
+        const {
+            filterable,
+            itemRenderer,
+            inputProps,
+            noResults,
+            popoverProps,
+            ...restProps,
+        } = this.props;
+
         return <this.TypedQueryList
-            {...props}
+            {...restProps}
             activeItem={this.state.activeItem}
             onActiveItemChange={this.handleActiveItemChange}
             onItemSelect={this.handleItemSelect}
@@ -248,9 +256,9 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
         Utils.safeInvoke(popoverProps.popoverWillClose);
     }
 
-    private handleQueryChange = (e: React.FormEvent<HTMLInputElement>) => {
-        this.setState({ query: e.currentTarget.value });
-        Utils.safeInvoke(this.props.inputProps.onChange, e);
+    private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
+        this.setState({ query: event.currentTarget.value });
+        Utils.safeInvoke(this.props.inputProps.onChange, event);
     }
     private resetQuery = () => this.setState({ activeItem: this.props.items[0], query: "" });
 }

--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -257,8 +257,9 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
     }
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
+        const { inputProps = {} } = this.props;
         this.setState({ query: event.currentTarget.value });
-        Utils.safeInvoke(this.props.inputProps.onChange, event);
+        Utils.safeInvoke(inputProps.onChange, event);
     }
     private resetQuery = () => this.setState({ activeItem: this.props.items[0], query: "" });
 }

--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -134,11 +134,11 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
             <InputGroup
                 autoFocus={true}
                 leftIconName="search"
-                onChange={this.handleQueryChange}
                 placeholder="Filter..."
                 rightElement={this.maybeRenderInputClearButton()}
                 value={listProps.query}
                 {...htmlInputProps}
+                onChange={this.handleQueryChange}
             />
         );
 
@@ -248,8 +248,9 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
         Utils.safeInvoke(popoverProps.popoverWillClose);
     }
 
-    private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
-        this.setState({ query: event.currentTarget.value });
+    private handleQueryChange = (e: React.FormEvent<HTMLInputElement>) => {
+        this.setState({ query: e.currentTarget.value });
+        Utils.safeInvoke(this.props.inputProps.onChange, e);
     }
     private resetQuery = () => this.setState({ activeItem: this.props.items[0], query: "" });
 }


### PR DESCRIPTION
- Consumers can use `inputProps.onChange` to listen to the query