### PR TITLE
[Button] Remove custom focus style in minimal state

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -296,8 +296,7 @@ $button-intents: (
   box-shadow: none;
   background: $minimal-button-background-color;
 
-  &:hover,
-  &:focus {
+  &:hover {
     box-shadow: none;
     background: $minimal-button-background-color-hover;
     text-decoration: none;
@@ -378,8 +377,7 @@ $button-intents: (
     color: $text-color;
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     background: rgba($intent-color, 0.15);
     color: $text-color;
   }
@@ -403,8 +401,7 @@ $button-intents: (
   .pt-dark & {
     color: $dark-text-color;
 
-    &:hover,
-    &:focus {
+    &:hover {
       background: rgba($intent-color, 0.2);
       color: $dark-text-color;
     }


### PR DESCRIPTION
#### Fixes #1381

> I traced back some old PRs internally, and it looks like we matched focus styles to hover styles before we ever had the `FocusStyleManager`, which made a lot of sense with regards to accessibility and keyboard navigation. Might be safe to remove now!

This PR removes these custom focus styles. Feels much better IMO.