### PR TITLE
[Table] Add pt-icon-standard to reordering drag handle

### DIFF
--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { Classes as CoreClasses } from "@blueprintjs/core";
+import { Classes as CoreClasses, IconClasses } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 
@@ -382,7 +382,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             : this.wrapInDragReorderable(index,
                 <div className={Classes.TABLE_REORDER_HANDLE_TARGET}>
                     <div className={Classes.TABLE_REORDER_HANDLE}>
-                        <span className={CoreClasses.iconClass("drag-handle-vertical")} />
+                        <span className={classNames(CoreClasses.ICON_STANDARD, IconClasses.DRAG_HANDLE_VERTICAL)} />
                     </div>
                 </div>);
     }


### PR DESCRIPTION
#### Fixes #1372 

#### Changes proposed in this pull request:

- __Fixed__ `Table` reordering handle now includes missing `pt-icon-standard` class
    - This fixes missing-icon issues on some browsers

![image](https://user-images.githubusercontent.com/443450/28548624-df4d6774-7089-11e7-94c1-c44c1e272c26.png)
