### PR TITLE
[TagInput] add separator, onChange, placeholder props

### DIFF
--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -55,8 +55,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         return (
             <TagInput
                 className={classes}
-                onAdd={this.handleAdd}
-                onRemove={this.handleRemove}
+                onChange={this.handleChange}
                 tagProps={getTagProps}
                 values={values}
             />
@@ -96,10 +95,5 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         ];
     }
 
-    private handleAdd = (newValues: string[]) => {
-        this.setState({ values: [...this.state.values, ...newValues] });
-    }
-    private handleRemove = (_removedValue: string, removedIndex: number) => {
-        this.setState({ values: this.state.values.filter((_, i) => i !== removedIndex) });
-    }
+    private handleChange = (values: string[]) => this.setState({ values });
 }

--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -96,8 +96,8 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         ];
     }
 
-    private handleAdd = (newValue: string) => {
-        this.setState({ values: [...this.state.values, newValue] });
+    private handleAdd = (newValues: string[]) => {
+        this.setState({ values: [...this.state.values, ...newValues] });
     }
     private handleRemove = (_removedValue: string, removedIndex: number) => {
         this.setState({ values: this.state.values.filter((_, i) => i !== removedIndex) });

--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -56,6 +56,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
             <TagInput
                 className={classes}
                 onChange={this.handleChange}
+                placeholder="Separate values with commas..."
                 tagProps={getTagProps}
                 values={values}
             />

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -55,7 +55,8 @@ export interface ITagInputProps extends IProps {
     onRemove?: (value: string, index: number) => void;
 
     /**
-     * HTML input placeholder text which will not appear if `values` contains any items.
+     * Input placeholder text which will not appear if `values` contains any items
+     * (consistent with default HTML input behavior).
      * Use `inputProps.placeholder` if you want the placeholder text to _always_ appear.
      *
      * If you define both `placeholder` and `inputProps.placeholder`, then the former will appear
@@ -66,7 +67,7 @@ export interface ITagInputProps extends IProps {
     /**
      * Separator pattern used to split input text into multiple values.
      * Explicit `false` value disables splitting (note that `onAdd` will still receive an array of length 1).
-     * @default  \/,\s*\/g
+     * @default ","
      */
     separator?: string | RegExp | false;
 
@@ -98,7 +99,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         inputProps: {},
-        separator: /,\s*/g,
+        separator: ",",
         tagProps: {},
     };
 

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -187,19 +187,17 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
     }
 
     /**
-     * Splits inputValue on separator prop and removes outer whitespace from each new value.
-     * Empty values are ignored.
+     * Splits inputValue on separator prop,
+     * trims whitespace from each new value,
+     * and ignores empty values.
      */
     private getValues(inputValue: string) {
         const { separator } = this.props;
-        const newValue = inputValue.trim();
-        if (separator === false) {
-            return [newValue];
-        } else {
-            // NOTE: split() typings define two overrides for string and RegExp which doesn't play
-            // well with union prop type, so we'll just cast to one of the valid types.
-            return newValue.split(separator as RegExp).filter((val) => val.length > 0);
-        }
+        // NOTE: split() typings define two overrides for string and RegExp.
+        // this does not play well with our union prop type, so we'll just declare it as a valid type.
+        return (separator === false ? [inputValue] : inputValue.split(separator as string))
+                .map((val) => val.trim())
+                .filter((val) => val.length > 0);
 
     }
 
@@ -234,6 +232,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
             // enter key on non-empty string invokes onAdd
             const newValues = this.getValues(value);
             let shouldClearInput = Utils.safeInvoke(this.props.onAdd, newValues);
+            // avoid a potentially expensive computation if this prop is omitted
             if (Utils.isFunction(this.props.onChange)) {
                 shouldClearInput = shouldClearInput || this.props.onChange([...this.props.values, ...newValues]);
             }
@@ -274,7 +273,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
         }
     }
 
-    /** Invokes `onAdd` and `onChange` accordingly to remove the item at the given index. */
+    /** Remove the item at the given index by invoking `onRemove` and `onChange` accordingly. */
     private removeIndexFromValues(index: number) {
         const { onChange, onRemove, values } = this.props;
         Utils.safeInvoke(onRemove, values[index], index);

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -55,6 +55,15 @@ export interface ITagInputProps extends IProps {
     onRemove?: (value: string, index: number) => void;
 
     /**
+     * HTML input placeholder text which will not appear if `values` contains any items.
+     * Use `inputProps.placeholder` if you want the placeholder text to _always_ appear.
+     *
+     * If you define both `placeholder` and `inputProps.placeholder`, then the former will appear
+     * when `values` is empty and the latter at all other times.
+     */
+    placeholder?: string;
+
+    /**
      * Separator pattern used to split input text into multiple values.
      * Explicit `false` value disables splitting (note that `onAdd` will still receive an array of length 1).
      * @default  \/,\s*\/g
@@ -112,11 +121,15 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
     };
 
     public render() {
-        const { className, inputProps, values } = this.props;
+        const { className, inputProps, placeholder, values } = this.props;
 
         const classes = classNames(CoreClasses.INPUT, Classes.TAG_INPUT, {
             [CoreClasses.ACTIVE]: this.state.isInputFocused,
         }, className);
+
+        const resolvedPlaceholder = placeholder == null || values.length > 0
+            ? inputProps.placeholder
+            : placeholder;
 
         return (
             <div
@@ -131,6 +144,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                     onFocus={this.handleInputFocus}
                     onChange={this.handleInputChange}
                     onKeyDown={this.handleInputKeyDown}
+                    placeholder={resolvedPlaceholder}
                     ref={this.refHandlers.input}
                     className={classNames(Classes.INPUT_GHOST, inputProps.className)}
                 />

--- a/packages/labs/src/labs.md
+++ b/packages/labs/src/labs.md
@@ -136,16 +136,15 @@ This interface is generic, accepting a type parameter `<T>` for an item in the l
 
 `TagInput` renders [`Tag`](#core/components/tag)s inside an input, followed by an actual text input. The container is merely styled to look like a Blueprint input; the actual editable element appears after the last tag. Clicking anywhere on the container will focus the text input for seamless interaction.
 
-
 @reactExample TagInputExample
 
-`TagInput` must be controlled, meaning the `values` prop is required and event handlers are strongly suggested. The component controls the text input internally to support the `onAdd` event, but you can wrest control by supplying your own `inputProps`.
+**`TagInput` must be controlled,** meaning the `values` prop is required and event handlers are strongly suggested. Typing in the input and pressing <kbd class="pt-key">enter</kbd> will **add new items** by invoking callbacks. A `separator` prop is supported to allow multiple items to be added at once; the default splits on commas.
 
-`Tag` appearance can be customized with `tagProps`: supply an object to apply the same props to every tag, or supply a callback to apply dynamic props per tag. Tag `values` must be an array of strings so you may need a transformation step between your state and these props.
+**Tags can be removed** by clicking their <span class="pt-icon-standard pt-icon-cross"></span> buttons, or by pressing <kbd class="pt-key">backspace</kbd> repeatedly. Arrow keys can also be used to focus on a particular tag before removing it. The cursor must be at the beginning of the text input for these interactions.
 
-Tags can be removed by clicking their X buttons, or by pressing <kbd class="pt-key">backspace</kbd> repeatedly.
-Arrow keys can also be used to focus on a particular tag before removing it. The cursor must be at the beginning
-of the text input for these interactions.
+**`Tag` appearance can be customized** with `tagProps`: supply an object to apply the same props to every tag, or supply a callback to apply dynamic props per tag. Tag `values` must be an array of strings so you may need a transformation step between your state and these props.
+
+`TagInput` provides granular `onAdd` and `onRemove` **event props**, which are passed the added or removed items in response to the user interactions above. It also provides `onChange`, which combines both events and is passed the updated `values` array, with new items appended to the end and removed items filtered away. Supply `inputProps` to customize the `<input>` element or add your own event handlers.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
     <h5>Handling long words</h5>

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -98,23 +98,22 @@ describe("<TagInput>", () => {
             const onAdd = sinon.stub();
             // this is actually the defaultProps value, but reproducing here for explicitness
             const wrapper = mountTagInput(onAdd, { separator: /,\s*/g });
-            // extra spaces to exercise `\s*` in regexp
-            pressEnterInInput(wrapper, [NEW_VALUE, NEW_VALUE, NEW_VALUE].join(",   "));
+            // various forms of whitespace properly ignored
+            pressEnterInInput(wrapper, [NEW_VALUE, NEW_VALUE, "    ", NEW_VALUE].join(",   "));
             assert.deepEqual(onAdd.args[0][0], [NEW_VALUE, NEW_VALUE, NEW_VALUE]);
         });
 
         it("splits input value on separator string", () => {
             const onAdd = sinon.stub();
             const wrapper = mountTagInput(onAdd, { separator: "  |  " });
-            pressEnterInInput(wrapper, "1 |  2  |   3   |    4    |");
-            assert.deepEqual(onAdd.args[0][0], ["1 |  2", " 3 ", "  4    |"]);
+            pressEnterInInput(wrapper, "1 |  2  |   3   |    4    |  \t  |   ");
+            assert.deepEqual(onAdd.args[0][0], ["1 |  2", "3", "4"]);
         });
 
         it("separator=false emits one-element values array", () => {
             const value = "one, two, three";
             const onAdd = sinon.stub();
             const wrapper = mountTagInput(onAdd, { separator: false });
-            // extra spaces to exercise `\s*` in regexp
             pressEnterInInput(wrapper, value);
             assert.deepEqual(onAdd.args[0][0], [value]);
         });

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -10,7 +10,7 @@ import { mount, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 
 import { Intent, Keys, Tag } from "@blueprintjs/core";
-import { TagInput } from "../src/index";
+import { ITagInputProps, TagInput } from "../src/index";
 
 describe("<TagInput>", () => {
     const VALUES = ["one", "two", "three"];
@@ -67,7 +67,7 @@ describe("<TagInput>", () => {
             const wrapper = mountTagInput(onAdd);
             pressEnterInInput(wrapper, NEW_VALUE);
             assert.isTrue(onAdd.calledOnce);
-            assert.strictEqual(onAdd.args[0][0], NEW_VALUE);
+            assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
         });
 
         it("does not clear the input if onAdd returns false", () => {
@@ -94,8 +94,33 @@ describe("<TagInput>", () => {
             assert.strictEqual(wrapper.state().inputValue, "");
         });
 
-        function mountTagInput(onAdd: Sinon.SinonStub) {
-            return shallow(<TagInput onAdd={onAdd} values={VALUES} />);
+        it("splits input value on separator RegExp", () => {
+            const onAdd = sinon.stub();
+            // this is actually the defaultProps value, but reproducing here for explicitness
+            const wrapper = mountTagInput(onAdd, { separator: /,\s*/g });
+            // extra spaces to exercise `\s*` in regexp
+            pressEnterInInput(wrapper, [NEW_VALUE, NEW_VALUE, NEW_VALUE].join(",   "));
+            assert.deepEqual(onAdd.args[0][0], [NEW_VALUE, NEW_VALUE, NEW_VALUE]);
+        });
+
+        it("splits input value on separator string", () => {
+            const onAdd = sinon.stub();
+            const wrapper = mountTagInput(onAdd, { separator: "  |  " });
+            pressEnterInInput(wrapper, "1 |  2  |   3   |    4    |");
+            assert.deepEqual(onAdd.args[0][0], ["1 |  2", " 3 ", "  4    |"]);
+        });
+
+        it("separator=false emits one-element values array", () => {
+            const value = "one, two, three";
+            const onAdd = sinon.stub();
+            const wrapper = mountTagInput(onAdd, { separator: false });
+            // extra spaces to exercise `\s*` in regexp
+            pressEnterInInput(wrapper, value);
+            assert.deepEqual(onAdd.args[0][0], [value]);
+        });
+
+        function mountTagInput(onAdd: Sinon.SinonStub, props?: Partial<ITagInputProps>) {
+            return shallow(<TagInput onAdd={onAdd} values={VALUES} {...props} />);
         }
 
         function pressEnterInInput(wrapper: ShallowWrapper<any, any>, value: string) {

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -239,6 +239,31 @@ describe("<TagInput>", () => {
         });
     });
 
+    describe("placeholder", () => {
+        it("appears only when values is empty", () => {
+            const wrapper = shallow(<TagInput placeholder="hold the door" values={[]} />);
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "hold the door");
+            wrapper.setProps({ values: VALUES });
+            assert.isUndefined(wrapper.find("input").prop("placeholder"));
+        });
+
+        it("inputProps.placeholder appears all the time", () => {
+            const wrapper = shallow(<TagInput inputProps={{ placeholder: "hold the door" }} values={[]} />);
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "hold the door");
+            wrapper.setProps({ values: VALUES });
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "hold the door");
+        });
+
+        it("setting both shows placeholder when empty and inputProps.placeholder otherwise", () => {
+            const wrapper = shallow(
+                <TagInput inputProps={{ placeholder: "inputProps" }} placeholder="props" values={[]} />,
+            );
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "props");
+            wrapper.setProps({ values: VALUES });
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "inputProps");
+        });
+    });
+
     describe("when input is not empty", () => {
         it("pressing backspace does not remove item", () => {
             const onRemove = sinon.spy();


### PR DESCRIPTION
#### Addresses #1412 

#### Changes proposed in this pull request:

- `separator` prop allows adding multiple entries at once 
- `onChange` prop combines `onAdd` and `onRemove` for easy controlling (and implements basic array manipulation logic)
- `placeholder` prop appears only when `values` is empty
  - use `inputProps.placeholder` if you want it to appear all the time
- 🔥 __API BREAK__: `onAdd` now receives `string[]` instead of single `string`
    ```diff
    - private handleAdd = (value: string) => this.setState([...this.state.values, value])
    + private handleAdd = (values: string[]) => this.setState([...this.state.values, ...values])
    ```

#### Reviewers should focus on:

- definitely review the individual commits here: one per added prop (tests included!)
- how awesome are these props?