### PR TITLE
[Table/EditableCell] Only update saved and dirty values if value changed

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -77,7 +77,9 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
 
     public componentWillReceiveProps(nextProps: IEditableCellProps) {
         const { value } = nextProps;
-        this.setState({ savedValue: value, dirtyValue: value });
+        if (value !== this.props.value) {
+            this.setState({ savedValue: value, dirtyValue: value });
+        }
     }
 
     public render() {

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -72,6 +72,37 @@ describe("<EditableCell>", () => {
         expect(onConfirm.called).to.be.true;
     });
 
+    it("doesn't change edited value on non-value prop changes", () => {
+        const onCancel = sinon.spy();
+        const onChange = sinon.spy();
+        const onConfirm = sinon.spy();
+        const elem = harness.mount(
+            <EditableCell value="test-value-5000" onCancel={onCancel} onChange={onChange} onConfirm={onConfirm} />,
+        );
+
+        // double click to edit
+        doubleClickToEdit(elem);
+        const input = getInput(elem);
+        expect(input.element).to.equal(document.activeElement);
+
+        // edit
+        input.change("my-changed-value");
+        expect(onChange.called).to.be.true;
+        expect(onCancel.called).to.be.false;
+        expect(onConfirm.called).to.be.false;
+        expect(elem.find(".pt-editable-content").text()).to.equal("my-changed-value");
+
+        harness.mount(
+            <EditableCell value="test-value-5000" onCancel={onCancel} onChange={null} onConfirm={onConfirm} />,
+        );
+        expect(elem.find(".pt-editable-content").text()).to.equal("my-changed-value");
+
+        // confirm
+        input.blur();
+        expect(onCancel.called).to.be.false;
+        expect(onConfirm.called).to.be.true;
+    });
+
     it("passes index prop to callbacks if index was provided", () => {
         const onCancelSpy = sinon.spy();
         const onChangeSpy = sinon.spy();


### PR DESCRIPTION
#### Fixes #1261

#### Changes proposed in this pull request:

We were updating saved and dirty value to match the value whenever _any_ prop changed, no matter what. Even if `shouldComponentUpdate` would have returned false, because `componentWillReceiveProps` is always true. So if there were any changes made before rendering got there (because batched rendering), it'd reset those changes. Now this no longer happens. 

#### Reviewers should focus on:

Is `componentWillReceiveProps` even the right place for this? It apparently can't live in `componentWillUpdate` because that won't take a `setState`, but... is there a better lifecycle spot for this? 

Or more generally: is there a better way to do what I'm doing? 
