### PR TITLE
remove small font-size from small buttons

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -423,5 +423,4 @@ $button-intents: (
 @mixin pt-button-small() {
   @include pt-button-height($pt-button-height-small);
   padding: $button-padding-small;
-  font-size: $pt-font-size-small;
 }


### PR DESCRIPTION
#### Fixes issue described in https://github.com/palantir/blueprint/pull/1391#issuecomment-318222513

#### Changes proposed in this pull request:

- this small change fixes icon centering in small buttons
- there is also precedent for this in `InputGroup` which defines its own [small button styles](https://github.com/palantir/blueprint/blob/master/packages/core/src/components/forms/_input-group.scss#L76-L81) (before the button modifier existed) and does _not set_ `font-size` and no one complained.