### PR TITLE
[Submenus] Switch popover from relative to absolute positioning

### DIFF
--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -35,7 +35,7 @@
 
   // minor adjustments to popover position so top submenu item lines up with submenu trigger item
   .pt-popover {
-    position: relative;
+    position: absolute;
     top: -$half-grid-size;
     left: $half-grid-size;
 


### PR DESCRIPTION
#### Fixes #1668 

#### Checklist

- [ ] Include tests

#### Changes proposed in this pull request:

Change the `position` of submenu popovers to be `absolute` instead of `relative`

#### Reviewers should focus on:

Any particular reason why it was `relative` in the first place?
