### PR TITLE
Make gradients configurable.

### DIFF
--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -34,10 +34,14 @@ $pt-dark-intent-text-colors: (
   @if ($fallback-color == none) {
     background: $start-color;
     // explicit `none` argument disables second gradient
-    background: $gradient left no-repeat;
+    @if ($pt-use-gradient == true) {
+      background: $gradient left no-repeat;
+    }
   } @else {
     background: $fallback-color;
-    background: $gradient left no-repeat, center no-repeat $fallback-color;
+    @if ($pt-use-gradient == true) {
+      background: $gradient left no-repeat, center no-repeat $fallback-color;
+    }
   }
   // stylelint-enable declaration-block-no-duplicate-properties
 }

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -67,6 +67,9 @@ $pt-drop-shadow-opacity: 0.2 !default;
 $pt-dark-border-shadow-opacity: $pt-border-shadow-opacity * 2 !default;
 $pt-dark-drop-shadow-opacity: $pt-drop-shadow-opacity * 2 !default;
 
+// Gradient
+$pt-use-gradient: true !default;
+
 // Elevations
 // all shadow lists must be the same length to avoid flicker in transitions.
 $pt-elevation-shadow-0: 0 0 0 1px $pt-divider-black,


### PR DESCRIPTION
Adding pt-use-gradients allows an option makes the blueprintjs styles
more customizable without having to reach out to !important.


I am not sure whatever `linear-gradient-with-fallback` is the right place to control this, or perhaps it could use better name?