### PR TITLE
[Core] Skip flaky test, add comments mentioning FLUP issue

### DIFF
--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -163,6 +163,8 @@ describe("<Overlay>", () => {
         const testsContainerElement = document.createElement("div");
         document.documentElement.appendChild(testsContainerElement);
 
+        // this test was flaky, but we should reenable eventually.
+        // see: https://github.com/palantir/blueprint/issues/1680
         it.skip("brings focus to overlay if autoFocus=true", done => {
             wrapper = mount(
                 <Overlay autoFocus={true} inline={false} isOpen={true}>

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -119,7 +119,9 @@ describe("Toaster", () => {
         assert.isFalse(errorSpy.calledWithMatch("two children with the same key"), "mutation side effect!");
     });
 
-    describe("with autoFocus set to true", () => {
+    // this test was flaky, but we should reenable eventually.
+    // see: https://github.com/palantir/blueprint/issues/1680
+    describe.skip("with autoFocus set to true", () => {
         before(() => {
             testsContainerElement = document.createElement("div");
             document.documentElement.appendChild(testsContainerElement);


### PR DESCRIPTION
#### Changes proposed in this pull request:

- __FIXED__ `Toaster` flaky test has been disabled until we can fix it.
    - Follow up issue: https://github.com/palantir/blueprint/issues/1680