### PR TITLE
Add two different abstract components, pure and not

### DIFF
--- a/packages/core/src/common/abstractPureComponent.ts
+++ b/packages/core/src/common/abstractPureComponent.ts
@@ -11,7 +11,7 @@ import { isNodeEnv } from "./utils";
  * An abstract component that Blueprint components can extend
  * in order to add some common functionality like runtime props validation.
  */
-export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
+export abstract class AbstractPureComponent<P, S> extends React.PureComponent<P, S> {
     /** Component displayName should be `public static`. This property exists to prevent incorrect usage. */
     protected displayName: never;
 

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./abstractComponent";
+export * from "./abstractPureComponent";
 export * from "./colors";
 export * from "./intent";
 export * from "./position";

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent, Classes, Intent, IProps } from "../../common";
+import { AbstractPureComponent, Classes, Intent, IProps } from "../../common";
 import { ALERT_WARN_CANCEL_PROPS } from "../../common/errors";
 import { Button } from "../button/buttons";
 import { Dialog } from "../dialog/dialog";
@@ -55,7 +55,7 @@ export interface IAlertProps extends IProps {
     onConfirm(e: React.MouseEvent<HTMLButtonElement>): void;
 }
 
-export class Alert extends AbstractComponent<IAlertProps, {}> {
+export class Alert extends AbstractPureComponent<IAlertProps, {}> {
     public static defaultProps: IAlertProps = {
         confirmButtonText: "OK",
         isOpen: false,

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
@@ -83,7 +83,7 @@ export enum AnimationStates {
  * isOpen = false: OPEN -> CLOSING_START -> CLOSING_END -> CLOSED
  * These are all animated.
  */
-export class Collapse extends AbstractComponent<ICollapseProps, ICollapseState> {
+export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseState> {
     public static displayName = "Blueprint.Collapse";
 
     public static defaultProps: ICollapseProps = {

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -8,7 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { Position } from "../../common/position";
 import { safeInvoke } from "../../common/utils";
@@ -33,7 +33,7 @@ const TETHER_OPTIONS = {
 const TRANSITION_DURATION = 100;
 
 /* istanbul ignore next */
-class ContextMenu extends AbstractComponent<{}, IContextMenuState> {
+class ContextMenu extends AbstractPureComponent<{}, IContextMenuState> {
     public state: IContextMenuState = {
         isOpen: false,
     };

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { IProps } from "../../common/props";
@@ -62,7 +62,7 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
     transitionName?: string;
 }
 
-export class Dialog extends AbstractComponent<IDialogProps, {}> {
+export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
     public static defaultProps: IDialogProps = {
         canOutsideClickClose: true,
         isOpen: false,

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IIntentProps, IProps } from "../../common/props";
@@ -104,7 +104,7 @@ export interface IEditableTextState {
 const BUFFER_WIDTH_EDGE = 5;
 const BUFFER_WIDTH_IE = 30;
 
-export class EditableText extends AbstractComponent<IEditableTextProps, IEditableTextState> {
+export class EditableText extends AbstractPureComponent<IEditableTextProps, IEditableTextState> {
     public static defaultProps: IEditableTextProps = {
         confirmOnEnterKey: false,
         defaultValue: "",

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -8,7 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import {
-    AbstractComponent,
+    AbstractPureComponent,
     Classes,
     HTMLInputProps,
     IconName,
@@ -128,7 +128,7 @@ enum IncrementDirection {
     UP = +1,
 }
 
-export class NumericInput extends AbstractComponent<HTMLInputProps & INumericInputProps, INumericInputState> {
+export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumericInputProps, INumericInputState> {
     public static displayName = "Blueprint.NumericInput";
 
     public static VALUE_EMPTY = "";

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { IOptionProps, IProps } from "../../common/props";
@@ -56,7 +56,7 @@ function nextName() {
     return `${RadioGroup.displayName}-${counter++}`;
 }
 
-export class RadioGroup extends AbstractComponent<IRadioGroupProps, {}> {
+export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
     public static displayName = "Blueprint.RadioGroup";
 
     // a unique name for this group, which can be overridden by `name` prop.

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { AbstractComponent } from "../../common";
+import { AbstractPureComponent } from "../../common";
 import { KeyCombo } from "./keyCombo";
 
 export interface IHotkeyProps {
@@ -72,7 +72,7 @@ export interface IHotkeyProps {
     onKeyUp?(e: KeyboardEvent): any;
 }
 
-export class Hotkey extends AbstractComponent<IHotkeyProps, {}> {
+export class Hotkey extends AbstractPureComponent<IHotkeyProps, {}> {
     public static defaultProps = {
         allowInInput: false,
         disabled: false,

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { AbstractComponent, IProps } from "../../common";
+import { AbstractPureComponent, IProps } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
 import { Hotkey, IHotkeyProps } from "./hotkey";
 
@@ -28,7 +28,7 @@ export interface IHotkeysProps extends IProps {
     tabIndex?: number;
 }
 
-export class Hotkeys extends AbstractComponent<IHotkeysProps, {}> {
+export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}> {
     public static defaultProps = {
         tabIndex: 0,
     };

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -8,7 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
@@ -75,7 +75,7 @@ const REACT_CONTEXT_TYPES: React.ValidationMap<IMenuItemState> = {
     },
 };
 
-export class MenuItem extends AbstractComponent<IMenuItemProps, IMenuItemState> {
+export class MenuItem extends AbstractPureComponent<IMenuItemProps, IMenuItemState> {
     public static defaultProps: IMenuItemProps = {
         disabled: false,
         popoverProps: {},

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { findDOMNode } from "react-dom";
 import * as Tether from "tether";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import * as PosUtils from "../../common/position";
@@ -216,7 +216,7 @@ export interface IPopoverState {
     targetWidth?: number;
 }
 
-export class Popover extends AbstractComponent<IPopoverProps, IPopoverState> {
+export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState> {
     public static defaultProps: IPopoverProps = {
         arrowSize: 30,
         className: "",

--- a/packages/core/src/components/popover2/popover2.tsx
+++ b/packages/core/src/components/popover2/popover2.tsx
@@ -12,7 +12,7 @@ import { Manager, Popper, Target } from "react-popper";
 export type PopperModifiers = PopperJS.Modifiers;
 export type Placement = PopperJS.Placement;
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
@@ -202,7 +202,7 @@ export interface IPopover2State {
     placement?: Placement;
 }
 
-export class Popover2 extends AbstractComponent<IPopover2Props, IPopover2State> {
+export class Popover2 extends AbstractPureComponent<IPopover2Props, IPopover2State> {
     public static displayName = "Blueprint.Popover2";
 
     public static defaultProps: IPopover2Props = {

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { IProps } from "../../common/props";
@@ -80,7 +80,7 @@ export interface ISliderState {
     tickSize?: number;
 }
 
-export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractComponent<P, ISliderState> {
+export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPureComponent<P, ISliderState> {
     public className = Classes.SLIDER;
 
     private trackElement: HTMLElement;

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IProps } from "../../common/props";
@@ -37,7 +37,7 @@ export interface IHandleState {
 // props that require number values, for validation
 const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"];
 
-export class Handle extends AbstractComponent<IHandleProps, IHandleState> {
+export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
     public static displayName = "Blueprint.SliderHandle";
 
     public state = {

--- a/packages/core/src/components/tabs/tabList.tsx
+++ b/packages/core/src/components/tabs/tabList.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
 
@@ -26,7 +26,7 @@ export interface ITabListState {
     shouldAnimate?: boolean;
 }
 
-export class TabList extends AbstractComponent<ITabListProps, {}> {
+export class TabList extends AbstractPureComponent<ITabListProps, {}> {
     public static displayName = "Blueprint.TabList";
 
     public state: ITabListState = {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -8,7 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import { findDOMNode } from "react-dom";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import * as Keys from "../../common/keys";
@@ -57,7 +57,7 @@ export interface ITabsState {
 
 const TAB_CSS_SELECTOR = "li[role=tab]";
 
-export class Tabs extends AbstractComponent<ITabsProps, ITabsState> {
+export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
     public static defaultProps: ITabsProps = {
         initialSelectedTabIndex: 0,
     };

--- a/packages/core/src/components/tabs2/tabs2.tsx
+++ b/packages/core/src/components/tabs2/tabs2.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IProps } from "../../common/props";
@@ -83,7 +83,7 @@ export interface ITabs2State {
     selectedTabId?: TabId;
 }
 
-export class Tabs2 extends AbstractComponent<ITabs2Props, ITabs2State> {
+export class Tabs2 extends AbstractPureComponent<ITabs2Props, ITabs2State> {
     /** Insert a `Tabs2.Expander` between any two children to right-align all subsequent children. */
     public static Expander = Expander;
 

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { HTMLInputProps, IProps } from "../../common/props";
@@ -121,7 +121,7 @@ export interface ITagInputState {
 /** special value for absence of active tag */
 const NONE = -1;
 
-export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> {
+export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputState> {
     public static displayName = "Blueprint.TagInput";
 
     public static defaultProps: Partial<ITagInputProps> & object = {

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { IActionProps, IIntentProps, ILinkProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
@@ -43,7 +43,7 @@ export interface IToastProps extends IProps, IIntentProps {
     timeout?: number;
 }
 
-export class Toast extends AbstractComponent<IToastProps, {}> {
+export class Toast extends AbstractPureComponent<IToastProps, {}> {
     public static defaultProps: IToastProps = {
         className: "",
         message: "",

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -8,7 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { AbstractComponent } from "../../common/abstractComponent";
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { TOASTER_WARN_INLINE, TOASTER_WARN_LEFT_RIGHT } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
@@ -77,7 +77,7 @@ export interface IToasterState {
     toasts: IToastOptions[];
 }
 
-export class Toaster extends AbstractComponent<IToasterProps, IToasterState> implements IToaster {
+export class Toaster extends AbstractPureComponent<IToasterProps, IToasterState> implements IToaster {
     public static defaultProps: IToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as ReactDayPicker from "react-day-picker";
 
 import {
-    AbstractComponent,
+    AbstractPureComponent,
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
@@ -165,7 +165,7 @@ export interface IDateInputState {
     isOpen?: boolean;
 }
 
-export class DateInput extends AbstractComponent<IDateInputProps, IDateInputState> {
+export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInputState> {
     public static defaultProps: IDateInputProps = {
         closeOnSelection: true,
         dayPickerProps: {},

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { AbstractComponent, Button, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent, Button, IProps, Utils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 import * as ReactDayPicker from "react-day-picker";
@@ -67,7 +67,7 @@ export interface IDatePickerState {
     value?: Date;
 }
 
-export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerState> {
+export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePickerState> {
     public static defaultProps: IDatePickerProps = {
         canClearSelection: true,
         dayPickerProps: {},

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as ReactDayPicker from "react-day-picker";
 
 import {
-    AbstractComponent,
+    AbstractPureComponent,
     Classes,
     HTMLInputProps,
     IInputGroupProps,
@@ -215,7 +215,7 @@ interface IStateKeysAndValuesObject {
     };
 }
 
-export class DateRangeInput extends AbstractComponent<IDateRangeInputProps, IDateRangeInputState> {
+export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, IDateRangeInputState> {
     public static defaultProps: IDateRangeInputProps = {
         allowSingleDayRange: false,
         closeOnSelection: true,

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { AbstractComponent, Classes, IProps, Menu, MenuItem, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent, Classes, IProps, Menu, MenuItem, Utils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 import * as ReactDayPicker from "react-day-picker";
@@ -112,7 +112,7 @@ export interface IDateRangePickerState {
     value?: DateRange;
 }
 
-export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, IDateRangePickerState> {
+export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps, IDateRangePickerState> {
     public static defaultProps: IDateRangePickerProps = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -7,7 +7,7 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent, IProps, Utils } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -57,7 +57,7 @@ export interface IDateTimePickerState {
     timeValue?: Date;
 }
 
-export class DateTimePicker extends AbstractComponent<IDateTimePickerProps, IDateTimePickerState> {
+export class DateTimePicker extends AbstractPureComponent<IDateTimePickerProps, IDateTimePickerState> {
     public static defaultProps: IDateTimePickerProps = {
         canClearSelection: true,
         defaultValue: new Date(),

--- a/packages/labs/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/labs/src/components/timezone-picker/timezonePicker.tsx
@@ -8,7 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import {
-    AbstractComponent,
+    AbstractPureComponent,
     Button,
     Classes as CoreClasses,
     HTMLInputProps,
@@ -100,7 +100,7 @@ export interface ITimezonePickerState {
 
 const TypedSelect = Select.ofType<ITimezoneItem>();
 
-export class TimezonePicker extends AbstractComponent<ITimezonePickerProps, ITimezonePickerState> {
+export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, ITimezonePickerState> {
     public static displayName = "Blueprint.TimezonePicker";
 
     public static defaultProps: Partial<ITimezonePickerProps> = {

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -7,7 +7,15 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent, Icon, IconName, IProps, Popover, Position, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    AbstractPureComponent,
+    Icon,
+    IconName,
+    IProps,
+    Popover,
+    Position,
+    Utils as CoreUtils,
+} from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import * as Errors from "../common/errors";
@@ -75,7 +83,7 @@ export function HorizontalCellDivider(): JSX.Element {
     return <div className={Classes.TABLE_HORIZONTAL_CELL_DIVIDER} />;
 }
 
-export class ColumnHeaderCell extends AbstractComponent<IColumnHeaderCellProps, IColumnHeaderCellState> {
+export class ColumnHeaderCell extends AbstractPureComponent<IColumnHeaderCellProps, IColumnHeaderCellState> {
     public static defaultProps: IColumnHeaderCellProps = {
         enableColumnInteractionBar: false,
         isActive: false,

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { AbstractComponent, IProps } from "@blueprintjs/core";
+import { AbstractPureComponent, IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import * as Errors from "../common/errors";
@@ -25,7 +25,7 @@ export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
     isRowSelected?: boolean;
 }
 
-export class RowHeaderCell extends AbstractComponent<IRowHeaderCellProps, {}> {
+export class RowHeaderCell extends AbstractPureComponent<IRowHeaderCellProps, {}> {
     public render() {
         const {
             // from IRowHeaderCellProps

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Hotkey, Hotkeys, HotkeysTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent, Hotkey, Hotkeys, HotkeysTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
 
@@ -405,9 +405,8 @@ export interface ITableState {
     viewportRect?: Rect;
 }
 
-// avoid using AbstractComponent since this component is impure
 @HotkeysTarget
-export class Table extends React.Component<ITableProps, ITableState> {
+export class Table extends AbstractComponent<ITableProps, ITableState> {
     public static defaultProps: ITableProps = {
         defaultColumnWidth: 150,
         defaultRowHeight: 20,


### PR DESCRIPTION
Fix table -- make there exist an AbstractPureComponent as well as an AbstractComponent that isn't pure. 

We may want to revisit all the places we presently use React.Component and see if we want to use AbstractComponent there now that we possibly can. 
