### PR TITLE
[Icons] Move default icon colors to core

### DIFF
--- a/packages/core/src/_icons.scss
+++ b/packages/core/src/_icons.scss
@@ -7,6 +7,11 @@
 
 #{$icon-classes} {
   display: inline-block;
+  color: $pt-icon-color;
+
+  .pt-dark & {
+    color: $pt-dark-icon-color;
+  }
 
   @each $intent, $color in $pt-intent-colors {
     &.pt-intent-#{$intent} {

--- a/packages/site-docs/src/styles/_icons.scss
+++ b/packages/site-docs/src/styles/_icons.scss
@@ -59,21 +59,13 @@ $icons-per-row: 5;
     position: relative;
   }
 
-  .pt-icon-large {
-    color: $pt-icon-color;
-  }
-
   .pt-dark & {
     &::before {
-      background-color: $dark-gray3;
-    }
-
-    &:active::before {
       background-color: $dark-gray2;
     }
 
-    .pt-icon-large {
-      color: $pt-dark-icon-color;
+    &:active::before {
+      background-color: $dark-gray1;
     }
   }
 }


### PR DESCRIPTION
Any reason why this was in docs and not core? 