### PR TITLE
[Table] Frozen Rows/Cols - Part 4.5: resize guides

### DIFF
--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -2,9 +2,10 @@
 
 @import "../common/variables";
 
+$resize-handle-target-width: 5px !default;
 $resize-handle-width: 3px !default;
 $resize-handle-position-correction: -3px !default;
-$resize-handle-padding: 0 !default;
+$resize-handle-padding: 2px !default;
 $resize-handle-color: $pt-intent-primary !default;
 $resize-handle-dragging-color: $pt-intent-primary !default;
 
@@ -87,17 +88,17 @@ $resize-handle-dragging-color: $pt-intent-primary !default;
   &.bp-table-resize-vertical {
     top: 0;
     right: 0;
-    bottom: -1px;
+    bottom: -$cell-border-width;
     cursor: $resize-vertical-cursor;
-    width: 5px;
+    width: $resize-handle-target-width;
   }
 
   &.bp-table-resize-horizontal {
-    right: -1px;
+    right: -$cell-border-width;
     bottom: 0;
     left: 0;
     cursor: $resize-horizontal-cursor;
-    height: 5px;
+    height: $resize-handle-target-width;
   }
 }
 
@@ -114,12 +115,12 @@ $resize-handle-dragging-color: $pt-intent-primary !default;
 .bp-table-resize-vertical .bp-table-resize-handle {
   top: 0;
   bottom: 0;
-  left: 2px;
+  left: $resize-handle-padding;
   width: $resize-handle-width;
 }
 
 .bp-table-resize-horizontal .bp-table-resize-handle {
-  top: 2px;
+  top: $resize-handle-padding;
   right: 0;
   left: 0;
   height: $resize-handle-width;

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -3,8 +3,8 @@
 @import "../common/variables";
 
 $resize-handle-width: 3px !default;
-$resize-handle-position-correction: -2px !default;
-$resize-handle-padding: $pt-grid-size / 2 !default;
+$resize-handle-position-correction: -3px !default;
+$resize-handle-padding: 0 !default;
 $resize-handle-color: $pt-intent-primary !default;
 $resize-handle-dragging-color: $pt-intent-primary !default;
 
@@ -86,18 +86,18 @@ $resize-handle-dragging-color: $pt-intent-primary !default;
 
   &.bp-table-resize-vertical {
     top: 0;
-    right: -$resize-handle-padding;
-    bottom: -$cell-border-width;
+    right: 0;
+    bottom: -1px;
     cursor: $resize-vertical-cursor;
-    width: $resize-handle-padding * 2;
+    width: 5px;
   }
 
   &.bp-table-resize-horizontal {
-    right: -$cell-border-width;
-    bottom: -$resize-handle-padding / 2;
+    right: -1px;
+    bottom: 0;
     left: 0;
     cursor: $resize-horizontal-cursor;
-    height: $resize-handle-padding;
+    height: 5px;
   }
 }
 
@@ -114,12 +114,12 @@ $resize-handle-dragging-color: $pt-intent-primary !default;
 .bp-table-resize-vertical .bp-table-resize-handle {
   top: 0;
   bottom: 0;
-  left: $resize-handle-padding - ceil($resize-handle-width / 2);
+  left: 2px;
   width: $resize-handle-width;
 }
 
 .bp-table-resize-horizontal .bp-table-resize-handle {
-  top: $resize-handle-padding / 2 - ceil($resize-handle-width / 2);
+  top: 2px;
   right: 0;
   left: 0;
   height: $resize-handle-width;

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -88,7 +88,7 @@ export interface ITableQuadrantProps extends IProps {
     /**
      * A callback that renders either all of or just the frozen section of the column header.
      */
-    renderColumnHeader?: ( showFrozenColumnsOnly?: boolean) => JSX.Element;
+    renderColumnHeader?: (showFrozenColumnsOnly?: boolean) => JSX.Element;
 
     /**
      * A callback that renders either all of or just the frozen section of the row header.

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -88,7 +88,7 @@ export interface ITableQuadrantProps extends IProps {
     /**
      * A callback that renders either all of or just the frozen section of the column header.
      */
-    renderColumnHeader?: (showFrozenColumnsOnly?: boolean) => JSX.Element;
+    renderColumnHeader?: ( showFrozenColumnsOnly?: boolean) => JSX.Element;
 
     /**
      * A callback that renders either all of or just the frozen section of the row header.
@@ -132,6 +132,7 @@ export class TableQuadrant extends AbstractComponent<ITableQuadrantProps, {}> {
 
         const maybeMenu = isRowHeaderShown ? this.props.renderMenu() : undefined;
         const maybeRowHeader = isRowHeaderShown ? this.props.renderRowHeader(showFrozenRowsOnly) : undefined;
+        const columnHeader = this.props.renderColumnHeader(showFrozenColumnsOnly);
 
         // need to set bottom container size to prevent overlay clipping on scroll
         const bottomContainerStyle = {
@@ -149,7 +150,7 @@ export class TableQuadrant extends AbstractComponent<ITableQuadrantProps, {}> {
                 >
                     <div className={Classes.TABLE_TOP_CONTAINER}>
                         {maybeMenu}
-                        {this.props.renderColumnHeader(showFrozenColumnsOnly)}
+                        {columnHeader}
                     </div>
                     <div className={Classes.TABLE_BOTTOM_CONTAINER} style={bottomContainerStyle}>
                         {maybeRowHeader}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1927,7 +1927,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleColumnsReordering = (oldIndex: number, newIndex: number, length: number) => {
         const guideIndex = Utils.reorderedIndexToGuideIndex(oldIndex, newIndex, length);
         const leftOffset = this.grid.getCumulativeWidthBefore(guideIndex);
-        const quadrantType = guideIndex <= this.props.numFrozenColumns ? QuadrantType.TOP_LEFT : QuadrantType.TOP;
+        const quadrantType = guideIndex <= this.getNumFrozenColumnsClamped() ? QuadrantType.TOP_LEFT : QuadrantType.TOP;
         const verticalGuides = this.adjustVerticalGuides([leftOffset], quadrantType);
         this.setState({ isReordering: true, verticalGuides } as ITableState);
     }
@@ -1940,7 +1940,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleRowsReordering = (oldIndex: number, newIndex: number, length: number) => {
         const guideIndex = Utils.reorderedIndexToGuideIndex(oldIndex, newIndex, length);
         const topOffset = this.grid.getCumulativeHeightBefore(guideIndex);
-        const quadrantType = guideIndex <= this.props.numFrozenRows ? QuadrantType.TOP_LEFT : QuadrantType.LEFT;
+        const quadrantType = guideIndex <= this.getNumFrozenRowsClamped() ? QuadrantType.TOP_LEFT : QuadrantType.LEFT;
         const horizontalGuides = this.adjustHorizontalGuides([topOffset], quadrantType);
         this.setState({ isReordering: true, horizontalGuides } as ITableState);
     }


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Modify styling so that the row and column resize guides only show up in the right places
- Use math and logic to figure out the exact position where the guides need to be drawn based on which quadrant they came from. 
