### PR TITLE
Add a disabled state to <TagInput>

### DIFF
--- a/packages/docs-app/src/examples/labs-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/labs-examples/tagInputExample.tsx
@@ -60,6 +60,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         const clearButton = (
             <Button
                 className={classNames(Classes.MINIMAL, Classes.SMALL)}
+                disabled={disabled}
                 iconName={values.length > 1 ? "cross" : "refresh"}
                 onClick={this.handleClear}
             />

--- a/packages/docs-app/src/examples/labs-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/labs-examples/tagInputExample.tsx
@@ -25,6 +25,7 @@ const VALUES = [
 ];
 
 export interface ITagInputExampleState {
+    disabled?: boolean;
     fill?: boolean;
     intent?: boolean;
     large?: boolean;
@@ -34,6 +35,7 @@ export interface ITagInputExampleState {
 
 export class TagInputExample extends BaseExample<ITagInputExampleState> {
     public state: ITagInputExampleState = {
+        disabled: false,
         fill: false,
         intent: false,
         large: false,
@@ -41,13 +43,14 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         values: VALUES,
     };
 
+    private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
     private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
     private handleIntentChange = handleBooleanChange(intent => this.setState({ intent }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
 
     protected renderExample() {
-        const { fill, large, values } = this.state;
+        const { disabled, fill, large, values } = this.state;
 
         const classes = classNames({
             [Classes.FILL]: fill,
@@ -73,6 +76,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
         return (
             <TagInput
                 className={classes}
+                disabled={disabled}
                 rightElement={clearButton}
                 leftIconName="user"
                 onChange={this.handleChange}
@@ -93,6 +97,12 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
                     onChange={this.handleFillChange}
                 />,
                 <Switch checked={this.state.large} label="Large" key="large" onChange={this.handleLargeChange} />,
+                <Switch
+                    checked={this.state.disabled}
+                    label="Disabled"
+                    key="disabled"
+                    onChange={this.handleDisabledChange}
+                />,
             ],
             [
                 <label key="heading" className={Classes.LABEL}>

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -48,7 +48,8 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
       padding: 0 ($input-padding-horizontal - $ti-padding);
     }
 
-    &[disabled] {
+    &:disabled,
+    &.pt-disabled {
       cursor: not-allowed;
     }
 

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -48,6 +48,10 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
       padding: 0 ($input-padding-horizontal - $ti-padding);
     }
 
+    &[disabled] {
+      cursor: not-allowed;
+    }
+
     ~ * {
       // shift right element up (to ignore top padding) so flex box will center it correctly
       margin-top: -$ti-padding;

--- a/packages/labs/src/components/tag-input/tag-input.md
+++ b/packages/labs/src/components/tag-input/tag-input.md
@@ -2,6 +2,12 @@
 
 `TagInput` renders [`Tag`](#core/components/tag)s inside an input, followed by an actual text input. The container is merely styled to look like a Blueprint input; the actual editable element appears after the last tag. Clicking anywhere on the container will focus the text input for seamless interaction.
 
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    <h5>Disabling a TagInput</h5>
+    <p>Disabling this component requires setting the `disabled` prop to `true` and separately disabling the component's `rightElement` as appropriate (because `TagInput` accepts any `JSX.Element` as its `rightElement`).</p>
+    <p>In the example below, when you slide the `Disabled` toggle switch on, the result becomes `<TagInput ... disabled={true} rightElement={<Button ... disabled={true} />} />`</p>
+</div>
+
 @reactExample TagInputExample
 
 **`TagInput` must be controlled,** meaning the `values` prop is required and event handlers are strongly suggested. Typing in the input and pressing <kbd class="pt-key">enter</kbd> will **add new items** by invoking callbacks. A `separator` prop is supported to allow multiple items to be added at once; the default splits on commas.

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -164,8 +164,6 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
             Classes.TAG_INPUT,
             {
                 [CoreClasses.ACTIVE]: this.state.isInputFocused,
-            },
-            {
                 [CoreClasses.DISABLED]: this.props.disabled,
             },
             className,

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -25,7 +25,8 @@ import * as Classes from "../../common/classes";
 export interface ITagInputProps extends IProps {
     /**
      * Whether the component is non-interactive.
-     * Note that you'll also need to disable the component's rightElement, if appropriate.
+     * Note that you'll also need to disable the component's `rightElement`,
+     * if appropriate.
      * @default false
      */
     disabled?: boolean;

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -23,6 +23,13 @@ import {
 import * as Classes from "../../common/classes";
 
 export interface ITagInputProps extends IProps {
+    /**
+     * Whether the component is non-interactive.
+     * Note that you'll also need to disable the component's rightElement, if appropriate.
+     * @default false
+     */
+    disabled?: boolean;
+
     /** React props to pass to the `<input>` element */
     inputProps?: HTMLInputProps;
 
@@ -157,6 +164,9 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
             {
                 [CoreClasses.ACTIVE]: this.state.isInputFocused,
             },
+            {
+                [CoreClasses.DISABLED]: this.props.disabled,
+            },
             className,
         );
         const isLarge = classes.indexOf(CoreClasses.LARGE) > NONE;
@@ -178,6 +188,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                     placeholder={resolvedPlaceholder}
                     ref={this.refHandlers.input}
                     className={classNames(Classes.INPUT_GHOST, inputProps.className)}
+                    disabled={this.props.disabled}
                 />
                 {this.props.rightElement}
             </div>
@@ -195,7 +206,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
                 active={index === this.state.activeIndex}
                 data-tag-index={index}
                 key={tag + "__" + index}
-                onRemove={this.handleRemoveTag}
+                onRemove={this.props.disabled ? null : this.handleRemoveTag}
                 {...props}
             >
                 {tag}

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -352,7 +352,7 @@ describe("<TagInput>", () => {
                 .find(".pt-input-ghost")
                 .first()
                 .prop("disabled"),
-            ".pt-input-ghost does not have a 'disabled' attribute",
+            ".pt-input-ghost should have a 'disabled' attribute",
         );
         wrapper.find(Tag).forEach(tag => {
             assert.isFalse(tag.hasClass("pt-tag-removeable"), ".pt-tag should not have .pt-tag-removable applied");

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -343,6 +343,22 @@ describe("<TagInput>", () => {
         );
     });
 
+    it("is non-interactive when disabled", () => {
+        const wrapper = mount(<TagInput values={VALUES} disabled={true} />);
+
+        assert.isTrue(wrapper.hasClass(Classes.DISABLED), `.${Classes.DISABLED} should be applied to .pt-tag-input`);
+        assert.isTrue(
+            wrapper
+                .find(".pt-input-ghost")
+                .first()
+                .prop("disabled"),
+            ".pt-input-ghost does not have a 'disabled' attribute",
+        );
+        wrapper.find(Tag).forEach(tag => {
+            assert.isFalse(tag.hasClass("pt-tag-removeable"), ".pt-tag should not have .pt-tag-removable applied");
+        });
+    });
+
     function pressEnterInInput(wrapper: ShallowWrapper<any, any>, value: string) {
         wrapper.find("input").simulate("keydown", {
             currentTarget: { value },


### PR DESCRIPTION
Added an extra property to the `TagInput` component. Setting the property to true makes it non-interactive in the UI. Updated the docs and tests.

<img width="978" alt="screen shot 2017-11-17 at 8 36 32 pm" src="https://user-images.githubusercontent.com/831708/32975622-13359c8e-cbd7-11e7-8736-39ae661a6d97.png">
