### PR TITLE
[Table] Added option to truncated format for truncated by approx

### DIFF
--- a/packages/karma-build-scripts/createKarmaConfig.js
+++ b/packages/karma-build-scripts/createKarmaConfig.js
@@ -6,7 +6,7 @@ const path = require("path");
 const webpack = require("webpack");
 const webpackConfig = require("./webpack.karma.config");
 
-const COVERAGE_PERCENT = 80;
+const COVERAGE_PERCENT = 75;
 const COVERAGE_PERCENT_HIGH = 90;
 const KARMA_SERVER_PORT = 9876;
 

--- a/packages/karma-build-scripts/createKarmaConfig.js
+++ b/packages/karma-build-scripts/createKarmaConfig.js
@@ -6,7 +6,7 @@ const path = require("path");
 const webpack = require("webpack");
 const webpackConfig = require("./webpack.karma.config");
 
-const COVERAGE_PERCENT = 75;
+const COVERAGE_PERCENT = 80;
 const COVERAGE_PERCENT_HIGH = 90;
 const KARMA_SERVER_PORT = 9876;
 

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -85,6 +85,7 @@ const TRUNCATED_POPOVER_MODES: TruncatedPopoverMode[] = [
     TruncatedPopoverMode.ALWAYS,
     TruncatedPopoverMode.NEVER,
     TruncatedPopoverMode.WHEN_TRUNCATED,
+    TruncatedPopoverMode.WHEN_TRUNCATED_APPROX,
 ];
 
 const TRUNCATION_LENGTHS: number[] = [20, 80, 100, 1000];
@@ -884,6 +885,8 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                 return "Never";
             case TruncatedPopoverMode.WHEN_TRUNCATED:
                 return "When truncated";
+            case TruncatedPopoverMode.WHEN_TRUNCATED_APPROX:
+                return "Truncated approx";
             default:
                 return "";
         }

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -157,8 +157,8 @@ export class Cell extends React.Component<ICellProps, {}> {
                     // only add props if child is truncated format
                     if (isTruncatedFormat) {
                         return React.cloneElement(child as React.ReactElement<any>, {
-                            parentCellHeight: style.height,
-                            parentCellWidth: style.width,
+                            parentCellHeight: parseInt(style.height, 10),
+                            parentCellWidth: parseInt(style.width, 10),
                         });
                     }
                 }

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -81,7 +81,7 @@ export interface ITruncatedFormatProps extends IProps {
     truncationSuffix?: string;
 
     /**
-     * Approximate character width, used to determine whether to display the popover in approx truncation mode.
+     * Approximate character width (in pixels), used to determine whether to display the popover in approx truncation mode.
      * The default value should work for normal table styles,
      * but should be changed as necessary if the fonts or styles are changed significantly.
      * @default 8
@@ -89,7 +89,7 @@ export interface ITruncatedFormatProps extends IProps {
     approximateCharWidth?: number;
 
     /**
-     * Approximate character width, used to determine whether to display the popover in approx truncation mode.
+     * Approximate line height (in pixels), used to determine whether to display the popover in approx truncation mode.
      * The default value should work for normal table styles, but should be changed if the fonts or styles are changed significantly.
      * @default 18
      */
@@ -105,6 +105,8 @@ export interface ITruncatedFormatProps extends IProps {
 
     /**
      * Number of buffer lines desired, used to determine whether to display the popover in approx truncation mode.
+     * Buffer lines are extra lines at the bottom of the cell that space is made for, to make sure that the cell text will fit
+     * after the math calculates how many lines the text is expected to take.
      * The default value should work for normal table styles,
      * but should be changed as necessary if the fonts or styles are changed significantly.
      * @default 0

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -388,4 +388,23 @@ export const Utils = {
     shallowCompareKeys<T extends object>(objA: T, objB: T, keys?: IKeyBlacklist<T> | IKeyWhitelist<T>) {
         return CoreUtils.shallowCompareKeys(objA, objB, keys);
     },
+
+    getApproxCellHeight(
+        cellText: string,
+        columnWidth: number,
+        approxCharWidth: number,
+        approxLineHeight: number,
+        horizontalPadding: number,
+        numBufferLines: number,
+    ) {
+        const numCharsInCell = cellText == null ? 0 : cellText.length;
+
+        const actualCellWidth = columnWidth;
+        const availableCellWidth = actualCellWidth - horizontalPadding;
+        const approxCharsPerLine = availableCellWidth / approxCharWidth;
+        const approxNumLinesDesired = Math.ceil(numCharsInCell / approxCharsPerLine) + numBufferLines;
+
+        const approxCellHeight = approxNumLinesDesired * approxLineHeight;
+        return approxCellHeight;
+    },
 };

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -566,14 +566,14 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
                 } = this.resolveResizeRowsByApproximateHeightOptions(options, rowIndex, columnIndex);
 
                 const cellText = getCellText(rowIndex, columnIndex);
-                const numCharsInCell = cellText == null ? 0 : cellText.length;
-
-                const actualCellWidth = columnWidths[columnIndex];
-                const availableCellWidth = actualCellWidth - horizontalPadding;
-                const approxCharsPerLine = availableCellWidth / approxCharWidth;
-                const approxNumLinesDesired = Math.ceil(numCharsInCell / approxCharsPerLine) + numBufferLines;
-
-                const approxCellHeight = approxNumLinesDesired * approxLineHeight;
+                const approxCellHeight = Utils.getApproxCellHeight(
+                    cellText,
+                    columnWidths[columnIndex],
+                    approxCharWidth,
+                    approxLineHeight,
+                    horizontalPadding,
+                    numBufferLines,
+                );
 
                 if (approxCellHeight > maxCellHeightInRow) {
                     maxCellHeightInRow = approxCellHeight;

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -71,6 +71,44 @@ describe("Formats", () => {
             expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.exist;
         });
 
+        it("can automatically truncate and show popover when truncated and word wrapped in approx mode", () => {
+            const str = `
+                We are going to die, and that makes us the lucky ones. Most
+                people are never going to die because they are never going to
+                be born. The potential people who could have been here in my
+                place but who will in fact never see the light of day
+                outnumber the sand grains of Arabia. Certainly those unborn
+                ghosts include greater poets than Keats, scientists greater
+                than Newton. We know this because the set of possible people
+                allowed by our DNA so massively outnumbers the set of actual
+                people. In the teeth of these stupefying odds it is you and I,
+                in our ordinariness, that are here. We privileged few, who won
+                the lottery of birth against all odds, how dare we whine at
+                our inevitable return to that prior state from which the vast
+                majority have never stirred?
+            `;
+
+            // fix the container's width and height to ensure this test passes
+            // regardless of the page's dimensions.
+            const style: React.CSSProperties = { height: "300px", width: "300px", position: "relative" };
+
+            const comp = harness.mount(
+                <div className={Classes.TABLE_TRUNCATED_TEXT} style={style}>
+                    <TruncatedFormat
+                        detectTruncation={true}
+                        showPopover={TruncatedPopoverMode.WHEN_TRUNCATED_APPROX}
+                        parentCellHeight={300}
+                        parentCellWidth={300}
+                    >
+                        {str}
+                    </TruncatedFormat>
+                </div>,
+            );
+            const textElement = comp.element.query(`.${Classes.TABLE_TRUNCATED_VALUE}`);
+            expect(textElement.scrollHeight).to.be.greaterThan(textElement.clientHeight);
+            expect(comp.find(`.${Classes.TABLE_TRUNCATED_POPOVER_TARGET}`).element).to.exist;
+        });
+
         it("can manually truncate and show popover when truncated", () => {
             const str = createStringOfLength(TruncatedFormat.defaultProps.truncateLength + 1);
             const comp = harness.mount(<TruncatedFormat detectTruncation={false}>{str}</TruncatedFormat>);


### PR DESCRIPTION
#### Changes proposed in this pull request:

Create a faster, less-accurate "truncate by approx" that is synchronous rather than async and doesn't require measuring the DOM, for extra speeds. 

It's definitely somewhat faster in batch-on-update mode, and _much_ faster (visibly takes much less time) on "none" render mode. Pick "json" for the cell contents to make this more obvious. 

#### Reviewers should focus on:

This isn't... quite done yet -- there are a couple open questions. Namely:
- currently the defaults are hardcoded into the class, the same way table is -- we should probably be pulling this out somewhere common, yes? Where should they go?
- additionally -- the defaults for "buffer lines" are slightly different -- having a buffer line if you're not wrapping the text means the cell needs to be twice as long, which is silly. Should we be passing the "wrap text" down from the parent the same we do for other things? 
