### PR TITLE
[Table] Prototype: resizeRowsByApproximateHeight

### DIFF
--- a/packages/table/preview/mutableTable.tsx
+++ b/packages/table/preview/mutableTable.tsx
@@ -639,6 +639,9 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                 {this.renderButton("Resize rows by tallest cell", {
                     onClick: this.handleResizeRowsByTallestCellButtonClick,
                 })}
+                {this.renderButton("Resize rows by approx height", {
+                    onClick: this.handleResizeRowsByApproxHeightButtonClick,
+                })}
 
                 <h4>Cells</h4>
                 <h6>Display</h6>
@@ -968,6 +971,15 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
 
     private handleResizeRowsByTallestCellButtonClick = () => {
         this.tableInstance.resizeRowsByTallestCell();
+    };
+
+    private handleResizeRowsByApproxHeightButtonClick = () => {
+        this.tableInstance.resizeRowsByApproximateHeight(this.getCellText);
+    };
+
+    private getCellText = (rowIndex: number, columnIndex: number) => {
+        const content = this.store.get(rowIndex, columnIndex);
+        return this.state.cellContent === CellContent.LARGE_JSON ? JSON.stringify(content) : content;
     };
 
     // State updates

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -543,6 +543,45 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         this.quadrantStackInstance.scrollToPosition(correctedScrollLeft, correctedScrollTop);
     }
 
+    public resizeRowsByApproximateHeight(getCellText: (rowIndex: number, columnIndex: number) => string) {
+        const APPROX_CHAR_WIDTH = 8;
+        const APPROX_LINE_HEIGHT = 18;
+        const NUM_EXTRA_LINES = 1; // extra lines
+        const CELL_HORIZONTAL_PADDING = 10;
+
+        const { numRows } = this.props;
+        const { columnWidths } = this.state;
+        const numColumns = columnWidths.length;
+
+        const rowHeights: number[] = [];
+
+        for (let rowIndex = 0; rowIndex < numRows; rowIndex++) {
+            let maxCellHeightInRow = 0;
+
+            // iterate through each cell in the row
+            for (let columnIndex = 0; columnIndex < numColumns; columnIndex++) {
+                const strLength = getCellText(rowIndex, columnIndex).length; // assume non-null
+                const cellWidth = columnWidths[columnIndex];
+
+                const availableCellWidth = cellWidth - 2 * CELL_HORIZONTAL_PADDING;
+                const approxCharsPerLine = availableCellWidth / APPROX_CHAR_WIDTH;
+                const approxNumLinesDesired = Math.ceil(strLength / approxCharsPerLine) + NUM_EXTRA_LINES;
+
+                const approxCellHeight = approxNumLinesDesired * APPROX_LINE_HEIGHT;
+
+                if (approxCellHeight > maxCellHeightInRow) {
+                    maxCellHeightInRow = approxCellHeight;
+                }
+            }
+
+            rowHeights.push(maxCellHeightInRow);
+        }
+
+        this.invalidateGrid();
+        this.didUpdateColumnOrRowSizes = true;
+        this.setState({ rowHeights });
+    }
+
     // React lifecycle
     // ===============
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- 🎉 __Prototype:__ An scheme for resizing rows to their approximate actual/"desired" size assuming fixed column widths, via **`resizeRowsByApproximateHeight`**!
    - Given fixed column widths, sets each row height to the maximum approximate height of the cells in that row, based on average character width and line height (currently hardcoded).
    - Verdict: the scheme works rather well!
    - Does _zero_ DOM access...at the moment.
    - If we want to invest more effort, we can use canvas's `measureText` function to:
        - determine the average alpha character width using the provided font. 
        - determine the line height using the provided font (maybe using https://stackoverflow.com/questions/1134586/how-can-you-find-the-height-of-text-on-an-html-canvas)

#### Reviewers should focus on:

To test:
1. Set `Word wrap: on`.
1. Set `Cell content: "Long text"`
1. Click the `Resize rows by approx height` button.

**What do you think?**
