### PR TITLE
[Labs] Add resetOnClose prop to Select

### DIFF
--- a/packages/labs/examples/selectExample.tsx
+++ b/packages/labs/examples/selectExample.tsx
@@ -19,6 +19,7 @@ export interface ISelectExampleState {
     film?: Film;
     filterable?: boolean;
     minimal?: boolean;
+    resetOnClose?: boolean;
     resetOnSelect?: boolean;
 }
 
@@ -28,12 +29,14 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
         film: TOP_100_FILMS[0],
         filterable: true,
         minimal: false,
+        resetOnClose: false,
         resetOnSelect: false,
     };
 
     private handleFilterableChange = this.handleSwitchChange("filterable");
     private handleMinimalChange = this.handleSwitchChange("minimal");
-    private handleResetChange = this.handleSwitchChange("resetOnSelect");
+    private handleResetOnCloseChange = this.handleSwitchChange("resetOnClose");
+    private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
 
     protected renderExample() {
         const { film, minimal, ...flags } = this.state;
@@ -65,10 +68,16 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
                     onChange={this.handleFilterableChange}
                 />,
                 <Switch
-                    key="reset"
-                    label="Reset on select"
+                    key="resetOnClose"
+                    label="Reset query on close"
+                    checked={this.state.resetOnClose}
+                    onChange={this.handleResetOnCloseChange}
+                />,
+                <Switch
+                    key="resetOnSelect"
+                    label="Reset query on select"
                     checked={this.state.resetOnSelect}
-                    onChange={this.handleResetChange}
+                    onChange={this.handleResetOnSelectChange}
                 />,
                 <Switch
                     key="minimal"

--- a/packages/labs/examples/selectExample.tsx
+++ b/packages/labs/examples/selectExample.tsx
@@ -69,13 +69,13 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
                 />,
                 <Switch
                     key="resetOnClose"
-                    label="Reset query on close"
+                    label="Reset on close"
                     checked={this.state.resetOnClose}
                     onChange={this.handleResetOnCloseChange}
                 />,
                 <Switch
                     key="resetOnSelect"
-                    label="Reset query on select"
+                    label="Reset on select"
                     checked={this.state.resetOnSelect}
                     onChange={this.handleResetOnSelectChange}
                 />,

--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -60,6 +60,13 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      * @default false
      */
     resetOnSelect?: boolean;
+
+    /**
+     * Whether the filtering state should be reset to initial when the popover closes.
+     * The query will become the empty string and the first item will be made active.
+     * @default false
+     */
+    resetOnClose?: boolean;
 }
 
 export interface ISelectItemRendererProps<T> {
@@ -217,10 +224,14 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
     }
 
     private handlePopoverWillOpen = () => {
+        const { popoverProps = {}, resetOnClose } = this.props;
         // save currently focused element before popover steals focus, so we can restore it when closing.
         this.previousFocusedElement = document.activeElement as HTMLElement;
 
-        const { popoverProps = {} } = this.props;
+        if (resetOnClose) {
+            this.resetQuery();
+        }
+
         Utils.safeInvoke(popoverProps.popoverWillOpen);
     }
 
@@ -251,5 +262,6 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
         this.setState({ query: event.currentTarget.value });
     }
+
     private resetQuery = () => this.setState({ activeItem: this.props.items[0], query: "" });
 }


### PR DESCRIPTION
#### Fixes #1387

#### Checklist

- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

- Add a `resetOnClose` prop that when set to `true` resets the query every time the popover is about to open
