### PR TITLE
Avoid using a reserved word as an identifier

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -576,8 +576,8 @@ export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInp
         return !this.isFloatingPointNumericCharacter(e.key);
     }
 
-    private isFloatingPointNumericCharacter(char: string) {
-        return NumericInput.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(char);
+    private isFloatingPointNumericCharacter(character: string) {
+        return NumericInput.FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(character);
     }
 
     private getStepMaxPrecision(props: HTMLInputProps & INumericInputProps) {


### PR DESCRIPTION
#### Fixes #1763

#### Changes proposed in this pull request:

Rename `char` identifier to `character` in a couple of places, since `char` is a ClosureScript reserved word.
