### PR TITLE
[Table] Pass parent width/height props to TruncatedFormat

### DIFF
--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -102,7 +102,15 @@ export class Cell extends React.Component<ICellProps, {}> {
             },
         );
 
-        const content = <div className={textClasses}>{this.props.children}</div>;
+        const modifiedChildren = React.Children.map(this.props.children, (child) => {
+            if (React.isValidElement(child)) {
+                return React.cloneElement(child as React.ReactElement<any>,
+                    {parentCellHeight: style.height, parentCellWidth: style.width});
+            }
+            return child;
+        });
+
+        const content = <div className={textClasses}>{modifiedChildren}</div>;
 
         return (
             <div className={classes} style={style} title={tooltip}>

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -103,7 +103,7 @@ export class Cell extends React.Component<ICellProps, {}> {
         );
 
         const modifiedChildren = React.Children.map(this.props.children, (child) => {
-            if (React.isValidElement(child)) {
+            if (style != null && React.isValidElement(child)) {
                 return React.cloneElement(child as React.ReactElement<any>,
                     {parentCellHeight: style.height, parentCellWidth: style.width});
             }

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -102,6 +102,8 @@ export class Cell extends React.Component<ICellProps, {}> {
             },
         );
 
+        // add width and height to the children, for use in shouldComponentUpdate in truncatedFormat
+        // note: these aren't actually used by truncated format, just in shouldComponentUpdate
         const modifiedChildren = React.Children.map(this.props.children, (child) => {
             if (style != null && React.isValidElement(child)) {
                 return React.cloneElement(child as React.ReactElement<any>,

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -157,14 +157,16 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
 
         // if the popover handle exists, take it into account
-        let popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
-        // add a slight bit of buffer space where we don't show the popover, to deal with cases
-        // where everything isn't pixel perfect
-        popoverHandleAdjustmentFactor += .5;
+        const popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
 
-        const isTruncated = this.contentDiv !== undefined &&
+        let isTruncated = this.contentDiv !== undefined &&
             (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||
             this.contentDiv.scrollHeight > this.contentDiv.clientHeight);
+        // don't remove the popover if the widths are equal, because this can cause issues with pixel-perfectness
+        if (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor === this.contentDiv.clientWidth &&
+            this.state.isTruncated) {
+                isTruncated = true;
+            }
         if (this.state.isTruncated !== isTruncated) {
             this.setState({ isTruncated });
         }

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -195,8 +195,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             || actualContentWidth > containerWidth
             || actualContentHeight > containerHeight;
 
-        if (isTruncated !== shouldTruncate) {
-            this.setState({ isTruncated: shouldTruncate });
-        }
+        this.setState({ isTruncated: shouldTruncate });
     }
 }

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -14,7 +14,7 @@ import * as Classes from "../../common/classes";
 
 // amount in pixels that the content div width changes when truncated vs when
 // not truncated. Note: could be modified by styles
-const CONTENT_DIV_WIDTH_DELTA = 25;
+const CONTENT_DIV_WIDTH_DELTA = 26;
 
 export enum TruncatedPopoverMode {
     ALWAYS,

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -156,19 +156,38 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
             return;
         }
 
-        // if the popover handle exists, take it into account
-        const popoverHandleAdjustmentFactor = this.state.isTruncated ? CONTENT_DIV_WIDTH_DELTA : 0;
+        if (this.contentDiv === undefined) {
+            this.setState({ isTruncated: false });
+            return;
+        }
 
-        let isTruncated = this.contentDiv !== undefined &&
-            (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor > this.contentDiv.clientWidth ||
-            this.contentDiv.scrollHeight > this.contentDiv.clientHeight);
-        // don't remove the popover if the widths are equal, because this can cause issues with pixel-perfectness
-        if (this.contentDiv.scrollWidth - popoverHandleAdjustmentFactor === this.contentDiv.clientWidth &&
-            this.state.isTruncated) {
-                isTruncated = true;
-            }
-        if (this.state.isTruncated !== isTruncated) {
-            this.setState({ isTruncated });
+        const { isTruncated } = this.state;
+
+        // take all measurements at once to avoid excessive DOM reflows.
+        const {
+            clientHeight: containerHeight,
+            clientWidth: containerWidth,
+            scrollHeight: actualContentHeight,
+            scrollWidth: contentWidth,
+        } = this.contentDiv;
+
+        // if the content is truncated, then a popover handle will be present as a
+        // sibling of the content. we don't want to consider that handle when
+        // calculating the width of the actual content, so subtract it.
+        const actualContentWidth = isTruncated
+            ? contentWidth - CONTENT_DIV_WIDTH_DELTA
+            : contentWidth;
+
+        // we of course truncate the content if it doesn't fit in the container. but we
+        // also aggressively truncate if they're the same size with truncation enabled;
+        // this addresses browser-crashing stack-overflow bugs at various zoom levels.
+        // (see: https://github.com/palantir/blueprint/pull/1519)
+        const shouldTruncate = (isTruncated && actualContentWidth === containerWidth)
+            || actualContentWidth > containerWidth
+            || actualContentHeight > containerHeight;
+
+        if (isTruncated !== shouldTruncate) {
+            this.setState({ isTruncated: shouldTruncate });
         }
     }
 }

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -6,12 +6,11 @@
  */
 
 import { Icon, IProps, Popover, Position } from "@blueprintjs/core";
-
 import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { Utils } from "../../common/utils";
 
 // amount in pixels that the content div width changes when truncated vs when
 // not truncated. Note: could be modified by styles
@@ -74,6 +73,7 @@ export interface ITruncatedFormatState {
     isTruncated: boolean;
 }
 
+@PureRender
 export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITruncatedFormatState> {
     public static defaultProps: ITruncatedFormatProps = {
         detectTruncation: true,
@@ -134,11 +134,6 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
 
     public componentDidUpdate(prevProps: ITruncatedFormatProps) {
         this.setTruncationState(prevProps);
-    }
-
-    public shouldComponentUpdate(nextProps: ITruncatedFormatProps, nextState: ITruncatedFormatState) {
-        return !Utils.shallowCompareKeys(this.props, nextProps)
-            || !Utils.shallowCompareKeys(this.state, nextState);
     }
 
     private handleContentDivRef = (ref: HTMLDivElement) => this.contentDiv = ref;

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -132,8 +132,8 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         this.setTruncationState();
     }
 
-    public componentDidUpdate() {
-        this.setTruncationState();
+    public componentDidUpdate(prevProps: ITruncatedFormatProps) {
+        this.setTruncationState(prevProps);
     }
 
     public shouldComponentUpdate(nextProps: ITruncatedFormatProps, nextState: ITruncatedFormatState) {
@@ -160,8 +160,24 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
     }
 
-    private setTruncationState() {
-        if (!this.props.detectTruncation || this.props.showPopover !== TruncatedPopoverMode.WHEN_TRUNCATED) {
+    private setTruncationState(prevProps?: ITruncatedFormatProps) {
+        const {
+            detectTruncation,
+            parentCellHeight,
+            parentCellWidth,
+            showPopover: popoverMode,
+        } = this.props;
+
+        // this is where we get our savings from the injected parent-size props.
+        // if they haven't changed between updates, then no need to remeasure!
+        if (!detectTruncation
+            || popoverMode !== TruncatedPopoverMode.WHEN_TRUNCATED
+            || (
+                prevProps != null
+                && prevProps.parentCellHeight === parentCellHeight
+                && prevProps.parentCellWidth === parentCellWidth
+            )
+        ) {
             return;
         }
 

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -14,7 +14,9 @@ import * as Classes from "../../common/classes";
 
 // amount in pixels that the content div width changes when truncated vs when
 // not truncated. Note: could be modified by styles
-const CONTENT_DIV_WIDTH_DELTA = 26;
+// Note 2: this doesn't come from the width of the popover element, but the "right" style
+// on the div, which comes from styles
+const CONTENT_DIV_WIDTH_DELTA = 25;
 
 export enum TruncatedPopoverMode {
     ALWAYS,
@@ -33,7 +35,14 @@ export interface ITruncatedFormatProps extends IProps {
      */
     detectTruncation?: boolean;
 
+    /**
+     * Height of the parent cell. Used by shouldComponentUpdate only
+     */
     parentCellHeight?: string;
+
+    /**
+     * Width of the parent cell. Used by shouldComponentUpdate only
+     */
     parentCellWidth?: string;
 
     /**
@@ -132,8 +141,8 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         this.setTruncationState();
     }
 
-    public componentDidUpdate(prevProps: ITruncatedFormatProps) {
-        this.setTruncationState(prevProps);
+    public componentDidUpdate() {
+        this.setTruncationState();
     }
 
     private handleContentDivRef = (ref: HTMLDivElement) => this.contentDiv = ref;
@@ -155,27 +164,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         }
     }
 
-    private setTruncationState(prevProps?: ITruncatedFormatProps) {
-        const {
-            detectTruncation,
-            parentCellHeight,
-            parentCellWidth,
-            showPopover: popoverMode,
-        } = this.props;
-
-        // this is where we get our savings from the injected parent-size props.
-        // if they haven't changed between updates, then no need to remeasure!
-        if (!detectTruncation
-            || popoverMode !== TruncatedPopoverMode.WHEN_TRUNCATED
-            || (
-                prevProps != null
-                && prevProps.parentCellHeight === parentCellHeight
-                && prevProps.parentCellWidth === parentCellWidth
-            )
-        ) {
-            return;
-        }
-
+    private setTruncationState() {
         if (this.contentDiv === undefined) {
             this.setState({ isTruncated: false });
             return;

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -165,6 +165,10 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
     }
 
     private setTruncationState() {
+        if (!this.props.detectTruncation || this.props.showPopover !== TruncatedPopoverMode.WHEN_TRUNCATED) {
+            return;
+        }
+
         if (this.contentDiv === undefined) {
             this.setState({ isTruncated: false });
             return;

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -11,6 +11,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
+import { Utils } from "../../common/utils";
 
 // amount in pixels that the content div width changes when truncated vs when
 // not truncated. Note: could be modified by styles
@@ -32,6 +33,9 @@ export interface ITruncatedFormatProps extends IProps {
      * @default true;
      */
     detectTruncation?: boolean;
+
+    parentCellHeight?: string;
+    parentCellWidth?: string;
 
     /**
      * Sets the popover content style to `white-space: pre` if `true` or
@@ -130,6 +134,11 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
 
     public componentDidUpdate() {
         this.setTruncationState();
+    }
+
+    public shouldComponentUpdate(nextProps: ITruncatedFormatProps, nextState: ITruncatedFormatState) {
+        return !Utils.shallowCompareKeys(this.props, nextProps)
+            || !Utils.shallowCompareKeys(this.state, nextState);
     }
 
     private handleContentDivRef = (ref: HTMLDivElement) => this.contentDiv = ref;


### PR DESCRIPTION
#### Changes proposed in this pull request:

Pass cell height and width to child, for use in shouldComponentUpdate

~The props aren't used by the element, but its presence means faster redraw for cells with truncated formats.~ The props are used by the element to avoid re-measuring if the parent size didn't change across updates.

#### Reviewers should focus on:

This is on top of another in-progress PR -- ignore the first two commits.

I'm cloning all the cell children -- does this make sense? 
