### PR TITLE
[Table] Improve shift-select behavior

### DIFF
--- a/packages/table/src/common/errors.ts
+++ b/packages/table/src/common/errors.ts
@@ -25,3 +25,9 @@ export const TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING =
 
 export const TABLE_NUM_FROZEN_ROWS_BOUND_WARNING =
     `${ns} <Table> numFrozenRows must be in [0, numRows]`;
+
+export const TABLE_EXPAND_FOCUSED_SELECTION_MULTI_ROW_REGION =
+    `${ns} <Table> Cannot expand a FULL_COLUMNS selection using a multi-row region`;
+
+export const TABLE_EXPAND_FOCUSED_SELECTION_MULTI_COLUMN_REGION =
+    `${ns} <Table> Cannot expand a FULL_COLUMNS selection using a multi-column region`;

--- a/packages/table/src/common/errors.ts
+++ b/packages/table/src/common/errors.ts
@@ -26,8 +26,8 @@ export const TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING =
 export const TABLE_NUM_FROZEN_ROWS_BOUND_WARNING =
     `${ns} <Table> numFrozenRows must be in [0, numRows]`;
 
-export const TABLE_EXPAND_FOCUSED_SELECTION_MULTI_ROW_REGION =
+export const TABLE_EXPAND_FOCUSED_REGION_MULTI_ROW_REGION =
     `${ns} <Table> Cannot expand a FULL_COLUMNS selection using a multi-row region`;
 
-export const TABLE_EXPAND_FOCUSED_SELECTION_MULTI_COLUMN_REGION =
+export const TABLE_EXPAND_FOCUSED_REGION_MULTI_COLUMN_REGION =
     `${ns} <Table> Cannot expand a FULL_COLUMNS selection using a multi-column region`;

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -38,16 +38,14 @@ export function getInitialFocusedCell(
 }
 
 /**
- * Expands a set of selected regions to a new region in accordance with the
- * current location of the focused cell.
- *
- * @param focusedCell the currently focused cell
- * @param selectedRegions the currently selected regions
- * @param newRegion the new region to expand to
+ * Expands an existing region to new region based on the current focused cell.
+ * The focused cell is an invariant and should not move as a result of this
+ * operation. This function is used, for instance, to expand a selected region
+ * on shift+click.
  */
-export function expandSelectedRegions(
+export function expandRegions(
     focusedCell: IFocusedCellCoordinates,
-    selectedRegions: IRegion[],
+    oldRegion: IRegion,
     newRegion: IRegion,
 ): IRegion[] {
     // TODO

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -27,10 +27,11 @@ export function getInitialFocusedCell(
         // use the current focused cell from state
         return focusedCellFromState;
     } else if (selectedRegions.length > 0) {
-        // focus the top-left cell of the first selection
+        // focus the top-left cell of the last selection
+        const lastIndex = selectedRegions.length - 1;
         return {
-            ...Regions.getFocusCellCoordinatesFromRegion(selectedRegions[0]),
-            focusSelectionIndex: 0,
+            ...Regions.getFocusCellCoordinatesFromRegion(selectedRegions[lastIndex]),
+            focusSelectionIndex: lastIndex,
         };
     } else {
         // focus the top-left cell of the table

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -43,7 +43,7 @@ export function getInitialFocusedCell(
  * operation. This function is used, for instance, to expand a selected region
  * on shift+click.
  */
-export function expandRegions(
+export function expandRegion(
     focusedCell: IFocusedCellCoordinates,
     oldRegion: IRegion,
     newRegion: IRegion,

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { IRegion, RegionCardinality, Regions } from "../../regions";
-import { IFocusedCellCoordinates } from "../cell";
+import { ICellCoordinates, IFocusedCellCoordinates } from "../cell";
 import * as Errors from "../errors";
 
 /**
@@ -36,6 +36,17 @@ export function getInitialFocusedCell(
         // focus the top-left cell of the table
         return { col: 0, row: 0, focusSelectionIndex: 0 };
     }
+}
+
+/**
+ * Returns a new cell-coordinates object that includes a focusSelectionIndex property.
+ * The returned object will have the proper IFocusedCellCoordinates type.
+ */
+export function toFullCoordinates(
+    cellCoords: ICellCoordinates,
+    focusSelectionIndex: number = 0,
+): IFocusedCellCoordinates {
+    return { ...cellCoords, focusSelectionIndex };
 }
 
 /**

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -36,3 +36,20 @@ export function getInitialFocusedCell(
         return { col: 0, row: 0, focusSelectionIndex: 0 };
     }
 }
+
+/**
+ * Expands a set of selected regions to a new region in accordance with the
+ * current location of the focused cell.
+ *
+ * @param focusedCell the currently focused cell
+ * @param selectedRegions the currently selected regions
+ * @param newRegion the new region to expand to
+ */
+export function expandSelectedRegions(
+    focusedCell: IFocusedCellCoordinates,
+    selectedRegions: IRegion[],
+    newRegion: IRegion,
+): IRegion[] {
+    // TODO
+    return null;
+}

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -81,10 +81,10 @@ function getExpandedRegionIndices(
     focusedCellDimension: "row" | "col",
     regionDimension: "rows" | "cols",
 ) {
-    const srcIndex = focusedCell[focusedCellDimension];
-    const [dstIndex, dstIndexEnd] = newRegion[regionDimension];
+    const sourceIndex = focusedCell[focusedCellDimension];
+    const [destinationIndex, destinationIndexEnd] = newRegion[regionDimension];
 
-    if (dstIndex !== dstIndexEnd) {
+    if (destinationIndex !== destinationIndexEnd) {
         if (regionDimension === "rows") {
             throw new Error(Errors.TABLE_EXPAND_FOCUSED_REGION_MULTI_ROW_REGION);
         } else if (regionDimension === "cols") {
@@ -92,7 +92,7 @@ function getExpandedRegionIndices(
         }
     }
 
-    return srcIndex <= dstIndex
-        ? [srcIndex, dstIndex]
-        : [dstIndex, srcIndex];
+    return sourceIndex <= destinationIndex
+        ? [sourceIndex, destinationIndex]
+        : [destinationIndex, sourceIndex];
 }

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -71,6 +71,7 @@ function getExpandedRegionIndices(
 ) {
     const srcIndex = focusedCell[focusedCellDimension];
     const [dstIndex, dstIndexEnd] = newRegion[regionDimension];
+
     if (dstIndex !== dstIndexEnd) {
         if (regionDimension === "rows") {
             throw new Error(Errors.TABLE_EXPAND_FOCUSED_REGION_MULTI_ROW_REGION);
@@ -78,6 +79,8 @@ function getExpandedRegionIndices(
             throw new Error(Errors.TABLE_EXPAND_FOCUSED_REGION_MULTI_COLUMN_REGION);
         }
     }
-    return srcIndex <= dstIndex ? [srcIndex, dstIndex] : [dstIndex, srcIndex];
-}
 
+    return srcIndex <= dstIndex
+        ? [srcIndex, dstIndex]
+        : [dstIndex, srcIndex];
+}

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -44,20 +44,7 @@ export function getInitialFocusedCell(
  * operation. This function is used, for instance, to expand a selected region
  * on shift+click.
  */
-export function expandFocusedRegion(focusedCell: IFocusedCellCoordinates, oldRegion: IRegion, newRegion: IRegion) {
-    switch (Regions.getRegionCardinality(oldRegion)) {
-        case RegionCardinality.CELLS:
-            return expandCellRegion(focusedCell, newRegion);
-        case RegionCardinality.FULL_COLUMNS:
-            return expandColumnRegion(focusedCell, newRegion);
-        case RegionCardinality.FULL_ROWS:
-            return expandRowRegion(focusedCell, newRegion);
-        default:
-            return expandFullTableRegion(focusedCell, newRegion);
-    }
-}
-
-function expandColumnRegion(focusedCell: IFocusedCellCoordinates, newRegion: IRegion) {
+export function expandFocusedRegion(focusedCell: IFocusedCellCoordinates, newRegion: IRegion) {
     switch (Regions.getRegionCardinality(newRegion)) {
         case RegionCardinality.FULL_COLUMNS: {
             const [indexStart, indexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "col", "cols");
@@ -76,18 +63,6 @@ function expandColumnRegion(focusedCell: IFocusedCellCoordinates, newRegion: IRe
     }
 }
 
-function expandRowRegion(_focusedCell: IFocusedCellCoordinates, _newRegion: IRegion) {
-    // TODO
-}
-
-function expandCellRegion(_focusedCell: IFocusedCellCoordinates, _newRegion: IRegion) {
-    // TODO
-}
-
-function expandFullTableRegion(_focusedCell: IFocusedCellCoordinates, _newRegion: IRegion) {
-    // TODO
-}
-
 function getExpandedRegionIndices(
     focusedCell: IFocusedCellCoordinates,
     newRegion: IRegion,
@@ -103,9 +78,6 @@ function getExpandedRegionIndices(
             throw new Error(Errors.TABLE_EXPAND_FOCUSED_REGION_MULTI_COLUMN_REGION);
         }
     }
-    return sortIndices(srcIndex, dstIndex);
+    return srcIndex <= dstIndex ? [srcIndex, dstIndex] : [dstIndex, srcIndex];
 }
 
-function sortIndices(index1?: number, index2?: number) {
-    return index1 <= index2 ? [index1, index2] : [index2, index1];
-}

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -14,9 +14,9 @@ import { Utils } from "../common/index";
 import { IClientCoordinates } from "../interactions/draggable";
 import { IIndexedResizeCallback } from "../interactions/resizable";
 import { Orientation } from "../interactions/resizeHandle";
-import { IRegion, RegionCardinality, Regions } from "../regions";
+import { RegionCardinality, Regions } from "../regions";
 import { ColumnHeaderCell, IColumnHeaderCellProps } from "./columnHeaderCell";
-import { Header, IHeaderProps, shouldHeaderComponentUpdate } from "./header";
+import { Header, IHeaderProps } from "./header";
 
 export type IColumnHeaderRenderer = (columnIndex: number) => React.ReactElement<IColumnHeaderCellProps>;
 
@@ -47,10 +47,6 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
         isResizable: true,
         loading: false,
     };
-
-    public shouldComponentUpdate(nextProps: IColumnHeaderProps) {
-        return shouldHeaderComponentUpdate(this.props, nextProps, this.isSelectedRegionRelevant);
-    }
 
     public render() {
         const {
@@ -197,11 +193,5 @@ private wrapCells = (cells: Array<React.ReactElement<any>>) => {
 
     private toRegion = (index1: number, index2?: number) => {
         return Regions.column(index1, index2);
-    }
-
-    private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
-        const regionCardinality = Regions.getRegionCardinality(selectedRegion);
-        return regionCardinality === RegionCardinality.FULL_COLUMNS
-            || regionCardinality === RegionCardinality.FULL_TABLE;
     }
 }

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -51,17 +51,17 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
     public render() {
         const {
             // from IColumnHeaderProps
-            cellRenderer,
+            cellRenderer: renderHeaderCell,
             onColumnWidthChanged,
 
             // from IColumnWidths
-            minColumnWidth,
-            maxColumnWidth,
+            minColumnWidth: minSize,
+            maxColumnWidth: maxSize,
             defaultColumnWidth,
 
             // from IColumnIndices
-            columnIndexStart,
-            columnIndexEnd,
+            columnIndexStart: indexStart,
+            columnIndexEnd: indexEnd,
 
             // from IHeaderProps
             ...spreadableProps,
@@ -70,7 +70,6 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
         return (
             <Header
                 convertPointToIndex={this.convertPointToColumn}
-                endIndex={this.props.columnIndexEnd}
                 fullRegionCardinality={RegionCardinality.FULL_COLUMNS}
                 getCellExtremaClasses={this.getCellExtremaClasses}
                 getCellIndexClass={Classes.columnCellIndexClass}
@@ -83,14 +82,15 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps, {}> {
                 handleSizeChanged={this.handleSizeChanged}
                 headerCellIsReorderablePropName={"isColumnReorderable"}
                 headerCellIsSelectedPropName={"isColumnSelected"}
+                indexEnd={indexEnd}
+                indexStart={indexStart}
                 isCellSelected={this.isCellSelected}
                 isGhostIndex={this.isGhostIndex}
-                maxSize={this.props.maxColumnWidth}
-                minSize={this.props.minColumnWidth}
+                maxSize={maxSize}
+                minSize={minSize}
                 renderGhostCell={this.renderGhostCell}
-                renderHeaderCell={this.props.cellRenderer}
+                renderHeaderCell={renderHeaderCell}
                 resizeOrientation={Orientation.VERTICAL}
-                startIndex={this.props.columnIndexStart}
                 toRegion={this.toRegion}
                 wrapCells={this.wrapCells}
                 {...spreadableProps}
@@ -130,8 +130,8 @@ private wrapCells = (cells: Array<React.ReactElement<any>>) => {
         return locator != null ? locator.convertPointToColumn(clientXOrY, useMidpoint) : null;
     }
 
-    private getCellExtremaClasses = (index: number, endIndex: number) => {
-        return this.props.grid.getExtremaClasses(0, index, 1, endIndex);
+    private getCellExtremaClasses = (index: number, indexEnd: number) => {
+        return this.props.grid.getExtremaClasses(0, index, 1, indexEnd);
     }
 
     private getColumnWidth = (index: number) => {

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 
 import { Grid } from "../common";
 import { Batcher } from "../common/batcher";
+import { IFocusedCellCoordinates } from "../common/cell";
 import * as Classes from "../common/classes";
 import { Utils } from "../common/utils";
 import { IClientCoordinates, ICoordinateData } from "../interactions/draggable";
@@ -25,6 +26,11 @@ import { IHeaderCellProps } from "./headerCell";
 export type IHeaderCellRenderer = (index: number) => React.ReactElement<IHeaderCellProps>;
 
 export interface IHeaderProps extends ILockableLayout, IReorderableProps, ISelectableProps {
+    /**
+     * The currently focused cell.
+     */
+    focusedCell?: IFocusedCellCoordinates;
+
     /**
      * The grid computes sizes of cells, rows, or columns from the
      * configurable `columnWidths` and `rowHeights`.
@@ -69,7 +75,6 @@ export interface IHeaderProps extends ILockableLayout, IReorderableProps, ISelec
  * They don't need to be exposed to the outside world.
  */
 export interface IInternalHeaderProps extends IHeaderProps {
-
     /**
      * The cardinality of a fully selected region. Should be FULL_COLUMNS for column headers and
      * FULL_ROWS for row headers.
@@ -216,6 +221,7 @@ export interface IHeaderState {
 }
 
 const SHALLOW_COMPARE_PROP_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = [
+    "focusedCell",
     "selectedRegions",
 ];
 
@@ -347,6 +353,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             <DragSelectable
                 allowMultipleSelection={this.props.allowMultipleSelection}
                 disabled={isEntireCellTargetReorderable}
+                focusedCell={this.props.focusedCell}
                 ignoredSelectors={[`.${Classes.TABLE_REORDER_HANDLE_TARGET}`]}
                 key={getIndexClass(index)}
                 locateClick={this.locateClick}

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -287,11 +287,13 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
         return this.props.toRegion(this.activationIndex);
     }
 
-    private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData): IRegion => {
+    private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData, returnEndOnly = false): IRegion => {
         const coord = this.props.getDragCoordinate(coords.current);
         const indexStart = this.activationIndex;
         const indexEnd = this.props.convertPointToIndex(coord);
-        return this.props.toRegion(indexStart, indexEnd);
+        return returnEndOnly
+            ? this.props.toRegion(indexEnd)
+            : this.props.toRegion(indexStart, indexEnd);
     }
 
     private locateDragForReordering = (_event: MouseEvent, coords: ICoordinateData): number => {

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -69,10 +69,6 @@ export interface IHeaderProps extends ILockableLayout, IReorderableProps, ISelec
  * They don't need to be exposed to the outside world.
  */
 export interface IInternalHeaderProps extends IHeaderProps {
-    /**
-     * The highest cell index to render.
-     */
-    endIndex: number;
 
     /**
      * The cardinality of a fully selected region. Should be FULL_COLUMNS for column headers and
@@ -94,6 +90,16 @@ export interface IInternalHeaderProps extends IHeaderProps {
      * The name of the header-cell prop specifying whether the header cell is selected or not.
      */
     headerCellIsSelectedPropName: string;
+
+    /**
+     * The highest cell index to render.
+     */
+    indexEnd: number;
+
+    /**
+     * The lowest cell index to render.
+     */
+    indexStart: number;
 
     /**
      * The maximum permitted size of the header in pixels. Corresponds to a width for column headers and
@@ -119,11 +125,6 @@ export interface IInternalHeaderProps extends IHeaderProps {
     selectedRegions: IRegion[];
 
     /**
-     * The lowest cell index to render.
-     */
-    startIndex: number;
-
-    /**
      * Converts a point on the screen to a row or column index in the table grid.
      */
     convertPointToIndex?: (clientXOrY: number, useMidpoint?: boolean) => number;
@@ -131,7 +132,7 @@ export interface IInternalHeaderProps extends IHeaderProps {
     /**
      * Provides any extrema classes for the provided index range in the table grid.
      */
-    getCellExtremaClasses: (index: number, endIndex: number) => string[];
+    getCellExtremaClasses: (index: number, indexEnd: number) => string[];
 
     /**
      * Provides the index class for the cell. Should be Classes.columnCellIndexClass for column
@@ -219,8 +220,8 @@ const SHALLOW_COMPARE_PROP_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = [
 ];
 
 const RESET_CELL_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = [
-    "endIndex",
-    "startIndex",
+    "indexEnd",
+    "indexStart",
 ];
 
 export class Header extends React.Component<IInternalHeaderProps, IHeaderState> {
@@ -282,9 +283,9 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
     private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData): IRegion => {
         const coord = this.props.getDragCoordinate(coords.current);
-        const startIndex = this.activationIndex;
-        const endIndex = this.props.convertPointToIndex(coord);
-        return this.props.toRegion(startIndex, endIndex);
+        const indexStart = this.activationIndex;
+        const indexEnd = this.props.convertPointToIndex(coord);
+        return this.props.toRegion(indexStart, indexEnd);
     }
 
     private locateDragForReordering = (_event: MouseEvent, coords: ICoordinateData): number => {
@@ -294,11 +295,10 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     }
 
     private renderCells = () => {
-        const startIndex = this.props.startIndex;
-        const endIndex = this.props.endIndex;
+        const { indexStart, indexEnd } = this.props;
 
         this.batcher.startNewBatch();
-        for (let index = startIndex; index <= endIndex; index++) {
+        for (let index = indexStart; index <= indexEnd; index++) {
             this.batcher.addArgsToBatch(index);
         }
         this.batcher.removeOldAddNew(this.renderNewCell);
@@ -310,7 +310,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     }
 
     private renderNewCell = (index: number) => {
-        const extremaClasses = this.props.getCellExtremaClasses(index, this.props.endIndex);
+        const extremaClasses = this.props.getCellExtremaClasses(index, this.props.indexEnd);
         const renderer = this.props.isGhostIndex(index)
             ? this.props.renderGhostCell
             : this.renderCell;

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -13,8 +13,8 @@ import { IRowIndices } from "../common/grid";
 import { IClientCoordinates } from "../interactions/draggable";
 import { IIndexedResizeCallback } from "../interactions/resizable";
 import { Orientation } from "../interactions/resizeHandle";
-import { IRegion, RegionCardinality, Regions } from "../regions";
-import { Header, IHeaderProps, shouldHeaderComponentUpdate } from "./header";
+import { RegionCardinality, Regions } from "../regions";
+import { Header, IHeaderProps } from "./header";
 import { IRowHeaderCellProps, RowHeaderCell } from "./rowHeaderCell";
 
 export type IRowHeaderRenderer = (rowIndex: number) => React.ReactElement<IRowHeaderCellProps>;
@@ -41,10 +41,6 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
     public defaultProps = {
         renderRowHeader: renderDefaultRowHeader,
     };
-
-    public shouldComponentUpdate(nextProps: IRowHeaderProps) {
-        return shouldHeaderComponentUpdate(this.props, nextProps, this.isSelectedRegionRelevant);
-    }
 
     public render() {
         const {
@@ -174,12 +170,6 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
     private toRegion = (index1: number, index2?: number) => {
         // the `this` value is messed up for Regions.row, so we have to have a wrapper function here
         return Regions.row(index1, index2);
-    }
-
-    private isSelectedRegionRelevant = (selectedRegion: IRegion) => {
-        const regionCardinality = Regions.getRegionCardinality(selectedRegion);
-        return regionCardinality === RegionCardinality.FULL_ROWS
-            || regionCardinality === RegionCardinality.FULL_TABLE;
     }
 }
 

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -46,16 +46,16 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
         const {
             // from IRowHeaderProps
             onRowHeightChanged,
-            renderRowHeader,
+            renderRowHeader: renderHeaderCell,
 
             // from IRowHeights
-            minRowHeight,
-            maxRowHeight,
+            minRowHeight: minSize,
+            maxRowHeight: maxSize,
             defaultRowHeight,
 
             // from IRowIndices
-            rowIndexStart,
-            rowIndexEnd,
+            rowIndexStart: indexStart,
+            rowIndexEnd: indexEnd,
 
             // from IHeaderProps
             ...spreadableProps,
@@ -64,7 +64,6 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
         return (
             <Header
                 convertPointToIndex={this.convertPointToRow}
-                endIndex={this.props.rowIndexEnd}
                 fullRegionCardinality={RegionCardinality.FULL_ROWS}
                 getCellExtremaClasses={this.getCellExtremaClasses}
                 getCellIndexClass={Classes.rowCellIndexClass}
@@ -76,14 +75,15 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
                 handleSizeChanged={this.handleSizeChanged}
                 headerCellIsReorderablePropName={"isRowReorderable"}
                 headerCellIsSelectedPropName={"isRowSelected"}
+                indexEnd={indexEnd}
+                indexStart={indexStart}
                 isCellSelected={this.isCellSelected}
                 isGhostIndex={this.isGhostIndex}
-                maxSize={this.props.maxRowHeight}
-                minSize={this.props.minRowHeight}
+                maxSize={maxSize}
+                minSize={minSize}
                 renderGhostCell={this.renderGhostCell}
-                renderHeaderCell={this.props.renderRowHeader}
+                renderHeaderCell={renderHeaderCell}
                 resizeOrientation={Orientation.HORIZONTAL}
-                startIndex={this.props.rowIndexStart}
                 toRegion={this.toRegion}
                 wrapCells={this.wrapCells}
                 {...spreadableProps}
@@ -121,8 +121,8 @@ export class RowHeader extends React.Component<IRowHeaderProps, {}> {
         return locator != null ? locator.convertPointToRow(clientXOrY, useMidpoint) : null;
     }
 
-    private getCellExtremaClasses = (index: number, endIndex: number) => {
-        return this.props.grid.getExtremaClasses(index, 0, endIndex, 1);
+    private getCellExtremaClasses = (index: number, indexEnd: number) => {
+        return this.props.grid.getExtremaClasses(index, 0, indexEnd, 1);
     }
 
     private getRowHeight = (index: number) => {

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -39,8 +39,9 @@ export interface IReorderableProps {
 
     /**
      * An array containing the table's selection Regions.
+     * @default []
      */
-    selectedRegions: IRegion[];
+    selectedRegions?: IRegion[];
 }
 
 export interface IDragReorderable extends IReorderableProps {
@@ -72,6 +73,10 @@ export interface IDragReorderable extends IReorderableProps {
 
 @PureRender
 export class DragReorderable extends React.Component<IDragReorderable, {}> {
+    public static defaultProps: Partial<IDragReorderable> = {
+        selectedRegions: [],
+    };
+
     private selectedRegionStartIndex: number;
     private selectedRegionLength: number;
 

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -25,6 +25,11 @@ export interface ISelectableProps {
     allowMultipleSelection: boolean;
 
     /**
+     * The currently focused cell.
+     */
+    focusedCell?: IFocusedCellCoordinates;
+
+    /**
      * When the user focuses something, this callback is called with new
      * focused cell coordinates. This should be considered the new focused cell
      * state for the entire table.
@@ -255,12 +260,12 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     }
 
     private handleExpandSelection = (region: IRegion) => {
-        const { onSelection, selectedRegions } = this.props;
+        const { focusedCell, onSelection, selectedRegions } = this.props;
         this.didExpandSelectionOnActivate = true;
 
         // there should be only one selected region after expanding. do not
         // update the focused cell.
-        const nextSelectedRegions = expandSelectedRegions(selectedRegions, region);
+        const nextSelectedRegions = expandSelectedRegions(selectedRegions, region, focusedCell);
         onSelection(nextSelectedRegions);
     }
 
@@ -314,7 +319,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     }
 
     private getDragSelectedRegions(event: MouseEvent, coords: ICoordinateData) {
-        const { selectedRegions, selectedRegionTransform } = this.props;
+        const { focusedCell, selectedRegions, selectedRegionTransform } = this.props;
 
         let region = this.props.allowMultipleSelection
             ? this.props.locateDrag(event, coords)
@@ -329,16 +334,18 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         }
 
         return this.didExpandSelectionOnActivate
-            ? expandSelectedRegions(selectedRegions, region)
+            ? expandSelectedRegions(selectedRegions, region, focusedCell)
             : Regions.update(selectedRegions, region);
     }
 
 }
 
-function expandSelectedRegions(regions: IRegion[], region: IRegion) {
+function expandSelectedRegions(regions: IRegion[], region: IRegion, focusedCell: IFocusedCellCoordinates) {
     if (regions.length === 0) {
         return [region];
     }
+
+    console.log("  [DragSelectable.expandSelectedRegions] focusedCell =", focusedCell);
 
     const lastRegion = regions[regions.length - 1];
     const lastRegionCardinality = Regions.getRegionCardinality(lastRegion);

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -90,7 +90,7 @@ export interface IDragSelectableProps extends ISelectableProps {
      * coordinate data representing a drag. If no valid region can be found,
      * `null` may be returned.
      */
-    locateDrag: (event: MouseEvent, coords: ICoordinateData) => IRegion;
+    locateDrag: (event: MouseEvent, coords: ICoordinateData, returnEndOnly?: boolean) => IRegion;
 }
 
 @PureRender
@@ -320,10 +320,10 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     }
 
     private getDragSelectedRegions(event: MouseEvent, coords: ICoordinateData) {
-        const { focusedCell, selectedRegions, selectedRegionTransform } = this.props;
+        const { allowMultipleSelection, focusedCell, selectedRegions, selectedRegionTransform } = this.props;
 
-        let region = this.props.allowMultipleSelection
-            ? this.props.locateDrag(event, coords)
+        let region = allowMultipleSelection
+            ? this.props.locateDrag(event, coords, /* returnEndOnly? */ this.didExpandSelectionOnActivate)
             : this.props.locateClick(event);
 
         if (!Regions.isValid(region)) {

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -121,6 +121,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         }
 
         const {
+            allowMultipleSelection,
             onSelection,
             selectedRegions,
             selectedRegionTransform,
@@ -154,11 +155,12 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         }
 
         let focusSelectionIndex = null;
-        if (event.shiftKey && selectedRegions.length > 0) {
+
+        if (event.shiftKey && selectedRegions.length > 0 && allowMultipleSelection) {
             this.didExpandSelectionOnActivate = true;
             onSelection(expandSelectedRegions(selectedRegions, region));
             focusSelectionIndex = 0;
-        } else if (DragEvents.isAdditive(event) && this.props.allowMultipleSelection) {
+        } else if (DragEvents.isAdditive(event) && allowMultipleSelection) {
             onSelection(Regions.add(selectedRegions, region));
             // the focus should be in the newly created region,
             // which is at index of the current list of regions plus one,

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -219,8 +219,8 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     // ==============
 
     private shouldExpandSelection = (event: MouseEvent) => {
-        const { allowMultipleSelection, selectedRegions } = this.props;
-        return event.shiftKey && selectedRegions.length > 0 && allowMultipleSelection;
+        const { allowMultipleSelection } = this.props;
+        return event.shiftKey && allowMultipleSelection;
     }
 
     private shouldAddDisjointSelection = (event: MouseEvent) => {

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -252,6 +252,11 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         // update the focused cell.
         const nextSelectedRegions = this.expandSelectedRegions(selectedRegions, region, focusedCell);
         onSelection(nextSelectedRegions);
+
+        // move the focused cell into the new region if there were no selections before
+        if (selectedRegions == null || selectedRegions.length === 0) {
+            this.invokeOnFocusCallbackForRegion(region);
+        }
     }
 
     private handleAddDisjointSelection = (region: IRegion) => {

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -286,7 +286,9 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
 
     private maybeInvokeSelectionCallback(nextSelectedRegions: IRegion[]) {
         const { onSelection, selectedRegions } = this.props;
-        // invoke only if the selection changed
+        // invoke only if the selection changed. this is useful only on
+        // mousemove; there's special handling for mousedown interactions that
+        // target an already-selected region.
         if (!Utils.deepCompareKeys(selectedRegions, nextSelectedRegions)) {
             onSelection(nextSelectedRegions);
         }

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -572,6 +572,43 @@ export class Regions {
     }
 
     /**
+     * Expands an old region to the minimal bounding region that also contains
+     * the new region. If the regions have different cardinalities, then the new
+     * region is returned. Useful for expanding a selected region on
+     * shift+click, for instance.
+     */
+    public static expandRegion(oldRegion: IRegion, newRegion: IRegion): IRegion {
+        const oldRegionCardinality = Regions.getRegionCardinality(oldRegion);
+        const newRegionCardinality = Regions.getRegionCardinality(newRegion);
+
+        if (newRegionCardinality !== oldRegionCardinality) {
+            return newRegion;
+        }
+
+        switch (newRegionCardinality) {
+            case RegionCardinality.FULL_ROWS: {
+                const rowStart = Math.min(oldRegion.rows[0], newRegion.rows[0]);
+                const rowEnd = Math.max(oldRegion.rows[1], newRegion.rows[1]);
+                return Regions.row(rowStart, rowEnd);
+            }
+            case RegionCardinality.FULL_COLUMNS: {
+                const colStart = Math.min(oldRegion.cols[0], newRegion.cols[0]);
+                const colEnd = Math.max(oldRegion.cols[1], newRegion.cols[1]);
+                return Regions.column(colStart, colEnd);
+            }
+            case RegionCardinality.CELLS: {
+                const rowStart = Math.min(oldRegion.rows[0], newRegion.rows[0]);
+                const colStart = Math.min(oldRegion.cols[0], newRegion.cols[0]);
+                const rowEnd = Math.max(oldRegion.rows[1], newRegion.rows[1]);
+                const colEnd = Math.max(oldRegion.cols[1], newRegion.cols[1]);
+                return Regions.cell(rowStart, colStart, rowEnd, colEnd);
+            }
+            default:
+                return Regions.table();
+        }
+    }
+
+    /**
      * Iterates over the cells within an `IRegion`, invoking the callback with
      * each cell's coordinates.
      */

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -870,18 +870,13 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private selectAll = () => {
-        const { enableFocus } = this.props;
-
         const selectionHandler = this.getEnabledSelectionHandler(RegionCardinality.FULL_TABLE);
         // clicking on upper left hand corner sets selection to "all"
         // regardless of current selection state (clicking twice does not deselect table)
         selectionHandler([Regions.table()]);
 
-        // move the focus cell to the top left
-        if (enableFocus) {
-            const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
-            this.handleFocus(FocusedCellUtils.toFullCoordinates(newFocusedCellCoordinates));
-        }
+        const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
+        this.handleFocus(FocusedCellUtils.toFullCoordinates(newFocusedCellCoordinates));
     }
 
     private handleSelectAllHotkey = (e: KeyboardEvent) => {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -870,19 +870,24 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private selectAll = () => {
+        const { enableFocus } = this.props;
+        const { focusedCell } = this.state;
+
         const selectionHandler = this.getEnabledSelectionHandler(RegionCardinality.FULL_TABLE);
         // clicking on upper left hand corner sets selection to "all"
         // regardless of current selection state (clicking twice does not deselect table)
         selectionHandler([Regions.table()]);
 
-        // move the focus cell to the top left
-        const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
-        const fullFocusCellCoordinates: IFocusedCellCoordinates = {
-            col: newFocusedCellCoordinates.col,
-            focusSelectionIndex: 0,
-            row: newFocusedCellCoordinates.row,
-        };
-        this.handleFocus(fullFocusCellCoordinates);
+        // move the focus cell to the top left only if there isn't one already active
+        if (enableFocus && focusedCell == null) {
+            const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
+            const fullFocusCellCoordinates: IFocusedCellCoordinates = {
+                col: newFocusedCellCoordinates.col,
+                focusSelectionIndex: 0,
+                row: newFocusedCellCoordinates.row,
+            };
+            this.handleFocus(fullFocusCellCoordinates);
+        }
     }
 
     private handleSelectAllHotkey = (e: KeyboardEvent) => {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -940,7 +940,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         showFrozenColumnsOnly: boolean = false,
     ) => {
         const { grid, locator } = this;
-        const { selectedRegions, viewportRect } = this.state;
+        const { focusedCell, selectedRegions, viewportRect } = this.state;
         const {
             allowMultipleSelection,
             fillBodyWithGhostCells,
@@ -968,6 +968,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 <ColumnHeader
                     allowMultipleSelection={allowMultipleSelection}
                     cellRenderer={this.columnHeaderCellRenderer}
+                    focusedCell={focusedCell}
                     grid={grid}
                     isReorderable={isColumnReorderable}
                     isResizable={isColumnResizable}
@@ -1002,7 +1003,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         showFrozenRowsOnly: boolean = false,
     ) => {
         const { grid, locator } = this;
-        const { selectedRegions, viewportRect } = this.state;
+        const { focusedCell, selectedRegions, viewportRect } = this.state;
         const {
             allowMultipleSelection,
             fillBodyWithGhostCells,
@@ -1030,6 +1031,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             >
                 <RowHeader
                     allowMultipleSelection={allowMultipleSelection}
+                    focusedCell={focusedCell}
                     grid={grid}
                     locator={locator}
                     isReorderable={isRowReorderable}
@@ -1074,6 +1076,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         showFrozenColumnsOnly: boolean = false,
     ) => {
         const { grid, locator } = this;
+        const { focusedCell, selectedRegions, viewportRect } = this.state;
         const {
             allowMultipleSelection,
             fillBodyWithGhostCells,
@@ -1086,9 +1089,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const numFrozenColumns = this.getNumFrozenColumnsClamped();
         const numFrozenRows = this.getNumFrozenRowsClamped();
 
-        const { selectedRegions, viewportRect/*, verticalGuides, horizontalGuides*/ } = this.state;
-
-        // const style = grid.getRect().sizeStyle();
         const rowIndices = grid.getRowIndicesInRect(viewportRect, fillBodyWithGhostCells);
         const columnIndices = grid.getColumnIndicesInRect(viewportRect, fillBodyWithGhostCells);
 
@@ -1107,6 +1107,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 <TableBody
                     allowMultipleSelection={allowMultipleSelection}
                     cellRenderer={this.bodyCellRenderer}
+                    focusedCell={focusedCell}
                     grid={grid}
                     loading={this.hasLoadingOption(loadingOptions, TableLoadingOption.CELLS)}
                     locator={locator}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -843,11 +843,17 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             <div
                 className={classes}
                 ref={refHandler}
-                onMouseDown={this.selectAll}
+                onMouseDown={this.handleMenuMouseDown}
             >
                 {this.maybeRenderRegions(this.styleMenuRegion)}
             </div>
         );
+    }
+
+    private handleMenuMouseDown = (e: React.MouseEvent<HTMLElement>) => {
+        // the shift+click interaction expands the region from the focused cell.
+        // thus, if shift is pressed we shouldn't move the focused cell.
+        this.selectAll(!e.shiftKey);
     }
 
     private maybeScrollTableIntoView() {
@@ -869,14 +875,16 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.syncViewportPosition(nextScrollLeft, nextScrollTop);
     }
 
-    private selectAll = () => {
+    private selectAll = (shouldUpdateFocusedCell: boolean) => {
         const selectionHandler = this.getEnabledSelectionHandler(RegionCardinality.FULL_TABLE);
         // clicking on upper left hand corner sets selection to "all"
         // regardless of current selection state (clicking twice does not deselect table)
         selectionHandler([Regions.table()]);
 
-        const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
-        this.handleFocus(FocusedCellUtils.toFullCoordinates(newFocusedCellCoordinates));
+        if (shouldUpdateFocusedCell) {
+            const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
+            this.handleFocus(FocusedCellUtils.toFullCoordinates(newFocusedCellCoordinates));
+        }
     }
 
     private handleSelectAllHotkey = (e: KeyboardEvent) => {
@@ -884,7 +892,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         e.preventDefault();
         e.stopPropagation();
 
-        this.selectAll();
+        // selecting-all via the keyboard should not move the focused cell.
+        this.selectAll(false);
     }
 
     private getColumnProps(columnIndex: number) {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -843,7 +843,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             <div
                 className={classes}
                 ref={refHandler}
-                onClick={this.selectAll}
+                onMouseDown={this.selectAll}
             >
                 {this.maybeRenderRegions(this.styleMenuRegion)}
             </div>

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -871,22 +871,16 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
     private selectAll = () => {
         const { enableFocus } = this.props;
-        const { focusedCell } = this.state;
 
         const selectionHandler = this.getEnabledSelectionHandler(RegionCardinality.FULL_TABLE);
         // clicking on upper left hand corner sets selection to "all"
         // regardless of current selection state (clicking twice does not deselect table)
         selectionHandler([Regions.table()]);
 
-        // move the focus cell to the top left only if there isn't one already active
-        if (enableFocus && focusedCell == null) {
+        // move the focus cell to the top left
+        if (enableFocus) {
             const newFocusedCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(Regions.table());
-            const fullFocusCellCoordinates: IFocusedCellCoordinates = {
-                col: newFocusedCellCoordinates.col,
-                focusSelectionIndex: 0,
-                row: newFocusedCellCoordinates.row,
-            };
-            this.handleFocus(fullFocusCellCoordinates);
+            this.handleFocus(FocusedCellUtils.toFullCoordinates(newFocusedCellCoordinates));
         }
     }
 

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -89,6 +89,7 @@ export interface ITableBodyProps extends ISelectableProps, IRowIndices, IColumnI
  * `ITableBodyProps` since those are only used when a context menu is launched.
  */
 const UPDATE_PROPS_KEYS: Array<keyof ITableBodyProps> = [
+    "focusedCell",
     "grid",
     "locator",
     "viewportRect",
@@ -165,6 +166,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
     public render() {
         const {
             allowMultipleSelection,
+            focusedCell,
             grid,
             numFrozenColumns,
             numFrozenRows,
@@ -189,6 +191,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         return (
             <DragSelectable
                 allowMultipleSelection={allowMultipleSelection}
+                focusedCell={focusedCell}
                 locateClick={this.locateClick}
                 locateDrag={this.locateDrag}
                 onFocus={onFocus}

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -318,10 +318,12 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
         return Regions.cell(this.activationCell.row, this.activationCell.col);
     }
 
-    private locateDrag = (_event: MouseEvent, coords: ICoordinateData) => {
+    private locateDrag = (_event: MouseEvent, coords: ICoordinateData, returnEndOnly = false) => {
         const start = this.activationCell;
         const end = this.props.locator.convertPointToCell(coords.current[0], coords.current[1]);
-        return Regions.cell(start.row, start.col, end.row, end.col);
+        return returnEndOnly
+            ? Regions.cell(end.row, end.col)
+            : Regions.cell(start.row, start.col, end.row, end.col);
     }
 
     private maybeInvokeOnCompleteRender() {

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -7,7 +7,7 @@
 
 import { expect } from "chai";
 
-import { IFocusedCellCoordinates, ICellCoordinates } from "../../../src/common/cell";
+import { ICellCoordinates, IFocusedCellCoordinates } from "../../../src/common/cell";
 import * as FocusedCellUtils from "../../../src/common/internal/focusedCellUtils";
 import { IRegion, Regions } from "../../../src/regions";
 
@@ -50,17 +50,18 @@ describe("FocusedCellUtils", () => {
             expect(focusedCell).to.deep.equal(FOCUSED_CELL_FROM_STATE);
         });
 
-        it("returns the focused cell for the first selected region if " +
-           "focusedCellFromState and focusedCellFromProps not defined", () => {
+        // tslint:disable-next-line:max-line-length
+        it("returns the focused cell for the last selected region if focusedCell not provided", () => {
             const focusedCell = FocusedCellUtils.getInitialFocusedCell(
                 true,
                 null,
                 null,
                 SELECTED_REGIONS,
             );
+            const lastIndex = SELECTED_REGIONS.length - 1;
             const expectedFocusedCell = {
-                ...Regions.getFocusCellCoordinatesFromRegion(SELECTED_REGIONS[0]),
-                focusSelectionIndex: 0,
+                ...Regions.getFocusCellCoordinatesFromRegion(SELECTED_REGIONS[lastIndex]),
+                focusSelectionIndex: lastIndex,
             };
             expect(focusedCell).to.deep.equal(expectedFocusedCell);
         });

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -9,7 +9,7 @@ import { expect } from "chai";
 
 import { IFocusedCellCoordinates } from "../../../src/common/cell";
 import * as FocusedCellUtils from "../../../src/common/internal/focusedCellUtils";
-import { Regions } from "../../../src/regions";
+import { IRegion, Regions } from "../../../src/regions";
 
 describe("FocusedCellUtils", () => {
     describe("getInitialFocusedCell", () => {
@@ -86,205 +86,121 @@ describe("FocusedCellUtils", () => {
     });
 
     describe.only("expandFocusedRegion", () => {
-        const focusedCell = toCellCoords(3, 3);
+        const FOCUSED_ROW = 3;
+        const FOCUSED_COL = 3;
+
+        const PREV_ROW = FOCUSED_ROW - 2;
+        const NEXT_ROW = FOCUSED_ROW + 2;
+        const PREV_COL = FOCUSED_COL - 2;
+        const NEXT_COL = FOCUSED_COL + 2;
+
+        const focusedCell = toCellCoords(FOCUSED_ROW, FOCUSED_COL);
 
         // shorthand
         const fn = FocusedCellUtils.expandFocusedRegion;
 
-        describe("Expands a FULL_COLUMNS selection", () => {
-            const oldRegion = Regions.column(3);
-
-            describe("to another FULL_COLUMNS selection", () => {
-                it("leftward", () => {
-                    const newRegion = Regions.column(1);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.column(1, 3));
-                });
-
-                it("rightward", () => {
-                    const newRegion = Regions.column(5);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.column(3, 5));
-                });
-
-                it("to itself", () => {
-                    const newRegion = Regions.column(3);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.column(3, 3));
-                });
+        describe("Expands to a FULL_ROWS selection", () => {
+            it("upward", () => {
+                const newRegion = Regions.row(PREV_ROW);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.row(PREV_ROW, FOCUSED_COL));
             });
 
-            describe("to a FULL_ROWS selection", () => {
-                it("if focused cell is in same row", () => {
-                    const newRegion = Regions.row(3);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.row(3));
-                });
-
-                describe("if focused cell is in different row", () => {
-                    it("upward", () => {
-                        const newRegion = Regions.row(1);
-                        const result = fn(focusedCell, oldRegion, newRegion);
-                        checkEqual(result, Regions.row(1, 3));
-                    });
-
-                    it("downward", () => {
-                        const newRegion = Regions.row(5);
-                        const result = fn(focusedCell, oldRegion, newRegion);
-                        checkEqual(result, Regions.row(3, 5));
-                    });
-                });
+            it("downward", () => {
+                const newRegion = Regions.row(NEXT_ROW);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.row(FOCUSED_ROW, NEXT_ROW));
             });
 
-            describe("to a CELLS selection", () => {
-                it("toward bottom-right", () => {
-                    const newRegion = Regions.cell(5, 5);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.cell(3, 3, 5, 5));
-                });
-
-                it("toward top-left", () => {
-                    const newRegion = Regions.cell(3, 1);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.cell(3, 1, 3, 3));
-                });
-
-                // assume the other directions are fine too (there's no special
-                // logic governing strictly leftward/downward selections, e.g.)
-            });
-
-            it("to a FULL_TABLE selection", () => {
-                const newRegion = Regions.table();
-                const result = fn(focusedCell, oldRegion, newRegion);
-                checkEqual(result, Regions.table());
+            it("same row", () => {
+                const newRegion = Regions.row(FOCUSED_ROW);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.row(FOCUSED_ROW, FOCUSED_COL));
             });
         });
 
-        describe("Expands a FULL_ROWS selection", () => {
-            const oldRegion = Regions.row(3);
-
-            describe("to another FULL_ROWS selection", () => {
-                it("upward", () => {
-                    const newRegion = Regions.row(1);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.row(1, 3));
-                });
-
-                it("downward", () => {
-                    const newRegion = Regions.row(5);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.row(3, 5));
-                });
-
-                it("to itself", () => {
-                    const newRegion = Regions.row(3);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.row(3, 3));
-                });
+        describe("Expands to a FULL_COLUMNS selection", () => {
+            it("leftward", () => {
+                const newRegion = Regions.column(PREV_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.column(PREV_COL, FOCUSED_COL));
             });
 
-            describe("to a FULL_COLUMNS selection", () => {
-                it("if focused cell is in same column", fail);
-
-                describe("if focused cell is in different column", () => {
-                    it("leftward", () => {
-                        const newRegion = Regions.column(1);
-                        const result = fn(focusedCell, oldRegion, newRegion);
-                        checkEqual(result, Regions.column(1, 3));
-                    });
-
-                    it("rightward", () => {
-                        const newRegion = Regions.column(5);
-                        const result = fn(focusedCell, oldRegion, newRegion);
-                        checkEqual(result, Regions.column(3, 5));
-                    });
-                });
+            it("rightward", () => {
+                const newRegion = Regions.column(NEXT_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.column(FOCUSED_COL, NEXT_COL));
             });
 
-            describe("to a CELLS selection", () => {
-                it("toward bottom-right", () => {
-                    const newRegion = Regions.cell(5, 5);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.cell(3, 3, 5, 5));
-                });
-
-                it("toward top-left", () => {
-                    const newRegion = Regions.cell(3, 1);
-                    const result = fn(focusedCell, oldRegion, newRegion);
-                    checkEqual(result, Regions.cell(3, 1, 3, 3));
-                });
-
-                // assume the other directions are fine too (there's no special
-                // logic governing strictly leftward/downward selections, e.g.)
-            });
-
-            it("to a FULL_TABLE selection", () => {
-                const newRegion = Regions.table();
-                const result = fn(focusedCell, oldRegion, newRegion);
-                checkEqual(result, Regions.table());
+            it("same column", () => {
+                const newRegion = Regions.column(FOCUSED_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.column(FOCUSED_COL, FOCUSED_COL));
             });
         });
 
-        describe("Expands a CELLS selection", () => {
-            describe("to another CELLS selection", () => {
-                it("toward top-left", fail);
-
-                it("toward top", fail);
-
-                it("toward top-right", fail);
-
-                it("toward right", fail);
-
-                it("toward bottom-right", fail);
-
-                it("toward bottom", fail);
-
-                it("toward bottom-left", fail);
-
-                it("toward left", fail);
+        describe("Expands to a CELLS selection", () => {
+            it("toward top-left", () => {
+                const newRegion = Regions.cell(PREV_ROW, PREV_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(PREV_ROW, PREV_COL, FOCUSED_ROW, FOCUSED_COL));
             });
 
-            describe("to a FULL_COLUMNS selection", () => {
-                it("upward", fail);
-
-                it("leftward", fail);
-
-                it("rightward", fail);
+            it("toward top", () => {
+                const newRegion = Regions.cell(FOCUSED_ROW, PREV_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(FOCUSED_ROW, PREV_COL, FOCUSED_ROW, FOCUSED_COL));
             });
 
-            describe("to a FULL_ROWS selection", () => {
-                it("leftward", fail);
-
-                it("upward", fail);
-
-                it("downward", fail);
+            it("toward top-right", () => {
+                const newRegion = Regions.cell(PREV_ROW, NEXT_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(PREV_ROW, FOCUSED_COL, FOCUSED_ROW, NEXT_COL));
             });
 
-            it("to a FULL_TABLE selection", fail);
+            it("toward right", () => {
+                const newRegion = Regions.cell(FOCUSED_ROW, NEXT_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(FOCUSED_ROW, FOCUSED_COL, FOCUSED_ROW, NEXT_COL));
+            });
 
-            it("to itself", fail);
+            it("toward bottom-right", () => {
+                const newRegion = Regions.cell(NEXT_ROW, NEXT_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(FOCUSED_ROW, FOCUSED_COL, NEXT_ROW, NEXT_COL));
+            });
+
+            it("toward bottom", () => {
+                const newRegion = Regions.cell(NEXT_ROW, FOCUSED_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(FOCUSED_ROW, FOCUSED_COL, NEXT_ROW, FOCUSED_COL));
+            });
+
+            it("toward bottom-left", () => {
+                const newRegion = Regions.cell(NEXT_ROW, PREV_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(FOCUSED_ROW, PREV_COL, NEXT_ROW, FOCUSED_COL));
+            });
+
+            it("toward left", () => {
+                const newRegion = Regions.cell(FOCUSED_ROW, PREV_COL);
+                const result = fn(focusedCell, newRegion);
+                checkEqual(result, Regions.cell(FOCUSED_ROW, PREV_COL, FOCUSED_ROW, FOCUSED_COL));
+            });
         });
 
-        describe("Expands a FULL_TABLE selection", () => {
-            it("to a FULL_COLUMNS selection", fail);
-
-            it("to a FULL_ROWS selection", fail);
-
-            it("to a CELLS selection", fail);
-
-            it("to a FULL_TABLE selection", fail);
+        it("Expands to a FULL_TABLE selection", () => {
+            const newRegion = Regions.table();
+            const result = fn(focusedCell, newRegion);
+            checkEqual(result, Regions.table());
         });
 
         function checkEqual(result: IRegion, expected: IRegion) {
             expect(result).to.deep.equal(expected);
         }
+
+        function toCellCoords(row: number, col: number): IFocusedCellCoordinates {
+            return { row, col, focusSelectionIndex: 0 };
+        }
     });
-
-    function fail() {
-        expect(true, "unimplemented test").to.be.false;
-    }
-
-    function toCellCoords(row: number, col: number): IFocusedCellCoordinates {
-        return { row, col, focusSelectionIndex: 0 };
-    }
 });

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -86,28 +86,77 @@ describe("FocusedCellUtils", () => {
     });
 
     describe.only("expandFocusedRegion", () => {
+        // shorthand
+        const fn = FocusedCellUtils.expandFocusedRegion;
+
         describe("Expands a FULL_COLUMNS selection", () => {
+            const focusedCell = toCellCoords(3, 3);
+            const oldRegion = Regions.column(3);
+
             describe("to another FULL_COLUMNS selection", () => {
-                it("leftward", fail);
+                it("leftward", () => {
+                    const newRegion = Regions.column(1);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.column(1, 3));
+                });
 
-                it("rightward", fail);
-            });
+                it("rightward", () => {
+                    const newRegion = Regions.column(5);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.column(3, 5));
+                });
 
-            describe("to a FULL_ROWS selection", () => {
-                it("if focused cell is in same row", fail);
-
-                describe("if focused cell is in different row", () => {
-                    it("upward", fail);
-
-                    it("downward", fail);
+                it("to itself", () => {
+                    const newRegion = Regions.column(3);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.column(3, 3));
                 });
             });
 
-            it("to a CELLS selection", fail);
+            describe("to a FULL_ROWS selection", () => {
+                it("if focused cell is in same row", () => {
+                    const newRegion = Regions.row(3);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.row(3));
+                });
 
-            it("to a FULL_TABLE selection", fail);
+                describe("if focused cell is in different row", () => {
+                    it("upward", () => {
+                        const newRegion = Regions.row(1);
+                        const result = fn(focusedCell, oldRegion, newRegion);
+                        checkEqual(result, Regions.row(1, 3));
+                    });
 
-            it("to itself");
+                    it("downward", () => {
+                        const newRegion = Regions.row(5);
+                        const result = fn(focusedCell, oldRegion, newRegion);
+                        checkEqual(result, Regions.row(3, 5));
+                    });
+                });
+            });
+
+            describe("to a CELLS selection", () => {
+                it("toward bottom-right", () => {
+                    const newRegion = Regions.cell(5, 5);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.cell(3, 3, 5, 5));
+                });
+
+                it("toward top-left", () => {
+                    const newRegion = Regions.cell(3, 1);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.cell(3, 1, 3, 3));
+                });
+
+                // assume the other directions are fine too (there's no special
+                // logic governing strictly leftward/downward selections, e.g.)
+            });
+
+            it("to a FULL_TABLE selection", () => {
+                const newRegion = Regions.table();
+                const result = fn(focusedCell, oldRegion, newRegion);
+                checkEqual(result, Regions.table());
+            });
         });
 
         describe("Expands a FULL_ROWS selection", () => {
@@ -131,7 +180,7 @@ describe("FocusedCellUtils", () => {
 
             it("to a FULL_TABLE selection", fail);
 
-            it("to itself");
+            it("to itself", fail);
         });
 
         describe("Expands a CELLS selection", () => {
@@ -171,7 +220,7 @@ describe("FocusedCellUtils", () => {
 
             it("to a FULL_TABLE selection", fail);
 
-            it("to itself");
+            it("to itself", fail);
         });
 
         describe("Expands a FULL_TABLE selection", () => {
@@ -183,9 +232,17 @@ describe("FocusedCellUtils", () => {
 
             it("to a FULL_TABLE selection", fail);
         });
+
+        function checkEqual(result: IRegion, expected: IRegion) {
+            expect(result).to.deep.equal(expected);
+        }
     });
 
     function fail() {
         expect(true, "unimplemented test").to.be.false;
+    }
+
+    function toCellCoords(row: number, col: number): IFocusedCellCoordinates {
+        return { row, col, focusSelectionIndex: 0 };
     }
 });

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -85,7 +85,7 @@ describe("FocusedCellUtils", () => {
         }
     });
 
-    describe.only("expandFocusedRegion", () => {
+    describe("expandFocusedRegion", () => {
         const FOCUSED_ROW = 3;
         const FOCUSED_COL = 3;
 

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -85,7 +85,107 @@ describe("FocusedCellUtils", () => {
         }
     });
 
-    describe("", () => {
+    describe.only("expandSelectedRegions", () => {
+        describe("Expands a FULL_COLUMNS selection", () => {
+            describe("to another FULL_COLUMNS selection", () => {
+                it("leftward", fail);
 
+                it("rightward", fail);
+            });
+
+            describe("to a FULL_ROWS selection", () => {
+                it("if focused cell is in same row");
+
+                describe("if focused cell is in different row", () => {
+                    it("upward", fail);
+
+                    it("downward", fail);
+                });
+            });
+
+            it("to a CELLS selection", fail);
+
+            it("to a FULL_TABLE selection", fail);
+
+            it("to itself");
+        });
+
+        describe("Expands a FULL_ROWS selection", () => {
+            describe("to another FULL_ROWS selection", () => {
+                it("upward", fail);
+
+                it("downward", fail);
+            });
+
+            describe("to a FULL_COLUMNS selection", () => {
+                it("if focused cell is in same column");
+
+                describe("if focused cell is in different column", () => {
+                    it("leftward", fail);
+
+                    it("rightward", fail);
+                });
+            });
+
+            it("to a CELLS selection", fail);
+
+            it("to a FULL_TABLE selection", fail);
+
+            it("to itself");
+        });
+
+        describe("Expands a CELLS selection", () => {
+            describe("to another CELLS selection", () => {
+                it("toward top-left", fail);
+
+                it("toward top", fail);
+
+                it("toward top-right", fail);
+
+                it("toward right", fail);
+
+                it("toward bottom-right", fail);
+
+                it("toward bottom", fail);
+
+                it("toward bottom-left", fail);
+
+                it("toward left", fail);
+            });
+
+            describe("to a FULL_COLUMNS selection", () => {
+                it("upward", fail);
+
+                it("leftward", fail);
+
+                it("rightward", fail);
+            });
+
+            describe("to a FULL_ROWS selection", () => {
+                it("leftward", fail);
+
+                it("upward", fail);
+
+                it("downward", fail);
+            });
+
+            it("to a FULL_TABLE selection", fail);
+
+            it("to itself");
+        });
+
+        describe("Expands a FULL_TABLE selection", () => {
+            it("to a FULL_COLUMNS selection", fail);
+
+            it("to a FULL_ROWS selection", fail);
+
+            it("to a CELLS selection", fail);
+
+            it("to a FULL_TABLE selection", fail);
+        });
     });
+
+    function fail() {
+        expect(true, "unimplemented test").to.be.false;
+    }
 });

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -11,7 +11,7 @@ import { IFocusedCellCoordinates } from "../../../src/common/cell";
 import * as FocusedCellUtils from "../../../src/common/internal/focusedCellUtils";
 import { Regions } from "../../../src/regions";
 
-describe("focusCellUtils", () => {
+describe("FocusedCellUtils", () => {
     describe("getInitialFocusedCell", () => {
         const FOCUSED_CELL_FROM_PROPS = getFocusedCell(1, 2);
         const FOCUSED_CELL_FROM_STATE = getFocusedCell(3, 4);
@@ -83,5 +83,9 @@ describe("focusCellUtils", () => {
         function getFocusedCell(row: number, col: number, focusSelectionIndex: number = 0): IFocusedCellCoordinates {
             return { row, col, focusSelectionIndex };
         }
+    });
+
+    describe("", () => {
+
     });
 });

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -7,7 +7,7 @@
 
 import { expect } from "chai";
 
-import { IFocusedCellCoordinates } from "../../../src/common/cell";
+import { IFocusedCellCoordinates, ICellCoordinates } from "../../../src/common/cell";
 import * as FocusedCellUtils from "../../../src/common/internal/focusedCellUtils";
 import { IRegion, Regions } from "../../../src/regions";
 
@@ -202,5 +202,20 @@ describe("FocusedCellUtils", () => {
         function toCellCoords(row: number, col: number): IFocusedCellCoordinates {
             return { row, col, focusSelectionIndex: 0 };
         }
+    });
+
+    describe("toFullCoordinates", () => {
+        it("applies focusSelectionIndex=0 by default", () => {
+            const cellCoords: ICellCoordinates = { row: 2, col: 3 };
+            const result = FocusedCellUtils.toFullCoordinates(cellCoords);
+            expect(result).to.deep.equal({ ...result, focusSelectionIndex: 0 });
+        });
+
+        it("applies a custom focusSelectionIndex if provided", () => {
+            const cellCoords: ICellCoordinates = { row: 2, col: 3 };
+            const INDEX = 1;
+            const result = FocusedCellUtils.toFullCoordinates(cellCoords, INDEX);
+            expect(result).to.deep.equal({ ...result, focusSelectionIndex: INDEX });
+        });
     });
 });

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -85,7 +85,7 @@ describe("FocusedCellUtils", () => {
         }
     });
 
-    describe.only("expandSelectedRegions", () => {
+    describe.only("expandFocusedRegion", () => {
         describe("Expands a FULL_COLUMNS selection", () => {
             describe("to another FULL_COLUMNS selection", () => {
                 it("leftward", fail);

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -86,11 +86,12 @@ describe("FocusedCellUtils", () => {
     });
 
     describe.only("expandFocusedRegion", () => {
+        const focusedCell = toCellCoords(3, 3);
+
         // shorthand
         const fn = FocusedCellUtils.expandFocusedRegion;
 
         describe("Expands a FULL_COLUMNS selection", () => {
-            const focusedCell = toCellCoords(3, 3);
             const oldRegion = Regions.column(3);
 
             describe("to another FULL_COLUMNS selection", () => {
@@ -160,27 +161,68 @@ describe("FocusedCellUtils", () => {
         });
 
         describe("Expands a FULL_ROWS selection", () => {
-            describe("to another FULL_ROWS selection", () => {
-                it("upward", fail);
+            const oldRegion = Regions.row(3);
 
-                it("downward", fail);
+            describe("to another FULL_ROWS selection", () => {
+                it("upward", () => {
+                    const newRegion = Regions.row(1);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.row(1, 3));
+                });
+
+                it("downward", () => {
+                    const newRegion = Regions.row(5);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.row(3, 5));
+                });
+
+                it("to itself", () => {
+                    const newRegion = Regions.row(3);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.row(3, 3));
+                });
             });
 
             describe("to a FULL_COLUMNS selection", () => {
                 it("if focused cell is in same column", fail);
 
                 describe("if focused cell is in different column", () => {
-                    it("leftward", fail);
+                    it("leftward", () => {
+                        const newRegion = Regions.column(1);
+                        const result = fn(focusedCell, oldRegion, newRegion);
+                        checkEqual(result, Regions.column(1, 3));
+                    });
 
-                    it("rightward", fail);
+                    it("rightward", () => {
+                        const newRegion = Regions.column(5);
+                        const result = fn(focusedCell, oldRegion, newRegion);
+                        checkEqual(result, Regions.column(3, 5));
+                    });
                 });
             });
 
-            it("to a CELLS selection", fail);
+            describe("to a CELLS selection", () => {
+                it("toward bottom-right", () => {
+                    const newRegion = Regions.cell(5, 5);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.cell(3, 3, 5, 5));
+                });
 
-            it("to a FULL_TABLE selection", fail);
+                it("toward top-left", () => {
+                    const newRegion = Regions.cell(3, 1);
+                    const result = fn(focusedCell, oldRegion, newRegion);
+                    checkEqual(result, Regions.cell(3, 1, 3, 3));
+                });
 
-            it("to itself", fail);
+                // assume the other directions are fine too (there's no special
+                // logic governing strictly leftward/downward selections, e.g.)
+            });
+
+            it("to a FULL_TABLE selection", () => {
+                const newRegion = Regions.table();
+                const result = fn(focusedCell, oldRegion, newRegion);
+                checkEqual(result, Regions.table());
+            });
         });
 
         describe("Expands a CELLS selection", () => {

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -94,7 +94,7 @@ describe("FocusedCellUtils", () => {
             });
 
             describe("to a FULL_ROWS selection", () => {
-                it("if focused cell is in same row");
+                it("if focused cell is in same row", fail);
 
                 describe("if focused cell is in different row", () => {
                     it("upward", fail);
@@ -118,7 +118,7 @@ describe("FocusedCellUtils", () => {
             });
 
             describe("to a FULL_COLUMNS selection", () => {
-                it("if focused cell is in same column");
+                it("if focused cell is in same column", fail);
 
                 describe("if focused cell is in different column", () => {
                     it("leftward", fail);

--- a/packages/table/test/common/internal/index.ts
+++ b/packages/table/test/common/internal/index.ts
@@ -5,5 +5,5 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import "./focusCellUtilsTests";
+import "./focusedCellUtilsTests";
 import "./scrollUtilsTests";

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -122,6 +122,8 @@ export class ElementHarness {
             isMetaKeyDown = this.defaultValue(offsetXOrOptions.metaKey, false);
             isShiftKeyDown = this.defaultValue(offsetXOrOptions.shiftKey, false);
             button = this.defaultValue(offsetXOrOptions.button, 0);
+        } else {
+            offsetX = offsetXOrOptions as number;
         }
 
         const bounds = this.bounds();

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -14,6 +14,23 @@ import * as ReactDOM from "react-dom";
 export type MouseEventType = "click" | "mousedown" | "mouseup" | "mousemove" | "mouseenter" | "mouseleave" ;
 export type KeyboardEventType = "keypress" | "keydown" |  "keyup" ;
 
+export interface IHarnessMouseOptions {
+    /** @default 0 */
+    offsetX?: number;
+
+    /** @default 0 */
+    offsetY?: number;
+
+    /** @default false */
+    metaKey?: boolean;
+
+    /** @default false */
+    shiftKey?: boolean;
+
+    /** @default 0 */
+    button?: number;
+}
+
 function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: string, modKey = false) {
     const event = document.createEvent("KeyboardEvent");
     const keyCode = key.charCodeAt(0);
@@ -91,10 +108,22 @@ export class ElementHarness {
     }
 
     public mouse(eventType: MouseEventType = "click",
-                 offsetX = 0,
+                 offsetXOrOptions: number | IHarnessMouseOptions = 0, // TODO: Change all tests to the object API
                  offsetY = 0,
                  isMetaKeyDown = false,
-                 isShiftKeyDown = false) {
+                 isShiftKeyDown = false,
+                 button: number = 0) {
+
+        let offsetX: number;
+
+        if (typeof offsetXOrOptions === "object") {
+            offsetX = this.defaultValue(offsetXOrOptions.offsetX, 0);
+            offsetY = this.defaultValue(offsetXOrOptions.offsetY, 0);
+            isMetaKeyDown = this.defaultValue(offsetXOrOptions.metaKey, false);
+            isShiftKeyDown = this.defaultValue(offsetXOrOptions.shiftKey, false);
+            button = this.defaultValue(offsetXOrOptions.button, 0);
+        }
+
         const bounds = this.bounds();
         const x = bounds.left + bounds.width / 2 + offsetX;
         const y = bounds.top + bounds.height / 2 + offsetY;
@@ -111,7 +140,7 @@ export class ElementHarness {
             eventType, true, true, window,
             null, 0, 0, x, y,
             isMetaKeyDown, false, isShiftKeyDown, isMetaKeyDown,
-            0, null,
+            button, null,
         );
         this.element.dispatchEvent(event);
         return this;
@@ -141,6 +170,11 @@ export class ElementHarness {
         } else {
             return this.element.querySelector(query);
         }
+    }
+
+    /** Returns the default value if the provided value is not defined. */
+    private defaultValue(value: any | null | undefined, defaultValue: any) {
+        return value != null ? value : defaultValue;
     }
 }
 

--- a/packages/table/test/regionsTests.ts
+++ b/packages/table/test/regionsTests.ts
@@ -160,4 +160,42 @@ describe("Regions", () => {
             ["X", null],
         ]));
     });
+
+    describe("expandRegion", () => {
+        it("returns new region if cardinalities are different", () => {
+            const oldRegion = Regions.cell(0, 0);
+            const newRegion = Regions.table();
+            const result = Regions.expandRegion(oldRegion, newRegion);
+            // should have returned the newRegion instance
+            expect(result).to.equal(newRegion);
+        });
+
+        it("expands a FULL_ROWS region", () => {
+            const oldRegion = Regions.row(1, 2);
+            const newRegion = Regions.row(9, 10);
+            const result = Regions.expandRegion(oldRegion, newRegion);
+            expect(result).to.deep.equal(Regions.row(1, 10));
+        });
+
+        it("expands a FULL_COLUMNS region", () => {
+            const oldRegion = Regions.column(9, 10);
+            const newRegion = Regions.column(1, 2);
+            const result = Regions.expandRegion(oldRegion, newRegion);
+            expect(result).to.deep.equal(Regions.column(1, 10));
+        });
+
+        it("expands a CELLS region", () => {
+            const oldRegion = Regions.cell(1, 2);
+            const newRegion = Regions.cell(9, 10);
+            const result = Regions.expandRegion(oldRegion, newRegion);
+            expect(result).to.deep.equal(Regions.cell(1, 2, 9, 10));
+        });
+
+        it("expands a FULL_TABLE region", () => {
+            const oldRegion = Regions.table();
+            const newRegion = Regions.table();
+            const result = Regions.expandRegion(oldRegion, newRegion);
+            expect(result).to.deep.equal(Regions.table());
+        });
+    });
 });

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -286,8 +286,11 @@ describe("DragSelectable", () => {
 
         // wrap in a `describe` to preserve the output order
         describe("replaces the selection otherwise", () => {
-            it("using the clicked region by default", () => {
+            beforeEach(() => {
                 locateClick.returns(REGION_2);
+            });
+
+            it("using the clicked region by default", () => {
 
                 const component = mountDragSelectable({
                     selectedRegions: [REGION],
@@ -300,8 +303,6 @@ describe("DragSelectable", () => {
             });
 
             it("works with a selectedRegionTransform too", () => {
-                locateClick.returns(REGION_2);
-
                 const component = mountDragSelectable({
                     selectedRegionTransform: sinon.stub().returns(TRANSFORMED_REGION_2),
                     selectedRegions: [REGION],
@@ -481,6 +482,18 @@ describe("DragSelectable", () => {
             );
         });
 
+        it("doesn't invoke onSelection if the selection didn't change", () => {
+            locateDrag.returns(REGION_3);
+
+            const component = mountDragSelectable({ selectedRegions: [REGION_3] });
+            const item = getItem(component);
+
+            item.mouse("mousedown");
+            expect(onSelection.callCount, "calls onSelection on mousedown").to.equal(1);
+            item.mouse("mousemove");
+            expect(onSelection.callCount, "does not call onSelection again on mousemove").to.equal(1);
+        });
+
         // running these checks separately clarifies the subsequent effects of the "mousemove" event.
         function runMouseDownChecks() {
             expect(locateClick.calledOnce, "calls locateClick on mousedown").to.be.true;
@@ -570,297 +583,4 @@ describe("DragSelectable", () => {
             focusSelectionIndex,
         });
     }
-
-    /*
-
-    it("does click selection", () => {
-        const onSelection = sinon.spy();
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub().returns(Regions.column(0));
-        const locateDrag = sinon.stub().throws();
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={true}
-                selectedRegions={[]}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                locateClick={locateClick}
-                locateDrag={locateDrag}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        selectable.find(".selectable", 0).mouse("mousedown").mouse("mouseup");
-        expect(onSelection.called).to.be.true;
-        expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0)]);
-        expect(onFocus.called).to.be.true;
-        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0, focusSelectionIndex: 0});
-    });
-
-    it("restricts to single selection when allowMultipleSelection={false}", () => {
-        const onSelection = sinon.spy();
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub();
-        const locateDrag = sinon.stub().throws();
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={false}
-                selectedRegions={[]}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                locateClick={locateClick}
-                locateDrag={locateDrag}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        locateClick.onCall(0).returns(Regions.column(0));
-        locateClick.onCall(1).returns(Regions.column(0));
-        selectable.find(".selectable", 0).mouse("mousedown").mouse("mouseup");
-        expect(onSelection.called).to.be.true;
-        expect(onSelection.lastCall.args[0]).to.deep.equal([Regions.column(0)]);
-
-        locateClick.reset();
-        locateClick.onCall(0).returns(Regions.column(1));
-        locateClick.onCall(1).returns(Regions.column(2));
-        locateClick.onCall(2).returns(Regions.column(2));
-        selectable.find(".selectable", 1).mouse("mousedown");
-        selectable.find(".selectable", 2).mouse("mousemove").mouse("mouseup");
-        expect(onSelection.lastCall.args[0]).to.deep.equal([Regions.column(2)]);
-    });
-
-    it("moves focus cell with dragging selection when allowMultipleSelection=false", () => {
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub();
-
-        locateClick.onCall(0).returns(Regions.column(0));
-        locateClick.onCall(1).returns(Regions.column(1));
-        locateClick.onCall(2).returns(Regions.column(2));
-        locateClick.onCall(3).returns(Regions.column(2));
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={false}
-                selectedRegions={[]}
-                onFocus={onFocus}
-                onSelection={sinon.stub()}
-                locateClick={locateClick}
-                locateDrag={sinon.stub()}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        selectable.find(".selectable", 0).mouse("mousedown");
-        selectable.find(".selectable", 1).mouse("mousemove");
-        selectable.find(".selectable", 2).mouse("mousemove").mouse("mouseup");
-
-        expect(onFocus.callCount).to.equal(4);
-        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0, focusSelectionIndex: 0});
-        expect(onFocus.args[1][0]).to.deep.equal({col: 1, row: 0, focusSelectionIndex: 0});
-        expect(onFocus.args[2][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
-        expect(onFocus.args[3][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
-    });
-
-    it("does drag selection", () => {
-        const onSelection = sinon.spy();
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub();
-        const locateDrag = sinon.stub();
-
-        locateClick.returns(Regions.column(0));
-        locateDrag.onCall(0).returns(Regions.column(0, 1));
-        locateDrag.onCall(1).returns(Regions.column(0, 2));
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={true}
-                selectedRegions={[]}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                locateClick={locateClick}
-                locateDrag={locateDrag}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        selectable.find(".selectable", 0).mouse("mousedown");
-        selectable.find(".selectable", 1).mouse("mousemove");
-        selectable.find(".selectable", 2).mouse("mousemove").mouse("mouseup");
-
-        expect(onSelection.callCount).to.equal(3);
-        expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0, 0)]);
-        expect(onSelection.args[1][0]).to.deep.equal([Regions.column(0, 1)]);
-        expect(onSelection.args[2][0]).to.deep.equal([Regions.column(0, 2)]);
-        expect(onFocus.callCount).to.equal(1);
-        expect(onFocus.args[0][0]).to.deep.equal({col: 0, row: 0, focusSelectionIndex: 0});
-    });
-
-    it("expands the selection on shift+click", () => {
-        const onSelection = sinon.spy();
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub().returns(Regions.column(2));
-        const locateDrag = sinon.stub().throws();
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={true}
-                selectedRegions={[Regions.column(0)]}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                locateClick={locateClick}
-                locateDrag={locateDrag}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        const shiftKey = true;
-        selectable.find(".selectable", 0).mouse("mousedown", 0, 0, false, shiftKey).mouse("mouseup");
-        expect(onSelection.called).to.be.true;
-        expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0, 2)]);
-        expect(onFocus.called).to.be.true;
-        // this isn't proper behavior in the long run, but we'll address focus-cell stuff later
-        // (see: https://github.com/palantir/blueprint/issues/823)
-        expect(onFocus.args[0][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
-    });
-
-    it("does not expand the selection on shift+click if allowMultipleSelection=false", () => {
-        const onSelection = sinon.spy();
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub().returns(Regions.column(2));
-        const locateDrag = sinon.stub().throws();
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={false}
-                selectedRegions={[Regions.column(0)]}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                locateClick={locateClick}
-                locateDrag={locateDrag}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        const shiftKey = true;
-        selectable.find(".selectable", 0).mouse("mousedown", 0, 0, false, shiftKey).mouse("mouseup");
-        expect(onSelection.called).to.be.true;
-        expect(onSelection.args[0][0]).to.deep.equal([Regions.column(2, 2)]);
-    });
-
-    it("re-select clears region", () => {
-        const onSelection = sinon.spy();
-        const onFocus = sinon.spy();
-        const locateClick = sinon.stub().returns(Regions.column(0));
-        const locateDrag = sinon.stub().throws();
-
-        const selectable = harness.mount(
-            <DragSelectable
-                allowMultipleSelection={true}
-                selectedRegions={[Regions.column(0), Regions.column(2)]}
-                onFocus={onFocus}
-                onSelection={onSelection}
-                locateClick={locateClick}
-                locateDrag={locateDrag}
-            >
-                {children}
-            </DragSelectable>,
-        );
-
-        selectable.find(".selectable", 0).mouse("mousedown").mouse("mouseup");
-        expect(onSelection.lastCall.args[0]).to.deep.equal([], "no meta clears everything");
-
-        selectable.find(".selectable", 0).mouse("mousedown", 0, 0, true).mouse("mouseup", 0, 0, true);
-        expect(onSelection.lastCall.args[0]).to.deep.equal([Regions.column(2)], "meta only clears exact region");
-    });
-
-    describe("ignores invalid interactions", () => {
-        it("ignores invalid mousedown", () => {
-            const onSelection = sinon.spy();
-            const onFocus = sinon.spy();
-            const locateClick = sinon.stub().returns(Regions.column(-1));
-            const locateDrag = sinon.stub().throws();
-
-            const selectable = harness.mount(
-                <DragSelectable
-                    allowMultipleSelection={true}
-                    selectedRegions={[]}
-                    onFocus={onFocus}
-                    onSelection={onSelection}
-                    locateClick={locateClick}
-                    locateDrag={locateDrag}
-                >
-                    {children}
-                </DragSelectable>,
-            );
-
-            selectable.find(".selectable", 0).mouse("mousedown").mouse("mouseup");
-            expect(onSelection.called).to.be.false;
-            expect(onFocus.called).to.be.false;
-        });
-
-        it("ignores invalid mouseup", () => {
-            const onSelection = sinon.spy();
-            const onFocus = sinon.spy();
-            const locateClick = sinon.stub();
-            const locateDrag = sinon.stub().throws();
-
-            locateClick.onCall(0).returns(Regions.column(0));
-            locateClick.onCall(1).returns(Regions.column(-1));
-
-            const selectable = harness.mount(
-                <DragSelectable
-                    allowMultipleSelection={true}
-                    selectedRegions={[]}
-                    onFocus={onFocus}
-                    onSelection={onSelection}
-                    locateClick={locateClick}
-                    locateDrag={locateDrag}
-                >
-                    {children}
-                </DragSelectable>,
-            );
-
-            selectable.find(".selectable", 0).mouse("mousedown").mouse("mouseup");
-            expect(onSelection.callCount).to.equal(1);
-            expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0)]);
-        });
-
-        it("ignores invalid drag", () => {
-            const onSelection = sinon.spy();
-            const onFocus = sinon.spy();
-            const locateClick = sinon.stub();
-            const locateDrag = sinon.stub();
-
-            locateClick.returns(Regions.column(0));
-            locateDrag.returns(Regions.column(-1));
-
-            const selectable = harness.mount(
-                <DragSelectable
-                    allowMultipleSelection={true}
-                    selectedRegions={[]}
-                    onFocus={onFocus}
-                    onSelection={onSelection}
-                    locateClick={locateClick}
-                    locateDrag={locateDrag}
-                >
-                    {children}
-                </DragSelectable>,
-            );
-
-            selectable.find(".selectable", 0).mouse("mousedown");
-            selectable.find(".selectable", 1).mouse("mousemove").mouse("mouseup");
-
-            expect(onSelection.callCount).to.equal(1);
-            expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0)]);
-        });
-    });
-    */
 });

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -7,12 +7,27 @@
 
 import { expect } from "chai";
 import * as React from "react";
-import { Regions } from "../src/";
-import { DragSelectable } from "../src/interactions/selectable";
-import { ReactHarness } from "./harness";
+
+import { IFocusedCellCoordinates } from "../src/common/cell";
+import * as FocusedCellUtils from "../src/common/internal/focusedCellUtils";
+import { DragSelectable, IDragSelectableProps } from "../src/interactions/selectable";
+import { IRegion, Regions } from "../src/regions";
+import { ElementHarness, ReactHarness } from "./harness";
+
+const REGION = Regions.cell(0, 0);
+const REGION_2 = Regions.cell(1, 1);
+const REGION_3 = Regions.cell(2, 2);
+const TRANSFORMED_REGION = Regions.row(0);
+const TRANSFORMED_REGION_2 = Regions.row(1);
 
 describe("DragSelectable", () => {
     const harness = new ReactHarness();
+
+    const onSelection = sinon.spy();
+    const onFocus = sinon.spy();
+    const locateClick = sinon.stub();
+    const locateDrag = sinon.stub();
+
     const children = (
         <div className="single-child">
             <div className="selectable">Zero</div>
@@ -23,11 +38,540 @@ describe("DragSelectable", () => {
 
     afterEach(() => {
         harness.unmount();
+
+        onSelection.reset();
+        onFocus.reset();
+
+        locateClick.returns(undefined);
+        locateDrag.returns(undefined);
+
+        locateClick.reset();
+        locateDrag.reset();
     });
 
     after(() => {
         harness.destroy();
     });
+
+    describe("on mousedown", () => {
+        describe("has no effect", () => {
+            beforeEach(() => {
+                locateClick.returns(Regions.cell(0, 0));
+            });
+
+            it("if event happened within any ignoredSelectors", () => {
+                const component = mountDragSelectable({ ignoredSelectors: [".single-child"] });
+
+                getItem(component).mouse("mousedown");
+
+                expectOnSelectionNotCalled();
+                expectOnFocusNotCalled();
+            });
+
+            it("if props.disabled=true", () => {
+                const component = mountDragSelectable({ disabled: true });
+
+                getItem(component).mouse("mousedown");
+
+                expectOnSelectionNotCalled();
+                expectOnFocusNotCalled();
+            });
+
+            it("if was triggered by a right- or middle-click", () => {
+                const component = mountDragSelectable();
+
+                const RIGHT_BUTTON = 1;
+                const MIDDLE_BUTTON = 2;
+
+                getItem(component).mouse("mousedown", { button: RIGHT_BUTTON });
+                getItem(component).mouse("mousedown", { button: MIDDLE_BUTTON });
+
+                expectOnSelectionNotCalled();
+                expectOnFocusNotCalled();
+            });
+
+            it("if clicked region is invalid", () => {
+                locateClick.returns(null);
+                const component = mountDragSelectable();
+
+                getItem(component).mouse("mousedown");
+
+                expectOnSelectionNotCalled();
+                expectOnFocusNotCalled();
+            });
+        });
+
+        describe("if region matches one already selected", () => {
+            beforeEach(() => {
+                locateClick.returns(REGION);
+            });
+
+            it("deselects just that region if CMD key was depressed", () => {
+                const component = mountDragSelectable({
+                    selectedRegions: [REGION_2, REGION, REGION_3],
+                });
+
+                getItem(component).mouse("mousedown", { metaKey: true });
+
+                expectOnSelectionCalledWith([REGION_2, REGION_3]);
+                expectOnFocusCalledWith(REGION_3, 1);
+            });
+
+            it("deselects all regions if no modifier keys were depressed", () => {
+                const component = mountDragSelectable({
+                    selectedRegions: [REGION_2, REGION, REGION_3],
+                });
+
+                getItem(component).mouse("mousedown");
+
+                expectOnSelectionCalledWith([]);
+                expectOnFocusNotCalled(); // leave focused cell where it is
+            });
+
+            it("works with a selectedRegionTransform too", () => {
+                const component = mountDragSelectable({
+                    selectedRegionTransform: sinon.stub().returns(TRANSFORMED_REGION),
+                    selectedRegions: [REGION_2, TRANSFORMED_REGION, REGION_3],
+                });
+
+                getItem(component).mouse("mousedown", { metaKey: true });
+
+                expectOnSelectionCalledWith([REGION_2, REGION_3]);
+                expectOnFocusCalledWith(REGION_3, 1);
+            });
+        });
+
+        describe("if SHIFT key was depressed", () => {
+            beforeEach(() => {
+                locateClick.returns(REGION_2);
+            });
+
+            it("does not expand selection if allowMultipleSelection=false", () => {
+                const component = mountDragSelectable({
+                    allowMultipleSelection: false,
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { shiftKey: true });
+
+                expectOnSelectionCalledWith([REGION_2]);
+                expectOnFocusCalledWith(REGION_2, 0);
+            });
+
+            it("if no active selections, selects just the clicked region", () => {
+                const component = mountDragSelectable({
+                    selectedRegions: [],
+                });
+
+                getItem(component).mouse("mousedown", { shiftKey: true });
+
+                expectOnSelectionCalledWith([REGION_2]);
+                expectOnFocusCalledWith(REGION_2, 0);
+            });
+
+            it("if focusedCell exists, expands the most recent selection using focusedCell and clicked region", () => {
+                // meta assertions (just need to do this in one place)
+                expectSingleCellRegion(REGION);
+                expectSingleCellRegion(REGION_2);
+
+                const expandFocusedSpy = sinon.spy(FocusedCellUtils, "expandFocusedRegion");
+                const expandSpy = sinon.spy(Regions, "expandRegion");
+                const component = mountDragSelectable({
+                    focusedCell: toFocusedCell(REGION),
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { shiftKey: true });
+
+                expect(expandFocusedSpy.calledOnce).to.be.true;
+                expect(expandSpy.called).to.be.false;
+                expectOnSelectionCalledWith([expandFocusedSpy.firstCall.returnValue]);
+
+                // unwrap the sinon spies
+                (FocusedCellUtils.expandFocusedRegion as any).restore();
+                (Regions.expandRegion as any).restore();
+            });
+
+            it("otherwise, expands the most recent one to the clicked region", () => {
+                const expandFocusedSpy = sinon.spy(FocusedCellUtils, "expandFocusedRegion");
+                const expandSpy = sinon.spy(Regions, "expandRegion");
+                const component = mountDragSelectable({
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { shiftKey: true });
+
+                expect(expandFocusedSpy.calledOnce).to.be.false;
+                expect(expandSpy.called).to.be.true;
+                expectOnSelectionCalledWith([expandSpy.firstCall.returnValue]);
+
+                (FocusedCellUtils.expandFocusedRegion as any).restore();
+                (Regions.expandRegion as any).restore();
+            });
+
+            it("expands selection even if CMD key was pressed", () => {
+                const expandFocusedSpy = sinon.spy(FocusedCellUtils, "expandFocusedRegion");
+                const component = mountDragSelectable({
+                    focusedCell: toFocusedCell(REGION),
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { shiftKey: true, metaKey: true });
+
+                expect(expandFocusedSpy.calledOnce).to.be.true;
+                expectOnSelectionCalledWith([expandFocusedSpy.firstCall.returnValue]);
+
+                (FocusedCellUtils.expandFocusedRegion as any).restore();
+            });
+
+            it("works with a selectedRegionTransform too", () => {
+                const expandFocusedSpy = sinon.spy(FocusedCellUtils, "expandFocusedRegion");
+                const focusedCell = toFocusedCell(REGION);
+                const component = mountDragSelectable({
+                    focusedCell,
+                    selectedRegionTransform: sinon.stub().returns(TRANSFORMED_REGION_2),
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { shiftKey: true, metaKey: true });
+
+                expect(expandFocusedSpy.calledOnce).to.be.true;
+                expect(expandFocusedSpy.firstCall.calledWith(focusedCell, TRANSFORMED_REGION_2)).to.be.true;
+
+                (FocusedCellUtils.expandFocusedRegion as any).restore();
+            });
+        });
+
+        describe("if CMD key was pressed", () => {
+            beforeEach(() => {
+                locateClick.returns(REGION_2);
+            });
+
+            it("does not add disjoint selection if allowMultipleSelection=false", () => {
+                const component = mountDragSelectable({
+                    allowMultipleSelection: false,
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { metaKey: true });
+
+                expectOnSelectionCalledWith([REGION_2]);
+                expectOnFocusCalledWith(REGION_2, 0);
+            });
+
+            it("adds clicked region as a new disjoint selection", () => {
+                const component = mountDragSelectable({
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { metaKey: true });
+
+                expectOnSelectionCalledWith([REGION, REGION_2]);
+                expectOnFocusCalledWith(REGION_2, 1);
+            });
+
+            it("works with a selectedRegionTransform too", () => {
+                const component = mountDragSelectable({
+                    selectedRegionTransform: sinon.stub().returns(TRANSFORMED_REGION_2),
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { metaKey: true });
+
+                const expectedFocusedCell = Regions.getFocusCellCoordinatesFromRegion(TRANSFORMED_REGION_2);
+                expectOnSelectionCalledWith([REGION, TRANSFORMED_REGION_2]);
+                expectOnFocusCalledWith(FocusedCellUtils.toFullCoordinates(expectedFocusedCell), 1);
+            });
+        });
+
+        // wrap in a `describe` to preserve the output order
+        describe("replaces the selection otherwise", () => {
+            it("using the clicked region by default", () => {
+                locateClick.returns(REGION_2);
+
+                const component = mountDragSelectable({
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown");
+
+                expectOnSelectionCalledWith([REGION_2]);
+                expectOnFocusCalledWith(REGION_2, 0);
+            });
+
+            it("works with a selectedRegionTransform too", () => {
+                locateClick.returns(REGION_2);
+
+                const component = mountDragSelectable({
+                    selectedRegionTransform: sinon.stub().returns(TRANSFORMED_REGION_2),
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown");
+
+                const expectedFocusedCell = Regions.getFocusCellCoordinatesFromRegion(TRANSFORMED_REGION_2);
+                expectOnSelectionCalledWith([TRANSFORMED_REGION_2]);
+                expectOnFocusCalledWith(FocusedCellUtils.toFullCoordinates(expectedFocusedCell), 0);
+            });
+        });
+    });
+
+    describe("on click (i.e. on immediate mouseup with no mousemove)", () => {
+        it("invokes onSelectionEnd", () => {
+            locateClick.returns(REGION_2);
+
+            const onSelectionEnd = sinon.spy();
+            const selectedRegions = [REGION]; // create a new array instance
+
+            const component = mountDragSelectable({ onSelectionEnd, selectedRegions });
+
+            // be sure to test "click"s as sequentional "mousedown"-"mouseup"s, because those
+            // are the events we actually listen for deep in DragEvents.
+            getItem(component).mouse("mousedown").mouse("mouseup");
+
+            expect(onSelectionEnd.calledOnce).to.be.true;
+            expect(onSelectionEnd.firstCall.args[0] === selectedRegions).to.be.true; // check for same instance
+        });
+    });
+
+    describe("on drag move", () => {
+        beforeEach(() => {
+            locateClick.returns(REGION_2);
+        });
+
+        describe("if SHIFT depressed", () => {
+            let expandFocusedSpy: Sinon.SinonSpy;
+            let expandSpy: Sinon.SinonSpy;
+
+            beforeEach(() => {
+                expandFocusedSpy = sinon.spy(FocusedCellUtils, "expandFocusedRegion");
+                expandSpy = sinon.spy(Regions, "expandRegion");
+                locateDrag.returns(REGION_3);
+            });
+
+            afterEach(() => {
+                (FocusedCellUtils.expandFocusedRegion as any).restore();
+                (Regions.expandRegion as any).restore();
+            });
+
+            it("expands selection from focused cell (if provided)", () => {
+                const component = mountDragSelectable({
+                    focusedCell: toFocusedCell(REGION),
+                    selectedRegions: [REGION],
+                });
+                const item = getItem(component);
+
+                item.mouse("mousedown", { shiftKey: true });
+                expect(expandFocusedSpy.calledOnce, "calls FCU.expandFocusedRegion on mousedown").to.be.true;
+                expect(onSelection.calledOnce, "calls onSelection on mousedown").to.be.true;
+
+                item.mouse("mousemove", { shiftKey: true });
+                expect(expandFocusedSpy.calledTwice, "calls FCU.expandFocusedRegion on mousemove").to.be.true;
+                expect(onSelection.calledTwice, "calls onSelection on mousemove").to.be.true;
+                expect(
+                    onSelection.secondCall.calledWith([expandFocusedSpy.secondCall.returnValue]),
+                    "calls onSelection on mousemove with proper args",
+                ).to.be.true;
+
+                expect(expandSpy.called, "doesn't call Regions.expandRegion").to.be.false;
+                expect(onFocus.called, "doesn't call onFocus").to.be.false;
+            });
+
+            it("expands selection using Regions.expandRegion if focusedCell not provided", () => {
+                const component = mountDragSelectable({ selectedRegions: [REGION] });
+                const item = getItem(component);
+
+                item.mouse("mousedown", { shiftKey: true });
+                expect(expandSpy.calledOnce, "calls Regions.expandRegion on mousedown").to.be.true;
+
+                item.mouse("mousemove", { shiftKey: true });
+                expect(expandSpy.calledTwice, "calls Regions.expandRegion on mousemove").to.be.true;
+                expect(onSelection.calledTwice, "calls onSelection on mousemove").to.be.true;
+                expect(
+                    onSelection.secondCall.calledWith([expandSpy.secondCall.returnValue]),
+                    "calls onSelection on mousemove with proper args",
+                ).to.be.true;
+
+                expect(expandFocusedSpy.called, "calls FocusedCellUtils.expandFocusedRegion").to.be.false;
+                expect(onFocus.called, "doesn't call onFocus").to.be.false;
+            });
+        });
+
+        it("if SHIFT not depressed, replaces last region with the result of locateDrag", () => {
+            const boundingRegion = Regions.cell(
+                // the bounding region of the two subregions
+                REGION_2.rows[0],
+                REGION_2.cols[0],
+                REGION_3.rows[0],
+                REGION_3.cols[0],
+            );
+            locateDrag.returns(boundingRegion);
+
+            const component = mountDragSelectable({ selectedRegions: [REGION, REGION_3] });
+            const item = getItem(component);
+
+            item.mouse("mousedown");
+            runMouseDownChecks();
+
+            item.mouse("mousemove");
+            expect(locateDrag.calledOnce, "calls locateDrag on mousemove").to.be.true;
+            expect(onSelection.calledTwice, "calls onSelection on mousemove").to.be.true;
+            expect(
+                onSelection.secondCall.calledWith([REGION, boundingRegion]),
+                "calls onSelection on mousemove with proper args",
+            ).to.be.true;
+            expect(onFocus.calledTwice, "doesn't call onFocus on mousedown").to.be.false;
+        });
+
+        it("has no effect if dragged region is invalid", () => {
+            locateDrag.returns(null); // invalid
+
+            const component = mountDragSelectable({ selectedRegions: [REGION] });
+            const item = getItem(component);
+
+            item.mouse("mousedown");
+            runMouseDownChecks();
+
+            item.mouse("mousemove");
+            expect(onSelection.calledTwice, "doesn't call onSelection on mousemove").to.be.false;
+            expect(onFocus.calledTwice, "doesn't call onFocus on mousemove").to.be.false;
+        });
+
+        it("applies a selectedRegionTransform if provided", () => {
+            locateDrag.returns(REGION_3);
+
+            const component = mountDragSelectable({
+                selectedRegionTransform: sinon.stub().returns(TRANSFORMED_REGION),
+                selectedRegions: [REGION],
+            });
+
+            getItem(component).mouse("mousedown").mouse("mousemove");
+
+            expect(onSelection.calledTwice, "calls onSelection on mousemove").to.be.true;
+            expect(
+                onSelection.secondCall.calledWith([TRANSFORMED_REGION]),
+                "calls onSelection on mousemove with proper args",
+            ).to.be.true;
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it("if allowMultipleSelection=false, moves selection (and focused cell) instead of expanding it", () => {
+            locateClick.onCall(0).returns(REGION_2);
+            locateClick.onCall(1).returns(REGION_3);
+
+            const component = mountDragSelectable({
+                allowMultipleSelection: false,
+                selectedRegions: [REGION],
+            });
+
+            getItem(component)
+                .mouse("mousedown")
+                .mouse("mousemove");
+
+            expect(locateClick.calledTwice, "calls locateClick on mousemove").to.be.true;
+            expect(locateDrag.called, "doesn't call locateDrag on mousemove").to.be.false;
+            expect(onSelection.calledTwice, "calls onSelection on mousemove").to.be.true;
+            expect(
+                onSelection.secondCall.calledWith([REGION_3]),
+                "calls onSelection on mousemove with proper args",
+            ).to.be.true;
+            expect(
+                onFocus.secondCall.calledWith(toFocusedCell(REGION_3)),
+                "moves focusedCell with the selection",
+            );
+        });
+
+        // running these checks separately clarifies the subsequent effects of the "mousemove" event.
+        function runMouseDownChecks() {
+            expect(locateClick.calledOnce, "calls locateClick on mousedown").to.be.true;
+            expect(onSelection.calledOnce, "calls onSelection on mousedown").to.be.true;
+            expect(onFocus.calledOnce, "calls onFocus on mousedown").to.be.true;
+        }
+    });
+
+    describe("on drag end", () => {
+        it("invokes onSelectionEnd", () => {
+            locateClick.returns(REGION_2);
+
+            const onSelectionEnd = sinon.spy();
+            const selectedRegions = [REGION]; // create a new array instance
+
+            const component = mountDragSelectable({ onSelectionEnd, selectedRegions });
+
+            getItem(component)
+                .mouse("mousedown")
+                .mouse("mousemove")
+                .mouse("mouseup");
+
+            expect(onSelectionEnd.calledOnce).to.be.true;
+            expect(onSelectionEnd.firstCall.args[0] === selectedRegions).to.be.true;
+        });
+    });
+
+    function mountDragSelectable(props: Partial<IDragSelectableProps> & object = {}) {
+        return harness.mount(
+            <DragSelectable
+                allowMultipleSelection={true}
+                onFocus={onFocus}
+                onSelection={onSelection}
+                locateClick={locateClick}
+                locateDrag={locateDrag}
+                {...props}
+            >
+                {children}
+            </DragSelectable>,
+        );
+    }
+
+    function getItem(component: ElementHarness, index: number = 0) {
+        return component.find(".selectable", index);
+    }
+
+    function toCell(region: IRegion) {
+        // assumes a 1-cell region
+        return { row: region.rows[0], col: region.cols[0] };
+    }
+
+    function toFocusedCell(singleCellRegion: IRegion) {
+        return FocusedCellUtils.toFullCoordinates(toCell(singleCellRegion));
+    }
+
+    function expectSingleCellRegion(region: IRegion) {
+        // helper function to assert the test regions are all single cells
+        const [startRow, endRow] = region.rows;
+        const [startCol, endCol] = region.cols;
+        expect(startRow, "single-cell region should not span multiple rows").to.equal(endRow);
+        expect(startCol, "single-cell region should not span multiple columns").to.equal(endCol);
+    }
+
+    function expectOnSelectionNotCalled() {
+        expect(onSelection.called).to.be.false;
+    }
+
+    function expectOnFocusNotCalled() {
+        expect(onFocus.called).to.be.false;
+    }
+
+    function expectOnSelectionCalledWith(selectedRegions: IRegion[]) {
+        expect(onSelection.called, "should call onSelection").to.be.true;
+        expect(onSelection.firstCall.args[0], "should call onSelection with correct arg")
+            .to.deep.equal(selectedRegions);
+    }
+
+    function expectOnFocusCalledWith(regionOrCoords: IRegion | IFocusedCellCoordinates, focusSelectionIndex: number) {
+        expect(onFocus.called, "should call onFocus").to.be.true;
+
+        const region = regionOrCoords as IRegion;
+        const expectedCoords = region.rows != null
+            ? { col: region.cols[0], row: region.rows[0] }
+            : regionOrCoords as IFocusedCellCoordinates;
+        expect(onFocus.firstCall.args[0], "should call onFocus with correct arg").to.deep.equal({
+            ...expectedCoords,
+            focusSelectionIndex,
+        });
+    }
+
+    /*
 
     it("does click selection", () => {
         const onSelection = sinon.spy();
@@ -318,4 +862,5 @@ describe("DragSelectable", () => {
             expect(onSelection.args[0][0]).to.deep.equal([Regions.column(0)]);
         });
     });
+    */
 });

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -186,6 +186,31 @@ describe("DragSelectable", () => {
         expect(onFocus.args[0][0]).to.deep.equal({col: 2, row: 0, focusSelectionIndex: 0});
     });
 
+    it("does not expand the selection on shift+click if allowMultipleSelection=false", () => {
+        const onSelection = sinon.spy();
+        const onFocus = sinon.spy();
+        const locateClick = sinon.stub().returns(Regions.column(2));
+        const locateDrag = sinon.stub().throws();
+
+        const selectable = harness.mount(
+            <DragSelectable
+                allowMultipleSelection={false}
+                selectedRegions={[Regions.column(0)]}
+                onFocus={onFocus}
+                onSelection={onSelection}
+                locateClick={locateClick}
+                locateDrag={locateDrag}
+            >
+                {children}
+            </DragSelectable>,
+        );
+
+        const shiftKey = true;
+        selectable.find(".selectable", 0).mouse("mousedown", 0, 0, false, shiftKey).mouse("mouseup");
+        expect(onSelection.called).to.be.true;
+        expect(onSelection.args[0][0]).to.deep.equal([Regions.column(2, 2)]);
+    });
+
     it("re-select clears region", () => {
         const onSelection = sinon.spy();
         const onFocus = sinon.spy();

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -199,6 +199,14 @@ describe("<Table>", () => {
             expect(onFocus.args[0][0]).to.deep.equal({ col: 0, row: 0, focusSelectionIndex: 0 });
         });
 
+        it("Does not move focused cell on shift+click", () => {
+            const table = mountTable();
+            selectFullTable(table, { shiftKey: true });
+
+            expect(onSelection.args[0][0]).to.deep.equal([Regions.table()]);
+            expect(onFocus.called).to.be.false;
+        });
+
         it("Selects and deselects column/row headers when selecting and deselecting the full table", () => {
             const table = mountTable();
             const columnHeader = table.find(COLUMN_HEADER_SELECTOR).at(0);
@@ -266,9 +274,9 @@ describe("<Table>", () => {
             );
         }
 
-        function selectFullTable(table: ReactWrapper<any, {}>) {
+        function selectFullTable(table: ReactWrapper<any, {}>, ...mouseEventArgs: any[]) {
             const menu = table.find(`.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_MENU}`);
-            menu.simulate("mousedown").simulate("mouseup");
+            menu.simulate("mousedown", ...mouseEventArgs).simulate("mouseup", ...mouseEventArgs);
         }
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -268,7 +268,7 @@ describe("<Table>", () => {
 
         function selectFullTable(table: ReactWrapper<any, {}>) {
             const menu = table.find(`.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_MENU}`);
-            menu.simulate("click");
+            menu.simulate("mousedown").simulate("mouseup");
         }
     });
 


### PR DESCRIPTION
#### Fixes #823, Fixes #1249, Fixes #1285, Fixes #1323, Addresses #298, Addresses #1080

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

Improve shift-selection behavior.
- 🐛 __FIXED__ `Table` expand-selection behavior now expands from the focused cell. #823 #298 #1285 #1080
- 🐛 __FIXED__ `Table` <kbd>Shift+Click</kbd> no longer expands the selection when `allowMultipleSelection=false`. #1323
- 🐛 __FIXED__ `Table` disjoint-selection behavior (no longer results in janky updates). #1249
- __CHANGED__ `Table` `menuElement` now selects-all `onMouseDown`, not `onClick` (for consistency with `Header`s).

#### Reviewers should focus on:

- The `returnEndOnly` flag feels unclean, but...it gets the job done.
- I put the expand-region logic in `FocusedCellUtils` to make it slightly easier to unit-test.
- Do the interactions feel correct?

#### Screenshot

_SINGLE SELECTION:_
![2017-09-05 00 53 15](https://user-images.githubusercontent.com/443450/30047050-c1625ec4-91d4-11e7-9fde-f82c79e11dac.gif)

_DISJOINT SELECTIONS:_
![2017-09-05 00 55 05](https://user-images.githubusercontent.com/443450/30047081-ecf3db8a-91d4-11e7-96e4-525a0d9d3ec1.gif)

