### PR TITLE
[DateTimePicker] Fix where changing TimePicker clears date

### DIFF
--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -96,7 +96,9 @@ export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDat
     }
 
     public componentWillReceiveProps(nextProps: IDatePickerProps) {
-        if (nextProps.value != null) {
+        if (this.props.value === nextProps.value) {
+            return;
+        } else if (nextProps.value != null) {
             this.setState({
                 dateValue: nextProps.value,
                 timeValue: nextProps.value,

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -101,13 +101,14 @@ describe("<DateTimePicker>", () => {
             });
         }
 
-        it("Passing the same value prop twice does not clear the selected date", () => {
+        it("Passing an undefined value prop twice does not clear the selected date", () => {
             const { root, getSelectedDay } = wrap(<DateTimePicker />);
             assert.isTrue(getSelectedDay().exists());
             root.setProps({ value: undefined });
             assert.isNotNull(root.state("dateValue"));
             assert.isTrue(getSelectedDay().exists());
         });
+
     });
 
     function wrap(dtp: JSX.Element) {

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -8,6 +8,7 @@
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
+
 import { DateTimePicker } from "../src/dateTimePicker";
 import { Classes, DatePicker, TimePicker } from "../src/index";
 
@@ -108,7 +109,6 @@ describe("<DateTimePicker>", () => {
             assert.isNotNull(root.state("dateValue"));
             assert.isTrue(getSelectedDay().exists());
         });
-
     });
 
     function wrap(dtp: JSX.Element) {
@@ -124,5 +124,4 @@ describe("<DateTimePicker>", () => {
             root,
         };
     }
-
 });

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -8,7 +8,6 @@
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
-
 import { DateTimePicker } from "../src/dateTimePicker";
 import { Classes, DatePicker, TimePicker } from "../src/index";
 
@@ -101,6 +100,14 @@ describe("<DateTimePicker>", () => {
                 assert.isFalse(getSelectedDay().exists());
             });
         }
+
+        it("Passing the same value prop twice does not clear the selected date", () => {
+            const { root, getSelectedDay } = wrap(<DateTimePicker />);
+            assert.isTrue(getSelectedDay().exists());
+            root.setProps({ value: undefined });
+            assert.isNotNull(root.state("dateValue"));
+            assert.isTrue(getSelectedDay().exists());
+        });
     });
 
     function wrap(dtp: JSX.Element) {
@@ -116,4 +123,5 @@ describe("<DateTimePicker>", () => {
             root,
         };
     }
+
 });

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -101,11 +101,22 @@ describe("<DateTimePicker>", () => {
                 assert.isFalse(getSelectedDay().exists());
             });
         }
+    });
 
+    describe("when uncontrolled", () => {
         it("Passing an undefined value prop twice does not clear the selected date", () => {
             const { root, getSelectedDay } = wrap(<DateTimePicker />);
             assert.isTrue(getSelectedDay().exists());
             root.setProps({ value: undefined });
+            assert.isNotNull(root.state("dateValue"));
+            assert.isTrue(getSelectedDay().exists());
+        });
+
+        it("Rerendering with an undefined value prop does not clear the selected date", () => {
+            const { root, getSelectedDay } = wrap(<DateTimePicker />);
+            assert.isNotNull(root.state("dateValue"));
+            assert.isTrue(getSelectedDay().exists());
+            root.update();
             assert.isNotNull(root.state("dateValue"));
             assert.isTrue(getSelectedDay().exists());
         });


### PR DESCRIPTION
#### Fixes #1402 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Add unit tests

#### Changes proposed in this pull request:
In dateTimePicker component, we should only reset the state based on props if the props have actually changed. Otherwise, we will needless clear or reset DateTimePicker state based on props that have not changed. 

<!-- fill this out -->

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot
![bugfix](https://user-images.githubusercontent.com/1528181/29499500-eddcaa0e-85c7-11e7-9aab-721a04523bb6.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/blueprint/1474)
<!-- Reviewable:end -->
