### PR TITLE
[Popover2] Make sure targetElement exists before trying to call its function

### DIFF
--- a/packages/labs/src/components/popover/popover2.tsx
+++ b/packages/labs/src/components/popover/popover2.tsx
@@ -383,7 +383,10 @@ export class Popover2 extends AbstractComponent<IPopover2Props, IPopover2State> 
 
     private updateDarkParent() {
         if (!this.props.inline && this.state.isOpen) {
-            const hasDarkParent = this.targetElement !== null && this.targetElement.closest(`.${Classes.DARK}`) != null;
+            const hasDarkParent =
+                this.targetElement != null &&
+                typeof this.targetElement !== "undefined" &&
+                this.targetElement.closest(`.${Classes.DARK}`) != null;
             this.setState({ hasDarkParent });
         }
     }

--- a/packages/labs/src/components/popover/popover2.tsx
+++ b/packages/labs/src/components/popover/popover2.tsx
@@ -385,7 +385,6 @@ export class Popover2 extends AbstractComponent<IPopover2Props, IPopover2State> 
         if (!this.props.inline && this.state.isOpen) {
             const hasDarkParent =
                 this.targetElement != null &&
-                typeof this.targetElement !== "undefined" &&
                 this.targetElement.closest(`.${Classes.DARK}`) != null;
             this.setState({ hasDarkParent });
         }

--- a/packages/labs/src/components/popover/popover2.tsx
+++ b/packages/labs/src/components/popover/popover2.tsx
@@ -383,7 +383,7 @@ export class Popover2 extends AbstractComponent<IPopover2Props, IPopover2State> 
 
     private updateDarkParent() {
         if (!this.props.inline && this.state.isOpen) {
-            const hasDarkParent = this.targetElement && this.targetElement.closest(`.${Classes.DARK}`) != null;
+            const hasDarkParent = this.targetElement !== null && this.targetElement.closest(`.${Classes.DARK}`) != null;
             this.setState({ hasDarkParent });
         }
     }

--- a/packages/labs/src/components/popover/popover2.tsx
+++ b/packages/labs/src/components/popover/popover2.tsx
@@ -383,7 +383,7 @@ export class Popover2 extends AbstractComponent<IPopover2Props, IPopover2State> 
 
     private updateDarkParent() {
         if (!this.props.inline && this.state.isOpen) {
-            const hasDarkParent = this.targetElement.closest(`.${Classes.DARK}`) != null;
+            const hasDarkParent = this.targetElement && this.targetElement.closest(`.${Classes.DARK}`) != null;
             this.setState({ hasDarkParent });
         }
     }


### PR DESCRIPTION
#### Fixes #1856

#### Checklist
- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)

#### Changes proposed in this pull request:

Make sure targetElement exists before trying to call `closest` on it