### PR TITLE
[Table] Deselect cells on cmd+click only

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -50,6 +50,31 @@ export function safeInvoke(func: Function | undefined, ...args: any[]) {
     }
 }
 
+/**
+ * Safely invoke the provided entity if it is a function; otherwise, return the
+ * entity itself.
+ */
+export function safeInvokeOrValue<R>(funcOrValue: (() => R) | R | undefined): R;
+export function safeInvokeOrValue<A, R>(funcOrValue: ((arg1: A) => R) | R | undefined, arg1: A): R;
+export function safeInvokeOrValue<A, B, R>(funcOrValue: ((arg1: A, arg2: B) => R) | R | undefined, arg1: A, arg2: B): R;
+export function safeInvokeOrValue<A, B, C, R>(
+    funcOrValue: ((arg1: A, arg2: B, arg3: C) => R) | R | undefined,
+    arg1: A,
+    arg2: B,
+    arg3: C,
+): R;
+export function safeInvokeOrValue<A, B, C, D, R>(
+    funcOrValue: ((arg1: A, arg2: B, arg3: C, arg4: D) => R) | R | undefined,
+    arg1: A,
+    arg2: B,
+    arg3: C,
+    arg4: D,
+): R;
+// tslint:disable-next-line:ban-types
+export function safeInvokeOrValue(funcOrValue: Function | any | undefined, ...args: any[]) {
+    return isFunction(funcOrValue) ? funcOrValue(...args) : funcOrValue;
+}
+
 export function elementIsOrContains(element: HTMLElement, testElement: HTMLElement) {
     return element === testElement || element.contains(testElement);
 }

--- a/packages/core/test/common/utilsTests.ts
+++ b/packages/core/test/common/utilsTests.ts
@@ -24,6 +24,20 @@ describe("Utils", () => {
         assert.isTrue(callback.firstCall.calledWith(1, "2", true, 4));
     });
 
+    it("safeInvokeOrValue", () => {
+        assert.doesNotThrow(() => Utils.safeInvokeOrValue(undefined, 1, "2", true, 4));
+
+        // try the max number of args (4)
+        const callback = sinon.spy();
+        Utils.safeInvokeOrValue(callback, 1, "2", true, 4);
+        assert.isTrue(callback.firstCall.calledWith(1, "2", true, 4));
+
+        // try passing a value
+        const value = "3";
+        const result = Utils.safeInvokeOrValue(value);
+        assert.strictEqual(result, value);
+    });
+
     it("elementIsOrContains", () => {
         const child = document.createElement("span");
         const parent = document.createElement("div");

--- a/packages/table/src/common/internal/platformUtils.ts
+++ b/packages/table/src/common/internal/platformUtils.ts
@@ -9,8 +9,9 @@
  * Returns `true` if `navigator.platform` matches a known Mac platform, or
  * `false` otherwise.
  */
-export function isMac() {
-    const platform = typeof navigator !== "undefined" ? navigator.platform : undefined;
+export function isMac(platformOverride?: string) {
+    const platformActual = typeof navigator !== "undefined" ? navigator.platform : undefined;
+    const platform = platformOverride != null ? platformOverride : platformActual;
     return platform == null ? false : /Mac|iPod|iPhone|iPad/.test(platform);
 }
 
@@ -18,7 +19,7 @@ export function isMac() {
  * Returns `true` if (1) the platform is Mac and the keypress includes the `cmd`
  * key, or (2) the platform is non-Mac and the keypress includes the `ctrl` key.
  */
-export const isModKeyPressed = (event: KeyboardEvent) => {
-    const isMacPlatform = isMac();
+export const isModKeyPressed = (event: KeyboardEvent, platformOverride?: string) => {
+    const isMacPlatform = isMac(platformOverride);
     return (isMacPlatform && event.metaKey) || (!isMacPlatform && event.ctrlKey);
 };

--- a/packages/table/src/common/internal/platformUtils.ts
+++ b/packages/table/src/common/internal/platformUtils.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+/**
+ * Returns `true` if `navigator.platform` matches a known Mac platform, or
+ * `false` otherwise.
+ */
+export function isMac() {
+    const platform = typeof navigator !== "undefined" ? navigator.platform : undefined;
+    return platform == null ? false : /Mac|iPod|iPhone|iPad/.test(platform);
+}
+
+/**
+ * Returns `true` if (1) the platform is Mac and the keypress includes the `cmd`
+ * key, or (2) the platform is non-Mac and the keypress includes the `ctrl` key.
+ */
+export const isModKeyPressed = (event: KeyboardEvent) => {
+    const isMacPlatform = isMac();
+    return (isMacPlatform && event.metaKey) || (!isMacPlatform && event.ctrlKey);
+};

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -224,19 +224,12 @@ const SHALLOW_COMPARE_PROP_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = [
 const RESET_CELL_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = ["indexEnd", "indexStart"];
 
 export class Header extends React.Component<IInternalHeaderProps, IHeaderState> {
-    public state: IHeaderState;
-
     protected activationIndex: number;
     private batcher = new Batcher<JSX.Element>();
 
-    public constructor(props?: IHeaderProps, context?: any) {
+    public constructor(props?: IInternalHeaderProps, context?: any) {
         super(props, context);
-
-        // a selection is already defined, so enable reordering interactions
-        // right away if other criteria are satisfied too.
-        this.state = {
-            hasSelectionEnded: props.selectedRegions != null && props.selectedRegions.length > 0,
-        };
+        this.state = { hasSelectionEnded: this.isSelectedRegionsControlledAndNonEmpty(props) };
     }
 
     public componentWillUnmount() {
@@ -244,11 +237,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     }
 
     public componentWillReceiveProps(nextProps?: IInternalHeaderProps) {
-        if (nextProps.selectedRegions != null && nextProps.selectedRegions.length > 0) {
-            this.setState({ hasSelectionEnded: true });
-        } else {
-            this.setState({ hasSelectionEnded: false });
-        }
+        this.setState({ hasSelectionEnded: this.isSelectedRegionsControlledAndNonEmpty(nextProps) });
     }
 
     public shouldComponentUpdate(nextProps?: IInternalHeaderProps, nextState?: IHeaderState) {
@@ -270,6 +259,10 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
     public render() {
         return this.props.wrapCells(this.renderCells());
+    }
+
+    private isSelectedRegionsControlledAndNonEmpty(props: IInternalHeaderProps = this.props) {
+        return props.selectedRegions != null && props.selectedRegions.length > 0;
     }
 
     private convertEventToIndex = (event: MouseEvent): number => {

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -437,7 +437,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
     private isDragSelectableDisabled = (event: MouseEvent) => {
         if (DragEvents.isAdditive(event)) {
-            // if the meta/crtl key was pressed, we want to forcefully ignore
+            // if the meta/ctrl key was pressed, we want to forcefully ignore
             // reordering interactions and prioritize drag-selection
             // interactions (e.g. to make it possible to deselect a row).
             return false;

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -213,11 +213,12 @@ export interface IInternalHeaderProps extends IHeaderProps {
 
 export interface IHeaderState {
     /**
-     * Whether the drag-select interaction has finished (via mouseup). When
+     * Whether the component has a valid selection specified either via props
+     * (i.e. controlled mode) or via a completed drag-select interaction. When
      * true, DragReorderable will know that it can override the click-and-drag
      * interactions that would normally be reserved for drag-select behavior.
      */
-    hasSelectionEnded?: boolean;
+    hasValidSelection?: boolean;
 }
 
 const SHALLOW_COMPARE_PROP_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = ["focusedCell", "selectedRegions"];
@@ -230,7 +231,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
     public constructor(props?: IInternalHeaderProps, context?: any) {
         super(props, context);
-        this.state = { hasSelectionEnded: this.isSelectedRegionsControlledAndNonEmpty(props) };
+        this.state = { hasValidSelection: this.isSelectedRegionsControlledAndNonEmpty(props) };
     }
 
     public componentWillUnmount() {
@@ -238,7 +239,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     }
 
     public componentWillReceiveProps(nextProps?: IInternalHeaderProps) {
-        this.setState({ hasSelectionEnded: this.isSelectedRegionsControlledAndNonEmpty(nextProps) });
+        this.setState({ hasValidSelection: this.isSelectedRegionsControlledAndNonEmpty(nextProps) });
     }
 
     public shouldComponentUpdate(nextProps?: IInternalHeaderProps, nextState?: IHeaderState) {
@@ -393,6 +394,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
                           <span className={classNames(CoreClasses.ICON_STANDARD, IconClasses.DRAG_HANDLE_VERTICAL)} />
                       </div>
                   </div>,
+                  false,
               );
     }
 
@@ -403,7 +405,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     private wrapInDragReorderable(
         index: number,
         children: JSX.Element,
-        disabled: boolean | ((event: MouseEvent) => boolean) = false,
+        disabled: boolean | ((event: MouseEvent) => boolean),
     ) {
         return (
             <DragReorderable
@@ -425,12 +427,12 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
     private handleDragSelectableSelection = (selectedRegions: IRegion[]) => {
         this.props.onSelection(selectedRegions);
-        this.setState({ hasSelectionEnded: false });
+        this.setState({ hasValidSelection: false });
     };
 
     private handleDragSelectableSelectionEnd = () => {
         this.activationIndex = null; // not strictly required, but good practice
-        this.setState({ hasSelectionEnded: true });
+        this.setState({ hasValidSelection: true });
     };
 
     private isDragSelectableDisabled = (event: MouseEvent) => {
@@ -467,7 +469,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             // because reordering multiple disjoint row/column selections is a UX morass with no clear best
             // behavior.
             this.props.isCellSelected(index) &&
-            this.state.hasSelectionEnded &&
+            this.state.hasValidSelection &&
             Regions.getRegionCardinality(selectedRegions[0]) === this.props.fullRegionCardinality &&
             // selected regions can be updated during mousedown+drag and before mouseup; thus, we
             // add a final check to make sure we don't enable reordering until the selection

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -447,8 +447,8 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             // it possible to deselect a row).
             return false;
         }
-        const regionIndex = this.convertEventToIndex(event);
-        return this.isEntireCellTargetReorderable(regionIndex);
+        const cellIndex = this.convertEventToIndex(event);
+        return this.isEntireCellTargetReorderable(cellIndex);
     };
 
     private isDragReorderableDisabled = (event: MouseEvent) => {
@@ -459,14 +459,12 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             // selection and reorder the same selection simultaneously - confusing!
             return true;
         }
-
-        const regionIndex = this.convertEventToIndex(event);
-        return !this.isEntireCellTargetReorderable(regionIndex);
+        const cellIndex = this.convertEventToIndex(event);
+        return !this.isEntireCellTargetReorderable(cellIndex);
     };
 
     private isEntireCellTargetReorderable = (index: number) => {
         const { selectedRegions } = this.props;
-
         // although reordering may be generally enabled for this row/column (via props.isReorderable), the
         // row/column shouldn't actually become reorderable from a user perspective until a few other
         // conditions are true:

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -13,6 +13,7 @@ import { Grid } from "../common";
 import { Batcher } from "../common/batcher";
 import { IFocusedCellCoordinates } from "../common/cell";
 import * as Classes from "../common/classes";
+import { DragEvents } from "../interactions/dragEvents";
 import { IClientCoordinates, ICoordinateData } from "../interactions/draggable";
 import { DragReorderable, IReorderableProps } from "../interactions/reorderable";
 import { Resizable } from "../interactions/resizable";
@@ -433,10 +434,10 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     };
 
     private isDragSelectableDisabled = (event: MouseEvent) => {
-        if (event.metaKey) {
-            // if the meta key is pressed, we want to forcefully ignore reordering
-            // interactions and prioritize drag-selection interactions (e.g. to make
-            // it possible to deselect a row).
+        if (DragEvents.isAdditive(event)) {
+            // if the meta/crtl key was pressed, we want to forcefully ignore
+            // reordering interactions and prioritize drag-selection
+            // interactions (e.g. to make it possible to deselect a row).
             return false;
         }
         const cellIndex = this.convertEventToIndex(event);

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -224,23 +224,19 @@ const SHALLOW_COMPARE_PROP_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = [
 const RESET_CELL_KEYS_BLACKLIST: Array<keyof IInternalHeaderProps> = ["indexEnd", "indexStart"];
 
 export class Header extends React.Component<IInternalHeaderProps, IHeaderState> {
-    public state: IHeaderState = {
-        hasSelectionEnded: false,
-    };
+    public state: IHeaderState;
 
     protected activationIndex: number;
     private batcher = new Batcher<JSX.Element>();
 
     public constructor(props?: IHeaderProps, context?: any) {
         super(props, context);
-    }
 
-    public componentDidMount() {
-        if (this.props.selectedRegions != null && this.props.selectedRegions.length > 0) {
-            // we already have a selection defined, so we'll want to enable reordering interactions
-            // right away if other criteria are satisfied too.
-            this.setState({ hasSelectionEnded: true });
-        }
+        // a selection is already defined, so enable reordering interactions
+        // right away if other criteria are satisfied too.
+        this.state = {
+            hasSelectionEnded: props.selectedRegions != null && props.selectedRegions.length > 0,
+        };
     }
 
     public componentWillUnmount() {

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -353,7 +353,6 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
                 onFocus={this.props.onFocus}
                 onSelection={this.handleDragSelectableSelection}
                 onSelectionEnd={this.handleDragSelectableSelectionEnd}
-                requireMetaKeyToDeselect={true}
                 selectedRegions={selectedRegions}
                 selectedRegionTransform={this.props.selectedRegionTransform}
             >

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -57,7 +57,7 @@ export interface IDragReorderable extends IReorderableProps {
      * Whether the reordering behavior is disabled.
      * @default false
      */
-    disabled?: boolean;
+    disabled?: boolean | ((event: MouseEvent) => boolean);
 
     /**
      * A callback that determines a `Region` for the single `MouseEvent`. If
@@ -108,7 +108,8 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
     }
 
     private handleActivate = (event: MouseEvent) => {
-        if (!Utils.isLeftClick(event) || this.props.disabled) {
+        // we reserve drag event is additive
+        if (this.shouldIgnoreMouseDown(event)) {
             return false;
         }
 
@@ -178,6 +179,14 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
         this.selectedRegionStartIndex = undefined;
         this.selectedRegionLength = undefined;
     };
+
+    private shouldIgnoreMouseDown(event: MouseEvent) {
+        const { disabled } = this.props;
+
+        const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
+
+        return !Utils.isLeftClick(event) || isDisabled;
+    }
 
     private maybeSelectRegion(region: IRegion) {
         const nextSelectedRegions = [region];

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -108,7 +108,6 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
     }
 
     private handleActivate = (event: MouseEvent) => {
-        // we reserve drag event is additive
         if (this.shouldIgnoreMouseDown(event)) {
             return false;
         }
@@ -182,9 +181,7 @@ export class DragReorderable extends React.Component<IDragReorderable, {}> {
 
     private shouldIgnoreMouseDown(event: MouseEvent) {
         const { disabled } = this.props;
-
         const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
-
         return !Utils.isLeftClick(event) || isDisabled;
     }
 

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -154,8 +154,6 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
 
         if (matchesExistingSelection) {
             const shouldIgnoreSubsequentDragMove = this.handleUpdateExistingSelection(foundIndex, event);
-            // if this flag is true, we'll want to allow the current mousedown
-            // event to be the start of a new drag-selection if desired.
             if (shouldIgnoreSubsequentDragMove) {
                 return false;
             }
@@ -231,7 +229,6 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
 
         const isLeftClick = Utils.isLeftClick(event);
         const isContextMenuTrigger = isLeftClick && event.ctrlKey;
-
         const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
 
         return (

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -8,8 +8,10 @@
 import { Utils as CoreUtils } from "@blueprintjs/core";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
+
 import { IFocusedCellCoordinates } from "../common/cell";
 import * as FocusedCellUtils from "../common/internal/focusedCellUtils";
+import * as PlatformUtils from "../common/internal/platformUtils";
 import { Utils } from "../common/utils";
 import { IRegion, Regions } from "../regions";
 import { DragEvents } from "./dragEvents";
@@ -227,7 +229,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         const element = event.target as HTMLElement;
 
         const isLeftClick = Utils.isLeftClick(event);
-        const isContextMenuTrigger = isLeftClick && event.ctrlKey;
+        const isContextMenuTrigger = isLeftClick && event.ctrlKey && PlatformUtils.isMac();
         const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
 
         return (

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -149,15 +149,8 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
             region = selectedRegionTransform(region, event);
         }
 
-        console.log("[handleActivate]");
-        console.log("  region =", region);
-        console.log("  selectedRegions =", ...selectedRegions);
-
         const foundIndex = Regions.findMatchingRegion(selectedRegions, region);
         const matchesExistingSelection = foundIndex !== -1;
-
-        console.log("  foundIndex =", foundIndex);
-        console.log("  matchesExistingSelection =", matchesExistingSelection);
 
         if (matchesExistingSelection) {
             const shouldIgnoreSubsequentDragMove = this.handleUpdateExistingSelection(foundIndex, event);
@@ -256,17 +249,10 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     private handleUpdateExistingSelection = (selectedRegionIndex: number, event: MouseEvent) => {
         const { requireMetaKeyToDeselect, selectedRegions } = this.props;
 
-        console.log("  [handleUpdateExistingSelection]");
-        console.log("    requireMetaKeyToDeselect:", requireMetaKeyToDeselect);
-        console.log("    selectedRegionIndex:", selectedRegionIndex);
-        console.log("    event.metaKey:", event.metaKey);
-
         if (DragEvents.isAdditive(event)) {
-            console.log("      A");
             // remove just the clicked region, leaving other selected regions in place
             const nextSelectedRegions = selectedRegions.slice();
             nextSelectedRegions.splice(selectedRegionIndex, 1);
-            console.log("        nextSelectedRegions", ...nextSelectedRegions);
             this.maybeInvokeSelectionCallback(nextSelectedRegions);
 
             // if there are still any selections, move the focused cell to the
@@ -281,14 +267,12 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
             // quite unintuitive, so ignore subsequent drag-move's.
             return true;
         } else if (requireMetaKeyToDeselect) {
-            console.log("      B (clearing selection)");
             // not additive, so that means we just clicked on one of the selected cells.
             // in that case, leave only that cell selected.
             const nextSelectedRegion = selectedRegions[selectedRegionIndex];
             this.maybeInvokeSelectionCallback([nextSelectedRegion]);
             this.invokeOnFocusCallbackForRegion(nextSelectedRegion, 0);
         } else {
-            console.log("      C (clearing selection)");
             // not additive and no need to wait for a meta key to deselect, so
             // clear all selections. in this case, don't move the focused cell.
             this.maybeInvokeSelectionCallback([]);

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -164,7 +164,6 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         } else {
             this.handleReplaceSelection(region);
         }
-
         return true;
     };
 

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -79,7 +79,7 @@ export interface IDragSelectableProps extends ISelectableProps {
      * Whether the selection behavior is disabled.
      * @default false
      */
-    disabled?: boolean;
+    disabled?: boolean | ((event: MouseEvent) => boolean);
 
     /**
      * A callback that determines a `Region` for the single `MouseEvent`. If
@@ -226,16 +226,18 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
     };
 
     private shouldIgnoreMouseDown(event: MouseEvent) {
-        const { ignoredSelectors = [] } = this.props;
+        const { disabled, ignoredSelectors = [] } = this.props;
         const element = event.target as HTMLElement;
 
         const isLeftClick = Utils.isLeftClick(event);
         const isContextMenuTrigger = isLeftClick && event.ctrlKey;
 
+        const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
+
         return (
             !isLeftClick ||
             isContextMenuTrigger ||
-            this.props.disabled ||
+            isDisabled ||
             ignoredSelectors.some((selector: string) => element.closest(selector) != null)
         );
     }

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -230,7 +230,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
 
         const isLeftClick = Utils.isLeftClick(event);
         const isContextMenuTrigger = isLeftClick && event.ctrlKey && PlatformUtils.isMac();
-        const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
+        const isDisabled = CoreUtils.safeInvokeOrValue(disabled, event);
 
         return (
             !isLeftClick ||

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -85,7 +85,6 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
                 onFocus={this.props.onFocus}
                 onSelection={this.props.onSelection}
                 onSelectionEnd={this.handleSelectionEnd}
-                requireMetaKeyToDeselect={true}
                 selectedRegions={this.props.selectedRegions}
                 selectedRegionTransform={this.props.selectedRegionTransform}
             >

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -85,6 +85,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
                 onFocus={this.props.onFocus}
                 onSelection={this.props.onSelection}
                 onSelectionEnd={this.handleSelectionEnd}
+                requireMetaKeyToDeselect={true}
                 selectedRegions={this.props.selectedRegions}
                 selectedRegionTransform={this.props.selectedRegionTransform}
             >

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -13,7 +13,6 @@ import { shallow } from "enzyme";
 import * as React from "react";
 
 import * as Classes from "../src/common/classes";
-import * as Errors from "../src/common/errors";
 import { ColumnHeaderCell, IColumnHeaderCellProps } from "../src/index";
 import { ElementHarness, ReactHarness } from "./harness";
 import { createTableOfSize } from "./mocks/table";

--- a/packages/table/test/common/internal/index.ts
+++ b/packages/table/test/common/internal/index.ts
@@ -6,4 +6,5 @@
  */
 
 import "./focusedCellUtilsTests";
+import "./platformUtilsTests";
 import "./scrollUtilsTests";

--- a/packages/table/test/common/internal/platformUtilsTests.ts
+++ b/packages/table/test/common/internal/platformUtilsTests.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { expect } from "chai";
+
+import * as PlatformUtils from "../../../src/common/internal/platformUtils";
+
+describe("platformUtils", () => {
+    describe("isMac", () => {
+        it("returns false for non-Mac platforms", () => {
+            expect(PlatformUtils.isMac("Win32")).to.be.false;
+            expect(PlatformUtils.isMac("linux")).to.be.false;
+        });
+
+        it("returns true for Mac platforms", () => {
+            expect(PlatformUtils.isMac("Mac")).to.be.true;
+            expect(PlatformUtils.isMac("iPhone")).to.be.true;
+            expect(PlatformUtils.isMac("iPod")).to.be.true;
+            expect(PlatformUtils.isMac("iPad")).to.be.true;
+        });
+    });
+
+    describe("isModKeyPressed", () => {
+        describe("on non-Mac platform", () => {
+            const PLATFORM = "Win32";
+
+            it("returns true if CTRL key pressed", () => {
+                const fakeEvent: any = { metaKey: false, ctrlKey: true };
+                expect(PlatformUtils.isModKeyPressed(fakeEvent, PLATFORM)).to.be.true;
+            });
+
+            it("returns false if META key pressed", () => {
+                const fakeEvent: any = { metaKey: true, ctrlKey: false };
+                expect(PlatformUtils.isModKeyPressed(fakeEvent, PLATFORM)).to.be.false;
+            });
+
+            it("returns true if both CTRL and META keys pressed", () => {
+                const fakeEvent: any = { metaKey: true, ctrlKey: true };
+                expect(PlatformUtils.isModKeyPressed(fakeEvent, PLATFORM)).to.be.true;
+            });
+        });
+
+        describe("on Mac platform", () => {
+            const PLATFORM = "Mac";
+
+            it("returns true if META key pressed", () => {
+                const fakeEvent: any = { metaKey: true, ctrlKey: false };
+                expect(PlatformUtils.isModKeyPressed(fakeEvent, PLATFORM)).to.be.true;
+            });
+
+            it("returns false if CTRL key pressed", () => {
+                const fakeEvent: any = { metaKey: false, ctrlKey: true };
+                expect(PlatformUtils.isModKeyPressed(fakeEvent, PLATFORM)).to.be.false;
+            });
+
+            it("returns true if both CTRL and META keys pressed", () => {
+                const fakeEvent: any = { metaKey: true, ctrlKey: true };
+                expect(PlatformUtils.isModKeyPressed(fakeEvent, PLATFORM)).to.be.true;
+            });
+        });
+    });
+});

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -139,6 +139,18 @@ describe("DragSelectable", () => {
                 expectOnSelectionCalledWith([REGION_2, REGION_3]);
                 expectOnFocusCalledWith(REGION_3, 1);
             });
+
+            it("selects just the clicked region requireMetaKeyToDeselect=true", () => {
+                const component = mountDragSelectable({
+                    requireMetaKeyToDeselect: true,
+                    selectedRegions: [REGION_2, REGION, REGION_3],
+                });
+
+                getItem(component).mouse("mousedown");
+
+                expectOnSelectionCalledWith([REGION]);
+                expectOnFocusCalledWith(REGION, 0);
+            });
         });
 
         describe("if SHIFT key was depressed", () => {
@@ -509,6 +521,36 @@ describe("DragSelectable", () => {
             expect(onSelection.callCount, "calls onSelection on mousedown").to.equal(1);
             item.mouse("mousemove");
             expect(onSelection.callCount, "does not call onSelection again on mousemove").to.equal(1);
+        });
+
+        it("triggered when a region receives mousedown with requireMetaKeyToDeselect=true", () => {
+            locateDrag.returns(REGION); // different from the locateClick region
+
+            const component = mountDragSelectable({
+                requireMetaKeyToDeselect: true,
+                selectedRegions: [REGION_2, REGION, REGION_3],
+            });
+
+            const item = getItem(component);
+            item.mouse("mousedown");
+            expect(onSelection.callCount, "calls onSelection on mousedown").to.equal(1);
+            item.mouse("mousemove");
+            expect(onSelection.callCount, "calls onSelection again on mousemove").to.equal(2);
+        });
+
+        it("isn't triggered when one of multiple selected regions received mousedown", () => {
+            locateDrag.returns(REGION); // different from the locateClick region
+
+            const component = mountDragSelectable({
+                requireMetaKeyToDeselect: true,
+                selectedRegions: [REGION_2, REGION, REGION_3],
+            });
+
+            const item = getItem(component);
+            item.mouse("mousedown");
+            expect(onSelection.callCount, "calls onSelection on mousedown").to.equal(1);
+            item.mouse("mousemove");
+            expect(onSelection.callCount, "calls onSelection again on mousemove").to.equal(2);
         });
 
         // running these checks separately clarifies the subsequent effects of the "mousemove" event.

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -106,7 +106,18 @@ describe("DragSelectable", () => {
                 locateClick.returns(REGION);
             });
 
-            it("deselects just that region if CMD key was depressed", () => {
+            it("deselects just that region if CMD key was depressed (one region)", () => {
+                const component = mountDragSelectable({
+                    selectedRegions: [REGION],
+                });
+
+                getItem(component).mouse("mousedown", { metaKey: true });
+
+                expectOnSelectionCalledWith([]);
+                expectOnFocusNotCalled();
+            });
+
+            it("deselects just that region if CMD key was depressed (many regions)", () => {
                 const component = mountDragSelectable({
                     selectedRegions: [REGION_2, REGION, REGION_3],
                 });
@@ -117,15 +128,15 @@ describe("DragSelectable", () => {
                 expectOnFocusCalledWith(REGION_3, 1);
             });
 
-            it("deselects all regions if no modifier keys were depressed", () => {
+            it("leaves just the clicked region selected if CMD key not depressed", () => {
                 const component = mountDragSelectable({
                     selectedRegions: [REGION_2, REGION, REGION_3],
                 });
 
                 getItem(component).mouse("mousedown");
 
-                expectOnSelectionCalledWith([]);
-                expectOnFocusNotCalled(); // leave focused cell where it is
+                expectOnSelectionCalledWith([REGION]);
+                expectOnFocusCalledWith(REGION, 0);
             });
 
             it("works with a selectedRegionTransform too", () => {
@@ -138,18 +149,6 @@ describe("DragSelectable", () => {
 
                 expectOnSelectionCalledWith([REGION_2, REGION_3]);
                 expectOnFocusCalledWith(REGION_3, 1);
-            });
-
-            it("selects just the clicked region requireMetaKeyToDeselect=true", () => {
-                const component = mountDragSelectable({
-                    requireMetaKeyToDeselect: true,
-                    selectedRegions: [REGION_2, REGION, REGION_3],
-                });
-
-                getItem(component).mouse("mousedown");
-
-                expectOnSelectionCalledWith([REGION]);
-                expectOnFocusCalledWith(REGION, 0);
             });
         });
 

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -525,12 +525,9 @@ describe("DragSelectable", () => {
         it("triggered when a region receives mousedown with requireMetaKeyToDeselect=true", () => {
             locateDrag.returns(REGION); // different from the locateClick region
 
-            const component = mountDragSelectable({
-                requireMetaKeyToDeselect: true,
-                selectedRegions: [REGION_2, REGION, REGION_3],
-            });
-
+            const component = mountDragSelectable({ selectedRegions: [REGION_2, REGION, REGION_3] });
             const item = getItem(component);
+
             item.mouse("mousedown");
             expect(onSelection.callCount, "calls onSelection on mousedown").to.equal(1);
             item.mouse("mousemove");
@@ -540,12 +537,9 @@ describe("DragSelectable", () => {
         it("isn't triggered when one of multiple selected regions received mousedown", () => {
             locateDrag.returns(REGION); // different from the locateClick region
 
-            const component = mountDragSelectable({
-                requireMetaKeyToDeselect: true,
-                selectedRegions: [REGION_2, REGION, REGION_3],
-            });
-
+            const component = mountDragSelectable({ selectedRegions: [REGION_2, REGION, REGION_3] });
             const item = getItem(component);
+
             item.mouse("mousedown");
             expect(onSelection.callCount, "calls onSelection on mousedown").to.equal(1);
             item.mouse("mousemove");

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -103,6 +103,7 @@ describe("Selection", () => {
             .find(COLUMN_TH_SELECTOR)
             .mouse("mousedown")
             .mouse("mouseup");
+        onSelection.reset();
 
         // select a row
         table
@@ -111,14 +112,6 @@ describe("Selection", () => {
             .mouse("mouseup");
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.row(0)]]);
-        onSelection.reset();
-
-        // doesn't deselect on re-click
-        table
-            .find(ROW_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
-        expect(onSelection.called).to.equal(false);
         onSelection.reset();
 
         // deselects on cmd+click
@@ -132,7 +125,7 @@ describe("Selection", () => {
         onSelection.reset();
     });
 
-    it("Doesn't select twice the same column on click", () => {
+    it("Column selection works when enabled", () => {
         const onSelection = sinon.spy();
         const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection }));
 
@@ -144,14 +137,6 @@ describe("Selection", () => {
         expect(onSelection.called).to.equal(true, "first select");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
-        onSelection.reset();
-
-        // leaves the selection in place on re-click
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
-        expect(onSelection.called).to.equal(false);
         onSelection.reset();
 
         // deselects on cmd+click
@@ -180,6 +165,28 @@ describe("Selection", () => {
             .mouse("mouseup", 0, 0, isMetaKeyDown);
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[]], "meta key clear");
+    });
+
+    it("Keeps same column selected and reinvokes onSelection when clicked again", () => {
+        const onSelection = sinon.spy();
+        const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection }));
+
+        // leaves the selection in place on re-click
+        const column = table.find(COLUMN_TH_SELECTOR);
+        column.mouse("mousedown").mouse("mouseup");
+        column.mouse("mousedown").mouse("mouseup");
+        expect(onSelection.callCount).to.equal(2);
+    });
+
+    it("Keeps same row selected and reinvokes onSelection when clicked again", () => {
+        const onSelection = sinon.spy();
+        const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection }));
+
+        // leaves the selection in place on re-click
+        const row = table.find(ROW_TH_SELECTOR);
+        row.mouse("mousedown").mouse("mouseup");
+        row.mouse("mousedown").mouse("mouseup");
+        expect(onSelection.callCount).to.equal(2);
     });
 
     it("Transforms regions on selections", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -751,6 +751,60 @@ describe("<Table>", () => {
             expect(onSelection.getCall(1).args).to.deep.equal([[Regions.column(newIndex)]]);
         });
 
+        it("Deselects a selected row on cmd+click (without reordering)", () => {
+            const table = mountTable({
+                isRowReorderable: true,
+                onRowsReordered,
+                onSelection,
+                selectedRegions: [Regions.row(OLD_INDEX)],
+            });
+            const headerCell = getHeaderCell(getRowHeadersWrapper(table), 0);
+            headerCell.mouse("mousedown", { metaKey: true }).mouse("mousemove", 0, OFFSET_Y);
+
+            const guide = table.find(`.${Classes.TABLE_HORIZONTAL_GUIDE}`);
+            expect(guide.exists(), "guide not drawn").be.false;
+
+            headerCell.mouse("mouseup", 0, OFFSET_Y);
+            expect(onSelection.called, "onSelection called").to.be.true;
+            expect(onSelection.calledWith([]), "onSelection called with []").to.be.true;
+            expect(onRowsReordered.called, "onRowsReordered not called").to.be.false;
+        });
+
+        it("Deselects a selected column on cmd+click (without reordering)", () => {
+            const table = mountTable({
+                isColumnReorderable: true,
+                onColumnsReordered,
+                onSelection,
+                selectedRegions: [Regions.column(OLD_INDEX)],
+            });
+            const headerCell = getHeaderCell(getColumnHeadersWrapper(table), 0);
+            headerCell.mouse("mousedown", { metaKey: true }).mouse("mousemove", 0, OFFSET_Y);
+
+            const guide = table.find(`.${Classes.TABLE_VERTICAL_GUIDE}`);
+            expect(guide.exists(), "guide not drawn").be.false;
+
+            headerCell.mouse("mouseup", 0, OFFSET_Y);
+            expect(onSelection.called, "onSelection called").to.be.true;
+            expect(onSelection.calledWith([]), "onSelection called with []").to.be.true;
+            expect(onColumnsReordered.called, "onColumnsReordered not called").to.be.false;
+        });
+
+        it("Does not deselect a selected column when the reorder handle is cmd+click'd", () => {
+            const table = mountTable({
+                isColumnReorderable: true,
+                onColumnsReordered,
+                onSelection,
+            });
+            const headerCell = getHeaderCell(getColumnHeadersWrapper(table), 0);
+            const reorderHandle = getReorderHandle(headerCell);
+            reorderHandle
+                .mouse("mousedown", { metaKey: true })
+                .mouse("mousemove", getAdjustedOffsetX(OFFSET_X, reorderHandle))
+                .mouse("mouseup", getAdjustedOffsetX(OFFSET_X, reorderHandle));
+            expect(onColumnsReordered.called).to.be.true;
+            expect(onSelection.firstCall.calledWith([Regions.column(0)]));
+        });
+
         function mountTable(props: Partial<ITableProps>) {
             const table = harness.mount(
                 <div style={{ width: CONTAINER_WIDTH_IN_PX, height: CONTAINER_HEIGHT_IN_PX }}>


### PR DESCRIPTION
#### Fixes #1073, Addresses #1079

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

A morning surprise for @llorca.

- 🔄 __CHANGED__ `Table` no longer toggles selection on click; now, you must `cmd` + click to deselect cells, columns, or rows.
- 🐛 __FIXED__ `Table` `ctrl` + click now works on Windows again.

#### Reviewers should focus on:

- There was an edge case for rows due to the fact that selected rows become reorderable, meaning the `DragReorderable` component would swallow all clicks (even `cmd` + clicks meant for deselecting). The fix required a refactor of the `disabled?` prop to optionally be a function that accepts the current `MouseEvent`, so it can check if the `metaKey` is pressed.
- This isn't an issue for columns, because the reorder handle is the only trigger for reordering; the rest of the column header cell is managed by the `DragSelectable` layer.
- This isn't an issue for body cells either, because reordering isn't even a thing there.
- You can still start new drag-selections from an already-selected cell. 🎉


