### PR TITLE
[DateRangeInput] Speed up the DRI tests

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -244,9 +244,14 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
 
     public constructor(props: IDateRangeInputProps, context?: any) {
         super(props, context);
+        this.reset(props);
+    }
 
+    /**
+     * Public method intended for unit testing only. Do not use in feature work!
+     */
+    public reset(props: IDateRangeInputProps = this.props) {
         const [selectedStart, selectedEnd] = this.getInitialRange();
-
         this.state = {
             formattedMaxDateString: this.getFormattedMinMaxDateString(props, "maxDate"),
             formattedMinDateString: this.getFormattedMinMaxDateString(props, "minDate"),

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -771,13 +771,12 @@ describe("<DateRangeInput>", () => {
             let getDayElement: (dayNumber?: number, fromLeftMonth?: boolean) => WrappedComponentDayElement;
             let dayElement: WrappedComponentDayElement;
 
-            const DEFAULT_RANGE: DateRange = [HOVER_TEST_DATE_2, HOVER_TEST_DATE_4];
-
             before(() => {
                 const result = wrap(<DateRangeInput
                     closeOnSelection={false}
-                    defaultValue={DEFAULT_RANGE}
+                    defaultValue={[HOVER_TEST_DATE_2, HOVER_TEST_DATE_4]}
                 />);
+
                 root = result.root;
                 rootInstance = root.instance() as DateRangeInput;
                 getDayElement = result.getDayElement;

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -765,28 +765,37 @@ describe("<DateRangeInput>", () => {
             }
 
             let root: WrappedComponentRoot;
+            let rootInstance: DateRangeInput;
             let startInput: WrappedComponentInput;
             let endInput: WrappedComponentInput;
             let getDayElement: (dayNumber?: number, fromLeftMonth?: boolean) => WrappedComponentDayElement;
             let dayElement: WrappedComponentDayElement;
 
-            beforeEach(() => {
+            const DEFAULT_RANGE: DateRange = [HOVER_TEST_DATE_2, HOVER_TEST_DATE_4];
+
+            before(() => {
                 const result = wrap(<DateRangeInput
                     closeOnSelection={false}
-                    defaultValue={[HOVER_TEST_DATE_2, HOVER_TEST_DATE_4]}
+                    defaultValue={DEFAULT_RANGE}
                 />);
-
                 root = result.root;
+                rootInstance = root.instance() as DateRangeInput;
                 getDayElement = result.getDayElement;
                 startInput = getStartInput(root);
                 endInput = getEndInput(root);
+            });
 
+            beforeEach(() => {
                 // clear the inputs to start from a fresh state, but do so
                 // *after* opening the popover so that the calendar doesn't
                 // move away from the view we expect for these tests.
                 root.setState({ isOpen: true });
                 changeInputText(startInput, "");
                 changeInputText(endInput, "");
+            });
+
+            afterEach(() => {
+                rootInstance.reset();
             });
 
             function setSelectedRangeForHoverTest(selectedDateConfigs: IHoverTextDateConfig[]) {


### PR DESCRIPTION
#### Fixes #1423 

#### Changes proposed in this pull request:

Use a single component instance for all DRI hover tests. This ultimately shaves `20 seconds` off the time for the DRI tests, a nearly `30%` reduction.

_Before:_
`1 min 9.075 secs`

_After_:
`49.435 secs`

#### Reviewers should focus on:

Is the new, public `DRI.reset()` method okay to have?