### PR TITLE
[Table] Fix interaction-bar cursor when selection disabled

### DIFF
--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -249,7 +249,6 @@ $dark-selectable-header-menu-selected-hover-background:
 
 .bp-table-column-headers .bp-table-interaction-bar {
   position: relative;
-  cursor: $select-column-cursor;
   height: $interaction-bar-height;
 }
 


### PR DESCRIPTION
#### Fixes #1534

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `Table` no longer shows misleading cursor over interaction bar when selection disabled.

#### Screenshot

Toggling between selection disabled and selection enabled: 
![2017-09-19 17 11 51](https://user-images.githubusercontent.com/443450/30621016-ae1593c4-9d5d-11e7-9aa5-649ab5edb427.gif)
