### PR TITLE
[Table] Resizing columns no longer throws error when row header is hidden

### DIFF
--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -632,7 +632,7 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
 
     private adjustVerticalGuides(verticalGuides: number[], quadrantType: QuadrantType) {
         const scrollAmount = this.quadrantRefs[quadrantType].scrollContainer.scrollLeft;
-        const rowHeaderWidth = this.quadrantRefs[quadrantType].rowHeader.clientWidth;
+        const rowHeaderWidth = this.getRowHeaderWidth(quadrantType);
 
         const adjustedVerticalGuides = verticalGuides != null
             ? verticalGuides.map((verticalGuide) => verticalGuide - scrollAmount + rowHeaderWidth)
@@ -650,5 +650,12 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
             : horizontalGuides;
 
         return adjustedHorizontalGuides;
+    }
+
+    private getRowHeaderWidth(quadrantType: QuadrantType) {
+        // unlike the column header, the row header can be toggled, so we need to handle the case
+        // when it's not showing
+        const { rowHeader } = this.quadrantRefs[quadrantType];
+        return rowHeader == null ? 0 : rowHeader.clientWidth;
     }
 }

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -574,11 +574,11 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         leftQuadrantElement.style.bottom = `${scrollbarHeight}px`;
 
         // resize top and top-left quadrant row headers if main quadrant scrolls
-        this.syncRowHeaderSize(topQuadrantRowHeaderElement, rowHeaderWidth);
-        this.syncRowHeaderSize(topLeftQuadrantRowHeaderElement, rowHeaderWidth);
+        this.maybeSyncRowHeaderSize(topQuadrantRowHeaderElement, rowHeaderWidth);
+        this.maybeSyncRowHeaderSize(topLeftQuadrantRowHeaderElement, rowHeaderWidth);
     }
 
-    private syncRowHeaderSize(rowHeaderElement: HTMLElement, width: number) {
+    private maybeSyncRowHeaderSize(rowHeaderElement: HTMLElement, width: number) {
         if (rowHeaderElement == null) {
             return;
         }

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -628,7 +628,7 @@ describe("<Table>", () => {
         it("Resizes selected rows together", () => {
             const table = mountTable();
             const rows = getRowHeadersWrapper(table);
-            const resizeHandleTarget = getRowResizeHandle(rows, 0);
+            const resizeHandleTarget = getResizeHandle(rows, 0);
 
             resizeHandleTarget.mouse("mousemove")
                 .mouse("mousedown")
@@ -646,9 +646,22 @@ describe("<Table>", () => {
             expect(rows.find(`.${Classes.TABLE_HEADER}`, 8).bounds().height).to.equal(3);
         });
 
+        it("Resizes columns when row headers are hidden without throwing an error", () => {
+            const table = mountTable({ isRowHeaderShown: false });
+            const columnHeader = table.find(`.${Classes.TABLE_COLUMN_HEADERS}`);
+            const resizeHandleTarget = getResizeHandle(columnHeader, 0);
+
+            expect(() => {
+                resizeHandleTarget.mouse("mousemove")
+                    .mouse("mousedown")
+                    .mouse("mousemove", 0, 2)
+                    .mouse("mouseup");
+            }).not.to.throw();
+        });
+
         it("Hides selected-region styles while resizing", () => {
             const table = mountTable();
-            const resizeHandleTarget = getRowResizeHandle(getRowHeadersWrapper(table), 0);
+            const resizeHandleTarget = getResizeHandle(getRowHeadersWrapper(table), 0);
 
             resizeHandleTarget.mouse("mousemove")
                 .mouse("mousedown")
@@ -659,7 +672,7 @@ describe("<Table>", () => {
             expect(table.find(`.${Classes.TABLE_SELECTION_REGION}`).exists()).to.be.true;
         });
 
-        function mountTable() {
+        function mountTable(tableProps: Partial<ITableProps> & object = {}) {
             return harness.mount(
                 // set the row height so small so they can all fit in the viewport and be rendered
                 <Table
@@ -668,6 +681,7 @@ describe("<Table>", () => {
                     minRowHeight={1}
                     numRows={10}
                     selectedRegions={[Regions.row(0, 1), Regions.row(4, 6), Regions.row(8)]}
+                    {...tableProps}
                 >
                     <Column renderCell={renderCell}/>
                     <Column renderCell={renderCell}/>
@@ -680,8 +694,8 @@ describe("<Table>", () => {
             return table.find(`.${Classes.TABLE_ROW_HEADERS}`);
         }
 
-        function getRowResizeHandle(rows: ElementHarness, rowIndex: number) {
-            return rows.find(`.${Classes.TABLE_RESIZE_HANDLE_TARGET}`, rowIndex);
+        function getResizeHandle(header: ElementHarness, index: number) {
+            return header.find(`.${Classes.TABLE_RESIZE_HANDLE_TARGET}`, index);
         }
     });
 


### PR DESCRIPTION
#### Fixes #1500

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `Table` resizing columns no longer throws an error when `isRowHeaderShown={false}`

#### Reviewers should focus on:

I know the `getRowHeaderWidth` function is used in only one place, but it felt cleaner and clearer to me to pull that consideration out into a separate helper.
