### PR TITLE
[Labs/TimezonePicker] Use correct popover props for TimezonePicker

### DIFF
--- a/packages/labs/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/labs/src/components/timezone-picker/timezonePicker.tsx
@@ -15,12 +15,12 @@ import {
     HTMLInputProps,
     IButtonProps,
     IInputGroupProps,
-    IPopoverProps,
     IProps,
     MenuItem,
     Utils,
 } from "@blueprintjs/core";
 import * as Classes from "../../common/classes";
+import { IPopover2Props } from "../popover/popover2";
 import { ISelectItemRendererProps, Select } from "../select/select";
 import { formatTimezone, TimezoneDisplayFormat } from "./timezoneDisplayFormat";
 import { getInitialTimezoneItems, getTimezoneItems, ITimezoneItem } from "./timezoneItems";
@@ -89,8 +89,8 @@ export interface ITimezonePickerProps extends IProps {
      */
     inputProps?: IInputGroupProps & HTMLInputProps;
 
-    /** Props to spread to `Popover`. Note that `content` cannot be changed. */
-    popoverProps?: Partial<IPopoverProps> & object;
+    /** Props to spread to `Popover2`. Note that `content` cannot be changed. */
+    popoverProps?: Partial<IPopover2Props> & object;
 }
 
 export interface ITimezonePickerState {
@@ -135,7 +135,7 @@ export class TimezonePicker extends AbstractComponent<ITimezonePickerProps, ITim
             placeholder: "Search for timezones...",
             ...inputProps,
         };
-        const finalPopoverProps: Partial<IPopoverProps> & object = {
+        const finalPopoverProps: Partial<IPopover2Props> & object = {
             ...popoverProps,
             popoverClassName: classNames(Classes.TIMEZONE_PICKER_POPOVER, popoverProps.popoverClassName),
         };

--- a/packages/labs/test/timezonePickerTests.tsx
+++ b/packages/labs/test/timezonePickerTests.tsx
@@ -16,10 +16,10 @@ import {
     IInputGroupProps,
     IInputGroupState,
     InputGroup,
-    IPopoverProps,
     IPopoverState,
     MenuItem,
 } from "@blueprintjs/core";
+import { IPopover2Props } from "../src/components/popover/popover2";
 import {
     getInitialTimezoneItems,
     getLocalTimezoneItem,
@@ -43,7 +43,7 @@ import {
 type TimezonePickerShallowWrapper = ShallowWrapper<ITimezonePickerProps, ITimezonePickerState>;
 type SelectShallowWrapper = ShallowWrapper<ISelectProps<ITimezoneItem>, ISelectState<ITimezoneItem>>;
 type QueryListShallowWrapper = ShallowWrapper<IQueryListProps<ITimezoneItem>, IQueryListState<ITimezoneItem>>;
-type PopoverShallowWrapper = ShallowWrapper<IPopoverProps, IPopoverState>;
+type PopoverShallowWrapper = ShallowWrapper<IPopover2Props, IPopoverState>;
 type InputGroupShallowWrapper = ShallowWrapper<IInputGroupProps, IInputGroupState>;
 
 describe("<TimezonePicker>", () => {
@@ -221,16 +221,15 @@ describe("<TimezonePicker>", () => {
     });
 
     it("popover can be controlled with popover props", () => {
-        const popoverProps: IPopoverProps = {
+        const popoverProps: IPopover2Props = {
             inline: true,
             isOpen: true,
-            tetherOptions: { constraints: [{ attachment: "together", pin: true, to: "window" }] },
-            useSmartArrowPositioning: true,
+            placement: "right",
         };
         const timezonePicker = shallow(<TimezonePicker popoverProps={popoverProps} />);
         const popover = findPopover(timezonePicker);
         for (const key of Object.keys(popoverProps)) {
-            assert.deepEqual(popover.prop(key), popoverProps[key as keyof IPopoverProps]);
+            assert.deepEqual(popover.prop(key), popoverProps[key as keyof IPopover2Props]);
         }
     });
 
@@ -260,10 +259,10 @@ describe("<TimezonePicker>", () => {
     });
 
     function getPopoverProps(
-        overrides: Partial<IPopoverProps> = {},
-        keysToUnset: Array<keyof IPopoverProps> = [],
-    ): Partial<IPopoverProps> {
-        const popoverProps: Partial<IPopoverProps> = {
+        overrides: Partial<IPopover2Props> = {},
+        keysToUnset: Array<keyof IPopover2Props> = [],
+    ): Partial<IPopover2Props> {
+        const popoverProps: Partial<IPopover2Props> = {
             inline: true,
             isOpen: true,
             ...overrides,


### PR DESCRIPTION
#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

This changes the type of `popoverProps` in the `TimezonePicker` component from `IPopoverProps` to `IPopover2Props`.  It seems like it used `IPopoverProps` in error because the underlying implementation uses `Popover2` (through `<Select />`).  I discovered this when I tried to pass in a `position` prop, but it had no effect; the correct prop to use was `placement`.

#### Reviewers should focus on:

Is this change safe?  Since it was using the incorrect props before, this catches usages of Popover(1) and will force consumers to use the new props.

#### Screenshot

This is now possible:

![screen shot 2017-12-11 at 10 50 12 am](https://user-images.githubusercontent.com/1829450/33847954-1d800bba-de61-11e7-976f-ccb7a110f934.png)

