### PR TITLE
[Table] Turn off text truncation by default and raise fixed truncation limit

### DIFF
--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -35,7 +35,7 @@ export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
         omitQuotesOnStrings: true,
         showPopover: TruncatedPopoverMode.WHEN_TRUNCATED,
         stringify: (obj: any) => JSON.stringify(obj, null, 2),
-        truncateLength: 500,
+        truncateLength: 2000,
     };
 
     public render() {

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -31,10 +31,11 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
 
 export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
     public static defaultProps: IJSONFormatProps = {
-        detectTruncation: true,
+        detectTruncation: false,
         omitQuotesOnStrings: true,
         showPopover: TruncatedPopoverMode.WHEN_TRUNCATED,
         stringify: (obj: any) => JSON.stringify(obj, null, 2),
+        truncateLength: 500,
     };
 
     public render() {

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -67,7 +67,7 @@ export interface ITruncatedFormatProps extends IProps {
      * Number of characters that are displayed before being truncated and appended with the
      * `truncationSuffix` prop. A value of 0 will disable truncation. This prop is ignored if
      * `detectTruncation` is `false`.
-     * @default 500
+     * @default 2000
      */
     truncateLength?: number;
 
@@ -89,7 +89,7 @@ export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITru
         detectTruncation: false,
         preformatted: false,
         showPopover: TruncatedPopoverMode.WHEN_TRUNCATED,
-        truncateLength: 500,
+        truncateLength: 2000,
         truncationSuffix: "...",
     };
 

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -31,7 +31,7 @@ export interface ITruncatedFormatProps extends IProps {
      * Should the component keep track of the truncation state of the string content. If true, the
      * value of `truncateLength` is ignored. When combined with a `showPopover` value of
      * `WHEN_TRUNCATED`, popovers will only render when necessary.
-     * @default true;
+     * @default false;
      */
     detectTruncation?: boolean;
 
@@ -66,8 +66,8 @@ export interface ITruncatedFormatProps extends IProps {
     /**
      * Number of characters that are displayed before being truncated and appended with the
      * `truncationSuffix` prop. A value of 0 will disable truncation. This prop is ignored if
-     * `detectTruncation` is `true`.
-     * @default 80
+     * `detectTruncation` is `false`.
+     * @default 500
      */
     truncateLength?: number;
 
@@ -86,10 +86,10 @@ export interface ITruncatedFormatState {
 @PureRender
 export class TruncatedFormat extends React.Component<ITruncatedFormatProps, ITruncatedFormatState> {
     public static defaultProps: ITruncatedFormatProps = {
-        detectTruncation: true,
+        detectTruncation: false,
         preformatted: false,
         showPopover: TruncatedPopoverMode.WHEN_TRUNCATED,
-        truncateLength: 80,
+        truncateLength: 500,
         truncationSuffix: "...",
     };
 

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -23,23 +23,9 @@ describe("Formats", () => {
         harness.destroy();
     });
 
-    describe("Truncated Format", () => {
+    describe.only("Truncated Format", () => {
         it("can automatically truncate and show popover when truncated", () => {
-            const str = `
-                We are going to die, and that makes us the lucky ones. Most
-                people are never going to die because they are never going to
-                be born. The potential people who could have been here in my
-                place but who will in fact never see the light of day
-                outnumber the sand grains of Arabia. Certainly those unborn
-                ghosts include greater poets than Keats, scientists greater
-                than Newton. We know this because the set of possible people
-                allowed by our DNA so massively outnumbers the set of actual
-                people. In the teeth of these stupefying odds it is you and I,
-                in our ordinariness, that are here. We privileged few, who won
-                the lottery of birth against all odds, how dare we whine at
-                our inevitable return to that prior state from which the vast
-                majority have never stirred?
-            `;
+            const str = createStringOfLength(TruncatedFormat.defaultProps.truncateLength + 1);
 
             const comp = harness.mount(
                 <div className={Classes.TABLE_NO_WRAP_TEXT}>
@@ -71,11 +57,11 @@ describe("Formats", () => {
                 majority have never stirred?
             `;
 
-            const style = { height: "200px", position: "relative" };
+            const style = { height: "300px", width: "300px", position: "relative" };
 
             const comp = harness.mount(
                 <div className={Classes.TABLE_TRUNCATED_TEXT} style={style}>
-                    <TruncatedFormat>{str}</TruncatedFormat>
+                    <TruncatedFormat detectTruncation={true}>{str}</TruncatedFormat>
                 </div>,
             );
             const textElement = comp.element.query(`.${Classes.TABLE_TRUNCATED_VALUE}`);
@@ -84,18 +70,7 @@ describe("Formats", () => {
         });
 
         it("can manually truncate and show popover when truncated", () => {
-            const str = `
-                As Gregor Samsa awoke one morning from uneasy dreams he found
-                himself transformed in his bed into a gigantic insect. He was
-                lying on his hard, as it were armor-plated, back and when he
-                lifted his head a little he could see his dome-like brown belly
-                divided into stiff arched segments on top of which the bed quilt
-                could hardly keep in position and was about to slide off
-                completely. His numerous legs, which were pitifully thin
-                compared to the rest of his bulk, waved helplessly before his
-                eyes.
-            `;
-
+            const str = createStringOfLength(TruncatedFormat.defaultProps.truncateLength + 1);;
             const comp = harness.mount(<TruncatedFormat detectTruncation={false}>{str}</TruncatedFormat>);
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_VALUE}`).text().length).to.equal(
                 TruncatedFormat.defaultProps.truncateLength + 3,
@@ -154,7 +129,7 @@ describe("Formats", () => {
             `;
             const comp = harness.mount(
                 <div className={Classes.TABLE_NO_WRAP_TEXT}>
-                    <TruncatedFormat truncateLength={0}>{str}</TruncatedFormat>
+                    <TruncatedFormat detectTruncation={true} truncateLength={0}>{str}</TruncatedFormat>
                 </div>,
             );
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_VALUE}`).text()).to.have.lengthOf(str.length);
@@ -204,3 +179,7 @@ describe("Formats", () => {
         });
     });
 });
+
+function createStringOfLength(length: number) {
+    return new Array(length).fill("a").join("");
+}

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -23,7 +23,7 @@ describe("Formats", () => {
         harness.destroy();
     });
 
-    describe.only("Truncated Format", () => {
+    describe("Truncated Format", () => {
         it("can automatically truncate and show popover when truncated", () => {
             const str = createStringOfLength(TruncatedFormat.defaultProps.truncateLength + 1);
 

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -70,7 +70,7 @@ describe("Formats", () => {
         });
 
         it("can manually truncate and show popover when truncated", () => {
-            const str = createStringOfLength(TruncatedFormat.defaultProps.truncateLength + 1);;
+            const str = createStringOfLength(TruncatedFormat.defaultProps.truncateLength + 1);
             const comp = harness.mount(<TruncatedFormat detectTruncation={false}>{str}</TruncatedFormat>);
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_VALUE}`).text().length).to.equal(
                 TruncatedFormat.defaultProps.truncateLength + 3,
@@ -129,7 +129,9 @@ describe("Formats", () => {
             `;
             const comp = harness.mount(
                 <div className={Classes.TABLE_NO_WRAP_TEXT}>
-                    <TruncatedFormat detectTruncation={true} truncateLength={0}>{str}</TruncatedFormat>
+                    <TruncatedFormat detectTruncation={true} truncateLength={0}>
+                        {str}
+                    </TruncatedFormat>
                 </div>,
             );
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_VALUE}`).text()).to.have.lengthOf(str.length);


### PR DESCRIPTION
- Benefits: No more detecting truncation, which is expensive. Performance benefits
- Drawbacks: A mix of little … and big …s, but I think this will be uncommon and the big … can change meaning from “contents don’t fit cell” to “contents are really big”, also an icon change will help
- Drawbacks: Wrapped text no longer gets … of any sort (unless real big). I’m fine with this, it’s pretty common. Apps that wrap should also resizeByTallest
-How we do it: 
— Change the default from detectTruncation to fixedTruncation
— Choose sane default
— Write good release notes



I may have missed spots