### PR TITLE
Add prop to keep Collapse children mounted

### DIFF
--- a/packages/core/examples/collapseExample.tsx
+++ b/packages/core/examples/collapseExample.tsx
@@ -6,19 +6,29 @@
 
 import * as React from "react";
 
-import { Button, Collapse } from "@blueprintjs/core";
-import { BaseExample } from "@blueprintjs/docs";
+import { Button, Collapse, Switch } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange } from "@blueprintjs/docs";
 
-export class CollapseExample extends BaseExample<{ isOpen: boolean }> {
-    public state = {
+export interface ICollapseExampleState {
+    isOpen?: boolean;
+    keepChildrenMounted?: boolean;
+}
+
+export class CollapseExample extends BaseExample<ICollapseExampleState> {
+    public state: ICollapseExampleState = {
         isOpen: false,
+        keepChildrenMounted: false,
     };
+
+    private handleChildrenMountedChange = handleBooleanChange(keepChildrenMounted => {
+        this.setState({ keepChildrenMounted });
+    });
 
     protected renderExample() {
         return (
             <div>
                 <Button onClick={this.handleClick}>{this.state.isOpen ? "Hide" : "Show"} build logs</Button>
-                <Collapse isOpen={this.state.isOpen}>
+                <Collapse isOpen={this.state.isOpen} keepChildrenMounted={this.state.keepChildrenMounted}>
                     <pre>
                         [11:53:30] Finished 'typescript-bundle-blueprint' after 769 ms<br />
                         [11:53:30] Starting 'typescript-typings-blueprint'...<br />
@@ -29,6 +39,19 @@ export class CollapseExample extends BaseExample<{ isOpen: boolean }> {
                 </Collapse>
             </div>
         );
+    }
+
+    protected renderOptions() {
+        return [
+            [
+                <Switch
+                    checked={this.state.keepChildrenMounted}
+                    key="keepChildrenMounted"
+                    label="Keep children mounted"
+                    onChange={this.handleChildrenMountedChange}
+                />,
+            ],
+        ];
     }
 
     private handleClick = () => {

--- a/packages/core/src/components/collapse/_collapse.scss
+++ b/packages/core/src/components/collapse/_collapse.scss
@@ -12,5 +12,9 @@ $collapse-transition: ($pt-transition-duration * 2) $pt-transition-ease !default
 
   .pt-collapse-body {
     transition: transform $collapse-transition;
+
+    &[aria-hidden="true"] {
+      display: none;
+    }
   }
 }

--- a/packages/core/src/components/collapse/collapse.md
+++ b/packages/core/src/components/collapse/collapse.md
@@ -15,7 +15,8 @@ Any content should be a child of the `Collapse` element. Content must be in the 
 flow (e.g. `position: absolute;` wouldn't work, as the parent element would inherit a height of 0).
 
 Toggling the `isOpen` prop triggers the open and close animations.
-Once the component is in the closed state, the children are no longer rendered.
+Once the component is in the closed state, the children are no longer rendered, unless the
+`keepChildrenMounted` prop is true.
 
 ```tsx
 export interface ICollapseExampleState {

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -26,8 +26,8 @@ export interface ICollapseProps extends IProps {
     isOpen?: boolean;
 
     /**
-     * Whether the child components will remain mounted when the collapse is closed.
-     * Setting to true may improve performance of the collapse component, by avoiding re-rendering.
+     * Whether the child components will remain mounted when the `Collapse` is closed.
+     * Setting to true may improve performance by avoiding re-mounting children.
      * @default false
      */
     keepChildrenMounted?: boolean;
@@ -125,13 +125,13 @@ export class Collapse extends AbstractComponent<ICollapseProps, ICollapseState> 
     }
 
     public render() {
-        const contentsVisible = this.state.animationState !== AnimationStates.CLOSED;
-        const renderChildren = contentsVisible || this.props.keepChildrenMounted;
-        const displayWithTransform = contentsVisible && this.state.animationState !== AnimationStates.CLOSING_END;
+        const isContentVisible = this.state.animationState !== AnimationStates.CLOSED;
+        const shouldRenderChildren = isContentVisible || this.props.keepChildrenMounted;
+        const displayWithTransform = isContentVisible && this.state.animationState !== AnimationStates.CLOSING_END;
         const isAutoHeight = this.state.height === "auto";
 
         const containerStyle = {
-            height: contentsVisible ? this.state.height : undefined,
+            height: isContentVisible ? this.state.height : undefined,
             overflowY: (isAutoHeight ? "visible" : undefined) as "visible" | undefined,
             transition: isAutoHeight ? "none" : undefined,
         };
@@ -153,9 +153,9 @@ export class Collapse extends AbstractComponent<ICollapseProps, ICollapseState> 
                 className="pt-collapse-body"
                 ref={this.contentsRefHandler}
                 style={contentsStyle}
-                aria-hidden={!contentsVisible && this.props.keepChildrenMounted}
+                aria-hidden={!isContentVisible && this.props.keepChildrenMounted}
             >
-                {renderChildren ? this.props.children : null}
+                {shouldRenderChildren ? this.props.children : null}
             </div>,
         );
     }

--- a/packages/core/test/collapse/collapseTests.tsx
+++ b/packages/core/test/collapse/collapseTests.tsx
@@ -39,4 +39,22 @@ describe("<Collapse>", () => {
     it("supports custom Component", () => {
         assert.isTrue(shallow(<Collapse component={MenuItem} />).is(MenuItem));
     });
+
+    it("unmounts children by default", () => {
+        const collapse = mount(
+            <Collapse isOpen={false}>
+                <div className="removed-child" />
+            </Collapse>,
+        );
+        assert.lengthOf(collapse.find(".removed-child"), 0);
+    });
+
+    it("keepChildrenMounted keeps child mounted", () => {
+        const collapse = mount(
+            <Collapse isOpen={false} keepChildrenMounted={true}>
+                <div className="hidden-child" />
+            </Collapse>,
+        );
+        assert.lengthOf(collapse.find(".hidden-child"), 1);
+    });
 });


### PR DESCRIPTION
#### Fixes #583

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Allow the `Collapse` component to take in a prop `keepChildrenMounted` which allows its children to remain rendered. Helps with React performance, especially if the children are complex.

