### PR TITLE
[MultiSelect/TagInput] Visual consistency of placeholder with normal inputs

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -97,11 +97,7 @@ $control-group-stack: (
   transition: $input-transition;
   appearance: none;
 
-  &::placeholder {
-    // normalize.css sets an opacity less than 1, we don't want this
-    opacity: 1;
-    color: $input-placeholder-color;
-  }
+  @include pt-input-placeholder();
 
   &:focus,
   &.pt-active {
@@ -123,6 +119,14 @@ $control-group-stack: (
   &:disabled,
   &.pt-disabled {
     @include pt-input-disabled();
+  }
+}
+
+@mixin pt-input-placeholder() {
+  &::placeholder {
+    // normalize.css sets an opacity less than 1, we don't want this
+    opacity: 1;
+    color: $input-placeholder-color;
   }
 }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -82,6 +82,8 @@ $control-group-stack: (
 }
 
 @mixin pt-input() {
+  @include pt-input-placeholder();
+
   outline: none;
   border: none;
   border-radius: $pt-border-radius;
@@ -96,8 +98,6 @@ $control-group-stack: (
   font-weight: $input-font-weight;
   transition: $input-transition;
   appearance: none;
-
-  @include pt-input-placeholder();
 
   &:focus,
   &.pt-active {

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -45,7 +45,7 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
     line-height: $tag-height;
 
     // match padding of other input elements iff no tags are selected
-    &:not(first-child) {
+    &:not(:first-child) {
       padding: 0 ($input-padding-horizontal - $ti-padding);
     }
 

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -42,12 +42,11 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
     margin-bottom: $ti-padding;
     // essentially a min-width, cuz flex allows it to grow or shrink:
     width: $pt-grid-size * 10;
-    padding: 0 ($input-padding-horizontal - $ti-padding);
     line-height: $tag-height;
 
     // match padding of other input elements iff no tags are selected
-    &:first-child {
-      padding: 0 $input-padding-horizontal;
+    &:not(first-child) {
+      padding: 0 ($input-padding-horizontal - $ti-padding);
     }
 
     ~ * {
@@ -100,7 +99,7 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
   border: none;
   box-shadow: none;
   background: none;
-  padding: 0;
+  padding: 0 $input-padding-horizontal;
 
   &:focus {
     // remove focus state too

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -45,6 +45,11 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
     padding: 0 ($input-padding-horizontal - $ti-padding);
     line-height: $tag-height;
 
+    // match padding of other input elements iff no tags are selected
+    &:first-child {
+      padding: 0 $input-padding-horizontal;
+    }
+
     ~ * {
       // shift right element up (to ignore top padding) so flex box will center it correctly
       margin-top: -$ti-padding;
@@ -89,6 +94,8 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
 
 // TODO: this is probably a useful modifier that we should pull into core, and use in EditableText
 .pt-input-ghost {
+  @include pt-input-placeholder();
+
   // reset browser input styles (we're using an input solely because you can type in it)
   border: none;
   box-shadow: none;

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -11,6 +11,7 @@
 
 $ti-padding: ($pt-input-height - $tag-height) / 2;
 $ti-padding-right: ($pt-input-height - $pt-button-height-small) / 2;
+$ti-large-padding-right: ($pt-input-height-large - $pt-button-height-small) / 2;
 
 $ti-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
 $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
@@ -57,6 +58,7 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
 
   &.pt-large {
     height: auto;
+    padding-right: $ti-large-padding-right;
 
     .pt-tag-input-icon {
       // stylelint-disable-next-line max-line-length


### PR DESCRIPTION
#### Fixes #0000

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
~~- [ ] Include tests~~
~~- [ ] Update documentation~~

#### Changes proposed in this pull request:

Making the color of the placeholder for `MultiSelect` and `TagInput` consistent with normal `.pt-input` as well as the padding.

#### Reviewers should focus on:

Whether this disrupts other configurations

#### Screenshot

before:

![image](https://user-images.githubusercontent.com/4211838/29587927-8d68bcc0-875d-11e7-833d-a24da9a71ae5.png)

after:

![image](https://user-images.githubusercontent.com/4211838/29588278-e4f6fcf8-875e-11e7-911b-812bbd1a5791.png)


