### PR TITLE
[Table] Add emphasized borders for frozen columns and rows

### DIFF
--- a/packages/table/src/cell/_borders.scss
+++ b/packages/table/src/cell/_borders.scss
@@ -8,13 +8,13 @@ We use box shadows instead of borders since it makes the size and position
 calculations much more well-behaved. This mixin allows us to define the themes
 for all borders with minimal duplication. See the bottom of this file.
 */
-@mixin bp-table-borders-mixin($border-width, $border-color, $border-color-frozen) {
+@mixin bp-table-borders-mixin($border-width, $frozen-border-width, $border-color) {
   $border-right-default: $border-width 0 0 $border-color;
   $border-bottom-default: 0 $border-width 0 $border-color;
   $inset-border-right-default: inset (-$border-width) 0 0 $border-color;
   $inset-border-bottom-default: inset 0 (-$border-width) 0 $border-color;
-  $inset-border-right-frozen: inset -2px 0 0 $border-color-frozen;
-  $inset-border-bottom-frozen: inset 0 -2px 0 $border-color-frozen;
+  $inset-border-right-frozen: inset (-$frozen-border-width) 0 0 $border-color;
+  $inset-border-bottom-frozen: inset 0 (-$frozen-border-width) 0 $border-color;
 
   .bp-table-container {
     box-shadow: 0 0 0 $border-width $border-color;
@@ -92,7 +92,7 @@ for all borders with minimal duplication. See the bottom of this file.
 
         &::before {
           // hover shadow
-          right: 2px;
+          right: $frozen-border-width;
           bottom: 0;
         }
       }
@@ -103,7 +103,7 @@ for all borders with minimal duplication. See the bottom of this file.
         &::before {
           // hover shadow
           right: 0;
-          bottom: 2px;
+          bottom: $frozen-border-width;
         }
       }
     }
@@ -118,12 +118,12 @@ for all borders with minimal duplication. See the bottom of this file.
   }
 }
 
-@include bp-table-borders-mixin($cell-border-width, $cell-border-color, $cell-border-color-frozen);
+@include bp-table-borders-mixin($cell-border-width, $frozen-cell-border-width, $cell-border-color);
 
 .pt-dark {
   @include bp-table-borders-mixin(
     $cell-border-width,
-    $dark-cell-border-color,
-    $dark-cell-border-color-frozen
+    $frozen-cell-border-width,
+    $dark-cell-border-color
   );
 }

--- a/packages/table/src/cell/_borders.scss
+++ b/packages/table/src/cell/_borders.scss
@@ -8,13 +8,13 @@ We use box shadows instead of borders since it makes the size and position
 calculations much more well-behaved. This mixin allows us to define the themes
 for all borders with minimal duplication. See the bottom of this file.
 */
-@mixin bp-table-borders-mixin($border-width, $border-color) {
+@mixin bp-table-borders-mixin($border-width, $border-color, $border-color-frozen) {
   $border-right-default: $border-width 0 0 $border-color;
   $border-bottom-default: 0 $border-width 0 $border-color;
   $inset-border-right-default: inset (-$border-width) 0 0 $border-color;
   $inset-border-bottom-default: inset 0 (-$border-width) 0 $border-color;
-  $inset-border-right-frozen: inset -2px 0 0 $border-color;
-  $inset-border-bottom-frozen: inset 0 -2px 0 $border-color;
+  $inset-border-right-frozen: inset -2px 0 0 $border-color-frozen;
+  $inset-border-bottom-frozen: inset 0 -2px 0 $border-color-frozen;
 
   .bp-table-container {
     box-shadow: 0 0 0 $border-width $border-color;
@@ -118,8 +118,12 @@ for all borders with minimal duplication. See the bottom of this file.
   }
 }
 
-@include bp-table-borders-mixin($cell-border-width, $cell-border-color);
+@include bp-table-borders-mixin($cell-border-width, $cell-border-color, $cell-border-color-frozen);
 
 .pt-dark {
-  @include bp-table-borders-mixin($cell-border-width, $dark-cell-border-color);
+  @include bp-table-borders-mixin(
+    $cell-border-width,
+    $dark-cell-border-color,
+    $dark-cell-border-color-frozen
+  );
 }

--- a/packages/table/src/cell/_borders.scss
+++ b/packages/table/src/cell/_borders.scss
@@ -8,13 +8,13 @@ We use box shadows instead of borders since it makes the size and position
 calculations much more well-behaved. This mixin allows us to define the themes
 for all borders with minimal duplication. See the bottom of this file.
 */
-@mixin bp-table-borders-mixin($border-width, $border-color, $border-color-frozen) {
+@mixin bp-table-borders-mixin($border-width, $border-color) {
   $border-right-default: $border-width 0 0 $border-color;
   $border-bottom-default: 0 $border-width 0 $border-color;
   $inset-border-right-default: inset (-$border-width) 0 0 $border-color;
   $inset-border-bottom-default: inset 0 (-$border-width) 0 $border-color;
-  $inset-border-right-frozen: inset -2px 0 0 $border-color-frozen;
-  $inset-border-bottom-frozen: inset 0 -2px 0 $border-color-frozen;
+  $inset-border-right-frozen: inset -2px 0 0 $border-color;
+  $inset-border-bottom-frozen: inset 0 -2px 0 $border-color;
 
   .bp-table-container {
     box-shadow: 0 0 0 $border-width $border-color;
@@ -40,10 +40,6 @@ for all borders with minimal duplication. See the bottom of this file.
   .bp-table-column-headers .bp-table-header {
     box-shadow: $border-bottom-default, $inset-border-right-default;
 
-    &.bp-table-last-in-row {
-      box-shadow: $border-bottom-default, $inset-border-right-frozen;
-    }
-
     &::before {
       // hover shadow
       right: $border-width;
@@ -53,10 +49,6 @@ for all borders with minimal duplication. See the bottom of this file.
 
   .bp-table-row-headers .bp-table-header {
     box-shadow: $inset-border-bottom-default, $border-right-default;
-
-    &.bp-table-last-in-column {
-      box-shadow: $inset-border-bottom-frozen, $border-right-default;
-    }
 
     &::before {
       // hover shadow
@@ -79,28 +71,55 @@ for all borders with minimal duplication. See the bottom of this file.
     }
   }
 
-  .bp-table-quadrant-left,
   .bp-table-quadrant-top-left {
-    .bp-table-last-in-row {
-      box-shadow: $inset-border-bottom-default, $inset-border-right-frozen;
+    .bp-table-cell {
+      &.bp-table-last-in-row {
+        box-shadow: $inset-border-bottom-default, $inset-border-right-frozen;
+      }
+
+      &.bp-table-last-in-column {
+        box-shadow: $inset-border-bottom-frozen, $inset-border-right-default;
+      }
+
+      &.bp-table-last-in-column.bp-table-last-in-row {
+        box-shadow: $inset-border-bottom-frozen, $inset-border-right-frozen;
+      }
+    }
+
+    .bp-table-header {
+      &.bp-table-last-in-row {
+        box-shadow: $border-bottom-default, $inset-border-right-frozen;
+
+        &::before {
+          // hover shadow
+          right: 2px;
+          bottom: 0;
+        }
+      }
+
+      &.bp-table-last-in-column {
+        box-shadow: $inset-border-bottom-frozen, $border-right-default;
+
+        &::before {
+          // hover shadow
+          right: 0;
+          bottom: 2px;
+        }
+      }
     }
   }
 
-  .bp-table-quadrant-top .bp-table-last-in-column {
-    box-shadow: $inset-border-bottom-frozen, $inset-border-right-default;
+  .bp-table-quadrant-left .bp-table-cell.bp-table-last-in-row {
+    box-shadow: $inset-border-bottom-default, $inset-border-right-frozen;
   }
 
-  .bp-table-quadrant-top-left .bp-table-last-in-column.bp-table-last-in-row {
-    box-shadow: $inset-border-bottom-frozen, $inset-border-right-frozen;
+  .bp-table-quadrant-top .bp-table-cell.bp-table-last-in-column {
+    box-shadow: $inset-border-bottom-frozen, $inset-border-right-default;
   }
 }
 
-@include bp-table-borders-mixin($cell-border-width, $cell-border-color, $cell-border-color-frozen);
+@include bp-table-borders-mixin($cell-border-width, $cell-border-color);
 
 .pt-dark {
-  @include bp-table-borders-mixin(
-    $cell-border-width,
-    $dark-cell-border-color,
-    $dark-cell-border-color-frozen
-  );
+  @include bp-table-borders-mixin($cell-border-width, $dark-cell-border-color);
 }

--- a/packages/table/src/cell/_borders.scss
+++ b/packages/table/src/cell/_borders.scss
@@ -8,23 +8,28 @@ We use box shadows instead of borders since it makes the size and position
 calculations much more well-behaved. This mixin allows us to define the themes
 for all borders with minimal duplication. See the bottom of this file.
 */
-@mixin bp-table-borders-mixin($border-width, $border-color) {
+@mixin bp-table-borders-mixin($border-width, $border-color, $border-color-frozen) {
+  $border-right-default: $border-width 0 0 $border-color;
+  $border-bottom-default: 0 $border-width 0 $border-color;
+  $inset-border-right-default: inset (-$border-width) 0 0 $border-color;
+  $inset-border-bottom-default: inset 0 (-$border-width) 0 $border-color;
+  $inset-border-right-frozen: inset -2px 0 0 $border-color-frozen;
+  $inset-border-bottom-frozen: inset 0 -2px 0 $border-color-frozen;
+
   .bp-table-container {
     box-shadow: 0 0 0 $border-width $border-color;
   }
 
   .bp-table-menu {
-    box-shadow: $border-width 0 0 $border-color,
-                0 $border-width 0 $border-color;
+    box-shadow: $border-bottom-default, $border-right-default;
   }
 
   .bp-table-header {
-    box-shadow: 0 $border-width 0 $border-color;
+    box-shadow: $border-bottom-default;
   }
 
   .bp-table-cell {
-    box-shadow: inset (-$border-width) 0 0 $border-color,
-                inset 0 (-$border-width) 0 $border-color;
+    box-shadow: $inset-border-bottom-default, $inset-border-right-default;
   }
 
   .bp-table-horizontal-cell-divider {
@@ -33,8 +38,11 @@ for all borders with minimal duplication. See the bottom of this file.
   }
 
   .bp-table-column-headers .bp-table-header {
-    box-shadow: inset (-$border-width) 0 0 $border-color,
-                0 $border-width 0 $border-color;
+    box-shadow: $border-bottom-default, $inset-border-right-default;
+
+    &.bp-table-last-in-row {
+      box-shadow: $border-bottom-default, $inset-border-right-frozen;
+    }
 
     &::before {
       // hover shadow
@@ -44,8 +52,11 @@ for all borders with minimal duplication. See the bottom of this file.
   }
 
   .bp-table-row-headers .bp-table-header {
-    box-shadow: inset 0 (-$border-width) 0 $border-color,
-                $border-width 0 0 $border-color;
+    box-shadow: $inset-border-bottom-default, $border-right-default;
+
+    &.bp-table-last-in-column {
+      box-shadow: $inset-border-bottom-frozen, $border-right-default;
+    }
 
     &::before {
       // hover shadow
@@ -56,24 +67,40 @@ for all borders with minimal duplication. See the bottom of this file.
 
   .bp-table-body {
     .bp-table-last-in-row {
-      box-shadow: inset 0 (-$border-width) 0 $border-color,
-                  $border-width 0 0 $border-color;
+      box-shadow: $inset-border-bottom-default, $border-right-default;
     }
 
     .bp-table-last-in-column {
-      box-shadow: inset (-$border-width) 0 0 $border-color,
-                  0 $border-width 0 $border-color;
+      box-shadow: $border-bottom-default, $inset-border-right-default;
     }
 
     .bp-table-last-in-row.bp-table-last-in-column {
-      box-shadow: $border-width 0 0 $border-color,
-                  0 $border-width 0 $border-color;
+      box-shadow: $border-bottom-default, $border-right-default;
     }
+  }
+
+  .bp-table-quadrant-left,
+  .bp-table-quadrant-top-left {
+    .bp-table-last-in-row {
+      box-shadow: $inset-border-bottom-default, $inset-border-right-frozen;
+    }
+  }
+
+  .bp-table-quadrant-top .bp-table-last-in-column {
+    box-shadow: $inset-border-bottom-frozen, $inset-border-right-default;
+  }
+
+  .bp-table-quadrant-top-left .bp-table-last-in-column.bp-table-last-in-row {
+    box-shadow: $inset-border-bottom-frozen, $inset-border-right-frozen;
   }
 }
 
-@include bp-table-borders-mixin($cell-border-width, $cell-border-color);
+@include bp-table-borders-mixin($cell-border-width, $cell-border-color, $cell-border-color-frozen);
 
 .pt-dark {
-  @include bp-table-borders-mixin($cell-border-width, $dark-cell-border-color);
+  @include bp-table-borders-mixin(
+    $cell-border-width,
+    $dark-cell-border-color,
+    $dark-cell-border-color-frozen
+  );
 }

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -13,9 +13,11 @@ $large-cell-height: $pt-grid-size * 3 !default;
 $cell-background-color: $white !default;
 $cell-background-color-opacity: 0.1 !default;
 $cell-border-color: $pt-divider-black !default;
+$cell-border-color-frozen: $blue4;
 $cell-text-color: $pt-text-color !default;
 $dark-cell-background-color: $dark-gray3 !default;
 $dark-cell-border-color: $pt-dark-divider-black !default;
+$dark-cell-border-color-frozen: $blue1;
 $dark-cell-text-color: $pt-dark-text-color !default;
 
 $cell-transition-duration: $pt-transition-duration * 3;

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -3,6 +3,7 @@
 @import "../common/variables";
 
 $cell-border-width: 1px !default;
+$frozen-cell-border-width: 3px !default;
 
 $cell-padding-horizontal: $pt-grid-size !default;
 $cell-padding-vertical: 0 !default;
@@ -13,11 +14,9 @@ $large-cell-height: $pt-grid-size * 3 !default;
 $cell-background-color: $white !default;
 $cell-background-color-opacity: 0.1 !default;
 $cell-border-color: $pt-divider-black !default;
-$cell-border-color-frozen: rgba($black, 0.25) !default;
 $cell-text-color: $pt-text-color !default;
 $dark-cell-background-color: $dark-gray3 !default;
 $dark-cell-border-color: $pt-dark-divider-black !default;
-$dark-cell-border-color-frozen: rgba($black, 0.5) !default;
 $dark-cell-text-color: $pt-dark-text-color !default;
 
 $cell-transition-duration: $pt-transition-duration * 3;

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -13,11 +13,11 @@ $large-cell-height: $pt-grid-size * 3 !default;
 $cell-background-color: $white !default;
 $cell-background-color-opacity: 0.1 !default;
 $cell-border-color: $pt-divider-black !default;
-$cell-border-color-frozen: $blue4;
+$cell-border-color-frozen: rgba($black, 0.25) !default;
 $cell-text-color: $pt-text-color !default;
 $dark-cell-background-color: $dark-gray3 !default;
 $dark-cell-border-color: $pt-dark-divider-black !default;
-$dark-cell-border-color-frozen: $blue1;
+$dark-cell-border-color-frozen: rgba($black, 0.5) !default;
 $dark-cell-text-color: $pt-dark-text-color !default;
 
 $cell-transition-duration: $pt-transition-duration * 3;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1157,9 +1157,9 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const columnIndices = this.grid.getColumnIndicesInRect(viewportRect, fillBodyWithGhostCells);
 
         const columnIndexStart = showFrozenColumnsOnly ? 0 : columnIndices.columnIndexStart;
-        const columnIndexEnd = showFrozenColumnsOnly ? numFrozenColumns : columnIndices.columnIndexEnd;
+        const columnIndexEnd = showFrozenColumnsOnly ? numFrozenColumns - 1 : columnIndices.columnIndexEnd;
         const rowIndexStart = showFrozenRowsOnly ? 0 : rowIndices.rowIndexStart;
-        const rowIndexEnd = showFrozenRowsOnly ? numFrozenRows : rowIndices.rowIndexEnd;
+        const rowIndexEnd = showFrozenRowsOnly ? numFrozenRows - 1 : rowIndices.rowIndexEnd;
 
         // the main quadrant contains all cells in the table, so listen only to that quadrant
         const onCompleteRender = quadrantType === QuadrantType.MAIN ? this.handleCompleteRender : undefined;


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/1685

#### Changes proposed in this pull request:

Add 2px inset box-shadow to frozen columns and rows.

![screen shot 2017-10-10 at 7 10 46 pm](https://user-images.githubusercontent.com/3681045/31383789-e4bcf498-adee-11e7-8f67-2a1c32ce55e9.png)

![screen shot 2017-10-10 at 7 11 29 pm](https://user-images.githubusercontent.com/3681045/31383787-e478257a-adee-11e7-917e-da07ced20dc8.png)

#### Reviewers should focus on

- Colors? I picked blue4 for light theme and blue1 for dark theme
- I refactored the border styles to be more readable (would be nice if everything could just be inset styles in a future PR)