### PR TITLE
[Core/ProgressBar] Change pt-progress-meter to display: block

### DIFF
--- a/packages/core/src/components/progress/_progress-bar.scss
+++ b/packages/core/src/components/progress/_progress-bar.scss
@@ -64,7 +64,6 @@ $progress-bar-gradient: linear-gradient(
   overflow: hidden;
 
   .pt-progress-meter {
-    display: inline-block;
     position: absolute;
     border-radius: $progress-bar-border-radius;
     background: $progress-bar-gradient;


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/1859

#### Changes proposed in this pull request:

- __FIXED__ Change `pt-progress-meter` to `display: block` so it stops erroneously responding to `text-align` rules applied to parents.

#### Reviewers should focus on:

Suggested by @llorca in https://github.com/palantir/blueprint/issues/1859#issuecomment-349058985.

#### Screenshot

See dev preview.