### PR TITLE
[Table/TableQuadrantStack] Fix 'clamp' error when grid smaller than container

### DIFF
--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -601,7 +601,7 @@ export class TableQuadrantStack extends AbstractComponent<ITableQuadrantStackPro
             : this.cache.getScrollContainerClientHeight() - this.cache.getColumnHeaderHeight();
 
         const gridSize = isHorizontal ? grid.getWidth() : grid.getHeight();
-        const maxScrollOffset = gridSize - containerSize;
+        const maxScrollOffset = Math.max(0, gridSize - containerSize);
         const currScrollOffset = this.cache.getScrollOffset(scrollKey);
         const nextScrollOffset = CoreUtils.clamp(currScrollOffset + delta, 0, maxScrollOffset);
 


### PR DESCRIPTION
Fixes a bug introduced in #1637 when the grid is smaller than the container. (`Utils.clamp` would complain that `max` can't be less than `min`.)