### PR TITLE
[DateRangePicker] Show selected date's end month on init if contiguousCalendarMonths=false

### DIFF
--- a/packages/datetime/src/common/monthAndYear.ts
+++ b/packages/datetime/src/common/monthAndYear.ts
@@ -7,6 +7,10 @@
 import { getDateNextMonth, getDatePreviousMonth } from "./dateUtils";
 
 export class MonthAndYear {
+    public static fromDate(date: Date) {
+        return date == null ? undefined : new MonthAndYear(date.getMonth(), date.getFullYear());
+    }
+
     private date: Date;
 
     constructor(month?: number, year?: number) {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -187,20 +187,24 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             initialMonth = DateUtils.getDateBetween([props.minDate, props.maxDate]);
         }
 
-        /*
-        * if the initial month is the last month of the picker's
-        * allowable range, the react-day-picker library will show
-        * the max month on the left and the *min* month on the right.
-        * subtracting one avoids that weird, wraparound state (#289).
-        */
+        // if the initial month is the last month of the picker's
+        // allowable range, the react-day-picker library will show
+        // the max month on the left and the *min* month on the right.
+        // subtracting one avoids that weird, wraparound state (#289).
         const initialMonthEqualsMinMonth = DateUtils.areSameMonth(initialMonth, props.minDate);
         const initalMonthEqualsMaxMonth = DateUtils.areSameMonth(initialMonth, props.maxDate);
         if (!initialMonthEqualsMinMonth && initalMonthEqualsMaxMonth) {
             initialMonth.setMonth(initialMonth.getMonth() - 1);
         }
 
-        const leftView = new MonthAndYear(initialMonth.getMonth(), initialMonth.getFullYear());
-        const rightView = leftView.getNextMonth();
+        // show the selected end date's encompassing month in the right view if
+        // the calendars don't have to be contiguous.
+        const leftView = MonthAndYear.fromDate(initialMonth);
+        const rightDate = value[1];
+        const rightView =
+            !props.contiguousCalendarMonths && rightDate != null
+                ? MonthAndYear.fromDate(rightDate)
+                : leftView.getNextMonth();
         this.state = { leftView, rightView, value, hoverValue: [null, null] };
     }
 
@@ -254,7 +258,6 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
                 </div>
             );
         } else {
-            debugger;
             // const rightMonth = contiguousCalendarMonths ? rightView.getFullDate()
             return (
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
@@ -629,7 +632,6 @@ function getStateChange(
                     leftView = nextValueStartMonthAndYear;
                     rightView = nextValueStartMonthAndYear.getNextMonth();
                 }
-
             } else {
                 // Different start and end date months, adjust display months.
                 if (!leftView.isSame(nextValueStartMonthAndYear)) {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -254,6 +254,8 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
                 </div>
             );
         } else {
+            debugger;
+            // const rightMonth = contiguousCalendarMonths ? rightView.getFullDate()
             return (
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
                     {this.maybeRenderShortcuts()}
@@ -576,12 +578,10 @@ function getStateChange(
         let leftView = state.leftView.clone();
         let rightView = state.rightView.clone();
 
-        /*
-        * Only end date selected.
-        * If the newly selected end date isn't in either of the displayed months, then
-        *   - set the right DayPicker to the month of the selected end date
-        *   - ensure the left DayPicker is before the right, changing if needed
-        */
+        // Only end date selected.
+        // If the newly selected end date isn't in either of the displayed months, then
+        //   - set the right DayPicker to the month of the selected end date
+        //   - ensure the left DayPicker is before the right, changing if needed
         if (nextValueStart == null && nextValueEnd != null) {
             const nextValueEndMonthAndYear = new MonthAndYear(nextValueEnd.getMonth(), nextValueEnd.getFullYear());
 
@@ -591,13 +591,11 @@ function getStateChange(
                     leftView = rightView.getPreviousMonth();
                 }
             }
-            /*
-        * Only start date selected.
-        * If the newly selected start date isn't in either of the displayed months, then
-        *   - set the left DayPicker to the month of the selected start date
-        *   - ensure the right DayPicker is before the left, changing if needed
-        */
         } else if (nextValueStart != null && nextValueEnd == null) {
+            // Only start date selected.
+            // If the newly selected start date isn't in either of the displayed months, then
+            //   - set the left DayPicker to the month of the selected start date
+            //   - ensure the right DayPicker is before the left, changing if needed
             const nextValueStartMonthAndYear = new MonthAndYear(
                 nextValueStart.getMonth(),
                 nextValueStart.getFullYear(),
@@ -609,22 +607,18 @@ function getStateChange(
                     rightView = leftView.getNextMonth();
                 }
             }
-            /*
-        * Both start date and end date selected.
-        */
         } else if (nextValueStart != null && nextValueEnd != null) {
+            // Both start date and end date selected.
             const nextValueStartMonthAndYear = new MonthAndYear(
                 nextValueStart.getMonth(),
                 nextValueStart.getFullYear(),
             );
             const nextValueEndMonthAndYear = new MonthAndYear(nextValueEnd.getMonth(), nextValueEnd.getFullYear());
 
-            /*
-            * Both start and end date months are identical
-            * If the selected month isn't in either of the displayed months, then
-            *   - set the left DayPicker to be the selected month
-            *   - set the right DayPicker to +1
-            */
+            // Both start and end date months are identical
+            // If the selected month isn't in either of the displayed months, then
+            //   - set the left DayPicker to be the selected month
+            //   - set the right DayPicker to +1
             if (DateUtils.areSameMonth(nextValueStart, nextValueEnd)) {
                 const potentialLeftEqualsNextValueStart = leftView.isSame(nextValueStartMonthAndYear);
                 const potentialRightEqualsNextValueStart = rightView.isSame(nextValueStartMonthAndYear);
@@ -635,10 +629,9 @@ function getStateChange(
                     leftView = nextValueStartMonthAndYear;
                     rightView = nextValueStartMonthAndYear.getNextMonth();
                 }
-                /*
-            * Different start and end date months, adjust display months.
-            */
+
             } else {
+                // Different start and end date months, adjust display months.
                 if (!leftView.isSame(nextValueStartMonthAndYear)) {
                     leftView = nextValueStartMonthAndYear;
                     rightView = nextValueStartMonthAndYear.getNextMonth();

--- a/packages/datetime/src/index.md
+++ b/packages/datetime/src/index.md
@@ -19,6 +19,9 @@ The __@blueprintjs/datetime__ NPM package provides several components for intera
 - [`DateInput`](#datetime/dateinput), which composes a text input with a `DatePicker` in
   a `Popover`, for use in forms.
 
+- [`DateRangeInput`](#datetime/daterangeinput), which composes two text inputs with a `DateRangePicker` in
+  a `Popover`, for use in forms.
+
 They are available in the __@blueprintjs/datetime__ package on
 [NPM](https://www.npmjs.com/package/@blueprintjs/datetime).
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -386,6 +386,13 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.leftView.getYear(), YEAR);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.DECEMBER);
         });
+
+        it("right calendar shows the month immediately after the left view by default", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.JULY, 5);
+            renderDateRangePicker({ value: [startDate, endDate] });
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
+        });
     });
 
     describe("left/right calendar when not sequential", () => {
@@ -528,6 +535,13 @@ describe("<DateRangePicker>", () => {
             TestUtils.Simulate.click(prevBtn[1]);
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.APRIL);
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.MAY);
+        });
+
+        it("right calendar shows the month containing the selected end date", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.JULY, 5);
+            renderDateRangePicker({ contiguousCalendarMonths: false, value: [startDate, endDate] });
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JULY);
         });
     });
 


### PR DESCRIPTION
#### Fixes #1774

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- `DateRangePicker` with `contiguousCalendarMonths=false` now shows selected end date in right view on init. 
    - (Before, the right view always showed the month immediately after the left view, which wasn't always helpful.) 


#### Screenshot

Demonstrated in `DateRangeInput`:

![2017-11-05 23 08 41](https://user-images.githubusercontent.com/443450/32429172-4f49f79a-c27e-11e7-981b-a5e81be5b7a4.gif)
