### PR TITLE
[Table] Fix selection off-by-1px alignment issues

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1268,27 +1268,31 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const fixedHeight = this.grid.getHeight();
         const fixedWidth = this.grid.getWidth();
 
+        // include a correction in some cases to hide borders along quadrant boundaries
+        const alignmentCorrection = 1;
+        const alignmentCorrectionString = `-${alignmentCorrection}px`;
+
         switch (cardinality) {
             case RegionCardinality.CELLS:
                 return style;
             case RegionCardinality.FULL_COLUMNS:
-                style.top = "-1px";
-                style.height = fixedHeight;
+                style.top = alignmentCorrectionString;
+                style.height = fixedHeight + alignmentCorrection;
                 return style;
             case RegionCardinality.FULL_ROWS:
-                style.left = "-1px";
-                style.width = fixedWidth;
+                style.left = alignmentCorrectionString;
+                style.width = fixedWidth + alignmentCorrection;
                 if (canHideRightBorder) {
-                    style.right = "-1px";
+                    style.right = alignmentCorrectionString;
                 }
                 return style;
             case RegionCardinality.FULL_TABLE:
-                style.left = "-1px";
-                style.top = "-1px";
-                style.width = fixedWidth;
-                style.height = fixedHeight;
+                style.left = alignmentCorrectionString;
+                style.top = alignmentCorrectionString;
+                style.width = fixedWidth + alignmentCorrection;
+                style.height = fixedHeight + alignmentCorrection;
                 if (canHideRightBorder) {
-                    style.right = "-1px";
+                    style.right = alignmentCorrectionString;
                 }
                 return style;
             default:


### PR DESCRIPTION
#### Fixes #1481

#### Checklist

- [x] Include tests (for `FULL_TABLE` selection only, not `FULL_ROWS` or `FULL_COLUMNS`)

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `Table` `FULL_ROWS`, `FULL_COLUMNS`, and `FULL_TABLE` selection overlays now align properly to cells on their bottom/right sides.

#### Reviewers should focus on:

- Are the `alignmentCorrection` and `alignmentCorrectionString` variables overkill?

#### Screenshot

**_Before:_**
`FULL_ROWS` selection is 1px too narrow.
![image](https://user-images.githubusercontent.com/443450/29747018-7421c4ea-8aa1-11e7-9d75-5876aaf716aa.png)

`FULL_COLUMNS` selection is 1px too short.
![image](https://user-images.githubusercontent.com/443450/29747020-7d43cfbe-8aa1-11e7-82ee-a456a6bbf886.png)

`FULL_TABLE` selection is 1px too short and 1px too narrow.
![image](https://user-images.githubusercontent.com/443450/29746804-c34129aa-8a9a-11e7-8c30-532cea066392.png)

**_After:_**
All overlays align perfectly with the cell borders below.

![image](https://user-images.githubusercontent.com/443450/29747037-b673da18-8aa1-11e7-955e-0880e01f5b15.png)

![image](https://user-images.githubusercontent.com/443450/29747032-ac24bd2a-8aa1-11e7-8bac-67e1f3039ce3.png)

![image](https://user-images.githubusercontent.com/443450/29746797-7a544376-8a9a-11e7-8f19-eb48b547d8bb.png)
