### PR TITLE
[DateInput] Make timePickerProps configurable

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -33,7 +33,7 @@ import { DATEINPUT_WARN_DEPRECATED_OPEN_ON_FOCUS, DATEINPUT_WARN_DEPRECATED_POPO
 import { DatePicker } from "./datePicker";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
 import { DateTimePicker } from "./dateTimePicker";
-import { TimePickerPrecision } from "./timePicker";
+import { ITimePickerProps, TimePickerPrecision } from "./timePicker";
 
 export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     /**
@@ -141,6 +141,13 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     value?: Date;
 
     /**
+     * Any props to be passed on to the `TimePicker` when . `value`, `onChange`,
+     * and `timePrecision` will be ignored in favor of the top-level props by
+     * the same name.
+     */
+    timePickerProps?: ITimePickerProps;
+
+    /**
      * Adds a time chooser to the bottom of the popover.
      * Passed to the `DateTimePicker` component.
      */
@@ -166,6 +173,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
         popoverPosition: Position.BOTTOM,
+        timePickerProps: {},
     };
 
     public static displayName = "Blueprint.DateInput";
@@ -199,7 +207,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                     onChange={this.handleDateChange}
                     value={dateValue}
                     datePickerProps={this.props}
-                    timePickerProps={{ precision: this.props.timePrecision }}
+                    timePickerProps={{ ...this.props.timePickerProps, precision: this.props.timePrecision }}
                 />
             );
         // assign default empty object here to prevent mutation

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -141,9 +141,9 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     value?: Date;
 
     /**
-     * Any props to be passed on to the `TimePicker` when . `value`, `onChange`,
-     * and `timePrecision` will be ignored in favor of the top-level props by
-     * the same name.
+     * Any props to be passed on to the `TimePicker`. `value`, `onChange`, and
+     * `timePrecision` will be ignored in favor of the corresponding top-level
+     * props on this component.
      */
     timePickerProps?: ITimePickerProps;
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -68,6 +68,38 @@ describe("<DateInput>", () => {
         });
     });
 
+    it("with TimePicker passes timePickerProps correctly to DateTimePicker", () => {
+        const onChange = sinon.spy();
+        const value = new Date(2017, Months.MAY, 5);
+
+        const timePickerProps = {
+            disabled: true,
+            // these will each be overridden by top-level props:
+            onChange,
+            precision: TimePickerPrecision.MILLISECOND,
+            value: new Date(2017, Months.MAY, 6),
+        };
+
+        const wrapper = mount(
+            <DateInput
+                timePrecision={TimePickerPrecision.SECOND}
+                onChange={sinon.spy()}
+                value={value}
+                timePickerProps={timePickerProps}
+            />,
+        ).setState({ isOpen: true });
+
+        const timePicker = wrapper.find(TimePicker);
+
+        // ensure the top-level props override props by the same name in timePickerProps
+        assert.equal(timePicker.prop("precision"), TimePickerPrecision.SECOND);
+        assert.notEqual(timePicker.prop("onChange"), onChange);
+        DateTestUtils.assertDatesEqual(timePicker.prop("value"), value);
+
+        // ensure this additional prop was passed through undeterred.
+        assert.equal(timePicker.prop("disabled"), true);
+    });
+
     it("inputProps are passed to InputGroup", () => {
         const inputRef = sinon.spy();
         const onFocus = sinon.spy();


### PR DESCRIPTION
#### Fixes #1727 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- `DateInput` now accepts custom `timePickerProps`

#### Reviewers should focus on:

- Are all the component `timePickerProps` being overridden correctly by top-level props?