### PR TITLE
[KeyCombo] Render span element instead of div

### DIFF
--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -54,6 +54,6 @@ export class KeyCombo extends React.Component<IKeyComboProps, {}> {
                 );
             }
         }
-        return <div className="pt-key-combo">{components}</div>;
+        return <span className="pt-key-combo">{components}</span>;
     }
 }


### PR DESCRIPTION
Per offline discussion with @giladgray, return span instead of div such that the keycombo can be used inline, e.g. to prompt users to use keyboard combinations to do things.