### PR TITLE
TruncatedFormat: Fix default TruncatedPopoverMode in docs

### DIFF
--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -56,9 +56,9 @@ export interface ITruncatedFormatProps extends IProps {
      * Configures when the popover is shown with the `TruncatedPopoverMode` enum.
      *
      * The enum values are:
-     * - `ALWAYS`: show the popover (default).
+     * - `ALWAYS`: show the popover.
      * - `NEVER`: don't show the popover.
-     * - `WHEN_TRUNCATED`: show the popover only when the text is truncated.
+     * - `WHEN_TRUNCATED`: show the popover only when the text is truncated (default).
      * @default WHEN_TRUNCATED
      */
     showPopover?: TruncatedPopoverMode;


### PR DESCRIPTION
`@default WHEN_TRUNCATED`

And yet we say in the unstructured description that `ALWAYS` is the default. This PR fixes that inconsistency. 