### PR TITLE
allow React 16 in core peerDependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,9 +17,9 @@
     "tslib": "^1.5.0"
   },
   "peerDependencies": {
-    "react": "^15.0.1 || ^0.14",
+    "react": "^16.0.0 || ^15.0.1 || ^0.14",
     "react-addons-css-transition-group": "^15.0.1 || ^0.14",
-    "react-dom": "^15.0.1 || ^0.14"
+    "react-dom": "^16.0.0 || ^15.0.1 || ^0.14"
   },
   "devDependencies": {
     "bourbon": "4.3.2",


### PR DESCRIPTION
#### Fixes #866 

#### Changes proposed in this pull request:

Allow React 16 to be installed alongside Blueprint. 

This *does not guarantee full support* for React 16, but I've manually tested locally and all components render without errors. There may still be issues with deeper interaction logic (though I'm optimistic they'll be very rare), so at least this way folks can encounter those bugs and report them!

Note that until we begin work on 2.0, we are not doing any automated testing against React 16 (see #1659). We are also still using (very old) React typings (see #1031).
