### PR TITLE
[DateRangeInput] Pass locale to moment for formatting, part 2

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -277,3 +277,11 @@ export function getDateNextMonth(date: Date): Date {
         return new Date(date.getFullYear(), date.getMonth() + 1);
     }
 }
+
+/**
+ * Returns a date string in the provided format localized to the provided locale.
+ */
+export function toLocalizedDateString(momentDate: moment.Moment, format: string, locale: string | undefined) {
+    const adjustedMomentDate = (locale != null) ? momentDate.locale(locale) : momentDate;
+    return adjustedMomentDate.format(format);
+}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -27,6 +27,7 @@ import {
     isMomentInRange,
     isMomentNull,
     isMomentValidAndInRange,
+    toLocalizedDateString,
 } from "./common/dateUtils";
 import { DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS, DATEINPUT_WARN_DEPRECATED_POPOVER_POSITION } from "./common/errors";
 import { DatePicker } from "./datePicker";
@@ -252,21 +253,13 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         return moment(valueString, this.props.format, this.props.locale);
     }
 
-    private localizedFormat(value: moment.Moment) {
-        if (this.props.locale) {
-            return value.locale(this.props.locale).format(this.props.format);
-        } else {
-            return value.format(this.props.format);
-        }
-    }
-
     private getDateString = (value: moment.Moment) => {
         if (isMomentNull(value)) {
             return "";
         }
         if (value.isValid()) {
             if (this.isMomentInRange(value)) {
-                return this.localizedFormat(value);
+                return toLocalizedDateString(value, this.props.format, this.props.locale);
             } else {
                 return this.props.outOfRangeMessage;
             }
@@ -333,7 +326,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         if (isMomentNull(this.state.value)) {
             valueString = "";
         } else {
-            valueString = this.localizedFormat(this.state.value);
+            valueString = toLocalizedDateString(this.state.value, this.props.format, this.props.locale);
         }
 
         if (this.props.openOnFocus) {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -688,7 +688,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         if (this.isInputEmpty(dateString)) {
             return moment(null);
         }
-        return moment(dateString, this.props.format);
+        return moment(dateString, this.props.format, this.props.locale);
     }
 
     private getInitialRange = (props = this.props) => {
@@ -790,13 +790,18 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             : this.refHandlers.endInputRef;
     }
 
-    private getFormattedDateString = (momentDate: moment.Moment, format?: string) => {
+    private getFormattedDateString = (momentDate: moment.Moment, formatOverride?: string) => {
         if (isMomentNull(momentDate)) {
             return "";
         } else if (!momentDate.isValid()) {
             return this.props.invalidDateMessage;
         } else {
-            return momentDate.format((format != null) ? format : this.props.format);
+            const format = (formatOverride != null) ? formatOverride : this.props.format;
+            if (this.props.locale) {
+                return momentDate.locale(this.props.locale).format(format);
+            } else {
+                return momentDate.format(format);
+            }
         }
     }
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -33,6 +33,7 @@ import {
     isMomentNull,
     isMomentValidAndInRange,
     MomentDateRange,
+    toLocalizedDateString,
 } from "./common/dateUtils";
 import * as Errors from "./common/errors";
 import {
@@ -797,11 +798,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             return this.props.invalidDateMessage;
         } else {
             const format = (formatOverride != null) ? formatOverride : this.props.format;
-            if (this.props.locale) {
-                return momentDate.locale(this.props.locale).format(format);
-            } else {
-                return momentDate.format(format);
-            }
+            return toLocalizedDateString(momentDate, format, this.props.locale);
         }
     }
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -297,7 +297,7 @@ describe("<DateInput>", () => {
             assert.isTrue(onChange.calledWith(null));
         });
 
-        it("Formats locale specific format strings properly", () => {
+        it("Formats locale-specific format strings properly", () => {
             const wrapper = mount(<DateInput locale="de" format="L" value={DATE2}/>);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_DE_STR);
         });

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -298,7 +298,7 @@ describe("<DateInput>", () => {
         });
 
         it("Formats locale-specific format strings properly", () => {
-            const wrapper = mount(<DateInput locale="de" format="L" value={DATE2}/>);
+            const wrapper = mount(<DateInput locale="de" format="L" value={DATE2} />);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_DE_STR);
         });
     });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2306,7 +2306,7 @@ describe("<DateRangeInput>", () => {
             assertInputTextsEqual(root, START_STR, "");
         });
 
-        it("Formats locale specific format strings properly", () => {
+        it("Formats locale-specific format strings properly", () => {
             const { root } = wrap(<DateRangeInput locale="de" format="L" value={DATE_RANGE_2}/>);
             assertInputTextsEqual(root, START_DE_STR_2, END_DE_STR_2);
         });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -37,8 +37,10 @@ describe("<DateRangeInput>", () => {
 
     const START_DATE_2 = new Date(2017, Months.JANUARY, 1);
     const START_STR_2 = DateTestUtils.toHyphenatedDateString(START_DATE_2);
+    const START_DE_STR_2 = "01.01.2017";
     const END_DATE_2 = new Date(2017, Months.JANUARY, 31);
     const END_STR_2 = DateTestUtils.toHyphenatedDateString(END_DATE_2);
+    const END_DE_STR_2 = "31.01.2017";
     const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
 
     const INVALID_STR = "<this is an invalid date string>";
@@ -2302,6 +2304,11 @@ describe("<DateRangeInput>", () => {
 
             startInput.simulate("blur");
             assertInputTextsEqual(root, START_STR, "");
+        });
+
+        it("Formats locale specific format strings properly", () => {
+            const { root } = wrap(<DateRangeInput locale="de" format="L" value={DATE_RANGE_2}/>);
+            assertInputTextsEqual(root, START_DE_STR_2, END_DE_STR_2);
         });
     });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2307,7 +2307,7 @@ describe("<DateRangeInput>", () => {
         });
 
         it("Formats locale-specific format strings properly", () => {
-            const { root } = wrap(<DateRangeInput locale="de" format="L" value={DATE_RANGE_2}/>);
+            const { root } = wrap(<DateRangeInput locale="de" format="L" value={DATE_RANGE_2} />);
             assertInputTextsEqual(root, START_DE_STR_2, END_DE_STR_2);
         });
     });


### PR DESCRIPTION
#### Fixes #1428 for date range inputs

This PR is closely related to #1429. We didn't notice that the date range input was a separate component from the date input. This applies the same two fixes (applying the locale at parsing time and at formatting time) to the date range input.

#### Screenshot

<img width="766" alt="screen shot 2017-08-21 at 7 47 09 pm" src="https://user-images.githubusercontent.com/5733346/29546490-a2d93e90-86a9-11e7-9a6f-c660713a1347.png">

(Note: To get the screenshot of the change, I had to add "L" to the list of formats and set the locale of the DateRangeInput. Neither of these changes are currently in the PR.)