### PR TITLE
[Tabs2] Add 'large' prop

### DIFF
--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -46,6 +46,14 @@ export interface ITabs2Props extends IProps {
     id: TabId;
 
     /**
+     * If set to `true`, the tabs will display with larger styling.
+     * This is equivalent to setting `pt-large` on the `.pt-tab-list` element.
+     * This will apply large styles only to the tabs at this level, not to nested tabs.
+     * @default false
+     */
+    large?: boolean;
+
+    /**
      * Whether inactive tab panels should be removed from the DOM and unmounted in React.
      * This can be a performance enhancement when rendering many complex panels, but requires
      * careful support for unmounting and remounting.
@@ -86,6 +94,7 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
 
     public static defaultProps: Partial<ITabs2Props> = {
         animate: true,
+        large: false,
         renderActiveTabPanelOnly: false,
         vertical: false,
     };
@@ -121,11 +130,14 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
         );
 
         const classes = classNames(Classes.TABS, { [Classes.VERTICAL]: this.props.vertical }, this.props.className);
+        const tabListClasses = classNames(Classes.TAB_LIST, {
+            [Classes.LARGE]: this.props.large,
+        });
 
         return (
             <div className={classes}>
                 <div
-                    className={Classes.TAB_LIST}
+                    className={tabListClasses}
                     onKeyDown={this.handleKeyDown}
                     onKeyPress={this.handleKeyPress}
                     ref={this.refHandlers.tablist}

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -10,6 +10,7 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import * as Classes from "../../src/common/classes";
 import * as Keys from "../../src/common/keys";
 import { Tab2 } from "../../src/components/tabs2/tab2";
 import { ITabs2Props, ITabs2State, Tabs2 } from "../../src/components/tabs2/tabs2";
@@ -75,6 +76,16 @@ describe("<Tabs2>", () => {
             // hidden unless it is active
             assert.equal(tabs.at(i).prop("aria-hidden"), i !== activeIndex);
         }
+    });
+
+    it("renders without `pt-large` when by default", () => {
+        const wrapper = mount(<Tabs2 id={ID}>{getTabsContents()}</Tabs2>);
+        assert.lengthOf(wrapper.find(`.${Classes.TAB_LIST}.${Classes.LARGE}`), 0);
+    });
+
+    it("renders using `pt-large` when large={true}", () => {
+        const wrapper = mount(<Tabs2 id={ID} large={true}>{getTabsContents()}</Tabs2>);
+        assert.lengthOf(wrapper.find(`.${Classes.TAB_LIST}.${Classes.LARGE}`), 1);
     });
 
     it("renderActiveTabPanelOnly only renders active tab panel", () => {


### PR DESCRIPTION
#### Fixes #1506

#### Checklist

- [x] Include tests
- [x] Update documentation (automatically with new prop)

#### Changes proposed in this pull request:

- 💎 __NEW__ `Tabs2` now offers the `large?: boolean` prop to set `pt-large` styling via the JavaScript API.
    - ⚠️ This PR fixes a regression introduced in 1.26.0 (#1476 via #1494).
    - The deprecated `Tabs` component is not prohibitively affected by the regression, because consumers must supply their own `<TabList>` child that they can style with `pt-large` (small changes like this were a known risk of merging #1476).

#### Reviewers should focus on:

- Prop description language. I took inspiration from `NumericInput`'s `large`-prop description.
- **Should we cut a patch release (1.26.1)?**