### PR TITLE
[Table] Frozen Rows/Cols - Part 3: Tests for new code

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -68,6 +68,9 @@ export function approxEqual(a: number, b: number, tolerance = 0.00001) {
 
 /** Clamps the given number between min and max values. Returns value if within range, or closest bound. */
 export function clamp(val: number, min: number, max: number) {
+    if (val == null) {
+        return val;
+    }
     if (max < min) {
         throw new Error(CLAMP_MIN_MAX);
     }

--- a/packages/core/test/common/utilsTests.ts
+++ b/packages/core/test/common/utilsTests.ts
@@ -21,6 +21,8 @@ describe("Utils", () => {
     });
 
     it("clamp", () => {
+        assert.strictEqual(Utils.clamp(undefined, 0, 20), undefined, "value undefined");
+        assert.strictEqual(Utils.clamp(null, 0, 20), null, "value null");
         assert.strictEqual(Utils.clamp(10, 0, 20), 10, "value between min/max");
         assert.strictEqual(Utils.clamp(0, 10, 20), 10, "value below min");
         assert.strictEqual(Utils.clamp(40, 0, 20), 20, "value above max");

--- a/packages/table/src/common/errors.ts
+++ b/packages/table/src/common/errors.ts
@@ -20,7 +20,11 @@ export const QUADRANT_ON_SCROLL_UNNECESSARILY_DEFINED =
 export const QUADRANT_ON_WHEEL_UNNECESSARILY_DEFINED =
     `${ns} <TableQuadrant> onWheel need not be defined for the MAIN quadrant. Provide only onScroll instead.`;
 
-export const TABLE_NON_COLUMN_CHILDREN = `${ns} <Table> Children of Table must be Columns"`;
+export const TABLE_NON_COLUMN_CHILDREN_WARNING =
+    `${ns} <Table> Children of Table must be Columns"`;
 
-export const TABLE_NUM_FROZEN_COLUMNS_BOUND = `${ns} <Table> numFrozenColumns must be in [0, number of columns]`;
-export const TABLE_NUM_FROZEN_ROWS_BOUND = `${ns} <Table> numFrozenRows must be in [0, numRows]`;
+export const TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING =
+    `${ns} <Table> numFrozenColumns must be in [0, number of columns]`;
+
+export const TABLE_NUM_FROZEN_ROWS_BOUND_WARNING =
+    `${ns} <Table> numFrozenRows must be in [0, numRows]`;

--- a/packages/table/src/common/errors.ts
+++ b/packages/table/src/common/errors.ts
@@ -19,3 +19,8 @@ export const QUADRANT_ON_SCROLL_UNNECESSARILY_DEFINED =
 
 export const QUADRANT_ON_WHEEL_UNNECESSARILY_DEFINED =
     `${ns} <TableQuadrant> onWheel need not be defined for the MAIN quadrant. Provide only onScroll instead.`;
+
+export const TABLE_NON_COLUMN_CHILDREN = `${ns} <Table> Children of Table must be Columns"`;
+
+export const TABLE_NUM_FROZEN_COLUMNS_BOUND = `${ns} <Table> numFrozenColumns must be in [0, number of columns]`;
+export const TABLE_NUM_FROZEN_ROWS_BOUND = `${ns} <Table> numFrozenRows must be in [0, numRows]`;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -965,6 +965,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private syncRowHeaderSize(rowHeaderElement: HTMLElement, width: number) {
+        if (rowHeaderElement == null) {
+            return;
+        }
         const selector = `.${Classes.TABLE_ROW_HEADERS_CELLS_CONTAINER}`;
         // this child element dictates the width of all row-header cells
         const elementToResize = rowHeaderElement.querySelector(selector) as HTMLElement;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -15,6 +15,7 @@ import { Column, IColumnProps } from "./column";
 import { IFocusedCellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
 import { Clipboard } from "./common/clipboard";
+import * as Errors from "./common/errors";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
 import { Utils } from "./common/utils";
@@ -666,20 +667,28 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     protected validateProps(props: ITableProps & { children: React.ReactNode }) {
-        const WARNING_MESSAGE = "Children of Table must be Columns";
-        React.Children.forEach(props.children, (child: React.ReactElement<any>) => {
-            // save as a variable so that union type narrowing works
-            const cType = child.type;
+        const { children, numFrozenColumns, numFrozenRows } = props;
 
-            if (typeof cType === "string") {
-                console.warn(WARNING_MESSAGE);
+        React.Children.forEach(children, (child: React.ReactElement<any>) => {
+            // save as a variable so that union type narrowing works
+            const childType = child.type;
+
+            if (typeof childType === "string") {
+                console.warn(Errors.TABLE_NON_COLUMN_CHILDREN);
             } else {
-                const isColumn = cType.prototype === Column.prototype || Column.prototype.isPrototypeOf(cType);
+                const isColumn = childType.prototype === Column.prototype || Column.prototype.isPrototypeOf(childType);
                 if (!isColumn) {
-                    console.warn(WARNING_MESSAGE);
+                    console.warn(Errors.TABLE_NON_COLUMN_CHILDREN);
                 }
             }
         });
+
+        if (numFrozenColumns != null && (numFrozenColumns < 0 || numFrozenColumns > React.Children.count(children))) {
+            throw new Error(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
+        }
+        if (numFrozenRows != null && (numFrozenRows < 0 || numFrozenRows > props.numRows)) {
+            throw new Error(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
+        }
     }
 
     // Quadrant refs

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -256,6 +256,104 @@ describe("<Table>", () => {
         expect(table.state("selectedRegions").length).to.equal(1);
     });
 
+    describe("Quadrants", () => {
+        // const NUM_ROWS = 5;
+        // const NUM_COLUMNS = 5;
+        // const NUM_FROZEN_ROWS = 2;
+        // const NUM_FROZEN_COLUMNS = 2;
+
+        it.skip("resizes quadrants to clear the right scrollbar if scrollbar is showing");
+        it.skip("resizes quadrants to clear the bottom scrollbar if scrollbar is showing");
+        it.skip("resizes quadrants to be flush with parent if right scrollbar is not showing");
+        it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
+
+        describe.skip("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
+            // not actually sure how to test this, since useInteractionBar is a prop on Column,
+            // yet Enzyme lets you setProps only on the root element (i.e. the Table).
+            it.skip("syncs initial quadrant sizes properly");
+            it.skip("resizes quadrants properly when toggling interaction bar");
+            it.skip("resizes quadrants properly when toggling row headers on", () => {
+                // const attachTo = document.createElement("div");
+                // const table = mount(
+                //     <Table numRows={NUM_ROWS} isRowHeaderShown={true}>
+                //         {Utils.times(NUM_COLUMNS, () => <Column renderCell={renderCell} />)}
+                //     </Table>,
+                //     { attachTo },
+                // );
+                // const { mainQuadrant, leftQuadrant, topQuadrant, topLeftQuadrant } = findQuadrants(attachTo);
+
+                // expect(getWidth(leftQuadrant)).to.equal(0);
+                // expect(getWidth(topLeftQuadrant)).to.equal(0);
+
+                // table.setProps({ isRowHeaderShown: true });
+
+                // const mainQuadrantRowHeaderWidth = getWidth(mainQuadrant.find(`.${Classes.TABLE_ROW_HEADERS}`));
+                // expect(mainQuadrantRowHeaderWidth).to.be.greaterThan(0);
+                // expect(getWidth(leftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
+                // expect(getWidth(topLeftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
+            });
+            it("resizes quadrants properly when toggling row headers off", () => {
+                // const table = mount(
+                //     <Table numRows={NUM_ROWS} isRowHeaderShown={true}>
+                //         <Column name="My column" renderCell={renderCell} />
+                //     </Table>,
+                // );
+                // const { mainQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(table);
+
+                // const mainQuadrantRowHeaderWidth = getWidth(mainQuadrant.find(`.${Classes.TABLE_ROW_HEADERS}`));
+                // expect(mainQuadrantRowHeaderWidth).to.be.greaterThan(0);
+                // expect(getWidth(leftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
+                // expect(getWidth(topLeftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
+
+                // table.setProps({ isRowHeaderShown: false });
+                // expect(getWidth(leftQuadrant)).to.equal(0);
+                // expect(getWidth(topLeftQuadrant)).to.equal(0);
+            });
+            it.skip("resizes quadrants properly when setting numFrozenRows > 0");
+            it.skip("resizes quadrants properly when setting numFrozenColumns > 0");
+        });
+
+        describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
+            it.skip("syncs initial quadrant sizes properly");
+            it.skip("resizes quadrants properly when toggling interaction bar");
+            it.skip("resizes quadrants properly when toggling row headers");
+            it.skip("resizes quadrants properly when setting numFrozenRows = 0");
+            it.skip("resizes quadrants properly when setting numFrozenColumns > 0");
+        });
+
+        describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
+            it.skip("syncs initial quadrant sizes properly");
+            it.skip("resizes quadrants properly when toggling interaction bar");
+            it.skip("resizes quadrants properly when toggling row headers");
+            it.skip("resizes quadrants properly when setting numFrozenRows > 0");
+            it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
+        });
+
+        describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
+            it.skip("syncs initial quadrant sizes properly");
+            it.skip("resizes quadrants properly when toggling interaction bar");
+            it.skip("resizes quadrants properly when toggling row headers");
+            it.skip("resizes quadrants properly when setting numFrozenRows = 0");
+            it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
+        });
+
+        // function findQuadrants(attachTo: HTMLElement) { // table: ReactWrapper<ITableProps, any>) {
+        //     // this order is clearer than alphabetical order
+        //     // tslint:disable:object-literal-sort-keys
+        //     return {
+        //         mainQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_MAIN}`),
+        //         leftQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_LEFT}`),
+        //         topQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_TOP}`),
+        //         topLeftQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`),
+        //     };
+        //     // tslint:enable:object-literal-sort-keys
+        // }
+
+        // function getWidth(node: ReactWrapper<any, any>) {
+        //     return node.getDOMNode().getBoundingClientRect().width;
+        // }
+    });
+
     describe("Freezing", () => {
         it("should throw an error if numFrozenColumns < 0", () => {
             const mountFn = () => mount(<Table numFrozenColumns={-1} />);

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -15,6 +15,7 @@ import { dispatchMouseEvent } from "@blueprintjs/core/test/common/utils";
 import { Cell, Column, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
+import * as Errors from "../src/common/errors";
 import { IColumnIndices, IRowIndices } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
 import { IRegion, Regions } from "../src/regions";
@@ -253,6 +254,32 @@ describe("<Table>", () => {
         );
         table.setProps({ selectionModes: [] });
         expect(table.state("selectedRegions").length).to.equal(1);
+    });
+
+    describe("Freezing", () => {
+        it("should throw an error if numFrozenColumns < 0", () => {
+            const mountFn = () => mount(<Table numFrozenColumns={-1} />);
+            expect(mountFn).to.throw(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
+        });
+
+        it("should throw an error if numFrozenColumns > number of columns", () => {
+            const mountFn1 = () => mount(<Table numFrozenColumns={1} />);
+            const mountFn2 = () => mount(<Table numFrozenColumns={2}><Column /></Table>);
+            expect(mountFn1).to.throw(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
+            expect(mountFn2).to.throw(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
+        });
+
+        it("should throw an error if numFrozenRows < 0", () => {
+            const mountFn = () => mount(<Table numFrozenRows={-1} />);
+            expect(mountFn).to.throw(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
+        });
+
+        it("should throw an error if numFrozenRows > numRows", () => {
+            const mountFn1 = () => mount(<Table numFrozenRows={1} />);
+            const mountFn2 = () => mount(<Table numFrozenRows={2} numRows={1}><Column /></Table>);
+            expect(mountFn1).to.throw(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
+            expect(mountFn2).to.throw(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
+         });
     });
 
     describe("Resizing", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -6,7 +6,7 @@
  */
 
 import { expect } from "chai";
-import { mount, ReactWrapper } from "enzyme";
+import { mount, ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
@@ -16,7 +16,6 @@ import { dispatchMouseEvent } from "@blueprintjs/core/test/common/utils";
 import { Cell, Column, IColumnProps, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
-import * as Errors from "../src/common/errors";
 import { IColumnIndices, IRowIndices } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
 import { QuadrantType } from "../src/quadrants/tableQuadrant";
@@ -557,28 +556,28 @@ describe("<Table>", () => {
     });
 
     describe("Freezing", () => {
-        it("should throw an error if numFrozenColumns < 0", () => {
-            const mountFn = () => mount(<Table numFrozenColumns={-1} />);
-            expect(mountFn).to.throw(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
+        it("clamps out-of-bounds numFrozenColumns if < 0", () => {
+            const table = shallow(<Table numFrozenColumns={-1} />);
+            expect(table.state().numFrozenColumnsClamped).to.equal(0);
         });
 
-        it("should throw an error if numFrozenColumns > number of columns", () => {
-            const mountFn1 = () => mount(<Table numFrozenColumns={1} />);
-            const mountFn2 = () => mount(<Table numFrozenColumns={2}><Column /></Table>);
-            expect(mountFn1).to.throw(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
-            expect(mountFn2).to.throw(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND);
+        it("clamps out-of-bounds numFrozenColumns if > number of columns", () => {
+            const table1 = shallow(<Table numFrozenColumns={1} />);
+            expect(table1.state().numFrozenColumnsClamped).to.equal(0);
+            const table2 = shallow(<Table numFrozenColumns={2}><Column /></Table>);
+            expect(table2.state().numFrozenColumnsClamped).to.equal(1);
         });
 
-        it("should throw an error if numFrozenRows < 0", () => {
-            const mountFn = () => mount(<Table numFrozenRows={-1} />);
-            expect(mountFn).to.throw(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
+        it("clamps out-of-bounds numFrozenRows if < 0", () => {
+            const table = shallow(<Table numFrozenRows={-1} />);
+            expect(table.state().numFrozenRowsClamped).to.equal(0);
         });
 
-        it("should throw an error if numFrozenRows > numRows", () => {
-            const mountFn1 = () => mount(<Table numFrozenRows={1} />);
-            const mountFn2 = () => mount(<Table numFrozenRows={2} numRows={1}><Column /></Table>);
-            expect(mountFn1).to.throw(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
-            expect(mountFn2).to.throw(Errors.TABLE_NUM_FROZEN_ROWS_BOUND);
+        it("clamps out-of-bounds numFrozenRows if > numRows", () => {
+            const table1 = shallow(<Table numFrozenRows={1} />);
+            expect(table1.state().numFrozenRowsClamped).to.equal(0);
+            const table2 = shallow(<Table numFrozenRows={2} numRows={1}><Column /></Table>);
+            expect(table2.state().numFrozenRowsClamped).to.equal(1);
          });
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -311,6 +311,9 @@ describe("<Table>", () => {
             });
 
             it("syncs quadrant scroll offsets when scrolling the main quadrant", () => {
+                // simulating a "scroll" or "wheel" event doesn't seem to affect the
+                // scrollTop/scrollLeft the way it would in practice, so we need to tweak those
+                // explicitly before triggering.
                 mainScrollContainer.scrollLeft = SCROLL_OFFSET_X;
                 mainScrollContainer.scrollTop = SCROLL_OFFSET_Y;
                 TestUtils.Simulate.scroll(mainScrollContainer);
@@ -333,8 +336,6 @@ describe("<Table>", () => {
             });
 
             it("syncs quadrant scroll offsets when mouse-wheeling in the left quadrant", () => {
-                // simulating a "wheel" event doesn't affect the scrollTop the way it would in
-                // practice, so we need to tweak that explicitly before triggering.
                 leftScrollContainer.scrollTop = SCROLL_OFFSET_Y;
                 TestUtils.Simulate.wheel(leftScrollContainer, {
                     deltaX: SCROLL_OFFSET_X,

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -6,7 +6,7 @@
  */
 
 import { expect } from "chai";
-import { mount, ReactWrapper, shallow } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
@@ -557,28 +557,36 @@ describe("<Table>", () => {
 
     describe("Freezing", () => {
         it("clamps out-of-bounds numFrozenColumns if < 0", () => {
-            const table = shallow(<Table numFrozenColumns={-1} />);
-            expect(table.state().numFrozenColumnsClamped).to.equal(0);
+            const table = mount(<Table numFrozenColumns={-1} />);
+            expect(getNumClamped(table, "numFrozenColumns")).to.equal(0);
         });
 
         it("clamps out-of-bounds numFrozenColumns if > number of columns", () => {
-            const table1 = shallow(<Table numFrozenColumns={1} />);
-            expect(table1.state().numFrozenColumnsClamped).to.equal(0);
-            const table2 = shallow(<Table numFrozenColumns={2}><Column /></Table>);
-            expect(table2.state().numFrozenColumnsClamped).to.equal(1);
+            const table1 = mount(<Table numFrozenColumns={1} />);
+            expect(getNumClamped(table1, "numFrozenColumns")).to.equal(0);
+            const table2 = mount(<Table numFrozenColumns={2}><Column /></Table>);
+            expect(getNumClamped(table2, "numFrozenColumns")).to.equal(1);
         });
 
         it("clamps out-of-bounds numFrozenRows if < 0", () => {
-            const table = shallow(<Table numFrozenRows={-1} />);
-            expect(table.state().numFrozenRowsClamped).to.equal(0);
+            const table = mount(<Table numFrozenRows={-1} />);
+            expect(getNumClamped(table, "numFrozenRows")).to.equal(0);
         });
 
         it("clamps out-of-bounds numFrozenRows if > numRows", () => {
-            const table1 = shallow(<Table numFrozenRows={1} />);
-            expect(table1.state().numFrozenRowsClamped).to.equal(0);
-            const table2 = shallow(<Table numFrozenRows={2} numRows={1}><Column /></Table>);
-            expect(table2.state().numFrozenRowsClamped).to.equal(1);
-         });
+            const table1 = mount(<Table numFrozenRows={1} />);
+            expect(getNumClamped(table1, "numFrozenRows")).to.equal(0);
+            const table2 = mount(<Table numFrozenRows={2} numRows={1}><Column /></Table>);
+            expect(getNumClamped(table2, "numFrozenRows")).to.equal(1);
+        });
+
+        function getNumClamped(table: ReactWrapper<any, any>, propName: "numFrozenColumns" | "numFrozenRows") {
+            // cast as `any` to give us access to private members
+            const unprotectedTableNode = table.getNode() as any;
+            return propName === "numFrozenColumns"
+                ? unprotectedTableNode.getNumFrozenColumnsClamped()
+                : unprotectedTableNode.getNumFrozenRowsClamped();
+        }
     });
 
     describe("Resizing", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -264,8 +264,13 @@ describe("<Table>", () => {
         const ROW_HEADER_EXPECTED_WIDTH = 30;
         const COLUMN_HEADER_EXPECTED_HEIGHT = 30;
 
+        let table: Table;
         // const NUM_FROZEN_ROWS = 2;
         // const NUM_FROZEN_COLUMNS = 2;
+
+        afterEach(() => {
+            table = undefined;
+        });
 
         it.skip("resizes quadrants to clear the right scrollbar if scrollbar is showing");
         it.skip("resizes quadrants to clear the bottom scrollbar if scrollbar is showing");
@@ -324,8 +329,6 @@ describe("<Table>", () => {
         // ==============
 
         function assertDefaultQuadrantSizesCorrect(numFrozenRows?: number, numFrozenColumns?: number) {
-            let table: Table;
-
             const tableHarness = mountTable({
                 numFrozenColumns,
                 numFrozenRows,
@@ -338,8 +341,6 @@ describe("<Table>", () => {
         }
 
         function assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows?: number, numFrozenColumns?: number) {
-            let table: Table;
-
             const tableHarness = mountTable({
                 isRowHeaderShown: false,
                 numFrozenColumns,
@@ -354,14 +355,14 @@ describe("<Table>", () => {
         }
 
         function assertNonMainQuadrantSizesCorrect(
-            table: ElementHarness,
+            tableHarness: ElementHarness,
             expectedWidth: number,
             expectedHeight: number,
         ) {
             const expectedWidthString = toPxString(expectedWidth);
             const expectedHeightString = toPxString(expectedHeight);
 
-            const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(table);
+            const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(tableHarness);
 
             assertStyleEquals(leftQuadrant, "width", expectedWidthString);
             assertStyleEquals(topQuadrant, "height", expectedHeightString);
@@ -387,14 +388,14 @@ describe("<Table>", () => {
             return Utils.times(numColumns, () => <Column renderCell={renderCell} {...props} />);
         }
 
-        function findQuadrants(table: ElementHarness) {
+        function findQuadrants(tableHarness: ElementHarness) {
             // this order is clearer than alphabetical order
             // tslint:disable:object-literal-sort-keys
             return {
-                mainQuadrant: table.find(`.${Classes.TABLE_QUADRANT_MAIN}`),
-                leftQuadrant: table.find(`.${Classes.TABLE_QUADRANT_LEFT}`),
-                topQuadrant: table.find(`.${Classes.TABLE_QUADRANT_TOP}`),
-                topLeftQuadrant: table.find(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`),
+                mainQuadrant: tableHarness.find(`.${Classes.TABLE_QUADRANT_MAIN}`),
+                leftQuadrant: tableHarness.find(`.${Classes.TABLE_QUADRANT_LEFT}`),
+                topQuadrant: tableHarness.find(`.${Classes.TABLE_QUADRANT_TOP}`),
+                topLeftQuadrant: tableHarness.find(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`),
             };
             // tslint:enable:object-literal-sort-keys
         }

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -415,10 +415,6 @@ describe("<Table>", () => {
         function toPxString(value: number) {
             return `${value}px`;
         }
-
-        // function getWidth(node: ReactWrapper<any, any>) {
-        //     return node.getDOMNode().getBoundingClientRect().width;
-        // }
     });
 
     describe("Freezing", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -279,57 +279,40 @@ describe("<Table>", () => {
         it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
 
         describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
-            it("syncs initial quadrant sizes properly", () => {
-                assertDefaultQuadrantSizesCorrect(0, 0);
-            });
-            it("resizes quadrants properly when toggling interaction bar", () => {
-                assertQuadrantSizesCorrectIfInteractionBarVisible(0, 0);
-            });
-            it("syncs quadrants sizes properly when row header hidden", () => {
-                assertQuadrantSizesCorrectIfRowHeadersHidden(0, 0);
-            });
+            runQuadrantSizeTestSuite(0, 0);
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
-            it("syncs initial quadrant sizes properly", () => {
-                assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
-            });
-            it("resizes quadrants properly when toggling interaction bar", () => {
-                assertQuadrantSizesCorrectIfInteractionBarVisible(NUM_FROZEN_ROWS, 0);
-            });
-            it("syncs quadrants sizes properly when row header hidden", () => {
-                assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, 0);
-            });
+            runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, 0);
         });
 
         describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
-            it("syncs initial quadrant sizes properly", () => {
-                assertDefaultQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
-            });
-            it("resizes quadrants properly when toggling interaction bar", () => {
-                assertQuadrantSizesCorrectIfInteractionBarVisible(0, NUM_FROZEN_COLUMNS);
-            });
-            it("syncs quadrants sizes properly when row header hidden", () => {
-                assertQuadrantSizesCorrectIfRowHeadersHidden(0, NUM_FROZEN_COLUMNS);
-            });
+            runQuadrantSizeTestSuite(0, NUM_FROZEN_COLUMNS);
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
-            it("syncs initial quadrant sizes properly", () => {
-                assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
-            });
-            it("resizes quadrants properly when toggling interaction bar", () => {
-                assertQuadrantSizesCorrectIfInteractionBarVisible(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
-            });
-            it("syncs quadrants sizes properly when row header hidden", () => {
-                assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
-            });
+            runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
         });
 
         // Test templates
         // ==============
 
-        function assertDefaultQuadrantSizesCorrect(numFrozenRows?: number, numFrozenColumns?: number) {
+        function runQuadrantSizeTestSuite(numFrozenRows: number, numFrozenColumns: number) {
+            it("syncs initial quadrant sizes properly", () => {
+                assertDefaultQuadrantSizesCorrect(numFrozenRows, numFrozenColumns);
+            });
+            it("resizes quadrants properly when toggling interaction bar", () => {
+                assertQuadrantSizesCorrectIfInteractionBarVisible(numFrozenRows, numFrozenColumns);
+            });
+            it("syncs quadrants sizes properly when row header hidden", () => {
+                assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows, numFrozenColumns);
+            });
+        }
+
+        // Assertions
+        // ==========
+
+        function assertDefaultQuadrantSizesCorrect(numFrozenRows: number, numFrozenColumns: number) {
             const tableHarness = mountTable({
                 numFrozenColumns,
                 numFrozenRows,
@@ -341,7 +324,7 @@ describe("<Table>", () => {
             assertNonMainQuadrantSizesCorrect(tableHarness, expectedWidth, expectedHeight);
         }
 
-        function assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows?: number, numFrozenColumns?: number) {
+        function assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows: number, numFrozenColumns: number) {
             const tableHarness = mountTable({
                 isRowHeaderShown: false,
                 numFrozenColumns,
@@ -355,7 +338,7 @@ describe("<Table>", () => {
             assertNonMainQuadrantSizesCorrect(tableHarness, expectedWidth, expectedHeight);
         }
 
-        function assertQuadrantSizesCorrectIfInteractionBarVisible(numFrozenRows?: number, numFrozenColumns?: number) {
+        function assertQuadrantSizesCorrectIfInteractionBarVisible(numFrozenRows: number, numFrozenColumns: number) {
             const tableProps = {
                 numFrozenColumns,
                 numFrozenRows,

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -285,8 +285,6 @@ describe("<Table>", () => {
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, 0);
             });
-            it.skip("resizes quadrants properly when setting numFrozenRows > 0");
-            it.skip("resizes quadrants properly when setting numFrozenColumns > 0");
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
@@ -297,8 +295,6 @@ describe("<Table>", () => {
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, 0);
             });
-            it.skip("resizes quadrants properly when setting numFrozenRows = 0");
-            it.skip("resizes quadrants properly when setting numFrozenColumns > 0");
         });
 
         describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
@@ -309,8 +305,6 @@ describe("<Table>", () => {
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, NUM_FROZEN_COLUMNS);
             });
-            it.skip("resizes quadrants properly when setting numFrozenRows > 0");
-            it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
@@ -321,8 +315,6 @@ describe("<Table>", () => {
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
-            it.skip("resizes quadrants properly when setting numFrozenRows = 0");
-            it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
         });
 
         // Test templates

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from "react-dom";
 
 import { Keys } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/core/test/common/utils";
-import { Cell, Column, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
+import { Cell, Column, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils, IColumnProps } from "../src";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import * as Errors from "../src/common/errors";
@@ -273,80 +273,49 @@ describe("<Table>", () => {
         it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
 
         describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
-            it.only("syncs initial quadrant sizes properly", () => {
-                assertInitialQuadrantSizesCorrect(0, 0);
+            it("syncs initial quadrant sizes properly", () => {
+                assertDefaultQuadrantSizesCorrect(0, 0);
             });
-
-            // not actually sure how to test this, since useInteractionBar is a prop on Column,
-            // yet Enzyme lets you setProps only on the root element (i.e. the Table).
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.skip("resizes quadrants properly when toggling row headers on", () => {
-                // const attachTo = document.createElement("div");
-                // const table = mount(
-                //     <Table numRows={NUM_ROWS} isRowHeaderShown={true}>
-                //         {Utils.times(NUM_COLUMNS, () => <Column renderCell={renderCell} />)}
-                //     </Table>,
-                //     { attachTo },
-                // );
-                // const { mainQuadrant, leftQuadrant, topQuadrant, topLeftQuadrant } = findQuadrants(attachTo);
-
-                // expect(getWidth(leftQuadrant)).to.equal(0);
-                // expect(getWidth(topLeftQuadrant)).to.equal(0);
-
-                // table.setProps({ isRowHeaderShown: true });
-
-                // const mainQuadrantRowHeaderWidth = getWidth(mainQuadrant.find(`.${Classes.TABLE_ROW_HEADERS}`));
-                // expect(mainQuadrantRowHeaderWidth).to.be.greaterThan(0);
-                // expect(getWidth(leftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
-                // expect(getWidth(topLeftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
-            });
-            it("resizes quadrants properly when toggling row headers off", () => {
-                // const table = mount(
-                //     <Table numRows={NUM_ROWS} isRowHeaderShown={true}>
-                //         <Column name="My column" renderCell={renderCell} />
-                //     </Table>,
-                // );
-                // const { mainQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(table);
-
-                // const mainQuadrantRowHeaderWidth = getWidth(mainQuadrant.find(`.${Classes.TABLE_ROW_HEADERS}`));
-                // expect(mainQuadrantRowHeaderWidth).to.be.greaterThan(0);
-                // expect(getWidth(leftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
-                // expect(getWidth(topLeftQuadrant)).to.equal(mainQuadrantRowHeaderWidth);
-
-                // table.setProps({ isRowHeaderShown: false });
-                // expect(getWidth(leftQuadrant)).to.equal(0);
-                // expect(getWidth(topLeftQuadrant)).to.equal(0);
+            it.only("resizes quadrants properly when toggling row headers", () => {
+                assertQuadrantSizesCorrectIfRowHeadersHidden(0, 0);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
             it.skip("resizes quadrants properly when setting numFrozenColumns > 0");
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
-            it.only("syncs initial quadrant sizes properly", () => {
-                assertInitialQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
+            it("syncs initial quadrant sizes properly", () => {
+                assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.skip("resizes quadrants properly when toggling row headers");
+            it.only("resizes quadrants properly when toggling row headers", () => {
+                assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, 0);
+            });
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");
             it.skip("resizes quadrants properly when setting numFrozenColumns > 0");
         });
 
         describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
-            it.only("syncs initial quadrant sizes properly", () => {
-                assertInitialQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
+            it("syncs initial quadrant sizes properly", () => {
+                assertDefaultQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.skip("resizes quadrants properly when toggling row headers");
+            it.only("resizes quadrants properly when toggling row headers", () => {
+                assertQuadrantSizesCorrectIfRowHeadersHidden(0, NUM_FROZEN_COLUMNS);
+            });
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
             it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
-            it.only("syncs initial quadrant sizes properly", () => {
-                assertInitialQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            it("syncs initial quadrant sizes properly", () => {
+                assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.skip("resizes quadrants properly when toggling row headers");
+            it.only("resizes quadrants properly when toggling row headers", () => {
+                assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            });
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");
             it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
         });
@@ -354,27 +323,45 @@ describe("<Table>", () => {
         // Test templates
         // ==============
 
-        function assertInitialQuadrantSizesCorrect(numFrozenRows?: number, numFrozenColumns?: number) {
+        function assertDefaultQuadrantSizesCorrect(numFrozenRows?: number, numFrozenColumns?: number) {
             let table: Table;
-            const saveTable = (t: Table) => table = t;
 
-            const tableHarness = harness.mount(
-                <Table
-                    ref={saveTable}
-                    numRows={NUM_ROWS}
-                    numFrozenRows={numFrozenRows}
-                    numFrozenColumns={numFrozenColumns}
-                >
-                    {Utils.times(NUM_COLUMNS, () => <Column renderCell={renderCell} />)}
-                </Table>,
-            );
-            const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(tableHarness);
+            const tableHarness = mountTable({
+                numFrozenColumns,
+                numFrozenRows,
+                ref: (t: Table) => table = t,
+            });
 
-            const expectedFrozenRowsHeight = numFrozenRows * table.props.defaultRowHeight;
-            const expectedFrozenColumnsWidth = numFrozenColumns * table.props.defaultColumnWidth;
+            const expectedWidth = ROW_HEADER_EXPECTED_WIDTH + (numFrozenColumns * table.props.defaultColumnWidth);
+            const expectedHeight = COLUMN_HEADER_EXPECTED_HEIGHT + (numFrozenRows * table.props.defaultRowHeight);
+            assertNonMainQuadrantSizesCorrect(tableHarness, expectedWidth, expectedHeight);
+        }
 
-            const expectedWidthString = toPxString(ROW_HEADER_EXPECTED_WIDTH + expectedFrozenColumnsWidth);
-            const expectedHeightString = toPxString(COLUMN_HEADER_EXPECTED_HEIGHT + expectedFrozenRowsHeight);
+        function assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows?: number, numFrozenColumns?: number) {
+            let table: Table;
+
+            const tableHarness = mountTable({
+                isRowHeaderShown: false,
+                numFrozenColumns,
+                numFrozenRows,
+                ref: (t: Table) => table = t,
+            });
+
+            // add explicit 0 to communicate that we're considering the zero-width row headers
+            const expectedWidth = 0 + (numFrozenColumns * table.props.defaultColumnWidth);
+            const expectedHeight = COLUMN_HEADER_EXPECTED_HEIGHT + (numFrozenRows * table.props.defaultRowHeight);
+            assertNonMainQuadrantSizesCorrect(tableHarness, expectedWidth, expectedHeight);
+        }
+
+        function assertNonMainQuadrantSizesCorrect(
+            table: ElementHarness,
+            expectedWidth: number,
+            expectedHeight: number,
+        ) {
+            const expectedWidthString = toPxString(expectedWidth);
+            const expectedHeightString = toPxString(expectedHeight);
+
+            const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(table);
 
             assertStyleEquals(leftQuadrant, "width", expectedWidthString);
             assertStyleEquals(topQuadrant, "height", expectedHeightString);
@@ -384,6 +371,21 @@ describe("<Table>", () => {
 
         // Helpers
         // =======
+
+        function mountTable(
+            tableProps: Partial<ITableProps> & { ref?: (t: Table) => void } = {},
+            columnProps: Partial<IColumnProps> & object = {},
+        ) {
+            return harness.mount(
+                <Table numRows={NUM_ROWS} {...tableProps}>
+                    {renderColumns(columnProps)}
+                </Table>,
+            );
+        }
+
+        function renderColumns(props: Partial<IColumnProps> & object = {}, numColumns = NUM_COLUMNS) {
+            return Utils.times(numColumns, () => <Column renderCell={renderCell} {...props} />);
+        }
 
         function findQuadrants(table: ElementHarness) {
             // this order is clearer than alphabetical order

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -261,8 +261,11 @@ describe("<Table>", () => {
         const NUM_COLUMNS = 5;
         const NUM_FROZEN_ROWS = 1;
         const NUM_FROZEN_COLUMNS = 1;
+
         const ROW_HEADER_EXPECTED_WIDTH = 30;
         const COLUMN_HEADER_EXPECTED_HEIGHT = 30;
+        const COLUMN_INTERACTION_BAR_EXPECTED_HEIGHT = 20;
+        const COLUMN_INTERACTION_BAR_EXPECTED_BORDER_WIDTH = 1;
 
         let table: Table;
 
@@ -279,7 +282,9 @@ describe("<Table>", () => {
             it("syncs initial quadrant sizes properly", () => {
                 assertDefaultQuadrantSizesCorrect(0, 0);
             });
-            it.skip("resizes quadrants properly when toggling interaction bar");
+            it("resizes quadrants properly when toggling interaction bar", () => {
+                assertQuadrantSizesCorrectIfInteractionBarVisible(0, 0);
+            });
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, 0);
             });
@@ -289,7 +294,9 @@ describe("<Table>", () => {
             it("syncs initial quadrant sizes properly", () => {
                 assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
             });
-            it.skip("resizes quadrants properly when toggling interaction bar");
+            it("resizes quadrants properly when toggling interaction bar", () => {
+                assertQuadrantSizesCorrectIfInteractionBarVisible(NUM_FROZEN_ROWS, 0);
+            });
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, 0);
             });
@@ -299,7 +306,9 @@ describe("<Table>", () => {
             it("syncs initial quadrant sizes properly", () => {
                 assertDefaultQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
             });
-            it.skip("resizes quadrants properly when toggling interaction bar");
+            it("resizes quadrants properly when toggling interaction bar", () => {
+                assertQuadrantSizesCorrectIfInteractionBarVisible(0, NUM_FROZEN_COLUMNS);
+            });
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, NUM_FROZEN_COLUMNS);
             });
@@ -309,7 +318,9 @@ describe("<Table>", () => {
             it("syncs initial quadrant sizes properly", () => {
                 assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
-            it.skip("resizes quadrants properly when toggling interaction bar");
+            it("resizes quadrants properly when toggling interaction bar", () => {
+                assertQuadrantSizesCorrectIfInteractionBarVisible(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            });
             it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
@@ -341,6 +352,26 @@ describe("<Table>", () => {
             // add explicit 0 to communicate that we're considering the zero-width row headers
             const expectedWidth = 0 + (numFrozenColumns * table.props.defaultColumnWidth);
             const expectedHeight = COLUMN_HEADER_EXPECTED_HEIGHT + (numFrozenRows * table.props.defaultRowHeight);
+            assertNonMainQuadrantSizesCorrect(tableHarness, expectedWidth, expectedHeight);
+        }
+
+        function assertQuadrantSizesCorrectIfInteractionBarVisible(numFrozenRows?: number, numFrozenColumns?: number) {
+            const tableProps = {
+                numFrozenColumns,
+                numFrozenRows,
+                ref: (t: Table) => table = t,
+            };
+            const columnProps = {
+                useInteractionBar: true,
+            };
+            const tableHarness = mountTable(tableProps, columnProps);
+
+            const expectedWidth = ROW_HEADER_EXPECTED_WIDTH + (numFrozenColumns * table.props.defaultColumnWidth);
+            const expectedHeight =
+                COLUMN_INTERACTION_BAR_EXPECTED_HEIGHT
+                + COLUMN_INTERACTION_BAR_EXPECTED_BORDER_WIDTH
+                + COLUMN_HEADER_EXPECTED_HEIGHT
+                + (numFrozenRows * table.props.defaultRowHeight);
             assertNonMainQuadrantSizesCorrect(tableHarness, expectedWidth, expectedHeight);
         }
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -257,8 +257,11 @@ describe("<Table>", () => {
     });
 
     describe("Quadrants", () => {
-        // const NUM_ROWS = 5;
-        // const NUM_COLUMNS = 5;
+        const NUM_ROWS = 5;
+        const NUM_COLUMNS = 5;
+        const ROW_HEADER_EXPECTED_WIDTH = 30;
+        const COLUMN_HEADER_EXPECTED_HEIGHT = 30;
+
         // const NUM_FROZEN_ROWS = 2;
         // const NUM_FROZEN_COLUMNS = 2;
 
@@ -267,10 +270,26 @@ describe("<Table>", () => {
         it.skip("resizes quadrants to be flush with parent if right scrollbar is not showing");
         it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
 
-        describe.skip("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
+        describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
+            it.only("syncs initial quadrant sizes properly", () => {
+                const tableHarness = harness.mount(
+                    <Table numRows={NUM_ROWS}>
+                        {Utils.times(NUM_COLUMNS, () => <Column renderCell={renderCell} />)}
+                    </Table>,
+                );
+                const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(tableHarness);
+
+                const expectedWidthString = toPxString(ROW_HEADER_EXPECTED_WIDTH);
+                const expectedHeightString = toPxString(COLUMN_HEADER_EXPECTED_HEIGHT);
+
+                assertStyleEquals(leftQuadrant, "width", expectedWidthString);
+                assertStyleEquals(topQuadrant, "height", expectedHeightString);
+                assertStyleEquals(topLeftQuadrant, "width", expectedWidthString);
+                assertStyleEquals(topLeftQuadrant, "height", expectedHeightString);
+            });
+
             // not actually sure how to test this, since useInteractionBar is a prop on Column,
             // yet Enzyme lets you setProps only on the root element (i.e. the Table).
-            it.skip("syncs initial quadrant sizes properly");
             it.skip("resizes quadrants properly when toggling interaction bar");
             it.skip("resizes quadrants properly when toggling row headers on", () => {
                 // const attachTo = document.createElement("div");
@@ -337,17 +356,33 @@ describe("<Table>", () => {
             it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
         });
 
-        // function findQuadrants(attachTo: HTMLElement) { // table: ReactWrapper<ITableProps, any>) {
-        //     // this order is clearer than alphabetical order
-        //     // tslint:disable:object-literal-sort-keys
-        //     return {
-        //         mainQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_MAIN}`),
-        //         leftQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_LEFT}`),
-        //         topQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_TOP}`),
-        //         topLeftQuadrant: attachTo.query(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`),
-        //     };
-        //     // tslint:enable:object-literal-sort-keys
-        // }
+        function findQuadrants(table: ElementHarness) {
+            // this order is clearer than alphabetical order
+            // tslint:disable:object-literal-sort-keys
+            return {
+                mainQuadrant: table.find(`.${Classes.TABLE_QUADRANT_MAIN}`),
+                leftQuadrant: table.find(`.${Classes.TABLE_QUADRANT_LEFT}`),
+                topQuadrant: table.find(`.${Classes.TABLE_QUADRANT_TOP}`),
+                topLeftQuadrant: table.find(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`),
+            };
+            // tslint:enable:object-literal-sort-keys
+        }
+
+        function assertStyleEquals(
+            elementHarness: ElementHarness,
+            key: keyof React.CSSProperties,
+            expectedValue: any,
+        ) {
+            expect(toHtmlElement(elementHarness.element).style[key]).to.equal(expectedValue);
+        }
+
+        function toHtmlElement(element: Element) {
+            return element as HTMLElement;
+        }
+
+        function toPxString(value: number) {
+            return `${value}px`;
+        }
 
         // function getWidth(node: ReactWrapper<any, any>) {
         //     return node.getDOMNode().getBoundingClientRect().width;

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -265,8 +265,6 @@ describe("<Table>", () => {
         const COLUMN_HEADER_EXPECTED_HEIGHT = 30;
 
         let table: Table;
-        // const NUM_FROZEN_ROWS = 2;
-        // const NUM_FROZEN_COLUMNS = 2;
 
         afterEach(() => {
             table = undefined;

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -259,6 +259,8 @@ describe("<Table>", () => {
     describe("Quadrants", () => {
         const NUM_ROWS = 5;
         const NUM_COLUMNS = 5;
+        const NUM_FROZEN_ROWS = 1;
+        const NUM_FROZEN_COLUMNS = 1;
         const ROW_HEADER_EXPECTED_WIDTH = 30;
         const COLUMN_HEADER_EXPECTED_HEIGHT = 30;
 
@@ -272,20 +274,7 @@ describe("<Table>", () => {
 
         describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
             it.only("syncs initial quadrant sizes properly", () => {
-                const tableHarness = harness.mount(
-                    <Table numRows={NUM_ROWS}>
-                        {Utils.times(NUM_COLUMNS, () => <Column renderCell={renderCell} />)}
-                    </Table>,
-                );
-                const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(tableHarness);
-
-                const expectedWidthString = toPxString(ROW_HEADER_EXPECTED_WIDTH);
-                const expectedHeightString = toPxString(COLUMN_HEADER_EXPECTED_HEIGHT);
-
-                assertStyleEquals(leftQuadrant, "width", expectedWidthString);
-                assertStyleEquals(topQuadrant, "height", expectedHeightString);
-                assertStyleEquals(topLeftQuadrant, "width", expectedWidthString);
-                assertStyleEquals(topLeftQuadrant, "height", expectedHeightString);
+                assertInitialQuadrantSizesCorrect(0, 0);
             });
 
             // not actually sure how to test this, since useInteractionBar is a prop on Column,
@@ -333,7 +322,9 @@ describe("<Table>", () => {
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
-            it.skip("syncs initial quadrant sizes properly");
+            it.only("syncs initial quadrant sizes properly", () => {
+                assertInitialQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
+            });
             it.skip("resizes quadrants properly when toggling interaction bar");
             it.skip("resizes quadrants properly when toggling row headers");
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");
@@ -341,7 +332,9 @@ describe("<Table>", () => {
         });
 
         describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
-            it.skip("syncs initial quadrant sizes properly");
+            it.only("syncs initial quadrant sizes properly", () => {
+                assertInitialQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
+            });
             it.skip("resizes quadrants properly when toggling interaction bar");
             it.skip("resizes quadrants properly when toggling row headers");
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
@@ -349,12 +342,48 @@ describe("<Table>", () => {
         });
 
         describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
-            it.skip("syncs initial quadrant sizes properly");
+            it.only("syncs initial quadrant sizes properly", () => {
+                assertInitialQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            });
             it.skip("resizes quadrants properly when toggling interaction bar");
             it.skip("resizes quadrants properly when toggling row headers");
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");
             it.skip("resizes quadrants properly when setting numFrozenColumns = 0");
         });
+
+        // Test templates
+        // ==============
+
+        function assertInitialQuadrantSizesCorrect(numFrozenRows?: number, numFrozenColumns?: number) {
+            let table: Table;
+            const saveTable = (t: Table) => table = t;
+
+            const tableHarness = harness.mount(
+                <Table
+                    ref={saveTable}
+                    numRows={NUM_ROWS}
+                    numFrozenRows={numFrozenRows}
+                    numFrozenColumns={numFrozenColumns}
+                >
+                    {Utils.times(NUM_COLUMNS, () => <Column renderCell={renderCell} />)}
+                </Table>,
+            );
+            const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(tableHarness);
+
+            const expectedFrozenRowsHeight = numFrozenRows * table.props.defaultRowHeight;
+            const expectedFrozenColumnsWidth = numFrozenColumns * table.props.defaultColumnWidth;
+
+            const expectedWidthString = toPxString(ROW_HEADER_EXPECTED_WIDTH + expectedFrozenColumnsWidth);
+            const expectedHeightString = toPxString(COLUMN_HEADER_EXPECTED_HEIGHT + expectedFrozenRowsHeight);
+
+            assertStyleEquals(leftQuadrant, "width", expectedWidthString);
+            assertStyleEquals(topQuadrant, "height", expectedHeightString);
+            assertStyleEquals(topLeftQuadrant, "width", expectedWidthString);
+            assertStyleEquals(topLeftQuadrant, "height", expectedHeightString);
+        }
+
+        // Helpers
+        // =======
 
         function findQuadrants(table: ElementHarness) {
             // this order is clearer than alphabetical order

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -281,7 +281,7 @@ describe("<Table>", () => {
         it.skip("resizes quadrants to be flush with parent if right scrollbar is not showing");
         it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
 
-        describe("Scrolling", () => {
+        describe("Scroll syncing", () => {
             const SCROLL_OFFSET_X = 10;
             const SCROLL_OFFSET_Y = 20;
 
@@ -377,7 +377,7 @@ describe("<Table>", () => {
             }
         });
 
-        describe("Sizing", () => {
+        describe("Size syncing", () => {
             describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
                 runQuadrantSizeTestSuite(0, 0);
             });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -256,7 +256,7 @@ describe("<Table>", () => {
         expect(table.state("selectedRegions").length).to.equal(1);
     });
 
-    describe("Quadrants", () => {
+    describe.only("Quadrants", () => {
         const NUM_ROWS = 5;
         const NUM_COLUMNS = 5;
         const NUM_FROZEN_ROWS = 1;
@@ -277,7 +277,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(0, 0);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.only("resizes quadrants properly when toggling row headers", () => {
+            it("resizes quadrants properly when toggling row headers", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, 0);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
@@ -289,7 +289,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.only("resizes quadrants properly when toggling row headers", () => {
+            it("resizes quadrants properly when toggling row headers", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, 0);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");
@@ -301,7 +301,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.only("resizes quadrants properly when toggling row headers", () => {
+            it("resizes quadrants properly when toggling row headers", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
@@ -313,7 +313,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it.only("resizes quadrants properly when toggling row headers", () => {
+            it("resizes quadrants properly when toggling row headers", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -277,7 +277,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(0, 0);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it("resizes quadrants properly when toggling row headers", () => {
+            it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, 0);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
@@ -289,7 +289,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, 0);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it("resizes quadrants properly when toggling row headers", () => {
+            it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, 0);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");
@@ -301,7 +301,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(0, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it("resizes quadrants properly when toggling row headers", () => {
+            it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(0, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows > 0");
@@ -313,7 +313,7 @@ describe("<Table>", () => {
                 assertDefaultQuadrantSizesCorrect(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when toggling interaction bar");
-            it("resizes quadrants properly when toggling row headers", () => {
+            it("syncs quadrants sizes properly when row header hidden", () => {
                 assertQuadrantSizesCorrectIfRowHeadersHidden(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
             it.skip("resizes quadrants properly when setting numFrozenRows = 0");

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -308,16 +308,31 @@ describe("<Table>", () => {
 
             afterEach(() => {
                 ReactDOM.unmountComponentAtNode(container);
-                mainScrollContainer = undefined;
-                leftScrollContainer = undefined;
-                topScrollContainer = undefined;
-                topLeftScrollContainer = undefined;
             });
 
-            it.skip("syncs quadrant scroll offsets when scrolling the main quadrant");
-            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the main quadrant");
-            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the top quadrant");
-            it.only("syncs quadrant scroll offsets when mouse-wheeling in the left quadrant", () => {
+            it("syncs quadrant scroll offsets when scrolling the main quadrant", () => {
+                mainScrollContainer.scrollLeft = SCROLL_OFFSET_X;
+                mainScrollContainer.scrollTop = SCROLL_OFFSET_Y;
+                TestUtils.Simulate.scroll(mainScrollContainer);
+
+                assertScrollPositionEquals(topScrollContainer, SCROLL_OFFSET_X, 0);
+                assertScrollPositionEquals(leftScrollContainer, 0, SCROLL_OFFSET_Y);
+                assertScrollPositionEquals(topLeftScrollContainer, 0, 0);
+            });
+
+            it("syncs quadrant scroll offsets when mouse-wheeling in the top quadrant", () => {
+                topScrollContainer.scrollLeft = SCROLL_OFFSET_X;
+                TestUtils.Simulate.wheel(topScrollContainer, {
+                    deltaX: SCROLL_OFFSET_X,
+                    deltaY: SCROLL_OFFSET_Y,
+                });
+
+                assertScrollPositionEquals(mainScrollContainer, SCROLL_OFFSET_X, SCROLL_OFFSET_Y);
+                assertScrollPositionEquals(leftScrollContainer, 0, SCROLL_OFFSET_Y);
+                assertScrollPositionEquals(topLeftScrollContainer, 0, 0);
+            });
+
+            it("syncs quadrant scroll offsets when mouse-wheeling in the left quadrant", () => {
                 // simulating a "wheel" event doesn't affect the scrollTop the way it would in
                 // practice, so we need to tweak that explicitly before triggering.
                 leftScrollContainer.scrollTop = SCROLL_OFFSET_Y;
@@ -330,7 +345,17 @@ describe("<Table>", () => {
                 assertScrollPositionEquals(topScrollContainer, SCROLL_OFFSET_X, 0);
                 assertScrollPositionEquals(topLeftScrollContainer, 0, 0);
             });
-            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the top-left quadrant");
+
+            it("syncs quadrant scroll offsets when mouse-wheeling in the top-left quadrant", () => {
+                TestUtils.Simulate.wheel(topLeftScrollContainer, {
+                    deltaX: SCROLL_OFFSET_X,
+                    deltaY: SCROLL_OFFSET_Y,
+                });
+
+                assertScrollPositionEquals(mainScrollContainer, SCROLL_OFFSET_X, SCROLL_OFFSET_Y);
+                assertScrollPositionEquals(topScrollContainer, SCROLL_OFFSET_X, 0);
+                assertScrollPositionEquals(leftScrollContainer, 0, SCROLL_OFFSET_Y);
+            });
 
             function renderTableIntoDOM() {
                 const containerElement = document.createElement("div");

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -279,20 +279,30 @@ describe("<Table>", () => {
         it.skip("resizes quadrants to be flush with parent if right scrollbar is not showing");
         it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
 
-        describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
-            runQuadrantSizeTestSuite(0, 0);
+        describe("Scrolling", () => {
+            it.skip("syncs quadrant scroll offsets when scrolling the main quadrant");
+            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the main quadrant");
+            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the top quadrant");
+            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the left quadrant");
+            it.skip("syncs quadrant scroll offsets when mouse-wheeling in the top-left quadrant");
         });
 
-        describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
-            runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, 0);
-        });
+        describe("Sizing", () => {
+            describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
+                runQuadrantSizeTestSuite(0, 0);
+            });
 
-        describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
-            runQuadrantSizeTestSuite(0, NUM_FROZEN_COLUMNS);
-        });
+            describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
+                runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, 0);
+            });
 
-        describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
-            runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
+                runQuadrantSizeTestSuite(0, NUM_FROZEN_COLUMNS);
+            });
+
+            describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
+                runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            });
         });
 
         // Test templates

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -13,7 +13,7 @@ import * as TestUtils from "react-dom/test-utils";
 
 import { Keys } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/core/test/common/utils";
-import { Cell, Column, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils, IColumnProps } from "../src";
+import { Cell, Column, IColumnProps, ITableProps, RegionCardinality, Table, TableLoadingOption, Utils } from "../src";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import * as Errors from "../src/common/errors";

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -273,6 +273,7 @@ describe("<Table>", () => {
             table = undefined;
         });
 
+        // TODO: not sure how to control scrollbar visbility in phantom
         it.skip("resizes quadrants to clear the right scrollbar if scrollbar is showing");
         it.skip("resizes quadrants to clear the bottom scrollbar if scrollbar is showing");
         it.skip("resizes quadrants to be flush with parent if right scrollbar is not showing");

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -468,7 +468,8 @@ describe("<Table>", () => {
             key: keyof React.CSSProperties,
             expectedValue: any,
         ) {
-            expect(toHtmlElement(elementHarness.element).style[key]).to.equal(expectedValue);
+            // key's type should be okay, but TS was throwing error TS7015, hence the `any` cast
+            expect(toHtmlElement(elementHarness.element).style[key as any]).to.equal(expectedValue);
         }
 
         // Helpers

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -289,6 +289,24 @@ describe("<Table>", () => {
         it.skip("resizes quadrants to be flush with parent if right scrollbar is not showing");
         it.skip("resizes quadrants to be flush with parent if bottom scrollbar is not showing");
 
+        describe("Size syncing", () => {
+            describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
+                runQuadrantSizeTestSuite(0, 0);
+            });
+
+            describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
+                runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, 0);
+            });
+
+            describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
+                runQuadrantSizeTestSuite(0, NUM_FROZEN_COLUMNS);
+            });
+
+            describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
+                runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
+            });
+        });
+
         describe("Scroll syncing", () => {
             let container: HTMLElement;
             let leftScrollContainer: HTMLElement;
@@ -357,24 +375,6 @@ describe("<Table>", () => {
                 assertScrollPositionEquals(mainScrollContainer, SCROLL_OFFSET_X, SCROLL_OFFSET_Y);
                 assertScrollPositionEquals(topScrollContainer, SCROLL_OFFSET_X, 0);
                 assertScrollPositionEquals(leftScrollContainer, 0, SCROLL_OFFSET_Y);
-            });
-        });
-
-        describe("Size syncing", () => {
-            describe("if numFrozenRows == 0 && numFrozenColumns == 0", () => {
-                runQuadrantSizeTestSuite(0, 0);
-            });
-
-            describe("if numFrozenRows > 0 && numFrozenColumns == 0", () => {
-                runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, 0);
-            });
-
-            describe("if numFrozenRows == 0 && numFrozenColumns > 0", () => {
-                runQuadrantSizeTestSuite(0, NUM_FROZEN_COLUMNS);
-            });
-
-            describe("if numFrozenRows > 0 && numFrozenColumns > 0", () => {
-                runQuadrantSizeTestSuite(NUM_FROZEN_ROWS, NUM_FROZEN_COLUMNS);
             });
         });
 


### PR DESCRIPTION
## Targets `feature/table-frozen-rows-cols`

#### Addresses #503 · Builds on #1343

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Add validation for `numFrozenRows` bounds and `numFrozenColumns` bounds.
- Move an existing `Table` warning message into `errors.ts`.
- Fix bug in `Table#syncRowHeaderSize` when `rowHeaderElement == null`.
- Add tests for all the new quadrant sync'ing code.
    - Size sync'ing (e.g. when toggling `isRowHeaderShown` and `useInteractionBar`)
    - Scroll sync'ing

#### Reviewers should focus on:

- Do these tests look okay?
- Is the validation logic for `numFrozenColumns` and `numFrozenRows` okay? Feels slightly excessive but still helpful.
- I couldn't figure out how to write a few of the tests, so I left them as placeholders. LMK if you have ideas. (See: https://github.com/palantir/blueprint/pull/1361/files#diff-eea83e2366941709af74b6efcc2454bfR287)