### PR TITLE
[Core/Button] Fix erroneous padding when text=""

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -117,8 +117,11 @@ export abstract class AbstractButton<T> extends React.Component<React.HTMLProps<
         const { loading, rightIconName, text } = this.props;
 
         const children = React.Children.map(this.props.children, (child, index) => {
-            // must wrap string children in spans so loading prop can hide them
-            if (typeof child === "string") {
+            if (child === "") {
+                // render as undefined to avoid extra space after icon
+                return undefined;
+            } else if (typeof child === "string") {
+                // must wrap string children in spans so loading prop can hide them
                 return <span key={`text-${index}`}>{child}</span>;
             }
             return child;

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -42,6 +42,10 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             assert.equal(wrapper.find("em").length, 1, "em not found");
         });
 
+        it('doesn\'t render a span if text=""', () => {
+            assert.equal(button({}, true, "").find("span").length, 0);
+        });
+
         it("renders a loading spinner when the loading prop is true", () => {
             const wrapper = button({ loading: true });
             assert.lengthOf(wrapper.find(Spinner), 1);


### PR DESCRIPTION
#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🐛  __FIXED__ `Button` (and `AnchorButton`) with `iconName` no longer include erroneous right padding when `text=""`.
    - I'm coercing `""` children to `undefined` so that this rule is applied:
    ```scss
    // ensure icon button with no text is a perfect square
    &[class*="pt-icon-"]:empty {
        padding: 0;
    
        &::before {
          margin-right: 0;
        }
    }
    ```

#### Screenshot

___BEFORE:___

`text=""`

![image](https://user-images.githubusercontent.com/443450/32120127-4e917c02-bb0c-11e7-933b-5b3eee5fcb75.png)

`iconName="edit"`

![image](https://user-images.githubusercontent.com/443450/32120170-73b17186-bb0c-11e7-9f4c-dcb552f39389.png)

`rightIconName="edit"`

![image](https://user-images.githubusercontent.com/443450/32120153-67e34adc-bb0c-11e7-853d-4ab43b281798.png)

___AFTER:___

`text=""`
![image](https://user-images.githubusercontent.com/443450/32120127-4e917c02-bb0c-11e7-933b-5b3eee5fcb75.png)

`iconName="edit"`
![image](https://user-images.githubusercontent.com/443450/32120226-a0a3095c-bb0c-11e7-9388-2f4a2370d2ca.png)

`rightIconName="edit"` _(unchanged)_
![image](https://user-images.githubusercontent.com/443450/32120253-c2316654-bb0c-11e7-8792-21cdef2707c6.png)
