### PR TITLE
Added <title> support for the blueprint documentation website.

### DIFF
--- a/packages/docs/src/components/documentation.tsx
+++ b/packages/docs/src/components/documentation.tsx
@@ -136,6 +136,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         FocusStyleManager.onlyShowFocusOnTabs();
         this.scrollToActiveSection();
         this.maybeScrollToActivePageMenuItem();
+        this.updateTitle();
         Utils.safeInvoke(this.props.onComponentUpdate, this.state.activePageId);
         // whoa handling future history...
         window.addEventListener("hashchange", () => {
@@ -143,8 +144,10 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
                 // captures a pageview for new location hashes that are dynamically rendered without a full page request
                 (window as any).ga("send", "pageview", { page: location.pathname + location.search + location.hash });
             }
+
             // Don't call componentWillMount since the HotkeysTarget decorator will be invoked on every hashchange.
             this.updateHash();
+            this.updateTitle();
         });
         document.addEventListener("scroll", this.handleScroll);
     }
@@ -164,6 +167,19 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         }
 
         Utils.safeInvoke(this.props.onComponentUpdate, activePageId);
+    }
+
+    private updateTitle(){
+        // Update the page <title> when the hash changes
+        let title:string;
+        if(this.state.activePageId === 'blueprint' && this.state.activeSectionId === 'blueprint'){
+            const indexTitle: string = 'Blueprint - Documentation';
+            title = indexTitle;
+        } else {
+            const newTitle: string = document.getElementsByClassName('docs-title')[0].textContent;
+            title = `${newTitle} - Blueprint`;
+        }
+        document.title = title;
     }
 
     private updateHash() {

--- a/packages/docs/src/components/documentation.tsx
+++ b/packages/docs/src/components/documentation.tsx
@@ -175,7 +175,10 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         const docsTitle = document.getElementsByClassName("docs-title")[0].textContent;
         // Check to make sure the textContent of docsTitle has a useable value
         if (docsTitle !== undefined && docsTitle !== null) {
-            title = `${docsTitle} - Blueprint`;
+            // Only change the title if we aren't on the index homepage
+            if (this.state.activePageId !== "blueprint" && this.state.activeSectionId !== "blueprint") {
+                title = `${docsTitle} - Blueprint`;
+            }
         }
         return title;
     }

--- a/packages/docs/src/components/documentation.tsx
+++ b/packages/docs/src/components/documentation.tsx
@@ -169,14 +169,14 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         Utils.safeInvoke(this.props.onComponentUpdate, activePageId);
     }
 
-    private updateTitle(){
+    private updateTitle() {
         // Update the page <title> when the hash changes
-        let title:string;
-        if(this.state.activePageId === 'blueprint' && this.state.activeSectionId === 'blueprint'){
-            const indexTitle: string = 'Blueprint - Documentation';
+        let title: string;
+        if (this.state.activePageId === "blueprint" && this.state.activeSectionId === "blueprint") {
+            const indexTitle: string = "Blueprint - Documentation";
             title = indexTitle;
         } else {
-            const newTitle: string = document.getElementsByClassName('docs-title')[0].textContent;
+            const newTitle: string = document.getElementsByClassName("docs-title")[0].textContent;
             title = `${newTitle} - Blueprint`;
         }
         document.title = title;

--- a/packages/docs/src/components/documentation.tsx
+++ b/packages/docs/src/components/documentation.tsx
@@ -169,16 +169,20 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         Utils.safeInvoke(this.props.onComponentUpdate, activePageId);
     }
 
+    private getTitle() {
+        // Either get the title from the document, or return the default title
+        let title = "Blueprint - Documentation";
+        const docsTitle = document.getElementsByClassName("docs-title")[0].textContent;
+        // Check to make sure the textContent of docsTitle has a useable value
+        if (docsTitle !== undefined && docsTitle !== null) {
+            title = `${docsTitle} - Blueprint`;
+        }
+        return title;
+    }
+
     private updateTitle() {
         // Update the page <title> when the hash changes
-        let title: string;
-        if (this.state.activePageId === "blueprint" && this.state.activeSectionId === "blueprint") {
-            const indexTitle: string = "Blueprint - Documentation";
-            title = indexTitle;
-        } else {
-            const newTitle: string = document.getElementsByClassName("docs-title")[0].textContent;
-            title = `${newTitle} - Blueprint`;
-        }
+        const title = this.getTitle();
         document.title = title;
     }
 


### PR DESCRIPTION
#### Fixes #1829

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests = could not find any `tests` within `docs`
- [x] Update documentation = do not find that any documentation needs to be updated

#### Changes proposed in this pull request:

This PR makes it so that the `<title>` of the blueprint documentation website is updated appropriately. The main thing that I've added is a function called `updateTitle()` which is fired initially in the `componentDidMount` lifecycle and then fired again whenever the navigation changes (within the `hashchange` eventListner).

#### Reviewers should focus on:

As you can tell by the diff, only 1 new function has been added to the `documentation.tsx` file. So everything else should be functioning as expected.

#### Screenshot

![blueprint-title](https://user-images.githubusercontent.com/1383831/33106758-addbde88-cee8-11e7-806b-dfc34e5999fd.gif)

Note: I've never used circleci before, but I've followed the provided steps. Please let me know if I have to do anything to let the ci check pass.