### PR TITLE
[DateInput] Selected value stays selected when canClearSelection=false with timePrecision enabled

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -196,6 +196,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 <DatePicker {...this.props} onChange={this.handleDateChange} value={dateValue} />
             ) : (
                 <DateTimePicker
+                    canClearSelection={this.props.canClearSelection}
                     onChange={this.handleDateChange}
                     value={dateValue}
                     datePickerProps={this.props}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -298,9 +298,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         const prevMomentDate = this.state.value;
         const momentDate = fromDateToMoment(date);
 
-        // this change handler was triggered by a change in month, day, or (if enabled) time. for UX
-        // purposes, we want to close the popover only if the user explicitly clicked a day within
-        // the current month.
+        // this change handler was triggered by a change in month, day, or (if
+        // enabled) time. for UX purposes, we want to close the popover only if
+        // the user explicitly clicked a day within the current month.
         const isOpen =
             !hasUserManuallySelectedDate ||
             this.hasMonthChanged(prevMomentDate, momentDate) ||

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -321,6 +321,26 @@ describe("<DateInput>", () => {
             const wrapper = mount(<DateInput locale="de" format="L" value={DATE2} />);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_DE_STR);
         });
+
+        it.only("Clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
+            const onChange = sinon.spy();
+            const { getSelectedDays, root } = wrap(
+                <DateInput
+                    canClearSelection={false}
+                    onChange={onChange}
+                    timePrecision={TimePickerPrecision.SECOND}
+                    value={DATE}
+                />,
+            );
+            root.setState({ isOpen: true });
+
+            getSelectedDays()
+                .at(0)
+                .simulate("click");
+
+            assert.isTrue(onChange.calledOnce);
+            assert.deepEqual(onChange.firstCall.args, [DATE]);
+        });
     });
 
     /* Assert Date equals YYYY-MM-DD string. */

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -262,6 +262,25 @@ describe("<DateInput>", () => {
             assert.isTrue(onError.calledOnce);
             assert.isNaN((onError.args[0][0] as Date).valueOf());
         });
+
+        it("Clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
+            const DATE = new Date(2016, Months.APRIL, 4);
+            const onChange = sinon.spy();
+            const { getDay, root } = wrap(
+                <DateInput
+                    canClearSelection={false}
+                    defaultValue={DATE}
+                    onChange={onChange}
+                    timePrecision={TimePickerPrecision.SECOND}
+                />,
+            );
+            root.setState({ isOpen: true });
+
+            getDay(DATE.getDate()).simulate("click");
+
+            assert.isTrue(onChange.calledOnce);
+            assert.deepEqual(onChange.firstCall.args, [DATE]);
+        });
     });
 
     describe("when controlled", () => {
@@ -322,7 +341,7 @@ describe("<DateInput>", () => {
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_DE_STR);
         });
 
-        it.only("Clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
+        it("Clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
             const onChange = sinon.spy();
             const { getSelectedDays, root } = wrap(
                 <DateInput


### PR DESCRIPTION
#### Fixes #1737 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

BEFORE:
1. Make a `DateInput` with `canClearSelection=false` and `timePrecision` enabled.
1. Select a date.
1. Click the selected date again.
1. `onChange` is erroneously emitted with `null`, suggesting that the date has just been deselected, which shouldn't be possible.

AFTER:
`DateInput` no longer emits `onChange` with `null` when clicking selected date with `canClearSelection=false` with `timePrecision` enabled.

#### Reviewers should focus on:

Nothing in particular. Easy fix.

#### Screenshot

Here's a working example with the following props:

```tsx
<DateInput
    canClearSelection={false}
    value={new Date(2017, Months.NOVEMBER, 6)}
    onChange={console.log}
    timePrecision={TimePickerPrecision.SECOND}
/>
```

![2017-11-06 09 19 56](https://user-images.githubusercontent.com/443450/32454303-b00d2318-c2d3-11e7-8bf3-30ab2ec0f470.gif)
