### PR TITLE
[MenuItem] Pass popoverProps to menuItem

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -14,7 +14,7 @@ import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
 import { IActionProps, ILinkProps } from "../../common/props";
-import { Popover, PopoverInteractionKind } from "../popover/popover";
+import { IPopoverProps, Popover, PopoverInteractionKind } from "../popover/popover";
 import { Menu } from "./menu";
 
 export interface IMenuItemProps extends IActionProps, ILinkProps {
@@ -26,6 +26,9 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
      * Right-aligned label content, useful for displaying hotkeys.
      */
     label?: string | JSX.Element;
+
+    /** Props to spread to `Popover`. Note that `content` cannot be changed. */
+    popoverProps?: Partial<IPopoverProps> & object;
 
     /**
      * Whether an enabled, non-submenu item should automatically close the
@@ -76,6 +79,7 @@ const REACT_CONTEXT_TYPES: React.ValidationMap<IMenuItemState> = {
 export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> {
     public static defaultProps: IMenuItemProps = {
         disabled: false,
+        popoverProps: {},
         shouldDismissPopover: true,
         submenuViewportMargin: {},
         text: "",
@@ -94,7 +98,7 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
     private liElement: HTMLElement;
 
     public render() {
-        const { children, disabled, label, submenu } = this.props;
+        const { children, disabled, label, submenu, popoverProps } = this.props;
         const hasSubmenu = children != null || submenu != null;
         const liClasses = classNames({
             [Classes.MENU_SUBMENU]: hasSubmenu,
@@ -126,21 +130,25 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
         if (hasSubmenu) {
             const measureSubmenu = (this.props.useSmartPositioning) ? this.measureSubmenu : null;
             const submenuElement = <Menu ref={measureSubmenu}>{this.renderChildren()}</Menu>;
-            const popoverClasses = classNames({
-                [Classes.ALIGN_LEFT]: this.state.alignLeft,
-            });
+            const popoverClasses = classNames(
+                Classes.MINIMAL,
+                Classes.MENU_SUBMENU,
+                popoverProps.popoverClassName,
+                { [Classes.ALIGN_LEFT]: this.state.alignLeft },
+            );
 
             content = (
                 <Popover
-                    content={submenuElement}
                     isDisabled={disabled}
                     enforceFocus={false}
                     hoverCloseDelay={0}
                     inline={true}
                     interactionKind={PopoverInteractionKind.HOVER}
                     position={this.state.alignLeft ? Position.LEFT_TOP : Position.RIGHT_TOP}
-                    popoverClassName={classNames(Classes.MINIMAL, Classes.MENU_SUBMENU, popoverClasses)}
                     useSmartArrowPositioning={false}
+                    {...popoverProps}
+                    content={submenuElement}
+                    popoverClassName={popoverClasses}
                 >
                     {content}
                 </Popover>

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -11,8 +11,8 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 
-import { Classes, IMenuItemProps, IMenuProps, Menu, MenuDivider, MenuItem, Popover } from "../../src/index";
-import { MenuDividerFactory, MenuFactory, MenuItemFactory } from "../../src/index";
+import { Classes, IMenuItemProps, IMenuProps, Menu, MenuItem, Popover, PopoverInteractionKind } from "../../src/index";
+import { MenuDivider, MenuDividerFactory, MenuFactory, MenuItemFactory } from "../../src/index";
 
 describe("MenuItem", () => {
     it("React renders MenuItem", () => {
@@ -94,6 +94,26 @@ describe("MenuItem", () => {
         const wrapper = shallow(MenuItemFactory({ iconName: "graph", text: "Object" }));
         assert.lengthOf(wrapper.find(".pt-icon-graph"), 1);
         assert.strictEqual(wrapper.text(), "Object");
+    });
+
+    it("popover can be controlled with popoverProps", () => {
+        // Ensures that popover props are passed to Popover component, except content property
+        const popoverProps = {
+            content: "CUSTOM_CONTENT",
+            inline: false,
+            interactionKind: PopoverInteractionKind.CLICK,
+            popoverClassName: "CUSTOM_POPOVER_CLASS_NAME",
+        };
+        const wrapper = shallow(
+            <MenuItem iconName="style" text="Style" popoverProps={popoverProps}>
+                <MenuItem text="one" />
+                <MenuItem text="two" />
+            </MenuItem>,
+        );
+        assert.strictEqual(wrapper.find(Popover).prop("inline"), popoverProps.inline);
+        assert.strictEqual(wrapper.find(Popover).prop("interactionKind"), popoverProps.interactionKind);
+        assert.notStrictEqual(wrapper.find(Popover).prop("popoverClassName").indexOf(popoverProps.popoverClassName), 0);
+        assert.notStrictEqual(wrapper.find(Popover).prop("content"), popoverProps.content);
     });
 
     /**


### PR DESCRIPTION
#### Fixes #1567 

Pass `popoverProps` object to `menuItem`, like in `Labs/Select`.
I'm not sure if there are any test needed. If yes, tell me