### PR TITLE
Avoid using a reserved word as an identifier

### DIFF
--- a/docs/blueprint-landing.js
+++ b/docs/blueprint-landing.js
@@ -32218,8 +32218,8 @@
 	        // is a floating-point number character that we're allowed to print.
 	        return !this.isFloatingPointNumericCharacter(e.key);
 	    };
-	    NumericInput.prototype.isFloatingPointNumericCharacter = function (char) {
-	        return NumericInput_1.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(char);
+	    NumericInput.prototype.isFloatingPointNumericCharacter = function (ch) {
+	        return NumericInput_1.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(ch);
 	    };
 	    NumericInput.prototype.getStepMaxPrecision = function (props) {
 	        if (props.minorStepSize != null) {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -576,8 +576,8 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
         return !this.isFloatingPointNumericCharacter(e.key);
     }
 
-    private isFloatingPointNumericCharacter(char: string) {
-        return NumericInput.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(char);
+    private isFloatingPointNumericCharacter(ch: string) {
+        return NumericInput.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(ch);
     }
 
     private getStepMaxPrecision(props: HTMLInputProps & INumericInputProps) {


### PR DESCRIPTION
#### Fixes #1763

#### Changes proposed in this pull request:

Rename `char` identifier to `ch` in a couple of places, since `char` is a JavaScript reserved word.

#### Reviewers should focus on:

I changed this is all the places I found it. I thought the JS would be generated from the TypeScript, but it didn't appear to be and the JS is checked in to the repository, so it seemed best to fix it there as well.