### PR TITLE
[Overlay] Skip flaky unit test

### DIFF
--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -157,7 +157,7 @@ describe("<Overlay>", () => {
         const testsContainerElement = document.createElement("div");
         document.documentElement.appendChild(testsContainerElement);
 
-        it("brings focus to overlay if autoFocus=true", (done) => {
+        it.skip("brings focus to overlay if autoFocus=true", (done) => {
             wrapper = mount(
                 <Overlay autoFocus={true} inline={false} isOpen={true}>
                     <input type="text" />


### PR DESCRIPTION
This test fails quite often now, but not always:

```
<Overlay>
  Focus management
    ✖ brings focus to overlay if autoFocus=true
```

Since this has been causing tons of build failures on branches that don't even touch `Overlay` code, I'm opening this PR to `.skip` this test for now.