### PR TITLE
Prepare release table-1.26.1

### DIFF
--- a/packages/site-docs/package.json
+++ b/packages/site-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprintjs.com/docs",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Blueprint Docs",
   "private": true,
   "dependencies": {
@@ -8,7 +8,7 @@
     "@blueprintjs/datetime": "^1.22.0",
     "@blueprintjs/docs": "^1.1.1",
     "@blueprintjs/labs": "^0.10.0",
-    "@blueprintjs/table": "^1.26.0",
+    "@blueprintjs/table": "^1.26.1",
     "bourbon": "^4.2.2",
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -20,7 +20,7 @@
     "watch": "onchange 'src/**' 'preview/*.ts*' -- npm-run-all build:gulp build:preview"
   },
   "dependencies": {
-    "@blueprintjs/core": "^1.23.0",
+    "@blueprintjs/core": "^1.25.0",
     "classnames": "^2.2",
     "es6-shim": "^0.35",
     "pure-render-decorator": "^1.1",


### PR DESCRIPTION
:book: **Latest docs**: [blueprintjs.com/docs](http://blueprintjs.com/docs)

## `@blueprintjs/table 1.26.1`

### 🐛  Bug fixes
- `@blueprintjs/table` now depends on `@blueprintjs/core` 1.25.0, which contains the new `Icon` component used throughout the table