### PR TITLE
[DateTime] Add `reverseMonthAndYearMenus` prop to all relevant components

### DIFF
--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -167,7 +167,9 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
       background: none;
       cursor: pointer;
       height: $pt-input-height;
-      padding: 0 $pt-grid-size;
+      // increase the size of the click target, clearing the caret on the right.
+      padding-right: $pt-icon-size-standard;
+      padding-left: $pt-grid-size;
       line-height: $pt-input-height;
       color: $pt-text-color;
       font-weight: 600;
@@ -180,6 +182,10 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
         // IE11 styling to hide the arrow
         display: none;
       }
+
+      &:hover + .pt-datepicker-caption-caret {
+        color: $pt-text-color;
+      }
     }
   }
 
@@ -189,10 +195,13 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   }
 
   .pt-datepicker-caption-caret {
-    display: none;
     position: absolute;
     top: $pt-grid-size * 0.2;
-    margin-left: $pt-grid-size;
+    // override library-imposed left offset
+    // stylelint-disable declaration-no-important
+    right: 0;
+    left: auto !important;
+    color: $pt-text-color-muted;
     pointer-events: none;
   }
 
@@ -203,10 +212,6 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     margin-bottom: -$pt-grid-size / 2;
     border-top: 1px solid $pt-divider-black;
     padding-top: $pt-grid-size / 2;
-  }
-
-  .DayPicker-Month:hover .pt-datepicker-caption-caret {
-    display: inline;
   }
 }
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -129,6 +129,13 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverProps?: Partial<IPopoverProps> & object;
 
     /**
+     * If `true`, the month menu will appear to the left of the year menu.
+     * Otherwise, the month menu will apear to the right of the year menu.
+     * @default false
+     */
+    reverseMonthAndYearMenus?: boolean;
+
+    /**
      * Element to render on right side of input.
      */
     rightElement?: JSX.Element;
@@ -173,6 +180,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         openOnFocus: true,
         outOfRangeMessage: "Out of range",
         popoverPosition: Position.BOTTOM,
+        reverseMonthAndYearMenus: false,
         timePickerProps: {},
     };
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -129,13 +129,6 @@ export interface IDateInputProps extends IDatePickerBaseProps, IProps {
     popoverProps?: Partial<IPopoverProps> & object;
 
     /**
-     * If `true`, the month menu will appear to the left of the year menu.
-     * Otherwise, the month menu will apear to the right of the year menu.
-     * @default false
-     */
-    reverseMonthAndYearMenus?: boolean;
-
-    /**
      * Element to render on right side of input.
      */
     rightElement?: JSX.Element;

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -49,6 +49,13 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
 
     /**
+     * If `true`, the month menu will appear to the left of the year menu.
+     * Otherwise, the month menu will apear to the right of the year menu.
+     * @default false
+     */
+    reverseMonthAndYearMenus?: boolean;
+
+    /**
      * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
      * @default false
      */
@@ -73,6 +80,7 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
         dayPickerProps: {},
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
+        reverseMonthAndYearMenus: false,
         showActionsBar: false,
     };
 
@@ -204,6 +212,7 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
             minDate={this.props.minDate}
             onMonthChange={this.handleMonthSelectChange}
             onYearChange={this.handleYearSelectChange}
+            reverseMonthAndYearMenus={this.props.reverseMonthAndYearMenus}
         />
     );
 

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -49,13 +49,6 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
 
     /**
-     * If `true`, the month menu will appear to the left of the year menu.
-     * Otherwise, the month menu will apear to the right of the year menu.
-     * @default false
-     */
-    reverseMonthAndYearMenus?: boolean;
-
-    /**
      * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
      * @default false
      */

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -17,6 +17,7 @@ export interface IDatePickerCaptionProps extends ReactDayPicker.CaptionElementPr
     minDate: Date;
     onMonthChange?: (month: number) => void;
     onYearChange?: (year: number) => void;
+    reverseMonthAndYearMenus?: boolean;
 }
 
 export class DatePickerCaption extends React.Component<IDatePickerCaptionProps, {}> {
@@ -72,28 +73,39 @@ export class DatePickerCaption extends React.Component<IDatePickerCaptionProps, 
         this.displayedYearText = displayYear.toString();
 
         const caretClasses = classNames("pt-icon-standard", "pt-icon-caret-down", Classes.DATEPICKER_CAPTION_CARET);
+
+        const monthSelect = (
+            <div className={Classes.DATEPICKER_CAPTION_SELECT} key="month">
+                <select
+                    className={Classes.DATEPICKER_MONTH_SELECT}
+                    onChange={this.handleMonthSelectChange}
+                    value={displayMonth.toString()}
+                >
+                    {monthOptionElements}
+                </select>
+                <span className={caretClasses} ref={this.monthArrowRefHandler} />
+            </div>
+        );
+        const yearSelect = (
+            <div className={Classes.DATEPICKER_CAPTION_SELECT} key="year">
+                <select
+                    className={Classes.DATEPICKER_YEAR_SELECT}
+                    onChange={this.handleYearSelectChange}
+                    value={displayYear.toString()}
+                >
+                    {yearOptionElements}
+                </select>
+                <span className={caretClasses} ref={this.yearArrowRefHandler} />
+            </div>
+        );
+
+        const orderedSelects = this.props.reverseMonthAndYearMenus
+            ? [yearSelect, monthSelect]
+            : [monthSelect, yearSelect];
+
         return (
             <div className={Classes.DATEPICKER_CAPTION} ref={this.containerRefHandler}>
-                <div className={Classes.DATEPICKER_CAPTION_SELECT}>
-                    <select
-                        className={Classes.DATEPICKER_MONTH_SELECT}
-                        onChange={this.handleMonthSelectChange}
-                        value={displayMonth.toString()}
-                    >
-                        {monthOptionElements}
-                    </select>
-                    <span className={caretClasses} ref={this.monthArrowRefHandler} />
-                </div>
-                <div className={Classes.DATEPICKER_CAPTION_SELECT}>
-                    <select
-                        className={Classes.DATEPICKER_YEAR_SELECT}
-                        onChange={this.handleYearSelectChange}
-                        value={displayYear.toString()}
-                    >
-                        {yearOptionElements}
-                    </select>
-                    <span className={caretClasses} ref={this.yearArrowRefHandler} />
-                </div>
+                {orderedSelects}
             </div>
         );
     }

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -47,6 +47,13 @@ export interface IDatePickerBaseProps {
      * See the [**react-day-picker** documentation](http://react-day-picker.js.org/Modifiers.html) to learn more.
      */
     modifiers?: IDatePickerModifiers;
+
+    /**
+     * If `true`, the month menu will appear to the left of the year menu.
+     * Otherwise, the month menu will apear to the right of the year menu.
+     * @default false
+     */
+    reverseMonthAndYearMenus?: boolean;
 }
 
 export const DISABLED_MODIFIER = "disabled";

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -119,6 +119,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
         dayPickerProps: {},
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
+        reverseMonthAndYearMenus: false,
         shortcuts: true,
     };
 
@@ -365,6 +366,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             minDate={this.props.minDate}
             onMonthChange={this.handleLeftMonthSelectChange}
             onYearChange={this.handleLeftYearSelectChange}
+            reverseMonthAndYearMenus={this.props.reverseMonthAndYearMenus}
         />
     );
 
@@ -375,6 +377,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             minDate={this.props.minDate}
             onMonthChange={this.handleLeftMonthSelectChange}
             onYearChange={this.handleLeftYearSelectChange}
+            reverseMonthAndYearMenus={this.props.reverseMonthAndYearMenus}
         />
     );
 
@@ -385,6 +388,7 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             minDate={DateUtils.getDateNextMonth(this.props.minDate)}
             onMonthChange={this.handleRightMonthSelectChange}
             onYearChange={this.handleRightYearSelectChange}
+            reverseMonthAndYearMenus={this.props.reverseMonthAndYearMenus}
         />
     );
 

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -17,6 +17,7 @@ export interface IDateInputExampleState {
     disabled?: boolean;
     format?: string;
     openOnFocus?: boolean;
+    reverseMonthAndYearMenus?: boolean;
     timePrecision?: TimePickerPrecision;
 }
 
@@ -26,12 +27,16 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
         disabled: false,
         format: FORMATS[0],
         openOnFocus: true,
+        reverseMonthAndYearMenus: false,
     };
 
     private toggleFocus = handleBooleanChange(openOnFocus => this.setState({ openOnFocus }));
     private toggleSelection = handleBooleanChange(closeOnSelection => this.setState({ closeOnSelection }));
     private toggleDisabled = handleBooleanChange(disabled => this.setState({ disabled }));
     private toggleFormat = handleStringChange(format => this.setState({ format }));
+    private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
+        this.setState({ reverseMonthAndYearMenus }),
+    );
     private toggleTimePrecision = handleNumberChange(timePrecision =>
         this.setState({
             timePrecision: timePrecision < 0 ? undefined : timePrecision,
@@ -39,7 +44,15 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
     );
 
     protected renderExample() {
-        return <DateInput {...this.state} defaultValue={new Date()} />;
+        return (
+            <DateInput
+                {...this.state}
+                defaultValue={new Date()}
+                className="foofoofoo"
+                popoverProps={{ popoverClassName: "barbarbar" }}
+                inputProps={{ className: "bazbazbaz" }}
+            />
+        );
     }
 
     protected renderOptions() {
@@ -58,6 +71,12 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     onChange={this.toggleSelection}
                 />,
                 <Switch checked={this.state.disabled} label="Disabled" key="Disabled" onChange={this.toggleDisabled} />,
+                <Switch
+                    checked={this.state.reverseMonthAndYearMenus}
+                    label="Reverse month and year menus"
+                    key="Reverse month and year menus"
+                    onChange={this.toggleReverseMonthAndYearMenus}
+                />,
                 <PrecisionSelect
                     label="Time Precision"
                     key="precision"

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -29,16 +29,21 @@ export const Moment: React.SFC<{ date: Date; format?: string }> = ({ date, forma
 
 export interface IDatePickerExampleState {
     date?: Date;
+    reverseMonthAndYearMenus?: boolean;
     showActionsBar?: boolean;
 }
 
 export class DatePickerExample extends BaseExample<IDatePickerExampleState> {
     public state: IDatePickerExampleState = {
         date: null,
+        reverseMonthAndYearMenus: false,
         showActionsBar: false,
     };
 
     private toggleActionsBar = handleBooleanChange(showActionsBar => this.setState({ showActionsBar }));
+    private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
+        this.setState({ reverseMonthAndYearMenus }),
+    );
 
     protected renderExample() {
         return (
@@ -46,6 +51,7 @@ export class DatePickerExample extends BaseExample<IDatePickerExampleState> {
                 <DatePicker
                     className={Classes.ELEVATION_1}
                     onChange={this.handleDateChange}
+                    reverseMonthAndYearMenus={this.state.reverseMonthAndYearMenus}
                     showActionsBar={this.state.showActionsBar}
                 />
                 <Moment date={this.state.date} />
@@ -61,6 +67,12 @@ export class DatePickerExample extends BaseExample<IDatePickerExampleState> {
                     label="Show actions bar"
                     key="Actions"
                     onChange={this.toggleActionsBar}
+                />,
+                <Switch
+                    checked={this.state.reverseMonthAndYearMenus}
+                    label="Reverse month and year menus"
+                    key="Reverse month and year menus"
+                    onChange={this.toggleReverseMonthAndYearMenus}
                 />,
             ],
         ];

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -17,6 +17,7 @@ export interface IDateRangeInputExampleState {
     contiguousCalendarMonths?: boolean;
     disabled?: boolean;
     format?: string;
+    reverseMonthAndYearMenus?: boolean;
     selectAllOnFocus?: boolean;
 }
 
@@ -27,6 +28,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
         contiguousCalendarMonths: true,
         disabled: false,
         format: FORMATS[0],
+        reverseMonthAndYearMenus: false,
         selectAllOnFocus: false,
     };
 
@@ -35,6 +37,9 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     });
     private toggleDisabled = handleBooleanChange(disabled => this.setState({ disabled }));
     private toggleFormat = handleStringChange(format => this.setState({ format }));
+    private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
+        this.setState({ reverseMonthAndYearMenus }),
+    );
     private toggleSelection = handleBooleanChange(closeOnSelection => this.setState({ closeOnSelection }));
     private toggleSelectAllOnFocus = handleBooleanChange(selectAllOnFocus => this.setState({ selectAllOnFocus }));
     private toggleSingleDay = handleBooleanChange(allowSingleDayRange => this.setState({ allowSingleDayRange }));
@@ -74,6 +79,12 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     label="Select all on focus"
                     key="Select all on focus"
                     onChange={this.toggleSelectAllOnFocus}
+                />,
+                <Switch
+                    checked={this.state.reverseMonthAndYearMenus}
+                    label="Reverse month and year menus"
+                    key="Reverse month and year menus"
+                    onChange={this.toggleReverseMonthAndYearMenus}
                 />,
             ],
         ];

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -18,6 +18,7 @@ export interface IDateRangePickerExampleState {
     dateRange?: DateRange;
     maxDateIndex?: number;
     minDateIndex?: number;
+    reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
 }
 
@@ -59,12 +60,16 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
         dateRange: [null, null],
         maxDateIndex: 0,
         minDateIndex: 0,
+        reverseMonthAndYearMenus: false,
         shortcuts: true,
     };
 
     private handleMaxDateIndexChange = handleNumberChange(maxDateIndex => this.setState({ maxDateIndex }));
     private handleMinDateIndexChange = handleNumberChange(minDateIndex => this.setState({ minDateIndex }));
 
+    private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
+        this.setState({ reverseMonthAndYearMenus }),
+    );
     private toggleSingleDay = handleBooleanChange(allowSingleDayRange => this.setState({ allowSingleDayRange }));
     private toggleShortcuts = handleBooleanChange(shortcuts => this.setState({ shortcuts }));
     private toggleContiguousCalendarMonths = handleBooleanChange(contiguousCalendarMonths => {
@@ -86,6 +91,7 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateChange}
+                    reverseMonthAndYearMenus={this.state.reverseMonthAndYearMenus}
                     shortcuts={this.state.shortcuts}
                 />
                 <div>
@@ -117,6 +123,12 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
                     key="Shortcuts"
                     label="Show shortcuts"
                     onChange={this.toggleShortcuts}
+                />,
+                <Switch
+                    checked={this.state.reverseMonthAndYearMenus}
+                    label="Reverse month and year menus"
+                    key="Reverse month and year menus"
+                    onChange={this.toggleReverseMonthAndYearMenus}
                 />,
             ],
             [


### PR DESCRIPTION
#### Fixes #1174

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🎉 __NEW__ `DateTime` components now support `reverseMonthAndYearMenus` prop to show year menu on the left.
    - `DatePicker`
    - `DateRangePicker`
    - `DateTimePicker`
    - `DateInput`
    - `DateRangeInput`
- 🔄 __CHANGED__ `DatePicker` menu styles:
    - Caret now shows persistently.
    - Caret is `$pt-text-muted-color`.
    - Caret is `$pt-text-color` on `select:hover`.

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

_`DatePicker`_

<img src="https://user-images.githubusercontent.com/443450/33004842-ccb342dc-cd77-11e7-846e-37c918a6a97d.gif" width="254" />

_`DateRangePicker`_

<img src="https://user-images.githubusercontent.com/443450/33004852-de1c2232-cd77-11e7-8441-1bfbb91e8124.gif" width="682" />

_`DateInput`_

<img src="https://user-images.githubusercontent.com/443450/33004889-0f2bec9a-cd78-11e7-86d4-f5b4ee3c45cb.gif" width="432" />

_`DateRangeInput`_

<img src="https://user-images.githubusercontent.com/443450/33004927-470280fc-cd78-11e7-91ba-0631a4c4c659.gif" width="765" />
