### PR TITLE
[Core/RangeSlider] When values equal, always move the nearest handle on track click

### DIFF
--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -105,9 +105,18 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
     }
 
     protected nearestHandleForValue(value: number, firstHandle: Handle, secondHandle: Handle) {
-        const firstDistance = Math.abs(value - firstHandle.props.value);
+        const firstHandleValue = firstHandle.props.value;
+        const firstDistance = Math.abs(value - firstHandleValue);
         const secondDistance = Math.abs(value - secondHandle.props.value);
-        return secondDistance < firstDistance ? secondHandle : firstHandle;
+        if (firstDistance < secondDistance) {
+            return firstHandle;
+        } else if (secondDistance < firstDistance) {
+            return secondHandle;
+        } else {
+            // if the values are equal, return the handle that is *able* to move
+            // in the necessary direction.
+            return value < firstHandleValue ? firstHandle : secondHandle;
+        }
     }
 
     protected validateProps(props: IRangeSliderProps) {

--- a/packages/core/test/slider/rangeSliderTests.tsx
+++ b/packages/core/test/slider/rangeSliderTests.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 
 import * as Keys from "../../src/common/keys";
 import { Handle } from "../../src/components/slider/handle";
-import { RangeSlider } from "../../src/index";
+import { Classes, RangeSlider } from "../../src/index";
 import { dispatchMouseEvent, dispatchTouchEvent } from "../common/utils";
 
 describe("<RangeSlider>", () => {
@@ -163,6 +163,25 @@ describe("<RangeSlider>", () => {
         handles.first().simulate("keydown", { which: Keys.ARROW_DOWN });
         handles.last().simulate("keydown", { which: Keys.ARROW_DOWN });
         assert.isTrue(changeSpy.notCalled, "onChange was called when disabled");
+    });
+
+    it("when values are equal, releasing mouse on a track still moves the nearest handle", () => {
+        const NEXT_LOW_VALUE = 1;
+        const NEXT_HIGH_VALUE = 9;
+        const VALUE = 5;
+
+        const changeSpy = sinon.spy();
+        const slider = renderSlider(<RangeSlider onChange={changeSpy} value={[VALUE, VALUE]} />);
+        const tickSize = slider.state("tickSize");
+
+        slider.find(`.${Classes.SLIDER}`).simulate("mousedown", { clientX: tickSize * NEXT_LOW_VALUE });
+        assert.equal(changeSpy.callCount, 1, "lower handle invokes onChange");
+        assert.deepEqual(changeSpy.firstCall.args[0], [NEXT_LOW_VALUE, VALUE], "lower handle moves");
+        changeSpy.reset();
+
+        slider.find(`.${Classes.SLIDER}`).simulate("mousedown", { clientX: tickSize * NEXT_HIGH_VALUE });
+        assert.equal(changeSpy.callCount, 1, "higher handle invokes onChange");
+        assert.deepEqual(changeSpy.firstCall.args[0], [VALUE, NEXT_HIGH_VALUE], "higher handle moves");
     });
 
     function renderSlider(slider: JSX.Element) {


### PR DESCRIPTION
#### Fixes #1770 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `RangeSlider` always moves the nearest handle, even when handle values are equal.

#### Reviewers should focus on:

- This will have minor merge conflicts with PR #1762.

#### Screenshot

![2017-11-07 10 12 47](https://user-images.githubusercontent.com/443450/32510090-3e66d6ce-c3a4-11e7-8614-c3279c3a91a2.gif)
