### PR TITLE
[Table] Edit focused cells on f2

### DIFF
--- a/packages/table/src/cell/_cell.scss
+++ b/packages/table/src/cell/_cell.scss
@@ -21,6 +21,11 @@
     @include cell-content-align-vertical();
     color: transparent;
   }
+
+  &:focus {
+    // disable focus outline on cells; we already have the focus border
+    outline: none;
+  }
 }
 
 .bp-table-cell-interactive {

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -71,12 +71,12 @@ export interface ICellProps extends IIntentProps, IProps {
     tabIndex?: number;
 
     /**
-     * Callback to be called when the cell is focused and a key is pressed down.
+     * Callback invoked when the cell is focused and a key is pressed down.
      */
     onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 
     /**
-     * Callback to be called when the cell is focused and a key is released.
+     * Callback invoked when the cell is focused and a key is released.
      */
     onKeyUp?: React.KeyboardEventHandler<HTMLElement>;
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -64,6 +64,26 @@ export interface ICellProps extends IIntentProps, IProps {
      * @default false
      */
     wrapText?: boolean;
+
+    /**
+     * Allows for setting a tab index on the cell, so the cell can be browser-focusable.
+     */
+    tabIndex?: number;
+
+    /**
+     * Callback to be called when cell is focused and key is pressed down.
+     */
+    onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
+
+    /**
+     * Callback to be called when cell is focused and key is released.
+     */
+    onKeyUp?: React.KeyboardEventHandler<HTMLElement>;
+
+    /**
+     * A ref handle to capture the outer div of this cell. Used internally.
+     */
+    cellRef?: (ref: HTMLElement) => void;
 }
 
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
@@ -85,7 +105,20 @@ export class Cell extends React.Component<ICellProps, {}> {
     }
 
     public render() {
-        const { style, intent, interactive, loading, tooltip, truncated, className, wrapText } = this.props;
+        const {
+            cellRef,
+            tabIndex,
+            onKeyDown,
+            onKeyUp,
+            style,
+            intent,
+            interactive,
+            loading,
+            tooltip,
+            truncated,
+            className,
+            wrapText,
+        } = this.props;
 
         const classes = classNames(
             Classes.TABLE_CELL,
@@ -132,7 +165,15 @@ export class Cell extends React.Component<ICellProps, {}> {
         const content = <div className={textClasses}>{modifiedChildren}</div>;
 
         return (
-            <div className={classes} style={style} title={tooltip}>
+            <div
+                className={classes}
+                style={style}
+                title={tooltip}
+                tabIndex={tabIndex}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
+                ref={cellRef}
+            >
                 <LoadableContent loading={loading} variableLength={true}>
                     {content}
                 </LoadableContent>

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -71,12 +71,12 @@ export interface ICellProps extends IIntentProps, IProps {
     tabIndex?: number;
 
     /**
-     * Callback to be called when cell is focused and key is pressed down.
+     * Callback to be called when the cell is focused and a key is pressed down.
      */
     onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 
     /**
-     * Callback to be called when cell is focused and key is released.
+     * Callback to be called when the cell is focused and a key is released.
      */
     onKeyUp?: React.KeyboardEventHandler<HTMLElement>;
 
@@ -165,15 +165,7 @@ export class Cell extends React.Component<ICellProps, {}> {
         const content = <div className={textClasses}>{modifiedChildren}</div>;
 
         return (
-            <div
-                className={classes}
-                style={style}
-                title={tooltip}
-                tabIndex={tabIndex}
-                onKeyDown={onKeyDown}
-                onKeyUp={onKeyUp}
-                ref={cellRef}
-            >
+            <div className={classes} title={tooltip} ref={cellRef} {...{ style, tabIndex, onKeyDown, onKeyUp }}>
                 <LoadableContent loading={loading} variableLength={true}>
                     {content}
                 </LoadableContent>

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -8,13 +8,18 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { EditableText, Utils as CoreUtils } from "@blueprintjs/core";
+import { EditableText, Hotkey, Hotkeys, HotkeysTarget, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { Draggable } from "../interactions/draggable";
 import { Cell, ICellProps } from "./cell";
 
 export interface IEditableCellProps extends ICellProps {
+    /**
+     * Whether or not the given cell is the current active/focused cell.
+     */
+    isFocused?: boolean;
+
     /**
      * The value displayed in the text box. Be sure to update this value when
      * rendering this component after a confirmed change.
@@ -53,11 +58,14 @@ export interface IEditableCellState {
     dirtyValue?: string;
 }
 
+@HotkeysTarget
 export class EditableCell extends React.Component<IEditableCellProps, IEditableCellState> {
     public static defaultProps = {
         truncated: true,
         wrapText: false,
     };
+
+    private cellRef: HTMLElement;
 
     public constructor(props: IEditableCellProps, context?: any) {
         super(props, context);
@@ -65,6 +73,14 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
             isEditing: false,
             savedValue: props.value,
         };
+    }
+
+    public componentDidMount() {
+        this.checkShouldFocus();
+    }
+
+    public componentDidUpdate() {
+        this.checkShouldFocus();
     }
 
     public shouldComponentUpdate(nextProps: IEditableCellProps, nextState: IEditableCellState) {
@@ -115,7 +131,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
         }
 
         return (
-            <Cell {...spreadableProps} truncated={false} interactive={interactive}>
+            <Cell {...spreadableProps} truncated={false} interactive={interactive} cellRef={this.handleCellRef}>
                 <Draggable
                     onActivate={this.handleCellActivate}
                     onDoubleClick={this.handleCellDoubleClick}
@@ -127,6 +143,31 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
             </Cell>
         );
     }
+
+    public renderHotkeys() {
+        return (
+            <Hotkeys>
+                <Hotkey
+                    key="edit-cell"
+                    label="Edit the currely focused cell"
+                    group="Table"
+                    combo="f2"
+                    onKeyDown={this.handleEdit}
+                />
+            </Hotkeys>
+        );
+    }
+
+    private checkShouldFocus() {
+        if (this.props.isFocused && !this.state.isEditing) {
+            // don't focus if we're editing -- we'll lose the fact that we're editing
+            this.cellRef.focus();
+        }
+    }
+
+    private handleCellRef = (cellRef: HTMLElement) => {
+        this.cellRef = cellRef;
+    };
 
     private handleEdit = () => {
         this.setState({ isEditing: true, dirtyValue: this.state.savedValue });

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -16,7 +16,7 @@ import { Cell, ICellProps } from "./cell";
 
 export interface IEditableCellProps extends ICellProps {
     /**
-     * Whether or not the given cell is the current active/focused cell.
+     * Whether the given cell is the current active/focused cell.
      */
     isFocused?: boolean;
 
@@ -66,6 +66,11 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
     };
 
     private cellRef: HTMLElement;
+    private refHandlers = {
+        cell: (ref: HTMLElement) => {
+            this.cellRef = ref;
+        },
+    };
 
     public constructor(props: IEditableCellProps, context?: any) {
         super(props, context);
@@ -131,7 +136,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
         }
 
         return (
-            <Cell {...spreadableProps} truncated={false} interactive={interactive} cellRef={this.handleCellRef}>
+            <Cell {...spreadableProps} truncated={false} interactive={interactive} cellRef={this.refHandlers.cell}>
                 <Draggable
                     onActivate={this.handleCellActivate}
                     onDoubleClick={this.handleCellDoubleClick}
@@ -149,7 +154,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
             <Hotkeys>
                 <Hotkey
                     key="edit-cell"
-                    label="Edit the currely focused cell"
+                    label="Edit the currently focused cell"
                     group="Table"
                     combo="f2"
                     onKeyDown={this.handleEdit}
@@ -164,10 +169,6 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
             this.cellRef.focus();
         }
     }
-
-    private handleCellRef = (cellRef: HTMLElement) => {
-        this.cellRef = cellRef;
-    };
 
     private handleEdit = () => {
         this.setState({ isEditing: true, dirtyValue: this.state.savedValue });

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -988,6 +988,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     group="Table"
                     combo="tab"
                     onKeyDown={this.handleFocusMoveRightInternal}
+                    allowInInput={true}
                 />,
                 <Hotkey
                     key="move shift-tab"
@@ -995,6 +996,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     group="Table"
                     combo="shift+tab"
                     onKeyDown={this.handleFocusMoveLeftInternal}
+                    allowInInput={true}
                 />,
                 <Hotkey
                     key="move enter"
@@ -1002,6 +1004,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     group="Table"
                     combo="enter"
                     onKeyDown={this.handleFocusMoveDownInternal}
+                    allowInInput={true}
                 />,
                 <Hotkey
                     key="move shift-enter"
@@ -1009,6 +1012,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                     group="Table"
                     combo="shift+enter"
                     onKeyDown={this.handleFocusMoveUpInternal}
+                    allowInInput={true}
                 />,
             ];
         } else {

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -95,6 +95,7 @@ export class TableBody extends React.Component<ITableBodyProps, {}> {
                 >
                     <TableBodyCells
                         cellRenderer={this.props.cellRenderer}
+                        focusedCell={this.props.focusedCell}
                         grid={grid}
                         loading={this.props.loading}
                         onCompleteRender={this.props.onCompleteRender}

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -25,7 +25,7 @@ export interface ITableBodyCellsProps extends IRowIndices, IColumnIndices, IProp
     cellRenderer: ICellRenderer;
 
     /**
-     * The location of the focused cell, for setting the "focused" property on cells
+     * The coordinates of the currently focused cell, for setting the "isFocused" prop on cells.
      */
     focusedCell?: IFocusedCellCoordinates;
 

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 
 import { emptyCellRenderer, ICellRenderer } from "./cell/cell";
 import { Batcher } from "./common/batcher";
+import { IFocusedCellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
 import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
@@ -22,6 +23,11 @@ export interface ITableBodyCellsProps extends IRowIndices, IColumnIndices, IProp
      * A cell renderer for the cells in the body.
      */
     cellRenderer: ICellRenderer;
+
+    /**
+     * The location of the focused cell, for setting the "focused" property on cells
+     */
+    focusedCell?: IFocusedCellCoordinates;
 
     /**
      * The grid computes sizes of cells, rows, or columns from the
@@ -170,7 +176,7 @@ export class TableBodyCells extends React.Component<ITableBodyCellsProps, {}> {
     };
 
     private renderCell = (rowIndex: number, columnIndex: number, extremaClasses: string[], isGhost: boolean) => {
-        const { cellRenderer, loading, grid } = this.props;
+        const { cellRenderer, focusedCell, loading, grid } = this.props;
         const baseCell = isGhost ? emptyCellRenderer() : cellRenderer(rowIndex, columnIndex);
         const className = classNames(
             cellClassNames(rowIndex, columnIndex),
@@ -187,7 +193,8 @@ export class TableBodyCells extends React.Component<ITableBodyCellsProps, {}> {
         const cellLoading = baseCell.props.loading != null ? baseCell.props.loading : loading;
 
         const style = { ...baseCell.props.style, ...Rect.style(rect) };
-        return React.cloneElement(baseCell, { className, key, loading: cellLoading, style });
+        const isFocused = focusedCell != null && focusedCell.row === rowIndex && focusedCell.col === columnIndex;
+        return React.cloneElement(baseCell, { className, key, isFocused, loading: cellLoading, style });
     };
 
     // Callbacks


### PR DESCRIPTION
#### Changes proposed in this pull request:
Editable cells can be edited when focused by pressing `f2` -- so one can edit editable tables merely with `f2`, `enter`, and the arrow keys -- no mouse required!

This is done by making cells able to be browser-focused, and having them focus themselves whenever, well, they become focused. This also lets the focus stay on the table when you're done editing a cell. 

#### Reviewers should focus on:

There's... a bit of a horrible hack to allow the hotkeys to... pass through to the div beneath. I'm not sure if we should keep this or if there's a better way, or what? We could make some sort of slightly better version of cells having these endpoints, and make it less of a hack, maybe? Or fix hotkeys to find the DOM element underneath using `ReactDOM.findDOMNode`?

This doesn't work as well with the cell render batching if you're far down and to the right enough -- you can press f2 before the rendering is caught up and be editing the wrong cell for a short period of time before the rendering catches up and snaps it away. I'm... not sure what to do about this. 

#### Screenshot

![oct-17-2017 17-31-51](https://user-images.githubusercontent.com/2463526/31690576-1afa44ee-b361-11e7-8b81-8e5a42362c9b.gif)
