### PR TITLE
fix normalize.css version on docs site

### DIFF
--- a/docs/docs/site-docs.css
+++ b/docs/docs/site-docs.css
@@ -7,76 +7,67 @@ and https://github.com/palantir/blueprint/blob/master/PATENTS
 */
 
 /**
- * 1. Correct the line height in all browsers.
- * 2. Prevent adjustments of font size after orientation changes in
- *    IE on Windows Phone and in iOS.
+ * 1. Change the default font family in all browsers (opinionated).
+ * 2. Prevent adjustments of font size after orientation changes in IE and iOS.
  */
 html {
-  line-height: 1.15;
+  font-family: sans-serif;
   
   -ms-text-size-adjust: 100%;
   
   -webkit-text-size-adjust: 100%;
    }
-
 /**
  * Remove the margin in all browsers (opinionated).
  */
 body {
   margin: 0; }
-/**
- * Add the correct display in IE 9-.
- */
-article,
-aside,
-footer,
-header,
-nav,
-section {
-  display: block; }
-/**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- */
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0; }
 
 /**
  * Add the correct display in IE 9-.
- * 1. Add the correct display in IE.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ * 2. Add the correct display in IE.
  */
+article,
+aside,
+details,
 figcaption,
 figure,
-main {
+footer,
+header,
+main,
+menu,
+nav,
+section,
+summary {
   
   display: block; }
 /**
- * Add the correct margin in IE 8.
+ * Add the correct display in IE 9-.
  */
-figure {
-  margin: 1em 40px; }
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; }
 /**
- * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
+ * Add the correct display in iOS 4-7.
  */
-hr {
-  -moz-box-sizing: content-box;
-       box-sizing: content-box;
-  
-  height: 0;
-  
-  overflow: visible;
-   }
+audio:not([controls]) {
+  display: none;
+  height: 0; }
 /**
- * 1. Correct the inheritance and scaling of font size in all browsers.
- * 2. Correct the odd `em` font sizing in all browsers.
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
-pre {
-  font-family: monospace, monospace;
-  
-  font-size: 1em;
-   }
+progress {
+  vertical-align: baseline; }
+/**
+ * Add the correct display in IE 10-.
+ * 1. Add the correct display in IE.
+ */
+template,
+[hidden] {
+  display: none; }
 
 /**
  * 1. Remove the gray background on active links in IE 10.
@@ -88,7 +79,15 @@ a {
   -webkit-text-decoration-skip: objects;
    }
 /**
- * 1. Remove the bottom border in Chrome 57- and Firefox 39-.
+ * Remove the outline on focused links when they are also active or hovered
+ * in all browsers (opinionated).
+ */
+a:active,
+a:hover {
+  outline-width: 0; }
+
+/**
+ * 1. Remove the bottom border in Firefox 39-.
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
@@ -113,21 +112,17 @@ b,
 strong {
   font-weight: bolder; }
 /**
- * 1. Correct the inheritance and scaling of font size in all browsers.
- * 2. Correct the odd `em` font sizing in all browsers.
- */
-code,
-kbd,
-samp {
-  font-family: monospace, monospace;
-  
-  font-size: 1em;
-   }
-/**
  * Add the correct font style in Android 4.3-.
  */
 dfn {
   font-style: italic; }
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0; }
 /**
  * Add the correct background and color in IE 9-.
  */
@@ -155,18 +150,6 @@ sup {
   top: -0.5em; }
 
 /**
- * Add the correct display in IE 9-.
- */
-audio,
-video {
-  display: inline-block; }
-/**
- * Add the correct display in iOS 4-7.
- */
-audio:not([controls]) {
-  display: none;
-  height: 0; }
-/**
  * Remove the border on images inside links in IE 10-.
  */
 img {
@@ -178,22 +161,52 @@ svg:not(:root) {
   overflow: hidden; }
 
 /**
- * 1. Change the font styles in all browsers (opinionated).
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  
+  font-size: 1em;
+   }
+/**
+ * Add the correct margin in IE 8.
+ */
+figure {
+  margin: 1em 40px; }
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+hr {
+  -moz-box-sizing: content-box;
+       box-sizing: content-box;
+  
+  height: 0;
+  
+  overflow: visible;
+   }
+
+/**
+ * 1. Change font properties to `inherit` in all browsers (opinionated).
  * 2. Remove the margin in Firefox and Safari.
  */
 button,
 input,
-optgroup,
 select,
 textarea {
-  font-family: sans-serif;
-  
-  font-size: 100%;
-  
-  line-height: 1.15;
+  font: inherit;
   
   margin: 0;
    }
+/**
+ * Restore the font weight unset by the previous rule.
+ */
+optgroup {
+  font-weight: bold; }
 /**
  * Show the overflow in IE.
  * 1. Show the overflow in Edge.
@@ -239,10 +252,12 @@ button:-moz-focusring,
 [type="submit"]:-moz-focusring {
   outline: 1px dotted ButtonText; }
 /**
- * Correct the padding in Firefox.
+ * Change the border, margin, and padding in all browsers (opinionated).
  */
 fieldset {
-  padding: 0.35em 0.75em 0.625em; }
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em; }
 /**
  * 1. Correct the text wrapping in Edge and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
@@ -262,15 +277,6 @@ legend {
   padding: 0;
   
   white-space: normal;
-   }
-/**
- * 1. Add the correct display in IE 9-.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
- */
-progress {
-  display: inline-block;
-  
-  vertical-align: baseline;
    }
 /**
  * Remove the default vertical scrollbar in IE.
@@ -304,11 +310,17 @@ textarea {
   outline-offset: -2px;
    }
 /**
- * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
  */
 [type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none; }
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54; }
 /**
  * 1. Correct the inability to style clickable types in iOS and Safari.
  * 2. Change font properties to `inherit` in Safari.
@@ -318,30 +330,6 @@ textarea {
   
   font: inherit;
    }
-
-details,
-menu {
-  display: block; }
-
-summary {
-  display: list-item; }
-
-/**
- * Add the correct display in IE 9-.
- */
-canvas {
-  display: inline-block; }
-/**
- * Add the correct display in IE.
- */
-template {
-  display: none; }
-
-/**
- * Add the correct display in IE 10-.
- */
-[hidden] {
-  display: none; }
 /**
  * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy

--- a/packages/site-docs/package.json
+++ b/packages/site-docs/package.json
@@ -14,7 +14,7 @@
     "classnames": "^2.2.5",
     "dom4": "^1.8.3",
     "moment": "^2.18.1",
-    "normalize.css": "^7.0.0",
+    "normalize.css": "~4.1.1",
     "react": "^15.6.1",
     "react-addons-css-transition-group": "^15.6.0",
     "react-dom": "^15.6.1",

--- a/packages/site-docs/yarn.lock
+++ b/packages/site-docs/yarn.lock
@@ -96,9 +96,9 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-normalize.css@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-7.0.0.tgz#abfb1dd82470674e0322b53ceb1aaf412938e4bf"
+normalize.css@~4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-4.1.1.tgz#4f0b1d5a235383252b04d8566b866cc5fcad9f0c"
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
#### Changes proposed in this pull request:

- fix normalize.css devDependency version in docs site so it matches __core__. due to #1276: https://github.com/palantir/blueprint/pull/1276/files#diff-7c55e4e59594216d1a073cc53cef843aR17
- rebuild docs site to silently fix buttons