### PR TITLE
[MultiSelect] Uncontrolled selectedItems no longer throws error

### DIFF
--- a/packages/labs/src/components/select/multiSelect.tsx
+++ b/packages/labs/src/components/select/multiSelect.tsx
@@ -111,7 +111,7 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { tagInputProps = {}, popoverProps = {}, selectedItems } = this.props;
+        const { tagInputProps = {}, popoverProps = {}, selectedItems = [] } = this.props;
         const { handleKeyDown, handleKeyUp, query } = listProps;
         const defaultInputProps: HTMLInputProps = {
             placeholder: "Search...",
@@ -121,8 +121,6 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
             ref: this.refHandlers.input,
             value: query,
         };
-
-        const tagInputValues = selectedItems == null ? [] : selectedItems.map(this.props.tagRenderer);
 
         return (
             <Popover
@@ -146,7 +144,7 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
                         {...tagInputProps}
                         inputProps={defaultInputProps}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
-                        values={tagInputValues}
+                        values={selectedItems.map(this.props.tagRenderer)}
                     />
                 </div>
                 <div onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)} onKeyUp={handleKeyUp}>

--- a/packages/labs/src/components/select/multiSelect.tsx
+++ b/packages/labs/src/components/select/multiSelect.tsx
@@ -111,7 +111,7 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { tagInputProps = {}, popoverProps = {} } = this.props;
+        const { tagInputProps = {}, popoverProps = {}, selectedItems } = this.props;
         const { handleKeyDown, handleKeyUp, query } = listProps;
         const defaultInputProps: HTMLInputProps = {
             placeholder: "Search...",
@@ -121,6 +121,8 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
             ref: this.refHandlers.input,
             value: query,
         };
+
+        const tagInputValues = selectedItems == null ? [] : selectedItems.map(this.props.tagRenderer);
 
         return (
             <Popover
@@ -144,7 +146,7 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
                         {...tagInputProps}
                         inputProps={defaultInputProps}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
-                        values={this.props.selectedItems.map(this.props.tagRenderer)}
+                        values={tagInputValues}
                     />
                 </div>
                 <div onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)} onKeyUp={handleKeyUp}>

--- a/packages/labs/test/multiSelectTests.tsx
+++ b/packages/labs/test/multiSelectTests.tsx
@@ -64,7 +64,7 @@ describe("<MultiSelect>", () => {
         assert.strictEqual(handlers.onItemSelect.args[0][0], TOP_100_FILMS[4]);
     });
 
-    it("selectedItems can be missing without throwing an error", () => {
+    it("selectedItems is optional", () => {
         assert.doesNotThrow(() => multiselect({ selectedItems: undefined }));
     });
 

--- a/packages/labs/test/multiSelectTests.tsx
+++ b/packages/labs/test/multiSelectTests.tsx
@@ -64,6 +64,10 @@ describe("<MultiSelect>", () => {
         assert.strictEqual(handlers.onItemSelect.args[0][0], TOP_100_FILMS[4]);
     });
 
+    it("selectedItems can be missing without throwing an error", () => {
+        assert.doesNotThrow(() => multiselect({ selectedItems: undefined }));
+    });
+
     function multiselect(props: Partial<IMultiSelectProps<Film>> = {}, query?: string) {
         const wrapper = mount(
             <FilmMultiSelect {...defaultProps} {...handlers} {...props}>


### PR DESCRIPTION
#### Fixes #1785 

#### Checklist
- [x] Include tests

#### Changes proposed in this pull request:
- `MultiSelect` no longer throws an error when `selectedItems` is not controlled.