### PR TITLE
don't calculate the position of the tab-indicator-wrapper if it won't…

### DIFF
--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -124,10 +124,12 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
             .filter(this.props.renderActiveTabPanelOnly ? tab => tab.props.id === selectedTabId : () => true)
             .map(this.renderTabPanel);
 
-        const tabIndicator = (
+        const tabIndicator = this.props.animate ? (
             <div className="pt-tab-indicator-wrapper" style={indicatorWrapperStyle}>
                 <div className="pt-tab-indicator" />
             </div>
+        ) : (
+            undefined
         );
 
         const classes = classNames(Classes.TABS, { [Classes.VERTICAL]: this.props.vertical }, this.props.className);
@@ -144,7 +146,7 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
                     ref={this.refHandlers.tablist}
                     role="tablist"
                 >
-                    {this.props.animate ? tabIndicator : undefined}
+                    {tabIndicator}
                     {tabTitles}
                 </div>
                 {tabPanels}
@@ -261,7 +263,7 @@ export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
      * Store the CSS values so the transition animation can start.
      */
     private moveSelectionIndicator() {
-        if (this.tablistElement === undefined) {
+        if (this.tablistElement === undefined || !this.props.animate) {
             return;
         }
 

--- a/packages/core/test/tabs/tabs2Tests.tsx
+++ b/packages/core/test/tabs/tabs2Tests.tsx
@@ -202,7 +202,7 @@ describe("<Tabs2>", () => {
                 {getTabsContents()}
             </Tabs2>,
         );
-        assertIndicatorPosition(wrapper, TAB_IDS[0]);
+        assert.isUndefined(wrapper.state().indicatorWrapperStyle);
         assert.equal(wrapper.find(".pt-tab-indicator").length, 0);
     });
 


### PR DESCRIPTION
… be shown

#### Fixes #0000

#### Changes proposed in this pull request:

Don't calculate the new position of the selected tab indicator if not required. (i.e. when not animating). This method involves calculating elements widths and therefore forces a layout which is non-trivial for performance (see  https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing#avoid-forced-synchronous-layouts).

Also include a mini-optimisation where the indicator div is never created if it won't be used. 
