### PR TITLE
[Table] Frozen Rows/Cols - Part 8: Fix tests

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -460,6 +460,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         } = nextProps;
 
         const newChildArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
+        const numCols = newChildArray.length;
 
         // Try to maintain widths of columns by looking up the width of the
         // column that had the same `ID` prop. If none is found, use the
@@ -473,15 +474,13 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         // as many existing widths/heights when possible. Also, apply the
         // sparse width/heights from props.
         let newColumnWidths = this.state.columnWidths;
-        newColumnWidths = Utils.arrayOfLength(newColumnWidths, newChildArray.length, defaultColumnWidth);
+        newColumnWidths = Utils.arrayOfLength(newColumnWidths, numCols, defaultColumnWidth);
         newColumnWidths = Utils.assignSparseValues(newColumnWidths, previousColumnWidths);
         newColumnWidths = Utils.assignSparseValues(newColumnWidths, columnWidths);
 
         let newRowHeights = this.state.rowHeights;
         newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
-
-        const numCols = newColumnWidths.length;
 
         let newSelectedRegions = selectedRegions;
         if (selectedRegions == null) {

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -56,7 +56,6 @@ describe("Column", () => {
         expect(table.find(selector, 2).text()).to.equal("C"); // default
     });
 
-    // TODO: Why was this test expecting four cells per column in a table with 5 rows?
     it("renders correctly with loading options", () => {
         const NUM_ROWS = 5;
         const cellValue = "my cell value";

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -25,8 +25,7 @@ describe("Column", () => {
         harness.destroy();
     });
 
-    // TODO: FROZEN
-    it.skip("displays a table with columns", () => {
+    it("displays a table with columns", () => {
         const table = harness.mount(
             <Table numRows={5}>
                 <Column />
@@ -34,11 +33,11 @@ describe("Column", () => {
                 <Column />
             </Table>,
         );
-
-        expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 0).element).to.exist;
-        expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 1).element).to.exist;
-        expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 2).element).to.exist;
-        expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 3).element).to.not.exist;
+        const selector = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_NAME_TEXT}`;
+        expect(table.find(selector, 0).element).to.exist;
+        expect(table.find(selector, 1).element).to.exist;
+        expect(table.find(selector, 2).element).to.exist;
+        expect(table.find(selector, 3).element).to.not.exist;
     });
 
     it("passes column name to renderer or defaults if none specified", () => {
@@ -50,18 +49,20 @@ describe("Column", () => {
             </Table>,
         );
 
-        expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 0).text()).to.equal("Zero");
-        expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 1).text()).to.equal("One");
-        // TODO: re-enable once other PR merges
-        // expect(table.find(`.${Classes.TABLE_COLUMN_NAME_TEXT}`, 2).text()).to.equal("C");
+        const selector = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_NAME_TEXT}`;
+
+        expect(table.find(selector, 0).text()).to.equal("Zero"); // custom
+        expect(table.find(selector, 1).text()).to.equal("One"); // custom
+        expect(table.find(selector, 2).text()).to.equal("C"); // default
     });
 
-    // TODO: FROZEN
-    it.skip("renders correctly with loading options", () => {
+    // TODO: Why was this test expecting four cells per column in a table with 5 rows?
+    it("renders correctly with loading options", () => {
+        const NUM_ROWS = 5;
         const cellValue = "my cell value";
         const renderCell = () => <Cell>{cellValue}</Cell>;
         const table = harness.mount(
-            <Table numRows={5}>
+            <Table numRows={NUM_ROWS}>
                 <Column name="Zero" loadingOptions={[ ColumnLoadingOption.CELLS ]} renderCell={renderCell} />
                 <Column
                     name="One"
@@ -72,25 +73,30 @@ describe("Column", () => {
             </Table>,
         );
 
-        const columnHeaders = table.element.queryAll(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`);
+        const columnHeaders = table.element.queryAll(
+            `.${Classes.TABLE_QUADRANT_TOP} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`);
+
         expectCellLoading(columnHeaders[0], CellType.COLUMN_HEADER, false);
         expectCellLoading(columnHeaders[1], CellType.COLUMN_HEADER);
         expectCellLoading(columnHeaders[2], CellType.COLUMN_HEADER, false);
 
-        const col0CellsSelector = `.${Classes.columnCellIndexClass(0)}.${Classes.TABLE_CELL}`;
+        const col0CellsSelector =
+            `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.columnCellIndexClass(0)}.${Classes.TABLE_CELL}`;
         const col0cells = table.element.queryAll(col0CellsSelector);
         col0cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
-        expect(col0cells.length).to.equal(4);
+        expect(col0cells.length).to.equal(NUM_ROWS);
 
-        const col1CellsSelector = `.${Classes.columnCellIndexClass(1)}.${Classes.TABLE_CELL}`;
+        const col1CellsSelector =
+            `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.columnCellIndexClass(1)}.${Classes.TABLE_CELL}`;
         const col1cells = table.element.queryAll(col1CellsSelector);
         col1cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
-        expect(col1cells.length).to.equal(4);
+        expect(col1cells.length).to.equal(NUM_ROWS);
 
-        const col2CellsSelector = `.${Classes.columnCellIndexClass(2)}.${Classes.TABLE_CELL}`;
+        const col2CellsSelector =
+            `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.columnCellIndexClass(2)}.${Classes.TABLE_CELL}`;
         const col2cells = table.element.queryAll(col2CellsSelector);
         col2cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL, false));
-        expect(col2cells.length).to.equal(4);
+        expect(col2cells.length).to.equal(NUM_ROWS);
     });
 
     it("passes custom class name to renderer", () => {

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -51,8 +51,10 @@ describe("Formats", () => {
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.exist;
         });
 
-        // TODO: FROZEN
-        it.skip("can automatically truncate and show popover when truncated and word wrapped", () => {
+        // This test was super flaky. It started failing without clear cause when the Table Frozen
+        // Columns/Rows changes merged, even though nothing about the TruncatedFormat component
+        // changed. Adding the position: relative rule fixes it, but more investigation is needed.
+        it("can automatically truncate and show popover when truncated and word wrapped", () => {
             const str = `
                 We are going to die, and that makes us the lucky ones. Most
                 people are never going to die because they are never going to
@@ -69,7 +71,7 @@ describe("Formats", () => {
                 majority have never stirred?
             `;
 
-            const style = { height: "200px" };
+            const style = { height: "200px", position: "relative" };
 
             const comp = harness.mount(
                 <div className={Classes.TABLE_TRUNCATED_TEXT} style={style}>

--- a/packages/table/test/loadingOptionsTests.tsx
+++ b/packages/table/test/loadingOptionsTests.tsx
@@ -75,7 +75,7 @@ class TableLoadingOptionsTester extends React.Component<ITableLoadingOptionsTest
 }
 
 // TODO: FROZEN
-describe.skip("Loading Options", () => {
+describe("Loading Options", () => {
     const harness = new ReactHarness();
     const allTableLoadingOptions = generatePowerSet([
         TableLoadingOption.CELLS,
@@ -108,12 +108,13 @@ describe.skip("Loading Options", () => {
 
                 // only testing the first column of body cells because the second and third
                 // columns are meant to test column related loading combinations
+                const quadrantSelector = `.${Classes.TABLE_QUADRANT_MAIN}`;
                 const cells = tableHarness.element
-                    .queryAll(`.${Classes.TABLE_CELL}.${Classes.columnCellIndexClass(0)}`);
+                    .queryAll(`${quadrantSelector} .${Classes.TABLE_CELL}.${Classes.columnCellIndexClass(0)}`);
                 const columnHeaders = tableHarness.element
-                    .queryAll(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`);
+                    .queryAll(`${quadrantSelector} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`);
                 const rowHeaders = tableHarness.element
-                    .queryAll(`.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`);
+                    .queryAll(`${quadrantSelector} .${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`);
                 testLoadingOptionOverrides(
                     columnHeaders,
                     CellType.COLUMN_HEADER,

--- a/packages/table/test/loadingOptionsTests.tsx
+++ b/packages/table/test/loadingOptionsTests.tsx
@@ -74,7 +74,6 @@ class TableLoadingOptionsTester extends React.Component<ITableLoadingOptionsTest
     }
 }
 
-// TODO: FROZEN
 describe("Loading Options", () => {
     const harness = new ReactHarness();
     const allTableLoadingOptions = generatePowerSet([

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -16,9 +16,12 @@ import { createTableOfSize } from "./mocks/table";
 
 describe("Selection", () => {
     const harness = new ReactHarness();
-    const TH_SELECTOR = `.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
-    const ROW_TH_SELECTOR = `.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`;
-    const CELL_SELECTOR = `.${Classes.rowCellIndexClass(2)}.${Classes.columnCellIndexClass(0)}`;
+    const TH_SELECTOR =
+        `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
+    const ROW_TH_SELECTOR =
+        `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`;
+    const CELL_SELECTOR =
+        `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.rowCellIndexClass(2)}.${Classes.columnCellIndexClass(0)}`;
 
     afterEach(() => {
         harness.unmount();
@@ -74,7 +77,7 @@ describe("Selection", () => {
     });
 
     // TODO: FROZEN
-    it.skip("Row selection works when enabled", () => {
+    it("Row selection works when enabled", () => {
         const onSelection = sinon.spy();
         const selectionModes = [
             RegionCardinality.FULL_COLUMNS,

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -76,7 +76,6 @@ describe("Selection", () => {
         expect(onSelection.lastCall.args).to.deep.equal([[]]);
     });
 
-    // TODO: FROZEN
     it("Row selection works when enabled", () => {
         const onSelection = sinon.spy();
         const selectionModes = [

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -64,7 +64,6 @@ describe("<Table>", () => {
         expect(hasCustomClass).to.be.true;
     });
 
-    // TODO: FROZEN
     it("Renders without ghost cells", () => {
         const table = harness.mount(
             <Table>
@@ -150,7 +149,6 @@ describe("<Table>", () => {
         expect(table.state.rowHeights[0]).to.equal(MAX_HEIGHT);
     });
 
-    // TODO: FROZEN
     it("Invokes onVisibleCellsChange on mount", () => {
         const onVisibleCellsChange = sinon.spy();
         const renderCell = () => <Cell>foo</Cell>;
@@ -168,7 +166,6 @@ describe("<Table>", () => {
         expect(onVisibleCellsChange.lastCall.calledWith(rowIndices, columnIndices)).to.be.true;
     });
 
-    // TODO: FROZEN
     it("Invokes onVisibleCellsChange when the table body scrolls", () => {
         const onVisibleCellsChange = sinon.spy();
         const renderCell = () => <Cell>foo</Cell>;
@@ -184,7 +181,6 @@ describe("<Table>", () => {
         expect(onVisibleCellsChange.lastCall.calledWith(rowIndices, columnIndices)).to.be.true;
     });
 
-    // TODO: FROZEN
     describe("Full-table selection", () => {
         const onFocus = sinon.spy();
         const onSelection = sinon.spy();
@@ -711,7 +707,6 @@ describe("<Table>", () => {
             onSelection = sinon.spy();
         });
 
-        // TODO: FROZEN
         it("Shows preview guide and invokes callback when columns reordered", () => {
             const table = mountTable({
                 isColumnReorderable: true,
@@ -729,7 +724,6 @@ describe("<Table>", () => {
             expect(onColumnsReordered.calledWith(OLD_INDEX, NEW_INDEX, LENGTH)).to.be.true;
         });
 
-        // TODO: FROZEN
         it("Shows preview guide and invokes callback when rows reordered", () => {
             const table = mountTable({
                 isRowReorderable: true,
@@ -771,7 +765,6 @@ describe("<Table>", () => {
             expect(onColumnsReordered.called).to.be.false;
         });
 
-        // TODO: FROZEN
         it("Selecting a column via click and then reordering it works", () => {
             const table = mountTable({
                 isColumnReorderable: true,
@@ -795,7 +788,6 @@ describe("<Table>", () => {
             expect(onColumnsReordered.calledWith(OLD_INDEX, newIndex, length)).to.be.true;
         });
 
-        // TODO: FROZEN
         it("Selecting multiple columns via click+drag and then reordering works", () => {
             const table = mountTable({
                 isColumnReorderable: true,
@@ -817,7 +809,6 @@ describe("<Table>", () => {
             expect(onColumnsReordered.calledWith(OLD_INDEX, NEW_INDEX, LENGTH)).to.be.true;
         });
 
-        // TODO: FROZEN
         it("Moves uncontrolled selection with reordered column when reordering is complete", () => {
             const table = mountTable({
                 isColumnReorderable: true,
@@ -1205,7 +1196,6 @@ describe("<Table>", () => {
         }
     });
 
-    // TODO: FROZEN
     describe("Autoscrolling when rows/columns decrease in count or size", () => {
         const COL_WIDTH = 400;
         const ROW_HEIGHT = 60;

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -18,13 +18,17 @@ import { ICellCoordinates, IFocusedCellCoordinates } from "../src/common/cell";
 import * as Classes from "../src/common/classes";
 import { IColumnIndices, IRowIndices } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
-import { QuadrantType } from "../src/quadrants/tableQuadrant";
+import { QuadrantType, TableQuadrant } from "../src/quadrants/tableQuadrant";
 import { IRegion, Regions } from "../src/regions";
 import { TableBody } from "../src/tableBody";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 import { ElementHarness, ReactHarness } from "./harness";
 
 describe("<Table>", () => {
+
+    const COLUMN_HEADER_SELECTOR =
+        `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
+
     const harness = new ReactHarness();
 
     afterEach(() => {
@@ -62,15 +66,14 @@ describe("<Table>", () => {
     });
 
     // TODO: FROZEN
-    it.skip("Renders without ghost cells", () => {
+    it("Renders without ghost cells", () => {
         const table = harness.mount(
             <Table>
                 <Column />
             </Table>,
         );
-
-        expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 0).element).to.be.ok;
-        expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 1).element).to.not.be.ok;
+        expect(table.find(COLUMN_HEADER_SELECTOR, 0).element).to.be.ok;
+        expect(table.find(COLUMN_HEADER_SELECTOR, 1).element).to.not.be.ok;
     });
 
     it("Renders ghost cells", () => {
@@ -80,8 +83,8 @@ describe("<Table>", () => {
             </Table>,
         );
 
-        expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 0).element).to.be.ok;
-        expect(table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`, 1).element).to.be.ok;
+        expect(table.find(COLUMN_HEADER_SELECTOR, 0).element).to.be.ok;
+        expect(table.find(COLUMN_HEADER_SELECTOR, 1).element).to.be.ok;
     });
 
     it("Renders correctly with loading options", () => {
@@ -103,7 +106,7 @@ describe("<Table>", () => {
         cells.forEach((cell) => expectCellLoading(cell, CellType.BODY_CELL));
 
         const columnHeaders = tableHarness.element
-            .queryAll(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`);
+            .queryAll(COLUMN_HEADER_SELECTOR);
         columnHeaders.forEach((columnHeader) => expectCellLoading(columnHeader, CellType.COLUMN_HEADER));
 
         const rowHeaders = tableHarness.element.queryAll(`.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`);
@@ -149,7 +152,7 @@ describe("<Table>", () => {
     });
 
     // TODO: FROZEN
-    it.skip("Invokes onVisibleCellsChange on mount", () => {
+    it("Invokes onVisibleCellsChange on mount", () => {
         const onVisibleCellsChange = sinon.spy();
         const renderCell = () => <Cell>foo</Cell>;
         mount(
@@ -167,7 +170,7 @@ describe("<Table>", () => {
     });
 
     // TODO: FROZEN
-    it.skip("Invokes onVisibleCellsChange when the table body scrolls", () => {
+    it("Invokes onVisibleCellsChange when the table body scrolls", () => {
         const onVisibleCellsChange = sinon.spy();
         const renderCell = () => <Cell>foo</Cell>;
         const table = mount(
@@ -183,7 +186,7 @@ describe("<Table>", () => {
     });
 
     // TODO: FROZEN
-    describe.skip("Full-table selection", () => {
+    describe("Full-table selection", () => {
         const onFocus = sinon.spy();
         const onSelection = sinon.spy();
 
@@ -202,7 +205,7 @@ describe("<Table>", () => {
 
         it("selects and deselects column/row headers when selecting and deselecting the full table", () => {
             const table = mountTable();
-            const columnHeader = table.find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`).at(0);
+            const columnHeader = table.find(COLUMN_HEADER_SELECTOR).at(0);
             const rowHeader = table.find(`.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`).at(0);
 
             // select the full table
@@ -232,7 +235,7 @@ describe("<Table>", () => {
         }
 
         function selectFullTable(table: ReactWrapper<any, {}>) {
-            const menu = table.find(`.${Classes.TABLE_MENU}`);
+            const menu = table.find(`.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_MENU}`);
             menu.simulate("click");
         }
     });
@@ -717,7 +720,7 @@ describe("<Table>", () => {
         });
 
         // TODO: FROZEN
-        it.skip("Shows preview guide and invokes callback when columns reordered", () => {
+        it("Shows preview guide and invokes callback when columns reordered", () => {
             const table = mountTable({
                 isColumnReorderable: true,
                 onColumnsReordered,
@@ -735,7 +738,7 @@ describe("<Table>", () => {
         });
 
         // TODO: FROZEN
-        it.skip("Shows preview guide and invokes callback when rows reordered", () => {
+        it("Shows preview guide and invokes callback when rows reordered", () => {
             const table = mountTable({
                 isRowReorderable: true,
                 onRowsReordered,
@@ -777,7 +780,7 @@ describe("<Table>", () => {
         });
 
         // TODO: FROZEN
-        it.skip("Selecting a column via click and then reordering it works", () => {
+        it("Selecting a column via click and then reordering it works", () => {
             const table = mountTable({
                 isColumnReorderable: true,
                 onColumnsReordered,
@@ -801,7 +804,7 @@ describe("<Table>", () => {
         });
 
         // TODO: FROZEN
-        it.skip("Selecting multiple columns via click+drag and then reordering works", () => {
+        it("Selecting multiple columns via click+drag and then reordering works", () => {
             const table = mountTable({
                 isColumnReorderable: true,
                 onColumnsReordered,
@@ -823,7 +826,7 @@ describe("<Table>", () => {
         });
 
         // TODO: FROZEN
-        it.skip("Moves uncontrolled selection with reordered column when reordering is complete", () => {
+        it("Moves uncontrolled selection with reordered column when reordering is complete", () => {
             const table = mountTable({
                 isColumnReorderable: true,
                 onColumnsReordered,
@@ -1211,7 +1214,7 @@ describe("<Table>", () => {
     });
 
     // TODO: FROZEN
-    describe.skip("Autoscrolling when rows/columns decrease in count or size", () => {
+    describe("Autoscrolling when rows/columns decrease in count or size", () => {
         const COL_WIDTH = 400;
         const ROW_HEIGHT = 60;
 
@@ -1309,7 +1312,11 @@ describe("<Table>", () => {
                 COL_WIDTH,
                 ROW_HEIGHT,
             );
-            table.find(TableBody).simulate("scroll");
+            table
+                .find(TableQuadrant)
+                .first()
+                .find(TableBody)
+                .simulate("scroll");
         }
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -178,7 +178,7 @@ describe("<Table>", () => {
                 <Column name="Column0" renderCell={renderCell} />
             </Table>,
         );
-        table.find(`.${Classes.TABLE_BODY}`).simulate("scroll");
+        table.find(`.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_QUADRANT_SCROLL_CONTAINER}`).simulate("scroll");
         expect(onVisibleCellsChange.callCount).to.be.greaterThan(1);
         const rowIndices = { rowIndexStart: 0, rowIndexEnd: 2 } as IRowIndices;
         const columnIndices = { columnIndexStart: 0, columnIndexEnd: 0 } as IColumnIndices;


### PR DESCRIPTION
#### Addresses #503 · Builds on #1416

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- Fix tests that I broke and `skip`'d in past PRs.
    - In particular, be sure to `delayToNextFrame` when testing anything to do with scrolling, which is now throttled via `requestAnimationFrame`.
    - Also, test the `MAIN` quadrant's scroll container by default.

#### Reviewers should focus on:

- ~HOW DO I FIX THE BROKEN `TruncatedFormat` test? Can't figure it out.~ Fixed with `position: relative;`. :(
    - https://github.com/palantir/blueprint/blob/cl/table-frozen-rows-cols-8-fix-tests/packages/table/test/formatsTests.tsx#L55