### PR TITLE
Circle CI build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
             - packages/core/node_modules
             - packages/datetime/node_modules
             - packages/docs/node_modules
+            - packages/icons/node_modules
             - packages/labs/node_modules
             - packages/select/node_modules
             - packages/table/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,17 +7,24 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-dependency-cache-{{ checksum "yarn.lock" }}
-            - v5-dependency-cache-
+            - v6-dependency-cache-{{ checksum "yarn.lock" }}
+            - v6-dependency-cache-
       - run: yarn
       - run: echo "Checking if lockfiles changed..." && git diff --exit-code
       - run: npm rebuild node-sass
       - save_cache:
-          key: v5-dependency-cache-{{ checksum "yarn.lock" }}
+          key: v6-dependency-cache-{{ checksum "yarn.lock" }}
           paths:
             - ~/yarn
             - ~/.cache/yarn
             - node_modules
+            - packages/core/node_modules
+            - packages/datetime/node_modules
+            - packages/docs/node_modules
+            - packages/labs/node_modules
+            - packages/select/node_modules
+            - packages/table/node_modules
+            - packages/timezone/node_modules
       - persist_to_workspace:
           root: '.'
           paths:
@@ -32,8 +39,8 @@ jobs:
           at: '.'
       - restore_cache:
           keys:
-            - v5-dependency-cache-{{ checksum "yarn.lock" }}
-            - v5-dependency-cache-
+            - v6-dependency-cache-{{ checksum "yarn.lock" }}
+            - v6-dependency-cache-
       - run: yarn compile
       - persist_to_workspace:
           root: '.'
@@ -50,8 +57,8 @@ jobs:
           at: '.'
       - restore_cache:
           keys:
-            - v5-dependency-cache-{{ checksum "yarn.lock" }}
-            - v5-dependency-cache-
+            - v6-dependency-cache-{{ checksum "yarn.lock" }}
+            - v6-dependency-cache-
       - run: yarn lint
 
   dist-libs:
@@ -62,7 +69,7 @@ jobs:
       - attach_workspace:
           at: '.'
       - restore_cache:
-          key: v5-dependency-cache-{{ checksum "yarn.lock" }}
+          key: v6-dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn dist:libs
       - persist_to_workspace:
           root: '.'
@@ -83,7 +90,7 @@ jobs:
       - attach_workspace:
           at: '.'
       - restore_cache:
-          key: v5-dependency-cache-{{ checksum "yarn.lock" }}
+          key: v6-dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn dist:apps
       - persist_to_workspace:
           root: '.'
@@ -101,17 +108,17 @@ jobs:
       - attach_workspace:
           at: '.'
       - restore_cache:
-          key: v5-dependency-cache-{{ checksum "yarn.lock" }}
+          key: v6-dependency-cache-{{ checksum "yarn.lock" }}
       - run:
           command: |
               case $CIRCLE_NODE_INDEX in \
-              0) yarn lerna run test --scope '@blueprintjs/core' ;; \
-              1) yarn lerna run test --scope '@blueprintjs/datetime' ;; \
-              2) yarn lerna run test --scope '@blueprintjs/icons' ;; \
-              3) yarn lerna run test --scope '@blueprintjs/labs' ;; \
-              4) yarn lerna run test --scope '@blueprintjs/select' ;; \
-              5) yarn lerna run test --scope '@blueprintjs/table' ;; \
-              6) yarn lerna run test --scope '@blueprintjs/timezone' ;; \
+              0) cd packages/core && yarn test ;; \
+              1) cd packages/datetime && yarn test ;; \
+              2) cd packages/icons && yarn test ;; \
+              3) cd packages/labs && yarn test ;; \
+              4) cd packages/select && yarn test ;; \
+              5) cd packages/table && yarn test ;; \
+              6) cd packages/timezone && yarn test ;; \
               esac
 
   deploy-preview:

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -44,6 +44,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "es6-shim": "^0.35.3",
     "karma": "^1.7.1",
+    "mocha": "^4.0.1",
     "npm-run-all": "^4.1.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
Inspired by build issues in #1891:
- Switch from `yarn lerna run test --scope '@blueprintjs/____` to `cd packages/____ && yarn test`.
    - The former was hanging without printing anything.
- To make the above work, add `packages/____/node_modules` to `save_cache.paths`.
- Bust the cache (changed v5 => v6).
- Add missing `mocha` dev dependency to `packages/timezone`.
    - Because of this: `"test:iso": "mocha test/isotest.js",`