### PR TITLE
Prepare release table-1.24.1

### DIFF
--- a/packages/site-docs/package.json
+++ b/packages/site-docs/package.json
@@ -8,7 +8,7 @@
     "@blueprintjs/datetime": "^1.22.0",
     "@blueprintjs/docs": "^1.1.1",
     "@blueprintjs/labs": "^0.8.0",
-    "@blueprintjs/table": "^1.24.0",
+    "@blueprintjs/table": "^1.24.1",
     "bourbon": "^4.2.2",
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
:book: **Latest docs**: [blueprintjs.com/docs](http://blueprintjs.com/docs)

## `@blueprintjs/table 1.24.1`

### 🐛  Bug fixes
- `@blueprintjs/table` now exports `RenderMode` enum (for use in `Table`'s `renderMode?: RenderMode` prop).