### PR TITLE
Portal only renders children after mounted

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -314,17 +314,19 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
         }
         openStack.push(this);
 
-        if (this.props.canOutsideClickClose && !this.props.hasBackdrop) {
-            document.addEventListener("mousedown", this.handleDocumentClick);
+        if (this.props.autoFocus) {
+            this.bringFocusInsideOverlay();
         }
         if (this.props.enforceFocus) {
             document.addEventListener("focus", this.handleDocumentFocus, /* useCapture */ true);
         }
+
+        if (this.props.canOutsideClickClose && !this.props.hasBackdrop) {
+            document.addEventListener("mousedown", this.handleDocumentClick);
+        }
+
         if (this.props.inline) {
             safeInvoke(this.props.didOpen);
-            if (this.props.autoFocus) {
-                this.bringFocusInsideOverlay();
-            }
         } else if (this.props.hasBackdrop) {
             // add a class to the body to prevent scrolling of content below the overlay
             document.body.classList.add(Classes.OVERLAY_OPEN);
@@ -356,9 +358,6 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
     private handleContentMount = () => {
         if (this.props.isOpen) {
             safeInvoke(this.props.didOpen);
-        }
-        if (this.props.autoFocus) {
-            this.bringFocusInsideOverlay();
         }
     };
 

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -8,6 +8,7 @@ import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
+import { spy } from "sinon";
 import { Classes, IPortalProps, Portal } from "../../src";
 
 describe("<Portal>", () => {
@@ -53,5 +54,15 @@ describe("<Portal>", () => {
 
         const portalElement = document.querySelector(`.${CLASS_TO_TEST}`);
         assert.isTrue(portalElement.classList.contains(Classes.PORTAL));
+    });
+
+    it("mounts children after Portal has mounted (autoFocus)", () => {
+        const focusSpy = spy();
+        portal = mount(
+            <Portal>
+                <input autoFocus={true} onFocus={focusSpy} />
+            </Portal>,
+        );
+        assert.equal(focusSpy.callCount, 1);
     });
 });

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -185,6 +185,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         const { ref, ...htmlInputProps } = inputProps;
         const input = (
             <InputGroup
+                autoFocus={true}
                 leftIconName="search"
                 placeholder="Filter..."
                 rightElement={this.maybeRenderInputClearButton()}


### PR DESCRIPTION
#### Fixes #1901 

```js
componentDidMount() {
    // The portal element is inserted in the DOM tree after
    // the Modal's children are mounted, meaning that children
    // will be mounted on a detached DOM node. If a child
    // component requires to be attached to the DOM tree
    // immediately when mounted, for example to measure a
    // DOM node, or uses 'autoFocus' in a descendant, add
    // state to Modal and only render the children when Modal
    // is inserted in the DOM tree.
    modalRoot.appendChild(this.el);
}
```
(https://reactjs.org/docs/portals.html#event-bubbling-through-portals)