### PR TITLE
[EditableText] Fix multiline height for long strings with no spaces

### DIFF
--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -153,5 +153,6 @@
   .pt-editable-content {
     overflow: auto;
     white-space: pre-wrap;
+    word-wrap: break-word;
   }
 }


### PR DESCRIPTION
#### Fixes #1572 

#### Changes proposed in this pull request:

<!-- fill this out -->

When a long string without any spaces is entered into multiline EditableText, the component's height will increase to fit the text. Previously, a vertical scrollbar will appear on the right side of the component.

#### Screenshot

Before fixing the bug (vertical scrollbar on the right will show when the component is in edit mode) :

<img width="761" alt="before" src="https://user-images.githubusercontent.com/10660656/30780667-4faf061a-a0c5-11e7-8467-4fe63904febb.png">

After fixing the bug (the component's height is increased to fit the text) :

<img width="781" alt="after" src="https://user-images.githubusercontent.com/10660656/30780669-57107e34-a0c5-11e7-9572-668e1abae899.png">

<!-- include an image of the most relevant user-facing change, if any -->
