### PR TITLE
[Core/Overlay] Fix overlay unmount issue that prevented scrolling

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -266,7 +266,9 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
                 if (lastOpenedOverlay.props.enforceFocus) {
                     document.addEventListener("focus", lastOpenedOverlay.handleDocumentFocus, /* useCapture */ true);
                 }
-            } else {
+            }
+
+            if (openStack.filter(o => !o.props.inline && o.props.hasBackdrop).length === 0) {
                 document.body.classList.remove(Classes.OVERLAY_OPEN);
             }
         }

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -336,6 +336,22 @@ describe("<Overlay>", () => {
             assertBodyScrollingDisabled(false, done);
         });
 
+        it("keeps scrolling disabled if hasBackdrop=true overlay exists following unmount", done => {
+            const backdropOverlay = mountOverlay(false, true);
+            wrapper = mountOverlay(false, true);
+            backdropOverlay.unmount();
+
+            assertBodyScrollingDisabled(true, done);
+        });
+
+        it("doesn't keep scrolling disabled if no hasBackdrop=true overlay exists following unmount", done => {
+            const backdropOverlay = mountOverlay(false, true);
+            wrapper = mountOverlay(false, false);
+            backdropOverlay.unmount();
+
+            assertBodyScrollingDisabled(false, done);
+        });
+
         function mountOverlay(inline: boolean, hasBackdrop: boolean) {
             return mount(
                 <Overlay hasBackdrop={hasBackdrop} inline={inline} isOpen={true}>


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests

#### Changes proposed in this pull request:

When overlays are unmounted, we currently only re-enable scrolling if there are no other overlays in the stack. However, if the none of the remaining overlays would prevent scrolling, we should also re-enable scrolling on unmount.

This has been causing the following issue:
1. A modal dialog is opened (which uses an overlay that prevents scrolling)
2. A user action triggers a toast (which also uses an overlay, but shouldn't prevent scrolling)
3. The dialog closes, but the toast remains visible. At this stage, scrolling should be re-enabled, but isn't.

#### Reviewers should focus on:

The new tests, and the logic for determining whether an overlay in the stack would prevent scrolling.
