### PR TITLE
[Table] Better editable names

### DIFF
--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -154,7 +154,9 @@ export class ColumnHeaderCell extends AbstractComponent<IColumnHeaderCellProps, 
 
         const nameComponent = (
             <LoadableContent loading={loading} variableLength={true}>
-                {renderName == null ? defaultName : renderName(name, index)}
+                {renderName == null
+                    ? defaultName
+                    : React.cloneElement(renderName(name, index) as JSX.Element, { index })}
             </LoadableContent>
         );
 

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
+import { EditableText, IIntentProps, IProps, Utils as CoreUtils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
@@ -35,24 +35,80 @@ export interface IEditableNameProps extends IIntentProps, IProps {
      * usually due to the `return` (or `enter`) key press.
      */
     onConfirm?: (value: string) => void;
+
+    /**
+     * The index of the name in the header. If provided, this will be passed as an argument to any
+     * callbacks when they are invoked.
+     */
+    index?: number;
+}
+
+export interface IEditableNameState {
+    isEditing?: boolean;
+    savedName?: string;
+    dirtyName?: string;
 }
 
 @PureRender
-export class EditableName extends React.Component<IEditableNameProps, {}> {
+export class EditableName extends React.Component<IEditableNameProps, IEditableNameState> {
+    public constructor(props: IEditableNameProps, context?: any) {
+        super(props, context);
+        this.state = {
+            dirtyName: props.name,
+            isEditing: false,
+            savedName: props.name,
+        };
+    }
+
+    public componentWillReceiveProps(nextProps: IEditableNameProps) {
+        const { name } = nextProps;
+        if (name !== this.props.name) {
+            this.setState({ savedName: name, dirtyName: name });
+        }
+    }
+
     public render() {
-        const { className, intent, name, onCancel, onChange, onConfirm } = this.props;
+        const { className, intent, name } = this.props;
+        const { isEditing, dirtyName, savedName } = this.state;
         return (
             <EditableText
                 className={classNames(className, Classes.TABLE_EDITABLE_NAME)}
                 defaultValue={name}
                 intent={intent}
                 minWidth={null}
-                onCancel={onCancel}
-                onChange={onChange}
-                onConfirm={onConfirm}
+                onCancel={this.handleCancel}
+                onChange={this.handleChange}
+                onConfirm={this.handleConfirm}
+                onEdit={this.handleEdit}
                 placeholder=""
                 selectAllOnFocus={true}
+                value={isEditing ? dirtyName : savedName}
             />
         );
+    }
+
+    private handleEdit = () => {
+        this.setState({ isEditing: true, dirtyName: this.state.savedName });
+    };
+
+    private handleCancel = (value: string) => {
+        // don't strictly need to clear the dirtyName, but it's better hygiene
+        this.setState({ isEditing: false, dirtyName: undefined });
+        this.invokeCallback(this.props.onCancel, value);
+    };
+
+    private handleChange = (value: string) => {
+        this.setState({ dirtyName: value });
+        this.invokeCallback(this.props.onChange, value);
+    };
+
+    private handleConfirm = (value: string) => {
+        this.setState({ isEditing: false, savedName: value, dirtyName: undefined });
+        this.invokeCallback(this.props.onConfirm, value);
+    };
+
+    private invokeCallback(callback: (value: string, columnIndex?: number) => void, value: string) {
+        const { index } = this.props;
+        CoreUtils.safeInvoke(callback, value, index);
     }
 }

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -41,11 +41,12 @@ describe("<ColumnHeaderCell>", () => {
     });
 
     it("passes index prop to renderName callback if index was provided", () => {
-        const renderNameSpy = sinon.spy();
+        const renderNameStub = sinon.stub();
+        renderNameStub.returns("string");
         const NAME = "my-name";
         const INDEX = 17;
-        shallow(<ColumnHeaderCell index={INDEX} name={NAME} renderName={renderNameSpy} />);
-        expect(renderNameSpy.firstCall.args).to.deep.equal([NAME, INDEX]);
+        shallow(<ColumnHeaderCell index={INDEX} name={NAME} renderName={renderNameStub} />);
+        expect(renderNameStub.firstCall.args).to.deep.equal([NAME, INDEX]);
     });
 
     describe("Custom renderer", () => {


### PR DESCRIPTION
#### Fixes #1262, #1257 

#### Changes proposed in this pull request:

Clone the header name so it gets the index as props when created, so it can use it to pass it in the callbacks. Also improve the header so that it actually is controlled mode, more or less. 
