### PR TITLE
[Labs] Add prop to keep <Select> popover open after selecting item

### DIFF
--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -78,6 +78,12 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
     resetOnClose?: boolean;
 
     /**
+     * Whether the popover should close once the user selects an option.
+     * @default true
+     */
+    closeOnSelect?: boolean;    
+
+    /**
      * Callback invoked when the query value changes,
      * through user input or when the filter is reset.
      */
@@ -144,10 +150,11 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
     public render() {
         // omit props specific to this component, spread the rest.
         const {
+            closeOnSelect,
             filterable,
             initialContent,
-            itemRenderer,
             inputProps,
+            itemRenderer,
             noResults,
             popoverProps,
             ...restProps,
@@ -264,7 +271,14 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
     };
 
     private handleItemSelect = (item: T, event: React.SyntheticEvent<HTMLElement>) => {
-        this.setState({ isOpen: false });
+        const { closeOnSelect = true } = this.props;
+
+        if (!closeOnSelect) {
+            event.stopPropagation();
+        } else {
+            this.setState({ isOpen: false });
+        }
+
         if (this.props.resetOnSelect) {
             this.resetQuery();
         }

--- a/packages/labs/src/components/select/select.tsx
+++ b/packages/labs/src/components/select/select.tsx
@@ -81,7 +81,7 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      * Whether the popover should close once the user selects an option.
      * @default true
      */
-    closeOnSelect?: boolean;    
+    closeOnSelect?: boolean;
 
     /**
      * Callback invoked when the query value changes,
@@ -273,10 +273,10 @@ export class Select<T> extends React.Component<ISelectProps<T>, ISelectState<T>>
     private handleItemSelect = (item: T, event: React.SyntheticEvent<HTMLElement>) => {
         const { closeOnSelect = true } = this.props;
 
-        if (!closeOnSelect) {
-            event.stopPropagation();
-        } else {
+        if (closeOnSelect) {
             this.setState({ isOpen: false });
+        } else {
+            event.stopPropagation();
         }
 
         if (this.props.resetOnSelect) {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Adds `closeOnSelect: boolean` prop to Labs `<Select />` component to allow consumers to keep the Popover open after selecting an item.

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
