### PR TITLE
[Table] Select the target cell on right-click

### DIFF
--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -21,7 +21,7 @@ import { ICoordinateData } from "./interactions/draggable";
 import { IContextMenuRenderer, MenuContext } from "./interactions/menus";
 import { DragSelectable, ISelectableProps } from "./interactions/selectable";
 import { ILocator } from "./locator";
-import { Regions } from "./regions";
+import { Regions, IRegion } from "./regions";
 
 export interface ITableBodyProps extends ISelectableProps, IRowIndices, IColumnIndices, IProps {
     /**
@@ -218,21 +218,20 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         const targetRegion = this.locateClick(e.nativeEvent as MouseEvent);
         const { numRows, numCols } = grid;
 
-        const menuContext = new MenuContext(targetRegion, selectedRegions, numRows, numCols);
-        const contextMenu = renderBodyContextMenu(menuContext);
-
-        if (contextMenu == null) {
-            return undefined;
-        }
+        let nextSelectedRegions: IRegion[] = selectedRegions;
 
         // if the event did not happen within a selected region, clear all
         // selections and select the right-clicked cell.
         const foundIndex = Regions.findContainingRegion(selectedRegions, targetRegion);
         if (foundIndex < 0) {
-            this.props.onSelection([targetRegion]);
+            nextSelectedRegions = [targetRegion];
+            this.props.onSelection(nextSelectedRegions);
         }
 
-        return contextMenu;
+        const menuContext = new MenuContext(targetRegion, nextSelectedRegions, numRows, numCols);
+        const contextMenu = renderBodyContextMenu(menuContext);
+
+        return contextMenu == null ? undefined : contextMenu;
     }
 
     // Render modes

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -215,8 +215,24 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
             return undefined;
         }
 
-        const target = this.locateClick(e.nativeEvent as MouseEvent);
-        return renderBodyContextMenu(new MenuContext(target, selectedRegions, grid.numRows, grid.numCols));
+        const targetRegion = this.locateClick(e.nativeEvent as MouseEvent);
+        const { numRows, numCols } = grid;
+
+        const menuContext = new MenuContext(targetRegion, selectedRegions, numRows, numCols);
+        const contextMenu = renderBodyContextMenu(menuContext);
+
+        if (contextMenu == null) {
+            return undefined;
+        }
+
+        // if the event did not happen within a selected region, clear all
+        // selections and select the right-clicked cell.
+        const foundIndex = Regions.findMatchingRegion(selectedRegions, targetRegion);
+        if (foundIndex < 0) {
+            this.props.onSelection([targetRegion]);
+        }
+
+        return contextMenu;
     }
 
     // Render modes

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -227,7 +227,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
 
         // if the event did not happen within a selected region, clear all
         // selections and select the right-clicked cell.
-        const foundIndex = Regions.findMatchingRegion(selectedRegions, targetRegion);
+        const foundIndex = Regions.findContainingRegion(selectedRegions, targetRegion);
         if (foundIndex < 0) {
             this.props.onSelection([targetRegion]);
         }

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -10,7 +10,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import { emptyCellRenderer, ICellProps, ICellRenderer } from "./cell/cell";
 import { Batcher } from "./common/batcher";
-import { ICellCoordinates, IFocusedCellCoordinates } from "./common/cell";
+import { ICellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
 import { ContextMenuTargetWrapper } from "./common/contextMenuTargetWrapper";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -15,8 +15,8 @@ import * as Classes from "../src/common/classes";
 import { Grid } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
 import { RenderMode } from "../src/common/renderMode";
-import { ITableBodyProps, TableBody } from "../src/tableBody";
 import { IRegion, Regions } from "../src/regions";
+import { ITableBodyProps, TableBody } from "../src/tableBody";
 
 describe("TableBody", () => {
     // use enough rows that batching won't render all of them in one pass.
@@ -110,7 +110,7 @@ describe("TableBody", () => {
 
         afterEach(() => {
             onSelection.reset();
-        })
+        });
 
         it("should select a right-clicked cell if there is no active selection", () => {
             const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -6,7 +6,7 @@
  */
 
 import { expect } from "chai";
-import { mount } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
 import { Cell } from "../src/cell/cell";
@@ -117,46 +117,64 @@ describe("TableBody", () => {
             renderBodyContextMenu.reset();
         });
 
-        it("selects a right-clicked cell if there is no active selection", () => {
-            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
-            tableBody.simulate("contextmenu");
-            checkOnSelectionCallback([TARGET_REGION]);
+        describe("on right-click", () => {
+            const simulateAction = (tableBody: ReactWrapper<any, any>) => {
+                tableBody.simulate("contextmenu");
+            };
+            runTestSuite(simulateAction);
         });
 
-        it("doesn't change the selected regions if the right-clicked cell is contained in one", () => {
-            const selectedRegions = [
-                Regions.row(TARGET_ROW + 1), // some other row
-                Regions.cell(0, 0, TARGET_ROW + 1, TARGET_COLUMN + 1), // includes the target cell
-            ];
-            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, selectedRegions);
-            tableBody.simulate("contextmenu");
-            expect(onSelection.called).to.be.false;
+        // TODO: make this work (tracked in https://github.com/palantir/blueprint/issues/1549)
+        describe.skip("on ctrl+click", () => {
+            // ctrl+click should also triggers the context menu and should behave in the exact same way
+            const simulateAction = (tableBody: ReactWrapper<any, any>) => {
+                tableBody.simulate("mousedown", { ctrlKey: true });
+            };
+            runTestSuite(simulateAction);
         });
 
-        // tslint:disable-next-line:max-line-length
-        it("clears selections and select the right-clicked cell if it isn't within any existing selection", () => {
-            const selectedRegions = [
-                Regions.row(TARGET_ROW + 1), // some other row
-                Regions.cell(TARGET_ROW + 1, TARGET_COLUMN + 1), // includes the target cell
-            ];
-            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, selectedRegions);
-            tableBody.simulate("contextmenu");
-            checkOnSelectionCallback([TARGET_REGION]);
-        });
+        function runTestSuite(simulateAction: (tableBody: ReactWrapper<any, any>) => void) {
+            it("selects a right-clicked cell if there is no active selection", () => {
+                const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+                simulateAction(tableBody);
+                checkOnSelectionCallback([TARGET_REGION]);
+            });
 
-        it("renders context menu using new selection if selection changed on right-click", () => {
-            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
-            tableBody.simulate("contextmenu");
-            const menuContext = renderBodyContextMenu.firstCall.args[0] as MenuContext;
-            expect(menuContext.getSelectedRegions()).to.deep.equal([TARGET_REGION]);
-        });
+            it("doesn't change the selected regions if the right-clicked cell is contained in one", () => {
+                const selectedRegions = [
+                    Regions.row(TARGET_ROW + 1), // some other row
+                    Regions.cell(0, 0, TARGET_ROW + 1, TARGET_COLUMN + 1), // includes the target cell
+                ];
+                const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, selectedRegions);
+                simulateAction(tableBody);
+                expect(onSelection.called).to.be.false;
+            });
 
-        it("moves focused cell to right-clicked cell if selection changed on right-click", () => {
-            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
-            tableBody.simulate("contextmenu");
-            expect(onFocus.calledOnce).to.be.true;
-            expect(onFocus.firstCall.args[0]).to.deep.equal({ ...TARGET_CELL_COORDS, focusSelectionIndex: 0 });
-        });
+            // tslint:disable-next-line:max-line-length
+            it("clears selections and select the right-clicked cell if it isn't within any existing selection", () => {
+                const selectedRegions = [
+                    Regions.row(TARGET_ROW + 1), // some other row
+                    Regions.cell(TARGET_ROW + 1, TARGET_COLUMN + 1), // includes the target cell
+                ];
+                const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, selectedRegions);
+                simulateAction(tableBody);
+                checkOnSelectionCallback([TARGET_REGION]);
+            });
+
+            it("renders context menu using new selection if selection changed on right-click", () => {
+                const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+                simulateAction(tableBody);
+                const menuContext = renderBodyContextMenu.firstCall.args[0] as MenuContext;
+                expect(menuContext.getSelectedRegions()).to.deep.equal([TARGET_REGION]);
+            });
+
+            it("moves focused cell to right-clicked cell if selection changed on right-click", () => {
+                const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+                simulateAction(tableBody);
+                expect(onFocus.calledOnce).to.be.true;
+                expect(onFocus.firstCall.args[0]).to.deep.equal({ ...TARGET_CELL_COORDS, focusSelectionIndex: 0 });
+            });
+        }
 
         function mountTableBodyForContextMenuTests(
             targetCellCoords: { row: number, col: number },

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -15,6 +15,7 @@ import * as Classes from "../src/common/classes";
 import { Grid } from "../src/common/grid";
 import { Rect } from "../src/common/rect";
 import { RenderMode } from "../src/common/renderMode";
+import { MenuContext } from "../src/interactions/menus/menuContext";
 import { IRegion, Regions } from "../src/regions";
 import { ITableBodyProps, TableBody } from "../src/tableBody";
 
@@ -107,15 +108,24 @@ describe("TableBody", () => {
         const TARGET_REGION = Regions.cell(TARGET_ROW, TARGET_COLUMN);
 
         const onSelection = sinon.spy();
+        const renderBodyContextMenu = sinon.stub().returns(<div />);
 
         afterEach(() => {
             onSelection.reset();
+            renderBodyContextMenu.reset();
         });
 
         it("should select a right-clicked cell if there is no active selection", () => {
             const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
             tableBody.simulate("contextmenu");
             checkOnSelectionCallback([TARGET_REGION]);
+        });
+
+        it("should render context menu using new selection if selection changed on right-click", () => {
+            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+            tableBody.simulate("contextmenu");
+            const menuContext = renderBodyContextMenu.firstCall.args[0] as MenuContext;
+            expect(menuContext.getSelectedRegions()).to.deep.equal([TARGET_REGION]);
         });
 
         it("should not change the selected regions if the right-clicked cell is contained in one", () => {
@@ -147,7 +157,7 @@ describe("TableBody", () => {
                 locator: {
                     convertPointToCell: sinon.stub().returns(targetCellCoords),
                 } as any,
-                renderBodyContextMenu: sinon.stub().returns(<div />),
+                renderBodyContextMenu,
                 selectedRegions,
                 onSelection,
             });

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -101,34 +101,29 @@ describe("TableBody", () => {
     });
 
     describe("renderBodyContextMenu", () => {
-         // 0-indexed coordinates
+        // 0-indexed coordinates
         const TARGET_ROW = 1;
         const TARGET_COLUMN = 1;
         const TARGET_CELL_COORDS = { row: TARGET_ROW, col: TARGET_COLUMN };
         const TARGET_REGION = Regions.cell(TARGET_ROW, TARGET_COLUMN);
 
+        const onFocus = sinon.spy();
         const onSelection = sinon.spy();
         const renderBodyContextMenu = sinon.stub().returns(<div />);
 
         afterEach(() => {
+            onFocus.reset();
             onSelection.reset();
             renderBodyContextMenu.reset();
         });
 
-        it("should select a right-clicked cell if there is no active selection", () => {
+        it("selects a right-clicked cell if there is no active selection", () => {
             const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
             tableBody.simulate("contextmenu");
             checkOnSelectionCallback([TARGET_REGION]);
         });
 
-        it("should render context menu using new selection if selection changed on right-click", () => {
-            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
-            tableBody.simulate("contextmenu");
-            const menuContext = renderBodyContextMenu.firstCall.args[0] as MenuContext;
-            expect(menuContext.getSelectedRegions()).to.deep.equal([TARGET_REGION]);
-        });
-
-        it("should not change the selected regions if the right-clicked cell is contained in one", () => {
+        it("doesn't change the selected regions if the right-clicked cell is contained in one", () => {
             const selectedRegions = [
                 Regions.row(TARGET_ROW + 1), // some other row
                 Regions.cell(0, 0, TARGET_ROW + 1, TARGET_COLUMN + 1), // includes the target cell
@@ -139,7 +134,7 @@ describe("TableBody", () => {
         });
 
         // tslint:disable-next-line:max-line-length
-        it("should clear selections and select the right-clicked cell if it isn't within any existing selection", () => {
+        it("clears selections and select the right-clicked cell if it isn't within any existing selection", () => {
             const selectedRegions = [
                 Regions.row(TARGET_ROW + 1), // some other row
                 Regions.cell(TARGET_ROW + 1, TARGET_COLUMN + 1), // includes the target cell
@@ -147,6 +142,20 @@ describe("TableBody", () => {
             const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, selectedRegions);
             tableBody.simulate("contextmenu");
             checkOnSelectionCallback([TARGET_REGION]);
+        });
+
+        it("renders context menu using new selection if selection changed on right-click", () => {
+            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+            tableBody.simulate("contextmenu");
+            const menuContext = renderBodyContextMenu.firstCall.args[0] as MenuContext;
+            expect(menuContext.getSelectedRegions()).to.deep.equal([TARGET_REGION]);
+        });
+
+        it("moves focused cell to right-clicked cell if selection changed on right-click", () => {
+            const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+            tableBody.simulate("contextmenu");
+            expect(onFocus.calledOnce).to.be.true;
+            expect(onFocus.firstCall.args[0]).to.deep.equal({ ...TARGET_CELL_COORDS, focusSelectionIndex: 0 });
         });
 
         function mountTableBodyForContextMenuTests(
@@ -159,6 +168,7 @@ describe("TableBody", () => {
                 } as any,
                 renderBodyContextMenu,
                 selectedRegions,
+                onFocus,
                 onSelection,
             });
         }


### PR DESCRIPTION
#### Fixes #1187

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🐛 __Fixed__ `Table` now selects the target cell on right-click if the cell is not already contained in a selection.