### PR TITLE
[Core] Add popoverProps to INVALID_PROPS

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -92,6 +92,7 @@ const INVALID_PROPS = [
     "leftIconName",
     "onChildrenMount",
     "onRemove",
+    "popoverProps",
     "rightElement",
     "rightIconName",
     "text",


### PR DESCRIPTION
addresses the following error:

```
Warning: Unknown prop `popoverProps` on <a> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in a (created by Blueprint.AnchorButton)
    ...
```

#### Fixes #0000

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

<!-- fill this out -->

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
