### PR TITLE
[Input group] More precise selector for spinners in input groups

### DIFF
--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -90,7 +90,9 @@ $input-button-height-large: $pt-button-height !default;
     color: $pt-icon-color;
   }
 
-  .pt-spinner {
+  // adjusting the margin of spinners in input groups
+  // we have to avoid targetting buttons that contain a spinner
+  .pt-input-action > .pt-spinner {
     margin: ($pt-input-height - $spinner-width * $spinner-width-factor-small) / 2;
   }
 
@@ -161,7 +163,7 @@ $input-button-height-large: $pt-button-height !default;
       }
     }
 
-    .pt-spinner {
+    .pt-input-action > .pt-spinner {
       margin: ($pt-input-height-large - $spinner-width * $spinner-width-factor-small) / 2;
     }
   }


### PR DESCRIPTION
#### Fixes #1605 

#### Reviewers should focus on:

Is the `.pt-input-action > .pt-spinner` selector acceptable?

#### Screenshot

Before:
![screen shot 2017-09-25 at 2 25 10 pm](https://user-images.githubusercontent.com/199754/30832518-2cabcd24-a200-11e7-9996-b1b901801821.png)
![screen shot 2017-09-25 at 2 25 15 pm](https://user-images.githubusercontent.com/199754/30832523-2eb19a18-a200-11e7-87c1-ae55396d020e.png)

After:
![screen shot 2017-09-25 at 2 24 41 pm](https://user-images.githubusercontent.com/199754/30832510-288eb698-a200-11e7-95c4-8da1ebeea52d.png)
![screen shot 2017-09-25 at 2 24 46 pm](https://user-images.githubusercontent.com/199754/30832514-2a2bf93e-a200-11e7-8d29-6264c44306ca.png)
