### PR TITLE
[TagInput] ignore falsy values

### DIFF
--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -58,7 +58,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         const clearButton = (
             <Button
                 className={classNames(Classes.MINIMAL, Classes.SMALL)}
-                iconName={values.length > 0 ? "cross" : "refresh"}
+                iconName={values.length > 1 ? "cross" : "refresh"}
                 onClick={this.handleClear}
             />
         );

--- a/packages/labs/examples/tagInputExample.tsx
+++ b/packages/labs/examples/tagInputExample.tsx
@@ -21,6 +21,8 @@ const VALUES = [
     ["Bar", <em key="thol">thol</em>, "omew"],
     // and supports simple strings
     "Casper",
+    // falsy values are not rendered and ignored by the keyboard
+    undefined,
 ];
 
 export interface ITagInputExampleState {

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -157,9 +157,10 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
         }, className);
         const isLarge = classes.indexOf(CoreClasses.LARGE) > NONE;
 
-        // use placeholder prop if defined and values list is empty or entirely falsy values
-        const resolvedPlaceholder = (placeholder != null && values.every((val) => !val))
-            ? placeholder : inputProps.placeholder;
+        // use placeholder prop only if it's defined and values list is empty or contains only falsy values
+        const isSomeValueDefined = values.some((val) => !!val);
+        const resolvedPlaceholder = (placeholder == null || isSomeValueDefined)
+            ? inputProps.placeholder : placeholder;
 
         return (
             <div

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -102,7 +102,8 @@ export interface ITagInputProps extends IProps {
 
     /**
      * Controlled tag values. Each value will be rendered inside a `Tag`, which can be customized
-     * using `tagProps`. Therefore, any valid React node can be used as a `TagInput` value.
+     * using `tagProps`. Therefore, any valid React node can be used as a `TagInput` value; falsy
+     * values will not be rendered.
      *
      * __Note about typed usage:__ If you know your `values` will always be of a certain `ReactNode`
      * subtype, such as `string` or `ReactChild`, you can use that type on all your handlers
@@ -171,7 +172,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                     iconName={leftIconName}
                     iconSize={isLarge ? 20 : 16}
                 />
-                {values.map(this.renderTag)}
+                {values.map(this.maybeRenderTag)}
                 <input
                     value={this.state.inputValue}
                     {...inputProps}
@@ -187,7 +188,8 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
         );
     }
 
-    private renderTag = (tag: React.ReactNode, index: number) => {
+    private maybeRenderTag = (tag: React.ReactNode, index: number) => {
+        if (!tag) { return null; }
         const { tagProps } = this.props;
         const props = Utils.isFunction(tagProps) ? tagProps(tag, index) : tagProps;
         return (
@@ -205,20 +207,24 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
 
     private getNextActiveIndex(direction: number) {
         const { activeIndex } = this.state;
-        const totalItems = this.props.values.length;
-
-        if (activeIndex === NONE && direction < 0) {
-            // nothing active, moving left: select last
-            return totalItems - 1;
-        } else if (activeIndex === NONE && direction > 0) {
-            // nothing active, moving right: do nothing
-            return NONE;
+        if (activeIndex === NONE) {
+            // nothing active & moving left: select last defined value. otherwise select nothing.
+            return direction < 0 ? this.findNextIndex(this.props.values.length, -1) : NONE;
         } else {
             // otherwise, move in direction and clamp to bounds.
             // note that upper bound allows going one beyond last item
             // so focus can move off the right end, into the text input.
-            return Utils.clamp(activeIndex + direction, 0, totalItems);
+            return this.findNextIndex(activeIndex, direction);
         }
+    }
+
+    private findNextIndex(startIndex: number, direction: number) {
+        const { values } = this.props;
+        let index = startIndex + direction;
+        while (index > 0 && index < values.length && !values[index]) {
+            index += direction;
+        }
+        return Utils.clamp(index, 0, values.length);
     }
 
     /**
@@ -264,12 +270,13 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
     private handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         const { selectionEnd, value } = event.currentTarget;
         if (event.which === Keys.ENTER && value.length > 0) {
+            const { onAdd, onChange, values } = this.props;
             // enter key on non-empty string invokes onAdd
             const newValues = this.getValues(value);
-            let shouldClearInput = Utils.safeInvoke(this.props.onAdd, newValues);
+            let shouldClearInput = Utils.safeInvoke(onAdd, newValues);
             // avoid a potentially expensive computation if this prop is omitted
-            if (Utils.isFunction(this.props.onChange)) {
-                shouldClearInput = shouldClearInput || this.props.onChange([...this.props.values, ...newValues]);
+            if (Utils.isFunction(onChange)) {
+                shouldClearInput = shouldClearInput || onChange([...values, ...newValues]);
             }
             // only explicit return false cancels text clearing
             if (shouldClearInput !== false) {

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -157,9 +157,9 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
         }, className);
         const isLarge = classes.indexOf(CoreClasses.LARGE) > NONE;
 
-        const resolvedPlaceholder = placeholder == null || values.length > 0
-            ? inputProps.placeholder
-            : placeholder;
+        // use placeholder prop if defined and values list is empty or entirely falsy values
+        const resolvedPlaceholder = (placeholder != null && values.every((val) => !val))
+            ? placeholder : inputProps.placeholder;
 
         return (
             <div

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -262,9 +262,11 @@ describe("<TagInput>", () => {
     describe("placeholder", () => {
         it("appears only when values is empty", () => {
             const wrapper = shallow(<TagInput placeholder="hold the door" values={[]} />);
-            assert.strictEqual(wrapper.find("input").prop("placeholder"), "hold the door");
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "hold the door", "empty array");
+            wrapper.setProps({ values: [undefined] });
+            assert.strictEqual(wrapper.find("input").prop("placeholder"), "hold the door", "[undefined]");
             wrapper.setProps({ values: VALUES });
-            assert.isUndefined(wrapper.find("input").prop("placeholder"));
+            assert.isUndefined(wrapper.find("input").prop("placeholder"), "normal values");
         });
 
         it("inputProps.placeholder appears all the time", () => {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1329,6 +1329,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     // no good way to call arrow-key keyboard events from tests
+    /* istanbul ignore next */
     private handleFocusMove = (e: KeyboardEvent, direction: "up" | "down" | "left" | "right") => {
         e.preventDefault();
         e.stopPropagation();
@@ -1374,6 +1375,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.scrollBodyToFocusedCell(newFocusedCell);
     }
 
+    // no good way to call arrow-key keyboard events from tests
+    /* istanbul ignore next */
     private handleFocusMoveInternal = (e: KeyboardEvent, direction: "up" | "down" | "left" | "right") => {
         e.preventDefault();
         e.stopPropagation();

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1329,7 +1329,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     // no good way to call arrow-key keyboard events from tests
-    /* istanbul ignore next */
     private handleFocusMove = (e: KeyboardEvent, direction: "up" | "down" | "left" | "right") => {
         e.preventDefault();
         e.stopPropagation();
@@ -1375,8 +1374,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.scrollBodyToFocusedCell(newFocusedCell);
     }
 
-    // no good way to call arrow-key keyboard events from tests
-    /* istanbul ignore next */
     private handleFocusMoveInternal = (e: KeyboardEvent, direction: "up" | "down" | "left" | "right") => {
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
#### Addresses #1412 

#### Changes proposed in this pull request:

- previously, falsy `values` would render as empty tags. it was weird, it was bad.
- now, they don't appear at all, and are excluded from keyboard nav.
- falsy values are preserved in the `onChange` array, they're just ignored by interactions.
  - i toyed with filtering them out on change, but it felt too intrusive.
