### PR TITLE
[Popover] Don't close HOVER* popover if target still focused on click

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -536,7 +536,10 @@ export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
             // popover open. we must do this check *after* the next element focuses, so we use a
             // timeout of 0 to flush the rest of the event queue before proceeding.
             requestAnimationFrame(() => {
-                if (this.popoverElement == null || !this.popoverElement.contains(document.activeElement)) {
+                const targetOrPopoverContainsFocusedElement =
+                    this.popoverElement.contains(document.activeElement) ||
+                    this.targetElement.contains(document.activeElement);
+                if (this.popoverElement == null || !targetOrPopoverContainsFocusedElement) {
                     this.handleMouseLeave(e);
                 }
             });


### PR DESCRIPTION
#### Fixes #1640 

#### Checklist

#### Changes proposed in this pull request:

- 🐛 __FIXED__ `Menu` no longer changes submenu's open state on click by default.
    - This is only true if the popover interaction kind is `HOVER*`

#### Reviewers should focus on:

- Not really sure how best to test this.

#### Screenshot

Take my word for it that clicks are happening in this GIF—and aren't doing anything, as expected.

![2017-11-09 00 07 10](https://user-images.githubusercontent.com/443450/32594814-4d27dec6-c4e2-11e7-8523-59317772cd71.gif)
