### PR TITLE
[Core] FormGroup component!

### DIFF
--- a/packages/core/src/components/forms/form-group.md
+++ b/packages/core/src/components/forms/form-group.md
@@ -4,6 +4,8 @@ Form groups support more complex form controls than [simple labels](#core/compon
 such as [control groups](#core/components/forms/control-group) or [`NumericInput`](#core/components/forms/numeric-input).
 They also support additional helper text to aid with user navigation.
 
+@## CSS API
+
 - Link each label to its respective control element with a `for={#id}` attribute on the `<label>` and
 `id={#id}` on the control.
 
@@ -15,3 +17,23 @@ Similar to labels, nested controls need to be styled separately.
 - Add `.pt-large` to `.pt-form-group` to align the label when used with large inline Blueprint controls.
 
 @css pt-form-group
+
+@## JavaScript API
+
+The `FormGroup` component is available in the __@blueprintjs/core__ package.
+Make sure to review the [general usage docs for JS components](#blueprint.usage).
+
+This component is a simple wrapper around the CSS API that abstracts away the HTML complexity.
+
+```tsx
+<FormGroup
+    helperText="Helper text with details..."
+    label="Label A"
+    labelFor="text-input"
+    required={true}
+>
+    <input id="text-input" placeholder="Placeholder text" />
+</FormGroup>
+```
+
+@interface IFormGroupProps

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -14,7 +14,7 @@ import { IIntentProps, IProps } from "../../common/props";
 export interface IFormGroupProps extends IIntentProps, IProps {
     /**
      * Whether form group should appear as non-interactive.
-     * Remember that input elements must be disabled separately.
+     * Remember that `input` elements must be disabled separately.
      */
     disabled?: boolean;
 
@@ -40,6 +40,7 @@ export interface IFormGroupProps extends IIntentProps, IProps {
      *
      * _Note:_ the default message element is exposed as `FormGroup.DEFAULT_REQUIRED_CONTENT` and
      * can be changed to provide a new global default for your app.
+     * @default false
      */
     requiredLabel?: boolean | React.ReactNode;
 }

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -41,7 +41,7 @@ export interface IFormGroupProps extends IIntentProps, IProps {
      * _Note:_ the default message element is exposed as `FormGroup.DEFAULT_REQUIRED_CONTENT` and
      * can be changed to provide a new global default for your app.
      */
-    required?: boolean | React.ReactNode;
+    requiredLabel?: boolean | React.ReactNode;
 }
 
 @PureRender
@@ -60,7 +60,7 @@ export class FormGroup extends React.Component<IFormGroupProps, {}> {
             <div className={this.getClassName()}>
                 <label className={Classes.LABEL} htmlFor={labelFor}>
                     {label}
-                    {this.maybeRenderRequired()}
+                    {this.maybeRenderRequiredLabel()}
                 </label>
                 <div className={Classes.FORM_CONTENT}>
                     {children}
@@ -83,9 +83,9 @@ export class FormGroup extends React.Component<IFormGroupProps, {}> {
         );
     }
 
-    private maybeRenderRequired() {
-        const { required } = this.props;
-        return required === true ? FormGroup.DEFAULT_REQUIRED_CONTENT : required;
+    private maybeRenderRequiredLabel() {
+        const { requiredLabel } = this.props;
+        return requiredLabel === true ? FormGroup.DEFAULT_REQUIRED_CONTENT : requiredLabel;
     }
 
     private maybeRenderHelperText() {

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
+import * as React from "react";
+import * as Classes from "../../common/classes";
+import { IIntentProps, IProps } from "../../common/props";
+
+export interface IFormGroupProps extends IIntentProps, IProps {
+    /**
+     * Whether form group should appear as non-interactive.
+     * Remember that input elements must be disabled separately
+     */
+    disabled?: boolean;
+
+    /** Optional helper text. Will be wrapped in `.pt-form-helper-text` and displayed beneath `children`. */
+    helperText?: React.ReactNode;
+
+    /** Whether to render label and control on a single line. */
+    inline?: boolean;
+
+    /** Label of this form group */
+    label?: React.ReactNode;
+
+    /**
+     * `id` attribute of the labelable form element that this `FormGroup` controls,
+     * used as `<label for>` attribute.
+     */
+    labelFor?: string;
+
+    /**
+     * Whether this form input should appear as required (does not affect HTML form required status).
+     * Providing a boolean value will render a default "required" message after the `label` prop.
+     * Providing a JSX value will render that content instead.
+     *
+     * Note: the default message element is exposed as `FormGroup.DEFAULT_REQUIRED_CONTENT` and
+     * can be changed to provide a new global default for your app.
+     */
+    required?: boolean | React.ReactNode;
+}
+
+@PureRender
+export class FormGroup extends React.Component<IFormGroupProps, {}> {
+    /**
+     * Element used to render `required` message when a boolean value is provided for that prop.
+     * Modifying the value of this property will change the default globally in your app.
+     *
+     * Defaults to `<span class="pt-text-muted">(required)</span>`.
+     */
+    public static DEFAULT_REQUIRED_CONTENT = <span className={Classes.TEXT_MUTED}>(required)</span>;
+
+    public render() {
+        const { children, helperText, label, labelFor } = this.props;
+        return (
+            <div className={this.getClassName()}>
+                <label className={Classes.LABEL} htmlFor={labelFor}>
+                    {label}
+                    {this.maybeRenderRequired()}
+                </label>
+                <div className={Classes.FORM_CONTENT}>
+                    {children}
+                    {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}
+                </div>
+            </div>
+        );
+    }
+
+    private getClassName() {
+        const { className, disabled, inline, intent } = this.props;
+        return classNames(
+            Classes.FORM_GROUP,
+            Classes.intentClass(intent),
+            {
+                [Classes.DISABLED]: disabled,
+                [Classes.INLINE]: inline,
+            },
+            className,
+        );
+    }
+
+    private maybeRenderRequired() {
+        const { required } = this.props;
+        if (required === true) {
+            return FormGroup.DEFAULT_REQUIRED_CONTENT;
+        } else {
+            return required;
+        }
+    }
+}

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -18,7 +18,7 @@ export interface IFormGroupProps extends IIntentProps, IProps {
      */
     disabled?: boolean;
 
-    /** Optional helper text. Will be wrapped in `.pt-form-helper-text` and displayed beneath `children`. */
+    /** Optional helper text. The given content will be wrapped in `.pt-form-helper-text` and displayed beneath `children`. */
     helperText?: React.ReactNode;
 
     /** Whether to render the label and children on a single line. */

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -14,17 +14,17 @@ import { IIntentProps, IProps } from "../../common/props";
 export interface IFormGroupProps extends IIntentProps, IProps {
     /**
      * Whether form group should appear as non-interactive.
-     * Remember that input elements must be disabled separately
+     * Remember that input elements must be disabled separately.
      */
     disabled?: boolean;
 
     /** Optional helper text. Will be wrapped in `.pt-form-helper-text` and displayed beneath `children`. */
     helperText?: React.ReactNode;
 
-    /** Whether to render label and control on a single line. */
+    /** Whether to render the label and children on a single line. */
     inline?: boolean;
 
-    /** Label of this form group */
+    /** Label of this form group. */
     label?: React.ReactNode;
 
     /**
@@ -35,10 +35,10 @@ export interface IFormGroupProps extends IIntentProps, IProps {
 
     /**
      * Whether this form input should appear as required (does not affect HTML form required status).
-     * Providing a boolean value will render a default "required" message after the `label` prop.
+     * Providing a boolean `true` value will render a default "required" message after the `label` prop.
      * Providing a JSX value will render that content instead.
      *
-     * Note: the default message element is exposed as `FormGroup.DEFAULT_REQUIRED_CONTENT` and
+     * _Note:_ the default message element is exposed as `FormGroup.DEFAULT_REQUIRED_CONTENT` and
      * can be changed to provide a new global default for your app.
      */
     required?: boolean | React.ReactNode;
@@ -55,7 +55,7 @@ export class FormGroup extends React.Component<IFormGroupProps, {}> {
     public static DEFAULT_REQUIRED_CONTENT = <span className={Classes.TEXT_MUTED}>(required)</span>;
 
     public render() {
-        const { children, helperText, label, labelFor } = this.props;
+        const { children, label, labelFor } = this.props;
         return (
             <div className={this.getClassName()}>
                 <label className={Classes.LABEL} htmlFor={labelFor}>
@@ -64,7 +64,7 @@ export class FormGroup extends React.Component<IFormGroupProps, {}> {
                 </label>
                 <div className={Classes.FORM_CONTENT}>
                     {children}
-                    {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}
+                    {this.maybeRenderHelperText()}
                 </div>
             </div>
         );
@@ -85,10 +85,14 @@ export class FormGroup extends React.Component<IFormGroupProps, {}> {
 
     private maybeRenderRequired() {
         const { required } = this.props;
-        if (required === true) {
-            return FormGroup.DEFAULT_REQUIRED_CONTENT;
-        } else {
-            return required;
+        return required === true ? FormGroup.DEFAULT_REQUIRED_CONTENT : required;
+    }
+
+    private maybeRenderHelperText() {
+        const { helperText } = this.props;
+        if (!helperText) {
+            return null;
         }
+        return <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>;
     }
 }

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -25,6 +25,7 @@ export * from "./context-menu/contextMenuTarget";
 export * from "./dialog/dialog";
 export * from "./editable-text/editableText";
 export * from "./forms/controls";
+export * from "./forms/formGroup";
 export * from "./forms/inputGroup";
 export * from "./forms/numericInput";
 export * from "./forms/radioGroup";

--- a/packages/core/test/forms/formGroupTests.tsx
+++ b/packages/core/test/forms/formGroupTests.tsx
@@ -36,14 +36,14 @@ describe("<FormGroup>", () => {
         assert.strictEqual(label.prop("htmlFor"), "foo");
     });
 
-    it("required=true renders default required content in label", () => {
-        const label = shallow(<FormGroup label="label" required={true} />).find("label");
+    it("requiredLabel=true renders default required content in label", () => {
+        const label = shallow(<FormGroup label="label" requiredLabel={true} />).find("label");
         assert.isTrue(label.containsMatchingElement(FormGroup.DEFAULT_REQUIRED_CONTENT));
     });
 
-    it("required=JSX renders JSX content in label", () => {
+    it("requiredLabel=JSX renders JSX content in label", () => {
         const required = <em>fill me out</em>;
-        const label = shallow(<FormGroup label="label" required={required} />).find("label");
+        const label = shallow(<FormGroup label="label" requiredLabel={required} />).find("label");
         assert.isTrue(label.containsMatchingElement(required));
     });
 

--- a/packages/core/test/forms/formGroupTests.tsx
+++ b/packages/core/test/forms/formGroupTests.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { assert } from "chai";
+import { shallow } from "enzyme";
+import * as React from "react";
+
+import { Classes, FormGroup, Intent } from "../../src/index";
+
+describe("<FormGroup>", () => {
+    it("supports className & intent", () => {
+        const wrapper = shallow(<FormGroup className="foo" intent={Intent.SUCCESS} />);
+        assert.isTrue(wrapper.hasClass(Classes.FORM_GROUP));
+        assert.isTrue(wrapper.hasClass(Classes.INTENT_SUCCESS));
+        assert.isTrue(wrapper.hasClass("foo"));
+    });
+
+    it("renders children in form content", () => {
+        const wrapper = shallow(
+            <FormGroup>
+                <input id="yes" />
+            </FormGroup>,
+        );
+        const content = wrapper.find(`.${Classes.FORM_CONTENT}`);
+        assert.strictEqual(content.find("input").prop("id"), "yes");
+    });
+
+    it("renders label & labelFor", () => {
+        const labelText = "This is the label.";
+        const label = shallow(<FormGroup label={labelText} labelFor="foo" />).find("label");
+        assert.strictEqual(label.text(), labelText);
+        assert.strictEqual(label.prop("htmlFor"), "foo");
+    });
+
+    it("required=true renders default required content in label", () => {
+        const label = shallow(<FormGroup label="label" required={true} />).find("label");
+        assert.isTrue(label.containsMatchingElement(FormGroup.DEFAULT_REQUIRED_CONTENT));
+    });
+
+    it("required=JSX renders JSX content in label", () => {
+        const required = <em>fill me out</em>;
+        const label = shallow(<FormGroup label="label" required={required} />).find("label");
+        assert.isTrue(label.containsMatchingElement(required));
+    });
+
+    it("renders helperText", () => {
+        const helperText = "Help me out";
+        const wrapper = shallow(<FormGroup helperText={helperText} />);
+        const helper = wrapper.find(`.${Classes.FORM_HELPER_TEXT}`);
+        assert.strictEqual(helper.text(), helperText);
+    });
+});

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -18,6 +18,7 @@ import "./controls/numericInputTests";
 import "./controls/radioGroupTests";
 import "./dialog/dialogTests";
 import "./editable-text/editableTextTests";
+import "./forms/formGroupTests";
 import "./hotkeys/hotkeysTests";
 import "./icon/iconTests";
 import "./menu/menuTests";


### PR DESCRIPTION
#### Changes proposed in this pull request:

add `FormGroup` component + tests + docs

#### Reviewers should focus on:

this component _does not support_ HTML props spread because it renders so many elements and we'd have several prop types conflicts (label, required, disabled).

took some creative liberties with the `required` implementation.
