### PR TITLE
Make vscode exclusions consistent with gitignore / stylelintignore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib"
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "files.exclude": {
+        "**/build": true,
+        "**/dist": true,
+        "**/coverage": true,
+        "**/generated": true,
+        "docs": true
+    }
 }


### PR DESCRIPTION
This helps guard against noisy project-wide searches.

Left off node_modules, since that is baked into vscode as an exclude.
https://github.com/palantir/blueprint/blob/master/.gitignore
https://github.com/palantir/blueprint/blob/master/.stylelintignore

How do we feel about having the vscode settings checked into the repo? Thought this sort of thing was generally discouraged.