### PR TITLE
[Table] Move focused cell when columns/rows are reordered

### DIFF
--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -393,6 +393,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
                 onReordered={this.props.onReordered}
                 onReordering={this.props.onReordering}
                 onSelection={this.props.onSelection}
+                onFocus={this.props.onFocus}
                 selectedRegions={this.props.selectedRegions}
                 toRegion={this.props.toRegion}
             >

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -136,9 +136,7 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
             this.selectedRegionLength = selectedInterval[1] - selectedInterval[0] + 1;
         } else {
             // select the new region to avoid complex and unintuitive UX w/r/t the existing selection
-            this.props.onSelection([region]);
-            // move the focused cell into the newly selected region
-            this.props.onFocus({ ...Regions.getFocusCellCoordinatesFromRegion(region), focusSelectionIndex: 0 });
+            this.maybeSelectRegion(region);
 
             const regionRange = isRowHeader ? region.rows : region.cols;
             this.selectedRegionStartIndex = regionRange[0];
@@ -166,12 +164,24 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
 
         // the newly reordered region becomes the only selection
         const newRegion = this.props.toRegion(reorderedIndex, reorderedIndex + length - 1);
-        this.props.onSelection([newRegion]);
-        // move the focused cell into the newly selected region
-        this.props.onFocus({ ...Regions.getFocusCellCoordinatesFromRegion(newRegion), focusSelectionIndex: 0 });
+        this.maybeSelectRegion(newRegion);
 
         // resetting is not strictly required, but it's cleaner
         this.selectedRegionStartIndex = undefined;
         this.selectedRegionLength = undefined;
+    }
+
+    private maybeSelectRegion(region: IRegion) {
+        const nextSelectedRegions = [region];
+
+        if (!Utils.deepCompareKeys(nextSelectedRegions, this.props.selectedRegions)) {
+            this.props.onSelection(nextSelectedRegions);
+
+            // move the focused cell into the newly selected region
+            this.props.onFocus({
+                ...Regions.getFocusCellCoordinatesFromRegion(region),
+                focusSelectionIndex: 0,
+            });
+        }
     }
 }

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -7,6 +7,7 @@
 
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
+import { IFocusedCellCoordinates } from "../common/cell";
 import { Utils } from "../common/utils";
 import { Draggable, ICoordinateData, IDraggableProps } from "../interactions/draggable";
 import { IRegion, RegionCardinality, Regions } from "../regions";
@@ -36,6 +37,12 @@ export interface IReorderableProps {
      * state for the entire table.
      */
     onSelection: (regions: IRegion[]) => void;
+
+    /**
+     * When the user reorders something, this callback is called with the new
+     * focus cell for the newly selected set of regions.
+     */
+    onFocus: (focusedCell: IFocusedCellCoordinates) => void;
 
     /**
      * An array containing the table's selection Regions.
@@ -130,6 +137,13 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
         } else {
             // select the new region to avoid complex and unintuitive UX w/r/t the existing selection
             this.props.onSelection([region]);
+            const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(region);
+            const fullFocusCellCoordinates: IFocusedCellCoordinates = {
+                col: focusCellCoordinates.col,
+                focusSelectionIndex: 1,
+                row: focusCellCoordinates.row,
+            };
+            this.props.onFocus(fullFocusCellCoordinates);
 
             const regionRange = isRowHeader ? region.rows : region.cols;
             this.selectedRegionStartIndex = regionRange[0];
@@ -158,6 +172,13 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
         // the newly reordered region becomes the only selection
         const newRegion = this.props.toRegion(reorderedIndex, reorderedIndex + length - 1);
         this.props.onSelection(Regions.update([], newRegion));
+        const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(newRegion);
+        const fullFocusCellCoordinates: IFocusedCellCoordinates = {
+            col: focusCellCoordinates.col,
+            focusSelectionIndex: 1,
+            row: focusCellCoordinates.row,
+        };
+        this.props.onFocus(fullFocusCellCoordinates);
 
         // resetting is not strictly required, but it's cleaner
         this.selectedRegionStartIndex = undefined;

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -137,13 +137,8 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
         } else {
             // select the new region to avoid complex and unintuitive UX w/r/t the existing selection
             this.props.onSelection([region]);
-            const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(region);
-            const fullFocusCellCoordinates: IFocusedCellCoordinates = {
-                col: focusCellCoordinates.col,
-                focusSelectionIndex: 1,
-                row: focusCellCoordinates.row,
-            };
-            this.props.onFocus(fullFocusCellCoordinates);
+            // move the focused cell into the newly selected region
+            this.props.onFocus({ ...Regions.getFocusCellCoordinatesFromRegion(region), focusSelectionIndex: 0 });
 
             const regionRange = isRowHeader ? region.rows : region.cols;
             this.selectedRegionStartIndex = regionRange[0];
@@ -171,14 +166,9 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
 
         // the newly reordered region becomes the only selection
         const newRegion = this.props.toRegion(reorderedIndex, reorderedIndex + length - 1);
-        this.props.onSelection(Regions.update([], newRegion));
-        const focusCellCoordinates = Regions.getFocusCellCoordinatesFromRegion(newRegion);
-        const fullFocusCellCoordinates: IFocusedCellCoordinates = {
-            col: focusCellCoordinates.col,
-            focusSelectionIndex: 1,
-            row: focusCellCoordinates.row,
-        };
-        this.props.onFocus(fullFocusCellCoordinates);
+        this.props.onSelection([newRegion]);
+        // move the focused cell into the newly selected region
+        this.props.onFocus({ ...Regions.getFocusCellCoordinatesFromRegion(newRegion), focusSelectionIndex: 0 });
 
         // resetting is not strictly required, but it's cleaner
         this.selectedRegionStartIndex = undefined;

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -264,6 +264,7 @@ describe("DragReorderable", () => {
         return {
             locateClick: sinon.stub(),
             locateDrag: sinon.stub(),
+            onFocus: sinon.stub(),
             onReordered: sinon.stub(),
             onReordering: sinon.stub(),
             onSelection: sinon.stub(),

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -244,6 +244,30 @@ describe("DragReorderable", () => {
                 Regions.column(NEW_INDEX, NEW_INDEX + MULTI_LENGTH - 1),
             ])).to.be.true;
         });
+
+        it("does not invoke callbacks if nothing was reordered after drag", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(OLD_INDEX));
+            callbacks.locateDrag.returns(OLD_INDEX); // same index
+
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[Regions.column(OLD_INDEX)]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+
+            element
+                .mouse("mousedown")
+                .mouse("mousemove")
+                .mouse("mouseup");
+            expect(callbacks.onSelection.called).to.be.false;
+            expect(callbacks.onFocus.called).to.be.false;
+        });
     });
 
     describe("focused cell", () => {

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -43,123 +43,126 @@ describe("DragReorderable", () => {
         harness.destroy();
     });
 
-    it("does not work if clicked region is invalid", () => {
-        const callbacks = initCallbackStubs();
-        callbacks.locateClick.returns(Regions.column(-1));
+    describe("has no effect if", () => {
+        it("clicked region is invalid", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(-1));
 
-        const reorderable = harness.mount(
-            <DragReorderable
-                {...callbacks}
-                selectedRegions={[Regions.column(OLD_INDEX)]}
-                toRegion={toFullColumnRegion}
-            >
-                {children}
-            </DragReorderable>,
-        );
-        const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[Regions.column(OLD_INDEX)]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-        element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
-        expect(callbacks.onReordering.called).to.be.false;
-        expect(callbacks.onReordered.called).to.be.false;
-        expect(callbacks.onSelection.called).to.be.false;
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
+            expect(callbacks.onReordering.called).to.be.false;
+            expect(callbacks.onReordered.called).to.be.false;
+            expect(callbacks.onSelection.called).to.be.false;
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it("an existing selection contains the clicked region but has a different cardinality (e.g. FULL_TABLE)", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(OLD_INDEX));
+            callbacks.locateDrag.returns(OLD_INDEX);
+
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[Regions.table()]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
+            expect(callbacks.onReordering.called).to.be.false;
+            expect(callbacks.onReordered.called).to.be.false;
+            expect(callbacks.onSelection.called).to.be.false;
+        });
+
+        it("disabled=true", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(OLD_INDEX));
+            callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
+
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    disabled={true}
+                    selectedRegions={[Regions.column(OLD_INDEX)]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
+            expect(callbacks.onReordering.called).to.be.false;
+            expect(callbacks.onReordered.called).to.be.false;
+            expect(callbacks.onSelection.called).to.be.false;
+        });
     });
 
-    it("does not work on a selection with FULL_TABLE cardinality", () => {
-        const callbacks = initCallbackStubs();
-        callbacks.locateClick.returns(Regions.column(OLD_INDEX));
-        callbacks.locateDrag.returns(OLD_INDEX);
+    describe("general behavior", () => {
+        it("selects the clicked region if the clicked region is not currently selected", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(OLD_INDEX));
+            callbacks.locateDrag.returns(OLD_INDEX);
 
-        const reorderable = harness.mount(
-            <DragReorderable
-                {...callbacks}
-                selectedRegions={[Regions.table()]}
-                toRegion={toFullColumnRegion}
-            >
-                {children}
-            </DragReorderable>,
-        );
-        const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-        element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
-        expect(callbacks.onReordering.called).to.be.false;
-        expect(callbacks.onReordered.called).to.be.false;
-        expect(callbacks.onSelection.called).to.be.false;
-    });
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
+            expect(callbacks.onReordering.called).to.be.true;
+            expect(callbacks.onReordered.called).to.be.true;
+            expect(callbacks.onSelection.called).to.be.true;
+        });
 
-    it("if enabled, selects the clicked region if the clicked region is not currently selected", () => {
-        const callbacks = initCallbackStubs();
-        callbacks.locateClick.returns(Regions.column(OLD_INDEX));
-        callbacks.locateDrag.returns(OLD_INDEX);
+        it("invokes callbacks appropriately throughout the drag-reorder interaction", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(OLD_INDEX));
+            callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
 
-        const reorderable = harness.mount(
-            <DragReorderable
-                {...callbacks}
-                selectedRegions={[]}
-                toRegion={toFullColumnRegion}
-            >
-                {children}
-            </DragReorderable>,
-        );
-        const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[Regions.column(OLD_INDEX)]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-        element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
-        expect(callbacks.onReordering.called).to.be.true;
-        expect(callbacks.onReordered.called).to.be.true;
-        expect(callbacks.onSelection.called).to.be.true;
-    });
+            element.mouse("mousedown").mouse("mousemove");
+            expect(callbacks.onReordering.calledWith(OLD_INDEX, NEW_INDEX, SINGLE_LENGTH)).to.be.true;
+            expect(callbacks.onReordered.called).to.be.false;
+            expect(callbacks.onSelection.called).to.be.false;
 
-    it("does nothing if disabled", () => {
-        const callbacks = initCallbackStubs();
-        callbacks.locateClick.returns(Regions.column(OLD_INDEX));
-        callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
+            element.mouse("mouseup");
+            expect(callbacks.onReordering.callCount).to.equal(2); // called on drag end too
+            expect(callbacks.onReordered.calledWith(OLD_INDEX, NEW_INDEX, SINGLE_LENGTH)).to.be.true;
+            expect(callbacks.onSelection.calledWith([Regions.column(NEW_INDEX)])).to.be.true;
+        });
 
-        const reorderable = harness.mount(
-            <DragReorderable
-                {...callbacks}
-                disabled={true}
-                selectedRegions={[Regions.column(OLD_INDEX)]}
-                toRegion={toFullColumnRegion}
-            >
-                {children}
-            </DragReorderable>,
-        );
-        const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
-
-        element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
-        expect(callbacks.onReordering.called).to.be.false;
-        expect(callbacks.onReordered.called).to.be.false;
-        expect(callbacks.onSelection.called).to.be.false;
-    });
-
-    it("invokes callbacks appropriately throughout the drag-reorder interaction", () => {
-        const callbacks = initCallbackStubs();
-        callbacks.locateClick.returns(Regions.column(OLD_INDEX));
-        callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
-
-        const reorderable = harness.mount(
-            <DragReorderable
-                {...callbacks}
-                selectedRegions={[Regions.column(OLD_INDEX)]}
-                toRegion={toFullColumnRegion}
-            >
-                {children}
-            </DragReorderable>,
-        );
-        const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
-
-        element.mouse("mousedown").mouse("mousemove");
-        expect(callbacks.onReordering.calledWith(OLD_INDEX, NEW_INDEX, SINGLE_LENGTH)).to.be.true;
-        expect(callbacks.onReordered.called).to.be.false;
-        expect(callbacks.onSelection.called).to.be.false;
-
-        element.mouse("mouseup");
-        expect(callbacks.onReordering.callCount).to.equal(2); // called on drag end too
-        expect(callbacks.onReordered.calledWith(OLD_INDEX, NEW_INDEX, SINGLE_LENGTH)).to.be.true;
-        expect(callbacks.onSelection.calledWith([Regions.column(NEW_INDEX)])).to.be.true;
-    });
-
-    describe("columns", () => {
-        it("works for one selected column", () => {
+        it("reorders a selection of one single element", () => {
             const callbacks = initCallbackStubs();
             callbacks.locateClick.returns(Regions.column(OLD_INDEX));
             callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
@@ -183,7 +186,7 @@ describe("DragReorderable", () => {
             expect(callbacks.onSelection.calledWith([Regions.column(NEW_INDEX)])).to.be.true;
         });
 
-        it("works for a selection of multiple contiguous columns", () => {
+        it("reorders a selection of multiple contiguous elements", () => {
             const callbacks = initCallbackStubs();
             callbacks.locateClick.returns(Regions.column(OLD_INDEX));
             callbacks.locateDrag.returns(GUIDE_INDEX_MULTI_CASE);
@@ -208,43 +211,24 @@ describe("DragReorderable", () => {
                 Regions.column(NEW_INDEX, NEW_INDEX + MULTI_LENGTH - 1),
             ])).to.be.true;
         });
-    });
 
-    describe("rows", () => {
-        it("works for one selected row", () => {
+        it("for a disjoint selection, reorders just the clicked region and clears all other selections", () => {
             const callbacks = initCallbackStubs();
-            callbacks.locateClick.returns(Regions.row(OLD_INDEX));
-            callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
-
-            const reorderable = harness.mount(
-                <DragReorderable
-                    {...callbacks}
-                    selectedRegions={[Regions.row(OLD_INDEX)]}
-                    toRegion={toFullRowRegion}
-                >
-                    {children}
-                </DragReorderable>,
-            );
-            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
-
-            element.mouse("mousedown").mouse("mousemove");
-            expect(callbacks.onReordering.calledWith(OLD_INDEX, NEW_INDEX, SINGLE_LENGTH)).to.be.true;
-
-            element.mouse("mouseup");
-            expect(callbacks.onReordered.calledWith(OLD_INDEX, NEW_INDEX, SINGLE_LENGTH)).to.be.true;
-            expect(callbacks.onSelection.calledWith([Regions.row(NEW_INDEX)])).to.be.true;
-        });
-
-        it("works for a selection of multiple contiguous rows", () => {
-            const callbacks = initCallbackStubs();
-            callbacks.locateClick.returns(Regions.row(OLD_INDEX));
+            callbacks.locateClick.returns(Regions.column(OLD_INDEX));
             callbacks.locateDrag.returns(GUIDE_INDEX_MULTI_CASE);
 
+            // try moving a contiguous multi-column selection
+            const selectedRegions = [
+                Regions.column(OLD_INDEX, OLD_INDEX + MULTI_LENGTH - 1),
+                Regions.column(NEW_INDEX),
+                Regions.column(NEW_INDEX + 1),
+            ];
+
             const reorderable = harness.mount(
                 <DragReorderable
                     {...callbacks}
-                    selectedRegions={[Regions.row(OLD_INDEX, OLD_INDEX + MULTI_LENGTH - 1)]}
-                    toRegion={toFullRowRegion}
+                    selectedRegions={selectedRegions}
+                    toRegion={toFullColumnRegion}
                 >
                     {children}
                 </DragReorderable>,
@@ -256,7 +240,69 @@ describe("DragReorderable", () => {
 
             element.mouse("mouseup");
             expect(callbacks.onReordered.calledWith(OLD_INDEX, NEW_INDEX, MULTI_LENGTH)).to.be.true;
-            expect(callbacks.onSelection.calledWith([Regions.row(NEW_INDEX, NEW_INDEX + MULTI_LENGTH - 1)])).to.be.true;
+            expect(callbacks.onSelection.calledWith([
+                Regions.column(NEW_INDEX, NEW_INDEX + MULTI_LENGTH - 1),
+            ])).to.be.true;
+        });
+    });
+
+    describe("focused cell", () => {
+        it("moves the focused cell into the region on mousedown if region was not already selected", () => {
+            const SELECTED_INDEX = NEW_INDEX;
+            const UNSELECTED_INDEX = OLD_INDEX;
+
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(UNSELECTED_INDEX));
+            callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
+
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[Regions.column(SELECTED_INDEX)]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, UNSELECTED_INDEX);
+
+            element.mouse("mousedown");
+            expect(callbacks.onFocus.called).to.be.true;
+            expect(callbacks.onFocus.firstCall.args[0]).to.deep.equal({
+                col: UNSELECTED_INDEX,
+                focusSelectionIndex: 0,
+                row: 0,
+            });
+        });
+
+        it("moves the focused cell into the newly selected region on drag end", () => {
+            const callbacks = initCallbackStubs();
+            callbacks.locateClick.returns(Regions.column(NEW_INDEX));
+            callbacks.locateDrag.returns(GUIDE_INDEX_SINGLE_CASE);
+
+            const reorderable = harness.mount(
+                <DragReorderable
+                    {...callbacks}
+                    selectedRegions={[Regions.column(OLD_INDEX)]}
+                    toRegion={toFullColumnRegion}
+                >
+                    {children}
+                </DragReorderable>,
+            );
+            const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
+
+            element
+                .mouse("mousedown")
+                .mouse("mousemove")
+                .mouse("mouseup");
+
+            // called once on mousedown and again on mouseup
+            expect(callbacks.onFocus.calledTwice).to.be.true;
+            expect(callbacks.onFocus.secondCall.args[0]).to.deep.equal({
+                col: NEW_INDEX,
+                focusSelectionIndex: 0,
+                row: 0,
+            });
         });
     });
 
@@ -276,9 +322,5 @@ describe("DragReorderable", () => {
 
     function toFullColumnRegion(index1: number, index2?: number) {
         return Regions.column(index1, index2);
-    }
-
-    function toFullRowRegion(index1: number, index2?: number) {
-        return Regions.row(index1, index2);
     }
 });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -962,7 +962,7 @@ describe("<Table>", () => {
                 isColumnReorderable: true,
                 onColumnsReordered,
                 onSelection,
-                selectedRegions: [Regions.column(1)], // some other column
+                selectedRegions: [Regions.column(2)], // some other column
             });
             const headerCell = getHeaderCell(getColumnHeadersWrapper(table), 0);
             const reorderHandle = getReorderHandle(headerCell);


### PR DESCRIPTION
#### Fixes #1258

#### Changes proposed in this pull request:

Add the focus cell logic to the selection logic for the drag handles. 
