### PR TITLE
[Labs] Add disabled prop to Select

### DIFF
--- a/packages/labs/examples/selectExample.tsx
+++ b/packages/labs/examples/selectExample.tsx
@@ -21,11 +21,13 @@ export interface ISelectExampleState {
     minimal?: boolean;
     resetOnClose?: boolean;
     resetOnSelect?: boolean;
+    disabled?: boolean;
 }
 
 export class SelectExample extends BaseExample<ISelectExampleState> {
 
     public state: ISelectExampleState = {
+        disabled: false,
         film: TOP_100_FILMS[0],
         filterable: true,
         minimal: false,
@@ -37,12 +39,14 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
     private handleMinimalChange = this.handleSwitchChange("minimal");
     private handleResetOnCloseChange = this.handleSwitchChange("resetOnClose");
     private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
+    private handleDisabledChange = this.handleSwitchChange("disabled");
 
     protected renderExample() {
-        const { film, minimal, ...flags } = this.state;
+        const { film, minimal, disabled, ...flags } = this.state;
         return (
             <FilmSelect
                 {...flags}
+                disabled={disabled}
                 items={TOP_100_FILMS}
                 itemPredicate={this.filterFilm}
                 itemRenderer={this.renderFilm}
@@ -53,6 +57,7 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
                 <Button
                     rightIconName="caret-down"
                     text={film ? film.title : "(No selection)"}
+                    disabled={disabled}
                 />
             </FilmSelect>
         );
@@ -84,6 +89,12 @@ export class SelectExample extends BaseExample<ISelectExampleState> {
                     label="Minimal popover style"
                     checked={this.state.minimal}
                     onChange={this.handleMinimalChange}
+                />,
+                <Switch
+                    key="disabled"
+                    label="Disabled"
+                    checked={this.state.disabled}
+                    onChange={this.handleDisabledChange}
                 />,
             ],
         ];

--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -40,6 +40,13 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      */
     itemRenderer: (itemProps: ISelectItemRendererProps<T>) => JSX.Element;
 
+    /**
+     * Whether the component is non-interactive.
+     * Note that you'll also need to disable the component's children, if appropriate.
+     * @default false
+     */
+    disabled?: boolean;
+
     /** React child to render when filtering items returns zero results. */
     noResults?: string | JSX.Element;
 
@@ -142,7 +149,7 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
-        const { filterable = true, inputProps = {}, popoverProps = {} } = this.props;
+        const { filterable = true, disabled = false, inputProps = {}, popoverProps = {} } = this.props;
 
         const { ref, ...htmlInputProps } = inputProps;
         const input = (
@@ -164,6 +171,7 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
                 position={Position.BOTTOM_LEFT}
+                isDisabled={disabled}
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}

--- a/packages/labs/src/labs.md
+++ b/packages/labs/src/labs.md
@@ -9,6 +9,13 @@
 
 Use `Select<T>` for choosing one item from a list. The component's children will be wrapped in a `Popover` that contains the list and an optional `InputGroup` to filter it. Provide a predicate to customize the filtering algorithm. The value of a `Select<T>` (the currently chosen item) is uncontrolled: listen to changes with `onItemSelect`.
 
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    <h5>Disabling a Select</h5>
+    <p>Disabling the component requires setting the `disabled` prop to `true`
+    and separately disabling the component's children as appropriate (because `Select` accepts arbitrary children).</p>
+    <p>For example, `<Select ... disabled={true}><Button ... disabled={true} /></Select>`</p>
+</div>
+
 @reactExample SelectExample
 
 ```tsx

--- a/packages/labs/test/selectTests.tsx
+++ b/packages/labs/test/selectTests.tsx
@@ -47,6 +47,12 @@ describe("<Select>", () => {
         assert.lengthOf(wrapper.find(Popover), 1, "should render Popover");
     });
 
+    it("disabled=false disables Popover", () => {
+        const wrapper = select({ disabled: true, popoverProps: {} });
+        wrapper.find("table").simulate("click");
+        assert.strictEqual(wrapper.find(Popover).prop("isOpen"), false);
+    });
+
     it("itemRenderer is called for each filtered child", () => {
         select({}, "1999");
         // each item rendered before setting query, then 4 items filtered rendered twice (TODO: why)


### PR DESCRIPTION
#### Fixes #1436

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Add a `disabled` prop that disables the internal popover if set