### PR TITLE
[Table] Make editable cells fill cells vertically

### DIFF
--- a/packages/table/src/cell/_cell.scss
+++ b/packages/table/src/cell/_cell.scss
@@ -54,7 +54,8 @@
 .bp-table-editable-text {
   position: absolute;
   top: 0;
-  right: 10px;
+  right: 0;
   bottom: 0;
-  left: 10px;
+  left: 0;
+  padding: $cell-padding;
 }

--- a/packages/table/src/cell/_cell.scss
+++ b/packages/table/src/cell/_cell.scss
@@ -50,3 +50,11 @@
 .bp-table-editable-name input {
   height: $cell-height; // fixed height for IE11
 }
+
+.bp-table-editable-text {
+  position: absolute;
+  top: 0;
+  right: 10px;
+  bottom: 0;
+  left: 10px;
+}

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -93,7 +93,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
             cellContents = (
                 <EditableText
                     isEditing={true}
-                    className={Classes.TABLE_EDITABLE_NAME}
+                    className={classNames(Classes.TABLE_EDITABLE_TEXT, Classes.TABLE_EDITABLE_NAME)}
                     intent={spreadableProps.intent}
                     minWidth={null}
                     onCancel={this.handleCancel}
@@ -106,7 +106,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
                 />
             );
         } else {
-            const textClasses = classNames({
+            const textClasses = classNames(Classes.TABLE_EDITABLE_TEXT, {
                 [Classes.TABLE_TRUNCATED_TEXT]: truncated,
                 [Classes.TABLE_NO_WRAP_TEXT]: !wrapText,
             });

--- a/packages/table/src/common/classes.ts
+++ b/packages/table/src/common/classes.ts
@@ -23,6 +23,7 @@ export const TABLE_COLUMN_NAME_TEXT = "bp-table-column-name-text";
 export const TABLE_CONTAINER = "bp-table-container";
 export const TABLE_DRAGGING = "bp-table-dragging";
 export const TABLE_EDITABLE_NAME = "bp-table-editable-name";
+export const TABLE_EDITABLE_TEXT = "bp-table-editable-text";
 export const TABLE_FOCUS_REGION = "bp-table-focus-region";
 export const TABLE_HAS_INTERACTION_BAR = "bp-table-has-interaction-bar";
 export const TABLE_HAS_REORDER_HANDLE = "bp-table-has-reorder-handle";

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -314,11 +314,8 @@ $dark-selectable-header-menu-selected-hover-background:
 
       &.bp-table-editable-text {
         &::before {
-          top: -$cell-padding-vertical + $cell-border-width - 1px;
           right: $cell-border-width;
-          bottom: -$cell-padding-vertical + 1px;
           left: $cell-border-width - 1px;
-          cursor: $select-text-cursor;
         }
       }
     }

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -303,12 +303,24 @@ $dark-selectable-header-menu-selected-hover-background:
       box-shadow: none;
     }
 
-    &.pt-editable-editing::before {
-      top: -$cell-padding-vertical + $cell-border-width - 1px;
-      right: -$cell-padding-horizontal + $cell-border-width;
-      bottom: -$cell-padding-vertical + 1px;
-      left: -$cell-padding-horizontal + $cell-border-width - 1px;
-      cursor: $select-text-cursor;
+    &.pt-editable-editing {
+      &::before {
+        top: -$cell-padding-vertical + $cell-border-width - 1px;
+        right: -$cell-padding-horizontal + $cell-border-width;
+        bottom: -$cell-padding-vertical + 1px;
+        left: -$cell-padding-horizontal + $cell-border-width - 1px;
+        cursor: $select-text-cursor;
+      }
+
+      &.bp-table-editable-text {
+        &::before {
+          top: -$cell-padding-vertical + $cell-border-width - 1px;
+          right: $cell-border-width;
+          bottom: -$cell-padding-vertical + 1px;
+          left: $cell-border-width - 1px;
+          cursor: $select-text-cursor;
+        }
+      }
     }
   }
 

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { EditableText, IIntentProps, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
@@ -23,55 +23,37 @@ export interface IEditableNameProps extends IIntentProps, IProps {
      * important to listen to if you are doing anything with `onChange` events,
      * since you'll likely want to revert whatever changes you made.
      */
-    onCancel?: (value: string, columnIndex?: number) => void;
+    onCancel?: (value: string) => void;
 
     /**
      * A listener that is triggered as soon as the editable name is modified.
      * This can be due, for example, to keyboard input or the clipboard.
      */
-    onChange?: (value: string, columnIndex?: number) => void;
+    onChange?: (value: string) => void;
 
     /**
      * A listener that is triggered once the editing is confirmed. This is
      * usually due to the `return` (or `enter`) key press.
      */
-    onConfirm?: (value: string, columnIndex?: number) => void;
+    onConfirm?: (value: string) => void;
 }
 
 @PureRender
 export class EditableName extends React.Component<IEditableNameProps, {}> {
     public render() {
-        const { className, intent, name } = this.props;
+        const { className, intent, name, onCancel, onChange, onConfirm } = this.props;
         return (
             <EditableText
                 className={classNames(className, Classes.TABLE_EDITABLE_NAME)}
                 defaultValue={name}
                 intent={intent}
                 minWidth={null}
-                onCancel={this.handleCancel}
-                onChange={this.handleChange}
-                onConfirm={this.handleConfirm}
+                onCancel={onCancel}
+                onChange={onChange}
+                onConfirm={onConfirm}
                 placeholder=""
                 selectAllOnFocus={true}
             />
         );
-    }
-
-    private handleCancel = (value: string) => {
-        this.invokeCallback(this.props.onCancel, value);
-    };
-
-    private handleChange = (value: string) => {
-        this.invokeCallback(this.props.onChange, value);
-    };
-
-    private handleConfirm = (value: string) => {
-        this.invokeCallback(this.props.onConfirm, value);
-    };
-
-    private invokeCallback(callback: (value: string, rowIndex?: number, columnIndex?: number) => void, value: string) {
-        // pass through the row and column indices if they were provided as props by the consumer
-        // const { columnIndex } = this.props;
-        CoreUtils.safeInvoke(callback, value);
     }
 }

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
+import { EditableText, IIntentProps, IProps, Utils as CoreUtils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
@@ -23,37 +23,55 @@ export interface IEditableNameProps extends IIntentProps, IProps {
      * important to listen to if you are doing anything with `onChange` events,
      * since you'll likely want to revert whatever changes you made.
      */
-    onCancel?: (value: string) => void;
+    onCancel?: (value: string, columnIndex?: number) => void;
 
     /**
      * A listener that is triggered as soon as the editable name is modified.
      * This can be due, for example, to keyboard input or the clipboard.
      */
-    onChange?: (value: string) => void;
+    onChange?: (value: string, columnIndex?: number) => void;
 
     /**
      * A listener that is triggered once the editing is confirmed. This is
      * usually due to the `return` (or `enter`) key press.
      */
-    onConfirm?: (value: string) => void;
+    onConfirm?: (value: string, columnIndex?: number) => void;
 }
 
 @PureRender
 export class EditableName extends React.Component<IEditableNameProps, {}> {
     public render() {
-        const { className, intent, name, onCancel, onChange, onConfirm } = this.props;
+        const { className, intent, name } = this.props;
         return (
             <EditableText
                 className={classNames(className, Classes.TABLE_EDITABLE_NAME)}
                 defaultValue={name}
                 intent={intent}
                 minWidth={null}
-                onCancel={onCancel}
-                onChange={onChange}
-                onConfirm={onConfirm}
+                onCancel={this.handleCancel}
+                onChange={this.handleChange}
+                onConfirm={this.handleConfirm}
                 placeholder=""
                 selectAllOnFocus={true}
             />
         );
+    }
+
+    private handleCancel = (value: string) => {
+        this.invokeCallback(this.props.onCancel, value);
+    };
+
+    private handleChange = (value: string) => {
+        this.invokeCallback(this.props.onChange, value);
+    };
+
+    private handleConfirm = (value: string) => {
+        this.invokeCallback(this.props.onConfirm, value);
+    };
+
+    private invokeCallback(callback: (value: string, rowIndex?: number, columnIndex?: number) => void, value: string) {
+        // pass through the row and column indices if they were provided as props by the consumer
+        // const { columnIndex } = this.props;
+        CoreUtils.safeInvoke(callback, value);
     }
 }


### PR DESCRIPTION
#### Fixes #1235

#### Changes proposed in this pull request:

Make some style modifications to the surrounding div of the editable text, with a new class, to make it always horizontally fill the cell. Double-clicking anywhere in the cell will open the input now, and it takes up the whole space. 

#### Reviewers should focus on:

Is position: absolute really the best way of doing this? I'm not happy with it, but I couldn't come up with anything better. 
