### PR TITLE
[Button] Refactor button gradients

### DIFF
--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -26,22 +26,6 @@ $pt-dark-intent-text-colors: (
   "danger" : $red5,
 ) !default;
 
-@mixin linear-gradient-with-fallback($start-color, $end-color, $fallback-color: $start-color) {
-  $gradient: linear-gradient(to bottom, $start-color, $end-color);
-
-  // fallback is a solid color (for very old browsers)
-  // stylelint-disable declaration-block-no-duplicate-properties
-  @if ($fallback-color == none) {
-    background: $start-color;
-    // explicit `none` argument disables second gradient
-    background: $gradient left no-repeat;
-  } @else {
-    background: $fallback-color;
-    background: $gradient left no-repeat, center no-repeat $fallback-color;
-  }
-  // stylelint-enable declaration-block-no-duplicate-properties
-}
-
 @mixin base-typography() {
   text-transform: none;
   line-height: $pt-line-height;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,8 +7,6 @@
 @import "../../common/variables";
 @import "../progress/common";
 
-$white-transparent: rgba($white, 0) !default;
-
 $button-border-width: 1px !default;
 $button-padding: 0 $pt-grid-size !default;
 $button-padding-small: 0 ($pt-grid-size * 0.7) !default;
@@ -62,6 +60,10 @@ $dark-button-intent-box-shadow-active:
   0 0 0 $button-border-width rgba($black, 0.4),
   inset 0 1px 2px rgba($black, 0.2) !default;
 
+$button-gradient: linear-gradient(to bottom, rgba($white, 0.5), rgba($white, 0)) !default;
+$button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;
+$dark-button-gradient: linear-gradient(to bottom, rgba($white, 0.05), rgba($white, 0)) !default;
+
 $button-color-disabled: $pt-text-color-disabled !default;
 $button-background-color: $light-gray5 !default;
 $button-background-color-hover: $light-gray4 !default;
@@ -69,7 +71,6 @@ $button-background-color-active: $light-gray2 !default;
 $button-background-color-disabled: rgba($light-gray1, 0.5) !default;
 $button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
 $button-intent-color-disabled: rgba($white, 0.6);
-
 $dark-button-color-disabled: $pt-dark-text-color-disabled !default;
 $dark-button-background-color: $dark-gray5 !default;
 $dark-button-background-color-hover: $dark-gray4 !default;
@@ -79,11 +80,9 @@ $dark-button-background-color-active-disabled: rgba($dark-gray5, 0.7) !default;
 $dark-button-intent-color-disabled: rgba($white, 0.3);
 
 $minimal-button-divider-width: 1px !default;
-
 $minimal-button-background-color: none !default;
 $minimal-button-background-color-hover: rgba($gray4, 0.3) !default;
 $minimal-button-background-color-active: rgba($gray2, 0.3) !default;
-
 $dark-minimal-button-background-color: none !default;
 $dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
 $dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
@@ -114,8 +113,9 @@ $button-intents: (
 }
 
 @mixin pt-button() {
-  @include linear-gradient-with-fallback($white, $white-transparent, $button-background-color);
   box-shadow: $button-box-shadow;
+  background-color: $button-background-color;
+  background-image: $button-gradient;
   color: $pt-text-color;
 
   &:hover {
@@ -134,13 +134,10 @@ $button-intents: (
 }
 
 @mixin pt-button-hover() {
-  @include linear-gradient-with-fallback(
-    rgba($white, 0.5),
-    $white-transparent,
-    $button-background-color-hover
-  );
   box-shadow: $button-box-shadow;
   background-clip: padding-box;
+  background-color: $button-background-color-hover;
+  background-image: $button-gradient;
 }
 
 @mixin pt-button-active() {
@@ -163,12 +160,9 @@ $button-intents: (
 }
 
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
-  @include linear-gradient-with-fallback(
-    rgba($white, 0.1),
-    $white-transparent,
-    $default-color
-  );
   box-shadow: $button-intent-box-shadow;
+  background-color: $default-color;
+  background-image: $button-intent-gradient;
   color: $white;
 
   &:hover,
@@ -178,12 +172,9 @@ $button-intents: (
   }
 
   &:hover {
-    @include linear-gradient-with-fallback(
-      rgba($white, 0.1),
-      $white-transparent,
-      $hover-color
-    );
     box-shadow: $button-intent-box-shadow;
+    background-color: $hover-color;
+    background-image: $button-intent-gradient;
   }
 
   &:active,
@@ -208,12 +199,9 @@ $button-intents: (
 }
 
 @mixin pt-dark-button() {
-  @include linear-gradient-with-fallback(
-    rgba($white, 0.05),
-    $white-transparent,
-    $dark-button-background-color
-  );
   box-shadow: $dark-button-box-shadow;
+  background-color: $dark-button-background-color;
+  background-image: $dark-button-gradient;
   color: $pt-dark-text-color;
 
   &:hover,
@@ -243,12 +231,9 @@ $button-intents: (
 }
 
 @mixin pt-dark-button-hover() {
-  @include linear-gradient-with-fallback(
-    rgba($white, 0.05),
-    $white-transparent,
-    $dark-button-background-color-hover
-  );
   box-shadow: $dark-button-box-shadow;
+  background-color: $dark-button-background-color-hover;
+  background-image: $dark-button-gradient;
 }
 
 @mixin pt-dark-button-active() {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -60,7 +60,7 @@ $dark-button-intent-box-shadow-active:
   0 0 0 $button-border-width rgba($black, 0.4),
   inset 0 1px 2px rgba($black, 0.2) !default;
 
-$button-gradient: linear-gradient(to bottom, rgba($white, 0.7), rgba($white, 0)) !default;
+$button-gradient: linear-gradient(to bottom, rgba($white, 0.8), rgba($white, 0)) !default;
 $button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;
 $dark-button-gradient: linear-gradient(to bottom, rgba($white, 0.05), rgba($white, 0)) !default;
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -60,7 +60,7 @@ $dark-button-intent-box-shadow-active:
   0 0 0 $button-border-width rgba($black, 0.4),
   inset 0 1px 2px rgba($black, 0.2) !default;
 
-$button-gradient: linear-gradient(to bottom, rgba($white, 0.5), rgba($white, 0)) !default;
+$button-gradient: linear-gradient(to bottom, rgba($white, 0.7), rgba($white, 0)) !default;
 $button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;
 $dark-button-gradient: linear-gradient(to bottom, rgba($white, 0.05), rgba($white, 0)) !default;
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -137,7 +137,6 @@ $button-intents: (
   box-shadow: $button-box-shadow;
   background-clip: padding-box;
   background-color: $button-background-color-hover;
-  background-image: $button-gradient;
 }
 
 @mixin pt-button-active() {
@@ -174,7 +173,6 @@ $button-intents: (
   &:hover {
     box-shadow: $button-intent-box-shadow;
     background-color: $hover-color;
-    background-image: $button-intent-gradient;
   }
 
   &:active,
@@ -233,7 +231,6 @@ $button-intents: (
 @mixin pt-dark-button-hover() {
   box-shadow: $dark-button-box-shadow;
   background-color: $dark-button-background-color-hover;
-  background-image: $dark-button-gradient;
 }
 
 @mixin pt-dark-button-active() {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -52,7 +52,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
   .pt-control-indicator {
     @include pt-icon($pt-icon-size-standard);
-    @include linear-gradient-with-fallback($white, $white-transparent, $control-background-color);
     position: absolute;
     top: 0;
     left: 0;
@@ -60,6 +59,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     border: none;
     box-shadow: $button-box-shadow;
     background-clip: padding-box;
+    background-color: $control-background-color;
+    background-image: $button-gradient;
     cursor: pointer;
     width: $control-indicator-size;
     height: $control-indicator-size;
@@ -73,31 +74,22 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   input:checked ~ .pt-control-indicator {
-    @include linear-gradient-with-fallback(
-      rgba($white, 0.1),
-      $white-transparent,
-      $control-checked-background-color
-    );
     box-shadow: $button-intent-box-shadow;
+    background-color: $control-checked-background-color;
+    background-image: $button-intent-gradient;
     color: $white;
   }
 
   &:hover {
     .pt-control-indicator {
-      @include linear-gradient-with-fallback(
-        rgba($white, 0.5),
-        $white-transparent,
-        $control-background-color-hover
-      );
+      background-color: $control-background-color-hover;
+      background-image: $button-gradient;
     }
 
     input:checked ~ .pt-control-indicator {
-      @include linear-gradient-with-fallback(
-        rgba($white, 0.1),
-        $white-transparent,
-        $control-checked-background-color-hover
-      );
       box-shadow: $button-intent-box-shadow;
+      background-color: $control-checked-background-color-hover;
+      background-image: $button-intent-gradient;
     }
   }
 
@@ -416,12 +408,9 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     }
 
     .pt-control-indicator {
-      @include linear-gradient-with-fallback(
-        rgba($white, 0.05),
-        $white-transparent,
-        $dark-control-background-color
-      );
       box-shadow: $dark-button-box-shadow;
+      background-color: $dark-control-background-color;
+      background-image: $dark-button-gradient;
     }
 
     input:checked ~ .pt-control-indicator {
@@ -430,11 +419,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
     &:hover {
       .pt-control-indicator {
-        @include linear-gradient-with-fallback(
-          rgba($black, 0.05),
-          $white-transparent,
-          $dark-control-background-color-hover
-        );
+        background-color: $dark-control-background-color-hover;
+        background-image: $dark-button-gradient;
       }
     }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -83,13 +83,11 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   &:hover {
     .pt-control-indicator {
       background-color: $control-background-color-hover;
-      background-image: $button-gradient;
     }
 
     input:checked ~ .pt-control-indicator {
       box-shadow: $button-intent-box-shadow;
       background-color: $control-checked-background-color-hover;
-      background-image: $button-intent-gradient;
     }
   }
 
@@ -420,7 +418,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     &:hover {
       .pt-control-indicator {
         background-color: $dark-control-background-color-hover;
-        background-image: $dark-button-gradient;
       }
     }
 


### PR DESCRIPTION
#### Follow up from #1367

#### Changes proposed in this pull request:

- Remove `linear-gradient-with-fallback` mixin and rely on straight CSS
  - Good browser support: http://caniuse.com/#search=linear-gradient)
- Gradients on buttons are `!default` variables that can be customized like all the other ones
