### PR TITLE
[Table] Fix for user-land sass compilation

### DIFF
--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -1,6 +1,6 @@
 
-@import "../../core/src/common/mixins";
-@import "./common/variables";
+@import "~@blueprintjs/core/src/common/mixins";
+@import "../common/variables";
 
 $table-quadrant-z-index-main: 0;
 $table-quadrant-z-index-top: $table-quadrant-z-index-main + 1;


### PR DESCRIPTION
Similar issue to #1456, but when importing the table's scss.

Without this I get `File to import not found or unreadable: ../../core/src/common/mixins.` and `File to import not found or unreadable: ./common/variables.`