### PR TITLE
Prepare Release table-1.29.1

### DIFF
--- a/packages/site-docs/package.json
+++ b/packages/site-docs/package.json
@@ -8,7 +8,7 @@
     "@blueprintjs/datetime": "^1.23.0",
     "@blueprintjs/docs": "^1.1.1",
     "@blueprintjs/labs": "^0.12.0",
-    "@blueprintjs/table": "^1.29.0",
+    "@blueprintjs/table": "^1.29.1",
     "bourbon": "^4.2.2",
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Scalable interactive table component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1999,7 +1999,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 this.scrollContainerElement.scrollTop = nextScrollTop + topCorrection;
             }
             if (didScrollLeftChange) {
-                const leftCorrection = this.shouldDisableHorizontalScroll() ? 0 : this.rowHeaderElement.clientWidth;
+                const leftCorrection =
+                    this.shouldDisableHorizontalScroll() || this.rowHeaderElement == null
+                        ? 0
+                        : this.rowHeaderElement.clientWidth;
+
                 this.scrollContainerElement.scrollLeft = nextScrollLeft + leftCorrection;
             }
 


### PR DESCRIPTION
:book: **Latest docs**: [blueprintjs.com/docs](http://blueprintjs.com/docs)

## `@blueprintjs/table 1.29.1`

### 🐛  Bug fixes
- `Table` Fix NPE error that was sometimes thrown when scrolling with `isRowHeaderShown=false`. (🎩  @mscolnick) 