### PR TITLE
[Table] Fix DragSelectable context-menu behavior on Ctrl + Click

### DIFF
--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -217,8 +217,13 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     private shouldIgnoreMouseDown(event: MouseEvent) {
         const { ignoredSelectors = [] } = this.props;
         const element = event.target as HTMLElement;
+
+        const isLeftClick = Utils.isLeftClick(event);
+        const isContextMenuTrigger = isLeftClick && event.ctrlKey;
+
         return (
-            !Utils.isLeftClick(event) ||
+            !isLeftClick ||
+            isContextMenuTrigger ||
             this.props.disabled ||
             ignoredSelectors.some((selector: string) => element.closest(selector) != null)
         );

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -22,6 +22,12 @@ export interface IHarnessMouseOptions {
     offsetY?: number;
 
     /** @default false */
+    altKey?: boolean;
+
+    /** @default false */
+    ctrlKey?: boolean;
+
+    /** @default false */
     metaKey?: boolean;
 
     /** @default false */
@@ -116,10 +122,14 @@ export class ElementHarness {
         button: number = 0,
     ) {
         let offsetX: number;
+        let isAltKeyDown: boolean;
+        let isCtrlKeyDown: boolean;
 
         if (typeof offsetXOrOptions === "object") {
             offsetX = this.defaultValue(offsetXOrOptions.offsetX, 0);
             offsetY = this.defaultValue(offsetXOrOptions.offsetY, 0);
+            isAltKeyDown = this.defaultValue(offsetXOrOptions.altKey, false);
+            isCtrlKeyDown = this.defaultValue(offsetXOrOptions.ctrlKey, false);
             isMetaKeyDown = this.defaultValue(offsetXOrOptions.metaKey, false);
             isShiftKeyDown = this.defaultValue(offsetXOrOptions.shiftKey, false);
             button = this.defaultValue(offsetXOrOptions.button, 0);
@@ -149,8 +159,8 @@ export class ElementHarness {
             0,
             x,
             y,
-            isMetaKeyDown,
-            false,
+            isCtrlKeyDown,
+            isAltKeyDown,
             isShiftKeyDown,
             isMetaKeyDown,
             button,

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -124,7 +124,7 @@ describe("TableBody", () => {
             runTestSuite(simulateAction);
         });
 
-        // TODO: make this work (tracked in https://github.com/palantir/blueprint/issues/1549)
+        // triggering onContextMenu via ctrl+click doesn't work in Phantom :/
         describe.skip("on ctrl+click", () => {
             // ctrl+click should also triggers the context menu and should behave in the exact same way
             const simulateAction = (tableBody: ReactWrapper<any, any>) => {


### PR DESCRIPTION
#### Fixes #1549

#### Checklist

- [x] ~Include tests~ (turns out Ctrl + Click doesn't trigger onContextMenu in Phantom 🙁) 

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `DragSelectable` now responds to <kbd>Ctrl + Click</kbd> the same way it does to right-click (vis-a-vis triggering context menus).

#### Reviewers should focus on:

- Should we try to handle <kbd>Ctrl + Click</kbd> events from `ContextMenuTarget` directly? That way no one ever has to worry about them behaving differently (in theory).

#### Screenshot

![2017-09-20 08 53 43](https://user-images.githubusercontent.com/443450/30653915-45caabea-9de1-11e7-90d2-eb0f2893328f.gif)
