### PR TITLE
[Core/Menu] Update styles to fix submenu hover semantics

### DIFF
--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -35,11 +35,17 @@
   .pt-popover {
     position: absolute;
     top: -$half-grid-size;
-    left: $half-grid-size;
+    box-shadow: none;
+    padding-left: $half-grid-size;
 
     &.pt-align-left {
-      right: $half-grid-size;
-      left: auto;
+      right: 0;
+      padding-right: $half-grid-size;
+      padding-left: 0;
+    }
+
+    > .pt-popover-content {
+      box-shadow: $pt-popover-box-shadow;
     }
   }
 }


### PR DESCRIPTION
#### Fixes #1773, Fixes #1726

#### Changes proposed in this pull request:

Extend .pt-popover-content to fill the gap between the menu item and its submenu.
Tested in Chrome 61.0.3163.100, and IE 11.0.9600.17420.

#### Screenshot

![image](https://user-images.githubusercontent.com/24275386/32583947-f938d392-c4c3-11e7-8ce8-276d45b678d2.png)
