### PR TITLE
[Table] Fix missing selection border on left edge of grid

### DIFF
--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -105,9 +105,9 @@ $table-quadrant-scroll-container-overflow: 20px;
     overflow-x: hidden;
   }
 
-  // correct missing left selecton border when selection includes
-  // cells in the first column (#516). we do this by requiring at least
-  // 1px of width on the body-cell wrapper element.
+  // require at least 1px of width to show the left selection border if
+  // necessary. this will be needed when selection includes cells in the first
+  // column (#1444).
   .bp-table-body-virtual-client {
     min-width: 1px;
   }

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -104,6 +104,13 @@ $table-quadrant-scroll-container-overflow: 20px;
     height: auto;
     overflow-x: hidden;
   }
+
+  // correct missing left selecton border when selection includes
+  // cells in the first column (#516). we do this by requiring at least
+  // 1px of width on the body-cell wrapper element.
+  .bp-table-body-virtual-client {
+    min-width: 1px;
+  }
 }
 
 .bp-table-quadrant-top-left {
@@ -117,5 +124,10 @@ $table-quadrant-scroll-container-overflow: 20px;
     bottom: -$table-quadrant-scroll-container-overflow;
     overflow-x: hidden;
     overflow-y: hidden;
+  }
+
+  // correct missing bottom-right corner in the menu-element (addresses #1444).
+  .bp-table-body-virtual-client {
+    min-width: 1px;
   }
 }


### PR DESCRIPTION
#### Addreses #1444

#### Changes proposed in this pull request:

- 🐛  __FIXED__ `Table` now displays a left border on selections that are flush with the left side of the grid.

#### Reviewers should focus on:

- You'll notice a visual regression with the left border when the row header is hidden. This is fixed in #1621, which hides the `LEFT` and `TOP_LEFT` quadrants when they're not needed. :)

![image](https://user-images.githubusercontent.com/443450/30884257-ca1022fe-a2c3-11e7-823e-d2c0de1e4ee0.png)

#### Screenshot

![2017-09-26 14 04 32](https://user-images.githubusercontent.com/443450/30884293-e5584cbc-a2c3-11e7-8e70-c283b2cac80f.gif)
