### PR TITLE
[Button] Remove small button icon restriction

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -204,12 +204,6 @@ Styleguide pt-button
   &.pt-small,
   .pt-small & {
     @include pt-button-small();
-
-    // small buttons are too small to contain any Blueprint icons
-    &[class*="pt-icon-"]::before,
-    #{$icon-classes} {
-      display: none;
-    }
   }
 
   // ensure icon button with no text is a perfect square


### PR DESCRIPTION
#### Fixes #1153 

Getting too many requests about this. Two solutions:
1. we lift the restriction
1. we create a whitelist of icons that are okay inside small buttons

This PR does the former. I really dislike the latter, and it seems to make sense to push this responsibility to consumers anyway.