### PR TITLE
[Table] Add missing `static` keyword on RowHeader defaultProps to fix React 16 warning

### DIFF
--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -38,7 +38,7 @@ export interface IRowHeaderProps extends IHeaderProps, IRowHeights, IRowIndices 
 }
 
 export class RowHeader extends React.Component<IRowHeaderProps, {}> {
-    public defaultProps = {
+    public static defaultProps = {
         renderRowHeader: renderDefaultRowHeader,
     };
 


### PR DESCRIPTION
#### Fixes #0000

Extremely simple fix to make defaultProps for RowHeader static so that React 16 doesn't complain.

![image](https://user-images.githubusercontent.com/3332598/31400865-0eee4f8a-adbf-11e7-98fd-655764db0970.png)
