### PR TITLE
[Popover] Prevent accessing the targetElement if it doesn't exist

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -422,7 +422,9 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     private componentDOMChange() {
-        if (!this.targetElement) return;
+        if (!this.targetElement) {
+            return;
+        }
         if (this.props.useSmartArrowPositioning) {
             this.setState({
                 targetHeight: this.targetElement.clientHeight,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -422,6 +422,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     private componentDOMChange() {
+        if (!this.targetElement) return;
         if (this.props.useSmartArrowPositioning) {
             this.setState({
                 targetHeight: this.targetElement.clientHeight,


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/1643

#### Changes proposed in this pull request:

if no targetElement is set, dont try to setState depending on its properties.
