### PR TITLE
[ColumnHeaderCell] Fix deprecated label on `useInteractionBar` prop

### DIFF
--- a/packages/docs/src/styles/_props.scss
+++ b/packages/docs/src/styles/_props.scss
@@ -33,12 +33,15 @@
 }
 
 .docs-prop-tags {
-  margin: $pt-grid-size 0 0;
+  $tag-top-margin: ($pt-grid-size / 10) * 3;
+
+  margin: ($pt-grid-size - $tag-top-margin) 0 0;
 
   &:empty { display: none; }
 
-  .pt-tag + .pt-tag {
-    margin-left: $pt-grid-size;
+  .pt-tag {
+    margin-top: $tag-top-margin;
+    margin-right: $pt-grid-size;
   }
 }
 

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -44,7 +44,7 @@ export interface IColumnNameProps {
      * clobbering the menu or other interactions.
      *
      * @default false
-     * @deprecated since @blueprintjs/table v1.27.0; pass this prop to `Table`
+     * @deprecated since blueprintjs/table v1.27.0; pass this prop to `Table`
      * instead. (If you don't, the `Table` will not be able to properly resize
      * the column header when `useInteractionBar` is toggled on and off.)
      */

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -45,8 +45,7 @@ export interface IColumnNameProps {
      *
      * @default false
      * @deprecated since blueprintjs/table v1.27.0; pass this prop to `Table`
-     * instead. (If you don't, the `Table` will not be able to properly resize
-     * the column header when `useInteractionBar` is toggled on and off.)
+     * instead.
      */
     useInteractionBar?: boolean;
 }


### PR DESCRIPTION
#### Fixes #1675

#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

- #1675 `ColumnHeaderCell`'s `useInteractionBar` deprecation label is no longer truncated.

#### Reviewers should focus on:

I changed some SCSS styles to add better handling for long tags in our prop descriptions.

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/443450/31351629-a54aab0c-ace0-11e7-8d76-e78500152c65.png)
