### PR TITLE
More accurate icons for selects

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -252,7 +252,7 @@ $control-group-stack: (
   right: $input-padding-horizontal * 0.7;
   line-height: $pt-button-height;
   color: $pt-icon-color;
-  content: $pt-icon-caret-down;
+  content: $pt-icon-double-caret-vertical;
   pointer-events: none;
 
   &.pt-disabled {

--- a/packages/labs/examples/selectExample.tsx
+++ b/packages/labs/examples/selectExample.tsx
@@ -48,7 +48,7 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
                 popoverProps={{ popoverClassName: minimal ? Classes.MINIMAL : "" }}
             >
                 <Button
-                    rightIconName="double-caret-vertical"
+                    rightIconName="caret-down"
                     text={film ? film.title : "(No selection)"}
                 />
             </FilmSelect>


### PR DESCRIPTION
Native `<select>` should be the double caret similarly to the native one:
<img width="168" alt="screen shot 2017-07-19 at 5 00 31 pm" src="https://user-images.githubusercontent.com/199754/28394712-dc04e270-6ca3-11e7-86c3-0898d53efd9e.png">

Our custom `<Select>` is more like a dropdown, can get caret down as used elsewhere:
<img width="252" alt="screen shot 2017-07-19 at 5 00 51 pm" src="https://user-images.githubusercontent.com/199754/28394731-ff83f7d6-6ca3-11e7-9f73-1533c58664c7.png">

