### PR TITLE
[DateInput/DateRangeInput] Commit typed value on 'Enter' key press

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -16,6 +16,7 @@ import {
     InputGroup,
     IPopoverProps,
     IProps,
+    Keys,
     Popover,
     Position,
     Utils,
@@ -248,6 +249,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                     onChange={this.handleInputChange}
                     onClick={this.handleInputClick}
                     onFocus={this.handleInputFocus}
+                    onKeyDown={this.handleInputKeyDown}
                     value={dateString}
                 />
             </Popover>
@@ -390,7 +392,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     };
 
     private handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-        const valueString = this.state.valueString;
+        const { valueString } = this.state;
         const value = this.createMoment(valueString);
         if (
             valueString.length > 0 &&
@@ -418,6 +420,13 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             }
         }
         this.safeInvokeInputProp("onBlur", e);
+    };
+
+    private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.which === Keys.ENTER) {
+            this.handleDateChange(new Date(this.state.valueString), true);
+            this.inputRef.blur();
+        }
     };
 
     private setInputRef = (el: HTMLElement) => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -437,6 +437,11 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             const nextValue = this.createMoment(this.state.valueString);
             const nextDate = fromMomentToDate(nextValue);
             this.handleDateChange(nextDate, true, true);
+        } else if (e.which === Keys.TAB && e.shiftKey) {
+            // close the popover if focus will move to the previous element on
+            // the page. tabbing forward should *not* close the popover, because
+            // focus will be moving into the popover itself.
+            this.setState({ isOpen: false });
         }
         this.safeInvokeInputProp("onKeyDown", e);
     };

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -329,7 +329,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         const isInputFocused = didSubmitWithEnter ? true : false;
 
         if (this.props.value === undefined) {
-            this.setState({ isInputFocused, isOpen, value: momentDate });
+            this.setState({ isInputFocused, isOpen, value: momentDate, valueString: this.getDateString(momentDate) });
         } else {
             this.setState({ isInputFocused, isOpen });
         }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -308,7 +308,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         this.setState({ isOpen: false });
     };
 
-    private handleDateChange = (date: Date, hasUserManuallySelectedDate: boolean) => {
+    private handleDateChange = (date: Date, hasUserManuallySelectedDate: boolean, didSubmitWithEnter = false) => {
         const prevMomentDate = this.state.value;
         const momentDate = fromDateToMoment(date);
 
@@ -321,10 +321,17 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             this.hasTimeChanged(prevMomentDate, momentDate) ||
             !this.props.closeOnSelection;
 
+        // if selecting a date via click or Tab, the input will already be
+        // blurred by now, so sync isInputFocused to false. if selecting via
+        // Enter, setting isInputFocused to false won't do anything by itself,
+        // plus we want the field to retain focus anyway.
+        // (note: spelling out the ternary explicitly reads more clearly.)
+        const isInputFocused = didSubmitWithEnter ? true : false;
+
         if (this.props.value === undefined) {
-            this.setState({ isInputFocused: false, isOpen, value: momentDate });
+            this.setState({ isInputFocused, isOpen, value: momentDate });
         } else {
-            this.setState({ isInputFocused: false, isOpen });
+            this.setState({ isInputFocused, isOpen });
         }
         Utils.safeInvoke(this.props.onChange, date === null ? null : fromMomentToDate(momentDate));
     };
@@ -429,9 +436,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         if (e.which === Keys.ENTER) {
             const nextValue = this.createMoment(this.state.valueString);
             const nextDate = fromMomentToDate(nextValue);
-            this.handleDateChange(nextDate, true);
-            this.inputRef.blur();
+            this.handleDateChange(nextDate, true, true);
         }
+        this.safeInvokeInputProp("onKeyDown", e);
     };
 
     private setInputRef = (el: HTMLElement) => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -424,7 +424,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.which === Keys.ENTER) {
-            this.handleDateChange(new Date(this.state.valueString), true);
+            const nextValue = this.createMoment(this.state.valueString);
+            const nextDate = fromMomentToDate(nextValue);
+            this.handleDateChange(nextDate, true);
             this.inputRef.blur();
         }
     };

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -561,15 +561,17 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
             isStartInputFocused = true;
             isEndInputFocused = false;
         } else if (wasStartFieldFocused && isEnterPressed) {
-            const nextStartValue = new Date(this.state.startInputString);
-            const nextEndValue = isMomentNull(selectedEnd) ? undefined : fromMomentToDate(selectedEnd);
-            this.handleDateRangePickerChange([nextStartValue, nextEndValue] as DateRange);
+            const nextStartValue = this.dateStringToMoment(this.state.startInputString);
+            const nextStartDate = fromMomentToDate(nextStartValue);
+            const nextEndDate = isMomentNull(selectedEnd) ? undefined : fromMomentToDate(selectedEnd);
+            this.handleDateRangePickerChange([nextStartDate, nextEndDate] as DateRange);
             isStartInputFocused = false;
             isEndInputFocused = true;
         } else if (wasEndFieldFocused && isEnterPressed) {
-            const nextStartValue = isMomentNull(selectedStart) ? undefined : fromMomentToDate(selectedStart);
-            const nextEndValue = new Date(this.state.endInputString);
-            this.handleDateRangePickerChange([nextStartValue, nextEndValue] as DateRange);
+            const nextStartDate = isMomentNull(selectedStart) ? undefined : fromMomentToDate(selectedStart);
+            const nextEndValue = this.dateStringToMoment(this.state.endInputString);
+            const nextEndDate = fromMomentToDate(nextEndValue);
+            this.handleDateRangePickerChange([nextStartDate, nextEndDate] as DateRange);
             isStartInputFocused = false;
             isEndInputFocused = false;
             // need to explicitly blur, because only .focus() is triggered in

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -392,7 +392,7 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     // Callbacks - DateRangePicker
     // ===========================
 
-    private handleDateRangePickerChange = (selectedRange: DateRange) => {
+    private handleDateRangePickerChange = (selectedRange: DateRange, didSubmitWithEnter = false) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
         if (!this.state.isOpen) {
             return;
@@ -424,7 +424,10 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         } else if (this.props.closeOnSelection) {
             isOpen = false;
             isStartInputFocused = false;
-            isEndInputFocused = false;
+            // if we submit via click or Tab, the focus will have moved already.
+            // it we submit with Enter, the focus won't have moved, and setting
+            // the flag to false won't have an effect anyway, so leave it true.
+            isEndInputFocused = didSubmitWithEnter ? true : false;
         } else if (this.state.lastFocusedField === DateRangeBoundary.START) {
             // keep the start field focused
             isStartInputFocused = true;
@@ -555,47 +558,50 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         const wasStartFieldFocused = this.state.lastFocusedField === DateRangeBoundary.START;
         const wasEndFieldFocused = this.state.lastFocusedField === DateRangeBoundary.END;
 
-        let isEndInputFocused: boolean;
-        let isStartInputFocused: boolean;
-
         // move focus to the other field
-        if (wasStartFieldFocused && isTabPressed && !isShiftPressed) {
-            isStartInputFocused = false;
-            isEndInputFocused = true;
-        } else if (wasEndFieldFocused && isTabPressed && isShiftPressed) {
-            isStartInputFocused = true;
-            isEndInputFocused = false;
+        if (isTabPressed) {
+            let isEndInputFocused: boolean;
+            let isStartInputFocused: boolean;
+            let isOpen = true;
+
+            if (wasStartFieldFocused && !isShiftPressed) {
+                isStartInputFocused = false;
+                isEndInputFocused = true;
+
+                // prevent the default focus-change behavior to avoid race conditions;
+                // we'll handle the focus change ourselves in componentDidUpdate.
+                e.preventDefault();
+            } else if (wasEndFieldFocused && isShiftPressed) {
+                isStartInputFocused = true;
+                isEndInputFocused = false;
+                e.preventDefault();
+            } else {
+                // don't prevent default here, otherwise Tab won't do anything.
+                isStartInputFocused = false;
+                isEndInputFocused = false;
+                isOpen = false;
+            }
+
+            this.setState({
+                isEndInputFocused,
+                isOpen,
+                isStartInputFocused,
+                wasLastFocusChangeDueToHover: false,
+            });
         } else if (wasStartFieldFocused && isEnterPressed) {
             const nextStartValue = this.dateStringToMoment(this.state.startInputString);
             const nextStartDate = fromMomentToDate(nextStartValue);
             const nextEndDate = isMomentNull(selectedEnd) ? undefined : fromMomentToDate(selectedEnd);
-            this.handleDateRangePickerChange([nextStartDate, nextEndDate] as DateRange);
-            isStartInputFocused = false;
-            isEndInputFocused = true;
+            this.handleDateRangePickerChange([nextStartDate, nextEndDate] as DateRange, true);
         } else if (wasEndFieldFocused && isEnterPressed) {
             const nextStartDate = isMomentNull(selectedStart) ? undefined : fromMomentToDate(selectedStart);
             const nextEndValue = this.dateStringToMoment(this.state.endInputString);
             const nextEndDate = fromMomentToDate(nextEndValue);
-            this.handleDateRangePickerChange([nextStartDate, nextEndDate] as DateRange);
-            isStartInputFocused = false;
-            isEndInputFocused = false;
-            // need to explicitly blur, because only .focus() is triggered in
-            // componentShouldUpdate.
-            this.endInputRef.blur();
+            this.handleDateRangePickerChange([nextStartDate, nextEndDate] as DateRange, true);
         } else {
             // let the default keystroke happen without side effects
             return;
         }
-
-        // prevent the default focus-change behavior to avoid race conditions;
-        // we'll handle the focus change ourselves in componentDidUpdate.
-        e.preventDefault();
-
-        this.setState({
-            isEndInputFocused,
-            isStartInputFocused,
-            wasLastFocusChangeDueToHover: false,
-        });
     };
 
     private handleInputMouseDown = () => {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -537,8 +537,11 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
     // - if focused in start field, Tab moves focus to end field
     // - if focused in end field, Shift+Tab moves focus to start field
     private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        const isTabPressed = e.keyCode === Keys.TAB;
+        const isTabPressed = e.which === Keys.TAB;
+        const isEnterPressed = e.which === Keys.ENTER;
         const isShiftPressed = e.shiftKey;
+
+        const { selectedStart, selectedEnd } = this.state;
 
         // order of JS events is our enemy here. when tabbing between fields,
         // this handler will fire in the middle of a focus exchange when no
@@ -557,6 +560,21 @@ export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDat
         } else if (wasEndFieldFocused && isTabPressed && isShiftPressed) {
             isStartInputFocused = true;
             isEndInputFocused = false;
+        } else if (wasStartFieldFocused && isEnterPressed) {
+            const nextStartValue = new Date(this.state.startInputString);
+            const nextEndValue = isMomentNull(selectedEnd) ? undefined : fromMomentToDate(selectedEnd);
+            this.handleDateRangePickerChange([nextStartValue, nextEndValue] as DateRange);
+            isStartInputFocused = false;
+            isEndInputFocused = true;
+        } else if (wasEndFieldFocused && isEnterPressed) {
+            const nextStartValue = isMomentNull(selectedStart) ? undefined : fromMomentToDate(selectedStart);
+            const nextEndValue = new Date(this.state.endInputString);
+            this.handleDateRangePickerChange([nextStartValue, nextEndValue] as DateRange);
+            isStartInputFocused = false;
+            isEndInputFocused = false;
+            // need to explicitly blur, because only .focus() is triggered in
+            // componentShouldUpdate.
+            this.endInputRef.blur();
         } else {
             // let the default keystroke happen without side effects
             return;

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -145,6 +145,15 @@ describe("<DateInput>", () => {
     });
 
     describe("when uncontrolled", () => {
+        it("Pressing Enter saves the inputted date and closes the popover", () => {
+            const wrapper = mount(<DateInput />).setState({ isOpen: true });
+            const input = wrapper.find("input").first();
+            input.simulate("change", { target: { value: "2/15/15" } });
+            input.simulate("keydown", { which: Keys.ENTER });
+            assert.isFalse(wrapper.state("isOpen"));
+            assert.equal(wrapper.find(InputGroup).prop("value"), "2015-02-15");
+        });
+
         it("Clicking a date puts it in the input box and closes the popover", () => {
             const wrapper = mount(<DateInput />).setState({ isOpen: true });
             assert.equal(wrapper.find(InputGroup).prop("value"), "");
@@ -322,6 +331,20 @@ describe("<DateInput>", () => {
         const DATE2 = new Date(2015, Months.FEBRUARY, 1);
         const DATE2_STR = "2015-02-01";
         const DATE2_DE_STR = "01.02.2015";
+
+        it("Pressing Enter saves the inputted date and closes the popover", () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateInput onChange={onChange} value={DATE} />);
+            root.setState({ isOpen: true });
+
+            const input = root.find("input").first();
+            input.simulate("change", { target: { value: DATE2_STR } });
+            input.simulate("keydown", { which: Keys.ENTER });
+
+            // onChange is called once on change, once on Enter
+            assert.isTrue(onChange.calledTwice, "onChange called twice");
+            assertDateEquals(onChange.args[1][0], DATE2_STR);
+        });
 
         it("Clicking a date invokes onChange callback with that date", () => {
             const onChange = sinon.spy();

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -148,7 +148,7 @@ describe("<DateInput>", () => {
         it("Pressing Enter saves the inputted date and closes the popover", () => {
             const wrapper = mount(<DateInput />).setState({ isOpen: true });
             const input = wrapper.find("input").first();
-            input.simulate("change", { target: { value: "2/15/15" } });
+            input.simulate("change", { target: { value: "2015-02-15" } });
             input.simulate("keydown", { which: Keys.ENTER });
             assert.isFalse(wrapper.state("isOpen"));
             assert.equal(wrapper.find(InputGroup).prop("value"), "2015-02-15");

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -167,12 +167,15 @@ describe("<DateInput>", () => {
 
     describe("when uncontrolled", () => {
         it("Pressing Enter saves the inputted date and closes the popover", () => {
-            const wrapper = mount(<DateInput />).setState({ isOpen: true });
+            const onKeyDown = sinon.spy();
+            const wrapper = mount(<DateInput inputProps={{ onKeyDown }} />).setState({ isOpen: true });
             const input = wrapper.find("input").first();
             input.simulate("change", { target: { value: "2015-02-15" } });
             input.simulate("keydown", { which: Keys.ENTER });
-            assert.isFalse(wrapper.state("isOpen"));
-            assert.equal(wrapper.find(InputGroup).prop("value"), "2015-02-15");
+            assert.isFalse(wrapper.state("isOpen"), "popover closed");
+            assert.isTrue(wrapper.state("isInputFocused"), "input still focused");
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), "2015-02-15");
+            assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
         });
 
         it("Clicking a date puts it in the input box and closes the popover", () => {
@@ -354,8 +357,9 @@ describe("<DateInput>", () => {
         const DATE2_DE_STR = "01.02.2015";
 
         it("Pressing Enter saves the inputted date and closes the popover", () => {
+            const onKeyDown = sinon.spy();
             const onChange = sinon.spy();
-            const { root } = wrap(<DateInput onChange={onChange} value={DATE} />);
+            const { root } = wrap(<DateInput inputProps={{ onKeyDown }} onChange={onChange} value={DATE} />);
             root.setState({ isOpen: true });
 
             const input = root.find("input").first();
@@ -365,6 +369,8 @@ describe("<DateInput>", () => {
             // onChange is called once on change, once on Enter
             assert.isTrue(onChange.calledTwice, "onChange called twice");
             assertDateEquals(onChange.args[1][0], DATE2_STR);
+            assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
+            assert.isTrue(root.state("isInputFocused"), "input still focused");
         });
 
         it("Clicking a date invokes onChange callback with that date", () => {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -167,14 +167,16 @@ describe("<DateInput>", () => {
 
     describe("when uncontrolled", () => {
         it("Pressing Enter saves the inputted date and closes the popover", () => {
+            const IMPROPERLY_FORMATTED_DATE_STRING = "2015-2-15";
+            const PROPERLY_FORMATTED_DATE_STRING = "2015-02-15";
             const onKeyDown = sinon.spy();
             const wrapper = mount(<DateInput inputProps={{ onKeyDown }} />).setState({ isOpen: true });
             const input = wrapper.find("input").first();
-            input.simulate("change", { target: { value: "2015-02-15" } });
+            input.simulate("change", { target: { value: IMPROPERLY_FORMATTED_DATE_STRING } });
             input.simulate("keydown", { which: Keys.ENTER });
             assert.isFalse(wrapper.state("isOpen"), "popover closed");
             assert.isTrue(wrapper.state("isInputFocused"), "input still focused");
-            assert.strictEqual(wrapper.find(InputGroup).prop("value"), "2015-02-15");
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), PROPERLY_FORMATTED_DATE_STRING);
             assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
         });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -257,6 +257,26 @@ describe("<DateRangeInput>", () => {
         expect(root.find(DateRangePicker).prop("shortcuts")).to.be.false;
     });
 
+    it("pressing Shift+Tab in the start field blurs the start field and closes the popover", () => {
+        const startInputProps = { onKeyDown: sinon.spy() };
+        const { root } = wrap(<DateRangeInput {...{ startInputProps }} />);
+        const startInput = getStartInput(root);
+        startInput.simulate("keydown", { which: Keys.TAB, shiftKey: true });
+        expect(root.state("isStartInputFocused"), "start input blurred").to.be.false;
+        expect(startInputProps.onKeyDown.calledOnce, "onKeyDown called once").to.be.true;
+        expect(root.state("isOpen"), "popover closed").to.be.false;
+    });
+
+    it("pressing Tab in the end field blurs the end field and closes the popover", () => {
+        const endInputProps = { onKeyDown: sinon.spy() };
+        const { root } = wrap(<DateRangeInput {...{ endInputProps }} />);
+        const endInput = getEndInput(root);
+        endInput.simulate("keydown", { which: Keys.TAB });
+        expect(root.state("isEndInputFocused"), "end input blurred").to.be.false;
+        expect(endInputProps.onKeyDown.calledOnce, "onKeyDown called once").to.be.true;
+        expect(root.state("isOpen"), "popover closed").to.be.false;
+    });
+
     describe("selectAllOnFocus", () => {
         it("if false (the default), does not select any text on focus", () => {
             const attachTo = document.createElement("div");
@@ -381,29 +401,31 @@ describe("<DateRangeInput>", () => {
         });
 
         it("Pressing Enter saves the inputted date and closes the popover", () => {
-            const { root } = wrap(<DateRangeInput />);
+            const startInputProps = { onKeyDown: sinon.spy() };
+            const endInputProps = { onKeyDown: sinon.spy() };
+            const { root } = wrap(<DateRangeInput {...{ startInputProps, endInputProps }} />);
             root.setState({ isOpen: true });
 
             const startInput = getStartInput(root);
             startInput.simulate("focus");
             startInput.simulate("change", { target: { value: START_STR } });
             startInput.simulate("keydown", { which: Keys.ENTER });
-            expect(isStartInputFocused(root), "start input blurred next").to.be.false;
+            expect(startInputProps.onKeyDown.calledOnce, "startInputProps.onKeyDown called once");
+            expect(isStartInputFocused(root), "start input still focused").to.be.false;
 
             expect(root.state("isOpen"), "popover still open").to.be.true;
 
             const endInput = getEndInput(root);
-            expect(isEndInputFocused(root), "end input focused next").to.be.true;
+            endInput.simulate("focus");
             endInput.simulate("change", { target: { value: END_STR } });
             endInput.simulate("keydown", { which: Keys.ENTER });
+            expect(endInputProps.onKeyDown.calledOnce, "endInputProps.onKeyDown called once");
+            expect(isEndInputFocused(root), "end input still focused").to.be.true;
 
             expect(startInput.prop("value")).to.equal(START_STR);
             expect(endInput.prop("value")).to.equal(END_STR);
 
             expect(root.state("isOpen"), "popover closed at end").to.be.false;
-            expect(isStartInputFocused(root), "start input blurred at end").to.be.false;
-            // TODO (clewis): fix failing statement (works in practice)
-            // expect(isEndInputFocused(root), "end input blurred at end").to.be.false;
         });
 
         it("Clicking a date invokes onChange with the new date range and updates the input fields", () => {
@@ -2095,8 +2117,7 @@ describe("<DateRangeInput>", () => {
             endInput.simulate("keydown", { which: Keys.ENTER });
 
             expect(isStartInputFocused(root), "start input blurred at end").to.be.false;
-            // TODO (clewis): fix failing statement (works in practice)
-            // expect(isEndInputFocused(root), "end input blurred at end").to.be.false;
+            expect(isEndInputFocused(root), "end input still focused at end").to.be.true;
 
             // onChange is called once on change, once on Enter
             expect(onChange.callCount, "onChange called four times").to.equal(4);


### PR DESCRIPTION
#### Fixes #1798 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- `DateInput` and `DateRangeInput` now save the typed value(s) on <kbd>Enter</kbd>.
    - They also move/transfer the focus state appropriately.

#### Reviewers should focus on:

- The tests don't corroborate my understanding of what should be happening. Maybe I just need to sleep on it. I've commented or omitted some checks in the meantime.
- Idea for followup: Revert to the old value on <kbd>Esc</kbd>? Thoughts?
- Does controlled mode look good?

#### Screenshot

_`DateInput`_

![2017-11-20 02 04 30](https://user-images.githubusercontent.com/443450/33012951-31fbb90c-cd97-11e7-8f10-6b526e4362f4.gif)

_`DateRangeInput`_

![2017-11-20 02 04 58](https://user-images.githubusercontent.com/443450/33012973-44992f86-cd97-11e7-93ac-a5eb4dde2a54.gif)
