### PR TITLE
[DateTime/___Input] Pass both className and popoverProps.className to popover targets

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -222,6 +222,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             },
             inputProps.className,
         );
+        const popoverClassName = classNames(popoverProps.className, this.props.className);
 
         return (
             <Popover
@@ -230,8 +231,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 position={this.props.popoverPosition}
                 {...popoverProps}
                 autoFocus={false}
-                enforceFocus={false}
+                className={popoverClassName}
                 content={popoverContent}
+                enforceFocus={false}
                 onClose={this.handleClosePopover}
                 popoverClassName={classNames("pt-dateinput-popover", popoverProps.popoverClassName)}
             >

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -286,6 +286,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     }
 
     public render() {
+        const { popoverProps = {} } = this.props;
+
         const popoverContent = (
             <DateRangePicker
                 {...this.props}
@@ -296,6 +298,8 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             />
         );
 
+        const popoverClassName = classNames(popoverProps.className, this.props.className);
+
         // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
@@ -305,6 +309,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
                 position={Position.BOTTOM_LEFT}
                 {...this.props.popoverProps}
                 autoFocus={false}
+                className={popoverClassName}
                 content={popoverContent}
                 enforceFocus={false}
                 onClose={this.handlePopoverClose}

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -9,7 +9,7 @@ import { mount } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
-import { InputGroup, Keys, Popover, Position } from "@blueprintjs/core";
+import { Classes as CoreClasses, InputGroup, Keys, Popover, Position } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes, DateInput, TimePicker, TimePickerPrecision } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -22,6 +22,18 @@ describe("<DateInput>", () => {
     it("handles string inputs without crashing", () => {
         // strings are not permitted in the interface, but are handled correctly by moment.
         assert.doesNotThrow(() => mount(<DateInput value={"1988-08-07 11:01:12" as any} />));
+    });
+
+    it("passes custom classNames to popover target", () => {
+        const CLASS_1 = "foo";
+        const CLASS_2 = "bar";
+
+        const wrapper = mount(<DateInput className={CLASS_1} popoverProps={{ className: CLASS_2 }} />);
+        wrapper.setState({ isOpen: true });
+
+        const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_TARGET}`);
+        assert.isTrue(popoverTarget.hasClass(CLASS_1));
+        assert.isTrue(popoverTarget.hasClass(CLASS_2));
     });
 
     it("Popover opens on input focus", () => {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -35,7 +35,7 @@ describe("<DateInput>", () => {
         assert.isTrue(popoverTarget.hasClass(CLASS_1));
         assert.isTrue(popoverTarget.hasClass(CLASS_2));
     });
-          
+
     it("supports custom input style", () => {
         const wrapper = mount(<DateInput inputProps={{ style: { background: "yellow" } }} />);
         const inputElement = wrapper

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -9,7 +9,14 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
-import { HTMLInputProps, IInputGroupProps, InputGroup, Popover, Position } from "@blueprintjs/core";
+import {
+    Classes as CoreClasses,
+    HTMLInputProps,
+    IInputGroupProps,
+    InputGroup,
+    Popover,
+    Position,
+} from "@blueprintjs/core";
 import { Months } from "../src/common/months";
 import { Classes as DateClasses, DateRange, DateRangeBoundary, DateRangeInput, DateRangePicker } from "../src/index";
 import * as DateTestUtils from "./common/dateTestUtils";
@@ -67,6 +74,18 @@ describe("<DateRangeInput>", () => {
     it("renders with two InputGroup children", () => {
         const component = mount(<DateRangeInput />);
         expect(component.find(InputGroup).length).to.equal(2);
+    });
+
+    it("passes custom classNames to popover target", () => {
+        const CLASS_1 = "foo";
+        const CLASS_2 = "bar";
+
+        const wrapper = mount(<DateRangeInput className={CLASS_1} popoverProps={{ className: CLASS_2 }} />);
+        wrapper.setState({ isOpen: true });
+
+        const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_TARGET}`);
+        expect(popoverTarget.hasClass(CLASS_1)).to.be.true;
+        expect(popoverTarget.hasClass(CLASS_2)).to.be.true;
     });
 
     it("inner DateRangePicker receives all supported props", () => {


### PR DESCRIPTION
#### Fixes #1821

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- `DateInput` and `DateRangeInput` now applies custom `className` to its `pt-popover-target` (along with `popoverProps.className)
