### PR TITLE
[Core/Button] Fix "Duplicate this page" button in docs

### DIFF
--- a/packages/core/examples/buttonsExample.tsx
+++ b/packages/core/examples/buttonsExample.tsx
@@ -76,7 +76,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                         className={classes}
                         disabled={this.state.disabled}
                         active={this.state.active}
-                        href="./"
+                        href="./#core/components/button.javascript-api"
                         iconName="duplicate"
                         intent={this.state.intent}
                         loading={this.state.loading}


### PR DESCRIPTION
Happy to change the button text or the href but currently the button opens http://blueprintjs.com/docs/ which isn't a duplicate of the page the button is on