### PR TITLE
[Table] Fix onCompleteRender for RenderMode.BATCH

### DIFF
--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -133,7 +133,6 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
 
     private activationCell: ICellCoordinates;
     private batcher = new Batcher<JSX.Element>();
-    private isRenderingBatchedCells = false;
 
     public componentDidMount() {
         this.maybeInvokeOnCompleteRender();
@@ -329,10 +328,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
     private maybeInvokeOnCompleteRender() {
         const { onCompleteRender, renderMode } = this.props;
 
-        if (renderMode === RenderMode.BATCH && this.isRenderingBatchedCells && this.batcher.isDone()) {
-            this.isRenderingBatchedCells = false;
-            CoreUtils.safeInvoke(onCompleteRender);
-        } else if (renderMode === RenderMode.NONE) {
+        if (renderMode === RenderMode.NONE || (renderMode === RenderMode.BATCH && this.batcher.isDone())) {
             CoreUtils.safeInvoke(onCompleteRender);
         }
     }

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -296,17 +296,31 @@ describe("<Table>", () => {
     });
 
     describe("onCompleteRender", () => {
-        it("triggers onCompleteRender only once: when cells finish rendering in the MAIN quadrant", () => {
+        it("triggers immediately on mount/update with RenderMode.NONE", () => {
             const onCompleteRenderSpy = sinon.spy();
-
-            // use RenderMode.NONE because it causes all cells to render synchronously
-            mount(
+            const table = mount(
                 <Table numRows={100} onCompleteRender={onCompleteRenderSpy} renderMode={RenderMode.NONE}>
                     <Column renderCell={renderCell} />
                 </Table>,
             );
-
             expect(onCompleteRenderSpy.callCount).to.equal(1);
+            table.setProps({ numRows: 101 });
+            expect(onCompleteRenderSpy.callCount).to.equal(2);
+        });
+
+        it("triggers immediately on mount/update with RenderMode.BATCH for very small batches", () => {
+            const onCompleteRenderSpy = sinon.spy();
+            const numRows = 1;
+
+            // RenderMode.BATCH is the default
+            const table = mount(
+                <Table numRows={numRows} onCompleteRender={onCompleteRenderSpy}>
+                    <Column renderCell={renderCell} />
+                </Table>,
+            );
+            expect(onCompleteRenderSpy.callCount).to.equal(1);
+            table.setProps({ numRows: 2 }); // still small enough to fit in one batch
+            expect(onCompleteRenderSpy.callCount).to.equal(2);
         });
     });
 


### PR DESCRIPTION
#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `Table` now fires `onCompleteRender` as expected when using `RenderMode.BATCH`.

#### Reviewers should focus on:

Not sure how this broke originally. :/ I tried and failed to add a test for a multi-frame batch render, so I added/updated a couple simple tests for now.

#### Screenshot

![2017-09-21 10 51 32](https://user-images.githubusercontent.com/443450/30710593-f8f27606-9eba-11e7-9935-ddcdf457e103.gif)
