### PR TITLE
Fix TagInput dark placeholder color

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -153,15 +153,19 @@ $control-group-stack: (
   color: $dark-input-color-disabled;
 }
 
+@mixin pt-dark-input-placeholder() {
+  &::placeholder {
+    color: $dark-input-placeholder-color;
+  }
+}
+
 @mixin pt-dark-input() {
+  @include pt-dark-input-placeholder();
+
   box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus),
               $pt-dark-input-box-shadow;
   background: $dark-input-background-color;
   color: $dark-input-color;
-
-  &::placeholder {
-    color: $dark-input-placeholder-color;
-  }
 
   &:focus {
     box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true),

--- a/packages/labs/src/components/tag-input/_tag-input.scss
+++ b/packages/labs/src/components/tag-input/_tag-input.scss
@@ -85,6 +85,8 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
     }
 
     .pt-input-ghost {
+      @include pt-dark-input-placeholder();
+
       color: $dark-input-color;
     }
 


### PR DESCRIPTION
#### Fixes #1806 

#### Changes proposed in this pull request:

Updated the `TagInput`'s placeholder color for consistency with other `input` elements.

#### Screenshot

![screen shot 2017-11-21 at 9 41 14 am](https://user-images.githubusercontent.com/831708/33078283-303dab66-cea0-11e7-9b41-dde6b7b40ce8.png)