### PR TITLE
[Dialog] Fix `user-select` value

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -79,7 +79,7 @@ $dialog-padding: $pt-grid-size * 2 !default;
   background: $light-gray4;
   width: $pt-grid-size * 50;
   padding-bottom: $pt-grid-size * 2;
-  user-select: initial;
+  user-select: text;
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
Change `user-select` from `initial` to `text` for `.pt-dialog`. Chrome 62 regression.

#### Reviewers should focus on:

Can someone check that it works as expected with Chrome <= 61?

