### PR TITLE
Fix flaky Overlay tests (hopefully)

### DIFF
--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -200,11 +200,16 @@ describe("<Overlay>", () => {
             let buttonRef: HTMLElement;
             const focusBtnAndAssert = () => {
                 buttonRef.focus();
+                // nested setTimeouts delay execution until the next frame, not
+                // just to the end of the current frame. necessary to wait for
+                // focus to change.
                 setTimeout(() => {
-                    wrapper.update();
-                    assert.notStrictEqual(buttonRef, document.activeElement);
-                    done();
-                }, 10);
+                    setTimeout(() => {
+                        wrapper.update();
+                        assert.notStrictEqual(buttonRef, document.activeElement);
+                        done();
+                    });
+                });
             };
 
             wrapper = mount(
@@ -302,12 +307,15 @@ describe("<Overlay>", () => {
 
         function assertFocus(selector: string, done: MochaDone) {
             wrapper.update();
-            // small explicit timeout reduces flakiness of these tests,
-            // which rely on requestAnimationFrame to update focus state.
+            // the behavior being tested relies on requestAnimationFrame. to
+            // avoid flakiness, use nested setTimeouts to delay execution until
+            // the next frame, not just to the end of the current frame.
             setTimeout(() => {
-                assert.strictEqual(document.querySelector(selector), document.activeElement);
-                done();
-            }, 10);
+                setTimeout(() => {
+                    assert.strictEqual(document.querySelector(selector), document.activeElement);
+                    done();
+                });
+            });
         }
     });
 


### PR DESCRIPTION
Use nested `setTimeout`s instead of an arbitrary short delay for one `setTimeout`. Goal is to delay the code execution until the end of the next frame, not just to the end of the current frame (which may in some instances cause code to invoke _before_ focus has changed / `requestAnimationFrame` has executed).