### PR TITLE
[Core] Add JS APIs for ControlGroup, FileUpload, Label, TextArea

### DIFF
--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -39,3 +39,18 @@ Add the class `pt-vertical` to create a vertical control group. Controls in a ve
 will all have the same width as the widest control.
 
 @css pt-control-group.pt-vertical
+
+@## JavaScript API
+
+The `ControlGroup` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+
+This components is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+
+```tsx
+<ControlGroup fill={true} vertical={false}>
+    <Button iconName="filter">Filter</Button>
+    <InputGroup placeholder="Find filters..." />
+</ControlGroup>
+```
+
+@interface IControlGroupProps

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -44,7 +44,7 @@ will all have the same width as the widest control.
 
 The `ControlGroup` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
 
-This components is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 
 ```tsx
 <ControlGroup fill={true} vertical={false}>

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -42,7 +42,7 @@ will all have the same width as the widest control.
 
 @## JavaScript API
 
-The `ControlGroup` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+The `ControlGroup` component is available in the __@blueprintjs/core__ package. Make sure to review [general usage docs for JS components](#blueprint.usage).
 
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -46,6 +46,8 @@ The `ControlGroup` component is available in the @blueprintjs/core package. Make
 
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 
+@reactExample ControlGroupExample
+
 ```tsx
 <ControlGroup fill={true} vertical={false}>
     <Button iconName="filter">Filter</Button>

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -46,13 +46,13 @@ The `ControlGroup` component is available in the @blueprintjs/core package. Make
 
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 
-@reactExample ControlGroupExample
-
 ```tsx
 <ControlGroup fill={true} vertical={false}>
     <Button iconName="filter">Filter</Button>
     <InputGroup placeholder="Find filters..." />
 </ControlGroup>
 ```
+
+@reactExample ControlGroupExample
 
 @interface IControlGroupProps

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
+import * as React from "react";
+import * as Classes from "../../common/classes";
+import { IProps } from "../../common/props";
+
+export interface IControlGroupProps extends React.HTMLProps<HTMLDivElement>, IProps {
+    /**
+     * Whether the control group should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * Whether the button group should appear with vertical styling.
+     */
+    vertical: boolean;
+}
+
+// this component is simple enough that tests would be purely tautological.
+/* istanbul ignore next */
+@PureRender
+export class ControlGroup extends React.Component<IControlGroupProps, {}> {
+    public static displayName = "Blueprint.ControlGroup";
+
+    public render() {
+        const { children, className, fill, vertical, ...htmlProps } = this.props;
+
+        const rootClasses = classNames(
+            Classes.CONTROL_GROUP,
+            {
+                [Classes.FILL]: fill,
+                [Classes.VERTICAL]: vertical,
+            },
+            className,
+        );
+
+        return (
+            <div {...htmlProps} className={rootClasses}>
+                {children}
+            </div>
+        );
+    }
+}

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -47,3 +47,5 @@ export class ControlGroup extends React.Component<IControlGroupProps, {}> {
         );
     }
 }
+
+export const ControlGroupFactory = React.createFactory(ControlGroup);

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -19,7 +19,7 @@ export interface IControlGroupProps extends React.HTMLProps<HTMLDivElement>, IPr
     /**
      * Whether the button group should appear with vertical styling.
      */
-    vertical: boolean;
+    vertical?: boolean;
 }
 
 // this component is simple enough that tests would be purely tautological.

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
-export interface IControlGroupProps extends React.HTMLProps<HTMLDivElement>, IProps {
+export interface IControlGroupProps extends React.AllHTMLAttributes<HTMLDivElement>, IProps {
     /**
      * Whether the control group should take up the full width of its container.
      */

--- a/packages/core/src/components/forms/file-upload.md
+++ b/packages/core/src/components/forms/file-upload.md
@@ -9,4 +9,18 @@ Wrap that all in a `label` with class `pt-file-upload`.
     you must implement it separately in JS.
 </div>
 
+@## CSS API
+
 @css pt-file-upload
+
+@## JavaScript API
+
+The `FileUpload` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+
+This components is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+
+```tsx
+<FileUpload disabled={true} text="Choose file..." inputProps={{ onChange: /* ... */ }} />
+```
+
+@interface IFileUploadProps

--- a/packages/core/src/components/forms/file-upload.md
+++ b/packages/core/src/components/forms/file-upload.md
@@ -20,7 +20,7 @@ The `FileUpload` component is available in the __@blueprintjs/core__ package. Ma
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 
 ```tsx
-<FileUpload disabled={true} text="Choose file..." inputProps={{ onChange: /* ... */ }} />
+<FileUpload disabled={true} text="Choose file..." onInputChange={...} />
 ```
 
 @interface IFileUploadProps

--- a/packages/core/src/components/forms/file-upload.md
+++ b/packages/core/src/components/forms/file-upload.md
@@ -15,7 +15,7 @@ Wrap that all in a `label` with class `pt-file-upload`.
 
 @## JavaScript API
 
-The `FileUpload` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+The `FileUpload` component is available in the __@blueprintjs/core__ package. Make sure to review the [general usage docs for JS components](#blueprint.usage).
 
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 

--- a/packages/core/src/components/forms/file-upload.md
+++ b/packages/core/src/components/forms/file-upload.md
@@ -17,7 +17,7 @@ Wrap that all in a `label` with class `pt-file-upload`.
 
 The `FileUpload` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
 
-This components is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 
 ```tsx
 <FileUpload disabled={true} text="Choose file..." inputProps={{ onChange: /* ... */ }} />

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -11,7 +11,7 @@ import { Utils } from "../../common";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
-export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IProps {
+export interface IFileUploadProps extends React.AllHTMLAttributes<HTMLLabelElement>, IProps {
     /**
      * Whether the file upload is non-interactive.
      * Setting this to `true` will automatically disable the child input too.

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -32,7 +32,7 @@ export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IPr
     /**
      * Whether the file upload should appear with large styling.
      */
-    large: boolean;
+    large?: boolean;
 
     /**
      * The text to display.

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -41,6 +41,8 @@ export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IPr
     text?: string;
 }
 
+// TODO: write tests (ignoring for now to get a build passing quickly)
+/* istanbul ignore next */
 @PureRender
 export class FileUpload extends React.Component<IFileUploadProps, {}> {
     public static displayName = "Blueprint.FileUpload";

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
+import * as React from "react";
+import * as Classes from "../../common/classes";
+import { IProps } from "../../common/props";
+
+export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IProps {
+    /**
+     * Whether the file upload is non-interactive.
+     * Setting this to `true` will automatically disable the child input too.
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether the file upload should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * The props to pass to the child input.
+     * `disabled` will be ignored in favor of the top-level prop.
+     * Pass `onChange` here to be notified when the user uploads a file.
+     */
+    inputProps?: React.HTMLProps<HTMLInputElement>;
+
+    /**
+     * Whether the file upload should appear with large styling.
+     */
+    large: boolean;
+
+    /**
+     * The text to display.
+     * @default "Choose a file..."
+     */
+    text?: string;
+}
+
+@PureRender
+export class FileUpload extends React.Component<IFileUploadProps, {}> {
+    public static displayName = "Blueprint.FileUpload";
+
+    public render() {
+        const { className, fill, disabled, inputProps, large, text, ...htmlProps } = this.props;
+
+        const rootClasses = classNames(
+            Classes.FILE_UPLOAD,
+            {
+                [Classes.DISABLED]: disabled,
+                [Classes.FILL]: fill,
+                [Classes.LARGE]: large,
+            },
+            className,
+        );
+
+        return (
+            <label {...htmlProps} className={rootClasses}>
+                <input {...inputProps} type="file" disabled={disabled} />
+                <span className={Classes.FILE_UPLOAD_INPUT}>{text}</span>
+            </label>
+        );
+    }
+}

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -92,3 +92,5 @@ export class FileUpload extends React.Component<IFileUploadProps, {}> {
         Utils.safeInvoke(this.props.inputProps.onChange, e);
     };
 }
+
+export const FileUploadFactory = React.createFactory(FileUpload);

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -25,6 +25,7 @@ export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IPr
     /**
      * The props to pass to the child input.
      * `disabled` will be ignored in favor of the top-level prop.
+     * `type` will be ignored, because the input _must_ be `type="file"`.
      * Pass `onChange` here to be notified when the user uploads a file.
      */
     inputProps?: React.HTMLProps<HTMLInputElement>;
@@ -36,7 +37,7 @@ export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IPr
 
     /**
      * The text to display.
-     * @default "Choose a file..."
+     * @default "Choose file..."
      */
     text?: string;
 }
@@ -46,6 +47,10 @@ export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IPr
 @PureRender
 export class FileUpload extends React.Component<IFileUploadProps, {}> {
     public static displayName = "Blueprint.FileUpload";
+
+    public static defaultProps: IFileUploadProps = {
+        text: "Choose file...",
+    };
 
     public render() {
         const { className, fill, disabled, inputProps, large, text, ...htmlProps } = this.props;

--- a/packages/core/src/components/forms/fileUpload.tsx
+++ b/packages/core/src/components/forms/fileUpload.tsx
@@ -7,6 +7,7 @@
 import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
+import { Utils } from "../../common";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
@@ -36,6 +37,18 @@ export interface IFileUploadProps extends React.HTMLProps<HTMLLabelElement>, IPr
     large?: boolean;
 
     /**
+     * Callback invoked on `input` `change` events.
+     *
+     * This callback is offered as a convenience; it is equivalent to passing
+     * `onChange` to `inputProps`.
+     *
+     * __Note:__ If you pass `onChange` as a top-level prop, it will be passed
+     * to the wrapping `label` rather than the `input`, which may not be what
+     * you expect.
+     */
+    onInputChange?: React.FormEventHandler<HTMLInputElement>;
+
+    /**
      * The text to display.
      * @default "Choose file..."
      */
@@ -49,6 +62,7 @@ export class FileUpload extends React.Component<IFileUploadProps, {}> {
     public static displayName = "Blueprint.FileUpload";
 
     public static defaultProps: IFileUploadProps = {
+        inputProps: {},
         text: "Choose file...",
     };
 
@@ -67,9 +81,14 @@ export class FileUpload extends React.Component<IFileUploadProps, {}> {
 
         return (
             <label {...htmlProps} className={rootClasses}>
-                <input {...inputProps} type="file" disabled={disabled} />
+                <input {...inputProps} onChange={this.handleInputChange} type="file" disabled={disabled} />
                 <span className={Classes.FILE_UPLOAD_INPUT}>{text}</span>
             </label>
         );
     }
+
+    private handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+        Utils.safeInvoke(this.props.onInputChange, e);
+        Utils.safeInvoke(this.props.inputProps.onChange, e);
+    };
 }

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -37,7 +37,7 @@ must add the `:disabled` attribute directly to any nested elements to disable th
 
 The `Label` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
 
-This components is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 
 ```tsx
 <Label

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -33,7 +33,7 @@ must add the `:disabled` attribute directly to any nested elements to disable th
 
 @css pt-label.pt-disabled
 
-@### JavaScript API
+@## JavaScript API
 
 The `Label` component is available in the __@blueprintjs/core__ package. Make sure to review the [general usage docs for JS components](#blueprint.usage).
 

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -45,7 +45,7 @@ This component is a simple wrapper around the corresponding CSS API. It supports
     text="Label A"
     required={true}
 >
-    <input id="text-input" placeholder="Placeholder text" />
+    <input className="pt-input" id="text-input" placeholder="Placeholder text" />
 </Label>
 ```
 

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -9,7 +9,9 @@ Labels enhance the usability of your forms.
     <p>Form groups support more complex control layouts but require more markup to maintain consistent visuals.</p>
 </div>
 
-@## Simple labels
+@## CSS API
+
+@### Simple labels
 
 Simple labels are useful for basic forms for a single `<input>`.
 
@@ -20,7 +22,7 @@ can click to activate the control. Notice how in the examples below, clicking a 
 
 @css pt-label
 
-@## Disabled labels
+@### Disabled labels
 
 Add the `.pt-label` and `.pt-disabled` class modifiers to a `<label>` to make the label appear
 disabled.
@@ -30,3 +32,21 @@ must add the `:disabled` attribute directly to any nested elements to disable th
 `pt-*` form control will need a `.pt-disabled` modifier. See the examples below.
 
 @css pt-label.pt-disabled
+
+@### JavaScript API
+
+The `Label` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+
+This components is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+
+```tsx
+<Label
+    helperText="Helper text with details..."
+    text="Label A"
+    required={true}
+>
+    <input id="text-input" placeholder="Placeholder text" />
+</Label>
+```
+
+@interface ILabelProps

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -35,7 +35,7 @@ must add the `:disabled` attribute directly to any nested elements to disable th
 
 @### JavaScript API
 
-The `Label` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+The `Label` component is available in the __@blueprintjs/core__ package. Make sure to review the [general usage docs for JS components](#blueprint.usage).
 
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -18,10 +18,10 @@ export interface ILabelProps extends React.HTMLProps<HTMLDivElement>, IProps {
     disabled?: boolean;
 
     /** The helper text to show next to the label. */
-    helperText?: JSX.Element | string;
+    helperText?: React.ReactNode;
 
     /** The text to show in the label. */
-    text: JSX.Element | string;
+    text: React.ReactNode;
 }
 
 // this component is simple enough that tests would be purely tautological.

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -50,3 +50,5 @@ export class Label extends React.Component<ILabelProps, {}> {
         );
     }
 }
+
+export const LabelFactory = React.createFactory(Label);

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -10,8 +10,6 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
-// allow the empty interface so we can label it clearly in the docs
-// tslint:disable-next-line:no-empty-interface
 export interface ILabelProps extends React.HTMLProps<HTMLDivElement>, IProps {
     /**
      * Whether the label is non-interactive.

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -14,10 +14,16 @@ import { IProps } from "../../common/props";
 // tslint:disable-next-line:no-empty-interface
 export interface ILabelProps extends React.HTMLProps<HTMLDivElement>, IProps {
     /**
-     * Whether the label is non-interactive or not.
-     * @default false
+     * Whether the label is non-interactive.
+     * Be sure to explicitly disable any child controls as well.
      */
     disabled?: boolean;
+
+    /** The helper text to show next to the label. */
+    helperText?: JSX.Element | string;
+
+    /** The text to show in the label. */
+    text: JSX.Element | string;
 }
 
 // this component is simple enough that tests would be purely tautological.
@@ -26,12 +32,8 @@ export interface ILabelProps extends React.HTMLProps<HTMLDivElement>, IProps {
 export class Label extends React.Component<ILabelProps, {}> {
     public static displayName = "Blueprint.Label";
 
-    public defaultProps: ILabelProps = {
-        disabled: false,
-    };
-
     public render() {
-        const { children, className, disabled, ...htmlProps } = this.props;
+        const { children, className, disabled, helperText, text, ...htmlProps } = this.props;
 
         const rootClasses = classNames(
             Classes.LABEL,
@@ -43,6 +45,8 @@ export class Label extends React.Component<ILabelProps, {}> {
 
         return (
             <div {...htmlProps} className={rootClasses}>
+                {text}
+                <span className={classNames(Classes.TEXT_MUTED)}>{helperText}</span>
                 {children}
             </div>
         );

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
-export interface ILabelProps extends React.HTMLProps<HTMLDivElement>, IProps {
+export interface ILabelProps extends React.AllHTMLAttributes<HTMLDivElement>, IProps {
     /**
      * Whether the label is non-interactive.
      * Be sure to explicitly disable any child controls as well.

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
+import * as React from "react";
+import * as Classes from "../../common/classes";
+import { IProps } from "../../common/props";
+
+// allow the empty interface so we can label it clearly in the docs
+// tslint:disable-next-line:no-empty-interface
+export interface ILabelProps extends React.HTMLProps<HTMLDivElement>, IProps {
+    /**
+     * Whether the label is non-interactive or not.
+     * @default false
+     */
+    disabled?: boolean;
+}
+
+// this component is simple enough that tests would be purely tautological.
+/* istanbul ignore next */
+@PureRender
+export class Label extends React.Component<ILabelProps, {}> {
+    public static displayName = "Blueprint.Label";
+
+    public defaultProps: ILabelProps = {
+        disabled: false,
+    };
+
+    public render() {
+        const { children, className, disabled, ...htmlProps } = this.props;
+
+        const rootClasses = classNames(
+            Classes.LABEL,
+            {
+                [Classes.DISABLED]: disabled,
+            },
+            className,
+        );
+
+        return (
+            <div {...htmlProps} className={rootClasses}>
+                {children}
+            </div>
+        );
+    }
+}

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -12,7 +12,7 @@ You should also specify `dir="auto"` on text areas
 
 @### JavaScript API
 
-The `TextArea` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+The `TextArea` component is available in the __@blueprintjs/core__ package. Make sure to review the [general usage docs for JS components](#blueprint.usage).
 
 This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
 

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -18,12 +18,9 @@ This component is a simple wrapper around the corresponding CSS API. It supports
 
 ```tsx
 <TextArea
-    dir="auto"
-    fill={true}
-    large={false}
+    large={true}
     intent={Intent.PRIMARY}
-    onChange={/* ... */}
+    onChange={this.handleChange}
+    value={this.state.value}
 />
 ```
-
-@interface ITextAreaProps

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -6,4 +6,24 @@ You should also specify `dir="auto"` on text areas
 [to better support RTL languages](http://www.w3.org/International/questions/qa-html-dir#dirauto)
 (in all browsers except Internet Explorer).
 
+@### CSS API
+
 @css pt-textarea
+
+@### JavaScript API
+
+The `TextArea` component is available in the @blueprintjs/core package. Make sure to review the general usage docs for JS components.
+
+This component is a simple wrapper around the corresponding CSS API. It supports the full range of HTML props.
+
+```tsx
+<TextArea
+    dir="auto"
+    fill={true}
+    large={false}
+    intent={Intent.PRIMARY}
+    onChange={/* ... */}
+/>
+```
+
+@interface ITextAreaProps

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -8,7 +8,6 @@ import * as classNames from "classnames";
 import * as PureRender from "pure-render-decorator";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { Intent } from "../../common/intent";
 import { IIntentProps, IProps } from "../../common/props";
 
 export interface ITextAreaProps extends React.HTMLProps<HTMLTextAreaElement>, IIntentProps, IProps {

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -44,3 +44,5 @@ export class TextArea extends React.Component<ITextAreaProps, {}> {
         return <textarea {...htmlProps} className={rootClasses} />;
     }
 }
+
+export const TextAreaFactory = React.createFactory(TextArea);

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as classNames from "classnames";
+import * as PureRender from "pure-render-decorator";
+import * as React from "react";
+import * as Classes from "../../common/classes";
+import { Intent } from "../../common/intent";
+import { IIntentProps, IProps } from "../../common/props";
+
+export interface ITextAreaProps extends React.HTMLProps<HTMLTextAreaElement>, IIntentProps, IProps {
+    /**
+     * Whether the text area should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * Whether the text area should appear with large styling.
+     */
+    large?: boolean;
+}
+
+// this component is simple enough that tests would be purely tautological.
+/* istanbul ignore next */
+@PureRender
+export class TextArea extends React.Component<ITextAreaProps, {}> {
+    public static displayName = "Blueprint.TextArea";
+
+    public render() {
+        const { className, fill, intent, large, ...htmlProps } = this.props;
+
+        const rootClasses = classNames(
+            Classes.INPUT,
+            Classes.intentClass(intent),
+            {
+                [Classes.FILL]: fill,
+                [Classes.LARGE]: large,
+            },
+            className,
+        );
+
+        return <textarea {...htmlProps} className={rootClasses} />;
+    }
+}

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IIntentProps, IProps } from "../../common/props";
 
-export interface ITextAreaProps extends React.HTMLProps<HTMLTextAreaElement>, IIntentProps, IProps {
+export interface ITextAreaProps extends React.AllHTMLAttributes<HTMLTextAreaElement>, IIntentProps, IProps {
     /**
      * Whether the text area should take up the full width of its container.
      */

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -25,6 +25,7 @@ export * from "./collapsible-list/collapsibleList";
 export * from "./context-menu/contextMenuTarget";
 export * from "./dialog/dialog";
 export * from "./editable-text/editableText";
+export * from "./forms/controlGroup";
 export * from "./forms/controls";
 export * from "./forms/formGroup";
 export * from "./forms/inputGroup";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -27,6 +27,7 @@ export * from "./dialog/dialog";
 export * from "./editable-text/editableText";
 export * from "./forms/controlGroup";
 export * from "./forms/controls";
+export * from "./forms/fileUpload";
 export * from "./forms/formGroup";
 export * from "./forms/inputGroup";
 export * from "./forms/numericInput";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -30,6 +30,7 @@ export * from "./forms/controls";
 export * from "./forms/fileUpload";
 export * from "./forms/formGroup";
 export * from "./forms/inputGroup";
+export * from "./forms/label";
 export * from "./forms/numericInput";
 export * from "./forms/radioGroup";
 export * from "./hotkeys/hotkeys";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -33,6 +33,7 @@ export * from "./forms/inputGroup";
 export * from "./forms/label";
 export * from "./forms/numericInput";
 export * from "./forms/radioGroup";
+export * from "./forms/textArea";
 export * from "./hotkeys/hotkeys";
 export * from "./icon/icon";
 export * from "./menu/menu";

--- a/packages/core/test/forms/fileUploadTests.tsx
+++ b/packages/core/test/forms/fileUploadTests.tsx
@@ -65,12 +65,18 @@ describe("<FileUpload>", () => {
         assert.strictEqual(span.text(), "Upload file...");
     });
 
-    it("onChange works", () => {
+    it("invokes change callbacks", () => {
+        const inputProps = { onChange: sinon.spy() };
         const onChange = sinon.spy();
-        const wrapper = shallow(<FileUpload inputProps={{ onChange }} />);
+        const onInputChange = sinon.spy();
+
+        const wrapper = shallow(<FileUpload {...{ onChange, onInputChange, inputProps }} />);
         const input = getInput(wrapper);
         input.simulate("change");
-        assert.isTrue(onChange.calledOnce);
+
+        assert.isFalse(onChange.called, "onChange not called"); // because it's spread to the label, not the input
+        assert.isTrue(onInputChange.calledOnce, "onInputChange called");
+        assert.isTrue(inputProps.onChange.calledOnce, "inputProps.onChange called");
     });
 });
 

--- a/packages/core/test/forms/fileUploadTests.tsx
+++ b/packages/core/test/forms/fileUploadTests.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { assert } from "chai";
+import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+
+import { Classes, FileUpload } from "../../src/index";
+
+describe("<FileUpload>", () => {
+    it("supports className, fill, & large", () => {
+        const CUSTOM_CLASS = "foo";
+        const wrapper = shallow(<FileUpload className={CUSTOM_CLASS} fill={true} large={true} />);
+        assert.isTrue(wrapper.hasClass(Classes.FILE_UPLOAD), "Classes.FILE_UPLOAD");
+        assert.isTrue(wrapper.hasClass(CUSTOM_CLASS), CUSTOM_CLASS);
+        assert.isTrue(wrapper.hasClass(Classes.FILL), "Classes.FILL");
+        assert.isTrue(wrapper.hasClass(Classes.LARGE), "Classes.LARGE");
+    });
+
+    it("supports custom input props", () => {
+        const wrapper = mount(
+            <FileUpload
+                inputProps={{
+                    className: "bar",
+                    required: true,
+                    type: "text", // overridden by type="file"
+                }}
+            />,
+        );
+        const input = getInput(wrapper);
+
+        assert.isTrue(input.hasClass("bar"), "has custom class");
+        assert.isTrue(input.prop("required"), "required attribute");
+        assert.strictEqual(input.prop("type"), "file", "type attribute");
+    });
+
+    it("applies top-level disabled prop to the root and input (overriding inputProps.disabled)", () => {
+        const wrapper = mount(<FileUpload disabled={true} inputProps={{ disabled: false }} />);
+        const input = getInput(wrapper);
+
+        // should ignore inputProps.disabled in favor of the top-level prop
+        assert.isTrue(wrapper.hasClass(Classes.DISABLED), "wrapper has disabled class");
+        assert.isTrue(input.prop("disabled"), "input is disabled");
+
+        wrapper.setProps({ disabled: false, inputProps: { disabled: true } });
+
+        // ensure inputProps.disabled is overriden in this case too
+        assert.isFalse(wrapper.hasClass(Classes.DISABLED), "wrapper no longer has disabled class");
+        assert.isFalse(input.prop("disabled"), "input no longer disabled");
+    });
+
+    it("renders default or custom text", () => {
+        const wrapper = mount(<FileUpload />);
+        const span = wrapper.find(`.${Classes.FILE_UPLOAD_INPUT}`);
+
+        // default text
+        assert.strictEqual(span.text(), "Choose file...");
+
+        // custom text
+        wrapper.setProps({ text: "Upload file..." });
+        assert.strictEqual(span.text(), "Upload file...");
+    });
+
+    it("onChange works", () => {
+        const onChange = sinon.spy();
+        const wrapper = shallow(<FileUpload inputProps={{ onChange }} />);
+        const input = getInput(wrapper);
+        input.simulate("change");
+        assert.isTrue(onChange.calledOnce);
+    });
+});
+
+function getInput(wrapper: ShallowWrapper<any, any> | ReactWrapper<any, any>) {
+    return wrapper.find("input");
+}

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -21,6 +21,7 @@ import "./controls/numericInputTests";
 import "./controls/radioGroupTests";
 import "./dialog/dialogTests";
 import "./editable-text/editableTextTests";
+import "./forms/fileUploadTests";
 import "./forms/formGroupTests";
 import "./hotkeys/hotkeysTests";
 import "./icon/iconTests";

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Button, ControlGroup, InputGroup, Switch } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange } from "@blueprintjs/docs";
+
+export interface IControlGroupExampleState {
+    fill?: boolean;
+    vertical?: boolean;
+}
+
+export class ControlGroupExample extends BaseExample<IControlGroupExampleState> {
+    public state: IControlGroupExampleState = {
+        fill: false,
+        vertical: false,
+    };
+
+    private toggleFill = handleBooleanChange(fill => this.setState({ fill }));
+    private toggleVertical = handleBooleanChange(fill => this.setState({ fill }));
+
+    protected renderExample() {
+        return (
+            <ControlGroup {...this.state}>
+                <Button iconName="filter">Filter</Button>
+                <InputGroup placeholder="Find filters..." />
+            </ControlGroup>
+        );
+    }
+
+    protected renderOptions() {
+        return [
+            [
+                <Switch checked={this.state.fill} key="fill" label="Fill" onChange={this.toggleFill} />,
+                <Switch checked={this.state.vertical} key="vertical" label="Vertical" onChange={this.toggleVertical} />,
+            ],
+        ];
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -21,11 +21,16 @@ export class ControlGroupExample extends BaseExample<IControlGroupExampleState> 
     };
 
     private toggleFill = handleBooleanChange(fill => this.setState({ fill }));
-    private toggleVertical = handleBooleanChange(fill => this.setState({ fill }));
+    private toggleVertical = handleBooleanChange(vertical => this.setState({ vertical }));
 
     protected renderExample() {
+        // have the container take up the full-width if `fill` is true;
+        // otherwise, disable full-width styles to keep a vertical control group
+        // from taking up the full width.
+        const style: React.CSSProperties = { flexGrow: this.state.fill ? 1 : undefined };
+
         return (
-            <ControlGroup {...this.state}>
+            <ControlGroup style={style} {...this.state}>
                 <Button iconName="filter">Filter</Button>
                 <InputGroup placeholder="Find filters..." />
             </ControlGroup>

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -10,6 +10,7 @@ export * from "./checkboxExample";
 export * from "./collapseExample";
 export * from "./cardExample";
 export * from "./collapsibleListExample";
+export * from "./controlGroupExample";
 export * from "./dialogExample";
 export * from "./contextMenuExample";
 export * from "./dropdownMenuExample";


### PR DESCRIPTION
#### Addresses #1560 

#### Checklist

- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Add JS APIs for `ControlGroup`, `FileUpload`, `Label`, `TextArea`.
- Add example for `ControlGroup`.
- Add tests for `FileUpload`.

#### Reviewers should focus on:

- There are some subtleties to the `FileUpload` component, so I added tests.
- I really think we should have at least a simple test for every component. Exact quotes from my experience trying to use the `FileUpload` component in a test:
    - "Damn, I accidentally specified a prop as required instead of optional"
    - "Damn, I accidentally forgot to export the component from `index.ts`"

I'd so much rather rely on a test for those things than on fallible human cognition in a code review.