### PR TITLE
[Table] Add renderMode prop

### DIFF
--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -42,7 +42,7 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 
 import { IFocusedCellCoordinates } from "../src/common/cell";
 import { IColumnIndices, IRowIndices } from "../src/common/grid";
-import { RenderOptimizationMode } from "../src/common/renderOptimizationMode";
+import { RenderMode } from "../src/common/renderMode";
 import { IRegion } from "../src/regions";
 import { DenseGridMutableStore } from "./denseGridMutableStore";
 
@@ -199,9 +199,9 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     // ===============
 
     public render() {
-        const renderOptimizationMode = this.state.enableBatchRendering
-            ? RenderOptimizationMode.BATCH
-            : RenderOptimizationMode.NONE;
+        const renderMode = this.state.enableBatchRendering
+            ? RenderMode.BATCH
+            : RenderMode.NONE;
         return (
             <div className="container">
                 <Table
@@ -227,7 +227,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     onRowHeightChanged={this.onRowHeightChanged}
                     onRowsReordered={this.onRowsReordered}
                     renderBodyContextMenu={this.renderBodyContextMenu}
-                    renderOptimizationMode={renderOptimizationMode}
+                    renderMode={renderMode}
                     renderRowHeader={this.renderRowHeader}
                     selectionModes={this.getEnabledSelectionModes()}
                     styledRegionGroups={this.getStyledRegionGroups()}

--- a/packages/table/preview/index.tsx
+++ b/packages/table/preview/index.tsx
@@ -42,6 +42,7 @@ ReactDOM.render(<Nav selected="perf" />, document.getElementById("nav"));
 
 import { IFocusedCellCoordinates } from "../src/common/cell";
 import { IColumnIndices, IRowIndices } from "../src/common/grid";
+import { RenderOptimizationMode } from "../src/common/renderOptimizationMode";
 import { IRegion } from "../src/regions";
 import { DenseGridMutableStore } from "./denseGridMutableStore";
 
@@ -56,6 +57,7 @@ type IMutableStateUpdateCallback =
 interface IMutableTableState {
     cellContent?: CellContent;
     cellTruncatedPopoverMode?: TruncatedPopoverMode;
+    enableBatchRendering?: boolean;
     enableCellEditing?: boolean;
     enableCellSelection?: boolean;
     enableCellTruncation?: boolean;
@@ -159,6 +161,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
         this.state = {
             cellContent: CellContent.CELL_NAMES,
             cellTruncatedPopoverMode: TruncatedPopoverMode.WHEN_TRUNCATED,
+            enableBatchRendering: true,
             enableCellEditing: false,
             enableCellSelection: true,
             enableCellTruncation: false,
@@ -196,6 +199,9 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
     // ===============
 
     public render() {
+        const renderOptimizationMode = this.state.enableBatchRendering
+            ? RenderOptimizationMode.BATCH
+            : RenderOptimizationMode.NONE;
         return (
             <div className="container">
                 <Table
@@ -209,11 +215,9 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     isRowReorderable={this.state.enableRowReordering}
                     isRowResizable={this.state.enableRowResizing}
                     loadingOptions={this.getEnabledLoadingOptions()}
+                    numFrozenColumns={this.state.numFrozenCols}
+                    numFrozenRows={this.state.numFrozenRows}
                     numRows={this.state.numRows}
-                    renderBodyContextMenu={this.renderBodyContextMenu}
-                    renderRowHeader={this.renderRowHeader}
-                    selectionModes={this.getEnabledSelectionModes()}
-                    styledRegionGroups={this.getStyledRegionGroups()}
                     onSelection={this.onSelection}
                     onColumnsReordered={this.onColumnsReordered}
                     onColumnWidthChanged={this.onColumnWidthChanged}
@@ -222,8 +226,11 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                     onVisibleCellsChange={this.onVisibleCellsChange}
                     onRowHeightChanged={this.onRowHeightChanged}
                     onRowsReordered={this.onRowsReordered}
-                    numFrozenColumns={this.state.numFrozenCols}
-                    numFrozenRows={this.state.numFrozenRows}
+                    renderBodyContextMenu={this.renderBodyContextMenu}
+                    renderOptimizationMode={renderOptimizationMode}
+                    renderRowHeader={this.renderRowHeader}
+                    selectionModes={this.getEnabledSelectionModes()}
+                    styledRegionGroups={this.getStyledRegionGroups()}
                 >
                     {this.renderColumns()}
                 </Table>
@@ -427,6 +434,7 @@ class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderSwitch("Inline", "showInline")}
                 {this.renderSwitch("Focus cell", "showFocusCell")}
                 {this.renderSwitch("Ghost cells", "showGhostCells")}
+                {this.renderSwitch("Batch rendering", "enableBatchRendering")}
                 <h6>Interactions</h6>
                 {this.renderSwitch("Body context menu", "enableContextMenu")}
                 {this.renderSwitch("Callback logs", "showCallbackLogs")}

--- a/packages/table/src/common/renderMode.ts
+++ b/packages/table/src/common/renderMode.ts
@@ -5,7 +5,7 @@
  * https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-export enum RenderOptimizationMode {
+export enum RenderMode {
     /**
      * Renders cells in batches across multiple animation frames. This improves
      * performance by spreading out work to keep a high FPS and avoid blocking

--- a/packages/table/src/common/renderOptimizationMode.ts
+++ b/packages/table/src/common/renderOptimizationMode.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved. Licensed
+ * under the BSD-3 License as modified (the “License”); you may obtain a copy of
+ * the license at https://github.com/palantir/blueprint/blob/master/LICENSE and
+ * https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+enum RenderOptimizationMode {
+    /**
+     * Renders cells in batches across multiple animation frames. This improves
+     * performance by spreading out work to keep a high FPS and avoid blocking
+     * the UI, but it also introduces a noticeable scan-line rendering artifact
+     * as successive batches of cells finish rendering.
+     */
+    BATCH,
+
+    /**
+     * Disables the batch-rendering behavior, rendering all cells synchronously
+     * at once. This may result in degraded performance on large tables and/or
+     * on tables with complex cells.
+     */
+    NONE,
+};

--- a/packages/table/src/common/renderOptimizationMode.ts
+++ b/packages/table/src/common/renderOptimizationMode.ts
@@ -5,7 +5,7 @@
  * https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-enum RenderOptimizationMode {
+export enum RenderOptimizationMode {
     /**
      * Renders cells in batches across multiple animation frames. This improves
      * performance by spreading out work to keep a high FPS and avoid blocking

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -18,7 +18,7 @@ import { Clipboard } from "./common/clipboard";
 import * as Errors from "./common/errors";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
-import { RenderOptimizationMode } from "./common/renderOptimizationMode";
+import { RenderMode } from "./common/renderMode";
 import { Utils } from "./common/utils";
 import { ColumnHeader, IColumnWidths } from "./headers/columnHeader";
 import { ColumnHeaderCell, IColumnHeaderCellProps } from "./headers/columnHeaderCell";
@@ -210,12 +210,11 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
 
     /**
      * Dictates how cells should be rendered. Supported modes are:
-     * - `RenderOptimizationMode.BATCH`: renders cells in batches to improve
-     *   performance
-     * - `RenderOptimizationMode.NONE`: renders cells synchronously all at once
-     * @default RenderOptimizationMode.BATCH
+     * - `RenderMode.BATCH`: renders cells in batches to improve performance
+     * - `RenderMode.NONE`: renders cells synchronously all at once
+     * @default RenderMode.BATCH
      */
-    renderOptimizationMode?: RenderOptimizationMode;
+    renderMode?: RenderMode;
 
     /**
      * Render each row's header cell.
@@ -354,7 +353,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         minColumnWidth: 50,
         minRowHeight: 20,
         numRows: 0,
-        renderOptimizationMode: RenderOptimizationMode.BATCH,
+        renderMode: RenderMode.BATCH,
         renderRowHeader: renderDefaultRowHeader,
         selectionModes: SelectionModes.ALL,
     };
@@ -1023,7 +1022,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             fillBodyWithGhostCells,
             loadingOptions,
             renderBodyContextMenu,
-            renderOptimizationMode,
+            renderMode,
             selectedRegionTransform,
         } = this.props;
 
@@ -1061,7 +1060,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                         onFocus={this.handleFocus}
                         onSelection={this.getEnabledSelectionHandler(RegionCardinality.CELLS)}
                         renderBodyContextMenu={renderBodyContextMenu}
-                        renderOptimizationMode={renderOptimizationMode}
+                        renderMode={renderMode}
                         selectedRegions={selectedRegions}
                         selectedRegionTransform={selectedRegionTransform}
                         viewportRect={viewportRect}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -354,6 +354,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         minColumnWidth: 50,
         minRowHeight: 20,
         numRows: 0,
+        renderOptimizationMode: RenderOptimizationMode.BATCH,
         renderRowHeader: renderDefaultRowHeader,
         selectionModes: SelectionModes.ALL,
     };
@@ -1022,6 +1023,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             fillBodyWithGhostCells,
             loadingOptions,
             renderBodyContextMenu,
+            renderOptimizationMode,
             selectedRegionTransform,
         } = this.props;
 
@@ -1059,6 +1061,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                         onFocus={this.handleFocus}
                         onSelection={this.getEnabledSelectionHandler(RegionCardinality.CELLS)}
                         renderBodyContextMenu={renderBodyContextMenu}
+                        renderOptimizationMode={renderOptimizationMode}
                         selectedRegions={selectedRegions}
                         selectedRegionTransform={selectedRegionTransform}
                         viewportRect={viewportRect}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -18,6 +18,7 @@ import { Clipboard } from "./common/clipboard";
 import * as Errors from "./common/errors";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
+import { RenderOptimizationMode } from "./common/renderOptimizationMode";
 import { Utils } from "./common/utils";
 import { ColumnHeader, IColumnWidths } from "./headers/columnHeader";
 import { ColumnHeaderCell, IColumnHeaderCellProps } from "./headers/columnHeaderCell";
@@ -206,6 +207,15 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
      * represents the clicked cell.
      */
     renderBodyContextMenu?: IContextMenuRenderer;
+
+    /**
+     * Dictates how cells should be rendered. Supported modes are:
+     * - `RenderOptimizationMode.BATCH`: renders cells in batches to improve
+     *   performance
+     * - `RenderOptimizationMode.NONE`: renders cells synchronously all at once
+     * @default RenderOptimizationMode.BATCH
+     */
+    renderOptimizationMode?: RenderOptimizationMode;
 
     /**
      * Render each row's header cell.

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -15,13 +15,13 @@ import * as Classes from "./common/classes";
 import { ContextMenuTargetWrapper } from "./common/contextMenuTargetWrapper";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
+import { RenderOptimizationMode } from "./common/renderOptimizationMode";
 import { Utils } from "./common/utils";
 import { ICoordinateData } from "./interactions/draggable";
 import { IContextMenuRenderer, MenuContext } from "./interactions/menus";
 import { DragSelectable, ISelectableProps } from "./interactions/selectable";
 import { ILocator } from "./locator";
 import { Regions } from "./regions";
-import { RenderOptimizationMode } from "./common/renderOptimizationMode";
 
 export interface ITableBodyProps extends ISelectableProps, IRowIndices, IColumnIndices, IProps {
     /**

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -15,7 +15,7 @@ import * as Classes from "./common/classes";
 import { ContextMenuTargetWrapper } from "./common/contextMenuTargetWrapper";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
-import { RenderOptimizationMode } from "./common/renderOptimizationMode";
+import { RenderMode } from "./common/renderMode";
 import { Utils } from "./common/utils";
 import { ICoordinateData } from "./interactions/draggable";
 import { IContextMenuRenderer, MenuContext } from "./interactions/menus";
@@ -71,12 +71,12 @@ export interface ITableBodyProps extends ISelectableProps, IRowIndices, IColumnI
 
     /**
      * Dictates how cells should be rendered. Supported modes are:
-     * - `RenderOptimizationMode.BATCH`: renders cells in batches to improve
+     * - `RenderMode.BATCH`: renders cells in batches to improve
      *   performance
-     * - `RenderOptimizationMode.NONE`: renders cells synchronously all at once
-     * @default RenderOptimizationMode.BATCH
+     * - `RenderMode.NONE`: renders cells synchronously all at once
+     * @default RenderMode.BATCH
      */
-    renderOptimizationMode?: RenderOptimizationMode;
+    renderMode?: RenderMode;
 }
 
 /**
@@ -110,7 +110,7 @@ const RESET_CELL_KEYS_BLACKLIST: Array<keyof ITableBodyProps> = [
 export class TableBody extends React.Component<ITableBodyProps, {}> {
     public static defaultProps = {
         loading: false,
-        renderOptimizationMode: RenderOptimizationMode.BATCH,
+        renderMode: RenderMode.BATCH,
     };
 
     /**
@@ -156,12 +156,12 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
             numFrozenRows,
             onFocus,
             onSelection,
-            renderOptimizationMode,
+            renderMode,
             selectedRegions,
             selectedRegionTransform,
         } = this.props;
 
-        const cells = (renderOptimizationMode === RenderOptimizationMode.BATCH)
+        const cells = (renderMode === RenderMode.BATCH)
             ? this.renderBatchedCells()
             : this.renderAllCells();
 

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -6,7 +6,15 @@
  */
 
 import { expect } from "chai";
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { Cell } from "../src/cell/cell";
+import { Batcher } from "../src/common/batcher";
 import * as Classes from "../src/common/classes";
+import { Grid } from "../src/common/grid";
+import { Rect } from "../src/common/rect";
+import { RenderOptimizationMode } from "../src/common/renderOptimizationMode";
 import { TableBody } from "../src/tableBody";
 
 describe("TableBody", () => {
@@ -22,4 +30,69 @@ describe("TableBody", () => {
         ]);
     });
 
+    describe("renderOptimizationMode", () => {
+        // use enough rows that batching won't render all of them in one pass.
+        // and careful: if this value is too big (~100), the batcher's reliance
+        // on `requestIdleCallback` may cause the tests to run multiple times.
+        const LARGE_NUM_ROWS = Batcher.DEFAULT_ADD_LIMIT * 2;
+        const NUM_COLUMNS = 1;
+
+        const COLUMN_WIDTH = 100;
+        const ROW_HEIGHT = 20;
+
+        it("renders all cells immediately if renderOptimizationMode === RenderOptimizationMode.NONE", () => {
+            const tableBody = mountTableBody(RenderOptimizationMode.NONE);
+
+            // expect all cells to have rendered in one pass
+            expect(tableBody.find(Cell).length).to.equal(LARGE_NUM_ROWS);
+        });
+
+        it("uses batch rendering if renderOptimizationMode === RenderOptimizationMode.BATCH", () => {
+            const tableBody = mountTableBody(RenderOptimizationMode.BATCH);
+
+            // run this assertion immediately, expecting that the batching hasn't finished yet.
+            expect(tableBody.find(Cell).length).to.equal(Batcher.DEFAULT_ADD_LIMIT);
+        });
+
+        function mountTableBody(renderOptimizationMode: RenderOptimizationMode) {
+            const rowHeights = Array(LARGE_NUM_ROWS).fill(ROW_HEIGHT);
+            const columnWidths = Array(NUM_COLUMNS).fill(COLUMN_WIDTH);
+
+            const grid = new Grid(rowHeights, columnWidths);
+            const viewportRect = new Rect(0, 0, NUM_COLUMNS * COLUMN_WIDTH, LARGE_NUM_ROWS * ROW_HEIGHT);
+
+            return mount(
+                <TableBody
+                    cellRenderer={renderCell}
+                    grid={grid}
+                    loading={false}
+                    locator={null}
+                    renderOptimizationMode={renderOptimizationMode}
+                    viewportRect={viewportRect}
+
+                    // ISelectableProps
+                    allowMultipleSelection={true}
+                    onFocus={noop}
+                    onSelection={noop}
+                    selectedRegions={[]}
+
+                    // IRowIndices
+                    rowIndexStart={0}
+                    rowIndexEnd={LARGE_NUM_ROWS - 1}
+
+                    // IColumnIndices
+                    columnIndexStart={0}
+                    columnIndexEnd={NUM_COLUMNS - 1}
+                />,
+            );
+        }
+
+        function renderCell() {
+            return <Cell>gg</Cell>;
+        }
+
+        function noop() {
+            return;
+        }
+    });
 });

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -14,7 +14,7 @@ import { Batcher } from "../src/common/batcher";
 import * as Classes from "../src/common/classes";
 import { Grid } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
-import { RenderOptimizationMode } from "../src/common/renderOptimizationMode";
+import { RenderMode } from "../src/common/renderMode";
 import { TableBody } from "../src/tableBody";
 
 describe("TableBody", () => {
@@ -30,7 +30,7 @@ describe("TableBody", () => {
         ]);
     });
 
-    describe("renderOptimizationMode", () => {
+    describe("renderMode", () => {
         // use enough rows that batching won't render all of them in one pass.
         // and careful: if this value is too big (~100), the batcher's reliance
         // on `requestIdleCallback` may cause the tests to run multiple times.
@@ -40,21 +40,21 @@ describe("TableBody", () => {
         const COLUMN_WIDTH = 100;
         const ROW_HEIGHT = 20;
 
-        it("renders all cells immediately if renderOptimizationMode === RenderOptimizationMode.NONE", () => {
-            const tableBody = mountTableBody(RenderOptimizationMode.NONE);
+        it("renders all cells immediately if renderMode === RenderMode.NONE", () => {
+            const tableBody = mountTableBody(RenderMode.NONE);
 
             // expect all cells to have rendered in one pass
             expect(tableBody.find(Cell).length).to.equal(LARGE_NUM_ROWS);
         });
 
-        it("uses batch rendering if renderOptimizationMode === RenderOptimizationMode.BATCH", () => {
-            const tableBody = mountTableBody(RenderOptimizationMode.BATCH);
+        it("uses batch rendering if renderMode === RenderMode.BATCH", () => {
+            const tableBody = mountTableBody(RenderMode.BATCH);
 
             // run this assertion immediately, expecting that the batching hasn't finished yet.
             expect(tableBody.find(Cell).length).to.equal(Batcher.DEFAULT_ADD_LIMIT);
         });
 
-        function mountTableBody(renderOptimizationMode: RenderOptimizationMode) {
+        function mountTableBody(renderMode: RenderMode) {
             const rowHeights = Array(LARGE_NUM_ROWS).fill(ROW_HEIGHT);
             const columnWidths = Array(NUM_COLUMNS).fill(COLUMN_WIDTH);
 
@@ -67,7 +67,7 @@ describe("TableBody", () => {
                     grid={grid}
                     loading={false}
                     locator={null}
-                    renderOptimizationMode={renderOptimizationMode}
+                    renderMode={renderMode}
                     viewportRect={viewportRect}
 
                     // ISelectableProps


### PR DESCRIPTION
#### Addresses #1374, #1415, #1495

#### Checklist

- [x] Include tests
- [x] Update documentation (contained in new prop's description)

#### Changes proposed in this pull request:

- 💎 __NEW__ `Table` now supports a `renderMode?: RenderMode` prop:
    - `RenderMode.BATCH` _(default)_: renders cells in batches to improve performance
    - `RenderMode.NONE`: renders cells synchronously all at once
- Added a new "Batch rendering" switch to the `Table` example:
![image](https://user-images.githubusercontent.com/443450/29735793-8b4912c8-89b0-11e7-86df-9385e2fc6d74.png)


#### Reviewers should focus on:

I designed the prop as a `RenderMode` enum instead of a `useBatchRendering` boolean to allow us to support additional rendering modes in the future. See: https://github.com/palantir/blueprint/issues/1374#issuecomment-318497948, pasted here for your convenience:

> Another idea is, instead of a prop `useBatchRendering?: boolean;`, to add a `renderOptimizationMode?: RenderOptimizationMode;` prop (working title) that accepts values like:
> - `RenderOptimizationMode.BATCH`: render as many new cells as possible per frame, and no more (this is what we currently have, and this scheme also has the strongest guarantee against bringing the UI to a crawl)
> - `RenderOptimizationMode.DEBOUNCE`: debounce scrolling, hiding cells on scroll start and rendering cells all at once after the scroll event finishes (this has a risk of locking the UI if the cells are small/numerous/complex/have truncated content, e.g.)
> - `RenderOptimizationMode.NONE`: no optimizations, just render everything (useful for smaller tables, but can easily bring the UI to a crawl on larger tables)
> 
> (Maybe also a `RenderOptimizationMode.THROTTLE` for throttling scrolling).
