### PR TITLE
[Core] v1.25.0 regression fix for user-land sass compilation

### DIFF
--- a/packages/core/src/components/icon/_icons.scss
+++ b/packages/core/src/components/icon/_icons.scss
@@ -3,7 +3,7 @@
 // of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
 // and https://github.com/palantir/blueprint/blob/master/PATENTS
 
-@import "common/icons";
+@import "../../common/icons";
 
 #{$icon-classes} {
   display: inline-block;


### PR DESCRIPTION
Without this I get Sass error `File to import not found or unreadable: common/icons.`

You may want to push a patch release for this, this is a regression from previous behaviour.
