### PR TITLE
[TagInput] values accepts any valid JSX

### DIFF
--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -28,7 +28,14 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         intent: false,
         large: false,
         minimal: false,
-        values: [<strong>Albert</strong>, undefined, undefined, ["Bar", <em key="thol">thol</em>, "omew"], "Casper"],
+        values: [
+            // supports single JSX elements
+            <strong>Albert</strong>,
+            // supports JSX "fragments" (don't forget `key` on elements in arrays!)
+            ["Bar", <em key="thol">thol</em>, "omew"],
+            // and supports simple strings
+            "Casper",
+        ],
     };
 
     private handleFillChange = handleBooleanChange((fill) => this.setState({ fill }));

--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -19,7 +19,7 @@ export interface ITagInputExampleState {
     intent?: boolean;
     large?: boolean;
     minimal?: boolean;
-    values?: string[];
+    values?: React.ReactNode[];
 }
 
 export class TagInputExample extends BaseExample<ITagInputExampleState> {
@@ -28,7 +28,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         intent: false,
         large: false,
         minimal: false,
-        values: ["Albert", "Bartholomew", "Casper"],
+        values: [<strong>Albert</strong>, undefined, undefined, ["Bar", <em key="thol">thol</em>, "omew"], "Casper"],
     };
 
     private handleFillChange = handleBooleanChange((fill) => this.setState({ fill }));

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -45,8 +45,17 @@ export interface ITagInputProps extends IProps {
      *
      * This callback essentially implements basic `onAdd` and `onRemove` functionality and merges
      * the two handlers into one to simplify controlled usage.
+     *
+     * **Note about typed usage:** Your handler can declare a subset type of `React.ReactNode[]`,
+     * such as `string[]` or `Array<string | JSX.Element>`, to match the type of your `values` array:
+     * ```tsx
+     * <TagInput
+     *     onChange={(values: string[]) => this.setState({ values })}
+     *     values={["apple", "banana", "cherry"]}
+     * />
+     * ```
      */
-    onChange?: (values: string[]) => boolean | void;
+    onChange?: (values: React.ReactNode[]) => boolean | void;
 
     /**
      * Callback invoked when the user clicks the X button on a tag.
@@ -78,10 +87,17 @@ export interface ITagInputProps extends IProps {
      * If you define `onRemove` here then you will have to implement your own tag removal
      * handling as `TagInput`'s own `onRemove` handler will never be invoked.
      */
-    tagProps?: ITagProps | ((value: string, index: number) => ITagProps);
+    tagProps?: ITagProps | ((value: React.ReactNode, index: number) => ITagProps);
 
-    /** Controlled tag values. */
-    values: string[];
+    /**
+     * Controlled tag values. Each value will be rendered inside a `Tag`, which can be customized
+     * using `tagProps`. Therefore, any valid React node can be used as a `TagInput` value.
+     *
+     * __Note about typed usage:__ If you know your `values` will always be of a certain `ReactNode`
+     * subtype, such as `string` or `ReactChild`, you can use that type on all your handlers
+     * to simplify type logic.
+     */
+    values: React.ReactNode[];
 }
 
 export interface ITagInputState {
@@ -153,7 +169,9 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
         );
     }
 
-    private renderTag = (tag: string, index: number) => {
+    private renderTag = (tag: React.ReactNode, index: number) => {
+        // ignore all falsy values
+        if (!tag) { return null; }
         const { tagProps } = this.props;
         const props = Utils.isFunction(tagProps) ? tagProps(tag, index) : tagProps;
         return (

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -31,6 +31,15 @@ describe("<TagInput>", () => {
         assert.lengthOf(wrapper.find(Tag), VALUES.length);
     });
 
+    it("values can be valid JSX nodes", () => {
+        const values = [<strong>Albert</strong>, ["Bar", <em key="thol">thol</em>, "omew"], "Casper", undefined];
+        const wrapper = mount(<TagInput values={values} />);
+        // undefined does not produce a tag
+        assert.lengthOf(wrapper.find(Tag), values.length - 1);
+        assert.lengthOf(wrapper.find("strong"), 1);
+        assert.lengthOf(wrapper.find("em"), 1);
+    });
+
     it("tagProps object is applied to each Tag", () => {
         const wrapper = mount(<TagInput tagProps={{ intent: Intent.PRIMARY }} values={VALUES} />);
         const intents = wrapper.find(Tag).map((tag) => tag.prop("intent"));


### PR DESCRIPTION
#### Addresses #1412 

#### Changes proposed in this pull request:

`values` array now accepts `React.ReactNode[]`, which is actually the same type as `children`! not using `children` for this makes the array nature explicit. One cool thing is you can now pass an array to do inline styling: `values: ["Barney", ["Bar", <em>thol</em>, "emew"], "Bertha"]`

had to widen the types of a few props to support this (but actually added only one line of actual code), so I added some notes to props docs about how you can declare your own simpler types on your handlers.

#### Reviewers should focus on:

- do we actually want this? the fact that i had to change no code and everything just works suggests, "why not!"
- `ReactNode` is basically the most permissive type out there.  Do we want to be a little more strict like `string | JSX.Element`?

#### Screenshot

![image](https://user-images.githubusercontent.com/464822/29052420-d958cb22-7b9e-11e7-9675-05e5c1fc9835.png)

