### PR TITLE
[Button] Add pt-placeholder modifier

### DIFF
--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -19,6 +19,7 @@ export interface IButtonsExampleState {
     loading?: boolean;
     large?: boolean;
     minimal?: boolean;
+    placeholder?: boolean;
     wiggling?: boolean;
 }
 
@@ -29,6 +30,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         large: false,
         loading: false,
         minimal: false,
+        placeholder: false,
         wiggling: false,
     };
 
@@ -37,6 +39,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
     private handleLoadingChange = handleBooleanChange(loading => this.setState({ loading }));
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
+    private handlePlaceholderChange = handleBooleanChange(placeholder => this.setState({ placeholder }));
     private handleIntentChange = handleNumberChange((intent: Intent) => this.setState({ intent }));
 
     private wiggleTimeoutId: number;
@@ -49,6 +52,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         const classes = classNames({
             [Classes.LARGE]: this.state.large,
             [Classes.MINIMAL]: this.state.minimal,
+            [Classes.PLACEHOLDER]: this.state.placeholder,
         });
 
         return (
@@ -114,6 +118,12 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                     key="minimal"
                     label="Minimal"
                     onChange={this.handleMinimalChange}
+                />,
+                <Switch
+                    checked={this.state.placeholder}
+                    key="placeholder"
+                    label="Placeholder"
+                    onChange={this.handlePlaceholderChange}
                 />,
             ],
             [<IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />],

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -24,6 +24,7 @@ export const FIXED = "pt-fixed";
 export const FIXED_TOP = "pt-fixed-top";
 export const VERTICAL = "pt-vertical";
 export const ROUND = "pt-round";
+export const PLACEHOLDER = "pt-placeholder";
 
 // text utilities
 export const TEXT_MUTED = "pt-text-muted";

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -16,6 +16,7 @@ Markup:
 
 :disabled - Disabled state
 .pt-disabled - Disabled appearance
+.pt-placeholder - Placeholder appearance
 .pt-intent-primary - Primary intent
 .pt-intent-success - Success intent
 .pt-intent-warning - Warning intent
@@ -171,6 +172,7 @@ Styleguide pt-button
   <button type="button" class="pt-button pt-minimal pt-icon-add {{.modifier}}" {{:modifier}}>Button</button>
 
   .pt-disabled - Disabled appearance
+  .pt-placeholder - Placeholder appearance
   .pt-intent-primary - Primary intent
   .pt-intent-success - Success intent
   .pt-intent-warning - Warning intent

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -65,19 +65,23 @@ $button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($whi
 $dark-button-gradient: linear-gradient(to bottom, rgba($white, 0.05), rgba($white, 0)) !default;
 
 $button-color-disabled: $pt-text-color-disabled !default;
+$button-color-placeholder: $pt-text-color-muted !default;
 $button-background-color: $light-gray5 !default;
 $button-background-color-hover: $light-gray4 !default;
 $button-background-color-active: $light-gray2 !default;
 $button-background-color-disabled: rgba($light-gray1, 0.5) !default;
 $button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
 $button-intent-color-disabled: rgba($white, 0.6);
+$button-intent-color-placeholder: rgba($white, 0.7);
 $dark-button-color-disabled: $pt-dark-text-color-disabled !default;
+$dark-button-color-placeholder: $pt-dark-text-color-muted !default;
 $dark-button-background-color: $dark-gray5 !default;
 $dark-button-background-color-hover: $dark-gray4 !default;
 $dark-button-background-color-active: $dark-gray2 !default;
 $dark-button-background-color-disabled: rgba($dark-gray5, 0.5) !default;
 $dark-button-background-color-active-disabled: rgba($dark-gray5, 0.7) !default;
 $dark-button-intent-color-disabled: rgba($white, 0.3);
+$dark-button-intent-color-placeholder: rgba($white, 0.6);
 
 $minimal-button-divider-width: 1px !default;
 $minimal-button-background-color: none !default;
@@ -131,6 +135,10 @@ $button-intents: (
   &.pt-disabled {
     @include pt-button-disabled();
   }
+
+  &.pt-placeholder {
+    @include pt-button-placeholder();
+  }
 }
 
 @mixin pt-button-hover() {
@@ -156,6 +164,10 @@ $button-intents: (
   &.pt-active {
     background: $button-background-color-active-disabled;
   }
+}
+
+@mixin pt-button-placeholder() {
+  color: $button-color-placeholder;
 }
 
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
@@ -186,6 +198,10 @@ $button-intents: (
   &.pt-disabled {
     @include pt-button-intent-disabled($default-color);
   }
+
+  &.pt-placeholder {
+    @include pt-button-intent-placeholder();
+  }
 }
 
 @mixin pt-button-intent-disabled($default-color) {
@@ -194,6 +210,10 @@ $button-intents: (
   background-color: rgba($default-color, 0.5);
   background-image: none;
   color: $button-intent-color-disabled;
+}
+
+@mixin pt-button-intent-placeholder() {
+  color: $button-intent-color-placeholder;
 }
 
 @mixin pt-dark-button() {
@@ -220,6 +240,10 @@ $button-intents: (
   &:disabled,
   &.pt-disabled {
     @include pt-dark-button-disabled();
+  }
+
+  &.pt-placeholder {
+    @include pt-dark-button-placeholder();
   }
 
   .pt-button-spinner .pt-spinner-head {
@@ -250,6 +274,10 @@ $button-intents: (
   }
 }
 
+@mixin pt-dark-button-placeholder() {
+  color: $dark-button-color-placeholder;
+}
+
 @mixin pt-dark-button-intent() {
   box-shadow: $dark-button-intent-box-shadow;
 
@@ -266,12 +294,20 @@ $button-intents: (
   &.pt-disabled {
     @include pt-dark-button-intent-disabled();
   }
+
+  &.pt-placeholder {
+    @include pt-dark-button-intent-placeholder();
+  }
 }
 
 @mixin pt-dark-button-intent-disabled() {
   box-shadow: none;
   background-image: none;
   color: $dark-button-intent-color-disabled;
+}
+
+@mixin pt-dark-button-intent-placeholder() {
+  color: $dark-button-intent-color-placeholder;
 }
 
 @mixin pt-button-minimal() {
@@ -299,6 +335,10 @@ $button-intents: (
     background: none;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
+  }
+
+  &.pt-placeholder {
+    color: $pt-text-color-muted;
   }
 
   .pt-dark & {
@@ -346,6 +386,10 @@ $button-intents: (
     cursor: not-allowed;
     color: $pt-dark-text-color-disabled;
   }
+
+  &.pt-placeholder {
+    color: $pt-dark-text-color-muted;
+  }
 }
 
 @mixin pt-button-minimal-intent($intent-color, $text-color, $dark-text-color) {
@@ -376,6 +420,10 @@ $button-intents: (
     color: rgba($text-color, 0.5);
   }
 
+  &.pt-placeholder {
+    color: rgba($text-color, 0.7);
+  }
+
   .pt-button-spinner .pt-spinner-head {
     stroke: $text-color;
   }
@@ -398,6 +446,10 @@ $button-intents: (
     &.pt-disabled {
       background: none;
       color: rgba($dark-text-color, 0.5);
+    }
+
+    &.pt-placeholder {
+      color: rgba($dark-text-color, 0.7);
     }
   }
 }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -64,24 +64,24 @@ $button-gradient: linear-gradient(to bottom, rgba($white, 0.8), rgba($white, 0))
 $button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;
 $dark-button-gradient: linear-gradient(to bottom, rgba($white, 0.05), rgba($white, 0)) !default;
 
-$button-color-disabled: $pt-text-color-disabled !default;
 $button-color-placeholder: $pt-text-color-muted !default;
+$button-color-disabled: $pt-text-color-disabled !default;
 $button-background-color: $light-gray5 !default;
 $button-background-color-hover: $light-gray4 !default;
 $button-background-color-active: $light-gray2 !default;
 $button-background-color-disabled: rgba($light-gray1, 0.5) !default;
 $button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
-$button-intent-color-disabled: rgba($white, 0.6);
 $button-intent-color-placeholder: rgba($white, 0.7);
-$dark-button-color-disabled: $pt-dark-text-color-disabled !default;
+$button-intent-color-disabled: rgba($white, 0.6);
 $dark-button-color-placeholder: $pt-dark-text-color-muted !default;
+$dark-button-color-disabled: $pt-dark-text-color-disabled !default;
 $dark-button-background-color: $dark-gray5 !default;
 $dark-button-background-color-hover: $dark-gray4 !default;
 $dark-button-background-color-active: $dark-gray2 !default;
 $dark-button-background-color-disabled: rgba($dark-gray5, 0.5) !default;
 $dark-button-background-color-active-disabled: rgba($dark-gray5, 0.7) !default;
-$dark-button-intent-color-disabled: rgba($white, 0.3);
 $dark-button-intent-color-placeholder: rgba($white, 0.6);
+$dark-button-intent-color-disabled: rgba($white, 0.3);
 
 $minimal-button-divider-width: 1px !default;
 $minimal-button-background-color: none !default;
@@ -131,13 +131,13 @@ $button-intents: (
     @include pt-button-active();
   }
 
+  &.pt-placeholder {
+    @include pt-button-placeholder();
+  }
+
   &:disabled,
   &.pt-disabled {
     @include pt-button-disabled();
-  }
-
-  &.pt-placeholder {
-    @include pt-button-placeholder();
   }
 }
 
@@ -153,6 +153,10 @@ $button-intents: (
   background-image: none;
 }
 
+@mixin pt-button-placeholder() {
+  color: $button-color-placeholder;
+}
+
 @mixin pt-button-disabled() {
   outline: none;
   box-shadow: none;
@@ -164,10 +168,6 @@ $button-intents: (
   &.pt-active {
     background: $button-background-color-active-disabled;
   }
-}
-
-@mixin pt-button-placeholder() {
-  color: $button-color-placeholder;
 }
 
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
@@ -194,14 +194,18 @@ $button-intents: (
     background-image: none;
   }
 
+  &.pt-placeholder {
+    @include pt-button-intent-placeholder();
+  }
+
   &:disabled,
   &.pt-disabled {
     @include pt-button-intent-disabled($default-color);
   }
+}
 
-  &.pt-placeholder {
-    @include pt-button-intent-placeholder();
-  }
+@mixin pt-button-intent-placeholder() {
+  color: $button-intent-color-placeholder;
 }
 
 @mixin pt-button-intent-disabled($default-color) {
@@ -210,10 +214,6 @@ $button-intents: (
   background-color: rgba($default-color, 0.5);
   background-image: none;
   color: $button-intent-color-disabled;
-}
-
-@mixin pt-button-intent-placeholder() {
-  color: $button-intent-color-placeholder;
 }
 
 @mixin pt-dark-button() {
@@ -237,13 +237,13 @@ $button-intents: (
     @include pt-dark-button-active();
   }
 
+  &.pt-placeholder {
+    @include pt-dark-button-placeholder();
+  }
+
   &:disabled,
   &.pt-disabled {
     @include pt-dark-button-disabled();
-  }
-
-  &.pt-placeholder {
-    @include pt-dark-button-placeholder();
   }
 
   .pt-button-spinner .pt-spinner-head {
@@ -263,6 +263,10 @@ $button-intents: (
   background-image: none;
 }
 
+@mixin pt-dark-button-placeholder() {
+  color: $dark-button-color-placeholder;
+}
+
 @mixin pt-dark-button-disabled() {
   box-shadow: none;
   background-color: $dark-button-background-color-disabled;
@@ -272,10 +276,6 @@ $button-intents: (
   &.pt-active {
     background: $dark-button-background-color-active-disabled;
   }
-}
-
-@mixin pt-dark-button-placeholder() {
-  color: $dark-button-color-placeholder;
 }
 
 @mixin pt-dark-button-intent() {
@@ -290,24 +290,24 @@ $button-intents: (
     box-shadow: $dark-button-intent-box-shadow-active;
   }
 
+  &.pt-placeholder {
+    @include pt-dark-button-intent-placeholder();
+  }
+
   &:disabled,
   &.pt-disabled {
     @include pt-dark-button-intent-disabled();
   }
+}
 
-  &.pt-placeholder {
-    @include pt-dark-button-intent-placeholder();
-  }
+@mixin pt-dark-button-intent-placeholder() {
+  color: $dark-button-intent-color-placeholder;
 }
 
 @mixin pt-dark-button-intent-disabled() {
   box-shadow: none;
   background-image: none;
   color: $dark-button-intent-color-disabled;
-}
-
-@mixin pt-dark-button-intent-placeholder() {
-  color: $dark-button-intent-color-placeholder;
 }
 
 @mixin pt-button-minimal() {
@@ -328,6 +328,10 @@ $button-intents: (
     color: $pt-text-color;
   }
 
+  &.pt-placeholder {
+    color: $pt-text-color-muted;
+  }
+
   &:disabled,
   &:disabled:hover,
   &.pt-disabled,
@@ -335,10 +339,6 @@ $button-intents: (
     background: none;
     cursor: not-allowed;
     color: $pt-text-color-disabled;
-  }
-
-  &.pt-placeholder {
-    color: $pt-text-color-muted;
   }
 
   .pt-dark & {
@@ -378,6 +378,10 @@ $button-intents: (
     color: $pt-dark-text-color;
   }
 
+  &.pt-placeholder {
+    color: $pt-dark-text-color-muted;
+  }
+
   &:disabled,
   &:disabled:hover,
   &.pt-disabled,
@@ -385,10 +389,6 @@ $button-intents: (
     background: none;
     cursor: not-allowed;
     color: $pt-dark-text-color-disabled;
-  }
-
-  &.pt-placeholder {
-    color: $pt-dark-text-color-muted;
   }
 }
 
@@ -414,14 +414,14 @@ $button-intents: (
     color: $text-color;
   }
 
+  &.pt-placeholder {
+    color: rgba($text-color, 0.7);
+  }
+
   &:disabled,
   &.pt-disabled {
     background: none;
     color: rgba($text-color, 0.5);
-  }
-
-  &.pt-placeholder {
-    color: rgba($text-color, 0.7);
   }
 
   .pt-button-spinner .pt-spinner-head {
@@ -442,14 +442,14 @@ $button-intents: (
       color: $dark-text-color;
     }
 
+    &.pt-placeholder {
+      color: rgba($dark-text-color, 0.7);
+    }
+
     &:disabled,
     &.pt-disabled {
       background: none;
       color: rgba($dark-text-color, 0.5);
-    }
-
-    &.pt-placeholder {
-      color: rgba($dark-text-color, 0.7);
     }
   }
 }

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -37,6 +37,13 @@ export interface IButtonProps extends IActionProps {
     loading?: boolean;
 
     /**
+     * If set to `true`, the button will display in a placeholder state.
+     * This is equivalent to setting `className="pt-placeholder"`.
+     * @default false
+     */
+    placeholder?: boolean;
+
+    /**
      * HTML `type` attribute of button. Common values are `"button"` and `"submit"`.
      * Note that this prop has no effect on `AnchorButton`; it only affects `Button`.
      * @default "button"
@@ -74,6 +81,7 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
                 [Classes.ACTIVE]: this.state.isActive || this.props.active,
                 [Classes.DISABLED]: disabled,
                 [Classes.LOADING]: this.props.loading,
+                [Classes.PLACEHOLDER]: this.props.placeholder,
             },
             Classes.iconClass(this.props.iconName),
             Classes.intentClass(this.props.intent),

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -37,13 +37,6 @@ export interface IButtonProps extends IActionProps {
     loading?: boolean;
 
     /**
-     * If set to `true`, the button will display in a placeholder state.
-     * This is equivalent to setting `className="pt-placeholder"`.
-     * @default false
-     */
-    placeholder?: boolean;
-
-    /**
      * HTML `type` attribute of button. Common values are `"button"` and `"submit"`.
      * Note that this prop has no effect on `AnchorButton`; it only affects `Button`.
      * @default "button"
@@ -81,7 +74,6 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
                 [Classes.ACTIVE]: this.state.isActive || this.props.active,
                 [Classes.DISABLED]: disabled,
                 [Classes.LOADING]: this.props.loading,
-                [Classes.PLACEHOLDER]: this.props.placeholder,
             },
             Classes.iconClass(this.props.iconName),
             Classes.intentClass(this.props.intent),


### PR DESCRIPTION
Motivation is to have a placeholder style for buttons that resembles ::placeholder style for inputs.
An example use case would be a `<Select>` target with a default value.

@llorca This PR adds the pt-placeholder class we had talked about.
Styles are pretty basic - just adds muted text color. Is there more we should do here?

Also, do I need to do anything with `$control-group-stack`?
https://github.com/palantir/blueprint/blob/625f343a48111025aa44b01002d5312e1e35eb5c/packages/core/src/components/forms/_common.scss#L36-L55