### PR TITLE
Switch to Flexbox layout for various components

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -94,7 +94,9 @@ $button-intents: (
 ) !default;
 
 @mixin pt-button-base() {
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   border-radius: $pt-border-radius;
   cursor: pointer;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -95,8 +95,8 @@ $button-intents: (
 
 @mixin pt-button-base() {
   display: inline-flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   border: none;
   border-radius: $pt-border-radius;
   cursor: pointer;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -21,7 +21,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
 // setting modifier to "" will generally apply it as default styles due to & selectors
 @mixin menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
   @include overflow-ellipsis();
-  display: block;
+  display: flex;
   border-radius: $menu-item-border-radius;
   padding: $menu-item-padding;
   line-height: $pt-icon-size-standard;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -55,13 +55,16 @@ Styleguide pt-menu
   &::before {
     // support pt-icon-* classes directly on this element
     @include pt-icon();
-    float: left;
     margin-right: $menu-item-padding;
   }
 
   &::before,
   &::after {
     color: $pt-icon-color;
+  }
+
+  .pt-menu-item-text {
+    flex: 1;
   }
 
   .pt-menu-item-label {

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -14,8 +14,6 @@
 
       &::after {
         @include pt-icon();
-        position: absolute;
-        right: $half-grid-size;
         content: $pt-icon-caret-right;
 
         .pt-large & {

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -127,8 +127,8 @@ export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> 
                 tabIndex={disabled ? undefined : 0}
                 target={this.props.target}
             >
+                <span className="pt-menu-item-text">{this.props.text}</span>
                 {labelElement}
-                {this.props.text}
             </a>
         );
 


### PR DESCRIPTION
#### Fixes #1425 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Update `.pt-button`
- [ ] Update `.pt-input-group`
- [x] ~~Update `.pt-tag-input`~~ (already using flexbox)
- [x] Update `.pt-menu-item`
- [x] Test in Chrome, Firefox and Edge

#### Changes proposed in this pull request:

Switch to using Flexbox layout for `.pt-button`, `.pt-input-group`, `.pt-tag-input` and `.pt-menu-item`. This PR removes a lot of the older layout/positioning hacks which were required prior to Flexbox.

#### Screenshot

No visual changes.
