### PR TITLE
[Core/Alert] Fix grammar in docs ("informations" => "information")

### DIFF
--- a/packages/core/src/components/alert/alert.md
+++ b/packages/core/src/components/alert/alert.md
@@ -4,7 +4,7 @@ Alerts notify users of important information and force them to acknowledge the a
 continuing.
 
 Although similar to [dialogs](#core/components/dialog), alerts are more restrictive and should only be
-used for important informations. The user can only exit the alert by clicking one of the
+used for important information. The user can only exit the alert by clicking one of the
 confirmation buttons—clicking the overlay or pressing the `esc` key will not close the alert.
 
 You can only use this component in controlled mode. Use the `onClick` handlers in the primary and


### PR DESCRIPTION
#### Changes proposed in this pull request:
- Fix grammar in docs

Reference
- https://jakubmarian.com/information-is-vs-informations-are-is-information-plural-or-singular-in-english/
- https://english.stackexchange.com/questions/117552/why-does-information-not-have-a-plural-form