### PR TITLE
[TagInput] leftIconName + rightElement

### DIFF
--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -14,6 +14,8 @@ import { TagInput } from "../src";
 
 const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Intent.WARNING];
 
+const VALUES = ["Albert", "Bartholomew", "Casper"];
+
 export interface ITagInputExampleState {
     fill?: boolean;
     intent?: boolean;
@@ -28,7 +30,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         intent: false,
         large: false,
         minimal: false,
-        values: ["Albert", "Bartholomew", "Casper"],
+        values: VALUES,
     };
 
     private handleFillChange = handleBooleanChange((fill) => this.setState({ fill }));
@@ -47,7 +49,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         const clearButton = (
             <Button
                 className={classNames(Classes.MINIMAL, Classes.SMALL)}
-                iconName="cross"
+                iconName={values.length > 0 ? "cross" : "refresh"}
                 onClick={this.handleClear}
             />
         );
@@ -108,5 +110,5 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
 
     private handleChange = (values: string[]) => this.setState({ values });
 
-    private handleClear = () => this.handleChange([]);
+    private handleClear = () => this.handleChange(this.state.values.length > 0 ? [] : VALUES);
 }

--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -55,6 +55,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         return (
             <TagInput
                 className={classes}
+                leftIconName="user"
                 onChange={this.handleChange}
                 placeholder="Separate values with commas..."
                 tagProps={getTagProps}

--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -8,7 +8,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Intent, ITagProps, Switch } from "@blueprintjs/core";
+import { Button, Classes, Intent, ITagProps, Switch } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange } from "@blueprintjs/docs";
 import { TagInput } from "../src";
 
@@ -44,6 +44,14 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
             [Classes.LARGE]: large,
         });
 
+        const clearButton = (
+            <Button
+                className={classNames(Classes.MINIMAL, Classes.SMALL)}
+                iconName="cross"
+                onClick={this.handleClear}
+            />
+        );
+
         // define a new function every time so switch changes will cause it to re-render
         // NOTE: avoid this pattern in your app (use this.getTagProps instead); this is only for
         // example purposes!!
@@ -55,6 +63,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         return (
             <TagInput
                 className={classes}
+                rightElement={clearButton}
                 leftIconName="user"
                 onChange={this.handleChange}
                 placeholder="Separate values with commas..."
@@ -98,4 +107,6 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
     }
 
     private handleChange = (values: string[]) => this.setState({ values });
+
+    private handleClear = () => this.handleChange([]);
 }

--- a/packages/labs/src/common/classes.ts
+++ b/packages/labs/src/common/classes.ts
@@ -13,3 +13,4 @@ export const OMNIBOX_OVERLAY = `${OMNIBOX}-overlay`;
 export const SELECT = "pt-select";
 export const SELECT_POPOVER = `${SELECT}-popover`;
 export const TAG_INPUT = "pt-tag-input";
+export const TAG_INPUT_ICON = `${TAG_INPUT}-icon`;

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -10,7 +10,7 @@
 @import "~@blueprintjs/core/src/components/tag/common";
 
 $ti-padding: ($pt-input-height - $tag-height) / 2;
-$ti-right-padding: ($pt-input-height - $pt-button-height-small) / 2;
+$ti-padding-right: ($pt-input-height - $pt-button-height-small) / 2;
 
 $ti-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
 $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
@@ -21,7 +21,7 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
   align-items: center;
   cursor: text;
   height: auto;
-  padding: $ti-padding $ti-right-padding 0 0;
+  padding: $ti-padding $ti-padding-right 0 0;
 
   .pt-tag-input-icon {
     // stylelint-disable-next-line max-line-length

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -43,6 +43,11 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard)
     width: $pt-grid-size * 10;
     padding: 0 ($input-padding-horizontal - $tag-input-padding);
     line-height: $tag-height;
+
+    ~ * {
+      // shift right element up (to ignore top padding) so flex box will center it correctly
+      margin-top: -$tag-input-padding;
+    }
   }
 
   &.pt-large {

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -11,22 +11,28 @@
 
 $tag-input-padding: ($pt-input-height - $tag-height) / 2;
 
+$tag-input-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
+$tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
+
 .pt-tag-input {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   cursor: text;
   height: auto;
-  padding: $tag-input-padding 0 0 $tag-input-padding;
+  padding: $tag-input-padding $tag-input-padding 0 0;
+
+  .pt-tag-input-icon {
+    // stylelint-disable-next-line max-line-length
+    margin: 0 ($tag-input-icon-padding - $tag-input-padding) $tag-input-padding $tag-input-icon-padding;
+    color: $pt-icon-color;
+  }
 
   .pt-tag {
-    margin: 0 0 $tag-input-padding 0;
+    margin: 0 0 $tag-input-padding $tag-input-padding;
     // NOTE: in order to wrap long words, you must set explicit width on TagInput,
     // or use .pt-fill CSS class modifier.
     overflow-wrap: break-word;
-
-    &:not(:last-of-type) {
-      margin-right: $tag-input-padding;
-    }
   }
 
   .pt-input-ghost {
@@ -42,6 +48,11 @@ $tag-input-padding: ($pt-input-height - $tag-height) / 2;
   &.pt-large {
     height: auto;
 
+    .pt-tag-input-icon {
+      // stylelint-disable-next-line max-line-length
+      margin: 0 ($tag-input-icon-padding-large - $tag-input-padding) $tag-input-padding $tag-input-icon-padding-large;
+    }
+
     .pt-input-ghost {
       line-height: $tag-height-large;
     }
@@ -54,6 +65,10 @@ $tag-input-padding: ($pt-input-height - $tag-height) / 2;
 
   .pt-dark &,
   &.pt-dark {
+    .pt-tag-input-icon {
+      color: $pt-dark-icon-color;
+    }
+
     .pt-input-ghost {
       color: $dark-input-color;
     }

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -9,10 +9,11 @@
 @import "~@blueprintjs/core/src/components/forms/common";
 @import "~@blueprintjs/core/src/components/tag/common";
 
-$tag-input-padding: ($pt-input-height - $tag-height) / 2;
+$ti-padding: ($pt-input-height - $tag-height) / 2;
+$ti-right-padding: ($pt-input-height - $pt-button-height-small) / 2;
 
-$tag-input-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
-$tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
+$ti-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
+$ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
 
 .pt-tag-input {
   display: flex;
@@ -20,16 +21,16 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard)
   align-items: center;
   cursor: text;
   height: auto;
-  padding: $tag-input-padding $tag-input-padding 0 0;
+  padding: $ti-padding $ti-right-padding 0 0;
 
   .pt-tag-input-icon {
     // stylelint-disable-next-line max-line-length
-    margin: 0 ($tag-input-icon-padding - $tag-input-padding) $tag-input-padding $tag-input-icon-padding;
+    margin: 0 ($ti-icon-padding - $ti-padding) $ti-padding $ti-icon-padding;
     color: $pt-icon-color;
   }
 
   .pt-tag {
-    margin: 0 0 $tag-input-padding $tag-input-padding;
+    margin: 0 0 $ti-padding $ti-padding;
     // NOTE: in order to wrap long words, you must set explicit width on TagInput,
     // or use .pt-fill CSS class modifier.
     overflow-wrap: break-word;
@@ -38,15 +39,15 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard)
   .pt-input-ghost {
     // input fills remaining line
     flex: 1 1 auto;
-    margin-bottom: $tag-input-padding;
+    margin-bottom: $ti-padding;
     // essentially a min-width, cuz flex allows it to grow or shrink:
     width: $pt-grid-size * 10;
-    padding: 0 ($input-padding-horizontal - $tag-input-padding);
+    padding: 0 ($input-padding-horizontal - $ti-padding);
     line-height: $tag-height;
 
     ~ * {
       // shift right element up (to ignore top padding) so flex box will center it correctly
-      margin-top: -$tag-input-padding;
+      margin-top: -$ti-padding;
     }
   }
 
@@ -55,7 +56,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard)
 
     .pt-tag-input-icon {
       // stylelint-disable-next-line max-line-length
-      margin: 0 ($tag-input-icon-padding-large - $tag-input-padding) $tag-input-padding $tag-input-icon-padding-large;
+      margin: 0 ($ti-icon-padding-large - $ti-padding) $ti-padding $ti-icon-padding-large;
     }
 
     .pt-input-ghost {

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -171,7 +171,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
         }
         const iconClass = classNames(
             Classes.TAG_INPUT_ICON,
-            useLarge ? CoreClasses.ICON_LARGE : CoreClasses.ICON_STANDARD ,
+            useLarge ? CoreClasses.ICON_LARGE : CoreClasses.ICON_STANDARD,
             CoreClasses.iconClass(leftIconName),
         );
         return <span className={iconClass} />;

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -68,6 +68,12 @@ export interface ITagInputProps extends IProps {
     placeholder?: string;
 
     /**
+     * Element to render on right side of input.
+     * For best results, use a small minimal button, tag, or spinner.
+     */
+    rightElement?: JSX.Element;
+
+    /**
      * Separator pattern used to split input text into multiple values.
      * Explicit `false` value disables splitting (note that `onAdd` will still receive an array of length 1).
      * @default ","
@@ -153,6 +159,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                     ref={this.refHandlers.input}
                     className={classNames(Classes.INPUT_GHOST, inputProps.className)}
                 />
+                {this.props.rightElement}
             </div>
         );
     }

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -25,6 +25,9 @@ export interface ITagInputProps extends IProps {
     /** React props to pass to the `<input>` element */
     inputProps?: HTMLInputProps;
 
+    /** Name of the icon (the part after `pt-icon-`) to render on left side of input. */
+    leftIconName?: string;
+
     /**
      * Callback invoked when new tags are added by the user pressing `enter` on the input.
      * Receives the current value of the input field split by `separator` into an array.
@@ -138,6 +141,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                 onBlur={this.handleBlur}
                 onClick={this.handleContainerClick}
             >
+                {this.maybeRenderLeftIcon(classes.indexOf(CoreClasses.LARGE) > NONE)}
                 {values.map(this.renderTag)}
                 <input
                     value={this.state.inputValue}
@@ -151,6 +155,19 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                 />
             </div>
         );
+    }
+
+    private maybeRenderLeftIcon(useLarge: boolean) {
+        const { leftIconName } = this.props;
+        if (leftIconName == null) {
+            return undefined;
+        }
+        const iconClass = classNames(
+            Classes.TAG_INPUT_ICON,
+            useLarge ? CoreClasses.ICON_LARGE : CoreClasses.ICON_STANDARD ,
+            CoreClasses.iconClass(leftIconName),
+        );
+        return <span className={iconClass} />;
     }
 
     private renderTag = (tag: string, index: number) => {

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { mount, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 
-import { Classes, Intent, Keys, Tag } from "@blueprintjs/core";
+import { Button, Classes, Intent, Keys, Tag } from "@blueprintjs/core";
 import { ITagInputProps, TagInput } from "../src/index";
 
 describe("<TagInput>", () => {
@@ -36,6 +36,11 @@ describe("<TagInput>", () => {
         assert.isTrue(wrapper.childAt(0).hasClass(Classes.ICON_STANDARD), "standard icon");
         wrapper.setProps({ className: Classes.LARGE });
         assert.isTrue(wrapper.childAt(0).hasClass(Classes.ICON_LARGE), "large icon");
+    });
+
+    it("rightElement appears as last child", () => {
+        const wrapper = mount(<TagInput rightElement={<Button />} values={VALUES} />);
+        assert.isTrue(wrapper.children().last().is(Button));
     });
 
     it("tagProps object is applied to each Tag", () => {

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { mount, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 
-import { Intent, Keys, Tag } from "@blueprintjs/core";
+import { Classes, Intent, Keys, Tag } from "@blueprintjs/core";
 import { ITagInputProps, TagInput } from "../src/index";
 
 describe("<TagInput>", () => {
@@ -29,6 +29,13 @@ describe("<TagInput>", () => {
     it("renders a Tag for each value", () => {
         const wrapper = mount(<TagInput values={VALUES} />);
         assert.lengthOf(wrapper.find(Tag), VALUES.length);
+    });
+
+    it("leftIconName renders an icon as first child", () => {
+        const wrapper = mount(<TagInput leftIconName="add" values={VALUES} />);
+        assert.isTrue(wrapper.childAt(0).hasClass(Classes.ICON_STANDARD), "standard icon");
+        wrapper.setProps({ className: Classes.LARGE });
+        assert.isTrue(wrapper.childAt(0).hasClass(Classes.ICON_LARGE), "large icon");
     });
 
     it("tagProps object is applied to each Tag", () => {

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -32,10 +32,9 @@ describe("<TagInput>", () => {
     });
 
     it("values can be valid JSX nodes", () => {
-        const values = [<strong>Albert</strong>, ["Bar", <em key="thol">thol</em>, "omew"], "Casper", undefined];
+        const values = [<strong>Albert</strong>, ["Bar", <em key="thol">thol</em>, "omew"], "Casper"];
         const wrapper = mount(<TagInput values={values} />);
-        // undefined does not produce a tag
-        assert.lengthOf(wrapper.find(Tag), values.length - 1);
+        assert.lengthOf(wrapper.find(Tag), values.length);
         assert.lengthOf(wrapper.find("strong"), 1);
         assert.lengthOf(wrapper.find("em"), 1);
     });


### PR DESCRIPTION
#### Addresses #1412 

#### Changes proposed in this pull request:

- `leftIconName` renders an icon as first child
- `rightElement` appears as last child
- just like `InputGroup`

<img width="414" alt="screen shot 2017-08-07 at 8 47 27 pm" src="https://user-images.githubusercontent.com/464822/29055488-a910684a-7bb1-11e7-8d00-d4fc1f75d116.png">
