### PR TITLE
[Popover] Change !targetElement to targetElement == null instead

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -422,7 +422,7 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
     }
 
     private componentDOMChange() {
-        if (!this.targetElement) {
+        if (this.targetElement == null) {
             return;
         }
         if (this.props.useSmartArrowPositioning) {


### PR DESCRIPTION
#### FLUP on #1644

nit: In `popover.tsx`, change `!targetElement` to `targetElement == null` instead.