### PR TITLE
[Core] Improve types: IContextMenuTarget.renderContextMenu can return undefined

### DIFF
--- a/packages/core/src/components/context-menu/context-menu.md
+++ b/packages/core/src/components/context-menu/context-menu.md
@@ -20,7 +20,7 @@ The `@ContextMenuTarget` [class decorator][ts-decorator] can be applied to any `
 class that meets the following requirements:
 
 - It defines an instance method called `renderContextMenu()` that returns a single `JSX.Element`
-(most likely a [`Menu`](#core/components/menu)).
+(most likely a [`Menu`](#core/components/menu)) or `undefined`.
 - Its root element supports the `"contextmenu"` event and the `onContextMenu` prop.
 
 This is always true if the decorated class uses an intrinsic element, such as `<div>`, as its

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -23,7 +23,7 @@ import { isDarkTheme } from "../../common/utils/isDarkTheme";
 import * as ContextMenu from "./contextMenu";
 
 export interface IContextMenuTarget extends React.Component<any, any> {
-    renderContextMenu(e: React.MouseEvent<HTMLElement>): JSX.Element;
+    renderContextMenu(e: React.MouseEvent<HTMLElement>): JSX.Element | undefined;
     onContextMenuClose?(): void;
 }
 


### PR DESCRIPTION
#### Fixes #1743

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

ContextMenuTarget already handles the case where renderContextMenu returns undefined or null. This changes the type of renderContextMenu in IContextMenuTarget to reflect that this is allowed.