### PR TITLE
[Table/EditableCell] Type in a cell to edit it now

### DIFF
--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -79,6 +79,11 @@ export interface ICellProps extends IIntentProps, IProps {
     onKeyUp?: React.KeyboardEventHandler<HTMLElement>;
 
     /**
+     * Callback invoked when a character-key is pressed
+     */
+    onKeyPress?: React.KeyboardEventHandler<HTMLElement>;
+
+    /**
      * A ref handle to capture the outer div of this cell. Used internally.
      */
     cellRef?: (ref: HTMLElement) => void;
@@ -108,6 +113,7 @@ export class Cell extends React.Component<ICellProps, {}> {
             tabIndex,
             onKeyDown,
             onKeyUp,
+            onKeyPress,
             style,
             intent,
             interactive,
@@ -163,7 +169,12 @@ export class Cell extends React.Component<ICellProps, {}> {
         const content = <div className={textClasses}>{modifiedChildren}</div>;
 
         return (
-            <div className={classes} title={tooltip} ref={cellRef} {...{ style, tabIndex, onKeyDown, onKeyUp }}>
+            <div
+                className={classes}
+                title={tooltip}
+                ref={cellRef}
+                {...{ style, tabIndex, onKeyDown, onKeyUp, onKeyPress }}
+            >
                 <LoadableContent loading={loading} variableLength={true}>
                     {content}
                 </LoadableContent>

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -79,7 +79,7 @@ export interface ICellProps extends IIntentProps, IProps {
     onKeyUp?: React.KeyboardEventHandler<HTMLElement>;
 
     /**
-     * Callback invoked when a character-key is pressed
+     * Callback invoked when a character-key is pressed.
      */
     onKeyPress?: React.KeyboardEventHandler<HTMLElement>;
 

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -120,7 +120,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
                     onConfirm={this.handleConfirm}
                     onEdit={this.handleEdit}
                     placeholder=""
-                    selectAllOnFocus={true}
+                    selectAllOnFocus={false}
                     value={dirtyValue}
                 />
             );
@@ -134,7 +134,13 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
         }
 
         return (
-            <Cell {...spreadableProps} truncated={false} interactive={interactive} cellRef={this.refHandlers.cell}>
+            <Cell
+                {...spreadableProps}
+                truncated={false}
+                interactive={interactive}
+                cellRef={this.refHandlers.cell}
+                onKeyPress={this.handleKeyPress}
+            >
                 <Draggable
                     onActivate={this.handleCellActivate}
                     onDoubleClick={this.handleCellDoubleClick}
@@ -167,6 +173,14 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
             this.cellRef.focus();
         }
     }
+
+    private handleKeyPress = () => {
+        if (this.state.isEditing) {
+            return;
+        }
+        // setting dirty value to empty string because apparently the text field will pick up the key and write it in there
+        this.setState({ isEditing: true, dirtyValue: "", savedValue: this.state.savedValue });
+    };
 
     private handleEdit = () => {
         this.setState({ isEditing: true, dirtyValue: this.state.savedValue });

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -175,7 +175,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
     }
 
     private handleKeyPress = () => {
-        if (this.state.isEditing) {
+        if (this.state.isEditing || !this.props.isFocused) {
             return;
         }
         // setting dirty value to empty string because apparently the text field will pick up the key and write it in there


### PR DESCRIPTION
#### Changes proposed in this pull request:

Typing any character now replaces the cell content with that character and puts it in edit mode, essentially letting you arrow around and type in the correct cell. 

