### PR TITLE
Revert "Revert "[DateTime] Add dayPickerProps to datetime components""

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -8,6 +8,7 @@
 import * as classNames from "classnames";
 import * as moment from "moment";
 import * as React from "react";
+import * as ReactDayPicker from "react-day-picker";
 
 import {
     AbstractComponent,
@@ -48,6 +49,16 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
      * @default true
      */
     closeOnSelection?: boolean;
+
+    /**
+     * Props to pass to ReactDayPicker. See API documentation
+     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     *
+     * The following props are managed by the component and cannot be configured:
+     * `canChangeMonth`, `captionElement`, `fromMonth` (use `minDate`), `month` (use
+     * `initialMonth`), `toMonth` (use `maxDate`).
+     */
+    dayPickerProps?: ReactDayPicker.Props;
 
     /**
      * Whether the date input is non-interactive.
@@ -147,6 +158,7 @@ export interface IDateInputState {
 export class DateInput extends AbstractComponent<IDateInputProps, IDateInputState> {
     public static defaultProps: IDateInputProps = {
         closeOnSelection: true,
+        dayPickerProps: {},
         disabled: false,
         format: "YYYY-MM-DD",
         invalidDateMessage: "Invalid date",

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -25,6 +25,16 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     canClearSelection?: boolean;
 
     /**
+     * Props to pass to ReactDayPicker. See API documentation
+     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     *
+     * The following props are managed by the component and cannot be configured:
+     * `canChangeMonth`, `captionElement`, `fromMonth` (use `minDate`), `month` (use
+     * `initialMonth`), `toMonth` (use `maxDate`).
+     */
+    dayPickerProps?: ReactDayPicker.Props;
+
+    /**
      * Initial day the calendar will display as selected.
      * This should not be set if `value` is set.
      */
@@ -61,6 +71,7 @@ export interface IDatePickerState {
 export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerState> {
     public static defaultProps: IDatePickerProps = {
         canClearSelection: true,
+        dayPickerProps: {},
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         showActionsBar: false,
@@ -106,20 +117,30 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
     }
 
     public render() {
-        const { className, locale, localeUtils, maxDate, minDate, showActionsBar } = this.props;
+        const {
+            className,
+            dayPickerProps,
+            locale,
+            localeUtils,
+            maxDate,
+            minDate,
+            modifiers,
+            showActionsBar,
+        } = this.props;
         const { displayMonth, displayYear } = this.state;
 
         return (
             <div className={classNames(Classes.DATEPICKER, className)}>
                 <ReactDayPicker
-                    canChangeMonth={true}
-                    captionElement={this.renderCaption}
-                    disabledDays={this.disabledDays}
                     enableOutsideDays={true}
-                    fromMonth={minDate}
                     locale={locale}
                     localeUtils={localeUtils}
-                    modifiers={this.props.modifiers}
+                    modifiers={modifiers}
+                    {...dayPickerProps}
+                    canChangeMonth={true}
+                    captionElement={this.renderCaption}
+                    disabledDays={this.getDisabledDaysModifier()}
+                    fromMonth={minDate}
                     month={new Date(displayYear, displayMonth)}
                     onDayClick={this.handleDayClick}
                     onMonthChange={this.handleMonthChange}
@@ -171,6 +192,12 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
 
     private disabledDays = (day: Date) => !DateUtils.isDayInRange(day, [this.props.minDate, this.props.maxDate]);
 
+    private getDisabledDaysModifier = () => {
+        const { dayPickerProps: { disabledDays } } = this.props;
+
+        return disabledDays instanceof Array ? [this.disabledDays, ...disabledDays] : [this.disabledDays, disabledDays];
+    };
+
     private renderCaption = (props: ReactDayPicker.CaptionElementProps) => (
         <DatePickerCaption
             {...props}
@@ -198,7 +225,13 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
         );
     }
 
-    private handleDayClick = (day: Date, modifiers: ReactDayPicker.DayModifiers) => {
+    private handleDayClick = (
+        day: Date,
+        modifiers: ReactDayPicker.DayModifiers,
+        e: React.MouseEvent<HTMLDivElement>,
+    ) => {
+        Utils.safeInvoke(this.props.dayPickerProps.onDayClick, day, modifiers, e);
+
         let newValue = day;
 
         if (this.props.canClearSelection && modifiers.selected) {
@@ -268,6 +301,8 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
             }
         }
 
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, value);
+
         this.setStateWithValueIfUncontrolled({ displayMonth, displayYear }, value);
     };
 
@@ -278,6 +313,8 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
             value = this.computeValidDateInSpecifiedMonthYear(value.getFullYear(), displayMonth);
             Utils.safeInvoke(this.props.onChange, value, false);
         }
+
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, value);
 
         this.setStateWithValueIfUncontrolled({ displayMonth }, value);
     };
@@ -302,6 +339,8 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
                 displayMonth = maxMonth;
             }
         }
+
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, value);
 
         this.setStateWithValueIfUncontrolled({ displayMonth, displayYear }, value);
     };

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -8,6 +8,7 @@
 import * as classNames from "classnames";
 import * as moment from "moment";
 import * as React from "react";
+import * as ReactDayPicker from "react-day-picker";
 
 import {
     AbstractComponent,
@@ -60,6 +61,16 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IProps {
      * @default true
      */
     contiguousCalendarMonths?: boolean;
+
+    /**
+     * Props to pass to ReactDayPicker. See API documentation
+     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     *
+     * The following props are managed by the component and cannot be configured:
+     * `canChangeMonth`, `captionElement`, `numberOfMonths`, `fromMonth` (use
+     * `minDate`), `month` (use `initialMonth`), `toMonth` (use `maxDate`).
+     */
+    dayPickerProps?: ReactDayPicker.Props;
 
     /**
      * The default date range to be used in the component when uncontrolled.
@@ -207,6 +218,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         allowSingleDayRange: false,
         closeOnSelection: true,
         contiguousCalendarMonths: true,
+        dayPickerProps: {},
         disabled: false,
         endInputProps: {},
         format: "YYYY-MM-DD",

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -8,7 +8,7 @@
 import { AbstractComponent, Classes, IProps, Menu, MenuItem, Utils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
-import * as DayPicker from "react-day-picker";
+import * as ReactDayPicker from "react-day-picker";
 
 import * as DateClasses from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -58,6 +58,15 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * @default true
      */
     contiguousCalendarMonths?: boolean;
+    /**
+     * Props to pass to ReactDayPicker. See API documentation
+     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     *
+     * The following props are managed by the component and cannot be configured:
+     * `canChangeMonth`, `captionElement`, `numberOfMonths`, `fromMonth` (use
+     * `minDate`), `month` (use `initialMonth`), `toMonth` (use `maxDate`).
+     */
+    dayPickerProps?: ReactDayPicker.Props;
 
     /**
      * Initial `DateRange` the calendar will display as selected.
@@ -108,6 +117,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
     public static defaultProps: IDateRangePickerProps = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,
+        dayPickerProps: {},
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
         shortcuts: true,
@@ -197,17 +207,27 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
 
     public render() {
         const modifiers = combineModifiers(this.modifiers, this.props.modifiers);
-        const { className, contiguousCalendarMonths, locale, localeUtils, maxDate, minDate } = this.props;
+        const {
+            className,
+            contiguousCalendarMonths,
+            dayPickerProps,
+            locale,
+            localeUtils,
+            maxDate,
+            minDate,
+        } = this.props;
         const isShowingOneMonth = DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
 
         const { leftView, rightView } = this.state;
-        const disabledDays = [{ before: this.props.minDate }, { after: this.props.maxDate }];
+        const disabledDays = this.getDisabledDaysModifier();
 
-        const dayPickerBaseProps: DayPicker.Props = {
-            disabledDays,
+        const dayPickerBaseProps: ReactDayPicker.Props = {
+            enableOutsideDays: true,
             locale,
             localeUtils,
             modifiers,
+            ...dayPickerProps,
+            disabledDays,
             onDayClick: this.handleDayClick,
             onDayMouseEnter: this.handleDayMouseEnter,
             onDayMouseLeave: this.handleDayMouseLeave,
@@ -223,7 +243,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             return (
                 <div className={classes}>
                     {this.maybeRenderShortcuts()}
-                    <DayPicker
+                    <ReactDayPicker
                         {...dayPickerBaseProps}
                         captionElement={this.renderSingleCaption}
                         fromMonth={minDate}
@@ -238,7 +258,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             return (
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
                     {this.maybeRenderShortcuts()}
-                    <DayPicker
+                    <ReactDayPicker
                         {...dayPickerBaseProps}
                         canChangeMonth={true}
                         captionElement={this.renderLeftCaption}
@@ -247,7 +267,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
                         onMonthChange={this.handleLeftMonthChange}
                         toMonth={DateUtils.getDatePreviousMonth(maxDate)}
                     />
-                    <DayPicker
+                    <ReactDayPicker
                         {...dayPickerBaseProps}
                         canChangeMonth={true}
                         captionElement={this.renderRightCaption}
@@ -304,6 +324,14 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         }
     }
 
+    private disabledDays = (day: Date) => !DateUtils.isDayInRange(day, [this.props.minDate, this.props.maxDate]);
+
+    private getDisabledDaysModifier = () => {
+        const { dayPickerProps: { disabledDays } } = this.props;
+
+        return disabledDays instanceof Array ? [this.disabledDays, ...disabledDays] : [this.disabledDays, disabledDays];
+    };
+
     private maybeRenderShortcuts() {
         const propsShortcuts = this.props.shortcuts;
         if (propsShortcuts == null || propsShortcuts === false) {
@@ -326,7 +354,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         return <Menu className={DateClasses.DATERANGEPICKER_SHORTCUTS}>{shortcutElements}</Menu>;
     }
 
-    private renderSingleCaption = (captionProps: DayPicker.CaptionElementProps) => (
+    private renderSingleCaption = (captionProps: ReactDayPicker.CaptionElementProps) => (
         <DatePickerCaption
             {...captionProps}
             maxDate={this.props.maxDate}
@@ -336,7 +364,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         />
     );
 
-    private renderLeftCaption = (captionProps: DayPicker.CaptionElementProps) => (
+    private renderLeftCaption = (captionProps: ReactDayPicker.CaptionElementProps) => (
         <DatePickerCaption
             {...captionProps}
             maxDate={DateUtils.getDatePreviousMonth(this.props.maxDate)}
@@ -346,7 +374,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         />
     );
 
-    private renderRightCaption = (captionProps: DayPicker.CaptionElementProps) => (
+    private renderRightCaption = (captionProps: ReactDayPicker.CaptionElementProps) => (
         <DatePickerCaption
             {...captionProps}
             maxDate={this.props.maxDate}
@@ -356,7 +384,13 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         />
     );
 
-    private handleDayMouseEnter = (day: Date, modifiers: DayPicker.DayModifiers) => {
+    private handleDayMouseEnter = (
+        day: Date,
+        modifiers: ReactDayPicker.DayModifiers,
+        e: React.MouseEvent<HTMLDivElement>,
+    ) => {
+        Utils.safeInvoke(this.props.dayPickerProps.onDayMouseEnter, day, modifiers, e);
+
         if (modifiers.disabled) {
             return;
         }
@@ -370,7 +404,12 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         Utils.safeInvoke(this.props.onHoverChange, dateRange, day, boundary);
     };
 
-    private handleDayMouseLeave = (day: Date, modifiers: DayPicker.DayModifiers) => {
+    private handleDayMouseLeave = (
+        day: Date,
+        modifiers: ReactDayPicker.DayModifiers,
+        e: React.MouseEvent<HTMLDivElement>,
+    ) => {
+        Utils.safeInvoke(this.props.dayPickerProps.onDayMouseLeave, day, modifiers, e);
         if (modifiers.disabled) {
             return;
         }
@@ -378,7 +417,13 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         Utils.safeInvoke(this.props.onHoverChange, undefined, day, undefined);
     };
 
-    private handleDayClick = (day: Date, modifiers: DayPicker.DayModifiers) => {
+    private handleDayClick = (
+        day: Date,
+        modifiers: ReactDayPicker.DayModifiers,
+        e: React.MouseEvent<HTMLDivElement>,
+    ) => {
+        Utils.safeInvoke(this.props.dayPickerProps.onDayClick, day, modifiers, e);
+
         if (modifiers.disabled) {
             // rerender base component to get around bug where you can navigate past bounds by clicking days
             this.forceUpdate();
@@ -394,7 +439,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
 
         // update the hovered date range after click to show the newly selected
         // state, at leasts until the mouse moves again
-        this.handleDayMouseEnter(day, modifiers);
+        this.handleDayMouseEnter(day, modifiers, e);
 
         this.handleNextState(nextValue);
     };
@@ -416,21 +461,25 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
 
     private handleLeftMonthChange = (newDate: Date) => {
         const leftView = new MonthAndYear(newDate.getMonth(), newDate.getFullYear());
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, leftView.getFullDate());
         this.updateLeftView(leftView);
     };
 
     private handleRightMonthChange = (newDate: Date) => {
         const rightView = new MonthAndYear(newDate.getMonth(), newDate.getFullYear());
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, rightView.getFullDate());
         this.updateRightView(rightView);
     };
 
     private handleLeftMonthSelectChange = (leftMonth: number) => {
         const leftView = new MonthAndYear(leftMonth, this.state.leftView.getYear());
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, leftView.getFullDate());
         this.updateLeftView(leftView);
     };
 
     private handleRightMonthSelectChange = (rightMonth: number) => {
         const rightView = new MonthAndYear(rightMonth, this.state.rightView.getYear());
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, rightView.getFullDate());
         this.updateRightView(rightView);
     };
 
@@ -459,6 +508,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
     */
     private handleLeftYearSelectChange = (leftDisplayYear: number) => {
         let leftView = new MonthAndYear(this.state.leftView.getMonth(), leftDisplayYear);
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, leftView.getFullDate());
         const { minDate, maxDate } = this.props;
         const adjustedMaxDate = DateUtils.getDatePreviousMonth(maxDate);
 
@@ -481,6 +531,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
 
     private handleRightYearSelectChange = (rightDisplayYear: number) => {
         let rightView = new MonthAndYear(this.state.rightView.getMonth(), rightDisplayYear);
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, rightView.getFullDate());
         const { minDate, maxDate } = this.props;
         const adjustedMinDate = DateUtils.getDateNextMonth(minDate);
 

--- a/packages/datetime/test/common/dateTestUtils.ts
+++ b/packages/datetime/test/common/dateTestUtils.ts
@@ -6,7 +6,9 @@
  */
 
 import { assert } from "chai";
+import { ReactWrapper } from "enzyme";
 import { padWithZeroes } from "../../src/common/utils";
+import { Classes } from "../../src/index";
 
 /**
  * Converts a date to a "YYYY-MM-DD" string without relying on moment.js.
@@ -28,6 +30,9 @@ export function createTimeObject(hour: number, minute: number = 0, second: numbe
     return new Date(IGNORED_YEAR, IGNORED_MONTH, IGNORED_DAY, hour, minute, second, millisecond);
 }
 
+const isDayHidden = (day: ReactWrapper<any, any>): boolean =>
+    day.prop("empty") && !day.prop("ariaSelected") && day.prop("ariaDisabled");
+
 export function assertTimeIs(time: Date, hours: number, minutes: number, seconds?: number, milliseconds?: number) {
     assert.strictEqual(time.getHours(), hours);
     assert.strictEqual(time.getMinutes(), minutes);
@@ -37,4 +42,16 @@ export function assertTimeIs(time: Date, hours: number, minutes: number, seconds
     if (milliseconds != null) {
         assert.strictEqual(time.getMilliseconds(), milliseconds);
     }
+}
+
+export function assertDatesEqual(a: Date, b: Date) {
+    assert.isTrue(a.getDay() === b.getDay() && a.getMonth() === b.getMonth() && a.getFullYear() === b.getFullYear());
+}
+
+export function assertDayDisabled(day: ReactWrapper<any, any>, expectDisabled: boolean = true) {
+    assert.equal(day.hasClass(Classes.DATEPICKER_DAY_DISABLED), expectDisabled);
+}
+
+export function assertDayHidden(day: ReactWrapper<any, any>, expectHidden: boolean = true) {
+    assert.equal(isDayHidden(day), expectHidden);
 }

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -8,12 +8,14 @@
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
+import { LocaleUtils } from "react-day-picker";
 
 import { Button } from "@blueprintjs/core";
 import * as DateUtils from "../src/common/dateUtils";
 import * as Errors from "../src/common/errors";
 import { Months } from "../src/common/months";
-import { Classes, DatePicker } from "../src/index";
+import { Classes, DatePicker, IDatePickerModifiers, IDatePickerProps } from "../src/index";
+import { assertDatesEqual, assertDayDisabled, assertDayHidden } from "./common/dateTestUtils";
 
 describe("<DatePicker>", () => {
     it(`renders .${Classes.DATEPICKER}`, () => {
@@ -24,6 +26,156 @@ describe("<DatePicker>", () => {
         const { getSelectedDays, root } = wrap(<DatePicker />);
         assert.lengthOf(getSelectedDays(), 0);
         assert.isUndefined(root.state("selectedDay"));
+    });
+
+    describe("reconciliates dayPickerProps", () => {
+        it("week starts with firstDayOfWeek value", () => {
+            const selectedFirstDay = 3;
+            const wrapper = mount(<DatePicker dayPickerProps={{ firstDayOfWeek: selectedFirstDay }} />);
+            const firstWeekday = wrapper.find("Weekday").first();
+            assert.equal(firstWeekday.prop("weekday"), selectedFirstDay);
+        });
+
+        it("shows outside days by default", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const firstDayInView = new Date(2017, Months.AUGUST, 27, 12, 0);
+            const wrapper = mount(<DatePicker defaultValue={defaultValue} />);
+            const firstDay = wrapper.find("Day").first();
+            assertDatesEqual(new Date(firstDay.prop("day")), firstDayInView);
+        });
+
+        it("doesn't show outside days if enableOutsideDays=false", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1, 12);
+            const wrapper = mount(
+                <DatePicker defaultValue={defaultValue} dayPickerProps={{ enableOutsideDays: false }} />,
+            );
+            const days = wrapper.find("Day");
+
+            assertDayHidden(days.at(0));
+            assertDayHidden(days.at(1));
+            assertDayHidden(days.at(2));
+            assertDayHidden(days.at(3));
+            assertDayHidden(days.at(4));
+            assertDayHidden(days.at(5), false);
+        });
+
+        it("disables days according to custom modifiers in addition to default modifiers", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const disableFridays = { daysOfWeek: [5] };
+            const { getDay } = wrap(
+                <DatePicker
+                    defaultValue={defaultValue}
+                    maxDate={new Date(2017, Months.SEPTEMBER, 20)}
+                    dayPickerProps={{ disabledDays: disableFridays }}
+                />,
+            );
+            assertDayDisabled(getDay(15));
+            assertDayDisabled(getDay(21));
+            assertDayDisabled(getDay(10), false);
+        });
+
+        it("disables out-of-range max dates", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const { getDay } = wrap(
+                <DatePicker defaultValue={defaultValue} maxDate={new Date(2017, Months.SEPTEMBER, 20)} />,
+            );
+            assertDayDisabled(getDay(21));
+            assertDayDisabled(getDay(10), false);
+        });
+
+        it("disables out-of-range min dates", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const { getDay, root } = wrap(
+                <DatePicker defaultValue={defaultValue} minDate={new Date(2017, Months.AUGUST, 20)} />,
+            );
+            const prevMonthButton = root.find(".DayPicker-NavButton--prev").first();
+            prevMonthButton.simulate("click");
+            assertDayDisabled(getDay(10));
+            assertDayDisabled(getDay(21), false);
+        });
+
+        it("allows top-level locale, localeUtils, and modifiers to be overridden by same props in dayPickerProps", () => {
+            const blueprintModifiers: IDatePickerModifiers = {
+                blueprint: () => true,
+            };
+            const blueprintLocaleUtils = {
+                ...LocaleUtils,
+                formatDay: () => "b",
+            };
+            const blueprintProps: IDatePickerProps = {
+                locale: "blueprint",
+                localeUtils: blueprintLocaleUtils,
+                modifiers: blueprintModifiers,
+            };
+
+            const dayPickerModifiers: IDatePickerModifiers = {
+                dayPicker: () => true,
+            };
+            const dayPickerLocaleUtils = {
+                ...LocaleUtils,
+                formatDay: () => "d",
+            };
+            const dayPickerProps: IDatePickerProps = {
+                locale: "dayPicker",
+                localeUtils: dayPickerLocaleUtils,
+                modifiers: dayPickerModifiers,
+            };
+
+            const wrapper = mount(<DatePicker {...blueprintProps} dayPickerProps={dayPickerProps} />);
+            const DayPicker = wrapper.find("DayPicker").first();
+            assert.equal(DayPicker.prop("locale"), dayPickerProps.locale);
+            assert.equal(DayPicker.prop("localeUtils"), dayPickerProps.localeUtils);
+            assert.equal(DayPicker.prop("modifiers"), dayPickerProps.modifiers);
+        });
+
+        describe("event handlers", () => {
+            it("calls onMonthChange on button next click", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(<DatePicker dayPickerProps={{ onMonthChange }} />);
+                root
+                    .find(".DayPicker-NavButton--next")
+                    .first()
+                    .simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(<DatePicker dayPickerProps={{ onMonthChange }} />);
+                root
+                    .find(".DayPicker-NavButton--prev")
+                    .first()
+                    .simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on month select change", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(<DatePicker dayPickerProps={{ onMonthChange }} />);
+                root
+                    .find({ className: Classes.DATEPICKER_MONTH_SELECT })
+                    .first()
+                    .simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on year select change", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(<DatePicker dayPickerProps={{ onMonthChange }} />);
+                root
+                    .find({ className: Classes.DATEPICKER_YEAR_SELECT })
+                    .first()
+                    .simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onDayClick", () => {
+                const onDayClick = sinon.spy();
+                const { getDay } = wrap(<DatePicker dayPickerProps={{ onDayClick }} />);
+                getDay().simulate("click");
+                assert.isTrue(onDayClick.called);
+            });
+        });
     });
 
     it("user-provided modifiers are applied", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -7,7 +7,9 @@
 
 import { Classes } from "@blueprintjs/core";
 import { assert } from "chai";
+import { mount } from "enzyme";
 import * as React from "react";
+import * as ReactDayPicker from "react-day-picker";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 
@@ -15,7 +17,14 @@ import * as DateUtils from "../src/common/dateUtils";
 import * as Errors from "../src/common/errors";
 import { Months } from "../src/common/months";
 import { IDateRangeShortcut } from "../src/dateRangePicker";
-import { Classes as DateClasses, DateRange, DateRangePicker, IDateRangePickerProps } from "../src/index";
+import {
+    Classes as DateClasses,
+    DateRange,
+    DateRangePicker,
+    IDatePickerModifiers,
+    IDateRangePickerProps,
+} from "../src/index";
+import { assertDatesEqual, assertDayDisabled, assertDayHidden } from "./common/dateTestUtils";
 
 describe("<DateRangePicker>", () => {
     let testsContainerElement: Element;
@@ -50,6 +59,219 @@ describe("<DateRangePicker>", () => {
 
         assert.isFalse(getDayElement(4).classList.contains("DayPicker-Day--odd"));
         assert.isTrue(getDayElement(5).classList.contains("DayPicker-Day--odd"));
+    });
+
+    describe("reconciliates dayPickerProps", () => {
+        it("week starts with firstDayOfWeek value", () => {
+            const selectedFirstDay = 3;
+            const wrapper = mount(<DateRangePicker dayPickerProps={{ firstDayOfWeek: selectedFirstDay }} />);
+            const firstWeekday = wrapper.find("Weekday").first();
+            assert.equal(firstWeekday.prop("weekday"), selectedFirstDay);
+        });
+
+        it("shows outside days by default", () => {
+            const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
+            const firstDayInView = new Date(2017, Months.AUGUST, 27, 12, 0);
+            const { leftView } = wrap(<DateRangePicker defaultValue={defaultValue} />);
+            const firstDay = leftView.find("Day").first();
+            assertDatesEqual(new Date(firstDay.prop("day")), firstDayInView);
+        });
+
+        it("doesn't show outside days if enableOutsideDays=false", () => {
+            const defaultValue = [new Date(2017, Months.SEPTEMBER, 1, 12), null] as DateRange;
+            const { leftView, rightView } = wrap(
+                <DateRangePicker defaultValue={defaultValue} dayPickerProps={{ enableOutsideDays: false }} />,
+            );
+            const leftDays = leftView.find("Day");
+            const rightDays = rightView.find("Day");
+
+            assertDayHidden(leftDays.at(0));
+            assertDayHidden(leftDays.at(1));
+            assertDayHidden(leftDays.at(2));
+            assertDayHidden(leftDays.at(3));
+            assertDayHidden(leftDays.at(4));
+            assertDayHidden(leftDays.at(5), false);
+
+            assertDayHidden(rightDays.at(30), false);
+            assertDayHidden(rightDays.at(31));
+            assertDayHidden(rightDays.at(32));
+            assertDayHidden(rightDays.at(33));
+            assertDayHidden(rightDays.at(34));
+        });
+
+        it("disables days according to custom modifiers in addition to default modifiers", () => {
+            const disableFridays = { daysOfWeek: [5] };
+            const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
+            const maxDate = new Date(2017, Months.OCTOBER, 20);
+
+            const { getDayLeftView, getDayRightView } = wrap(
+                <DateRangePicker
+                    dayPickerProps={{ disabledDays: disableFridays }}
+                    defaultValue={defaultValue}
+                    maxDate={maxDate}
+                />,
+            );
+
+            assertDayDisabled(getDayLeftView(15));
+            assertDayDisabled(getDayRightView(21));
+            assertDayDisabled(getDayLeftView(10), false);
+        });
+
+        it("disables out-of-range max dates", () => {
+            const defaultValue = [new Date(2017, Months.AUGUST, 1), null] as DateRange;
+            const { getDayRightView } = wrap(
+                <DateRangePicker defaultValue={defaultValue} maxDate={new Date(2017, Months.SEPTEMBER, 20)} />,
+            );
+            assertDayDisabled(getDayRightView(21));
+            assertDayDisabled(getDayRightView(10), false);
+        });
+
+        it("disables out-of-range min dates", () => {
+            const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
+            const { getDayLeftView, root } = wrap(
+                <DateRangePicker defaultValue={defaultValue} minDate={new Date(2017, Months.AUGUST, 20)} />,
+            );
+            const prevMonthButton = root.find(".DayPicker-NavButton--prev").first();
+            prevMonthButton.simulate("click");
+            assertDayDisabled(getDayLeftView(10));
+            assertDayDisabled(getDayLeftView(21), false);
+        });
+
+        it("allows top-level locale, localeUtils, and modifiers to be overridden by same props in dayPickerProps", () => {
+            const blueprintModifiers: IDatePickerModifiers = {
+                blueprint: () => true,
+            };
+            const blueprintLocaleUtils = {
+                ...ReactDayPicker.LocaleUtils,
+                formatDay: () => "b",
+            };
+            const blueprintProps: IDateRangePickerProps = {
+                locale: "blueprint",
+                localeUtils: blueprintLocaleUtils,
+                modifiers: blueprintModifiers,
+            };
+
+            const dayPickerModifiers: IDatePickerModifiers = {
+                dayPicker: () => true,
+            };
+            const dayPickerLocaleUtils = {
+                ...ReactDayPicker.LocaleUtils,
+                formatDay: () => "d",
+            };
+            const dayPickerProps: IDateRangePickerProps = {
+                locale: "dayPicker",
+                localeUtils: dayPickerLocaleUtils,
+                modifiers: dayPickerModifiers,
+            };
+
+            const wrapper = mount(<DateRangePicker {...blueprintProps} dayPickerProps={dayPickerProps} />);
+            const DayPicker = wrapper.find("DayPicker").first();
+            assert.equal(DayPicker.prop("locale"), dayPickerProps.locale);
+            assert.equal(DayPicker.prop("localeUtils"), dayPickerProps.localeUtils);
+            assert.equal(DayPicker.prop("modifiers"), dayPickerProps.modifiers);
+        });
+
+        describe("event handlers", () => {
+            it("calls onMonthChange on button next click", () => {
+                const onMonthChange = sinon.spy();
+                const { leftDayPickerNavbar } = wrap(<DateRangePicker dayPickerProps={{ onMonthChange }} />);
+                leftDayPickerNavbar.find(".DayPicker-NavButton--next").simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click", () => {
+                const onMonthChange = sinon.spy();
+                const { leftDayPickerNavbar } = wrap(<DateRangePicker dayPickerProps={{ onMonthChange }} />);
+                leftDayPickerNavbar.find(".DayPicker-NavButton--prev").simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button next click of left calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { leftDayPickerNavbar } = wrap(
+                    <DateRangePicker contiguousCalendarMonths={false} dayPickerProps={{ onMonthChange }} />,
+                );
+                leftDayPickerNavbar.find(".DayPicker-NavButton--next").simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click of left calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { leftDayPickerNavbar } = wrap(
+                    <DateRangePicker contiguousCalendarMonths={false} dayPickerProps={{ onMonthChange }} />,
+                );
+                leftDayPickerNavbar.find(".DayPicker-NavButton--prev").simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button next click of right calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { rightDayPickerNavbar } = wrap(
+                    <DateRangePicker contiguousCalendarMonths={false} dayPickerProps={{ onMonthChange }} />,
+                );
+                rightDayPickerNavbar.find(".DayPicker-NavButton--next").simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click of right calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { rightDayPickerNavbar } = wrap(
+                    <DateRangePicker contiguousCalendarMonths={false} dayPickerProps={{ onMonthChange }} />,
+                );
+                rightDayPickerNavbar.find(".DayPicker-NavButton--prev").simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on month select change in left calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { leftView } = wrap(<DateRangePicker dayPickerProps={{ onMonthChange }} />);
+                leftView.find({ className: DateClasses.DATEPICKER_MONTH_SELECT }).simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on month select change in right calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { rightView } = wrap(<DateRangePicker dayPickerProps={{ onMonthChange }} />);
+                rightView.find({ className: DateClasses.DATEPICKER_MONTH_SELECT }).simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on year select change in left calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { leftView } = wrap(<DateRangePicker dayPickerProps={{ onMonthChange }} />);
+                leftView.find({ className: DateClasses.DATEPICKER_YEAR_SELECT }).simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on year select change in right calendar", () => {
+                const onMonthChange = sinon.spy();
+                const { rightView } = wrap(<DateRangePicker dayPickerProps={{ onMonthChange }} />);
+                rightView.find({ className: DateClasses.DATEPICKER_YEAR_SELECT }).simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onDayMouseEnter", () => {
+                const onDayMouseEnter = sinon.spy();
+                renderDateRangePicker({ dayPickerProps: { onDayMouseEnter } });
+                mouseEnterDay(14);
+                assert.isTrue(onDayMouseEnter.called);
+            });
+
+            it("calls onDayMouseLeave", () => {
+                const onDayMouseLeave = sinon.spy();
+                renderDateRangePicker({ dayPickerProps: { onDayMouseLeave } });
+                mouseEnterDay(14);
+                mouseLeaveDay(14);
+                assert.isTrue(onDayMouseLeave.called);
+            });
+
+            it("calls onDayClick", () => {
+                const onDayClick = sinon.spy();
+                renderDateRangePicker({ dayPickerProps: { onDayClick } });
+                clickDay(14);
+                assert.isTrue(onDayClick.called);
+            });
+        });
     });
 
     describe("initially displayed month", () => {
@@ -939,6 +1161,34 @@ describe("<DateRangePicker>", () => {
             />,
             testsContainerElement,
         ) as DateRangePicker;
+    }
+
+    function wrap(datepicker: JSX.Element) {
+        const wrapper = mount(datepicker);
+        const dayPickers = wrapper.find(ReactDayPicker).find("Month");
+        const leftDayPicker = dayPickers.at(0);
+        const rightDayPicker = dayPickers.length > 1 ? dayPickers.at(1) : dayPickers.at(0);
+        return {
+            getDayLeftView: (dayNumber = 1) => {
+                return leftDayPicker
+                    .find(`.${DateClasses.DATEPICKER_DAY}`)
+                    .filterWhere(
+                        day => day.text() === "" + dayNumber && !day.hasClass(DateClasses.DATEPICKER_DAY_OUTSIDE),
+                    );
+            },
+            getDayRightView: (dayNumber = 1) => {
+                return rightDayPicker
+                    .find(`.${DateClasses.DATEPICKER_DAY}`)
+                    .filterWhere(
+                        day => day.text() === "" + dayNumber && !day.hasClass(DateClasses.DATEPICKER_DAY_OUTSIDE),
+                    );
+            },
+            leftDayPickerNavbar: wrapper.find("Navbar").at(0),
+            leftView: leftDayPicker,
+            rightDayPickerNavbar: wrapper.find("Navbar").at(1) || wrapper.find("Navbar").at(0),
+            rightView: rightDayPicker,
+            root: wrapper,
+        };
     }
 
     function clickDay(dayNumber = 1, fromLeftMonth = true) {


### PR DESCRIPTION
Reverts palantir/blueprint#1693

Undoing the revert to get the #1647 changes back into `master` now that we've cut the 1.31.0 release.