### PR TITLE
Fix Table column-header borders on ghost cells

### DIFF
--- a/packages/table/src/cell/_borders.scss
+++ b/packages/table/src/cell/_borders.scss
@@ -21,10 +21,6 @@ for all borders with minimal duplication. See the bottom of this file.
     box-shadow: 0 $border-width 0 $border-color;
   }
 
-  .bp-table-column-headers {
-    box-shadow: 0 $border-width 0 0 $border-color;
-  }
-
   .bp-table-row-headers {
     box-shadow: inset 0 $border-width 0 $border-color;
   }
@@ -40,7 +36,8 @@ for all borders with minimal duplication. See the bottom of this file.
   }
 
   .bp-table-column-headers .bp-table-header {
-    box-shadow: inset (-$border-width) 0 0 $border-color;
+    box-shadow: inset (-$border-width) 0 0 $border-color,
+                0 $border-width 0 $border-color;
 
     &::before {
       // hover shadow


### PR DESCRIPTION
#### Fixes #1511 

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `Table` column-header ghost cells are no longer missing borders.

#### Reviewers should focus on:

- Does the column-header border still look good in every case?
- I noticed some existing style weirdness with header borders when there are `0 rows` and/or `0 columns`. Can address that later.

#### Screenshot

_BEFORE_
![image](https://user-images.githubusercontent.com/443450/29892466-79d8e852-8d83-11e7-8423-cc851f522bf1.png)

_AFTER:_
![image](https://user-images.githubusercontent.com/443450/29892307-ff1c2aac-8d82-11e7-8f86-4687bf9c308e.png)
