### PR TITLE
[Table] Frozen Rows/Cols - Part 4: Selection

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -128,7 +128,7 @@ const TRUNCATED_POPOVER_MODES = [
     TruncatedPopoverMode.WHEN_TRUNCATED,
 ] as TruncatedPopoverMode[];
 
-const COLUMN_COUNT_DEFAULT_INDEX = 2;
+const COLUMN_COUNT_DEFAULT_INDEX = 3;
 const ROW_COUNT_DEFAULT_INDEX = 3;
 
 const FROZEN_COLUMN_COUNT_DEFAULT_INDEX = 2;
@@ -160,18 +160,18 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             cellContent: CellContent.CELL_NAMES,
             cellTruncatedPopoverMode: TruncatedPopoverMode.WHEN_TRUNCATED,
             enableCellEditing: false,
-            enableCellSelection: false,
+            enableCellSelection: true,
             enableCellTruncation: false,
             enableColumnNameEditing: false,
             enableColumnReordering: false,
             enableColumnResizing: false,
-            enableColumnSelection: false,
+            enableColumnSelection: true,
             enableContextMenu: false,
-            enableFullTableSelection: false,
+            enableFullTableSelection: true,
             enableMultiSelection: false,
             enableRowReordering: false,
             enableRowResizing: false,
-            enableRowSelection: false,
+            enableRowSelection: true,
             numCols: COLUMN_COUNTS[COLUMN_COUNT_DEFAULT_INDEX],
             numFrozenCols: FROZEN_COLUMN_COUNTS[FROZEN_COLUMN_COUNT_DEFAULT_INDEX],
             numFrozenRows: FROZEN_ROW_COUNTS[FROZEN_ROW_COUNT_DEFAULT_INDEX],
@@ -182,7 +182,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             showColumnHeadersLoading: false,
             showColumnInteractionBar: false,
             showColumnMenus: false,
-            showCustomRegions: true,
+            showCustomRegions: false,
             showFocusCell: false,
             showGhostCells: true,
             showInline: false,
@@ -201,10 +201,12 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <Table
                     allowMultipleSelection={this.state.enableMultiSelection}
                     className={classNames("table", { "is-inline": this.state.showInline })}
+                    defaultColumnWidth={50}
                     enableFocus={this.state.showFocusCell}
                     fillBodyWithGhostCells={this.state.showGhostCells}
                     isColumnResizable={this.state.enableColumnResizing}
                     isColumnReorderable={this.state.enableColumnReordering}
+                    isRowHeaderShown={this.state.showRowHeaders}
                     isRowReorderable={this.state.enableRowReordering}
                     isRowResizable={this.state.enableRowResizing}
                     loadingOptions={this.getEnabledLoadingOptions()}
@@ -212,7 +214,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     renderBodyContextMenu={this.renderBodyContextMenu}
                     renderRowHeader={this.renderRowHeader}
                     selectionModes={this.getEnabledSelectionModes()}
-                    isRowHeaderShown={this.state.showRowHeaders}
                     styledRegionGroups={this.getStyledRegionGroups()}
                     onSelection={this.onSelection}
                     onColumnsReordered={this.onColumnsReordered}

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -168,7 +168,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             enableColumnSelection: true,
             enableContextMenu: false,
             enableFullTableSelection: true,
-            enableMultiSelection: false,
+            enableMultiSelection: true,
             enableRowReordering: false,
             enableRowResizing: false,
             enableRowSelection: true,
@@ -201,7 +201,6 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 <Table
                     allowMultipleSelection={this.state.enableMultiSelection}
                     className={classNames("table", { "is-inline": this.state.showInline })}
-                    defaultColumnWidth={50}
                     enableFocus={this.state.showFocusCell}
                     fillBodyWithGhostCells={this.state.showGhostCells}
                     isColumnResizable={this.state.enableColumnResizing}

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -182,7 +182,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
             showColumnHeadersLoading: false,
             showColumnInteractionBar: false,
             showColumnMenus: false,
-            showCustomRegions: false,
+            showCustomRegions: true,
             showFocusCell: false,
             showGhostCells: true,
             showInline: false,

--- a/packages/table/src/layers/_layers.scss
+++ b/packages/table/src/layers/_layers.scss
@@ -13,6 +13,7 @@ $region-selected-color: $pt-intent-primary !default;
   bottom: 0;
   left: 0;
   z-index: $region-layer-z-index;
+  overflow: hidden;
   pointer-events: none;
 }
 

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -10,9 +10,10 @@ import * as classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../common/classes";
 import { Utils } from "../common/utils";
+import { QuadrantType } from "../quadrants/tableQuadrant";
 import { IRegion, Regions } from "../regions";
 
-export type IRegionStyler = (region: IRegion) => React.CSSProperties;
+export type IRegionStyler = (region: IRegion, quadrantType?: QuadrantType) => React.CSSProperties;
 
 export interface IRegionLayerProps extends IProps {
     /**

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -49,26 +49,51 @@ export interface ILocator {
 export class Locator implements ILocator {
     private static CELL_HORIZONTAL_PADDING = 10;
 
+    private grid: Grid;
+
+    private rowHeaderWidth: number;
+    private columnHeaderHeight: number;
+
+    private numFrozenRows: number;
+    private numFrozenColumns: number;
+
     public constructor(
         private tableElement: HTMLElement,
         private bodyElement: HTMLElement,
-        private grid: Grid,
-        private numFrozenRows: number,
-        private numFrozenColumns: number,
     ) {
+        // empty constructor
     }
+
+    // Setters
+    // =======
 
     public setGrid(grid: Grid) {
         this.grid = grid;
+        return this;
     }
 
     public setNumFrozenRows(numFrozenRows: number) {
         this.numFrozenRows = numFrozenRows;
+        return this;
     }
 
     public setNumFrozenColumns(numFrozenColumns: number) {
         this.numFrozenColumns = numFrozenColumns;
+        return this;
     }
+
+    public setColumnHeaderHeight(columnHeaderHeight: number) {
+        this.columnHeaderHeight = columnHeaderHeight;
+        return this;
+    }
+
+    public setRowHeaderWidth(rowHeaderWidth: number) {
+        this.rowHeaderWidth = rowHeaderWidth;
+        return this;
+    }
+
+    // Getters
+    // =======
 
     public getViewportRect() {
         return new Rect(
@@ -118,6 +143,9 @@ export class Locator implements ILocator {
         return max;
     }
 
+    // Converters
+    // ==========
+
     public convertPointToColumn(clientX: number, useMidpoint?: boolean): number {
         const tableRect = this.getTableRect();
         if (!tableRect.containsX(clientX)) {
@@ -148,6 +176,9 @@ export class Locator implements ILocator {
         return {col, row};
     }
 
+    // Private helpers
+    // ===============
+
     private getTableRect() {
         return Rect.wrap(this.tableElement.getBoundingClientRect());
     }
@@ -175,8 +206,7 @@ export class Locator implements ILocator {
     private toGridX = (clientX: number) => {
         const tableOffsetFromPageLeft = this.tableElement.getBoundingClientRect().left;
         const cursorOffsetFromTableLeft = clientX - tableOffsetFromPageLeft;
-        const cursorOffsetFromGridLeft = cursorOffsetFromTableLeft
-            - this.tableElement.querySelector(`.${Classes.TABLE_MENU}`).getBoundingClientRect().width;
+        const cursorOffsetFromGridLeft = cursorOffsetFromTableLeft - this.rowHeaderWidth;
         const scrollOffsetFromTableLeft = this.bodyElement.scrollLeft;
 
         const isCursorWithinFrozenColumns = this.numFrozenColumns != null
@@ -192,8 +222,7 @@ export class Locator implements ILocator {
     private toGridY = (clientY: number) => {
         const tableOffsetFromPageTop = this.tableElement.getBoundingClientRect().top;
         const cursorOffsetFromTableTop = clientY - tableOffsetFromPageTop;
-        const cursorOffsetFromGridTop = cursorOffsetFromTableTop
-            - this.tableElement.querySelector(`.${Classes.TABLE_MENU}`).getBoundingClientRect().height;
+        const cursorOffsetFromGridTop = cursorOffsetFromTableTop - this.columnHeaderHeight;
         const scrollOffsetFromTableTop = this.bodyElement.scrollTop;
 
         const isCursorWithinFrozenRows = this.numFrozenRows != null

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -51,11 +51,11 @@ export class Locator implements ILocator {
 
     private grid: Grid;
 
-    private rowHeaderWidth: number;
-    private columnHeaderHeight: number;
+    private rowHeaderWidth = 0;
+    private columnHeaderHeight = 0;
 
-    private numFrozenRows: number;
-    private numFrozenColumns: number;
+    private numFrozenRows = 0;
+    private numFrozenColumns = 0;
 
     public constructor(
         private tableElement: HTMLElement,

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -54,10 +54,6 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
     background: $red5;
   }
 
-  .bp-table-cell-client {
-    background: lighten($red5, 20%);
-  }
-
   .bp-table-quadrant-scroll-container {
     bottom: -20px;
     overflow-y: hidden;
@@ -77,10 +73,6 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
     background: $blue5;
   }
 
-  .bp-table-cell-client {
-    background: lighten($blue5, 20%);
-  }
-
   .bp-table-quadrant-scroll-container {
     right: -20px;
     overflow-x: hidden;
@@ -97,10 +89,6 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
   .bp-table-row-headers,
   .bp-table-column-headers {
     background: $green5;
-  }
-
-  .bp-table-cell-client {
-    background: lighten($green5, 20%);
   }
 
   .bp-table-quadrant-scroll-container {

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -1,4 +1,5 @@
 
+@import "../../core/src/common/mixins";
 @import "./common/variables";
 
 $table-quadrant-z-index-main: 0;
@@ -19,12 +20,14 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
 }
 
 .bp-table-quadrant-scroll-container {
+  @include force-hardware-acceleration();
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
   overflow: auto;
+  user-select: none;
 
   // We disable x or y scrolling when we are displaying "ghost" cells that
   // overflow the body.

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -45,6 +45,10 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
   right: 0;
   z-index: $table-quadrant-z-index-top;
 
+  .bp-table-menu {
+    background: $red5;
+  }
+
   .bp-table-row-headers,
   .bp-table-column-headers {
     background: $red5;
@@ -64,6 +68,10 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
   bottom: 0;
   z-index: $table-quadrant-z-index-left;
 
+  .bp-table-menu {
+    background: $blue5;
+  }
+
   .bp-table-row-headers,
   .bp-table-column-headers {
     background: $blue5;
@@ -81,6 +89,10 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
 
 .bp-table-quadrant-top-left {
   z-index: $table-quadrant-z-index-top-left;
+
+  .bp-table-menu {
+    background: $green5;
+  }
 
   .bp-table-row-headers,
   .bp-table-column-headers {

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -25,6 +25,17 @@ $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
   bottom: 0;
   left: 0;
   overflow: auto;
+
+  // We disable x or y scrolling when we are displaying "ghost" cells that
+  // overflow the body.
+
+  .bp-table-no-vertical-scroll & {
+    overflow-y: hidden;
+  }
+
+  .bp-table-no-horizontal-scroll & {
+    overflow-x: hidden;
+  }
 }
 
 .bp-table-quadrant-body-container {

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -91,7 +91,11 @@ export interface ITableQuadrantProps extends IProps {
     /**
      * A callback that renders either all of or just frozen sections of the table body.
      */
-    renderBody?: (showFrozenRowsOnly?: boolean, showFrozenColumnsOnly?: boolean) => JSX.Element;
+    renderBody: (
+        quadrantType: QuadrantType,
+        showFrozenRowsOnly?: boolean,
+        showFrozenColumnsOnly?: boolean,
+    ) => JSX.Element;
 
     /**
      * A callback that receives a `ref` to the quadrant's scroll-container element.
@@ -141,7 +145,7 @@ export class TableQuadrant extends AbstractComponent<ITableQuadrantProps, {}> {
                             className={Classes.TABLE_QUADRANT_BODY_CONTAINER}
                             ref={this.props.bodyRef}
                         >
-                            {this.props.renderBody(showFrozenRowsOnly, showFrozenColumnsOnly)}
+                            {this.props.renderBody(quadrantType, showFrozenRowsOnly, showFrozenColumnsOnly)}
                         </div>
                     </div>
                 </div>

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 
 import * as Classes from "../common/classes";
 import * as Errors from "../common/errors";
+import { Grid } from "../common/grid";
 
 export enum QuadrantType {
     /**
@@ -41,6 +42,12 @@ export interface ITableQuadrantProps extends IProps {
      * provided only for the MAIN quadrant, because that quadrant contains the main table body.
      */
     bodyRef?: React.Ref<HTMLElement>;
+
+    /**
+     * The grid computes sizes of cells, rows, or columns from the
+     * configurable `columnWidths` and `rowHeights`.
+     */
+    grid: Grid;
 
     /**
      * If `false`, hides the row headers and settings menu.
@@ -126,6 +133,12 @@ export class TableQuadrant extends AbstractComponent<ITableQuadrantProps, {}> {
         const maybeMenu = isRowHeaderShown ? this.props.renderMenu() : undefined;
         const maybeRowHeader = isRowHeaderShown ? this.props.renderRowHeader(showFrozenRowsOnly) : undefined;
 
+        // need to set bottom container size to prevent overlay clipping on scroll
+        const bottomContainerStyle = {
+            height: this.props.grid.getHeight(),
+            width: this.props.grid.getWidth(),
+        };
+
         return (
             <div className={className} style={this.props.style} ref={this.props.quadrantRef}>
                 <div
@@ -138,9 +151,8 @@ export class TableQuadrant extends AbstractComponent<ITableQuadrantProps, {}> {
                         {maybeMenu}
                         {this.props.renderColumnHeader(showFrozenColumnsOnly)}
                     </div>
-                    <div className={Classes.TABLE_BOTTOM_CONTAINER}>
+                    <div className={Classes.TABLE_BOTTOM_CONTAINER} style={bottomContainerStyle}>
                         {maybeRowHeader}
-                        {/* TODO: is it okay to put `position: relative` on every quadrant's body wrapper? */}
                         <div
                             className={Classes.TABLE_QUADRANT_BODY_CONTAINER}
                             ref={this.props.bodyRef}

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -111,18 +111,7 @@ $menu-z-index: $row-z-index + 1 !default;
   flex: 1 1 100%;
   position: relative;
   z-index: $body-z-index;
-
-  // We disable x or y scrolling when we are displaying "ghost" cells that
-  // overflow the body.
   overflow: scroll;
-
-  &.bp-table-no-vertical-scroll {
-    overflow-y: hidden;
-  }
-
-  &.bp-table-no-horizontal-scroll {
-    overflow-x: hidden;
-  }
 }
 
 .bp-table-body-scroll-client {

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -114,12 +114,6 @@ $menu-z-index: $row-z-index + 1 !default;
   overflow: scroll;
 }
 
-// .bp-table-body-scroll-client {
-//   @include force-hardware-acceleration();
-//   position: relative;
-//   user-select: none;
-// }
-
 .bp-table-body-virtual-client {
   position: relative;
 }

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -114,11 +114,11 @@ $menu-z-index: $row-z-index + 1 !default;
   overflow: scroll;
 }
 
-.bp-table-body-scroll-client {
-  @include force-hardware-acceleration();
-  position: relative;
-  user-select: none;
-}
+// .bp-table-body-scroll-client {
+//   @include force-hardware-acceleration();
+//   position: relative;
+//   user-select: none;
+// }
 
 .bp-table-body-virtual-client {
   position: relative;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -568,6 +568,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             >
                 <TableQuadrant
                     bodyRef={this.setBodyRef}
+                    grid={this.grid}
                     isRowHeaderShown={isRowHeaderShown}
                     onScroll={this.handleMainQuadrantScroll}
                     quadrantRef={this.quadrantRefHandlers[QuadrantType.MAIN].quadrant}
@@ -579,6 +580,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     scrollContainerRef={this.quadrantRefHandlers[QuadrantType.MAIN].scrollContainer}
                 />
                 <TableQuadrant
+                    grid={this.grid}
                     isRowHeaderShown={isRowHeaderShown}
                     onWheel={this.handleTopQuadrantWheel}
                     quadrantRef={this.quadrantRefHandlers[QuadrantType.TOP].quadrant}
@@ -590,6 +592,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     scrollContainerRef={this.quadrantRefHandlers[QuadrantType.TOP].scrollContainer}
                 />
                 <TableQuadrant
+                    grid={this.grid}
                     isRowHeaderShown={isRowHeaderShown}
                     onWheel={this.handleLeftQuadrantWheel}
                     quadrantRef={this.quadrantRefHandlers[QuadrantType.LEFT].quadrant}
@@ -601,6 +604,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     scrollContainerRef={this.quadrantRefHandlers[QuadrantType.LEFT].scrollContainer}
                 />
                 <TableQuadrant
+                    grid={this.grid}
                     isRowHeaderShown={isRowHeaderShown}
                     onWheel={this.handleTopLeftQuadrantWheel}
                     quadrantRef={this.quadrantRefHandlers[QuadrantType.TOP_LEFT].quadrant}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1484,8 +1484,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             (quadrantType === QuadrantType.TOP_LEFT || quadrantType === QuadrantType.LEFT)
             && numFrozenColumns != null && numFrozenColumns > 0;
 
-        const fixedHeight = this.grid.getCumulativeHeightAt(this.props.numRows - 1);
-        const fixedWidth = this.grid.getCumulativeWidthAt(this.childrenArray.length - 1);
+        const fixedHeight = this.grid.getHeight();
+        const fixedWidth = this.grid.getWidth();
 
         switch (cardinality) {
             case RegionCardinality.CELLS:

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -668,7 +668,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
         this.locator = new Locator(
             this.quadrantRefs[QuadrantType.MAIN].quadrant,
-            this.quadrantRefs[QuadrantType.MAIN].scrollContainer
+            this.quadrantRefs[QuadrantType.MAIN].scrollContainer,
         );
         this.updateLocator();
         this.updateViewportRect(this.locator.getViewportRect());

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -946,8 +946,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private syncQuadrantSizes() {
-        const mainQuadrantElement = this.quadrantRefs[QuadrantType.MAIN].quadrant;
-        const mainQuadrantMenuElement = this.quadrantRefs[QuadrantType.MAIN].menu;
         const mainQuadrantScrollElement = this.quadrantRefs[QuadrantType.MAIN].scrollContainer;
         const topQuadrantElement = this.quadrantRefs[QuadrantType.TOP].quadrant;
         const topQuadrantRowHeaderElement = this.quadrantRefs[QuadrantType.TOP].rowHeader;
@@ -968,17 +966,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         // all menus are the same size, so arbitrarily use the one from the main quadrant.
         // assumes that the menu element width has already been sync'd after the last render
 
-        let rowHeaderWidth;
-        let columnHeaderHeight;
-        if (mainQuadrantMenuElement != null) {
-            const { width, height } = mainQuadrantMenuElement.getBoundingClientRect();
-            rowHeaderWidth = width;
-            columnHeaderHeight = height;
-        } else {
-            const columnHeadersElement = mainQuadrantElement.querySelector(`.${Classes.TABLE_COLUMN_HEADERS}`);
-            rowHeaderWidth = 0;
-            columnHeaderHeight = columnHeadersElement.getBoundingClientRect().height;
-        }
+        const rowHeaderWidth = this.getQuadrantRowHeaderWidth(QuadrantType.MAIN);
+        const columnHeaderHeight = this.getQuadrantColumnHeaderHeight(QuadrantType.MAIN);
 
         // no need to sync the main quadrant, because it fills the entire viewport
         topQuadrantElement.style.height = `${frozenRowsCumulativeHeight + columnHeaderHeight}px`;
@@ -995,6 +984,19 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         // resize top and top-left quadrant row headers if main quadrant scrolls
         this.syncRowHeaderSize(topQuadrantRowHeaderElement, rowHeaderWidth);
         this.syncRowHeaderSize(topLeftQuadrantRowHeaderElement, rowHeaderWidth);
+    }
+
+    private getQuadrantColumnHeaderHeight(quadrantType: QuadrantType) {
+        const quadrantElement = this.quadrantRefs[quadrantType].quadrant;
+        const columnHeaderElement = quadrantElement.querySelector(`.${Classes.TABLE_COLUMN_HEADERS}`);
+        return columnHeaderElement.getBoundingClientRect().height;
+    }
+
+    private getQuadrantRowHeaderWidth(quadrantType: QuadrantType) {
+        const menuElement = this.quadrantRefs[quadrantType].menu;
+        return menuElement != null
+            ? menuElement.getBoundingClientRect().width
+            : 0;
     }
 
     private syncRowHeaderSize(rowHeaderElement: HTMLElement, width: number) {
@@ -1917,22 +1919,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private updateLocator() {
-        const { menu } = this.quadrantRefs[QuadrantType.MAIN];
-
-        let rowHeaderWidth = 0;
-        let columnHeaderHeight = 0;
-
-        if (menu != null) {
-            const menuRect = menu.getBoundingClientRect();
-            rowHeaderWidth = menuRect.width;
-            columnHeaderHeight = menuRect.height;
-        }
-
         this.locator.setGrid(this.grid)
             .setNumFrozenRows(this.getNumFrozenRowsClamped())
             .setNumFrozenColumns(this.getNumFrozenColumnsClamped())
-            .setRowHeaderWidth(rowHeaderWidth)
-            .setColumnHeaderHeight(columnHeaderHeight);
+            .setRowHeaderWidth(this.getQuadrantRowHeaderWidth(QuadrantType.MAIN))
+            .setColumnHeaderHeight(this.getQuadrantColumnHeaderHeight(QuadrantType.MAIN));
     }
 
     private updateViewportRect = (nextViewportRect: Rect) => {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -662,16 +662,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     public componentDidMount() {
         this.validateGrid();
 
-        const { menu, quadrant, scrollContainer } = this.quadrantRefs[QuadrantType.MAIN];
-        const menuRect = menu.getBoundingClientRect();
-        this.locator = new Locator(quadrant, scrollContainer);
-        this.locator
-            .setGrid(this.grid)
-            .setNumFrozenRows(this.getNumFrozenRowsClamped())
-            .setNumFrozenColumns(this.getNumFrozenColumnsClamped())
-            .setRowHeaderWidth(menuRect.width)
-            .setColumnHeaderHeight(menuRect.height);
-
+        this.locator = new Locator(
+            this.quadrantRefs[QuadrantType.MAIN].quadrant,
+            this.quadrantRefs[QuadrantType.MAIN].scrollContainer
+        );
+        this.updateLocator();
         this.updateViewportRect(this.locator.getViewportRect());
 
         this.resizeSensorDetach = ResizeSensor.attach(this.rootTableElement, () => {
@@ -694,14 +689,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     public componentDidUpdate() {
         if (this.locator != null) {
             this.validateGrid();
-            const { menu } = this.quadrantRefs[QuadrantType.MAIN];
-            const menuRect = menu.getBoundingClientRect();
-            this.locator
-                .setGrid(this.grid)
-                .setNumFrozenRows(this.getNumFrozenRowsClamped())
-                .setNumFrozenColumns(this.getNumFrozenColumnsClamped())
-                .setRowHeaderWidth(menuRect.width)
-                .setColumnHeaderHeight(menuRect.height);
+            this.updateLocator();
         }
 
         this.syncQuadrantMenuElementWidths();
@@ -1926,6 +1914,25 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             return undefined;
         }
         return loadingOptions.indexOf(loadingOption) >= 0;
+    }
+
+    private updateLocator() {
+        const { menu } = this.quadrantRefs[QuadrantType.MAIN];
+
+        let rowHeaderWidth = 0;
+        let columnHeaderHeight = 0;
+
+        if (menu != null) {
+            const menuRect = menu.getBoundingClientRect();
+            rowHeaderWidth = menuRect.width;
+            columnHeaderHeight = menuRect.height;
+        }
+
+        this.locator.setGrid(this.grid)
+            .setNumFrozenRows(this.getNumFrozenRowsClamped())
+            .setNumFrozenColumns(this.getNumFrozenColumnsClamped())
+            .setRowHeaderWidth(rowHeaderWidth)
+            .setColumnHeaderHeight(columnHeaderHeight);
     }
 
     private updateViewportRect = (nextViewportRect: Rect) => {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1480,14 +1480,19 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             (quadrantType === QuadrantType.TOP_LEFT || quadrantType === QuadrantType.LEFT)
             && numFrozenColumns != null && numFrozenColumns > 0;
 
+        const fixedHeight = this.grid.getCumulativeHeightAt(this.props.numRows - 1);
+        const fixedWidth = this.grid.getCumulativeWidthAt(this.childrenArray.length - 1);
+
         switch (cardinality) {
             case RegionCardinality.CELLS:
                 return style;
             case RegionCardinality.FULL_COLUMNS:
                 style.top = "-1px";
+                style.height = fixedHeight;
                 return style;
             case RegionCardinality.FULL_ROWS:
                 style.left = "-1px";
+                style.width = fixedWidth;
                 if (canHideRightBorder) {
                     style.right = "-1px";
                 }
@@ -1495,6 +1500,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             case RegionCardinality.FULL_TABLE:
                 style.left = "-1px";
                 style.top = "-1px";
+                style.width = fixedWidth;
+                style.height = fixedHeight;
                 if (canHideRightBorder) {
                     style.right = "-1px";
                 }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -591,7 +591,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
                 <div className={classNames(Classes.TABLE_OVERLAY_LAYER, "bp-table-reordering-cursor-overlay")} />
             </div>
-            // {this.maybeRenderRegions(this.styleBodyRegion)}
             // <GuideLayer
             //     className={Classes.TABLE_RESIZE_GUIDES}
             //     verticalGuides={verticalGuides}
@@ -1241,6 +1240,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
                 // {...rowIndices}
                 // {...columnIndices}
+                <div>
                     <TableBody
                         allowMultipleSelection={allowMultipleSelection}
                         cellRenderer={this.bodyCellRenderer}
@@ -1263,9 +1263,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                         numFrozenColumns={showFrozenColumnsOnly ? numFrozenColumns : undefined}
                         numFrozenRows={showFrozenRowsOnly ? numFrozenRows : undefined}
                     />
+                    {this.maybeRenderRegions(this.styleBodyRegion)}
+                </div>
                     // <div ref={this.setBodyRef} style={{ position: "relative" }}>
-                    // {this.maybeRenderRegions(this.styleBodyRegion)}
-
                     // <GuideLayer
                     //     className={Classes.TABLE_RESIZE_GUIDES}
                     //     verticalGuides={verticalGuides}
@@ -1455,30 +1455,30 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    // private styleBodyRegion = (region: IRegion): React.CSSProperties => {
-    //     const cardinality = Regions.getRegionCardinality(region);
-    //     const style = this.grid.getRegionStyle(region);
-    //     switch (cardinality) {
-    //         case RegionCardinality.CELLS:
-    //             return style;
+    private styleBodyRegion = (region: IRegion): React.CSSProperties => {
+        const cardinality = Regions.getRegionCardinality(region);
+        const style = this.grid.getRegionStyle(region);
+        switch (cardinality) {
+            case RegionCardinality.CELLS:
+                return style;
 
-    //         case RegionCardinality.FULL_COLUMNS:
-    //             style.top = "-1px";
-    //             return style;
+            case RegionCardinality.FULL_COLUMNS:
+                style.top = "-1px";
+                return style;
 
-    //         case RegionCardinality.FULL_ROWS:
-    //             style.left = "-1px";
-    //             return style;
+            case RegionCardinality.FULL_ROWS:
+                style.left = "-1px";
+                return style;
 
-    //         case RegionCardinality.FULL_TABLE:
-    //             style.left = "-1px";
-    //             style.top = "-1px";
-    //             return style;
+            case RegionCardinality.FULL_TABLE:
+                style.left = "-1px";
+                style.top = "-1px";
+                return style;
 
-    //         default:
-    //             return { display: "none" };
-    //     }
-    // }
+            default:
+                return { display: "none" };
+        }
+    }
 
     private styleMenuRegion = (region: IRegion): React.CSSProperties => {
         const { grid } = this;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -662,9 +662,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     public componentDidMount() {
         this.validateGrid();
         this.locator = new Locator(
-            this.rootTableElement,
+            this.quadrantRefs[QuadrantType.MAIN].quadrant,
             this.quadrantRefs[QuadrantType.MAIN].scrollContainer,
             this.grid,
+            this.getNumFrozenRowsClamped(),
+            this.getNumFrozenColumnsClamped(),
         );
         this.updateViewportRect(this.locator.getViewportRect());
 
@@ -689,6 +691,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         if (this.locator != null) {
             this.validateGrid();
             this.locator.setGrid(this.grid);
+            this.locator.setNumFrozenRows(this.getNumFrozenRowsClamped());
+            this.locator.setNumFrozenColumns(this.getNumFrozenColumnsClamped());
         }
 
         this.syncQuadrantMenuElementWidths();

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1528,11 +1528,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 style.left = "-1px";
                 style.borderLeft = "none";
                 style.bottom = "-1px";
-                style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
                 return style;
             case RegionCardinality.FULL_COLUMNS:
                 style.bottom = "-1px";
-                style.transform = `translate3d(${-viewportRect.left}px, 0, 0)`;
                 return style;
 
             default:
@@ -1553,11 +1551,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 style.top = "-1px";
                 style.borderTop = "none";
                 style.right = "-1px";
-                style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
                 return style;
             case RegionCardinality.FULL_ROWS:
                 style.right = "-1px";
-                style.transform = `translate3d(0, ${-viewportRect.top}px, 0)`;
                 return style;
 
             default:

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -661,13 +661,17 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
      */
     public componentDidMount() {
         this.validateGrid();
-        this.locator = new Locator(
-            this.quadrantRefs[QuadrantType.MAIN].quadrant,
-            this.quadrantRefs[QuadrantType.MAIN].scrollContainer,
-            this.grid,
-            this.getNumFrozenRowsClamped(),
-            this.getNumFrozenColumnsClamped(),
-        );
+
+        const { menu, quadrant, scrollContainer } = this.quadrantRefs[QuadrantType.MAIN];
+        const menuRect = menu.getBoundingClientRect();
+        this.locator = new Locator(quadrant, scrollContainer);
+        this.locator
+            .setGrid(this.grid)
+            .setNumFrozenRows(this.getNumFrozenRowsClamped())
+            .setNumFrozenColumns(this.getNumFrozenColumnsClamped())
+            .setRowHeaderWidth(menuRect.width)
+            .setColumnHeaderHeight(menuRect.height);
+
         this.updateViewportRect(this.locator.getViewportRect());
 
         this.resizeSensorDetach = ResizeSensor.attach(this.rootTableElement, () => {
@@ -690,9 +694,14 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     public componentDidUpdate() {
         if (this.locator != null) {
             this.validateGrid();
-            this.locator.setGrid(this.grid);
-            this.locator.setNumFrozenRows(this.getNumFrozenRowsClamped());
-            this.locator.setNumFrozenColumns(this.getNumFrozenColumnsClamped());
+            const { menu } = this.quadrantRefs[QuadrantType.MAIN];
+            const menuRect = menu.getBoundingClientRect();
+            this.locator
+                .setGrid(this.grid)
+                .setNumFrozenRows(this.getNumFrozenRowsClamped())
+                .setNumFrozenColumns(this.getNumFrozenColumnsClamped())
+                .setRowHeaderWidth(menuRect.width)
+                .setColumnHeaderHeight(menuRect.height);
         }
 
         this.syncQuadrantMenuElementWidths();

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -99,7 +99,6 @@ describe("Locator", () => {
 
     describe("convertPointToCell", () => {
         describe("with frozen quadrants", () => {
-            // let tableElement: HTMLElement;
             let bodyElement: HTMLElement;
 
             let originalOverflow: string;

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -52,8 +52,8 @@ describe("Locator", () => {
         locator = new Locator(
             divs.find(".table-wrapper").element as HTMLElement,
             divs.find(".body").element as HTMLElement,
-            grid,
         );
+        locator.setGrid(grid);
     });
 
     afterEach(() => {
@@ -81,7 +81,7 @@ describe("Locator", () => {
         runTestSuiteForConvertPointToRowOrColumn(COL_WIDTH, N_COLS, "convertPointToColumn");
     });
 
-    describe("convertPointToRowTopBoundary", () => {
+    describe("convertPointToRow", () => {
         describe("when useMidpoint = false", () => {
             it("locates a row", () => {
                 const top = divs.find(".body").bounds().top;

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -7,10 +7,11 @@
 
 import { expect } from "chai";
 import * as React from "react";
+import * as ReactDOM from "react-dom";
+
 import { Utils } from "../src";
 import { Grid } from "../src/common/grid";
 import { Locator } from "../src/locator";
-import { ElementHarness, ReactHarness } from "./harness";
 
 const N_ROWS = 10;
 const N_COLS = 10;
@@ -19,15 +20,13 @@ const ROW_HEIGHT = 10;
 const COL_WIDTH = 20;
 
 describe("Locator", () => {
-    const harness = new ReactHarness();
-
     const test10s = Utils.times(N_ROWS, () => ROW_HEIGHT);
     const test20s = Utils.times(N_COLS, () => COL_WIDTH);
 
     const grid = new Grid(test10s, test20s);
 
     let locator: Locator;
-    let divs: ElementHarness;
+    let containerElement: HTMLElement;
 
     beforeEach(() => {
         // for some reason, the height is only 18px by default. need to manually increase it to fit
@@ -42,26 +41,29 @@ describe("Locator", () => {
             height: (N_ROWS + 1) * ROW_HEIGHT,
             width: (N_COLS + 1) * COL_WIDTH,
         };
-        divs = harness.mount(
+
+        // mount in the DOM to let us test scrolling behavior.
+        // ".body" will be the scrollable region.
+        containerElement = document.createElement("div");
+        document.body.appendChild(containerElement);
+        ReactDOM.render(
             <div className="table-wrapper" style={style}>
-                <div className="body">
-                    <div className="body-client">B</div>
+                <div className="body" style={style}>
+                    <div className="body-client" style={style}>B</div>
                 </div>
             </div>,
+            containerElement,
         );
+
         locator = new Locator(
-            divs.find(".table-wrapper").element as HTMLElement,
-            divs.find(".body").element as HTMLElement,
+            containerElement.query(".table-wrapper") as HTMLElement,
+            containerElement.query(".body") as HTMLElement,
         );
         locator.setGrid(grid);
     });
 
     afterEach(() => {
-        harness.unmount();
-    });
-
-    after(() => {
-        harness.destroy();
+        ReactDOM.unmountComponentAtNode(containerElement);
     });
 
     it("constructs", () => {
@@ -71,7 +73,7 @@ describe("Locator", () => {
     describe("convertPointToColumn", () => {
         describe("when useMidpoint = false", () => {
             it("locates a column", () => {
-                const left = divs.find(".body").bounds().left;
+                const left = containerElement.query(".body").getBoundingClientRect().left;
                 expect(locator.convertPointToColumn(left + 10)).to.equal(0);
                 expect(locator.convertPointToColumn(left + 30)).to.equal(1);
                 expect(locator.convertPointToColumn(-1000)).to.equal(-1);
@@ -84,7 +86,7 @@ describe("Locator", () => {
     describe("convertPointToRow", () => {
         describe("when useMidpoint = false", () => {
             it("locates a row", () => {
-                const top = divs.find(".body").bounds().top;
+                const top = containerElement.query(".body").getBoundingClientRect().top;
                 expect(locator.convertPointToRow(top + 5)).to.equal(0);
                 expect(locator.convertPointToRow(top + 15)).to.equal(1);
                 expect(locator.convertPointToRow(top + (N_ROWS * ROW_HEIGHT) - (ROW_HEIGHT / 2))).to.equal(N_ROWS - 1);
@@ -93,6 +95,129 @@ describe("Locator", () => {
         });
 
         runTestSuiteForConvertPointToRowOrColumn(ROW_HEIGHT, N_ROWS, "convertPointToRow");
+    });
+
+    describe("convertPointToCell", () => {
+        describe("with frozen quadrants", () => {
+            // let tableElement: HTMLElement;
+            let bodyElement: HTMLElement;
+
+            let originalOverflow: string;
+            let originalHeight: string;
+            let originalWidth: string;
+            let originalScrollLeft: number;
+            let originalScrollTop: number;
+
+            const NUM_FROZEN_COLUMNS = 1;
+            const NUM_FROZEN_ROWS = 1;
+
+            const NUM_COLUMNS_SCROLLED_OUT_OF_VIEW = 1;
+            const NUM_ROWS_SCROLLED_OUT_OF_VIEW = 1;
+
+            beforeEach(() => {
+                bodyElement = containerElement.query(".body") as HTMLElement;
+
+                originalOverflow = bodyElement.style.overflow;
+                originalHeight = bodyElement.style.height;
+                originalWidth = bodyElement.style.width;
+                originalScrollLeft = bodyElement.scrollLeft;
+                originalScrollTop = bodyElement.scrollTop;
+
+                // make the table smaller, then scroll it one column and one row over
+                bodyElement.style.height = `${(N_ROWS / 2) * ROW_HEIGHT}px`;
+                bodyElement.style.width = `${(N_COLS / 2) * COL_WIDTH}px`;
+                bodyElement.style.overflow = "auto";
+                bodyElement.scrollLeft = NUM_COLUMNS_SCROLLED_OUT_OF_VIEW * COL_WIDTH;
+                bodyElement.scrollTop = NUM_ROWS_SCROLLED_OUT_OF_VIEW * ROW_HEIGHT;
+            });
+
+            afterEach(() => {
+                locator.setNumFrozenColumns(0);
+                locator.setNumFrozenRows(0);
+                bodyElement.scrollLeft = originalScrollLeft;
+                bodyElement.scrollTop = originalScrollTop;
+                bodyElement.style.overflow = originalOverflow;
+                bodyElement.style.width = originalWidth;
+                bodyElement.style.height = originalHeight;
+            });
+
+            describe("when table is scrolled downward and rightward", () => {
+                describe("with frozen column(s) only", () => {
+                    beforeEach(() => {
+                        locator.setNumFrozenColumns(NUM_FROZEN_COLUMNS);
+                    });
+
+                    it("locates a cell in the frozen LEFT quadrant", () => {
+                        const { x, y } = getUnscrolledCellCoords(0, 0);
+                        // frozen column still moves vertically on scroll
+                        assertCellLocatedProperly(x, y, NUM_ROWS_SCROLLED_OUT_OF_VIEW, 0);
+                    });
+
+                    it("locates a scrolled cell in the MAIN quadrant", () => {
+                        const lastFrozenIndex = NUM_FROZEN_COLUMNS - 1;
+                        const unfrozenIndex = lastFrozenIndex + 1;
+
+                        const { x, y } = getUnscrolledCellCoords(0, unfrozenIndex);
+
+                        // unfrozen column moves horizontall and vertically on scroll
+                        const expectedRow = NUM_ROWS_SCROLLED_OUT_OF_VIEW;
+                        const expectedCol = unfrozenIndex + NUM_ROWS_SCROLLED_OUT_OF_VIEW;
+                        assertCellLocatedProperly(x, y, expectedRow, expectedCol);
+                    });
+                });
+
+                describe("with frozen rows(s) only", () => {
+                    beforeEach(() => {
+                        locator.setNumFrozenRows(NUM_FROZEN_ROWS);
+                    });
+
+                    it("locates a cell in the frozen TOP quadrant", () => {
+                        const { x, y } = getUnscrolledCellCoords(0, 0);
+                        // frozen row still moves horizontally on scroll
+                        assertCellLocatedProperly(x, y, 0, NUM_COLUMNS_SCROLLED_OUT_OF_VIEW);
+                    });
+
+                    it("locates a scrolled cell in the MAIN quadrant", () => {
+                        const lastFrozenIndex = NUM_FROZEN_ROWS - 1;
+                        const unfrozenIndex = lastFrozenIndex + 1;
+
+                        const { x, y } = getUnscrolledCellCoords(unfrozenIndex, 0);
+
+                        // unfrozen column moves horizontall and vertically on scroll
+                        const expectedRow = unfrozenIndex + NUM_COLUMNS_SCROLLED_OUT_OF_VIEW;
+                        const expectedCol = NUM_COLUMNS_SCROLLED_OUT_OF_VIEW;
+                        assertCellLocatedProperly(x, y, expectedRow, expectedCol);
+                    });
+                });
+
+                describe("with frozen row(s) AND column(s)", () => {
+                    beforeEach(() => {
+                        locator.setNumFrozenRows(NUM_FROZEN_ROWS);
+                        locator.setNumFrozenColumns(NUM_FROZEN_COLUMNS);
+                    });
+
+                    it("locates a cell in a frozen row AND column (TOP_LEFT quadrant)", () => {
+                        const { x, y } = getUnscrolledCellCoords(0, 0);
+                        // top-left frozen area doesn't move on scroll
+                        assertCellLocatedProperly(x, y, 0, 0);
+                    });
+
+                    it("locates a scrolled cell in the MAIN quadrant", () => {
+                        const lastFrozenRowIndex = NUM_FROZEN_ROWS - 1;
+                        const lastFrozenColumnIndex = NUM_FROZEN_COLUMNS - 1;
+                        const unfrozenRowIndex = lastFrozenRowIndex + 1;
+                        const unfrozenColumnIndex = lastFrozenColumnIndex + 1;
+
+                        const { x, y } = getUnscrolledCellCoords(unfrozenRowIndex, unfrozenColumnIndex);
+
+                        // unfrozen column moves horizontall and vertically on scroll
+                        const expectedRow = unfrozenRowIndex + NUM_COLUMNS_SCROLLED_OUT_OF_VIEW;
+                        const expectedCol = unfrozenColumnIndex + NUM_COLUMNS_SCROLLED_OUT_OF_VIEW;
+                        assertCellLocatedProperly(x, y, expectedRow, expectedCol);
+                    });
+                });
+            });
+        });
     });
 
     function runTestSuiteForConvertPointToRowOrColumn(
@@ -146,11 +271,35 @@ describe("Locator", () => {
 
         function runTest(clientCoord: number, expectedResult: number) {
             it(`${clientCoord}px => ${expectedResult}`, () => {
-                const { top, left } = divs.find(".body").bounds();
+                const { top, left } = containerElement.query(".body").getBoundingClientRect();
                 const baseOffset = (testFnName === "convertPointToColumn") ? left : top;
                 const actualResult = locator[testFnName](baseOffset + clientCoord, true);
                 expect(actualResult).to.equal(expectedResult);
             });
         }
+    }
+
+    function assertCellLocatedProperly(
+        clientX: number,
+        clientY: number,
+        expectedRow: number,
+        expectedCol: number,
+    ) {
+        const cell = locator.convertPointToCell(clientX, clientY);
+        expect(cell).to.deep.equal({ row: expectedRow, col: expectedCol });
+    }
+
+    function getUnscrolledCellCoords(row: number, col: number) {
+        const bodyRect = containerElement.query(".body").getBoundingClientRect();
+
+        const colMidpointOffset = COL_WIDTH / 2;
+        const rowMidpointOffset = ROW_HEIGHT / 2;
+
+        // return the midpoint of the desired cell within the table container as if the table
+        // weren't scrolled
+        return {
+            x: bodyRect.left + (col * COL_WIDTH) + colMidpointOffset,
+            y: bodyRect.top + (row * ROW_HEIGHT) + rowMidpointOffset,
+        };
     }
 });


### PR DESCRIPTION
## Targets `feature/table-frozen-rows-cols`

#### Addresses #503 · Builds on #1361

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

##### `packages/table`
- __Fixed__ `Table` selection interactions now work properly in the multi-quadrant architecture.
    - Intermediate borders are no longer shown within the bounds of a selection (e.g. at quadrant boundaries) ([Link #1](https://github.com/palantir/blueprint/pull/1370/files#diff-6bc89efba539cc29af0dae9b17c57f75R1482), [Link #2](https://github.com/palantir/blueprint/pull/1370/files#diff-6bc89efba539cc29af0dae9b17c57f75R1483))
    - `FULL_TABLE`, `FULL_COLUMN`, and `FULL_ROW` selections no longer extend outside of smaller tables. ([Link #1](https://github.com/palantir/blueprint/pull/1370/files#diff-e78bd13417417b00c597bf8ad2ca9e1eR16), [Link #2]())
    - Mouse events now map to the proper cell coordinates in the grid. ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-85bb3412e972df58b0e3115a878bf248R154))
    - Disable scrolling if the table is smaller than the viewport. ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-b3f92715a0a3e506f1f493716f5908e8R35))
    - Disable user selection on the table body. ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-b3f92715a0a3e506f1f493716f5908e8R30))
    - Selection overlay is no longer clipped on scroll. ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-851e0d46f453d128800eec18dc4bb404R136))
    - Header selections no longer scroll twice as far as they should. ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-6bc89efba539cc29af0dae9b17c57f75L1525))
    - Don't trigger quadrant-to-quadrant scroll-sync'ing if scrolling is disabled. ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-6bc89efba539cc29af0dae9b17c57f75R815))
- Added tests ([Link](https://github.com/palantir/blueprint/pull/1370/files#diff-e247b54a837888117ccd650e0d7dd111R10))

##### Documentation
- __Changed__ `Table` example page now enables selection-related flags by default.
 
![2017-07-24 12 47 36](https://user-images.githubusercontent.com/443450/28541575-62673458-706e-11e7-817e-1c0f0d522632.gif)

#### Reviewers should focus on:

- Questions from my self-review
- Does everything seem to work w/r/t selection? (I know there are some scroll-sync/alignment issues but I'll address those in an upcoming PR) 