### PR TITLE
Prevent non-ideal state text from bleeding horizontally in IE.

### DIFF
--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -50,6 +50,6 @@ Styleguide pt-non-ideal-state
 
 .pt-non-ideal-state-title,
 .pt-non-ideal-state-description {
-  text-align: center;
   max-width: 100%; // for Internet Explorer (https://github.com/palantir/blueprint/issues/1193)
+  text-align: center;
 }

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -51,4 +51,5 @@ Styleguide pt-non-ideal-state
 .pt-non-ideal-state-title,
 .pt-non-ideal-state-description {
   text-align: center;
+  max-width: 100%; // for Internet Explorer (https://github.com/palantir/blueprint/issues/1193)
 }


### PR DESCRIPTION
#### Fixes #1193

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
Before:
<img width="968" alt="screen shot 2017-08-21 at 4 38 22 pm" src="https://user-images.githubusercontent.com/5733346/29546122-2a822eb8-86a7-11e7-875e-5013e5d02697.png">

After:
<img width="1004" alt="screen shot 2017-08-21 at 4 37 44 pm" src="https://user-images.githubusercontent.com/5733346/29546125-326d7592-86a7-11e7-932c-95ddde066b22.png">

I checked that Chrome and Firefox were unaffected by the change.