### PR TITLE
[RadioGroup] Add inline prop for radio button group

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -87,6 +87,7 @@ const INVALID_PROPS = [
     "iconName",
     "inputRef",
     "intent",
+    "inline",
     "loading",
     "leftIconName",
     "onChildrenMount",

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -73,9 +73,11 @@ export class Control<P extends IControlProps> extends React.Component<P, {}> {
         const className = classNames(
             Classes.CONTROL,
             typeClassName,
-            { [Classes.DISABLED]: this.props.disabled },
+            {
+                [Classes.DISABLED]: this.props.disabled,
+                [Classes.INLINE]: this.props.inline,
+            },
             this.props.className,
-            { [Classes.INLINE]: this.props.inline },
         );
         const inputProps = removeNonHTMLProps(this.props, INVALID_PROPS, true);
         return (

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -34,6 +34,9 @@ export interface IControlProps extends IProps, HTMLInputProps {
     /** Ref handler that receives HTML `<input>` element backing this component. */
     inputRef?: (ref: HTMLInputElement) => any;
 
+    /** Whether the control is inline. */
+    inline?: boolean;
+
     /**
      * Text label for the control.
      *
@@ -72,6 +75,7 @@ export class Control<P extends IControlProps> extends React.Component<P, {}> {
             typeClassName,
             { [Classes.DISABLED]: this.props.disabled },
             this.props.className,
+            { [Classes.INLINE]: this.props.inline },
         );
         const inputProps = removeNonHTMLProps(this.props, INVALID_PROPS, true);
         return (

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -20,6 +20,11 @@ export interface IRadioGroupProps extends IProps {
      */
     disabled?: boolean;
 
+    /**
+     * True if radio buttons are to be displayed inline horizontally.
+     */
+    inline?: boolean;
+
     /** Optional label text to display above the radio buttons. */
     label?: string;
 
@@ -89,11 +94,12 @@ export class RadioGroup extends AbstractComponent<IRadioGroupProps, {}> {
     }
 
     private getRadioProps(optionProps: IOptionProps) {
-        const { name } = this.props;
+        const { name, inline } = this.props;
         const { value, disabled } = optionProps;
         return {
             checked: value === this.props.selectedValue,
             disabled: disabled || this.props.disabled,
+            inline: inline == null ? false : inline,
             name: name == null ? this.autoGroupName : name,
             onChange: this.props.onChange,
         };

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -21,7 +21,7 @@ export interface IRadioGroupProps extends IProps {
     disabled?: boolean;
 
     /**
-     * True if radio buttons are to be displayed inline horizontally.
+     * Whether the radio buttons are to be displayed inline horizontally.
      */
     inline?: boolean;
 
@@ -94,12 +94,12 @@ export class RadioGroup extends AbstractComponent<IRadioGroupProps, {}> {
     }
 
     private getRadioProps(optionProps: IOptionProps) {
-        const { name, inline } = this.props;
+        const { name } = this.props;
         const { value, disabled } = optionProps;
         return {
             checked: value === this.props.selectedValue,
             disabled: disabled || this.props.disabled,
-            inline: inline == null ? false : inline,
+            inline: this.props.inline,
             name: name == null ? this.autoGroupName : name,
             onChange: this.props.onChange,
         };


### PR DESCRIPTION
#### Fixes #1399

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Update documentation

#### Changes proposed in this pull request:

Add `inline` as a prop to RadioGroup to enable inline radio buttons. 

#### Screenshot

<img width="287" alt="screen shot 2017-08-20 at 9 15 25 pm" src="https://user-images.githubusercontent.com/1528181/29503820-e67e8ee4-85ef-11e7-9aa1-5f400ed066bb.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/blueprint/1475)
<!-- Reviewable:end -->
