### PR TITLE
[Core,DateTime] Support custom `style` on InputGroup and datetime inputs

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -69,7 +69,7 @@ export class InputGroup extends React.Component<HTMLInputProps & IInputGroupProp
             },
             className,
         );
-        const style: React.CSSProperties = { paddingRight: this.state.rightElementWidth };
+        const style: React.CSSProperties = { ...this.props.style, paddingRight: this.state.rightElementWidth };
 
         return (
             <div className={classes}>

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -20,7 +20,10 @@ describe("<InputGroup>", () => {
 
     it("supports custom style", () => {
         const input = mount(<InputGroup leftIconName="star" style={{ background: "yellow" }} />);
-        const inputElement = input.find("input").getDOMNode() as HTMLElement;
+        const inputElement = input
+            .find("input")
+            .first()
+            .getDOMNode() as HTMLElement;
         assert.equal(inputElement.style.background, "yellow");
     });
 

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -18,6 +18,12 @@ describe("<InputGroup>", () => {
         assert.isTrue(input.childAt(1).hasClass("pt-input"));
     });
 
+    it("supports custom style", () => {
+        const input = mount(<InputGroup leftIconName="star" style={{ background: "yellow" }} />);
+        const inputElement = input.find("input").getDOMNode() as HTMLElement;
+        assert.equal(inputElement.style.background, "yellow");
+    });
+
     it("renders right element inside .pt-input-action after input", () => {
         const action = mount(<InputGroup rightElement={<address />} />).childAt(2);
         assert.isTrue(action.hasClass("pt-input-action"));

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -24,6 +24,15 @@ describe("<DateInput>", () => {
         assert.doesNotThrow(() => mount(<DateInput value={"1988-08-07 11:01:12" as any} />));
     });
 
+    it("supports custom input style", () => {
+        const wrapper = mount(<DateInput inputProps={{ style: { background: "yellow" } }} />);
+        const inputElement = wrapper
+            .find("input")
+            .first()
+            .getDOMNode() as HTMLElement;
+        assert.equal(inputElement.style.background, "yellow");
+    });
+
     it("Popover opens on input focus", () => {
         const wrapper = mount(<DateInput openOnFocus={true} />);
         wrapper.find("input").simulate("focus");

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -110,10 +110,7 @@ describe("<DateRangeInput>", () => {
 
             it("supports custom style", () => {
                 const { root } = mountFn({ style: { background: "yellow" } });
-                const inputElement = root
-                    .find("input")
-                    .first()
-                    .getDOMNode() as HTMLElement;
+                const inputElement = inputGetterFn(root).getDOMNode() as HTMLElement;
                 expect(inputElement.style.background).to.equal("yellow");
             });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -108,6 +108,15 @@ describe("<DateRangeInput>", () => {
                 expect(getInputPlaceholderText(inputGetterFn(root))).to.equal("Hello");
             });
 
+            it("supports custom style", () => {
+                const { root } = mountFn({ style: { background: "yellow" } });
+                const inputElement = root
+                    .find("input")
+                    .first()
+                    .getDOMNode() as HTMLElement;
+                expect(inputElement.style.background).to.equal("yellow");
+            });
+
             // verify custom callbacks are called for each event that we listen for internally.
             // (note: we could be more clever and accept just one string param here, but this
             // approach keeps both string params grep-able in the codebase.)


### PR DESCRIPTION
#### Fixes #1554 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- `InputGroup` now supports custom styles passed via the `style` prop.
- `DateInput` now supports custom input styles passed via the `inputProps` prop.
- `DateRangeInput` now supports custom input styles passed via the `(start,end)InputProps` props.

#### Reviewers should focus on:

Do we need to support a top-level style prop on `DateInput` and `DateRangeInput` too? See https://github.com/palantir/blueprint/issues/1554#issuecomment-330186724.