### PR TITLE
[Table] A slightly different tactic to hopefully fully popover overflow

### DIFF
--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -157,14 +157,16 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
 
         // if the popover handle exists, take it into account
-        let popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
-        // add a slight bit of buffer space where we don't show the popover, to deal with cases
-        // where everything isn't pixel perfect
-        popoverHandleAdjustmentFactor += .5;
+        const popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
 
-        const isTruncated = this.contentDiv !== undefined &&
+        let isTruncated = this.contentDiv !== undefined &&
             (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||
             this.contentDiv.scrollHeight > this.contentDiv.clientHeight);
+        // don't remove the popover if the widths are equal, because this can cause issues with pixel-perfectness
+        if (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor === this.contentDiv.clientWidth &&
+            this.state.isTruncated) {
+                isTruncated = true;
+            }
         if (this.state.isTruncated !== isTruncated) {
             this.setState({ isTruncated });
         }

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -156,19 +156,38 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             return;
         }
 
-        // if the popover handle exists, take it into account
-        const popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
+        if (this.contentDiv === undefined) {
+            this.setState({ isTruncated: false });
+            return;
+        }
 
-        let isTruncated = this.contentDiv !== undefined &&
-            (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||
-            this.contentDiv.scrollHeight > this.contentDiv.clientHeight);
-        // don't remove the popover if the widths are equal, because this can cause issues with pixel-perfectness
-        if (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor === this.contentDiv.clientWidth &&
-            this.state.isTruncated) {
-                isTruncated = true;
-            }
-        if (this.state.isTruncated !== isTruncated) {
-            this.setState({ isTruncated });
+        const { isTruncated } = this.state;
+
+        // take all measurements at once to avoid excessive DOM reflows.
+        const {
+            clientHeight: containerHeight,
+            clientWidth: containerWidth,
+            scrollHeight: actualContentHeight,
+            scrollWidth: contentWidth,
+        } = this.contentDiv;
+
+        // if the content is truncated, then a popover handle will be present as a
+        // sibling of the content. we don't want to consider that handle when
+        // calculating the width of the actual content, so subtract it.
+        const actualContentWidth = isTruncated
+            ? contentWidth - CONTENT_DIV_WIDTH_DELTA
+            : contentWidth;
+
+        // we of course truncate the content if it doesn't fit in the container. but we
+        // also aggressively truncate if they're the same size with truncation enabled;
+        // this addresses browser-crashing stack-overflow bugs at various zoom levels.
+        // (see: https://github.com/palantir/blueprint/pull/1519)
+        const shouldTruncate = (isTruncated && actualContentWidth === containerWidth)
+            || actualContentWidth > containerWidth
+            || actualContentHeight > containerHeight;
+
+        if (isTruncated !== shouldTruncate) {
+            this.setState({ isTruncated: shouldTruncate });
         }
     }
 }


### PR DESCRIPTION
#### Fixes #1459

#### Changes proposed in this pull request:

Modify the popover behavior so that it doesn't go away if the two things are equal, because of issues with pixel-perfectness at different zoom levels.

#### Reviewers should focus on:

This unfortunately means that double-clicking to resize a column won't always work. I really can't figure out a way to resolve this and also not have infinite loops at 90% zoom level, though. 

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
