### PR TITLE
[Table] Prevent overscroll, refactor scrolling logic in TableQuadrantStack

### DIFF
--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -572,10 +572,15 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
             : this.cache.getScrollContainerClientHeight();
 
         if (clientSize == null) {
-            // should trigger only on the first scroll of the wheel gesture
+            // should trigger only on the first scroll of the wheel gesture.
+            // will save client width and height sizes in the cache.
             clientSize = this.updateScrollContainerClientSize(isHorizontal);
         }
 
+        // by now, the client width and height will have been saved in cache, so
+        // they can't be nully anymore. also, events can only happen after
+        // mount, so we're guaranteed to have measured the header sizes in
+        // syncQuadrantViews() by now too, as it's invoked on mount.
         const containerSize = isHorizontal
             ? this.cache.getScrollContainerClientWidth() - this.cache.getRowHeaderWidth()
             : this.cache.getScrollContainerClientHeight() - this.cache.getColumnHeaderHeight();
@@ -802,6 +807,8 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
     };
 
     private maybeSetGlobalScrollOffset = (scrollKey: "scrollLeft" | "scrollTop", offset: number) => {
+        // the "global" scroll offset should always be set on the MAIN
+        // quadrant's scroll container; that's our single source of truth.
         this.quadrantRefs[QuadrantType.MAIN].scrollContainer[scrollKey] = offset;
         this.cache.setScrollOffset(scrollKey, offset);
 
@@ -809,10 +816,12 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         this.maybeSetQuadrantScrollOffset(dependentQuadrantType, scrollKey);
     };
 
+    /**
+     * This function is named 'update' instead of 'set', because a 'set'
+     * function typically takes the new value as a parameter. We avoid that to
+     * keep the isHorizontal logic tree contained within this function.
+     */
     private updateScrollContainerClientSize(isHorizontal: boolean) {
-        // this function is called 'update' instead of 'set', because a 'set'
-        // function typically takes the new value as a parameter. we avoid that
-        // to keep the isHorizontal logic tree contained within this function.
         const mainScrollContainer = this.quadrantRefs[QuadrantType.MAIN].scrollContainer;
         if (isHorizontal) {
             this.cache.setScrollContainerClientWidth(mainScrollContainer.clientWidth);

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -738,8 +738,8 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         this.maybesSetQuadrantRowHeaderSizes(rowHeaderWidth);
         this.maybeSetQuadrantMenuElementSizes(nextMenuElementWidth, nextMenuElementHeight);
         this.maybeSetQuadrantSizes(nextLeftQuadrantWidth, nextTopQuadrantHeight);
-        this.maybeSetQuadrantOffset(QuadrantType.TOP, "right", rightScrollBarWidth);
-        this.maybeSetQuadrantOffset(QuadrantType.LEFT, "bottom", bottomScrollBarHeight);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.TOP, "right", rightScrollBarWidth);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.LEFT, "bottom", bottomScrollBarHeight);
         this.maybeSetQuadrantScrollOffset(QuadrantType.LEFT, "scrollTop");
         this.maybeSetQuadrantScrollOffset(QuadrantType.TOP, "scrollLeft");
     };
@@ -758,7 +758,7 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         }
     };
 
-    private maybeSetQuadrantOffset = (quadrantType: QuadrantType, side: "right" | "bottom", value: number) => {
+    private maybeSetQuadrantPositionOffset = (quadrantType: QuadrantType, side: "right" | "bottom", value: number) => {
         const { quadrant } = this.quadrantRefs[quadrantType];
         if (quadrant != null) {
             quadrant.style[side] = `${value}px`;

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -547,6 +547,7 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         delta: number,
         quadrantTypesToSync: QuadrantType[],
     ) => {
+        const { grid } = this.props;
         const isHorizontal = direction === "horizontal";
 
         const scrollKey = isHorizontal ? "scrollLeft" : "scrollTop";
@@ -558,8 +559,14 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
             this.wasMainQuadrantScrollChangedFromOtherOnWheelCallback = true;
 
             const mainScrollContainer = this.quadrantRefs[QuadrantType.MAIN].scrollContainer;
+            const contentSize = isHorizontal ? grid.getWidth() : grid.getHeight();
+            const containerSize = isHorizontal
+                ? mainScrollContainer.clientWidth - this.cache.getRowHeaderWidth()
+                : mainScrollContainer.clientHeight - this.cache.getColumnHeaderHeight();
+
             const currScrollOffset = mainScrollContainer[scrollKey];
-            const nextScrollOffset = Math.max(0, mainScrollContainer[scrollKey] + delta);
+            const maxScrollOffset = contentSize - containerSize;
+            const nextScrollOffset = CoreUtils.clamp(mainScrollContainer[scrollKey] + delta, 0, maxScrollOffset);
 
             if (nextScrollOffset === currScrollOffset) {
                 return;

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -820,11 +820,9 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         this.maybeSetQuadrantScrollOffset(dependentQuadrantType, scrollKey);
     };
 
-    /**
-     * This function is named 'update' instead of 'set', because a 'set'
-     * function typically takes the new value as a parameter. We avoid that to
-     * keep the isHorizontal logic tree contained within this function.
-     */
+    // this function is named 'update' instead of 'set', because a 'set'
+    // function typically takes the new value as a parameter. we avoid that to
+    // keep the isHorizontal logic tree contained within this function.
     private updateScrollContainerClientSize(isHorizontal: boolean) {
         const mainScrollContainer = this.quadrantRefs[QuadrantType.MAIN].scrollContainer;
         if (isHorizontal) {

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -517,8 +517,8 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         const nextScrollTop = mainScrollContainer.scrollTop;
 
         // update the cache.
-        this.maybeSetGlobalScrollOffset("scrollLeft", nextScrollLeft);
-        this.maybeSetGlobalScrollOffset("scrollTop", nextScrollTop);
+        this.setScrollOffset("scrollLeft", nextScrollLeft);
+        this.setScrollOffset("scrollTop", nextScrollTop);
 
         // sync less important view stuff when scrolling/wheeling stops.
         this.syncQuadrantViewsDebounced();
@@ -543,8 +543,8 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         // of this onWheel callback, so we need to manually update the affected
         // quadrant's scroll position to make up for that. note that these DOM
         // writes are batched together after the reads above.
-        this.maybeSetGlobalScrollOffset("scrollLeft", nextScrollLeft);
-        this.maybeSetGlobalScrollOffset("scrollTop", nextScrollTop);
+        this.setScrollOffset("scrollLeft", nextScrollLeft);
+        this.setScrollOffset("scrollTop", nextScrollTop);
 
         // sync less important view stuff when scrolling/wheeling stops.
         this.syncQuadrantViewsDebounced();
@@ -805,9 +805,9 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         }
     };
 
-    private maybeSetGlobalScrollOffset = (scrollKey: "scrollLeft" | "scrollTop", offset: number) => {
-        // the "global" scroll offset should always be set on the MAIN
-        // quadrant's scroll container; that's our single source of truth.
+    private setScrollOffset = (scrollKey: "scrollLeft" | "scrollTop", offset: number) => {
+        // the scroll offset should be set on the MAIN quadrant's scroll
+        // container, since that's the one whose scroll bars are visible.
         this.quadrantRefs[QuadrantType.MAIN].scrollContainer[scrollKey] = offset;
         this.cache.setScrollOffset(scrollKey, offset);
 

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -517,8 +517,8 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         const nextScrollTop = mainScrollContainer.scrollTop;
 
         // update the cache.
-        this.setScrollOffset("scrollLeft", nextScrollLeft);
-        this.setScrollOffset("scrollTop", nextScrollTop);
+        this.setScrollOffset("scrollLeft", nextScrollLeft, /* setOffsetExplicitly */ false);
+        this.setScrollOffset("scrollTop", nextScrollTop, /* setOffsetExplicitly */ false);
 
         // sync less important view stuff when scrolling/wheeling stops.
         this.syncQuadrantViewsDebounced();
@@ -805,10 +805,15 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
         }
     };
 
-    private setScrollOffset = (scrollKey: "scrollLeft" | "scrollTop", offset: number) => {
-        // the scroll offset should be set on the MAIN quadrant's scroll
-        // container, since that's the one whose scroll bars are visible.
-        this.quadrantRefs[QuadrantType.MAIN].scrollContainer[scrollKey] = offset;
+    private setScrollOffset = (scrollKey: "scrollLeft" | "scrollTop", offset: number, setOffsetExplicitly = true) => {
+        if (setOffsetExplicitly) {
+            // the scroll offset should be set on the MAIN quadrant's scroll
+            // container, since that's the one whose scroll bars are visible.
+            // note: if this helper is invoked onScroll, then no need to update
+            // the offset explicitly, because it will have been done before the
+            // event fired.
+            this.quadrantRefs[QuadrantType.MAIN].scrollContainer[scrollKey] = offset;
+        }
         this.cache.setScrollOffset(scrollKey, offset);
 
         const dependentQuadrantType = scrollKey === "scrollLeft" ? QuadrantType.TOP : QuadrantType.LEFT;

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -620,24 +620,24 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
 
     // Rows
 
-    private handleRowResizeGuideMain = (verticalGuides: number[]) => {
-        this.invokeRowResizeHandler(verticalGuides, QuadrantType.MAIN);
+    private handleRowResizeGuideMain = (horizontalGuides: number[]) => {
+        this.invokeRowResizeHandler(horizontalGuides, QuadrantType.MAIN);
     };
 
-    private handleRowResizeGuideTop = (verticalGuides: number[]) => {
-        this.invokeRowResizeHandler(verticalGuides, QuadrantType.TOP);
+    private handleRowResizeGuideTop = (horizontalGuides: number[]) => {
+        this.invokeRowResizeHandler(horizontalGuides, QuadrantType.TOP);
     };
 
-    private handleRowResizeGuideLeft = (verticalGuides: number[]) => {
-        this.invokeRowResizeHandler(verticalGuides, QuadrantType.LEFT);
+    private handleRowResizeGuideLeft = (horizontalGuides: number[]) => {
+        this.invokeRowResizeHandler(horizontalGuides, QuadrantType.LEFT);
     };
 
-    private handleRowResizeGuideTopLeft = (verticalGuides: number[]) => {
-        this.invokeRowResizeHandler(verticalGuides, QuadrantType.TOP_LEFT);
+    private handleRowResizeGuideTopLeft = (horizontalGuides: number[]) => {
+        this.invokeRowResizeHandler(horizontalGuides, QuadrantType.TOP_LEFT);
     };
 
-    private invokeRowResizeHandler = (verticalGuides: number[], quadrantType: QuadrantType) => {
-        const adjustedGuides = this.adjustHorizontalGuides(verticalGuides, quadrantType);
+    private invokeRowResizeHandler = (horizontalGuides: number[], quadrantType: QuadrantType) => {
+        const adjustedGuides = this.adjustHorizontalGuides(horizontalGuides, quadrantType);
         CoreUtils.safeInvoke(this.props.handleRowResizeGuide, adjustedGuides);
     };
 

--- a/packages/table/src/quadrants/tableQuadrantStackCache.ts
+++ b/packages/table/src/quadrants/tableQuadrantStackCache.ts
@@ -12,6 +12,8 @@ export class TableQuadrantStackCache {
     private cachedColumnHeaderHeight: number;
     private cachedScrollLeft: number;
     private cachedScrollTop: number;
+    private cachedScrollContainerClientWidth: number;
+    private cachedScrollContainerClientHeight: number;
 
     public constructor() {
         this.reset();
@@ -39,6 +41,14 @@ export class TableQuadrantStackCache {
         return this.cachedColumnHeaderHeight;
     }
 
+    public getScrollContainerClientWidth() {
+        return this.cachedScrollContainerClientWidth;
+    }
+
+    public getScrollContainerClientHeight() {
+        return this.cachedScrollContainerClientHeight;
+    }
+
     // Setters
     // =======
 
@@ -56,5 +66,13 @@ export class TableQuadrantStackCache {
         } else {
             this.cachedScrollTop = offset;
         }
+    }
+
+    public setScrollContainerClientWidth(clientWidth: number | undefined) {
+        this.cachedScrollContainerClientWidth = clientWidth;
+    }
+
+    public setScrollContainerClientHeight(clientHeight: number | undefined) {
+        this.cachedScrollContainerClientHeight = clientHeight;
     }
 }


### PR DESCRIPTION
#### Addresses #1444

#### Checklist

- [x] ~Include tests~ (it's tricky/prohibitive to add a test for the prevent-overscroll case, since it's such a momentary effect and is more of a rendering artifact than anything)

#### Changes proposed in this pull request:

- #1444 `Table` no longer allows inertial scroll beyond the last row or column.
- #1573 `Table` now doesn't stick _as much_ when you try to scroll slowly leftward/upward from the last column/row.
    - Not really sure what the problem is here.
- `Table` now caches the scroll container's `clientWidth`/`clientHeight` upon the first `wheel` event in a gesture, reducing DOM reads during the gesture.  
    - The cached value is cleared in the debounced view-sync method after the gesture has ended.
    - This eliminates DOM reads during the wheel gesture.
    - ⚠️  This assumes the `clientWidth` and `clientHeight` won't change during the wheel gesture.

#### Reviewers should focus on:

- **Does scrolling actually feel better, or at least not worse?** 
- Is the ⚠️  assumption above okay for now? I guess this assumption may break if we eventually expand the table size while dragging to resize the last column (#1633).
    - If this is a problem, I can whittle that stuff out of this PR.
- If someone can help me figure out why the scrolling is slightly "stuck" at the end of the table, I'd appreciate it.

#### Screenshot

Things to note:
- No "overscroll" when you scroll to the end of the table.
- There's still a little stickiness at the end. :/
- There's not as much stickiness as there used to be (i.e. it doesn't take as forceful of a scroll to get out of the sticky zone).

![2017-09-28 13 51 30](https://user-images.githubusercontent.com/443450/30989890-355e238a-a454-11e7-818b-dd14208ce96e.gif)

