### PR TITLE
[Table] Don't render LEFT and TOP_LEFT quadrants if they're not needed

### DIFF
--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -104,13 +104,6 @@ $table-quadrant-scroll-container-overflow: 20px;
     height: auto;
     overflow-x: hidden;
   }
-
-  // correct missing left selecton border when selection includes
-  // cells in the first column (#516). we do this by requiring at least
-  // 1px of width on the body-cell wrapper element.
-  .bp-table-body-virtual-client {
-    min-width: 1px;
-  }
 }
 
 .bp-table-quadrant-top-left {
@@ -124,10 +117,5 @@ $table-quadrant-scroll-container-overflow: 20px;
     bottom: -$table-quadrant-scroll-container-overflow;
     overflow-x: hidden;
     overflow-y: hidden;
-  }
-
-  // correct missing bottom-right corner in the menu-element (addresses #1444).
-  .bp-table-body-virtual-client {
-    min-width: 1px;
   }
 }

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -104,6 +104,13 @@ $table-quadrant-scroll-container-overflow: 20px;
     height: auto;
     overflow-x: hidden;
   }
+
+  // correct missing left selecton border when selection includes
+  // cells in the first column (#516). we do this by requiring at least
+  // 1px of width on the body-cell wrapper element.
+  .bp-table-body-virtual-client {
+    min-width: 1px;
+  }
 }
 
 .bp-table-quadrant-top-left {
@@ -117,5 +124,10 @@ $table-quadrant-scroll-container-overflow: 20px;
     bottom: -$table-quadrant-scroll-container-overflow;
     overflow-x: hidden;
     overflow-y: hidden;
+  }
+
+  // correct missing bottom-right corner in the menu-element (addresses #1444).
+  .bp-table-body-virtual-client {
+    min-width: 1px;
   }
 }

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -36,8 +36,6 @@ export enum QuadrantType {
     TOP_LEFT,
 }
 
-export const QUADRANT_TYPES = [QuadrantType.MAIN, QuadrantType.TOP, QuadrantType.LEFT, QuadrantType.TOP_LEFT];
-
 export interface ITableQuadrantProps extends IProps {
     /**
      * A callback that receives a `ref` to the quadrant's body-wrapping element. Will need to be

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -540,7 +540,13 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
             this.wasMainQuadrantScrollChangedFromOtherOnWheelCallback = true;
 
             const mainScrollContainer = this.quadrantRefs[QuadrantType.MAIN].scrollContainer;
-            const nextScrollOffset = mainScrollContainer[scrollKey] + delta;
+            const currScrollOffset = mainScrollContainer[scrollKey];
+            const nextScrollOffset = Math.max(0, mainScrollContainer[scrollKey] + delta);
+
+            if (nextScrollOffset === currScrollOffset) {
+                return;
+            }
+
             mainScrollContainer[scrollKey] = nextScrollOffset;
 
             // update the cache.

--- a/packages/table/src/quadrants/tableQuadrantStackCache.ts
+++ b/packages/table/src/quadrants/tableQuadrantStackCache.ts
@@ -31,10 +31,6 @@ export class TableQuadrantStackCache {
         return scrollKey === "scrollLeft" ? this.cachedScrollLeft : this.cachedScrollTop;
     }
 
-    public getScrollTop() {
-        return this.cachedScrollTop;
-    }
-
     public getRowHeaderWidth() {
         return this.cachedRowHeaderWidth;
     }

--- a/packages/table/src/quadrants/tableQuadrantStackCache.ts
+++ b/packages/table/src/quadrants/tableQuadrantStackCache.ts
@@ -5,20 +5,13 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { QuadrantType } from "./tableQuadrant";
-
-export interface IScrollOffsetMap {
-    scrollLeft: number;
-    scrollTop: number;
-}
+export type ScrollKey = "scrollLeft" | "scrollTop";
 
 export class TableQuadrantStackCache {
     private cachedRowHeaderWidth: number;
     private cachedColumnHeaderHeight: number;
-    private cachedMainQuadrantScrollOffsets: IScrollOffsetMap;
-    private cachedTopQuadrantScrollOffsets: IScrollOffsetMap;
-    private cachedLeftQuadrantScrollOffsets: IScrollOffsetMap;
-    private cachedTopLeftQuadrantScrollOffsets: IScrollOffsetMap;
+    private cachedScrollLeft: number;
+    private cachedScrollTop: number;
 
     public constructor() {
         this.reset();
@@ -27,18 +20,19 @@ export class TableQuadrantStackCache {
     public reset() {
         this.cachedRowHeaderWidth = 0;
         this.cachedColumnHeaderHeight = 0;
-
-        this.cachedMainQuadrantScrollOffsets = this.createScrollOffsetMap();
-        this.cachedTopQuadrantScrollOffsets = this.createScrollOffsetMap();
-        this.cachedLeftQuadrantScrollOffsets = this.createScrollOffsetMap();
-        this.cachedTopLeftQuadrantScrollOffsets = this.createScrollOffsetMap();
+        this.cachedScrollLeft = 0;
+        this.cachedScrollTop = 0;
     }
 
     // Getters
     // =======
 
-    public getQuadrantScrollOffset(quadrantType: QuadrantType, scrollKey: keyof IScrollOffsetMap) {
-        return this.getQuadrantScrollOffsetMap(quadrantType)[scrollKey];
+    public getScrollOffset(scrollKey: ScrollKey) {
+        return scrollKey === "scrollLeft" ? this.cachedScrollLeft : this.cachedScrollTop;
+    }
+
+    public getScrollTop() {
+        return this.cachedScrollTop;
     }
 
     public getRowHeaderWidth() {
@@ -60,28 +54,11 @@ export class TableQuadrantStackCache {
         this.cachedRowHeaderWidth = width;
     }
 
-    public setQuadrantScrollOffset(quadrantType: QuadrantType, scrollKey: keyof IScrollOffsetMap, offset: number) {
-        this.getQuadrantScrollOffsetMap(quadrantType)[scrollKey] = offset;
-    }
-
-    // Helpers
-    // =======
-
-    private createScrollOffsetMap() {
-        return { scrollLeft: 0, scrollTop: 0 };
-    }
-
-    private getQuadrantScrollOffsetMap(quadrantType: QuadrantType) {
-        switch (quadrantType) {
-            case QuadrantType.MAIN:
-                return this.cachedMainQuadrantScrollOffsets;
-            case QuadrantType.TOP:
-                return this.cachedTopQuadrantScrollOffsets;
-            case QuadrantType.LEFT:
-                return this.cachedLeftQuadrantScrollOffsets;
-            default:
-                // i.e. case QuadrantType.TOP_LEFT:
-                return this.cachedTopLeftQuadrantScrollOffsets;
+    public setScrollOffset(scrollKey: ScrollKey, offset: number) {
+        if (scrollKey === "scrollLeft") {
+            this.cachedScrollLeft = offset;
+        } else {
+            this.cachedScrollTop = offset;
         }
     }
 }

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -438,13 +438,21 @@ describe("TableQuadrantStack", () => {
                     renderColumnHeader={renderColumnHeader}
                 />,
             );
-            // add explicit 0 to communicate that we're considering the zero-width row headers
-            const expectedWidth =
-                numFrozenColumns === 0 ? EXPECTED_HEADER_BORDER_WIDTH : 0 + numFrozenColumns * COLUMN_WIDTH;
+
             const expectedHeight =
                 COLUMN_HEADER_HEIGHT +
                 (numFrozenRows === 0 ? EXPECTED_HEADER_BORDER_WIDTH : numFrozenRows * ROW_HEIGHT);
-            assertNonMainQuadrantSizesCorrect(container, expectedWidth, expectedHeight);
+
+            const { topQuadrant, leftQuadrant, topLeftQuadrant } = findQuadrants(container);
+
+            if (numFrozenColumns === 0) {
+                expect(leftQuadrant).to.be.null;
+                expect(topLeftQuadrant).to.be.null;
+                assertStyleEquals(topQuadrant, "height", toPxString(expectedHeight));
+            } else {
+                const expectedWidth = numFrozenColumns * COLUMN_WIDTH;
+                assertNonMainQuadrantSizesCorrect(container, expectedWidth, expectedHeight);
+            }
         }
 
         function assertNonMainQuadrantSizesCorrect(


### PR DESCRIPTION
#### Addresses #1547

#### Checklist

- [x] Include tests (updated existing tests!)

#### Changes proposed in this pull request:

- If `isRowHeaderShown=false` and `numFrozenColumns=0`, don't render the `LEFT` or `TOP_LEFT` quadrants at all. 

#### Reviewers should focus on:

- **Edge case:**
    1. Set `isRowHeaderShown=false`.
    2. Scroll downward and rightward a bit.
    3. Set `isRowHeaderShown=true`.
    4. *Expected:*
        - The row header should appear pre-scrolled to the current scroll offset (as shown in the GIF below).
        - The menu element should appear sync'd to the proper row-header width.

#### Screenshot

![2017-09-26 13 57 50](https://user-images.githubusercontent.com/443450/30883973-c4da6106-a2c2-11e7-9c06-3e8cc9379025.gif)
