### PR TITLE
rewrite HotkeysTarget and ContextMenuTarget as HOCs

### DIFF
--- a/packages/core/src/common/constructor.ts
+++ b/packages/core/src/common/constructor.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+export interface IConstructor<T> {
+    new (...args: any[]): T;
+}

--- a/packages/core/src/common/constructor.ts
+++ b/packages/core/src/common/constructor.ts
@@ -4,6 +4,10 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+/**
+ * Generic interface defining constructor types, such as classes. This is used to type the class
+ * itself in meta-programming situations such as decorators.
+ */
 export interface IConstructor<T> {
     new (...args: any[]): T;
 }

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -15,8 +15,13 @@ export const COLLAPSIBLE_LIST_INVALID_CHILD = ns + ` <CollapsibleList> children 
 
 export const CONTEXTMENU_WARN_DECORATOR_NO_METHOD =
     ns + ` @ContextMenuTarget-decorated class should implement renderContextMenu.`;
+export const CONTEXTMENU_WARN_DECORATOR_NEEDS_REACT_ELEMENT =
+    ns + ` "@ContextMenuTarget-decorated components must return a single JSX.Element or an empty render.`;
 
 export const HOTKEYS_HOTKEY_CHILDREN = ns + ` <Hotkeys> only accepts <Hotkey> children.`;
+export const HOTKEYS_WARN_DECORATOR_NO_METHOD = ns + ` @HotkeysTarget-decorated class should implement renderHotkeys.`;
+export const HOTKEYS_WARN_DECORATOR_NEEDS_REACT_ELEMENT =
+    ns + ` "@HotkeysTarget-decorated components must return a single JSX.Element or an empty render.`;
 
 export const MENU_WARN_CHILDREN_SUBMENU_MUTEX =
     ns + ` <MenuItem> children and submenu props are mutually exclusive, with children taking priority.`;

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./abstractComponent";
 export * from "./colors";
+export * from "./constructor";
 export * from "./intent";
 export * from "./position";
 export * from "./props";

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -22,6 +22,16 @@ export function isFunction(value: any): value is Function {
     return typeof value === "function";
 }
 
+export interface IHasName {
+    name?: string;
+}
+
+export function getDisplayName(ComponentClass: React.ComponentClass | IHasName) {
+    return (ComponentClass as React.ComponentClass).displayName ||
+        (ComponentClass as IHasName).name ||
+        "Unknown";
+}
+
 /**
  * Safely invoke the function with the given arguments, if it is indeed a
  * function, and return its value.

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -27,9 +27,7 @@ export interface IHasName {
 }
 
 export function getDisplayName(ComponentClass: React.ComponentClass | IHasName) {
-    return (ComponentClass as React.ComponentClass).displayName ||
-        (ComponentClass as IHasName).name ||
-        "Unknown";
+    return (ComponentClass as React.ComponentClass).displayName || (ComponentClass as IHasName).name || "Unknown";
 }
 
 /**

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -22,12 +22,15 @@ export function isFunction(value: any): value is Function {
     return typeof value === "function";
 }
 
-export interface IHasName {
+/**
+ * Represents anything that has a `name` property such as Functions.
+ */
+export interface INamed {
     name?: string;
 }
 
-export function getDisplayName(ComponentClass: React.ComponentClass | IHasName) {
-    return (ComponentClass as React.ComponentClass).displayName || (ComponentClass as IHasName).name || "Unknown";
+export function getDisplayName(ComponentClass: React.ComponentClass | INamed) {
+    return (ComponentClass as React.ComponentClass).displayName || (ComponentClass as INamed).name || "Unknown";
 }
 
 /**

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -23,7 +23,7 @@ export function ContextMenuTarget<T extends IConstructor<IContextMenuTarget>>(Wr
         console.warn(CONTEXTMENU_WARN_DECORATOR_NO_METHOD);
     }
 
-    return class ContextMenuTarget extends WrappedComponent {
+    return class ContextMenuTargetClass extends WrappedComponent {
         public render() {
             // TODO handle being applied on a Component that doesn't return an actual Element
             const element = super.render() as JSX.Element;
@@ -46,12 +46,7 @@ export function ContextMenuTarget<T extends IConstructor<IContextMenuTarget>>(Wr
                         const htmlElement = ReactDOM.findDOMNode(this);
                         const darkTheme = htmlElement != null && isDarkTheme(htmlElement);
                         e.preventDefault();
-                        ContextMenu.show(
-                            menu,
-                            { left: e.clientX, top: e.clientY },
-                            this.onContextMenuClose,
-                            darkTheme
-                        );
+                        ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, this.onContextMenuClose, darkTheme);
                     }
                 }
 

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -9,7 +9,7 @@ import * as ReactDOM from "react-dom";
 
 import { IConstructor } from "../../common/constructor";
 import { CONTEXTMENU_WARN_DECORATOR_NO_METHOD } from "../../common/errors";
-import { isFunction, safeInvoke } from "../../common/utils";
+import { getDisplayName, isFunction, safeInvoke } from "../../common/utils";
 import { isDarkTheme } from "../../common/utils/isDarkTheme";
 import * as ContextMenu from "./contextMenu";
 
@@ -24,6 +24,8 @@ export function ContextMenuTarget<T extends IConstructor<IContextMenuTarget>>(Wr
     }
 
     return class ContextMenuTargetClass extends WrappedComponent {
+        public static displayName = `ContextMenuTarget(${getDisplayName(WrappedComponent)})`;
+
         public render() {
             // TODO handle being applied on a Component that doesn't return an actual Element
             const element = super.render() as JSX.Element;

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -7,6 +7,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import { IConstructor } from "../../common/constructor";
 import { CONTEXTMENU_WARN_DECORATOR_NO_METHOD } from "../../common/errors";
 import { isFunction, safeInvoke } from "../../common/utils";
 import { isDarkTheme } from "../../common/utils/isDarkTheme";
@@ -17,45 +18,47 @@ export interface IContextMenuTarget extends React.Component<any, any> {
     onContextMenuClose?(): void;
 }
 
-export function ContextMenuTarget<T extends { prototype: IContextMenuTarget }>(constructor: T) {
-    const { render, renderContextMenu, onContextMenuClose } = constructor.prototype;
-
-    if (!isFunction(renderContextMenu)) {
+export function ContextMenuTarget<T extends IConstructor<IContextMenuTarget>>(WrappedComponent: T) {
+    if (!isFunction(WrappedComponent.prototype.renderContextMenu)) {
         console.warn(CONTEXTMENU_WARN_DECORATOR_NO_METHOD);
     }
 
-    // patching classes like this requires preserving function context
-    // tslint:disable-next-line only-arrow-functions
-    constructor.prototype.render = function(this: IContextMenuTarget) {
-        /* tslint:disable:no-invalid-this */
-        const element = render.call(this) as JSX.Element;
+    return class ContextMenuTarget extends WrappedComponent {
+        public render() {
+            // TODO handle being applied on a Component that doesn't return an actual Element
+            const element = super.render() as JSX.Element;
 
-        if (element == null) {
-            // always return `element` in case caller is distinguishing between `null` and `undefined`
-            return element;
-        }
-
-        const oldOnContextMenu = element.props.onContextMenu as React.MouseEventHandler<HTMLElement>;
-        const onContextMenu = (e: React.MouseEvent<HTMLElement>) => {
-            // support nested menus (inner menu target would have called preventDefault())
-            if (e.defaultPrevented) {
-                return;
+            if (element == null) {
+                // always return `element` in case caller is distinguishing between `null` and `undefined`
+                return element;
             }
 
-            if (isFunction(this.renderContextMenu)) {
-                const menu = this.renderContextMenu(e);
-                if (menu != null) {
-                    const htmlElement = ReactDOM.findDOMNode(this);
-                    const darkTheme = htmlElement != null && isDarkTheme(htmlElement);
-                    e.preventDefault();
-                    ContextMenu.show(menu, { left: e.clientX, top: e.clientY }, onContextMenuClose, darkTheme);
+            const oldOnContextMenu = element.props.onContextMenu as React.MouseEventHandler<HTMLElement>;
+            const onContextMenu = (e: React.MouseEvent<HTMLElement>) => {
+                // support nested menus (inner menu target would have called preventDefault())
+                if (e.defaultPrevented) {
+                    return;
                 }
-            }
 
-            safeInvoke(oldOnContextMenu, e);
-        };
+                if (isFunction(this.renderContextMenu)) {
+                    const menu = this.renderContextMenu(e);
+                    if (menu != null) {
+                        const htmlElement = ReactDOM.findDOMNode(this);
+                        const darkTheme = htmlElement != null && isDarkTheme(htmlElement);
+                        e.preventDefault();
+                        ContextMenu.show(
+                            menu,
+                            { left: e.clientX, top: e.clientY },
+                            this.onContextMenuClose,
+                            darkTheme
+                        );
+                    }
+                }
 
-        return React.cloneElement(element, { onContextMenu });
-        /* tslint:enable:no-invalid-this */
+                safeInvoke(oldOnContextMenu, e);
+            };
+
+            return React.cloneElement(element, { onContextMenu });
+        }
     };
 }

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -17,6 +17,8 @@ export { IKeyCombo, comboMatches, getKeyCombo, getKeyComboString, parseKeyCombo 
 export { IHotkeysDialogProps, hideHotkeysDialog, setHotkeysDialogProps } from "./hotkeysDialog";
 
 export interface IHotkeysProps extends IProps {
+    children?: React.ReactNode;
+
     /**
      * In order to make local hotkeys work on elements that are not normally
      * focusable, such as `<div>`s or `<span>`s, we add a `tabIndex` attribute

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -17,8 +17,6 @@ export { IKeyCombo, comboMatches, getKeyCombo, getKeyComboString, parseKeyCombo 
 export { IHotkeysDialogProps, hideHotkeysDialog, setHotkeysDialogProps } from "./hotkeysDialog";
 
 export interface IHotkeysProps extends IProps {
-    children?: React.ReactNode;
-
     /**
      * In order to make local hotkeys work on elements that are not normally
      * focusable, such as `<div>`s or `<span>`s, we add a `tabIndex` attribute

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -37,7 +37,7 @@ export class HotkeysEvents {
         this.actions = [];
     }
 
-    public setHotkeys(props: IHotkeysProps & { children: ReactNode[] }) {
+    public setHotkeys(props: IHotkeysProps & { children?: ReactNode }) {
         const actions = [] as IHotkeyAction[];
         Children.forEach(props.children, (child: ReactElement<any>) => {
             if (Hotkey.isInstance(child) && this.isScope(child.props)) {

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 import { IConstructor } from "../../common/constructor";
-import { isFunction, safeInvoke } from "../../common/utils";
+import { getDisplayName, isFunction, safeInvoke } from "../../common/utils";
 
 import { IHotkeysProps } from "./hotkeys";
 import { HotkeyScope, HotkeysEvents } from "./hotkeysEvents";
@@ -25,6 +25,8 @@ export function HotkeysTarget<T extends IConstructor<IHotkeysTarget>>(WrappedCom
     }
 
     return class HotkeysTargetClass extends WrappedComponent {
+        public static displayName = `HotkeysTarget(${getDisplayName(WrappedComponent)})`;
+
         /** @internal */
         public globalHotkeysEvents?: HotkeysEvents;
 

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -24,7 +24,7 @@ export function HotkeysTarget<T extends IConstructor<IHotkeysTarget>>(WrappedCom
         throw new Error(`@HotkeysTarget-decorated class must implement \`renderHotkeys\`. ${WrappedComponent}`);
     }
 
-    return class HotkeysTarget extends WrappedComponent {
+    return class HotkeysTargetClass extends WrappedComponent {
         /** @internal */
         public globalHotkeysEvents?: HotkeysEvents;
 

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -11,12 +11,6 @@ import { IHotkeysProps } from "./hotkeys";
 import { HotkeyScope, HotkeysEvents } from "./hotkeysEvents";
 
 export interface IHotkeysTarget extends React.Component<any, any>, React.ComponentLifecycle<any, any> {
-    /** @internal */
-    globalHotkeysEvents?: HotkeysEvents;
-
-    /** @internal */
-    localHotkeysEvents?: HotkeysEvents;
-
     /**
      * Components decorated with the `HotkeysTarget` decorator must implement
      * this method, and it must return a `Hotkeys` React element.
@@ -24,78 +18,75 @@ export interface IHotkeysTarget extends React.Component<any, any>, React.Compone
     renderHotkeys(): React.ReactElement<IHotkeysProps>;
 }
 
-export function HotkeysTarget<T extends { prototype: IHotkeysTarget }>(constructor: T) {
-    const {
-        componentWillMount,
-        componentDidMount,
-        componentWillUnmount,
-        render,
-        renderHotkeys,
-    } = constructor.prototype;
+export interface IConstructor<T> {
+    new (...args: any[]): T;
+}
 
-    if (!isFunction(renderHotkeys)) {
-        throw new Error(`@HotkeysTarget-decorated class must implement \`renderHotkeys\`. ${constructor}`);
+export function HotkeysTarget<T extends IConstructor<IHotkeysTarget>>(WrappedComponent: T) {
+    if (!isFunction(WrappedComponent.prototype.renderHotkeys)) {
+        throw new Error(`@HotkeysTarget-decorated class must implement \`renderHotkeys\`. ${WrappedComponent}`);
     }
 
-    // tslint:disable no-invalid-this only-arrow-functions
-    constructor.prototype.componentWillMount = function() {
-        this.localHotkeysEvents = new HotkeysEvents(HotkeyScope.LOCAL);
-        this.globalHotkeysEvents = new HotkeysEvents(HotkeyScope.GLOBAL);
+    return class HotkeysTarget extends WrappedComponent {
+        /** @internal */
+        public globalHotkeysEvents?: HotkeysEvents;
 
-        if (componentWillMount != null) {
-            componentWillMount.call(this);
+        /** @internal */
+        public localHotkeysEvents?: HotkeysEvents;
+
+        public componentWillMount() {
+            if (super.componentWillMount != null) {
+                super.componentWillMount();
+            }
+            this.localHotkeysEvents = new HotkeysEvents(HotkeyScope.LOCAL);
+            this.globalHotkeysEvents = new HotkeysEvents(HotkeyScope.GLOBAL);
+        }
+
+        public componentDidMount() {
+            if (super.componentDidMount != null) {
+                super.componentDidMount();
+            }
+
+            // attach global key event listeners
+            document.addEventListener("keydown", this.globalHotkeysEvents.handleKeyDown);
+            document.addEventListener("keyup", this.globalHotkeysEvents.handleKeyUp);
+        }
+
+        public componentWillUnmount() {
+            if (super.componentWillUnmount != null) {
+                super.componentWillUnmount();
+            }
+            document.removeEventListener("keydown", this.globalHotkeysEvents.handleKeyDown);
+            document.removeEventListener("keyup", this.globalHotkeysEvents.handleKeyUp);
+
+            this.globalHotkeysEvents.clear();
+            this.localHotkeysEvents.clear();
+        }
+
+        public render() {
+            // TODO handle HotkeysTarget being applied on a Component that doesn't return an actual Element
+            const element = super.render() as React.ReactElement<any>;
+            const hotkeys = this.renderHotkeys();
+            this.localHotkeysEvents.setHotkeys(hotkeys.props);
+            this.globalHotkeysEvents.setHotkeys(hotkeys.props);
+
+            if (element != null && this.localHotkeysEvents.count() > 0) {
+                const tabIndex = hotkeys.props.tabIndex === undefined ? 0 : hotkeys.props.tabIndex;
+
+                const { keyDown: existingKeyDown, keyUp: existingKeyUp } = this.props;
+                const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+                    this.localHotkeysEvents.handleKeyDown(e.nativeEvent as KeyboardEvent);
+                    safeInvoke(existingKeyDown, e);
+                };
+
+                const onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
+                    this.localHotkeysEvents.handleKeyUp(e.nativeEvent as KeyboardEvent);
+                    safeInvoke(existingKeyUp, e);
+                };
+                return React.cloneElement(element, { tabIndex, onKeyDown, onKeyUp });
+            } else {
+                return element;
+            }
         }
     };
-
-    constructor.prototype.componentDidMount = function() {
-        // attach global key event listeners
-        document.addEventListener("keydown", this.globalHotkeysEvents.handleKeyDown);
-        document.addEventListener("keyup", this.globalHotkeysEvents.handleKeyUp);
-
-        if (componentDidMount != null) {
-            componentDidMount.call(this);
-        }
-    };
-
-    constructor.prototype.componentWillUnmount = function() {
-        // detach global key event listeners
-        document.removeEventListener("keydown", this.globalHotkeysEvents.handleKeyDown);
-        document.removeEventListener("keyup", this.globalHotkeysEvents.handleKeyUp);
-
-        this.globalHotkeysEvents.clear();
-        this.localHotkeysEvents.clear();
-
-        if (componentWillUnmount != null) {
-            componentWillUnmount.call(this);
-        }
-    };
-
-    constructor.prototype.render = function() {
-        const element = render.call(this) as JSX.Element;
-
-        const hotkeys = renderHotkeys.call(this);
-        this.localHotkeysEvents.setHotkeys(hotkeys.props);
-        this.globalHotkeysEvents.setHotkeys(hotkeys.props);
-
-        // attach local key event listeners
-        if (element != null && this.localHotkeysEvents.count() > 0) {
-            const tabIndex = hotkeys.props.tabIndex === undefined ? 0 : hotkeys.props.tabIndex;
-
-            const existingKeyDown = element.props.onKeyDown as React.KeyboardEventHandler<HTMLElement>;
-            const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-                this.localHotkeysEvents.handleKeyDown(e.nativeEvent as KeyboardEvent);
-                safeInvoke(existingKeyDown, e);
-            };
-
-            const existingKeyUp = element.props.onKeyUp as React.KeyboardEventHandler<HTMLElement>;
-            const onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
-                this.localHotkeysEvents.handleKeyUp(e.nativeEvent as KeyboardEvent);
-                safeInvoke(existingKeyUp, e);
-            };
-            return React.cloneElement(element, { tabIndex, onKeyDown, onKeyUp });
-        } else {
-            return element;
-        }
-    };
-    // tslint:enable
 }

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -5,6 +5,7 @@
  */
 
 import * as React from "react";
+import { IConstructor } from "../../common/constructor";
 import { isFunction, safeInvoke } from "../../common/utils";
 
 import { IHotkeysProps } from "./hotkeys";
@@ -16,10 +17,6 @@ export interface IHotkeysTarget extends React.Component<any, any>, React.Compone
      * this method, and it must return a `Hotkeys` React element.
      */
     renderHotkeys(): React.ReactElement<IHotkeysProps>;
-}
-
-export interface IConstructor<T> {
-    new (...args: any[]): T;
 }
 
 export function HotkeysTarget<T extends IConstructor<IHotkeysTarget>>(WrappedComponent: T) {
@@ -64,8 +61,8 @@ export function HotkeysTarget<T extends IConstructor<IHotkeysTarget>>(WrappedCom
         }
 
         public render() {
-            // TODO handle HotkeysTarget being applied on a Component that doesn't return an actual Element
-            const element = super.render() as React.ReactElement<any>;
+            // TODO handle being applied on a Component that doesn't return an actual Element
+            const element = super.render() as JSX.Element;
             const hotkeys = this.renderHotkeys();
             this.localHotkeysEvents.setHotkeys(hotkeys.props);
             this.globalHotkeysEvents.setHotkeys(hotkeys.props);
@@ -73,7 +70,7 @@ export function HotkeysTarget<T extends IConstructor<IHotkeysTarget>>(WrappedCom
             if (element != null && this.localHotkeysEvents.count() > 0) {
                 const tabIndex = hotkeys.props.tabIndex === undefined ? 0 : hotkeys.props.tabIndex;
 
-                const { keyDown: existingKeyDown, keyUp: existingKeyUp } = this.props;
+                const { keyDown: existingKeyDown, keyUp: existingKeyUp } = element.props;
                 const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
                     this.localHotkeysEvents.handleKeyDown(e.nativeEvent as KeyboardEvent);
                     safeInvoke(existingKeyDown, e);

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -26,6 +26,10 @@ describe("ContextMenu", () => {
 
     it("Decorator does not mutate the original class", () => {
         class TestComponent extends React.Component<{}, {}> {
+            public render() {
+                return <div />;
+            }
+
             public renderContextMenu() {
                 return MENU;
             }

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -22,6 +22,19 @@ describe("ContextMenu", () => {
     before(() => assert.isNull(getPopover()));
     afterEach(() => ContextMenu.hide());
 
+    it("Decorator does not mutate the original class", () => {
+        class TestComponent extends React.Component<{}, {}> {
+            public renderContextMenu() {
+                return MENU;
+            }
+        }
+
+        const TargettedTestComponent = ContextMenuTarget(TestComponent);
+
+        // it's not the same Component
+        assert.notStrictEqual(TargettedTestComponent, TestComponent);
+    });
+
     it("React renders ContextMenu", () => {
         ContextMenu.show(MENU, { left: 0, top: 0 });
         assertContextMenuWasRendered();

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -4,6 +4,8 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+// tslint:disable max-classes-per-file
+
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -47,6 +47,19 @@ describe("Hotkeys", () => {
         ).to.throw(HOTKEYS_HOTKEY_CHILDREN, "undefined");
     });
 
+    it("Decorator does not mutate the original class", () => {
+        class TestComponent extends React.Component<{}, {}> {
+            public renderHotkeys() {
+                return <Hotkeys />;
+            }
+        }
+
+        const TargettedTestComponent = HotkeysTarget(TestComponent);
+
+        // it's not the same Component
+        expect(TargettedTestComponent).to.not.equal(TestComponent);
+    });
+
     describe("Local/Global @HotkeysTarget", () => {
         let localKeyDownSpy: SinonSpy = null;
         let localKeyUpSpy: SinonSpy = null;

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -49,6 +49,10 @@ describe("Hotkeys", () => {
 
     it("Decorator does not mutate the original class", () => {
         class TestComponent extends React.Component<{}, {}> {
+            public render() {
+                return <div />;
+            }
+
             public renderHotkeys() {
                 return <Hotkeys />;
             }


### PR DESCRIPTION
#### Fixes #931 

#### Changes proposed in this pull request:

Implement `HotkeysTarget` and `ContextMenuTarget` by returning a new HOC rather than monkeypatching.

#### Reviewers should focus on:

Behavior is maintained from before.

- [x] wrap displayName