### PR TITLE
[Table] Shift + arrow keys to resize selection

### DIFF
--- a/packages/table/src/common/direction.ts
+++ b/packages/table/src/common/direction.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+export enum Direction {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT,
+}

--- a/packages/table/src/common/internal/directionUtils.ts
+++ b/packages/table/src/common/internal/directionUtils.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { Direction } from "../direction";
+import { IMovementDelta } from "../movementDelta";
+
+export function directionToDelta(direction: Direction): IMovementDelta {
+    switch (direction) {
+        case Direction.UP:
+            return { rows: -1, cols: 0 };
+        case Direction.DOWN:
+            return { rows: +1, cols: 0 };
+        case Direction.LEFT:
+            return { rows: 0, cols: -1 };
+        case Direction.RIGHT:
+            return { rows: 0, cols: +1 };
+        default:
+            return undefined;
+    }
+}

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -8,6 +8,23 @@
 import { IRegion, RegionCardinality, Regions } from "../../regions";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../cell";
 import * as Errors from "../errors";
+// import { IMovementDelta } from "../movementDelta";
+
+export function isFocusedCellAtRegionTop(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.rows != null && focusedCell.row === region.rows[0];
+}
+
+export function isFocusedCellAtRegionBottom(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.rows != null && focusedCell.row === region.rows[1];
+}
+
+export function isFocusedCellAtRegionLeft(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.cols != null && focusedCell.col === region.cols[0];
+}
+
+export function isFocusedCellAtRegionRight(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.cols != null && focusedCell.col === region.cols[1];
+}
 
 /**
  * Returns the proper focused cell for the given set of initial conditions.
@@ -75,6 +92,32 @@ export function expandFocusedRegion(focusedCell: IFocusedCellCoordinates, newReg
             return Regions.table();
     }
 }
+
+// export function getExpandDirection();
+
+// export function expandFocusedRegionWithDelta(
+//     focusedCell: IFocusedCellCoordinates,
+//     newRegion: IRegion,
+//     delta: IMovementDelta,
+// ) {
+//     switch (Regions.getRegionCardinality(newRegion)) {
+//         case RegionCardinality.FULL_COLUMNS: {
+//             const [indexStart, indexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "col", "cols");
+//             return Regions.column(indexStart, indexEnd);
+//         }
+//         case RegionCardinality.FULL_ROWS: {
+//             const [indexStart, indexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "row", "rows");
+//             return Regions.row(indexStart, indexEnd);
+//         }
+//         case RegionCardinality.CELLS:
+//             const [rowIndexStart, rowIndexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "row", "rows");
+//             const [colIndexStart, colIndexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "col", "cols");
+//             return Regions.cell(rowIndexStart, colIndexStart, rowIndexEnd, colIndexEnd);
+//         default:
+//             // i.e. `case RegionCardinality.FULL_TABLE:`
+//             return Regions.table();
+//     }
+// }
 
 function getExpandedRegionIndices(
     focusedCell: IFocusedCellCoordinates,

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -17,7 +17,7 @@ import * as Errors from "../errors";
 export function getFocusedOrLastSelectedIndex(selectedRegions: IRegion[], focusedCell?: IFocusedCellCoordinates) {
     if (selectedRegions.length === 0) {
         return undefined;
-    } else if (focusedCell != null && focusedCell.focusSelectionIndex != null) {
+    } else if (focusedCell != null) {
         return focusedCell.focusSelectionIndex;
     } else {
         return selectedRegions.length - 1;

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -93,32 +93,6 @@ export function expandFocusedRegion(focusedCell: IFocusedCellCoordinates, newReg
     }
 }
 
-// export function getExpandDirection();
-
-// export function expandFocusedRegionWithDelta(
-//     focusedCell: IFocusedCellCoordinates,
-//     newRegion: IRegion,
-//     delta: IMovementDelta,
-// ) {
-//     switch (Regions.getRegionCardinality(newRegion)) {
-//         case RegionCardinality.FULL_COLUMNS: {
-//             const [indexStart, indexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "col", "cols");
-//             return Regions.column(indexStart, indexEnd);
-//         }
-//         case RegionCardinality.FULL_ROWS: {
-//             const [indexStart, indexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "row", "rows");
-//             return Regions.row(indexStart, indexEnd);
-//         }
-//         case RegionCardinality.CELLS:
-//             const [rowIndexStart, rowIndexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "row", "rows");
-//             const [colIndexStart, colIndexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "col", "cols");
-//             return Regions.cell(rowIndexStart, colIndexStart, rowIndexEnd, colIndexEnd);
-//         default:
-//             // i.e. `case RegionCardinality.FULL_TABLE:`
-//             return Regions.table();
-//     }
-// }
-
 function getExpandedRegionIndices(
     focusedCell: IFocusedCellCoordinates,
     newRegion: IRegion,

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -26,6 +26,16 @@ export function isFocusedCellAtRegionRight(region: IRegion, focusedCell: IFocuse
     return region.cols != null && focusedCell.col === region.cols[1];
 }
 
+export function getFocusedOrLastSelectedIndex(selectedRegions: IRegion[], focusedCell?: IFocusedCellCoordinates) {
+    if (selectedRegions.length === 0) {
+        return undefined;
+    } else if (focusedCell != null && focusedCell.focusSelectionIndex != null) {
+        return focusedCell.focusSelectionIndex;
+    } else {
+        return selectedRegions.length - 1;
+    }
+}
+
 /**
  * Returns the proper focused cell for the given set of initial conditions.
  */

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -8,24 +8,12 @@
 import { IRegion, RegionCardinality, Regions } from "../../regions";
 import { ICellCoordinates, IFocusedCellCoordinates } from "../cell";
 import * as Errors from "../errors";
-// import { IMovementDelta } from "../movementDelta";
 
-export function isFocusedCellAtRegionTop(region: IRegion, focusedCell: IFocusedCellCoordinates) {
-    return region.rows != null && focusedCell.row === region.rows[0];
-}
-
-export function isFocusedCellAtRegionBottom(region: IRegion, focusedCell: IFocusedCellCoordinates) {
-    return region.rows != null && focusedCell.row === region.rows[1];
-}
-
-export function isFocusedCellAtRegionLeft(region: IRegion, focusedCell: IFocusedCellCoordinates) {
-    return region.cols != null && focusedCell.col === region.cols[0];
-}
-
-export function isFocusedCellAtRegionRight(region: IRegion, focusedCell: IFocusedCellCoordinates) {
-    return region.cols != null && focusedCell.col === region.cols[1];
-}
-
+/**
+ * Returns the `focusedSelectionIndex` if both the focused cell and that
+ * property are defined, or the last index of `selectedRegions` otherwise. If
+ * `selectedRegions` is empty, the function always returns `undefined`.
+ */
 export function getFocusedOrLastSelectedIndex(selectedRegions: IRegion[], focusedCell?: IFocusedCellCoordinates) {
     if (selectedRegions.length === 0) {
         return undefined;
@@ -64,6 +52,38 @@ export function getInitialFocusedCell(
         // focus the top-left cell of the table
         return { col: 0, row: 0, focusSelectionIndex: 0 };
     }
+}
+
+/**
+ * Returns `true` if the focused cell is located along the top boundary of the
+ * provided region, or `false` otherwise.
+ */
+export function isFocusedCellAtRegionTop(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.rows != null && focusedCell.row === region.rows[0];
+}
+
+/**
+ * Returns `true` if the focused cell is located along the bottom boundary of
+ * the provided region, or `false` otherwise.
+ */
+export function isFocusedCellAtRegionBottom(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.rows != null && focusedCell.row === region.rows[1];
+}
+
+/**
+ * Returns `true` if the focused cell is located along the left boundary of the
+ * provided region, or `false` otherwise.
+ */
+export function isFocusedCellAtRegionLeft(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.cols != null && focusedCell.col === region.cols[0];
+}
+
+/**
+ * Returns `true` if the focused cell is located along the right boundary of the
+ * provided region, or `false` otherwise.
+ */
+export function isFocusedCellAtRegionRight(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+    return region.cols != null && focusedCell.col === region.cols[1];
 }
 
 /**

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -7,13 +7,45 @@
 
 import { IRegion, Regions } from "../../regions";
 import { IFocusedCellCoordinates } from "../cell";
+import { Direction } from "../direction";
+import { IMovementDelta } from "../movementDelta";
 import * as FocusedCellUtils from "./focusedCellUtils";
 
 export function modifyLastSelectedRegion(
     selectedRegions: IRegion[],
-    delta: IMovementDelta,
+    direction: Direction,
     focusedCell?: IFocusedCellCoordinates,
 ) {
+    const lastSelectedRegion = getLastSelectedRegion(selectedRegions);
+    // const cardinality = Regions.getRegionCardinality(lastSelectedRegion);
+    const delta = directionToMovementDelta(direction);
+
+    // const expansionDestinationRegion: IRegion = {};
+
+    // if (cardinality === RegionCardinality.FULL_COLUMNS) {
+    //     if (direction === Direction.LEFT) {
+    //         expansionDestinationRegion.cols[0] += ;
+    //     }
+    // }
+
+    const nextRegion: IRegion = { ...lastSelectedRegion };
+
+    if (focusedCell != null) {
+        // TODO: Implement
+    } else {
+        // the region sans focused cell can never shrink
+        const affectedRowIndex = getIndexToModify(delta.rows);
+        const affectedColumnIndex = getIndexToModify(delta.cols);
+
+        if (nextRegion.rows != null) {
+            nextRegion.rows[affectedRowIndex] += delta.rows;
+        }
+        if (nextRegion.cols != null) {
+            nextRegion.cols[affectedColumnIndex] += delta.cols;
+        }
+    }
+
+    return nextRegion;
     // TODO: Implement
 }
 
@@ -45,4 +77,50 @@ export function getLastSelectedRegion(selectedRegions: IRegion[]) {
     return selectedRegions == null || selectedRegions.length === 0
         ? undefined
         : selectedRegions[selectedRegions.length - 1];
+}
+
+// function getModifiedRegion(region: IRegion, delta: IMovementDelta, focusedCell?: IFocusedCellCoordinates) {
+//     if (region == null) {
+//         return undefined;
+//     }
+
+//     const nextRegion: IRegion = { ...region };
+
+//     if (focusedCell != null) {
+//         // TODO: Implement
+//     } else {
+//         // the region sans focused cell can never shrink
+//         const affectedRowIndex = getIndexToModify(delta.rows);
+//         const affectedColumnIndex = getIndexToModify(delta.cols);
+
+//         if (nextRegion.rows != null) {
+//             nextRegion.rows[affectedRowIndex] += delta.rows;
+//         }
+//         if (nextRegion.cols != null) {
+//             nextRegion.cols[affectedColumnIndex] += delta.cols;
+//         }
+//     }
+
+//     return nextRegion;
+// }
+
+function getIndexToModify(deltaValue: number) {
+    const START = 0;
+    const END = 1;
+    return deltaValue < 0 ? START : END;
+}
+
+function directionToMovementDelta(direction: Direction): IMovementDelta {
+    switch (direction) {
+        case Direction.UP:
+            return { rows: -1, cols: 0 };
+        case Direction.DOWN:
+            return { rows: +1, cols: 0 };
+        case Direction.LEFT:
+            return { rows: 0, cols: -1 };
+        case Direction.RIGHT:
+            return { rows: 0, cols: +1 };
+        default:
+            return undefined;
+    }
 }

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { IRegion, Regions } from "../../regions";
+import { ICellInterval, IRegion, Regions } from "../../regions";
 import { IFocusedCellCoordinates } from "../cell";
 import { Direction } from "../direction";
 import { IMovementDelta } from "../movementDelta";
@@ -17,36 +17,26 @@ export function modifyLastSelectedRegion(
     focusedCell?: IFocusedCellCoordinates,
 ) {
     const lastSelectedRegion = getLastSelectedRegion(selectedRegions);
-    // const cardinality = Regions.getRegionCardinality(lastSelectedRegion);
     const delta = directionToMovementDelta(direction);
 
-    // const expansionDestinationRegion: IRegion = {};
-
-    // if (cardinality === RegionCardinality.FULL_COLUMNS) {
-    //     if (direction === Direction.LEFT) {
-    //         expansionDestinationRegion.cols[0] += ;
-    //     }
-    // }
-
-    const nextRegion: IRegion = { ...lastSelectedRegion };
+    const nextRegion: IRegion = {
+        cols: lastSelectedRegion.cols.slice() as ICellInterval,
+        rows: lastSelectedRegion.rows.slice() as ICellInterval,
+    };
 
     if (focusedCell != null) {
         // TODO: Implement
     } else {
-        // the region sans focused cell can never shrink
-        const affectedRowIndex = getIndexToModify(delta.rows);
-        const affectedColumnIndex = getIndexToModify(delta.cols);
-
-        if (nextRegion.rows != null) {
-            nextRegion.rows[affectedRowIndex] += delta.rows;
-        }
-        if (nextRegion.cols != null) {
-            nextRegion.cols[affectedColumnIndex] += delta.cols;
-        }
+        ["rows", "cols"].forEach((dimension: "rows" | "cols") => {
+            if (nextRegion[dimension] != null) {
+                const deltaValue = delta[dimension];
+                const affectedIndex = deltaValue < 0 ? 0 : 1;
+                nextRegion[dimension][affectedIndex] += deltaValue;
+            }
+        });
     }
 
-    return nextRegion;
-    // TODO: Implement
+    return expandLastSelectedRegion(selectedRegions, nextRegion, focusedCell);
 }
 
 /**
@@ -77,37 +67,6 @@ export function getLastSelectedRegion(selectedRegions: IRegion[]) {
     return selectedRegions == null || selectedRegions.length === 0
         ? undefined
         : selectedRegions[selectedRegions.length - 1];
-}
-
-// function getModifiedRegion(region: IRegion, delta: IMovementDelta, focusedCell?: IFocusedCellCoordinates) {
-//     if (region == null) {
-//         return undefined;
-//     }
-
-//     const nextRegion: IRegion = { ...region };
-
-//     if (focusedCell != null) {
-//         // TODO: Implement
-//     } else {
-//         // the region sans focused cell can never shrink
-//         const affectedRowIndex = getIndexToModify(delta.rows);
-//         const affectedColumnIndex = getIndexToModify(delta.cols);
-
-//         if (nextRegion.rows != null) {
-//             nextRegion.rows[affectedRowIndex] += delta.rows;
-//         }
-//         if (nextRegion.cols != null) {
-//             nextRegion.cols[affectedColumnIndex] += delta.cols;
-//         }
-//     }
-
-//     return nextRegion;
-// }
-
-function getIndexToModify(deltaValue: number) {
-    const START = 0;
-    const END = 1;
-    return deltaValue < 0 ? START : END;
 }
 
 function directionToMovementDelta(direction: Direction): IMovementDelta {

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -88,33 +88,3 @@ export function resizeRegion(region: IRegion, direction: Direction, focusedCell?
     // sanitizing the result.
     return nextRegion;
 }
-
-/**
- * Expands the last-selected region to the new region, and replaces the
- * last-selected region with the expanded region. If a focused cell is provided,
- * the focused cell will serve as an anchor for the expansion.
- */
-export function expandLastSelectedRegion(
-    selectedRegions: IRegion[],
-    newRegion: IRegion,
-    focusedCell?: IFocusedCellCoordinates,
-) {
-    if (selectedRegions.length === 0) {
-        return [newRegion];
-    } else if (focusedCell != null) {
-        const expandedRegion = FocusedCellUtils.expandFocusedRegion(focusedCell, newRegion);
-        return Regions.update(selectedRegions, expandedRegion);
-    } else {
-        const expandedRegion = Regions.expandRegion(selectedRegions[selectedRegions.length - 1], newRegion);
-        return Regions.update(selectedRegions, expandedRegion);
-    }
-}
-
-/**
- * Returns the last region in the provided `selectedRegions` array, or `undefined`.
- */
-export function getLastSelectedRegion(selectedRegions: IRegion[]) {
-    return selectedRegions == null || selectedRegions.length === 0
-        ? undefined
-        : selectedRegions[selectedRegions.length - 1];
-}

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -9,6 +9,14 @@ import { IRegion, Regions } from "../../regions";
 import { IFocusedCellCoordinates } from "../cell";
 import * as FocusedCellUtils from "./focusedCellUtils";
 
+export function modifyLastSelectedRegion(
+    selectedRegions: IRegion[],
+    delta: IMovementDelta,
+    focusedCell?: IFocusedCellCoordinates,
+) {
+    // TODO: Implement
+}
+
 /**
  * Expands the last-selected region to the new region, and replaces the
  * last-selected region with the expanded region. If a focused cell is provided,
@@ -28,4 +36,13 @@ export function expandLastSelectedRegion(
         const expandedRegion = Regions.expandRegion(selectedRegions[selectedRegions.length - 1], newRegion);
         return Regions.update(selectedRegions, expandedRegion);
     }
+}
+
+/**
+ * Returns the last region in the provided `selectedRegions` array, or `undefined`.
+ */
+export function getLastSelectedRegion(selectedRegions: IRegion[]) {
+    return selectedRegions == null || selectedRegions.length === 0
+        ? undefined
+        : selectedRegions[selectedRegions.length - 1];
 }

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -8,7 +8,7 @@
 import { IRegion, RegionCardinality, Regions } from "../../regions";
 import { IFocusedCellCoordinates } from "../cell";
 import { Direction } from "../direction";
-import { IMovementDelta } from "../movementDelta";
+import * as DirectionUtils from "./directionUtils";
 import * as FocusedCellUtils from "./focusedCellUtils";
 
 export function resizeSelectedRegion(region: IRegion, direction: Direction, focusedCell?: IFocusedCellCoordinates) {
@@ -46,7 +46,7 @@ export function resizeSelectedRegion(region: IRegion, direction: Direction, focu
         affectedColumnIndex = direction === Direction.RIGHT ? 1 : 0;
     }
 
-    const delta = directionToMovementDelta(direction);
+    const delta = DirectionUtils.directionToDelta(direction);
 
     if (nextRegion.rows != null) {
         nextRegion.rows[affectedRowIndex] += delta.rows;
@@ -88,19 +88,4 @@ export function getLastSelectedRegion(selectedRegions: IRegion[]) {
     return selectedRegions == null || selectedRegions.length === 0
         ? undefined
         : selectedRegions[selectedRegions.length - 1];
-}
-
-function directionToMovementDelta(direction: Direction): IMovementDelta {
-    switch (direction) {
-        case Direction.UP:
-            return { rows: -1, cols: 0 };
-        case Direction.DOWN:
-            return { rows: +1, cols: 0 };
-        case Direction.LEFT:
-            return { rows: 0, cols: -1 };
-        case Direction.RIGHT:
-            return { rows: 0, cols: +1 };
-        default:
-            return undefined;
-    }
 }

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { IRegion, Regions } from "../../regions";
+import { IFocusedCellCoordinates } from "../cell";
+import * as FocusedCellUtils from "./focusedCellUtils";
+
+/**
+ * Expands the last-selected region to the new region, and replaces the
+ * last-selected region with the expanded region. If a focused cell is provided,
+ * the focused cell will serve as an anchor for the expansion.
+ */
+export function expandLastSelectedRegion(
+    selectedRegions: IRegion[],
+    newRegion: IRegion,
+    focusedCell?: IFocusedCellCoordinates,
+) {
+    if (selectedRegions.length === 0) {
+        return [newRegion];
+    } else if (focusedCell != null) {
+        const expandedRegion = FocusedCellUtils.expandFocusedRegion(focusedCell, newRegion);
+        return Regions.update(selectedRegions, expandedRegion);
+    } else {
+        const expandedRegion = Regions.expandRegion(selectedRegions[selectedRegions.length - 1], newRegion);
+        return Regions.update(selectedRegions, expandedRegion);
+    }
+}

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -5,7 +5,7 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
-import { ICellInterval, IRegion, Regions } from "../../regions";
+import { IRegion, Regions } from "../../regions";
 import { IFocusedCellCoordinates } from "../cell";
 import { Direction } from "../direction";
 import { IMovementDelta } from "../movementDelta";
@@ -19,10 +19,7 @@ export function modifyLastSelectedRegion(
     const lastSelectedRegion = getLastSelectedRegion(selectedRegions);
     const delta = directionToMovementDelta(direction);
 
-    const nextRegion: IRegion = {
-        cols: lastSelectedRegion.cols.slice() as ICellInterval,
-        rows: lastSelectedRegion.rows.slice() as ICellInterval,
-    };
+    const nextRegion: IRegion = Regions.copy(lastSelectedRegion);
 
     if (focusedCell != null) {
         // TODO: Implement

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -11,7 +11,7 @@ import { Direction } from "../direction";
 import { IMovementDelta } from "../movementDelta";
 import * as FocusedCellUtils from "./focusedCellUtils";
 
-export function modifyLastSelectedRegion(
+export function resizeLastSelectedRegion(
     selectedRegions: IRegion[],
     direction: Direction,
     focusedCell?: IFocusedCellCoordinates,

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -38,7 +38,7 @@ import * as FocusedCellUtils from "./focusedCellUtils";
  * This function does not clamp the indices of the returned region; that is the
  * responsibility of the caller.
  */
-export function resizeSelectedRegion(region: IRegion, direction: Direction, focusedCell?: IFocusedCellCoordinates) {
+export function resizeRegion(region: IRegion, direction: Direction, focusedCell?: IFocusedCellCoordinates) {
     if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_TABLE) {
         // return the same instance to maintain referential integrity and
         // possibly avoid unnecessary update lifecycles.

--- a/packages/table/src/common/movementDelta.ts
+++ b/packages/table/src/common/movementDelta.ts
@@ -6,13 +6,9 @@
  */
 
 export interface IMovementDelta {
-    /**
-     * The number of rows by which to move.
-     */
+    /** The number of rows by which to move. */
     rows: number;
 
-    /**
-     * The number of columns by which to move.
-     */
+    /** The number of columns by which to move. */
     cols: number;
 }

--- a/packages/table/src/common/movementDelta.ts
+++ b/packages/table/src/common/movementDelta.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+export interface IMovementDelta {
+    /**
+     * The number of rows by which to move.
+     */
+    rows: number;
+
+    /**
+     * The number of columns by which to move.
+     */
+    cols: number;
+}

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -10,6 +10,7 @@ import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import { IFocusedCellCoordinates } from "../common/cell";
 import * as FocusedCellUtils from "../common/internal/focusedCellUtils";
+import * as SelectionUtils from "../common/internal/selectionUtils";
 import { Utils } from "../common/utils";
 import { IRegion, Regions } from "../regions";
 import { DragEvents } from "./dragEvents";
@@ -181,7 +182,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         }
 
         const nextSelectedRegions = this.didExpandSelectionOnActivate
-            ? this.expandSelectedRegions(selectedRegions, region, focusedCell)
+            ? SelectionUtils.expandLastSelectedRegion(selectedRegions, region, focusedCell)
             : Regions.update(selectedRegions, region);
 
         this.maybeInvokeSelectionCallback(nextSelectedRegions);
@@ -260,7 +261,7 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
 
         // there should be only one selected region after expanding. do not
         // update the focused cell.
-        const nextSelectedRegions = this.expandSelectedRegions(selectedRegions, region, focusedCell);
+        const nextSelectedRegions = SelectionUtils.expandLastSelectedRegion(selectedRegions, region, focusedCell);
         this.maybeInvokeSelectionCallback(nextSelectedRegions);
 
         // move the focused cell into the new region if there were no selections before
@@ -320,16 +321,4 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
         this.didExpandSelectionOnActivate = false;
         this.lastEmittedSelectedRegions = null;
     };
-
-    private expandSelectedRegions(regions: IRegion[], region: IRegion, focusedCell?: IFocusedCellCoordinates) {
-        if (regions.length === 0) {
-            return [region];
-        } else if (focusedCell != null) {
-            const expandedRegion = FocusedCellUtils.expandFocusedRegion(focusedCell, region);
-            return Regions.update(regions, expandedRegion);
-        } else {
-            const expandedRegion = Regions.expandRegion(regions[regions.length - 1], region);
-            return Regions.update(regions, expandedRegion);
-        }
-    }
 }

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -326,19 +326,15 @@ export class DragSelectable extends React.Component<IDragSelectableProps, {}> {
      * last-selected region with the expanded region. If a focused cell is provided,
      * the focused cell will serve as an anchor for the expansion.
      */
-    private expandSelectedRegions(
-        selectedRegions: IRegion[],
-        newRegion: IRegion,
-        focusedCell?: IFocusedCellCoordinates,
-    ) {
-        if (selectedRegions.length === 0) {
-            return [newRegion];
+    private expandSelectedRegions(regions: IRegion[], region: IRegion, focusedCell?: IFocusedCellCoordinates) {
+        if (regions.length === 0) {
+            return [region];
         } else if (focusedCell != null) {
-            const expandedRegion = FocusedCellUtils.expandFocusedRegion(focusedCell, newRegion);
-            return Regions.update(selectedRegions, expandedRegion);
+            const expandedRegion = FocusedCellUtils.expandFocusedRegion(focusedCell, region);
+            return Regions.update(regions, expandedRegion);
         } else {
-            const expandedRegion = Regions.expandRegion(selectedRegions[selectedRegions.length - 1], newRegion);
-            return Regions.update(selectedRegions, expandedRegion);
+            const expandedRegion = Regions.expandRegion(regions[regions.length - 1], region);
+            return Regions.update(regions, expandedRegion);
         }
     }
 }

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -169,6 +169,16 @@ export class Regions {
     }
 
     /**
+     * Returns a deep copy of the provided region.
+     */
+    public static copy(region: IRegion): IRegion {
+        return {
+            cols: region.cols == null ? region.cols : region.cols.slice() as ICellInterval,
+            rows: region.rows == null ? region.rows : region.rows.slice() as ICellInterval,
+        };
+    }
+
+    /**
      * Returns a region containing one or more cells.
      */
     public static cell(row: number, col: number, row2?: number, col2?: number): IRegion {

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -172,10 +172,20 @@ export class Regions {
      * Returns a deep copy of the provided region.
      */
     public static copy(region: IRegion): IRegion {
-        return {
-            cols: region.cols == null ? region.cols : region.cols.slice() as ICellInterval,
-            rows: region.rows == null ? region.rows : region.rows.slice() as ICellInterval,
-        };
+        const cardinality = Regions.getRegionCardinality(region);
+
+        // we need to be careful not to explicitly spell out `rows: undefined`
+        // (e.g.) if the "rows" key is completely absent, otherwise
+        // deep-equality checks will fail.
+        if (cardinality === RegionCardinality.CELLS) {
+            return Regions.cell(region.rows[0], region.cols[0], region.rows[1], region.cols[1]);
+        } else if (cardinality === RegionCardinality.FULL_COLUMNS) {
+            return Regions.column(region.cols[0], region.cols[1]);
+        } else if (cardinality === RegionCardinality.FULL_ROWS) {
+            return Regions.row(region.rows[0], region.rows[1]);
+        } else {
+            return Regions.table();
+        }
     }
 
     /**

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -221,13 +221,34 @@ export class Regions {
 
     /**
      * Replaces the region at the end of a cloned copy of the supplied region
-     * array.
+     * array, or at the specific index if one is provided.
      */
-    public static update(regions: IRegion[], region: IRegion) {
+    public static update(regions: IRegion[], region: IRegion, index?: number) {
         const copy = regions.slice();
-        copy.pop();
-        copy.push(region);
+        if (index != null) {
+            copy.splice(index, 1, region);
+        } else {
+            copy.pop();
+            copy.push(region);
+        }
         return copy;
+    }
+
+    /**
+     * Clamps the region's start and end indices between 0 and the provided
+     * maximum values.
+     */
+    public static clampRegion(region: IRegion, maxRows: number, maxColumns: number) {
+        const nextRegion = Regions.copy(region);
+        if (region.rows != null) {
+            nextRegion.rows[0] = Utils.clamp(region.rows[0], 0, maxRows - 1);
+            nextRegion.rows[1] = Utils.clamp(region.rows[1], 0, maxRows - 1);
+        }
+        if (region.cols != null) {
+            nextRegion.cols[0] = Utils.clamp(region.cols[0], 0, maxColumns - 1);
+            nextRegion.cols[1] = Utils.clamp(region.cols[1], 0, maxColumns - 1);
+        }
+        return nextRegion;
     }
 
     /**

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -248,15 +248,15 @@ export class Regions {
      * Clamps the region's start and end indices between 0 and the provided
      * maximum values.
      */
-    public static clampRegion(region: IRegion, maxRows: number, maxColumns: number) {
+    public static clampRegion(region: IRegion, maxRowIndex: number, maxColumnIndex: number) {
         const nextRegion = Regions.copy(region);
         if (region.rows != null) {
-            nextRegion.rows[0] = Utils.clamp(region.rows[0], 0, maxRows - 1);
-            nextRegion.rows[1] = Utils.clamp(region.rows[1], 0, maxRows - 1);
+            nextRegion.rows[0] = Utils.clamp(region.rows[0], 0, maxRowIndex);
+            nextRegion.rows[1] = Utils.clamp(region.rows[1], 0, maxRowIndex);
         }
         if (region.cols != null) {
-            nextRegion.cols[0] = Utils.clamp(region.cols[0], 0, maxColumns - 1);
-            nextRegion.cols[1] = Utils.clamp(region.cols[1], 0, maxColumns - 1);
+            nextRegion.cols[0] = Utils.clamp(region.cols[0], 0, maxColumnIndex);
+            nextRegion.cols[1] = Utils.clamp(region.cols[1], 0, maxColumnIndex);
         }
         return nextRegion;
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -691,6 +691,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             this.maybeRenderCopyHotkey(),
             this.maybeRenderSelectAllHotkey(),
             this.maybeRenderFocusHotkeys(),
+            this.maybeRenderSelectionHotkeys(),
         ];
         return <Hotkeys>{hotkeys.filter(element => element !== undefined)}</Hotkeys>;
     }
@@ -779,6 +780,13 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         if (numFrozenColumns != null && numFrozenColumns > numColumns) {
             console.warn(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING);
         }
+    }
+
+    // Hotkeys
+    // =======
+
+    private maybeRenderSelectionHotkeys() {
+        // TODO: Implement!
     }
 
     // Quadrant refs

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -931,11 +931,10 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         e.preventDefault();
         e.stopPropagation();
 
-        const { children, numRows } = this.props;
+        const { allowMultipleSelection } = this.props;
         const { focusedCell, selectedRegions } = this.state;
-        const numColumns = React.Children.count(children);
 
-        if (selectedRegions.length === 0) {
+        if (selectedRegions.length === 0 || !allowMultipleSelection) {
             return;
         }
 
@@ -943,12 +942,24 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const region = selectedRegions[index];
 
         const nextRegion = SelectionUtils.resizeSelectedRegion(region, direction, focusedCell);
-        const clampedNextRegion = Regions.clampRegion(nextRegion, numRows, numColumns);
+
+        this.updateSelectedRegionAtIndex(nextRegion, index);
+    };
+
+    /**
+     * Replaces the selected region at the specified array index, with the
+     * region provided.
+     */
+    private updateSelectedRegionAtIndex(region: IRegion, index: number) {
+        const { children, numRows } = this.props;
+        const { selectedRegions } = this.state;
+        const numColumns = React.Children.count(children);
+
+        const clampedNextRegion = Regions.clampRegion(region, numRows, numColumns);
         const nextSelectedRegions = Regions.update(selectedRegions, clampedNextRegion, index);
 
-        console.log("next selectedRegions:", nextSelectedRegions);
         this.handleSelection(nextSelectedRegions);
-    };
+    }
 
     // Quadrant refs
     // =============

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -807,29 +807,29 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private maybeRenderSelectionHotkeys() {
         return [
             <Hotkey
-                key="modify-selection-up"
-                label="Modify selection upward"
+                key="resize-selection-up"
+                label="Resize selection upward"
                 group="Table"
                 combo="shift+up"
                 onKeyDown={this.handleSelectionResizeUp}
             />,
             <Hotkey
-                key="modify-selection-down"
-                label="Modify selection downward"
+                key="resize-selection-down"
+                label="Resize selection downward"
                 group="Table"
                 combo="shift+down"
                 onKeyDown={this.handleSelectionResizeDown}
             />,
             <Hotkey
-                key="modify-selection-left"
-                label="Modify selection leftward"
+                key="resize-selection-left"
+                label="Resize selection leftward"
                 group="Table"
                 combo="shift+left"
                 onKeyDown={this.handleSelectionResizeLeft}
             />,
             <Hotkey
-                key="modify-selection-right"
-                label="Modify selection rightward"
+                key="resize-selection-right"
+                label="Resize selection rightward"
                 group="Table"
                 combo="shift+right"
                 onKeyDown={this.handleSelectionResizeRight}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -960,9 +960,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const { selectedRegions } = this.state;
         const numColumns = React.Children.count(children);
 
-        const clampedNextRegion = Regions.clampRegion(region, numRows, numColumns);
-        const nextSelectedRegions = Regions.update(selectedRegions, clampedNextRegion, index);
+        const maxRowIndex = Math.max(0, numRows - 1);
+        const maxColumnIndex = Math.max(0, numColumns - 1);
+        const clampedNextRegion = Regions.clampRegion(region, maxRowIndex, maxColumnIndex);
 
+        const nextSelectedRegions = Regions.update(selectedRegions, clampedNextRegion, index);
         this.handleSelection(nextSelectedRegions);
     }
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -811,28 +811,28 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 label="Modify selection upward"
                 group="Table"
                 combo="shift+up"
-                onKeyDown={this.handleSelectionModifyUp}
+                onKeyDown={this.handleSelectionResizeUp}
             />,
             <Hotkey
                 key="modify-selection-down"
                 label="Modify selection downward"
                 group="Table"
                 combo="shift+down"
-                onKeyDown={this.handleSelectionModifyDown}
+                onKeyDown={this.handleSelectionResizeDown}
             />,
             <Hotkey
                 key="modify-selection-left"
                 label="Modify selection leftward"
                 group="Table"
                 combo="shift+left"
-                onKeyDown={this.handleSelectionModifyLeft}
+                onKeyDown={this.handleSelectionResizeLeft}
             />,
             <Hotkey
                 key="modify-selection-right"
                 label="Modify selection rightward"
                 group="Table"
                 combo="shift+right"
-                onKeyDown={this.handleSelectionModifyRight}
+                onKeyDown={this.handleSelectionResizeRight}
             />,
         ];
     }
@@ -922,14 +922,14 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     // Modify selection
     // ----------------
 
-    private handleSelectionModifyUp = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.UP);
-    private handleSelectionModifyDown = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.DOWN);
-    private handleSelectionModifyLeft = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.LEFT);
-    private handleSelectionModifyRight = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.RIGHT);
+    private handleSelectionResizeUp = (e: KeyboardEvent) => this.handleSelectionResize(e, Direction.UP);
+    private handleSelectionResizeDown = (e: KeyboardEvent) => this.handleSelectionResize(e, Direction.DOWN);
+    private handleSelectionResizeLeft = (e: KeyboardEvent) => this.handleSelectionResize(e, Direction.LEFT);
+    private handleSelectionResizeRight = (e: KeyboardEvent) => this.handleSelectionResize(e, Direction.RIGHT);
 
-    private handleSelectionModify = (e: KeyboardEvent, direction: Direction) => {
+    private handleSelectionResize = (e: KeyboardEvent, direction: Direction) => {
         const { focusedCell, selectedRegions } = this.state;
-        const nextSelectedRegions = SelectionUtils.modifyLastSelectedRegion(selectedRegions, direction, focusedCell);
+        const nextSelectedRegions = SelectionUtils.resizeLastSelectedRegion(selectedRegions, direction, focusedCell);
         e.preventDefault();
         e.stopPropagation();
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -946,7 +946,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
         const index = FocusedCellUtils.getFocusedOrLastSelectedIndex(selectedRegions, focusedCell);
         const region = selectedRegions[index];
-        const nextRegion = SelectionUtils.resizeSelectedRegion(region, direction, focusedCell);
+        const nextRegion = SelectionUtils.resizeRegion(region, direction, focusedCell);
 
         this.updateSelectedRegionAtIndex(nextRegion, index);
     };

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -926,7 +926,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    // Modify selection
+    // Selection resize
     // ----------------
 
     private handleSelectionResizeUp = (e: KeyboardEvent) => this.handleSelectionResize(e, Direction.UP);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -948,9 +948,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
         console.log("next selectedRegions:", nextSelectedRegions);
         this.handleSelection(nextSelectedRegions);
-
-        // TODO: Scroll viewport to reveal the new end of the modified region
-        // TODO: Update the selected regions in state
     };
 
     // Quadrant refs

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -928,10 +928,23 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleSelectionResizeRight = (e: KeyboardEvent) => this.handleSelectionResize(e, Direction.RIGHT);
 
     private handleSelectionResize = (e: KeyboardEvent, direction: Direction) => {
-        const { focusedCell, selectedRegions } = this.state;
-        const nextSelectedRegions = SelectionUtils.resizeLastSelectedRegion(selectedRegions, direction, focusedCell);
         e.preventDefault();
         e.stopPropagation();
+
+        const { children, numRows } = this.props;
+        const { focusedCell, selectedRegions } = this.state;
+        const numColumns = React.Children.count(children);
+
+        if (selectedRegions.length === 0) {
+            return;
+        }
+
+        const index = FocusedCellUtils.getFocusedOrLastSelectedIndex(selectedRegions, focusedCell);
+        const region = selectedRegions[index];
+
+        const nextRegion = SelectionUtils.resizeSelectedRegion(region, direction, focusedCell);
+        const clampedNextRegion = Regions.clampRegion(nextRegion, numRows, numColumns);
+        const nextSelectedRegions = Regions.update(selectedRegions, clampedNextRegion, index);
 
         console.log("next selectedRegions:", nextSelectedRegions);
         this.handleSelection(nextSelectedRegions);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -372,6 +372,25 @@ export interface ITableState {
     viewportRect?: Rect;
 }
 
+enum Direction {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT,
+}
+
+interface IMovementDelta {
+    /**
+     * The number of rows by which to move.
+     */
+    rows: number;
+
+    /**
+     * The number of columns by which to move.
+     */
+    cols: number;
+}
+
 @HotkeysTarget
 export class Table extends AbstractComponent<ITableProps, ITableState> {
     public static defaultProps: ITableProps = {
@@ -803,7 +822,36 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private maybeRenderSelectionHotkeys() {
-        // TODO: Implement
+        return [
+            <Hotkey
+                key="modify-selection-up"
+                label="Modify selection upward"
+                group="Table"
+                combo="mod+up"
+                onKeyDown={this.handleSelectionModifyUp}
+            />,
+            <Hotkey
+                key="modify-selection-down"
+                label="Modify selection downward"
+                group="Table"
+                combo="mod+down"
+                onKeyDown={this.handleSelectionModifyDown}
+            />,
+            <Hotkey
+                key="modify-selection-left"
+                label="Modify selection leftward"
+                group="Table"
+                combo="mod+left"
+                onKeyDown={this.handleSelectionModifyLeft}
+            />,
+            <Hotkey
+                key="modify-selection-right"
+                label="Modify selection rightward"
+                group="Table"
+                combo="mod+right"
+                onKeyDown={this.handleSelectionModifyRight}
+            />,
+        ];
     }
 
     private maybeRenderFocusHotkeys() {
@@ -887,6 +935,18 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             return undefined;
         }
     }
+
+    // Modify selection
+    // ----------------
+
+    private handleSelectionModifyUp = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.UP);
+    private handleSelectionModifyDown = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.DOWN);
+    private handleSelectionModifyLeft = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.LEFT);
+    private handleSelectionModifyRight = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.RIGHT);
+
+    private handleSelectionModify = (e: KeyboardEvent, direction: Direction) => {
+        const delta = directionToMovementDelta(direction);
+    };
 
     // Quadrant refs
     // =============
@@ -1938,4 +1998,19 @@ function clampNumFrozenRows(props: ITableProps) {
 // order, and you can't have an optional param precede a required param.
 function clampPotentiallyNullValue(value: number | null | undefined, max: number) {
     return value == null ? 0 : Utils.clamp(value, 0, max);
+}
+
+function directionToMovementDelta(direction: Direction): IMovementDelta {
+    switch (direction) {
+        case Direction.UP:
+            return { rows: -1, cols: 0 };
+        case Direction.DOWN:
+            return { rows: +1, cols: 0 };
+        case Direction.LEFT:
+            return { rows: 0, cols: -1 };
+        case Direction.RIGHT:
+            return { rows: 0, cols: +1 };
+        default:
+            return undefined;
+    }
 }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -927,12 +927,15 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleSelectionModifyLeft = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.LEFT);
     private handleSelectionModifyRight = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.RIGHT);
 
-    private handleSelectionModify = (_e: KeyboardEvent, direction: Direction) => {
+    private handleSelectionModify = (e: KeyboardEvent, direction: Direction) => {
         const { focusedCell, selectedRegions } = this.state;
         const nextSelectedRegions = SelectionUtils.modifyLastSelectedRegion(selectedRegions, direction, focusedCell);
+        e.preventDefault();
+        e.stopPropagation();
 
         console.log("next selectedRegions:", nextSelectedRegions);
-        this.setState({ selectedRegions: nextSelectedRegions });
+        this.handleSelection(nextSelectedRegions);
+
         // TODO: Scroll viewport to reveal the new end of the modified region
         // TODO: Update the selected regions in state
     };

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -14,6 +14,7 @@ import { Column, IColumnProps } from "./column";
 import { IFocusedCellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
 import { Clipboard } from "./common/clipboard";
+import { Direction } from "./common/direction";
 import * as Errors from "./common/errors";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import * as FocusedCellUtils from "./common/internal/focusedCellUtils";
@@ -371,25 +372,6 @@ export interface ITableState {
      * performance enhancements.
      */
     viewportRect?: Rect;
-}
-
-enum Direction {
-    UP,
-    DOWN,
-    LEFT,
-    RIGHT,
-}
-
-interface IMovementDelta {
-    /**
-     * The number of rows by which to move.
-     */
-    rows: number;
-
-    /**
-     * The number of columns by which to move.
-     */
-    cols: number;
 }
 
 @HotkeysTarget
@@ -828,28 +810,28 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 key="modify-selection-up"
                 label="Modify selection upward"
                 group="Table"
-                combo="mod+up"
+                combo="shift+up"
                 onKeyDown={this.handleSelectionModifyUp}
             />,
             <Hotkey
                 key="modify-selection-down"
                 label="Modify selection downward"
                 group="Table"
-                combo="mod+down"
+                combo="shift+down"
                 onKeyDown={this.handleSelectionModifyDown}
             />,
             <Hotkey
                 key="modify-selection-left"
                 label="Modify selection leftward"
                 group="Table"
-                combo="mod+left"
+                combo="shift+left"
                 onKeyDown={this.handleSelectionModifyLeft}
             />,
             <Hotkey
                 key="modify-selection-right"
                 label="Modify selection rightward"
                 group="Table"
-                combo="mod+right"
+                combo="shift+right"
                 onKeyDown={this.handleSelectionModifyRight}
             />,
         ];
@@ -945,12 +927,12 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleSelectionModifyLeft = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.LEFT);
     private handleSelectionModifyRight = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.RIGHT);
 
-    private handleSelectionModify = (e: KeyboardEvent, direction: Direction) => {
+    private handleSelectionModify = (_e: KeyboardEvent, direction: Direction) => {
         const { focusedCell, selectedRegions } = this.state;
         const nextSelectedRegions = SelectionUtils.modifyLastSelectedRegion(selectedRegions, direction, focusedCell);
 
         console.log("next selectedRegions:", nextSelectedRegions);
-
+        this.setState({ selectedRegions: nextSelectedRegions });
         // TODO: Scroll viewport to reveal the new end of the modified region
         // TODO: Update the selected regions in state
     };
@@ -2005,19 +1987,4 @@ function clampNumFrozenRows(props: ITableProps) {
 // order, and you can't have an optional param precede a required param.
 function clampPotentiallyNullValue(value: number | null | undefined, max: number) {
     return value == null ? 0 : Utils.clamp(value, 0, max);
-}
-
-function directionToMovementDelta(direction: Direction): IMovementDelta {
-    switch (direction) {
-        case Direction.UP:
-            return { rows: -1, cols: 0 };
-        case Direction.DOWN:
-            return { rows: +1, cols: 0 };
-        case Direction.LEFT:
-            return { rows: 0, cols: -1 };
-        case Direction.RIGHT:
-            return { rows: 0, cols: +1 };
-        default:
-            return undefined;
-    }
 }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -18,6 +18,7 @@ import * as Errors from "./common/errors";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import * as FocusedCellUtils from "./common/internal/focusedCellUtils";
 import * as ScrollUtils from "./common/internal/scrollUtils";
+import * as SelectionUtils from "./common/internal/selectionUtils";
 import { Rect } from "./common/rect";
 import { RenderMode } from "./common/renderMode";
 import { Utils } from "./common/utils";
@@ -945,7 +946,13 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleSelectionModifyRight = (e: KeyboardEvent) => this.handleSelectionModify(e, Direction.RIGHT);
 
     private handleSelectionModify = (e: KeyboardEvent, direction: Direction) => {
-        const delta = directionToMovementDelta(direction);
+        const { focusedCell, selectedRegions } = this.state;
+        const nextSelectedRegions = SelectionUtils.modifyLastSelectedRegion(selectedRegions, direction, focusedCell);
+
+        console.log("next selectedRegions:", nextSelectedRegions);
+
+        // TODO: Scroll viewport to reveal the new end of the modified region
+        // TODO: Update the selected regions in state
     };
 
     // Quadrant refs

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -785,8 +785,107 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     // Hotkeys
     // =======
 
+    private maybeRenderCopyHotkey() {
+        const { getCellClipboardData } = this.props;
+        if (getCellClipboardData != null) {
+            return (
+                <Hotkey
+                    key="copy-hotkey"
+                    label="Copy selected table cells"
+                    group="Table"
+                    combo="mod+c"
+                    onKeyDown={this.handleCopy}
+                />
+            );
+        } else {
+            return undefined;
+        }
+    }
+
     private maybeRenderSelectionHotkeys() {
-        // TODO: Implement!
+        // TODO: Implement
+    }
+
+    private maybeRenderFocusHotkeys() {
+        const { enableFocus } = this.props;
+        if (enableFocus != null) {
+            return [
+                <Hotkey
+                    key="move left"
+                    label="Move focus cell left"
+                    group="Table"
+                    combo="left"
+                    onKeyDown={this.handleFocusMoveLeft}
+                />,
+                <Hotkey
+                    key="move right"
+                    label="Move focus cell right"
+                    group="Table"
+                    combo="right"
+                    onKeyDown={this.handleFocusMoveRight}
+                />,
+                <Hotkey
+                    key="move up"
+                    label="Move focus cell up"
+                    group="Table"
+                    combo="up"
+                    onKeyDown={this.handleFocusMoveUp}
+                />,
+                <Hotkey
+                    key="move down"
+                    label="Move focus cell down"
+                    group="Table"
+                    combo="down"
+                    onKeyDown={this.handleFocusMoveDown}
+                />,
+                <Hotkey
+                    key="move tab"
+                    label="Move focus cell tab"
+                    group="Table"
+                    combo="tab"
+                    onKeyDown={this.handleFocusMoveRightInternal}
+                />,
+                <Hotkey
+                    key="move shift-tab"
+                    label="Move focus cell shift tab"
+                    group="Table"
+                    combo="shift+tab"
+                    onKeyDown={this.handleFocusMoveLeftInternal}
+                />,
+                <Hotkey
+                    key="move enter"
+                    label="Move focus cell enter"
+                    group="Table"
+                    combo="enter"
+                    onKeyDown={this.handleFocusMoveDownInternal}
+                />,
+                <Hotkey
+                    key="move shift-enter"
+                    label="Move focus cell shift enter"
+                    group="Table"
+                    combo="shift+enter"
+                    onKeyDown={this.handleFocusMoveUpInternal}
+                />,
+            ];
+        } else {
+            return [];
+        }
+    }
+
+    private maybeRenderSelectAllHotkey() {
+        if (this.isSelectionModeEnabled(RegionCardinality.FULL_TABLE)) {
+            return (
+                <Hotkey
+                    key="select-all-hotkey"
+                    label="Select all"
+                    group="Table"
+                    combo="mod+a"
+                    onKeyDown={this.handleSelectAllHotkey}
+                />
+            );
+        } else {
+            return undefined;
+        }
     }
 
     // Quadrant refs
@@ -1295,23 +1394,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         });
     }
 
-    private maybeRenderCopyHotkey() {
-        const { getCellClipboardData } = this.props;
-        if (getCellClipboardData != null) {
-            return (
-                <Hotkey
-                    key="copy-hotkey"
-                    label="Copy selected table cells"
-                    group="Table"
-                    combo="mod+c"
-                    onKeyDown={this.handleCopy}
-                />
-            );
-        } else {
-            return undefined;
-        }
-    }
-
     private handleCompleteRender = () => {
         // the first onCompleteRender is triggered before the viewportRect is
         // defined and the second after the viewportRect has been set. the cells
@@ -1330,88 +1412,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     private handleFocusMoveUpInternal = (e: KeyboardEvent) => this.handleFocusMoveInternal(e, "up");
     private handleFocusMoveDown = (e: KeyboardEvent) => this.handleFocusMove(e, "down");
     private handleFocusMoveDownInternal = (e: KeyboardEvent) => this.handleFocusMoveInternal(e, "down");
-
-    private maybeRenderFocusHotkeys() {
-        const { enableFocus } = this.props;
-        if (enableFocus != null) {
-            return [
-                <Hotkey
-                    key="move left"
-                    label="Move focus cell left"
-                    group="Table"
-                    combo="left"
-                    onKeyDown={this.handleFocusMoveLeft}
-                />,
-                <Hotkey
-                    key="move right"
-                    label="Move focus cell right"
-                    group="Table"
-                    combo="right"
-                    onKeyDown={this.handleFocusMoveRight}
-                />,
-                <Hotkey
-                    key="move up"
-                    label="Move focus cell up"
-                    group="Table"
-                    combo="up"
-                    onKeyDown={this.handleFocusMoveUp}
-                />,
-                <Hotkey
-                    key="move down"
-                    label="Move focus cell down"
-                    group="Table"
-                    combo="down"
-                    onKeyDown={this.handleFocusMoveDown}
-                />,
-                <Hotkey
-                    key="move tab"
-                    label="Move focus cell tab"
-                    group="Table"
-                    combo="tab"
-                    onKeyDown={this.handleFocusMoveRightInternal}
-                />,
-                <Hotkey
-                    key="move shift-tab"
-                    label="Move focus cell shift tab"
-                    group="Table"
-                    combo="shift+tab"
-                    onKeyDown={this.handleFocusMoveLeftInternal}
-                />,
-                <Hotkey
-                    key="move enter"
-                    label="Move focus cell enter"
-                    group="Table"
-                    combo="enter"
-                    onKeyDown={this.handleFocusMoveDownInternal}
-                />,
-                <Hotkey
-                    key="move shift-enter"
-                    label="Move focus cell shift enter"
-                    group="Table"
-                    combo="shift+enter"
-                    onKeyDown={this.handleFocusMoveUpInternal}
-                />,
-            ];
-        } else {
-            return [];
-        }
-    }
-
-    private maybeRenderSelectAllHotkey() {
-        if (this.isSelectionModeEnabled(RegionCardinality.FULL_TABLE)) {
-            return (
-                <Hotkey
-                    key="select-all-hotkey"
-                    label="Select all"
-                    group="Table"
-                    combo="mod+a"
-                    onKeyDown={this.handleSelectAllHotkey}
-                />
-            );
-        } else {
-            return undefined;
-        }
-    }
 
     private styleBodyRegion = (region: IRegion, quadrantType: QuadrantType): React.CSSProperties => {
         const { numFrozenColumns } = this.props;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -693,7 +693,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
             this.maybeRenderCopyHotkey(),
             this.maybeRenderSelectAllHotkey(),
             this.maybeRenderFocusHotkeys(),
-            this.maybeRenderSelectionHotkeys(),
+            this.maybeRenderSelectionResizeHotkeys(),
         ];
         return <Hotkeys>{hotkeys.filter(element => element !== undefined)}</Hotkeys>;
     }
@@ -804,37 +804,44 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
     }
 
-    private maybeRenderSelectionHotkeys() {
-        return [
-            <Hotkey
-                key="resize-selection-up"
-                label="Resize selection upward"
-                group="Table"
-                combo="shift+up"
-                onKeyDown={this.handleSelectionResizeUp}
-            />,
-            <Hotkey
-                key="resize-selection-down"
-                label="Resize selection downward"
-                group="Table"
-                combo="shift+down"
-                onKeyDown={this.handleSelectionResizeDown}
-            />,
-            <Hotkey
-                key="resize-selection-left"
-                label="Resize selection leftward"
-                group="Table"
-                combo="shift+left"
-                onKeyDown={this.handleSelectionResizeLeft}
-            />,
-            <Hotkey
-                key="resize-selection-right"
-                label="Resize selection rightward"
-                group="Table"
-                combo="shift+right"
-                onKeyDown={this.handleSelectionResizeRight}
-            />,
-        ];
+    private maybeRenderSelectionResizeHotkeys() {
+        const { allowMultipleSelection, selectionModes } = this.props;
+        const isSomeSelectionModeEnabled = selectionModes.length > 0;
+
+        if (allowMultipleSelection && isSomeSelectionModeEnabled) {
+            return [
+                <Hotkey
+                    key="resize-selection-up"
+                    label="Resize selection upward"
+                    group="Table"
+                    combo="shift+up"
+                    onKeyDown={this.handleSelectionResizeUp}
+                />,
+                <Hotkey
+                    key="resize-selection-down"
+                    label="Resize selection downward"
+                    group="Table"
+                    combo="shift+down"
+                    onKeyDown={this.handleSelectionResizeDown}
+                />,
+                <Hotkey
+                    key="resize-selection-left"
+                    label="Resize selection leftward"
+                    group="Table"
+                    combo="shift+left"
+                    onKeyDown={this.handleSelectionResizeLeft}
+                />,
+                <Hotkey
+                    key="resize-selection-right"
+                    label="Resize selection rightward"
+                    group="Table"
+                    combo="shift+right"
+                    onKeyDown={this.handleSelectionResizeRight}
+                />,
+            ];
+        } else {
+            return undefined;
+        }
     }
 
     private maybeRenderFocusHotkeys() {
@@ -931,16 +938,14 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         e.preventDefault();
         e.stopPropagation();
 
-        const { allowMultipleSelection } = this.props;
         const { focusedCell, selectedRegions } = this.state;
 
-        if (selectedRegions.length === 0 || !allowMultipleSelection) {
+        if (selectedRegions.length === 0) {
             return;
         }
 
         const index = FocusedCellUtils.getFocusedOrLastSelectedIndex(selectedRegions, focusedCell);
         const region = selectedRegions[index];
-
         const nextRegion = SelectionUtils.resizeSelectedRegion(region, direction, focusedCell);
 
         this.updateSelectedRegionAtIndex(nextRegion, index);

--- a/packages/table/test/common/internal/directionUtilsTests.ts
+++ b/packages/table/test/common/internal/directionUtilsTests.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { expect } from "chai";
+
+import { Direction } from "../../../src/common/direction";
+import * as DirectionUtils from "../../../src/common/internal/directionUtils";
+
+describe("DirectionUtils", () => {
+    describe("directionToDelta", () => {
+        it("returns correct delta for Direction.UP", () => {
+            const delta = DirectionUtils.directionToDelta(Direction.UP);
+            expect(delta).to.deep.equal({ rows: -1, cols: 0 });
+        });
+
+        it("returns correct delta for Direction.DOWN", () => {
+            const delta = DirectionUtils.directionToDelta(Direction.DOWN);
+            expect(delta).to.deep.equal({ rows: 1, cols: 0 });
+        });
+
+        it("returns correct delta for Direction.LEFT", () => {
+            const delta = DirectionUtils.directionToDelta(Direction.LEFT);
+            expect(delta).to.deep.equal({ rows: 0, cols: -1 });
+        });
+
+        it("returns correct delta for Direction.RIGHT", () => {
+            const delta = DirectionUtils.directionToDelta(Direction.RIGHT);
+            expect(delta).to.deep.equal({ rows: 0, cols: +1 });
+        });
+    });
+});

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -12,67 +12,6 @@ import * as FocusedCellUtils from "../../../src/common/internal/focusedCellUtils
 import { IRegion, Regions } from "../../../src/regions";
 
 describe("FocusedCellUtils", () => {
-    describe("getInitialFocusedCell", () => {
-        const FOCUSED_CELL_FROM_PROPS = getFocusedCell(1, 2);
-        const FOCUSED_CELL_FROM_STATE = getFocusedCell(3, 4);
-        const SELECTED_REGIONS = [Regions.cell(1, 1, 4, 5), Regions.cell(5, 1, 6, 2)];
-
-        it("returns undefined if enableFocus=false", () => {
-            const focusedCell = FocusedCellUtils.getInitialFocusedCell(
-                false,
-                FOCUSED_CELL_FROM_PROPS,
-                FOCUSED_CELL_FROM_STATE,
-                SELECTED_REGIONS,
-            );
-            expect(focusedCell).to.be.undefined;
-        });
-
-        it("returns the focusedCellFromProps if defined", () => {
-            const focusedCell = FocusedCellUtils.getInitialFocusedCell(
-                true,
-                FOCUSED_CELL_FROM_PROPS,
-                FOCUSED_CELL_FROM_STATE,
-                SELECTED_REGIONS,
-            );
-            expect(focusedCell).to.deep.equal(FOCUSED_CELL_FROM_PROPS);
-        });
-
-        it("returns the focusedCellFromState if focusedCellFromProps not defined", () => {
-            const focusedCell = FocusedCellUtils.getInitialFocusedCell(
-                true,
-                null,
-                FOCUSED_CELL_FROM_STATE,
-                SELECTED_REGIONS,
-            );
-            expect(focusedCell).to.deep.equal(FOCUSED_CELL_FROM_STATE);
-        });
-
-        // tslint:disable-next-line:max-line-length
-        it("returns the focused cell for the last selected region if focusedCell not provided", () => {
-            const focusedCell = FocusedCellUtils.getInitialFocusedCell(true, null, null, SELECTED_REGIONS);
-            const lastIndex = SELECTED_REGIONS.length - 1;
-            const expectedFocusedCell = {
-                ...Regions.getFocusCellCoordinatesFromRegion(SELECTED_REGIONS[lastIndex]),
-                focusSelectionIndex: lastIndex,
-            };
-            expect(focusedCell).to.deep.equal(expectedFocusedCell);
-        });
-
-        it("returns cell (0, 0) if nothing else is defined", () => {
-            const focusedCell = FocusedCellUtils.getInitialFocusedCell(true, null, null, []);
-            const expectedFocusedCell = {
-                col: 0,
-                focusSelectionIndex: 0,
-                row: 0,
-            };
-            expect(focusedCell).to.deep.equal(expectedFocusedCell);
-        });
-
-        function getFocusedCell(row: number, col: number, focusSelectionIndex: number = 0): IFocusedCellCoordinates {
-            return { row, col, focusSelectionIndex };
-        }
-    });
-
     describe("expandFocusedRegion", () => {
         const FOCUSED_ROW = 3;
         const FOCUSED_COL = 3;
@@ -189,6 +128,67 @@ describe("FocusedCellUtils", () => {
 
         function toCellCoords(row: number, col: number): IFocusedCellCoordinates {
             return { row, col, focusSelectionIndex: 0 };
+        }
+    });
+
+    describe("getInitialFocusedCell", () => {
+        const FOCUSED_CELL_FROM_PROPS = getFocusedCell(1, 2);
+        const FOCUSED_CELL_FROM_STATE = getFocusedCell(3, 4);
+        const SELECTED_REGIONS = [Regions.cell(1, 1, 4, 5), Regions.cell(5, 1, 6, 2)];
+
+        it("returns undefined if enableFocus=false", () => {
+            const focusedCell = FocusedCellUtils.getInitialFocusedCell(
+                false,
+                FOCUSED_CELL_FROM_PROPS,
+                FOCUSED_CELL_FROM_STATE,
+                SELECTED_REGIONS,
+            );
+            expect(focusedCell).to.be.undefined;
+        });
+
+        it("returns the focusedCellFromProps if defined", () => {
+            const focusedCell = FocusedCellUtils.getInitialFocusedCell(
+                true,
+                FOCUSED_CELL_FROM_PROPS,
+                FOCUSED_CELL_FROM_STATE,
+                SELECTED_REGIONS,
+            );
+            expect(focusedCell).to.deep.equal(FOCUSED_CELL_FROM_PROPS);
+        });
+
+        it("returns the focusedCellFromState if focusedCellFromProps not defined", () => {
+            const focusedCell = FocusedCellUtils.getInitialFocusedCell(
+                true,
+                null,
+                FOCUSED_CELL_FROM_STATE,
+                SELECTED_REGIONS,
+            );
+            expect(focusedCell).to.deep.equal(FOCUSED_CELL_FROM_STATE);
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it("returns the focused cell for the last selected region if focusedCell not provided", () => {
+            const focusedCell = FocusedCellUtils.getInitialFocusedCell(true, null, null, SELECTED_REGIONS);
+            const lastIndex = SELECTED_REGIONS.length - 1;
+            const expectedFocusedCell = {
+                ...Regions.getFocusCellCoordinatesFromRegion(SELECTED_REGIONS[lastIndex]),
+                focusSelectionIndex: lastIndex,
+            };
+            expect(focusedCell).to.deep.equal(expectedFocusedCell);
+        });
+
+        it("returns cell (0, 0) if nothing else is defined", () => {
+            const focusedCell = FocusedCellUtils.getInitialFocusedCell(true, null, null, []);
+            const expectedFocusedCell = {
+                col: 0,
+                focusSelectionIndex: 0,
+                row: 0,
+            };
+            expect(focusedCell).to.deep.equal(expectedFocusedCell);
+        });
+
+        function getFocusedCell(row: number, col: number, focusSelectionIndex: number = 0): IFocusedCellCoordinates {
+            return { row, col, focusSelectionIndex };
         }
     });
 

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -131,6 +131,29 @@ describe("FocusedCellUtils", () => {
         }
     });
 
+    describe("getFocusedOrLastSelectedIndex", () => {
+        const fn = FocusedCellUtils.getFocusedOrLastSelectedIndex;
+
+        it("always returns `undefined` if selectedRegions is empty", () => {
+            const focusedCell = FocusedCellUtils.toFullCoordinates({ row: 0, col: 0 });
+            expect(fn([], undefined)).to.equal(undefined);
+            expect(fn([], focusedCell)).to.equal(undefined);
+        });
+
+        it("returns selectedRegions's last index if focused cell not defined", () => {
+            const selectedRegions = [Regions.row(0), Regions.row(1), Regions.row(3)];
+            const lastIndex = selectedRegions.length - 1;
+            expect(fn(selectedRegions, undefined)).to.deep.equal(lastIndex);
+        });
+
+        it("returns focusSelectionIndex if focused cell is defined", () => {
+            const INDEX = 1;
+            const selectedRegions = [Regions.row(0), Regions.row(1), Regions.row(3)];
+            const focusedCell = { row: 0, col: 0, focusSelectionIndex: INDEX };
+            expect(fn(selectedRegions, focusedCell)).to.deep.equal(INDEX);
+        });
+    });
+
     describe("getInitialFocusedCell", () => {
         const FOCUSED_CELL_FROM_PROPS = getFocusedCell(1, 2);
         const FOCUSED_CELL_FROM_STATE = getFocusedCell(3, 4);
@@ -190,6 +213,230 @@ describe("FocusedCellUtils", () => {
         function getFocusedCell(row: number, col: number, focusSelectionIndex: number = 0): IFocusedCellCoordinates {
             return { row, col, focusSelectionIndex };
         }
+    });
+
+    describe("itFocusedCellAtRegion___", () => {
+        const ROW_START = 3;
+        const ROW_END = 5;
+        const COL_START = 4;
+        const COL_END = 6;
+
+        const cellRegion = Regions.cell(ROW_START, COL_START, ROW_END, COL_END);
+        const columnRegion = Regions.column(COL_START, COL_END);
+        const rowRegion = Regions.row(ROW_START, ROW_END);
+        const tableRegion = Regions.table();
+
+        describe("isFocusedCellAtRegionTop", () => {
+            const fn = FocusedCellUtils.isFocusedCellAtRegionTop;
+
+            describe("CELLS region", () => {
+                it("returns true if focused cell at region top and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns true if focused cell at region top and not inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END + 1 });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region top", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START + 1, col: COL_START });
+                    expect(fn(cellRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_COLUMNS region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END + 1 });
+                    const focusedCell3 = FocusedCellUtils.toFullCoordinates({ row: ROW_START + 1, col: COL_START });
+                    expect(fn(columnRegion, focusedCell1)).to.be.false;
+                    expect(fn(columnRegion, focusedCell2)).to.be.false;
+                    expect(fn(columnRegion, focusedCell3)).to.be.false;
+                });
+            });
+
+            describe("FULL_ROWS region", () => {
+                it("returns true if focused cell at region top and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    expect(fn(rowRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region top", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START + 1, col: COL_START });
+                    expect(fn(rowRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_TABLE region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: 0, col: 0 });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    expect(fn(tableRegion, focusedCell1)).to.be.false;
+                    expect(fn(tableRegion, focusedCell2)).to.be.false;
+                });
+            });
+        });
+
+        describe("isFocusedCellAtRegionBottom", () => {
+            const fn = FocusedCellUtils.isFocusedCellAtRegionBottom;
+
+            describe("CELLS region", () => {
+                it("returns true if focused cell at region bottom and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END, col: COL_START });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns true if focused cell at region bottom and not inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END, col: COL_END + 1 });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region bottom", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END - 1, col: COL_START });
+                    expect(fn(cellRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_COLUMNS region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: ROW_END, col: COL_START });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_END, col: COL_END + 1 });
+                    const focusedCell3 = FocusedCellUtils.toFullCoordinates({ row: ROW_END - 1, col: COL_START });
+                    expect(fn(columnRegion, focusedCell1)).to.be.false;
+                    expect(fn(columnRegion, focusedCell2)).to.be.false;
+                    expect(fn(columnRegion, focusedCell3)).to.be.false;
+                });
+            });
+
+            describe("FULL_ROWS region", () => {
+                it("returns true if focused cell at region bottom and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END, col: COL_START });
+                    expect(fn(rowRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region bottom", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END + 1, col: COL_START });
+                    expect(fn(rowRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_TABLE region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: 0, col: 0 });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_END, col: COL_START });
+                    expect(fn(tableRegion, focusedCell1)).to.be.false;
+                    expect(fn(tableRegion, focusedCell2)).to.be.false;
+                });
+            });
+        });
+
+        describe("isFocusedCellAtRegionLeft", () => {
+            const fn = FocusedCellUtils.isFocusedCellAtRegionLeft;
+
+            describe("CELLS region", () => {
+                it("returns true if focused cell at region left and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns true if focused cell at region left and not inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END + 1, col: COL_START });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region left", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START + 1 });
+                    expect(fn(cellRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_COLUMNS region", () => {
+                it("returns true if focused cell at region left and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    expect(fn(columnRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region left", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START + 1 });
+                    expect(fn(columnRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_ROWS region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_END + 1, col: COL_START });
+                    const focusedCell3 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START + 1 });
+                    expect(fn(rowRegion, focusedCell1)).to.be.false;
+                    expect(fn(rowRegion, focusedCell2)).to.be.false;
+                    expect(fn(rowRegion, focusedCell3)).to.be.false;
+                });
+            });
+
+            describe("FULL_TABLE region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: 0, col: 0 });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_START });
+                    expect(fn(tableRegion, focusedCell1)).to.be.false;
+                    expect(fn(tableRegion, focusedCell2)).to.be.false;
+                });
+            });
+        });
+
+        describe("isFocusedCellAtRegionRight", () => {
+            const fn = FocusedCellUtils.isFocusedCellAtRegionRight;
+
+            describe("CELLS region", () => {
+                it("returns true if focused cell at region right and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns true if focused cell at region right and not inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_END + 1, col: COL_END });
+                    expect(fn(cellRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region right", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END - 1 });
+                    expect(fn(cellRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_COLUMNS region", () => {
+                it("returns true if focused cell at region right and inside region", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END });
+                    expect(fn(columnRegion, focusedCell)).to.be.true;
+                });
+
+                it("returns false if focused cell not at region right", () => {
+                    const focusedCell = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END - 1 });
+                    expect(fn(columnRegion, focusedCell)).to.be.false;
+                });
+            });
+
+            describe("FULL_ROWS region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_END + 1, col: COL_END });
+                    const focusedCell3 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END - 1 });
+                    expect(fn(rowRegion, focusedCell1)).to.be.false;
+                    expect(fn(rowRegion, focusedCell2)).to.be.false;
+                    expect(fn(rowRegion, focusedCell3)).to.be.false;
+                });
+            });
+
+            describe("FULL_TABLE region", () => {
+                it("always returns false", () => {
+                    const focusedCell1 = FocusedCellUtils.toFullCoordinates({ row: 0, col: 0 });
+                    const focusedCell2 = FocusedCellUtils.toFullCoordinates({ row: ROW_START, col: COL_END });
+                    expect(fn(tableRegion, focusedCell1)).to.be.false;
+                    expect(fn(tableRegion, focusedCell2)).to.be.false;
+                });
+            });
+        });
     });
 
     describe("toFullCoordinates", () => {

--- a/packages/table/test/common/internal/index.ts
+++ b/packages/table/test/common/internal/index.ts
@@ -8,3 +8,4 @@
 import "./directionUtilsTests";
 import "./focusedCellUtilsTests";
 import "./scrollUtilsTests";
+import "./selectionUtilsTests";

--- a/packages/table/test/common/internal/index.ts
+++ b/packages/table/test/common/internal/index.ts
@@ -5,5 +5,6 @@
  * and https://github.com/palantir/blueprint/blob/master/PATENTS
  */
 
+import "./directionUtilsTests";
 import "./focusedCellUtilsTests";
 import "./scrollUtilsTests";

--- a/packages/table/test/common/internal/selectionUtilsTests.ts
+++ b/packages/table/test/common/internal/selectionUtilsTests.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain a copy
+ * of the license at https://github.com/palantir/blueprint/blob/master/LICENSE
+ * and https://github.com/palantir/blueprint/blob/master/PATENTS
+ */
+
+import { expect } from "chai";
+
+import { IFocusedCellCoordinates } from "../../../src/common/cell";
+import { Direction } from "../../../src/common/direction";
+import * as SelectionUtils from "../../../src/common/internal/selectionUtils";
+import { Regions } from "../../../src/regions";
+
+describe("SelectionUtils", () => {
+    describe("resizeRegion", () => {
+        const fn = SelectionUtils.resizeRegion;
+
+        const ROW_START = 3;
+        const ROW_MIDDLE = 4;
+        const ROW_END = 5;
+
+        const COL_START = 4;
+        const COL_MIDDLE = 5;
+        const COL_END = 6;
+
+        describe("when focusedCell is defined", () => {
+            describe("CELLS region", () => {
+                const region = Regions.cell(ROW_START, COL_START, ROW_END, COL_END);
+
+                const regionExpandedTop = Regions.cell(ROW_START - 1, COL_START, ROW_END, COL_END);
+                const regionExpandedBottom = Regions.cell(ROW_START, COL_START, ROW_END + 1, COL_END);
+                const regionExpandedLeft = Regions.cell(ROW_START, COL_START - 1, ROW_END, COL_END);
+                const regionExpandedRight = Regions.cell(ROW_START, COL_START, ROW_END, COL_END + 1);
+
+                const regionShrunkenTop = Regions.cell(ROW_START + 1, COL_START, ROW_END, COL_END);
+                const regionShrunkenBottom = Regions.cell(ROW_START, COL_START, ROW_END - 1, COL_END);
+                const regionShrunkenLeft = Regions.cell(ROW_START, COL_START + 1, ROW_END, COL_END);
+                const regionShrunkenRight = Regions.cell(ROW_START, COL_START, ROW_END, COL_END - 1);
+
+                const singleCellRegion = Regions.cell(ROW_START, COL_START);
+                const singleCellRegionFocusedCell = getFocusedCell(ROW_START, COL_START);
+                const singleCellRegionExpandedTop = Regions.cell(ROW_START - 1, COL_START, ROW_START, COL_START);
+                const singleCellRegionExpandedBottom = Regions.cell(ROW_START, COL_START, ROW_START + 1, COL_START);
+                const singleCellRegionExpandedLeft = Regions.cell(ROW_START, COL_START - 1, ROW_START, COL_START);
+                const singleCellRegionExpandedRight = Regions.cell(ROW_START, COL_START, ROW_START, COL_START + 1);
+
+                const focusedCellTop = getFocusedCell(ROW_START, COL_MIDDLE);
+                const focusedCellBottom = getFocusedCell(ROW_END, COL_MIDDLE);
+                const focusedCellLeft = getFocusedCell(ROW_MIDDLE, COL_START);
+                const focusedCellRight = getFocusedCell(ROW_MIDDLE, COL_END);
+
+                it("on Direction.UP", () => {
+                    expect(fn(region, Direction.UP, focusedCellTop)).to.deep.equal(regionShrunkenBottom);
+                    expect(fn(region, Direction.UP, focusedCellBottom)).to.deep.equal(regionExpandedTop);
+                    expect(fn(region, Direction.UP, focusedCellLeft)).to.deep.equal(regionExpandedTop);
+                    expect(fn(region, Direction.UP, focusedCellRight)).to.deep.equal(regionExpandedTop);
+
+                    const result = fn(singleCellRegion, Direction.UP, singleCellRegionFocusedCell);
+                    expect(result).to.deep.equal(singleCellRegionExpandedTop);
+                });
+
+                it("on Direction.DOWN", () => {
+                    expect(fn(region, Direction.DOWN, focusedCellTop)).to.deep.equal(regionExpandedBottom);
+                    expect(fn(region, Direction.DOWN, focusedCellBottom)).to.deep.equal(regionShrunkenTop);
+                    expect(fn(region, Direction.DOWN, focusedCellLeft)).to.deep.equal(regionExpandedBottom);
+                    expect(fn(region, Direction.DOWN, focusedCellRight)).to.deep.equal(regionExpandedBottom);
+
+                    const result = fn(singleCellRegion, Direction.DOWN, singleCellRegionFocusedCell);
+                    expect(result).to.deep.equal(singleCellRegionExpandedBottom);
+                });
+
+                it("on Direction.LEFT", () => {
+                    expect(fn(region, Direction.LEFT, focusedCellTop)).to.deep.equal(regionExpandedLeft);
+                    expect(fn(region, Direction.LEFT, focusedCellBottom)).to.deep.equal(regionExpandedLeft);
+                    expect(fn(region, Direction.LEFT, focusedCellLeft)).to.deep.equal(regionShrunkenRight);
+                    expect(fn(region, Direction.LEFT, focusedCellRight)).to.deep.equal(regionExpandedLeft);
+
+                    const result = fn(singleCellRegion, Direction.LEFT, singleCellRegionFocusedCell);
+                    expect(result).to.deep.equal(singleCellRegionExpandedLeft);
+                });
+
+                it("on Direction.RIGHT", () => {
+                    expect(fn(region, Direction.RIGHT, focusedCellTop)).to.deep.equal(regionExpandedRight);
+                    expect(fn(region, Direction.RIGHT, focusedCellBottom)).to.deep.equal(regionExpandedRight);
+                    expect(fn(region, Direction.RIGHT, focusedCellLeft)).to.deep.equal(regionExpandedRight);
+                    expect(fn(region, Direction.RIGHT, focusedCellRight)).to.deep.equal(regionShrunkenLeft);
+
+                    const result = fn(singleCellRegion, Direction.RIGHT, singleCellRegionFocusedCell);
+                    expect(result).to.deep.equal(singleCellRegionExpandedRight);
+                });
+            });
+
+            describe("FULL_COLUMNS region", () => {
+                const region = Regions.column(COL_START, COL_END);
+
+                const regionExpandedLeft = Regions.column(COL_START - 1, COL_END);
+                const regionExpandedRight = Regions.column(COL_START, COL_END + 1);
+
+                const regionShrunkenLeft = Regions.column(COL_START + 1, COL_END);
+                const regionShrunkenRight = Regions.column(COL_START, COL_END - 1);
+
+                const singleColumnRegion = Regions.column(COL_START);
+                const singleColumnRegionFocusedCell = getFocusedCell(0, COL_START);
+                const singleColumnRegionExpandedLeft = Regions.column(COL_START - 1, COL_START);
+                const singleColumnRegionExpandedRight = Regions.column(COL_START, COL_START + 1);
+
+                const focusedCellLeft = getFocusedCell(1, COL_START);
+                const focusedCellRight = getFocusedCell(1, COL_END);
+
+                it("on Direction.UP", () => {
+                    expect(fn(region, Direction.UP, focusedCellLeft)).to.deep.equal(region);
+                    expect(fn(region, Direction.UP, focusedCellRight)).to.deep.equal(region);
+                });
+
+                it("on Direction.DOWN", () => {
+                    expect(fn(region, Direction.DOWN, focusedCellLeft)).to.deep.equal(region);
+                    expect(fn(region, Direction.DOWN, focusedCellRight)).to.deep.equal(region);
+                });
+
+                it("on Direction.LEFT", () => {
+                    expect(fn(region, Direction.LEFT, focusedCellLeft)).to.deep.equal(regionShrunkenRight);
+                    expect(fn(region, Direction.LEFT, focusedCellRight)).to.deep.equal(regionExpandedLeft);
+
+                    const result = fn(singleColumnRegion, Direction.LEFT, singleColumnRegionFocusedCell);
+                    expect(result).to.deep.equal(singleColumnRegionExpandedLeft);
+                });
+
+                it("on Direction.RIGHT", () => {
+                    expect(fn(region, Direction.RIGHT, focusedCellLeft)).to.deep.equal(regionExpandedRight);
+                    expect(fn(region, Direction.RIGHT, focusedCellRight)).to.deep.equal(regionShrunkenLeft);
+
+                    const result = fn(singleColumnRegion, Direction.RIGHT, singleColumnRegionFocusedCell);
+                    expect(result).to.deep.equal(singleColumnRegionExpandedRight);
+                });
+            });
+
+            describe("FULL_ROWS region", () => {
+                const region = Regions.row(ROW_START, ROW_END);
+
+                const regionExpandedTop = Regions.row(ROW_START - 1, ROW_END);
+                const regionExpandedBottom = Regions.row(ROW_START, ROW_END + 1);
+
+                const regionShrunkenTop = Regions.row(ROW_START + 1, ROW_END);
+                const regionShrunkenBottom = Regions.row(ROW_START, ROW_END - 1);
+
+                const singleRowRegion = Regions.row(ROW_START);
+                const singleRowRegionFocusedCell = getFocusedCell(0, ROW_START);
+                const singleRowRegionExpandedTop = Regions.row(ROW_START - 1, ROW_START);
+                const singleRowRegionExpandedBottom = Regions.row(ROW_START, ROW_START + 1);
+
+                const focusedCellTop = getFocusedCell(ROW_START, 1);
+                const focusedCellBottom = getFocusedCell(ROW_END, 1);
+
+                it("on Direction.UP", () => {
+                    expect(fn(region, Direction.UP, focusedCellTop)).to.deep.equal(regionShrunkenBottom);
+                    expect(fn(region, Direction.UP, focusedCellBottom)).to.deep.equal(regionExpandedTop);
+
+                    const result = fn(singleRowRegion, Direction.UP, singleRowRegionFocusedCell);
+                    expect(result).to.deep.equal(singleRowRegionExpandedTop);
+                });
+
+                it("on Direction.DOWN", () => {
+                    expect(fn(region, Direction.DOWN, focusedCellTop)).to.deep.equal(regionExpandedBottom);
+                    expect(fn(region, Direction.DOWN, focusedCellBottom)).to.deep.equal(regionShrunkenTop);
+
+                    const result = fn(singleRowRegion, Direction.DOWN, singleRowRegionFocusedCell);
+                    expect(result).to.deep.equal(singleRowRegionExpandedBottom);
+                });
+
+                it("on Direction.LEFT", () => {
+                    expect(fn(region, Direction.LEFT, focusedCellTop)).to.deep.equal(region);
+                    expect(fn(region, Direction.LEFT, focusedCellBottom)).to.deep.equal(region);
+                });
+
+                it("on Direction.RIGHT", () => {
+                    expect(fn(region, Direction.RIGHT, focusedCellTop)).to.deep.equal(region);
+                    expect(fn(region, Direction.RIGHT, focusedCellBottom)).to.deep.equal(region);
+                });
+            });
+
+            describe("FULL_TABLE region", () => {
+                it("returns the same region instance unchanged", () => {
+                    const region = Regions.table();
+                    const focusedCell = getFocusedCell(0, 0);
+                    expect(fn(region, Direction.UP, focusedCell)).to.equal(region);
+                    expect(fn(region, Direction.DOWN, focusedCell)).to.equal(region);
+                    expect(fn(region, Direction.LEFT, focusedCell)).to.equal(region);
+                    expect(fn(region, Direction.RIGHT, focusedCell)).to.equal(region);
+                });
+            });
+        });
+
+        describe("when focusedCell is not defined", () => {
+            it("expands CELLS regions horizontally or vertically", () => {
+                const cellRegion = Regions.cell(ROW_START, COL_START, ROW_END, COL_END);
+                const cellExpectedUp = Regions.cell(ROW_START - 1, COL_START, ROW_END, COL_END);
+                const cellExpectedDown = Regions.cell(ROW_START, COL_START, ROW_END + 1, COL_END);
+                const cellExpectedLeft = Regions.cell(ROW_START, COL_START - 1, ROW_END, COL_END);
+                const cellExpectedRight = Regions.cell(ROW_START, COL_START, ROW_END, COL_END + 1);
+
+                expect(fn(cellRegion, Direction.UP)).to.deep.equal(cellExpectedUp);
+                expect(fn(cellRegion, Direction.DOWN)).to.deep.equal(cellExpectedDown);
+                expect(fn(cellRegion, Direction.LEFT)).to.deep.equal(cellExpectedLeft);
+                expect(fn(cellRegion, Direction.RIGHT)).to.deep.equal(cellExpectedRight);
+            });
+
+            it("expands FULL_COLUMNS regions only horizontally", () => {
+                const columnRegion = Regions.column(COL_START, COL_END);
+                const columnExpectedUp = Regions.column(COL_START, COL_END);
+                const columnExpectedDown = Regions.column(COL_START, COL_END);
+                const columnExpectedLeft = Regions.column(COL_START - 1, COL_END);
+                const columnExpectedRight = Regions.column(COL_START, COL_END + 1);
+
+                expect(fn(columnRegion, Direction.UP)).to.deep.equal(columnExpectedUp);
+                expect(fn(columnRegion, Direction.DOWN)).to.deep.equal(columnExpectedDown);
+                expect(fn(columnRegion, Direction.LEFT)).to.deep.equal(columnExpectedLeft);
+                expect(fn(columnRegion, Direction.RIGHT)).to.deep.equal(columnExpectedRight);
+            });
+
+            it("expands FULL_ROWS regions only vertically", () => {
+                const rowRegion = Regions.row(ROW_START, ROW_END);
+                const rowExpectedUp = Regions.row(ROW_START - 1, ROW_END);
+                const rowExpectedDown = Regions.row(ROW_START, ROW_END + 1);
+                const rowExpectedLeft = Regions.row(ROW_START, ROW_END);
+                const rowExpectedRight = Regions.row(ROW_START, ROW_END);
+
+                expect(fn(rowRegion, Direction.UP)).to.deep.equal(rowExpectedUp);
+                expect(fn(rowRegion, Direction.DOWN)).to.deep.equal(rowExpectedDown);
+                expect(fn(rowRegion, Direction.LEFT)).to.deep.equal(rowExpectedLeft);
+                expect(fn(rowRegion, Direction.RIGHT)).to.deep.equal(rowExpectedRight);
+            });
+
+            it("returns the same FULL_TABLE region instance unchanged", () => {
+                const tableRegion = Regions.table();
+
+                expect(fn(tableRegion, Direction.UP)).to.equal(tableRegion);
+                expect(fn(tableRegion, Direction.DOWN)).to.equal(tableRegion);
+                expect(fn(tableRegion, Direction.LEFT)).to.equal(tableRegion);
+                expect(fn(tableRegion, Direction.RIGHT)).to.equal(tableRegion);
+            });
+        });
+    });
+});
+
+function getFocusedCell(row: number, col: number): IFocusedCellCoordinates {
+    return { row, col, focusSelectionIndex: 0 };
+}

--- a/packages/table/test/regionsTests.ts
+++ b/packages/table/test/regionsTests.ts
@@ -252,6 +252,69 @@ describe("Regions", () => {
         expect(JSON.stringify(sparse)).to.equal(JSON.stringify([["X", "X"], ["X", null], ["X", null]]));
     });
 
+    describe("clampRegion", () => {
+        const fn = Regions.clampRegion;
+
+        it("returns a deep copy of the region", () => {
+            const validRegion = Regions.table();
+            const clampedRegion = fn(validRegion, 1, 1);
+            expect(clampedRegion === validRegion).to.be.false;
+        });
+
+        it("clamps regions whose start indices are < 0", () => {
+            const cellRegion = Regions.cell(-1, 1);
+            expect(fn(cellRegion, 1, 1)).to.deep.equal(Regions.cell(0, 1));
+
+            const columnRegion = Regions.column(-1, 1);
+            expect(fn(columnRegion, 1, 1)).to.deep.equal(Regions.column(0, 1));
+
+            const rowRegion = Regions.row(-1, 1);
+            expect(fn(rowRegion, 1, 1)).to.deep.equal(Regions.row(0, 1));
+        });
+
+        it("clamps regions whose end indices are > max", () => {
+            const cellRegion = Regions.cell(0, 2);
+            expect(fn(cellRegion, 1, 1)).to.deep.equal(Regions.cell(0, 1));
+
+            const columnRegion = Regions.column(0, 2);
+            expect(fn(columnRegion, 1, 1)).to.deep.equal(Regions.column(0, 1));
+
+            const rowRegion = Regions.row(0, 2);
+            expect(fn(rowRegion, 1, 1)).to.deep.equal(Regions.row(0, 1));
+        });
+
+        it("returns a new FULL_TABLE region if provided", () => {
+            const tableRegion = Regions.table();
+            expect(fn(tableRegion, 1, 1)).to.deep.equal(Regions.table());
+        });
+    });
+
+    describe("copy", () => {
+        it("copies CELLS regions", () => {
+            const region = Regions.cell(0, 1, 2, 3);
+            const regionCopy = Regions.cell(0, 1, 2, 3);
+            expect(Regions.copy(region)).to.deep.equal(regionCopy);
+        });
+
+        it("copies FULL_COLUMNS regions", () => {
+            const region = Regions.column(0, 1);
+            const regionCopy = Regions.column(0, 1);
+            expect(Regions.copy(region)).to.deep.equal(regionCopy);
+        });
+
+        it("copies FULL_ROWS regions", () => {
+            const region = Regions.row(0, 1);
+            const regionCopy = Regions.row(0, 1);
+            expect(Regions.copy(region)).to.deep.equal(regionCopy);
+        });
+
+        it("copies FULL_TABLE regions", () => {
+            const region = Regions.table();
+            const regionCopy = Regions.table();
+            expect(Regions.copy(region)).to.deep.equal(regionCopy);
+        });
+    });
+
     describe("expandRegion", () => {
         it("returns new region if cardinalities are different", () => {
             const oldRegion = Regions.cell(0, 0);

--- a/packages/table/test/regionsTests.ts
+++ b/packages/table/test/regionsTests.ts
@@ -58,13 +58,23 @@ describe("Regions", () => {
             expect(Regions.lastRegionIsEqual(added, Regions.column(14, 3)));
         });
 
-        it("updates regions", () => {
+        it("updates regions at last index", () => {
             const regions = [Regions.row(1, 37)];
             const updated = Regions.update(regions, Regions.column(3, 14));
 
             expect(updated).to.not.equal(regions);
             expect(updated.length).to.equal(regions.length);
             expect(Regions.lastRegionIsEqual(updated, Regions.column(14, 3)));
+        });
+
+        it("updates regions at specified index", () => {
+            const INDEX = 1;
+            const regions = [Regions.row(1), Regions.column(1), Regions.cell(1, 1)];
+            const updated = Regions.update(regions, Regions.column(2), INDEX);
+
+            expect(updated).to.not.equal(regions);
+            expect(updated.length).to.equal(regions.length);
+            expect(updated[INDEX]).to.deep.equal(Regions.column(2));
         });
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -1142,31 +1142,6 @@ describe("<Table>", () => {
 
             return { attachTo, component };
         }
-
-        function createKeyEventConfig(
-            component: ReactWrapper<any, any>,
-            key: string,
-            keyCode: number,
-            shiftKey = false,
-        ) {
-            const eventConfig = {
-                key,
-                keyCode,
-                preventDefault: () => {
-                    /* Empty */
-                },
-                shiftKey,
-                stopPropagation: () => {
-                    /* Empty */
-                },
-                target: (component as any).getNode(), // `getNode` is a real Enzyme method, just not in the typings?
-                which: keyCode,
-            };
-            return {
-                eventConfig,
-                nativeEvent: eventConfig,
-            };
-        }
     });
 
     describe("Manually scrolling while drag-selecting", () => {
@@ -1794,6 +1769,80 @@ describe("<Table>", () => {
         }
     });
 
+    describe("Hotkey: shift + arrow keys", () => {
+        const NUM_ROWS = 3;
+        const NUM_COLS = 3;
+
+        const SELECTED_CELL_ROW = 1;
+        const SELECTED_CELL_COL = 1;
+        const selectedRegions = [Regions.cell(SELECTED_CELL_ROW, SELECTED_CELL_COL)];
+
+        it("resizes a selection on shift + arrow keys", () => {
+            const containerElement = document.createElement("div");
+            document.body.appendChild(containerElement);
+
+            const onSelection = sinon.spy();
+            const component = mount(createTableOfSize(NUM_COLS, NUM_ROWS, {}, { onSelection, selectedRegions }), {
+                attachTo: containerElement,
+            });
+
+            pressKeyWithShiftKey(component, Keys.ARROW_RIGHT);
+            expect(onSelection.calledOnce).to.be.true;
+            expect(onSelection.firstCall.args).to.deep.equal([
+                [Regions.cell(SELECTED_CELL_ROW, SELECTED_CELL_COL, SELECTED_CELL_ROW, SELECTED_CELL_COL + 1)],
+            ]);
+        });
+
+        it("resizes a selection on shift + arrow keys if focusedCell is defined", () => {
+            const containerElement = document.createElement("div");
+            document.body.appendChild(containerElement);
+
+            const onSelection = sinon.spy();
+            const focusedCell = { row: SELECTED_CELL_ROW, col: SELECTED_CELL_COL, focusSelectionIndex: 0 };
+            const tableProps = { enableFocus: true, focusedCell, onSelection, selectedRegions };
+            const component = mount(createTableOfSize(NUM_COLS, NUM_ROWS, {}, tableProps), {
+                attachTo: containerElement,
+            });
+
+            const expectedSelectedRegions = [
+                Regions.cell(SELECTED_CELL_ROW, SELECTED_CELL_COL, SELECTED_CELL_ROW, SELECTED_CELL_COL + 1),
+            ];
+
+            // expand rightward with a RIGHT keypress
+            pressKeyWithShiftKey(component, Keys.ARROW_RIGHT);
+            expect(onSelection.calledOnce).to.be.true;
+            expect(onSelection.firstCall.args).to.deep.equal([expectedSelectedRegions]);
+            onSelection.reset();
+
+            // pretend the selection change persisted
+            component.setProps({ selectedRegions: expectedSelectedRegions });
+
+            // undo the resize change with a LEFT keypress
+            pressKeyWithShiftKey(component, Keys.ARROW_LEFT);
+            expect(onSelection.calledOnce).to.be.true;
+            expect(onSelection.firstCall.args).to.deep.equal([selectedRegions]);
+        });
+
+        it("does not change a selection on shift + arrow keys if allowMultipleSelection=false", () => {
+            const containerElement = document.createElement("div");
+            document.body.appendChild(containerElement);
+
+            const onSelection = sinon.spy();
+            const tableProps = { allowMultipleSelection: false, onSelection, selectedRegions };
+            const component = mount(createTableOfSize(NUM_COLS, NUM_ROWS, {}, tableProps), {
+                attachTo: containerElement,
+            });
+
+            pressKeyWithShiftKey(component, Keys.ARROW_RIGHT);
+            expect(onSelection.calledOnce).to.be.false;
+        });
+
+        function pressKeyWithShiftKey(component: ReactWrapper<ITableProps, {}>, keyCode: number) {
+            const key = keyCode === Keys.ARROW_LEFT ? "left" : "right";
+            component.simulate("keyDown", createKeyEventConfig(component, key, keyCode, true));
+        }
+    });
+
     function renderDummyCell() {
         return <Cell>gg</Cell>;
     }
@@ -1829,5 +1878,25 @@ describe("<Table>", () => {
 
     function delayToNextFrame(callback: () => void) {
         setTimeout(callback);
+    }
+
+    function createKeyEventConfig(component: ReactWrapper<any, any>, key: string, keyCode: number, shiftKey = false) {
+        const eventConfig = {
+            key,
+            keyCode,
+            preventDefault: () => {
+                /* Empty */
+            },
+            shiftKey,
+            stopPropagation: () => {
+                /* Empty */
+            },
+            target: (component as any).getNode(), // `getNode` is a real Enzyme method, just not in the typings?
+            which: keyCode,
+        };
+        return {
+            eventConfig,
+            nativeEvent: eventConfig,
+        };
     }
 });


### PR DESCRIPTION
#### Addresses #1080 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- __NEW__ `Table` <kbd>Shift + ⬆️ / ⬇️ / ⬅️ / ➡️ </kbd> hotkeys to resize selection (using focused cell as anchor if present).
    - See function comments in the diff for details (in particular: [this comment](https://github.com/palantir/blueprint/pull/1707/files#diff-3c6700ce4c8768ee12a26d3b6b187392R14)).

#### Reviewers should focus on:

- Really would like to decompose `<Table>`, but not in this PR. 
- I discovered a bug with somewhat-related behavior: #1706 

#### Screenshot

When `allowMultipleSelection=true`:

![2017-10-12 00 47 04](https://user-images.githubusercontent.com/443450/31484928-ef12d720-aee6-11e7-8507-b0ed4abb9f44.gif)
