### PR TITLE
[EditableText] Add extra code to make sure we move scroll position to the end

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -128,6 +128,9 @@ export class EditableText extends AbstractComponent<IEditableTextProps, IEditabl
                 input.focus();
                 const { length } = input.value;
                 input.setSelectionRange(this.props.selectAllOnFocus ? 0 : length, length);
+                if (!this.props.selectAllOnFocus) {
+                    input.scrollLeft = input.scrollWidth;
+                }
             }
         },
     };


### PR DESCRIPTION
#### Fixes #1761

#### Changes proposed in this pull request:

Set scrollLeft as well as selection position to guarentee that the scroll is correct.

#### Reviewers should focus on:

I tried, repeatedly, to figure out why setSelectionRange doesn't seem to work properly, for us, in chrome. I... had a lot of trouble playing with it to get it to do it programmatically in _any_ browser. Even using existing examples. 

This method of doing it works in chrome, and other browsers, and will make sure we're scrolled to the end when we need to be. 
