### PR TITLE
Graduate Labs Components - Part 3: Popover docs

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -98,13 +98,13 @@ Styleguide pt-button-group
 
   // support wrapping buttons in a tooltip, which adds a wrapper element
   &:not(.pt-minimal) {
-    > .pt-popover-target:not(:first-child) .pt-button,
+    > .pt-popover-wrapper:not(:first-child) .pt-popover-target .pt-button,
     > .pt-button:not(:first-child) {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
 
-    > .pt-popover-target:not(:last-child) .pt-button,
+    > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
     > .pt-button:not(:last-child) {
       margin-right: -$button-border-width;
       border-top-right-radius: 0;
@@ -139,7 +139,7 @@ Styleguide pt-button-group
       }
     }
 
-    > .pt-popover-target:last-child .pt-button,
+    > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
     > .pt-button:last-child {
       margin-right: 0;
 
@@ -214,17 +214,17 @@ Styleguide pt-button-group
       margin-right: 0 !important; // stylelint-disable-line declaration-no-important
     }
 
-    > .pt-popover-target:first-child .pt-button,
+    > .pt-popover-wrapper:first-child .pt-popover-target .pt-button,
     > .pt-button:first-child {
       border-radius: $pt-border-radius $pt-border-radius 0 0;
     }
 
-    > .pt-popover-target:last-child .pt-button,
+    > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
     > .pt-button:last-child {
       border-radius: 0 0 $pt-border-radius $pt-border-radius;
     }
 
-    > .pt-popover-target:not(:last-child) .pt-button,
+    > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
     > .pt-button:not(:last-child) {
       margin-bottom: -$button-border-width;
     }
@@ -253,14 +253,18 @@ Styleguide pt-button-group
     // support wrapping buttons in a Blueprint.Tooltip, which adds a wrapper element
     // in dark theme, we adjust the spacing between buttons for best visual results
     &:not(.pt-minimal) {
-      > .pt-popover-target:not(:last-child) .pt-button,
+      // deeply nested selector necessary to target the appropriate popover
+      // wrapper, yet ensure we only style buttons within the target.
+      // stylelint-disable-next-line selector-max-compound-selectors
+      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
       > .pt-button:not(:last-child) {
         margin-right: $button-border-width;
       }
     }
 
     &.pt-vertical {
-      > .pt-popover-target:not(:last-child) .pt-button,
+      // stylelint-disable-next-line selector-max-compound-selectors
+      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
       > .pt-button:not(:last-child) {
         margin-bottom: $button-border-width;
       }

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -212,6 +212,8 @@ Styleguide pt-button-group
     .pt-button {
       // we never want that margin-right when vertical
       margin-right: 0 !important; // stylelint-disable-line declaration-no-important
+      // needed to ensure buttons take up the full width when wrapped in a Popover:
+      width: 100%;
     }
 
     > .pt-popover-wrapper:first-child .pt-popover-target .pt-button,

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -231,12 +231,16 @@ Styleguide pt-button-group
       margin-bottom: -$button-border-width;
     }
 
-    &.pt-minimal .pt-button {
-      &:not(:last-child) {
+    &.pt-minimal {
+      // apply the margin and divider to the .pt-popover-wrapper so that the
+      // popover arrow remains centered on the button.
+      > .pt-popover-wrapper:not(:last-child),
+      > .pt-button:not(:last-child) {
         margin-bottom: $pt-grid-size + $minimal-button-divider-width;
       }
 
-      &::after {
+      > .pt-popover-wrapper .pt-popover-target .pt-button::after,
+      > .pt-button::after {
         top: 100%;
         right: 0;
         bottom: auto;

--- a/packages/core/src/components/button/button-group.md
+++ b/packages/core/src/components/button/button-group.md
@@ -52,4 +52,28 @@ This component is a simple wrapper around the CSS API, and supports the full ran
 
 @reactExample ButtonGroupExample
 
+@### Usage with Popovers
+
+`Button`s inside a `ButtonGroup` can optionally be wrapped with a [`Popover`](#core/components/popover). The following example demonstrates this composition:
+
+```tsx
+<ButtonGroup className={Classes.ALIGN_LEFT}>
+    <Popover content={...}>
+        <Button iconName="document" rightIconName="caret-down" text="File" />
+    </Popover>
+    <Popover content={...}>
+        <Button iconName="edit" rightIconName="caret-down" text="Edit" />
+    </Popover>
+    <Popover content={...}>
+        <Button iconName="eye-open" rightIconName="caret-down" text="View" />
+    </Popover>
+</ButtonGroup>
+```
+
+@reactExample ButtonGroupPopoverExample
+
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    In vertical button groups, button content will be centered by default. You can align button content to the left or right using `pt-align-left` and `pt-align-right`, respectively.
+</div>
+
 @interface IButtonGroupProps

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -282,13 +282,15 @@ The backdrop element has the same opacity-fade transition as the `Dialog` backdr
 
 @### Inline rendering
 
-By default, popover contents are rendered in a newly created [`Portal`](#core/components/portal) appended to document.body. This works well for most layouts, because popovers by default will appear above everything else on the page without needing to manually adjust z-indices.
+By default, popover contents are rendered in a newly created [`Portal`](#core/components/portal) appended to `document.body`. This works well for most layouts, because popovers by default will appear above everything else on the page without needing to manually adjust z-indices.
 
 However, there are cases where it's preferable to render the popover contents inline in the DOM.
 
 For example, consider a scrolling table where cells have tooltips attached to them. As row items go out of view, cell tooltips should slide out of the viewport as well. This is best accomplished with inline popovers.
 
 Setting `inline={true}` will enable inline rendering.
+
+@reactExample PopoverInlineExample
 
 @## Style
 

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -303,11 +303,6 @@ Minimal popovers are also useful for context menus that require quick enter and 
 support fast workflows. You can see an example in the [context menus](#core/components/context-menu)
 documentation.
 
-@## SVG popover
-
-`SVGPopover` is a convenience component provided for SVG contexts. It is a simple wrapper around
-`Popover` that sets `rootElementTag="g"`.
-
 @## Testing
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -2,7 +2,7 @@
 
 Popovers display floating content next to a target element.
 
-`Popover` is built on top of the [__popper.js__](https://popper.js.org) library.
+`Popover` is built on top of the [__Popper.js__](https://popper.js.org) library.
 
 @reactExample PopoverExample
 
@@ -11,9 +11,13 @@ Popovers display floating content next to a target element.
 The `Popover` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [general usage docs for JS components](#blueprint.usage).
 
+@interface IPopoverProps
+
+@## Concepts
+
 @### Structure
 
-When creating a popover, you must specify both its _content_ and its _target_.
+When creating a popover, you must specify both its __content__ and its __target__.
 This can be done a few ways:
 
 1. Provide both the `content` and `target` props, which accept a string or a JSX element.
@@ -38,8 +42,8 @@ This can be done a few ways:
   </Popover>
   ```
 
-The _target_ acts as the trigger for the popover; user interaction will show the popover based on
-`interactionKind`. The _content_ will be shown in the popover itself. The popover's will always be
+The __target__ acts as the trigger for the popover; user interaction will show the popover based on
+`interactionKind`. The __content__ will be shown in the popover itself. The popover's will always be
 positioned on the page next to the target; the `position` prop determines the relative position (on
 which side of the target).
 
@@ -81,7 +85,7 @@ export class PopoverExample extends React.Component<{}, {}> {
 
 @### Position
 
-The `position` property controls the Popover's position relative to the target. There are two attributes to consider:
+The `position` prop controls the Popover's position relative to the target. There are two attributes to consider:
 
 - Which <span class="docs-popover-position-label-side">__side__</span> of the target the popover should render on.
 - The popover's <span class="docs-popover-position-label-alignment">__alignment__</span> relative to the target.
@@ -91,15 +95,16 @@ These two attributes can be expressed with a single value having the following s
 <pre class="docs-popover-position-value-code-block">
     <span class="docs-popover-position-label-side">[SIDE]</span>_<span class="docs-popover-position-label-alignment">[ALIGNMENT]</span>
 </pre>
+
 The __@blueprintjs/core__ package exports a `Position` enumeration that contains the full set of supported side/alignment combinations.
 
-@#### Example
+#### Example
 
-The following example shows all supported `Position`s and how each behaves in practice. Note that if <code class="docs-popover-position-label-alignment">_[ALIGNMENT]</code> is ommitted, the popover will align to the __center__ of the target.
+The following example shows all supported `Position`s and how each behaves in practice. Note that if <strong><code>_<span class="docs-popover-position-label-alignment">[ALIGNMENT]</span></code></strong> is ommitted, the popover will align to the __center__ of the target.
 
 @reactExample PopoverPositionExample
 
-@#### Automatic positioning
+#### Automatic positioning
 
 The `position` can also be set to the string literal `"auto"`, the default setting. In this mode, the Popover will continually re-position itself to the side with the most space available, adjusting its alignment intuitively as well. This is useful for guaranteeing that the Popover remains visible while scrolling within a parent container.
 
@@ -128,8 +133,6 @@ Modifiers are the tools through which you customize Popper.js's behavior. Popper
     To understand all the Popper.js modifiers available to you, you'll want to read [the Popper.js Modifiers documentation](https://popper.js.org/popper-documentation.html#modifiers).
 </div>
 
-@interface IPopoverProps
-
 @### Controlled mode
 
 If you prefer to have more control over your popover's behavior, you can specify the `isOpen`
@@ -146,7 +149,7 @@ It is important to pay attention to the value of the `nextOpenState` parameter a
 in your application logic whether you should care about a particular invocation (for instance,
 if the `nextOpenState` is not the same as the `Popover`'s current state).
 
-##### Example controlled usage
+#### Example controlled usage
 
 ```tsx
 const { Popover, Position } = "@blueprintjs/core";
@@ -182,82 +185,104 @@ export class ControlledPopoverExample extends React.Component<{}, { isOpen: bool
 }
 ```
 
-@### Inline popovers
+@### Opening and closing
 
-By default, popover contents are rendered in a newly created element appended to `document.body`.
+#### Interaction kinds
 
-This works well for most layouts, because you want popovers to appear above everything else in your
-application without having to manually adjust z-indices. For these "detached" popovers, we use the
-[Tether](http://github.hubspot.com/tether/) library to handle positioning popovers correctly
-relative to their targets. Tether is great at maintaining position in complex, dynamic UIs.
+The `interactionKind` prop governs how the popover should open and close in response to user interactions.
+The supported values are:
 
-However, there are cases where it's preferable to render the popover contents inline.
+- `HOVER`
+    - __Opens when:__ the target is hovered
+    - __Closes when:__ the cursor is no longer inside the target _or_ the popover
+- `HOVER_TARGET_ONLY`:
+    - __Opens when:__ the target is hovered
+    - __Closes when:__ the cursor is no longer inside the target
+- `CLICK`:
+    - __Opens when:__ the target is clicked
+    - __Closes when:__ the user clicks anywhere outside of the popover (including the target)
+- `CLICK_TARGET_ONLY`:
+    - __Opens when:__ the target is clicked
+    - __Closes when:__ the target is clicked
 
-Take, for example, a scrolling table where certain cells have tooltips attached to them. As row
-items go out of view, you want their tooltips to slide out of the viewport as well. This is best
-accomplished with inline popovers. Enable this feature by setting `inline={true}`.
+The __@blueprintjs/core__ package exports the above values in the `PopoverInteractionKind` enumeration.
 
-It is also important to note that "inline" popovers are much more performant than "detached" ones,
-particularly in response to page scrolling, because their position does not need to be recomputed on
-every interaction.
-
-@### Opening & closing popovers
-
-<div class="pt-callout pt-intent-success pt-icon-info-sign">
-    <h5>Conditionally styling popover targets</h5>
-    When a popover is open, the target has a `.pt-popover-open` class applied to it.
-    You can use this to style the target differently depending on whether the popover is open.
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    Refer to the top-level [Popover example](#core/components/popover) to experiment with the various `PopoverInteractionKind`s.
 </div>
 
-The different interaction kinds specify whether the popover closes when the user interacts with the
-target or the rest of the document, but by default, a user interacting with a popover's *contents*
-does __not__ close the popover.
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    <h5>Conditionally styling popover targets</h5>
+    When a popover is open, the target has a <code>.pt-popover-open</code> class applied to it.
+    You can use this to style the target differently when the popover is open.
+</div>
+
+#### Click-to-close elements
 
 To enable click-to-close behavior on an element inside a popover, simply add the class
-`pt-popover-dismiss` to that element. The "Dismiss" button in the demo [above](#core/components/popover)
-has this class. To enable this behavior on the entire popover, pass the
+`pt-popover-dismiss` to that element. For example, the "Dismiss" button in the top-level [Popover example](#core/components/popover) has this class. To enable this behavior on the entire popover, pass the
 `popoverClassName="pt-popover-dismiss"` prop.
 
-Note that dismiss elements won't have any effect in a popover with
-`PopoverInteractionKind.HOVER_TARGET_ONLY` because there is no way to interact with the popover
-content itself (the popover is dismissed the moment the user mouses away from the target).
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    Dismiss elements won't have any effect in a popover with
+    `PopoverInteractionKind.HOVER_TARGET_ONLY`, because there is no way to interact with the popover
+    content itself (the popover is dismissed the moment the user mouses away from the target).
+</div>
 
-@### Modal popovers
+@### Backdrop
 
-Setting the `isModal` prop to `true` will:
+The `hasBackdrop` prop governs whether a backdrop appears while the popover is open. When `true`:
 
-- Render a transparent backdrop beneath the popover that covers the entire viewport and prevents
-interaction with the document until the popover is closed. This is useful for preventing stray
-clicks or hovers in your app when the user tries to close a popover.
-- Focus the popover when opened to allow keyboard accessibility.
+- __A transparent backdrop will render beneath the popover__. This backdrop
+  covers the entire viewport and prevents interaction with the document until
+  the popover is closed. This is useful for preventing stray clicks or hovers in
+  your app when the user tries to close a popover.
+- __The popover will receive focus when opened__, allowing for better keyboard accessibility.
 
 Clicking the backdrop will:
 
 - _in uncontrolled mode_, close the popover.
 - _in controlled mode_, invoke the `onInteraction` callback with an argument of `false`.
 
-Modal behavior is only available for popovers with `interactionKind={PopoverInteractionKind.CLICK}`
-and an error is thrown if used otherwise.
+This backdrop behavior is only available for popovers having `interactionKind={PopoverInteractionKind.CLICK}`.
+An error is thrown if used otherwise.
+
+#### Styling the backdrop
 
 By default, the popover backdrop is invisible, but you can easily add your own styles to
 `.pt-popover-backdrop` to customize the appearance of the backdrop (for example, you could give it
 a translucent background color, like the backdrop for the [`Dialog`](#core/components/dialog) component).
 
-The backdrop element has the same opacity fade transition as the `Dialog` backdrop.
+The backdrop element has the same opacity-fade transition as the `Dialog` backdrop.
 
 <div class="pt-callout pt-intent-danger pt-icon-error">
     <h5>Dangerous edge case</h5>
-    Rendering a `<Popover isOpen={true} isModal={true}>` outside the viewport bounds can easily break
+    Rendering a `<Popover isOpen={true} hasBackdrop={true}>` outside the viewport bounds can easily break
     your application by covering the UI with an invisible non-interactive backdrop. This edge case
     must be handled by your application code or simply avoided if possible.
 </div>
 
-@### Sizing popovers
+@## Style
 
-Popovers by default have a max-width but no max-height. To constrain the height of a popover
+@### Dark theme
+
+The `Popover` component automatically detects whether its trigger is nested inside a `.pt-dark`
+container and applies the same class to itself. You can also explicitly apply the dark theme to
+the React component by providing the prop `popoverClassName="pt-dark"`.
+
+As a result, any component that you place inside a `Popover` (such as a `Menu`) automatically
+inherits the dark theme styles. Note that [`Tooltip`](#core/components/tooltip) uses `Popover` internally, so it also benefits
+from this behavior.
+
+This behavior can be disabled when the `Popover` is not rendered inline via the `inheritDarkTheme`
+prop.
+
+@### Sizing
+
+Popovers by default have a `max-width` but no `max-height`. To constrain the height of a popover
 and make its content scrollable, set the appropriate CSS rules on `.pt-popover-content`:
 
-```css.less
+```css.scss
 // pass "my-popover" to `popoverClassName` prop.
 .my-popover .pt-popover-content {
     max-height: $pt-grid-size * 30;
@@ -265,12 +290,7 @@ and make its content scrollable, set the appropriate CSS rules on `.pt-popover-c
 }
 ```
 
-@### SVG popover
-
-`SVGPopover` is a convenience component provided for SVG contexts. It is a simple wrapper around
-`Popover` that sets `rootElementTag="g"`.
-
-@### Minimal popovers
+@### Minimal style
 
 You can create a minimal popover with the `pt-minimal` modifier: `popoverClassName="pt-minimal"`.
 This removes the arrow from the popover and makes the transitions more subtle.
@@ -283,25 +303,19 @@ Minimal popovers are also useful for context menus that require quick enter and 
 support fast workflows. You can see an example in the [context menus](#core/components/context-menu)
 documentation.
 
-@### Dark theme
+@## SVG popover
 
-The `Popover` component automatically detects whether its trigger is nested inside a `.pt-dark`
-container and applies the same class to itself. You can also explicitly apply the dark theme to
-the React component by providing the prop `popoverClassName="pt-dark"`.
+`SVGPopover` is a convenience component provided for SVG contexts. It is a simple wrapper around
+`Popover` that sets `rootElementTag="g"`.
 
-As a result, any component that you place inside a `Popover` (such as a `Menu`) automatically
-inherits the dark theme styles. Note that `Tooltip` uses `Popover` internally, so it also benefits
-from this behavior.
-
-This behavior can be disabled when the `Popover` is not rendered inline via the `inheritDarkTheme`
-prop.
-
-@### Testing popovers
+@## Testing
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
     Your best resource for strategies in popover testing is
     [its own unit test suite.](https://github.com/palantir/blueprint/blob/master/packages/core/test/popover/popoverTests.tsx)
 </div>
+
+#### Animation delays
 
 `Popover` can be difficult to test because it uses `Portal` to inject its contents elsewhere in the
 DOM (outside the usual flow); this can be simplified by using `inline` Popovers in tests.
@@ -309,8 +323,34 @@ Hover interactions can also be tricky due to delays and transitions; this can be
 zeroing the default hover delays.
 
 ```tsx
- <Popover inline {...yourProps} hoverCloseDelay={0} hoverOpenDelay={0}>{yourTarget}</Popover>
+ <Popover inline {...yourProps} hoverCloseDelay={0} hoverOpenDelay={0}>
+    {yourTarget}
+</Popover>
 ```
+
+#### Rendering delays
+
+`Popover` delays rendering updates triggered on `mouseleave`, because the mouse might have moved from the popover to the target, which may require special handling depending on the current [`interactionKind`](http://localhost:9000/#core/components/popover.opening-and-closing). Popper.js also throttles rendering updates to improve performance. If your components are not updating in a synchronous fashion as expected, you may need to introduce a `setTimeout` to wait for asynchronous Popover rendering to catch up:
+
+```tsx
+wrapper = mount(
+    <Popover inline={true} interactionKind={PopoverInteractionKind.HOVER}>
+        <div>Target</div>
+        <div>Content</div>
+    </Popover>
+);
+
+wrapper.find(Target).simulate("mouseenter")
+wrapper.findClass(Classes.POPOVER).simulate("mouseenter")
+wrapper.findClass(Classes.POPOVER).simulate("mouseleave");
+
+setTimeout(() => {
+    // Popover defers popover closing, so need to defer this check
+    wrapper.assertIsOpen(false);
+});
+```
+
+#### Element refs
 
 If `inline` rendering is not an option, `Popover` instances expose `popoverElement` and
 `targetElement` refs of the actual DOM elements. Importantly, `popoverElement` points to the

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -155,13 +155,18 @@ state.
 
 Providing a non-null value for `isOpen` disables all automatic interaction and instead invokes
 the `onInteraction` callback prop any time the opened state _would have changed_ in response to
-user interaction under the current `interactionKind`. As a result, the `isDisabled` prop is
-incompatible with `isOpen`, and an error is thrown if both are set.
+user interaction under the current `interactionKind`.
 
 Note that there are cases where `onInteraction` is invoked with an unchanged open state.
 It is important to pay attention to the value of the `nextOpenState` parameter and determine
 in your application logic whether you should care about a particular invocation (for instance,
 if the `nextOpenState` is not the same as the `Popover`'s current state).
+
+<div class="pt-callout pt-intent-warning pt-icon-warning-sign">
+    <h5>Disabling controlled popovers</h5>
+    <p>If `disabled={true}`, a controlled popover will remain closed even if `isOpen={true}`.
+    The popover will re-open when `disabled` is set to `false.</p>
+</div>
 
 #### Example controlled usage
 

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -313,10 +313,12 @@ and make its content scrollable, set the appropriate CSS rules on `.pt-popover-c
 ```css.scss
 // pass "my-popover" to `popoverClassName` prop.
 .my-popover .pt-popover-content {
-    max-height: $pt-grid-size * 30;
+    max-height: $pt-grid-size * 15;
     overflow-y: auto;
 }
 ```
+
+@reactExample PopoverSizingExample
 
 @### Minimal style
 

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -382,8 +382,8 @@ wrapper = mount(
 wrapper.find(Target).simulate("mouseenter");
 
 // hostNodes() is an Enzyme 3 helper that retains only native-HTML nodes.
-wrapper.find(Classes.POPOVER).hostNodes().simulate("mouseenter");
-wrapper.find(Classes.POPOVER).hostNodes().simulate("mouseleave");
+wrapper.find(`.${Classes.POPOVER}`).hostNodes().simulate("mouseenter");
+wrapper.find(`.${Classes.POPOVER}`).hostNodes().simulate("mouseleave");
 
 setTimeout(() => {
     // Popover delays closing using setTimeout, so need to defer this check too.

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -319,6 +319,8 @@ and make its content scrollable, set the appropriate CSS rules on `.pt-popover-c
 You can create a minimal popover with the `pt-minimal` modifier: `popoverClassName="pt-minimal"`.
 This removes the arrow from the popover and makes the transitions more subtle.
 
+@reactExample PopoverMinimalExample
+
 This minimal style is recommended for popovers that are not triggered by an obvious action like the
 user clicking or hovering over something. For example, a minimal popover is useful for making
 typeahead menus where the menu appears almost instantly after the user starts typing.

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -3,6 +3,11 @@
 Popovers display floating content next to a target element.
 
 `Popover` is built on top of the [__Popper.js__](https://popper.js.org) library.
+Popper.js is a small (~6kb) library that offers a powerful, customizable
+positioning engine and operates at blazing speed (~60fps).
+
+The example below demonstrates some of the capabilities of our Popper.js-backed
+`Popover`.
 
 @reactExample PopoverExample
 
@@ -47,7 +52,26 @@ The __target__ acts as the trigger for the popover; user interaction will show t
 positioned on the page next to the target; the `position` prop determines the relative position (on
 which side of the target).
 
-Internally, the provided target is wrapped in a `span.pt-popover-target`. This is turn is wrapped in a `span.pt-popover-wrapper` to ensure all component-related nodes are contained in a single element; this is particularly necessary when rendering popovers [inline](#core/components/popover.inline-popovers).
+Internally, the provided target is wrapped in a `span.pt-popover-target`. This in turn is wrapped in a `span.pt-popover-wrapper`:
+
+```tsx
+<span class="pt-popover-wrapper">
+    <span class="pt-popover-target">
+        <Button text="My target" />
+    </span>
+</span>
+```
+
+The extra `pt-popover-wrapper` is present so that both the popover and target will be wrapped in a single element when rendering popovers [inline](#core/components/popover.inline-popovers):
+
+```tsx
+<span class="pt-popover-wrapper">
+    <span class="pt-popover-target">
+        <Button text="My target" />
+    </span>
+    <!-- Popover HTML goes here -->
+</span>
+```
 
 <div class="pt-callout pt-intent-warning pt-icon-warning-sign">
     <h5>Button targets</h5>
@@ -112,7 +136,7 @@ The `position` can also be set to the string literal `"auto"`, the default setti
 
 Modifiers are the tools through which you customize Popper.js's behavior. Popper.js defines several of its own modifiers to handle things such as flipping, preventing overflow from a boundary element, and positioning the arrow. `Popover` defines a few additional modifiers to support itself. You can even define your own modifiers, and customize the Popper.js defaults, through the `modifiers` prop. (Note: it is not currently possible to configure `Popover`'s modifiers through the `modifiers` prop, nor can you define your own with the same name.)
 
-**Popper.js modifiers, which can be customized via the `modifiers` prop:**
+**Popper.js modifiers that can be customized via the `modifiers` prop:**
 
 - [`shift`](https://popper.js.org/popper-documentation.html#modifiers..shift) applies the `-start`/`-end` portion of placement
 - [`offset`](https://popper.js.org/popper-documentation.html#modifiers..offset) can be configured to move the popper on both axes using a CSS-like syntax
@@ -124,7 +148,7 @@ Modifiers are the tools through which you customize Popper.js's behavior. Popper
 - [`hide`](https://popper.js.org/popper-documentation.html#modifiers..hide) hides the popper when its reference element is outside of the popper boundaries.
 - [`computeStyle`](https://popper.js.org/popper-documentation.html#modifiers..computeStyle) generates the CSS styles to apply to the DOM
 
-**`Popover` modifiers, _which cannot be used by you_:**
+**Popper.js modifiers that `Popover` manages and that cannot be customized:**
 
 - `arrowOffset` moves the popper a little bit to make room for the arrow
 - `updatePopoverState` saves off some popper data to `Popover` React state for fancy things
@@ -328,6 +352,11 @@ zeroing the default hover delays.
 `Popover` delays rendering updates triggered on `mouseleave`, because the mouse might have moved from the popover to the target, which may require special handling depending on the current [`interactionKind`](http://localhost:9000/#core/components/popover.opening-and-closing). Popper.js also throttles rendering updates to improve performance. If your components are not updating in a synchronous fashion as expected, you may need to introduce a `setTimeout` to wait for asynchronous Popover rendering to catch up:
 
 ```tsx
+import { Classes, Overlay, Popover, PopoverInteractionKind } from "@blueprintjs/core";
+import { assert } from "chai";
+import { mount } from "enzyme";
+import { Target } from "react-popper";
+
 wrapper = mount(
     <Popover inline={true} interactionKind={PopoverInteractionKind.HOVER}>
         <div>Target</div>
@@ -341,7 +370,8 @@ wrapper.findClass(Classes.POPOVER).simulate("mouseleave");
 
 setTimeout(() => {
     // Popover defers popover closing, so need to defer this check
-    wrapper.assertIsOpen(false);
+    const isOpen = wrapper.find(Overlay).prop("isOpen");
+    assert.equal(isOpen, false);
 });
 ```
 

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -6,7 +6,7 @@ Popovers display floating content next to a target element.
 Popper.js is a small (~6kb) library that offers a powerful, customizable
 positioning engine and operates at blazing speed (~60fps).
 
-The example below demonstrates some of the capabilities of our Popper.js-backed
+The example below demonstrates some of the capabilities of our Popper.js-powered
 `Popover`.
 
 @reactExample PopoverExample
@@ -52,24 +52,14 @@ The __target__ acts as the trigger for the popover; user interaction will show t
 positioned on the page next to the target; the `position` prop determines the relative position (on
 which side of the target).
 
-Internally, the provided target is wrapped in a `span.pt-popover-target`. This in turn is wrapped in a `span.pt-popover-wrapper`:
+Internally, the provided target is wrapped in a `span.pt-popover-target`. This in turn is wrapped in a `span.pt-popover-wrapper`. The extra `pt-popover-wrapper` is present so that both the popover and target will be wrapped in a single element when rendering popovers [inline](#core/components/popover.inline-rendering).
 
 ```tsx
 <span class="pt-popover-wrapper">
     <span class="pt-popover-target">
         <Button text="My target" />
     </span>
-</span>
-```
-
-The extra `pt-popover-wrapper` is present so that both the popover and target will be wrapped in a single element when rendering popovers [inline](#core/components/popover.inline-popovers):
-
-```tsx
-<span class="pt-popover-wrapper">
-    <span class="pt-popover-target">
-        <Button text="My target" />
-    </span>
-    <!-- Popover HTML goes here -->
+    <!-- inline Popover would render here -->
 </span>
 ```
 
@@ -84,7 +74,7 @@ The extra `pt-popover-wrapper` is present so that both the popover and target wi
 ```tsx
 const { Button, Intent, Popover, PopoverInteractionKind, Position } = "@blueprintjs/core";
 
-export class PopoverExample extends React.Component<{}, {}> {
+export class PopoverExample extends React.Component {
     public render() {
         // popover content gets no padding by default; add the "pt-popover-content-sizing"
         // class to the popover to set nice padding between its border and content,
@@ -290,6 +280,16 @@ The backdrop element has the same opacity-fade transition as the `Dialog` backdr
     must be handled by your application code or simply avoided if possible.
 </div>
 
+@### Inline rendering
+
+By default, popover contents are rendered in a newly created [`Portal`](#core/components/portal) appended to document.body. This works well for most layouts, because popovers by default will appear above everything else on the page without needing to manually adjust z-indices.
+
+However, there are cases where it's preferable to render the popover contents inline in the DOM.
+
+For example, consider a scrolling table where cells have tooltips attached to them. As row items go out of view, cell tooltips should slide out of the viewport as well. This is best accomplished with inline popovers.
+
+Setting `inline={true}` will enable inline rendering.
+
 @## Style
 
 @### Dark theme
@@ -322,7 +322,7 @@ and make its content scrollable, set the appropriate CSS rules on `.pt-popover-c
 
 @### Minimal style
 
-You can create a minimal popover with the `pt-minimal` modifier: `popoverClassName="pt-minimal"`.
+You can create a minimal popover by setting `minimal={true}`.
 This removes the arrow from the popover and makes the transitions more subtle.
 
 @reactExample PopoverMinimalExample
@@ -350,7 +350,7 @@ Hover interactions can also be tricky due to delays and transitions; this can be
 zeroing the default hover delays.
 
 ```tsx
- <Popover inline {...yourProps} hoverCloseDelay={0} hoverOpenDelay={0}>
+<Popover inline {...yourProps} hoverCloseDelay={0} hoverOpenDelay={0}>
     {yourTarget}
 </Popover>
 ```
@@ -372,12 +372,14 @@ wrapper = mount(
     </Popover>
 );
 
-wrapper.find(Target).simulate("mouseenter")
-wrapper.findClass(Classes.POPOVER).simulate("mouseenter")
-wrapper.findClass(Classes.POPOVER).simulate("mouseleave");
+wrapper.find(Target).simulate("mouseenter");
+
+// hostNodes() is an Enzyme 3 helper that retains only native-HTML nodes.
+wrapper.find(Classes.POPOVER).hostNodes().simulate("mouseenter");
+wrapper.find(Classes.POPOVER).hostNodes().simulate("mouseleave");
 
 setTimeout(() => {
-    // Popover defers popover closing, so need to defer this check
+    // Popover delays closing using setTimeout, so need to defer this check too.
     const isOpen = wrapper.find(Overlay).prop("isOpen");
     assert.equal(isOpen, false);
 });

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -229,6 +229,10 @@ The supported values are:
     - __Opens when:__ the target is clicked
     - __Closes when:__ the target is clicked
 
+The following example demonstrates the various interaction kinds (note: these Popovers contain [`MenuItem`](http://localhost:9000/#core/components/menu.menu-item)s with `shouldDismissPopover={false}`, for clarity):
+
+@reactExample PopoverInteractionKindExample
+
 The __@blueprintjs/core__ package exports the above values in the `PopoverInteractionKind` enumeration.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -1,52 +1,109 @@
 @# Popover
 
-**Changes from original [`Popover`](#core/components/popover):**
+Popovers display floating content next to a target element.
 
-- [Popper.js](https://popper.js.org) is a massive improvement over [Tether](http://tether.io/) in almost every way!
-  - all the fancy flipping behavior you could want _enabled by default_
-  - endlessly customizable if it isn't perfect _enough_ for you
-  - look, it puts the arrow exactly where it's supposed to be. _every time._
-- all the classic `Popover` features are still supported, with the same names except...
-  - `isModal` &rarr; `hasBackdrop` to match corresponding prop on `Overlay`
-  - `isDisabled` &rarr; `disabled` for consistency with HTML elements
-- ...and except for the handful of Tether-specific props, which are now Popper.js-specific:
-  - `position: Position` &rarr; [`placement: PopperJS.Placement`](#labs/popover.placement)
-  - `tetherOptions: ITetherOptions` &rarr; [`modifiers: PopperJS.Modifiers`](#labs/popover.modifiers)
-- ...and one special addition:
-  - `minimal: boolean` applies minimal styles, which includes removing the arrow and minimizing the transition
+`Popover` is built on top of the [__popper.js__](https://popper.js.org) library.
 
 @reactExample PopoverExample
 
-@interface IPopoverProps
+@## JavaScript API
 
-@## Placement
+The `Popover` component is available in the __@blueprintjs/core__ package.
+Make sure to review the [general usage docs for JS components](#blueprint.usage).
 
-Valid placements are:
+@### Structure
 
-- `auto`
-- `top`
-- `right`
-- `bottom`
-- `left`
+When creating a popover, you must specify both its _content_ and its _target_.
+This can be done a few ways:
 
-Each placement can have a suffix from this list, which determines the alignment along the opposite axis:
+1. Provide both the `content` and `target` props, which accept a string or a JSX element.
+  Omitting the `target` prop will produce an error.
+  ```tsx
+  <Popover content={<Content />} target={<Button text="Open" />} />
+  ```
 
-- `-start`
-- <small>_(nothing)_</small>
-- `-end`
+1. Provide one or two `children`. Omitting a `target` element will produce an error.
+  ```tsx
+  <Popover>
+      <Button text="Open" />
+      <Content />
+  </Popover>
+  ```
 
-For `top` and `bottom`, `-start` means left and `-end` means right. For `left` and `right`, `-start` means top and `-end` means bottom.
+1. It is possible to mix the two: provide the `content` prop and one React child as the target.
+  (Using the `target` prop with `children` is not supported and will produce a warning.)
+  ```tsx
+  <Popover content={<Content />}>
+      <Button text="Open" />
+  </Popover>
+  ```
 
-Therefore, `top-start` places the Popover along the top edge of the target and their left sides will be aligned.
-And `right-end` places the Popover along the right edge with their bottom sides aligned.
+The _target_ acts as the trigger for the popover; user interaction will show the popover based on
+`interactionKind`. The _content_ will be shown in the popover itself. The popover's will always be
+positioned on the page next to the target; the `position` prop determines the relative position (on
+which side of the target).
 
-`auto` will choose the best suitable placement given the Popover's position within its boundary element.
+Internally, the provided target is wrapped in a `span.pt-popover-target`. This is turn is wrapped in a `span.pt-popover-wrapper` to ensure all component-related nodes are contained in a single element; this is particularly necessary when rendering popovers [inline](#core/components/popover.inline-popovers).
 
-<div class="pt-callout pt-intent-primary pt-icon-info-sign">
-    Read more in [the Popper.js Placement documentation](https://popper.js.org/popper-documentation.html#Popper.placements).
+<div class="pt-callout pt-intent-warning pt-icon-warning-sign">
+    <h5>Button targets</h5>
+    Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
+    events, which interferes with the popover functioning. If you need to disable a button that
+    triggers a popover, you should use [`AnchorButton`](#core/components/button.anchor-button) instead.
+    See the [callout here](#core/components/button.javascript-api) for more details.
 </div>
 
-@## Modifiers
+```tsx
+const { Button, Intent, Popover, PopoverInteractionKind, Position } = "@blueprintjs/core";
+
+export class PopoverExample extends React.Component<{}, {}> {
+    public render() {
+        // popover content gets no padding by default; add the "pt-popover-content-sizing"
+        // class to the popover to set nice padding between its border and content,
+        // and a default width when inline.
+        return (
+            <Popover
+                interactionKind={PopoverInteractionKind.CLICK}
+                popoverClassName="pt-popover-content-sizing"
+                position={Position.RIGHT}
+            >
+                <Button intent={Intent.PRIMARY}>Popover target</Button>
+                <div>
+                    <h5>Popover title</h5>
+                    <p>...</p>
+                    <Button className="pt-popover-dismiss">Dismiss</Button>
+                </div>
+            </Popover>
+        );
+    }
+}
+```
+
+@### Position
+
+The `position` property controls the Popover's position relative to the target. There are two attributes to consider:
+
+- Which <span class="docs-popover-position-label-side">__side__</span> of the target the popover should render on.
+- The popover's <span class="docs-popover-position-label-alignment">__alignment__</span> relative to the target.
+
+These two attributes can be expressed with a single value having the following structure:
+
+<pre class="docs-popover-position-value-code-block">
+    <span class="docs-popover-position-label-side">[SIDE]</span>_<span class="docs-popover-position-label-alignment">[ALIGNMENT]</span>
+</pre>
+The __@blueprintjs/core__ package exports a `Position` enumeration that contains the full set of supported side/alignment combinations.
+
+@#### Example
+
+The following example shows all supported `Position`s and how each behaves in practice. Note that if <code class="docs-popover-position-label-alignment">_[ALIGNMENT]</code> is ommitted, the popover will align to the __center__ of the target.
+
+@reactExample PopoverPositionExample
+
+@#### Automatic positioning
+
+The `position` can also be set to the string literal `"auto"`, the default setting. In this mode, the Popover will continually re-position itself to the side with the most space available, adjusting its alignment intuitively as well. This is useful for guaranteeing that the Popover remains visible while scrolling within a parent container.
+
+@### Modifiers
 
 Modifiers are the tools through which you customize Popper.js's behavior. Popper.js defines several of its own modifiers to handle things such as flipping, preventing overflow from a boundary element, and positioning the arrow. `Popover` defines a few additional modifiers to support itself. You can even define your own modifiers, and customize the Popper.js defaults, through the `modifiers` prop. (Note: it is not currently possible to configure `Popover`'s modifiers through the `modifiers` prop, nor can you define your own with the same name.)
 
@@ -71,3 +128,200 @@ Modifiers are the tools through which you customize Popper.js's behavior. Popper
     To understand all the Popper.js modifiers available to you, you'll want to read [the Popper.js Modifiers documentation](https://popper.js.org/popper-documentation.html#modifiers).
 </div>
 
+@interface IPopoverProps
+
+@### Controlled mode
+
+If you prefer to have more control over your popover's behavior, you can specify the `isOpen`
+property to use the component in __controlled mode__. You are now in charge of the component's
+state.
+
+Providing a non-null value for `isOpen` disables all automatic interaction and instead invokes
+the `onInteraction` callback prop any time the opened state _would have changed_ in response to
+user interaction under the current `interactionKind`. As a result, the `isDisabled` prop is
+incompatible with `isOpen`, and an error is thrown if both are set.
+
+Note that there are cases where `onInteraction` is invoked with an unchanged open state.
+It is important to pay attention to the value of the `nextOpenState` parameter and determine
+in your application logic whether you should care about a particular invocation (for instance,
+if the `nextOpenState` is not the same as the `Popover`'s current state).
+
+##### Example controlled usage
+
+```tsx
+const { Popover, Position } = "@blueprintjs/core";
+
+export class ControlledPopoverExample extends React.Component<{}, { isOpen: boolean }> {
+    public state = { isOpen: false };
+
+    public render() {
+        let popoverContent = (
+            <div>
+                <h5>Popover Title</h5>
+                <p>...</p>
+                <button class="pt-button pt-popover-dismiss">Close popover</button>
+            </div>
+        );
+
+        return (
+            <Popover
+                content={popoverContent}
+                interactionKind={PopoverInteractionKind.CLICK}
+                isOpen={this.state.isOpen}
+                onInteraction={(state) => this.handleInteraction(state)}
+                position={Position.RIGHT}
+            >
+                <button className="pt-button pt-intent-primary">Popover target</button>
+            </Popover>
+        );
+    }
+
+    private handleInteraction(nextOpenState: boolean) {
+        this.setState({ isOpen: nextOpenState });
+    }
+}
+```
+
+@### Inline popovers
+
+By default, popover contents are rendered in a newly created element appended to `document.body`.
+
+This works well for most layouts, because you want popovers to appear above everything else in your
+application without having to manually adjust z-indices. For these "detached" popovers, we use the
+[Tether](http://github.hubspot.com/tether/) library to handle positioning popovers correctly
+relative to their targets. Tether is great at maintaining position in complex, dynamic UIs.
+
+However, there are cases where it's preferable to render the popover contents inline.
+
+Take, for example, a scrolling table where certain cells have tooltips attached to them. As row
+items go out of view, you want their tooltips to slide out of the viewport as well. This is best
+accomplished with inline popovers. Enable this feature by setting `inline={true}`.
+
+It is also important to note that "inline" popovers are much more performant than "detached" ones,
+particularly in response to page scrolling, because their position does not need to be recomputed on
+every interaction.
+
+@### Opening & closing popovers
+
+<div class="pt-callout pt-intent-success pt-icon-info-sign">
+    <h5>Conditionally styling popover targets</h5>
+    When a popover is open, the target has a `.pt-popover-open` class applied to it.
+    You can use this to style the target differently depending on whether the popover is open.
+</div>
+
+The different interaction kinds specify whether the popover closes when the user interacts with the
+target or the rest of the document, but by default, a user interacting with a popover's *contents*
+does __not__ close the popover.
+
+To enable click-to-close behavior on an element inside a popover, simply add the class
+`pt-popover-dismiss` to that element. The "Dismiss" button in the demo [above](#core/components/popover)
+has this class. To enable this behavior on the entire popover, pass the
+`popoverClassName="pt-popover-dismiss"` prop.
+
+Note that dismiss elements won't have any effect in a popover with
+`PopoverInteractionKind.HOVER_TARGET_ONLY` because there is no way to interact with the popover
+content itself (the popover is dismissed the moment the user mouses away from the target).
+
+@### Modal popovers
+
+Setting the `isModal` prop to `true` will:
+
+- Render a transparent backdrop beneath the popover that covers the entire viewport and prevents
+interaction with the document until the popover is closed. This is useful for preventing stray
+clicks or hovers in your app when the user tries to close a popover.
+- Focus the popover when opened to allow keyboard accessibility.
+
+Clicking the backdrop will:
+
+- _in uncontrolled mode_, close the popover.
+- _in controlled mode_, invoke the `onInteraction` callback with an argument of `false`.
+
+Modal behavior is only available for popovers with `interactionKind={PopoverInteractionKind.CLICK}`
+and an error is thrown if used otherwise.
+
+By default, the popover backdrop is invisible, but you can easily add your own styles to
+`.pt-popover-backdrop` to customize the appearance of the backdrop (for example, you could give it
+a translucent background color, like the backdrop for the [`Dialog`](#core/components/dialog) component).
+
+The backdrop element has the same opacity fade transition as the `Dialog` backdrop.
+
+<div class="pt-callout pt-intent-danger pt-icon-error">
+    <h5>Dangerous edge case</h5>
+    Rendering a `<Popover isOpen={true} isModal={true}>` outside the viewport bounds can easily break
+    your application by covering the UI with an invisible non-interactive backdrop. This edge case
+    must be handled by your application code or simply avoided if possible.
+</div>
+
+@### Sizing popovers
+
+Popovers by default have a max-width but no max-height. To constrain the height of a popover
+and make its content scrollable, set the appropriate CSS rules on `.pt-popover-content`:
+
+```css.less
+// pass "my-popover" to `popoverClassName` prop.
+.my-popover .pt-popover-content {
+    max-height: $pt-grid-size * 30;
+    overflow-y: auto;
+}
+```
+
+@### SVG popover
+
+`SVGPopover` is a convenience component provided for SVG contexts. It is a simple wrapper around
+`Popover` that sets `rootElementTag="g"`.
+
+@### Minimal popovers
+
+You can create a minimal popover with the `pt-minimal` modifier: `popoverClassName="pt-minimal"`.
+This removes the arrow from the popover and makes the transitions more subtle.
+
+This minimal style is recommended for popovers that are not triggered by an obvious action like the
+user clicking or hovering over something. For example, a minimal popover is useful for making
+typeahead menus where the menu appears almost instantly after the user starts typing.
+
+Minimal popovers are also useful for context menus that require quick enter and leave animations to
+support fast workflows. You can see an example in the [context menus](#core/components/context-menu)
+documentation.
+
+@### Dark theme
+
+The `Popover` component automatically detects whether its trigger is nested inside a `.pt-dark`
+container and applies the same class to itself. You can also explicitly apply the dark theme to
+the React component by providing the prop `popoverClassName="pt-dark"`.
+
+As a result, any component that you place inside a `Popover` (such as a `Menu`) automatically
+inherits the dark theme styles. Note that `Tooltip` uses `Popover` internally, so it also benefits
+from this behavior.
+
+This behavior can be disabled when the `Popover` is not rendered inline via the `inheritDarkTheme`
+prop.
+
+@### Testing popovers
+
+<div class="pt-callout pt-intent-primary pt-icon-info-sign">
+    Your best resource for strategies in popover testing is
+    [its own unit test suite.](https://github.com/palantir/blueprint/blob/master/packages/core/test/popover/popoverTests.tsx)
+</div>
+
+`Popover` can be difficult to test because it uses `Portal` to inject its contents elsewhere in the
+DOM (outside the usual flow); this can be simplified by using `inline` Popovers in tests.
+Hover interactions can also be tricky due to delays and transitions; this can be resolved by
+zeroing the default hover delays.
+
+```tsx
+ <Popover inline {...yourProps} hoverCloseDelay={0} hoverOpenDelay={0}>{yourTarget}</Popover>
+```
+
+If `inline` rendering is not an option, `Popover` instances expose `popoverElement` and
+`targetElement` refs of the actual DOM elements. Importantly, `popoverElement` points to the
+`.pt-popover` element inside the `Portal` so you can use it to easily query popover contents without
+knowing precisely where they are in the DOM. These properties exist primarily to simplify testing;
+do not rely on them for feature work.
+
+```tsx
+// using mount() from enzyme
+const wrapper = mount(<Popover content={<div className="test">test</div>} />);
+const { popoverElement } = wrapper.instance();
+// popoverElement is the parent element of .pt-popover
+popoverElement.querySelector(".test").textContent; // "test"
+```

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -436,8 +436,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         );
     }
 
-    // content and target can be specified as props or as children.
-    // this method normalizes the two approaches, preferring child over prop.
+    // content and target can be specified as props or as children. this method
+    // normalizes the two approaches, preferring child over prop.
     private understandChildren() {
         const { children, content: contentProp, target: targetProp } = this.props;
         // #validateProps asserts that 1 <= children.length <= 2 so content is optional

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -77,7 +77,7 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     interactionKind?: PopoverInteractionKind;
 
     /**
-     * Prevents the popover from appearing when `true`.
+     * Prevents the popover from appearing when `true`, even if `isOpen={true}`.
      * @default false
      */
     disabled?: boolean;
@@ -94,6 +94,7 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     /**
      * Whether the popover is visible. Passing this prop puts the popover in
      * controlled mode, where the only way to change visibility is by updating this property.
+     * If `disabled={true}`, this prop will be ignored, and the popover will remain closed.
      * @default undefined
      */
     isOpen?: boolean;

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -12,14 +12,14 @@ import * as React from "react";
 import { FileMenu } from "./common/fileMenu";
 import { IntentSelect } from "./common/intentSelect";
 
-export interface IPopoverButtonGroupExampleState {
+export interface IButtonGroupPopoverExampleState {
     intent?: Intent;
     large?: boolean;
     vertical?: boolean;
 }
 
-export class PopoverButtonGroupExample extends BaseExample<IPopoverButtonGroupExampleState> {
-    public state: IPopoverButtonGroupExampleState = {
+export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverExampleState> {
+    public state: IButtonGroupPopoverExampleState = {
         intent: Intent.NONE,
         large: false,
         vertical: false,
@@ -39,19 +39,13 @@ export class PopoverButtonGroupExample extends BaseExample<IPopoverButtonGroupEx
         return (
             <ButtonGroup {...{ large, vertical }} className={classNames({ [Classes.ALIGN_LEFT]: vertical })}>
                 <Popover content={menuContent} {...{ position }}>
-                    <Button intent={intent} iconName="document" {...{ rightIconName }}>
-                        File
-                    </Button>
+                    <Button intent={intent} iconName="document" {...{ rightIconName }} text="File" />
                 </Popover>
                 <Popover content={menuContent} {...{ position }}>
-                    <Button intent={intent} iconName="edit" {...{ rightIconName }}>
-                        Edit
-                    </Button>
+                    <Button intent={intent} iconName="edit" {...{ rightIconName }} text="Edit" />
                 </Popover>
                 <Popover content={menuContent} {...{ position }}>
-                    <Button intent={intent} iconName="eye-open" {...{ rightIconName }}>
-                        View
-                    </Button>
+                    <Button intent={intent} iconName="eye-open" {...{ rightIconName }} text="View" />
                 </Popover>
             </ButtonGroup>
         );

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -15,6 +15,7 @@ import { IntentSelect } from "./common/intentSelect";
 export interface IButtonGroupPopoverExampleState {
     intent?: Intent;
     large?: boolean;
+    minimal?: boolean;
     vertical?: boolean;
 }
 
@@ -22,6 +23,7 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
     public state: IButtonGroupPopoverExampleState = {
         intent: Intent.NONE,
         large: false,
+        minimal: false,
         vertical: false,
     };
 
@@ -29,15 +31,16 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
 
     private handleIntentChange = handleNumberChange(intent => this.setState({ intent }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
+    private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
     protected renderExample() {
-        const { intent, large, vertical } = this.state;
+        const { intent, large, minimal, vertical } = this.state;
         const menuContent = <FileMenu />;
         const rightIconName = vertical ? "caret-right" : "caret-down";
         const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
         return (
-            <ButtonGroup {...{ large, vertical }} className={classNames({ [Classes.ALIGN_LEFT]: vertical })}>
+            <ButtonGroup {...{ large, minimal, vertical }} className={classNames({ [Classes.ALIGN_LEFT]: vertical })}>
                 <Popover content={menuContent} {...{ position }}>
                     <Button intent={intent} iconName="document" {...{ rightIconName }} text="File" />
                 </Popover>
@@ -54,9 +57,20 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
     protected renderOptions() {
         return [
             [
-                <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
-                <Switch checked={this.state.large} onChange={this.handleLargeChange} label="Large" />,
-                <Switch checked={this.state.vertical} onChange={this.handleVerticalChange} label="Vertical" />,
+                <IntentSelect key="intent" intent={this.state.intent} onChange={this.handleIntentChange} />,
+                <Switch key="large" checked={this.state.large} onChange={this.handleLargeChange} label="Large" />,
+                <Switch
+                    key="minimal"
+                    checked={this.state.minimal}
+                    onChange={this.handleMinimalChange}
+                    label="Minimal"
+                />,
+                <Switch
+                    key="vertical"
+                    checked={this.state.vertical}
+                    onChange={this.handleVerticalChange}
+                    label="Vertical"
+                />,
             ],
         ];
     }

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Button, ButtonGroup, Classes, Intent, Popover, Position, Switch } from "@blueprintjs/core";
+import { Button, ButtonGroup, Classes, IconName, Intent, Popover, Position, Switch } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs";
 import * as classNames from "classnames";
 import * as React from "react";
@@ -35,21 +35,18 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
     protected renderExample() {
-        const { intent, large, minimal, vertical } = this.state;
-        const menuContent = <FileMenu />;
-        const rightIconName = vertical ? "caret-right" : "caret-down";
-        const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
+        const { large, minimal, vertical } = this.state;
+
         return (
-            <ButtonGroup {...{ large, minimal, vertical }} className={classNames({ [Classes.ALIGN_LEFT]: vertical })}>
-                <Popover content={menuContent} {...{ position }}>
-                    <Button intent={intent} iconName="document" {...{ rightIconName }} text="File" />
-                </Popover>
-                <Popover content={menuContent} {...{ position }}>
-                    <Button intent={intent} iconName="edit" {...{ rightIconName }} text="Edit" />
-                </Popover>
-                <Popover content={menuContent} {...{ position }}>
-                    <Button intent={intent} iconName="eye-open" {...{ rightIconName }} text="View" />
-                </Popover>
+            <ButtonGroup
+                large={large}
+                minimal={minimal}
+                vertical={vertical}
+                className={classNames({ [Classes.ALIGN_LEFT]: vertical })}
+            >
+                {this.renderButton("File", "document")}
+                {this.renderButton("Edit", "edit")}
+                {this.renderButton("View", "eye-open")}
             </ButtonGroup>
         );
     }
@@ -73,5 +70,16 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
                 />,
             ],
         ];
+    }
+
+    private renderButton(text: string, iconName: IconName) {
+        const { intent, vertical } = this.state;
+        const rightIconName: IconName = vertical ? "caret-right" : "caret-down";
+        const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
+        return (
+            <Popover content={<FileMenu />} position={position}>
+                <Button intent={intent} rightIconName={rightIconName} iconName={iconName} text={text} />
+            </Popover>
+        );
     }
 }

--- a/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import * as React from "react";
+
+export interface IFileMenuProps {
+    shouldDismissPopover?: boolean;
+}
+
+export const FileMenu: React.SFC<IFileMenuProps> = props => (
+    <Menu>
+        <MenuItem text="New" iconName="document" {...props} />
+        <MenuItem text="Open" iconName="folder-shared" {...props} />
+        <MenuItem text="Close" iconName="add-to-folder" {...props} />
+        <MenuDivider />
+        <MenuItem text="Save" iconName="floppy-disk" {...props} />
+        <MenuItem text="Save as..." iconName="floppy-disk" {...props} />
+        <MenuDivider />
+        <MenuItem text="Exit" iconName="cross" {...props} />
+    </Menu>
+);

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -7,6 +7,7 @@
 export * from "./alertExample";
 export * from "./buttonsExample";
 export * from "./buttonGroupExample";
+export * from "./buttonGroupPopoverExample";
 export * from "./checkboxExample";
 export * from "./collapseExample";
 export * from "./cardExample";
@@ -26,7 +27,6 @@ export * from "./numericInputExtendedExample";
 export * from "./nonIdealStateExample";
 export * from "./overlayExample";
 export * from "./popoverExample";
-export * from "./popoverButtonGroupExample";
 export * from "./popoverInteractionKindExample";
 export * from "./popoverMinimalExample";
 export * from "./popoverPositionExample";

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -29,6 +29,7 @@ export * from "./popoverExample";
 export * from "./popoverInteractionKindExample";
 export * from "./popoverMinimalExample";
 export * from "./popoverPositionExample";
+export * from "./popoverSizingExample";
 export * from "./progressExample";
 export * from "./rangeSliderExample";
 export * from "./radioExample";

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -26,6 +26,7 @@ export * from "./numericInputExtendedExample";
 export * from "./nonIdealStateExample";
 export * from "./overlayExample";
 export * from "./popoverExample";
+export * from "./popoverMinimalExample";
 export * from "./popoverPositionExample";
 export * from "./progressExample";
 export * from "./rangeSliderExample";

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -27,6 +27,7 @@ export * from "./numericInputExtendedExample";
 export * from "./nonIdealStateExample";
 export * from "./overlayExample";
 export * from "./popoverExample";
+export * from "./popoverInlineExample";
 export * from "./popoverInteractionKindExample";
 export * from "./popoverMinimalExample";
 export * from "./popoverPositionExample";

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -26,6 +26,7 @@ export * from "./numericInputExtendedExample";
 export * from "./nonIdealStateExample";
 export * from "./overlayExample";
 export * from "./popoverExample";
+export * from "./popoverButtonGroupExample";
 export * from "./popoverInteractionKindExample";
 export * from "./popoverMinimalExample";
 export * from "./popoverPositionExample";

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -26,6 +26,7 @@ export * from "./numericInputExtendedExample";
 export * from "./nonIdealStateExample";
 export * from "./overlayExample";
 export * from "./popoverExample";
+export * from "./popoverPositionExample";
 export * from "./progressExample";
 export * from "./rangeSliderExample";
 export * from "./radioExample";

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -26,6 +26,7 @@ export * from "./numericInputExtendedExample";
 export * from "./nonIdealStateExample";
 export * from "./overlayExample";
 export * from "./popoverExample";
+export * from "./popoverInteractionKindExample";
 export * from "./popoverMinimalExample";
 export * from "./popoverPositionExample";
 export * from "./progressExample";

--- a/packages/docs-app/src/examples/core-examples/popoverButtonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverButtonGroupExample.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { Button, ButtonGroup, Classes, Intent, Popover, Position, Switch } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs";
+import * as classNames from "classnames";
+import * as React from "react";
+
+import { FileMenu } from "./common/fileMenu";
+import { IntentSelect } from "./common/intentSelect";
+
+export interface IPopoverButtonGroupExampleState {
+    intent?: Intent;
+    large?: boolean;
+    vertical?: boolean;
+}
+
+export class PopoverButtonGroupExample extends BaseExample<IPopoverButtonGroupExampleState> {
+    public state: IPopoverButtonGroupExampleState = {
+        intent: Intent.NONE,
+        large: false,
+        vertical: false,
+    };
+
+    protected className = "docs-popover-button-group-example";
+
+    private handleIntentChange = handleNumberChange(intent => this.setState({ intent }));
+    private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
+    private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
+
+    protected renderExample() {
+        const { intent, large, vertical } = this.state;
+        const menuContent = <FileMenu />;
+        const rightIconName = vertical ? "caret-right" : "caret-down";
+        const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
+        return (
+            <ButtonGroup {...{ large, vertical }} className={classNames({ [Classes.ALIGN_LEFT]: vertical })}>
+                <Popover content={menuContent} {...{ position }}>
+                    <Button intent={intent} iconName="document" {...{ rightIconName }}>
+                        File
+                    </Button>
+                </Popover>
+                <Popover content={menuContent} {...{ position }}>
+                    <Button intent={intent} iconName="edit" {...{ rightIconName }}>
+                        Edit
+                    </Button>
+                </Popover>
+                <Popover content={menuContent} {...{ position }}>
+                    <Button intent={intent} iconName="eye-open" {...{ rightIconName }}>
+                        View
+                    </Button>
+                </Popover>
+            </ButtonGroup>
+        );
+    }
+
+    protected renderOptions() {
+        return [
+            [
+                <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
+                <Switch checked={this.state.large} onChange={this.handleLargeChange} label="Large" />,
+                <Switch checked={this.state.vertical} onChange={this.handleVerticalChange} label="Vertical" />,
+            ],
+        ];
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Button, Popover, Position } from "@blueprintjs/core";
+import { BaseExample } from "@blueprintjs/docs";
+import { FileMenu } from "./common/fileMenu";
+
+export class PopoverSizingExample extends BaseExample<{}> {
+    protected className = "docs-popover-sizing-example";
+
+    protected renderExample() {
+        return (
+            <div>
+                <Popover content={<FileMenu />} inline={true} position={Position.BOTTOM_LEFT}>
+                    <Button>Open...</Button>
+                </Popover>
+            </div>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -8,18 +8,82 @@ import * as React from "react";
 
 import { Button, Popover, Position } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
-import { FileMenu } from "./common/fileMenu";
 
-export class PopoverSizingExample extends BaseExample<{}> {
-    protected className = "docs-popover-sizing-example";
+export class PopoverInlineExample extends BaseExample<{}> {
+    protected className = "docs-popover-inline-example";
+
+    private scrollContainer1Ref: HTMLDivElement;
+    private scrollContainer2Ref: HTMLDivElement;
+    private refHandlers = {
+        scrollContainer1: (ref: HTMLDivElement) => (this.scrollContainer1Ref = ref),
+        scrollContainer2: (ref: HTMLDivElement) => (this.scrollContainer2Ref = ref),
+    };
+
+    public componentDidMount() {
+        this.recenter();
+    }
 
     protected renderExample() {
         return (
-            <div>
-                <Popover content={<FileMenu />} inline={true} position={Position.BOTTOM_LEFT}>
-                    <Button>Open...</Button>
-                </Popover>
+            <div className="docs-popover-inline-example-content">
+                <div className="docs-popover-inline-example-scroll-container" ref={this.refHandlers.scrollContainer1}>
+                    <div className="docs-popover-inline-example-scroll-content">
+                        <Popover
+                            content="I am a default popover."
+                            inline={false}
+                            isOpen={true}
+                            modifiers={{ preventOverflow: { boundariesElement: "window" } }}
+                            popoverClassName="docs-popover-inline-example-popover"
+                            position={Position.BOTTOM}
+                        >
+                            <Button>
+                                <code>{`inline={false}`}</code>
+                            </Button>
+                        </Popover>
+                    </div>
+                </div>
+                <div className="docs-popover-inline-example-scroll-container" ref={this.refHandlers.scrollContainer2}>
+                    <div className="docs-popover-inline-example-scroll-content">
+                        <Popover
+                            content="I am an inline popover."
+                            inline={true}
+                            isOpen={true}
+                            modifiers={{ preventOverflow: { boundariesElement: "window" } }}
+                            popoverClassName="docs-popover-inline-example-popover"
+                            position={Position.BOTTOM}
+                        >
+                            <Button>
+                                <code>{`inline={true}`}</code>
+                            </Button>
+                        </Popover>
+                    </div>
+                </div>
             </div>
         );
     }
+
+    protected renderOptions() {
+        return [
+            [
+                <Button
+                    key="recenter"
+                    text="Re-center"
+                    iconName="pt-icon-alignment-vertical-center"
+                    onClick={this.recenter}
+                />,
+            ],
+        ];
+    }
+
+    private recenter = () => {
+        this.scrollToCenter(this.scrollContainer1Ref);
+        this.scrollToCenter(this.scrollContainer2Ref);
+    };
+
+    private scrollToCenter = (scrollContainer?: HTMLDivElement) => {
+        if (scrollContainer != null) {
+            const contentWidth = scrollContainer.children[0].clientWidth;
+            scrollContainer.scrollLeft = contentWidth / 4;
+        }
+    };
 }

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Button, Intent, Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
+import { BaseExample } from "@blueprintjs/docs";
+import { FileMenu } from "./common/fileMenu";
+
+export class PopoverInteractionKindExample extends BaseExample<{}> {
+    protected className = "docs-popover-interaction-kind-example";
+
+    protected renderExample() {
+        return (
+            <div>
+                {this.renderPopover("HOVER", PopoverInteractionKind.HOVER)}
+                {this.renderPopover("HOVER_TARGET_ONLY", PopoverInteractionKind.HOVER_TARGET_ONLY)}
+                {this.renderPopover("CLICK", PopoverInteractionKind.CLICK)}
+                {this.renderPopover("CLICK_TARGET_ONLY", PopoverInteractionKind.CLICK_TARGET_ONLY)}
+            </div>
+        );
+    }
+
+    private renderPopover(buttonLabel: string, interactionKind: PopoverInteractionKind) {
+        // MenuItem's default shouldDismissPopover={true} behavior is confusing
+        // in this example, since it introduces an additional way popovers can
+        // close. set it to false here for clarity.
+        return (
+            <Popover
+                content={<FileMenu shouldDismissPopover={false} />}
+                position={Position.BOTTOM_LEFT}
+                {...{ interactionKind }}
+            >
+                <Button intent={Intent.PRIMARY}>{buttonLabel}</Button>
+            </Popover>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -32,7 +32,7 @@ export class PopoverInteractionKindExample extends BaseExample<{}> {
             <Popover
                 content={<FileMenu shouldDismissPopover={false} />}
                 position={Position.BOTTOM_LEFT}
-                {...{ interactionKind }}
+                interactionKind={interactionKind}
             >
                 <Button intent={Intent.PRIMARY}>{buttonLabel}</Button>
             </Popover>

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Button, Intent, IPopoverProps, Menu, MenuItem, Popover, Position } from "@blueprintjs/core";
+import { BaseExample } from "@blueprintjs/docs";
+
+export class PopoverMinimalExample extends BaseExample<{}> {
+    protected className = "docs-popover-minimal-example";
+
+    protected renderExample() {
+        const menuContent = (
+            <Menu>
+                <MenuItem text="New" iconName="document" />
+                <MenuItem text="Open" iconName="folder-shared" />
+                <MenuItem text="Close" iconName="add-to-folder" />
+            </Menu>
+        );
+
+        const baseProps: IPopoverProps = { content: menuContent, position: Position.BOTTOM_LEFT };
+
+        return (
+            <div>
+                <Popover {...baseProps}>
+                    <Button>Default</Button>
+                </Popover>
+                <Popover {...baseProps} minimal={true}>
+                    <Button intent={Intent.PRIMARY}>Minimal</Button>
+                </Popover>
+            </div>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -6,22 +6,15 @@
 
 import * as React from "react";
 
-import { Button, Intent, IPopoverProps, Menu, MenuItem, Popover, Position } from "@blueprintjs/core";
+import { Button, Intent, IPopoverProps, Popover, Position } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
+import { FileMenu } from "./common/fileMenu";
 
 export class PopoverMinimalExample extends BaseExample<{}> {
     protected className = "docs-popover-minimal-example";
 
     protected renderExample() {
-        const menuContent = (
-            <Menu>
-                <MenuItem text="New" iconName="document" />
-                <MenuItem text="Open" iconName="folder-shared" />
-                <MenuItem text="Close" iconName="add-to-folder" />
-            </Menu>
-        );
-
-        const baseProps: IPopoverProps = { content: menuContent, position: Position.BOTTOM_LEFT };
+        const baseProps: IPopoverProps = { content: <FileMenu />, position: Position.BOTTOM_LEFT };
 
         return (
             <div>

--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -33,41 +33,43 @@ export class PopoverPositionExample extends BaseExample<{}> {
     protected renderExample() {
         return (
             <table className={TABLE_CLASS}>
-                <tr className={ROW_CLASS}>
-                    <td className={CELL_LEFT_CLASS} />
-                    <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
-                        {this.renderPopover(Position.BOTTOM_LEFT, "BOTTOM", "LEFT")}
-                        {this.renderPopover(Position.BOTTOM, "BOTTOM")}
-                        {this.renderPopover(Position.BOTTOM_RIGHT, "BOTTOM", "RIGHT")}
-                    </td>
-                    <td className={CELL_RIGHT_CLASS} />
-                </tr>
-                <tr className={ROW_CLASS}>
-                    <td className={classNames(CELL_CLASS, CELL_LEFT_CLASS)}>
-                        {this.renderPopover(Position.RIGHT_TOP, "RIGHT", "TOP")}
-                        {this.renderPopover(Position.RIGHT, "RIGHT")}
-                        {this.renderPopover(Position.RIGHT_BOTTOM, "RIGHT", "BOTTOM")}
-                    </td>
-                    <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
-                        <span className={INSTRUCTIONS_CLASS}>
-                            Button positions are flipped here so that all popovers open inward.
-                        </span>
-                    </td>
-                    <td className={classNames(CELL_CLASS, CELL_RIGHT_CLASS)}>
-                        {this.renderPopover(Position.LEFT_TOP, "LEFT", "TOP")}
-                        {this.renderPopover(Position.LEFT, "LEFT")}
-                        {this.renderPopover(Position.LEFT_BOTTOM, "LEFT", "BOTTOM")}
-                    </td>
-                </tr>
-                <tr className={ROW_CLASS}>
-                    <td className={CELL_LEFT_CLASS} />
-                    <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
-                        {this.renderPopover(Position.TOP_LEFT, "TOP", "LEFT")}
-                        {this.renderPopover(Position.TOP, "TOP")}
-                        {this.renderPopover(Position.TOP_RIGHT, "TOP", "RIGHT")}
-                    </td>
-                    <td className={CELL_RIGHT_CLASS} />
-                </tr>
+                <tbody>
+                    <tr className={ROW_CLASS}>
+                        <td className={CELL_LEFT_CLASS} />
+                        <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
+                            {this.renderPopover(Position.BOTTOM_LEFT, "BOTTOM", "LEFT")}
+                            {this.renderPopover(Position.BOTTOM, "BOTTOM")}
+                            {this.renderPopover(Position.BOTTOM_RIGHT, "BOTTOM", "RIGHT")}
+                        </td>
+                        <td className={CELL_RIGHT_CLASS} />
+                    </tr>
+                    <tr className={ROW_CLASS}>
+                        <td className={classNames(CELL_CLASS, CELL_LEFT_CLASS)}>
+                            {this.renderPopover(Position.RIGHT_TOP, "RIGHT", "TOP")}
+                            {this.renderPopover(Position.RIGHT, "RIGHT")}
+                            {this.renderPopover(Position.RIGHT_BOTTOM, "RIGHT", "BOTTOM")}
+                        </td>
+                        <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
+                            <span className={INSTRUCTIONS_CLASS}>
+                                Button positions are flipped here so that all popovers open inward.
+                            </span>
+                        </td>
+                        <td className={classNames(CELL_CLASS, CELL_RIGHT_CLASS)}>
+                            {this.renderPopover(Position.LEFT_TOP, "LEFT", "TOP")}
+                            {this.renderPopover(Position.LEFT, "LEFT")}
+                            {this.renderPopover(Position.LEFT_BOTTOM, "LEFT", "BOTTOM")}
+                        </td>
+                    </tr>
+                    <tr className={ROW_CLASS}>
+                        <td className={CELL_LEFT_CLASS} />
+                        <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
+                            {this.renderPopover(Position.TOP_LEFT, "TOP", "LEFT")}
+                            {this.renderPopover(Position.TOP, "TOP")}
+                            {this.renderPopover(Position.TOP_RIGHT, "TOP", "RIGHT")}
+                        </td>
+                        <td className={CELL_RIGHT_CLASS} />
+                    </tr>
+                </tbody>
             </table>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -7,22 +7,25 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Button, ButtonGroup, Classes, Popover, Position } from "@blueprintjs/core";
+import { Button, Popover, Position } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
-
-const CENTER_LABEL = "(center)";
 
 const EXAMPLE_CLASS = "docs-popover-position-example";
 
-const TABLE_CLASS = `${EXAMPLE_CLASS}-table`;
-const ROW_CLASS = `${EXAMPLE_CLASS}-row`;
-const CELL_CLASS = `${EXAMPLE_CLASS}-cell`;
+// Avoid interpolation to ensure these values remain grep-able.
+const BUTTON_CLASS = "docs-popover-position-example-button";
+const INSTRUCTIONS_CLASS = "docs-popover-position-example-instructions";
 
-const CELL_LEFT_CLASS = `${CELL_CLASS}-left`;
-const CELL_CENTER_CLASS = `${CELL_CLASS}-center`;
-const CELL_RIGHT_CLASS = `${CELL_CLASS}-right`;
+const TABLE_CLASS = "docs-popover-position-example-table";
+const ROW_CLASS = "docs-popover-position-example-row";
+const CELL_CLASS = "docs-popover-position-example-cell";
 
-const INSTRUCTIONS_CLASS = `${EXAMPLE_CLASS}-instructions`;
+const CELL_LEFT_CLASS = "docs-popover-position-example-cell-left";
+const CELL_CENTER_CLASS = "docs-popover-position-example-cell-center";
+const CELL_RIGHT_CLASS = "docs-popover-position-example-cell-right";
+
+const SIDE_LABEL_CLASS = "docs-popover-position-label-side";
+const ALIGNMENT_LABEL_CLASS = "docs-popover-position-label-alignment";
 
 export class PopoverPositionExample extends BaseExample<{}> {
     protected className = EXAMPLE_CLASS;
@@ -33,17 +36,17 @@ export class PopoverPositionExample extends BaseExample<{}> {
                 <tr className={ROW_CLASS}>
                     <td className={CELL_LEFT_CLASS} />
                     <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
-                        {this.renderPopover(Position.BOTTOM_LEFT, "BOTTOM_LEFT", "BOTTOM", "LEFT")}
-                        {this.renderPopover(Position.BOTTOM, "BOTTOM", "BOTTOM", "(center)")}
-                        {this.renderPopover(Position.BOTTOM_RIGHT, "BOTTOM_RIGHT", "BOTTOM", "RIGHT")}
+                        {this.renderPopover(Position.BOTTOM_LEFT, "BOTTOM", "LEFT")}
+                        {this.renderPopover(Position.BOTTOM, "BOTTOM")}
+                        {this.renderPopover(Position.BOTTOM_RIGHT, "BOTTOM", "RIGHT")}
                     </td>
                     <td className={CELL_RIGHT_CLASS} />
                 </tr>
                 <tr className={ROW_CLASS}>
                     <td className={classNames(CELL_CLASS, CELL_LEFT_CLASS)}>
-                        {this.renderPopover(Position.RIGHT_TOP, "RIGHT_TOP", "RIGHT", "TOP")}
-                        {this.renderPopover(Position.RIGHT, "RIGHT", "RIGHT", "(center)")}
-                        {this.renderPopover(Position.RIGHT_BOTTOM, "RIGHT_BOTTOM", "RIGHT", "BOTTOM")}
+                        {this.renderPopover(Position.RIGHT_TOP, "RIGHT", "TOP")}
+                        {this.renderPopover(Position.RIGHT, "RIGHT")}
+                        {this.renderPopover(Position.RIGHT_BOTTOM, "RIGHT", "BOTTOM")}
                     </td>
                     <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
                         <span className={INSTRUCTIONS_CLASS}>
@@ -51,17 +54,17 @@ export class PopoverPositionExample extends BaseExample<{}> {
                         </span>
                     </td>
                     <td className={classNames(CELL_CLASS, CELL_RIGHT_CLASS)}>
-                        {this.renderPopover(Position.LEFT_TOP, "LEFT_TOP", "LEFT", "TOP")}
-                        {this.renderPopover(Position.LEFT, "LEFT", "LEFT", "(center)")}
-                        {this.renderPopover(Position.LEFT_BOTTOM, "LEFT_BOTTOM", "LEFT", "BOTTOM")}
+                        {this.renderPopover(Position.LEFT_TOP, "LEFT", "TOP")}
+                        {this.renderPopover(Position.LEFT, "LEFT")}
+                        {this.renderPopover(Position.LEFT_BOTTOM, "LEFT", "BOTTOM")}
                     </td>
                 </tr>
                 <tr className={ROW_CLASS}>
                     <td className={CELL_LEFT_CLASS} />
                     <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
-                        {this.renderPopover(Position.TOP_LEFT, "TOP_LEFT", "TOP", "LEFT")}
-                        {this.renderPopover(Position.TOP, "TOP", "TOP", "(center)")}
-                        {this.renderPopover(Position.TOP_RIGHT, "TOP_RIGHT", "TOP", "RIGHT")}
+                        {this.renderPopover(Position.TOP_LEFT, "TOP", "LEFT")}
+                        {this.renderPopover(Position.TOP, "TOP")}
+                        {this.renderPopover(Position.TOP_RIGHT, "TOP", "RIGHT")}
                     </td>
                     <td className={CELL_RIGHT_CLASS} />
                 </tr>
@@ -69,26 +72,39 @@ export class PopoverPositionExample extends BaseExample<{}> {
         );
     }
 
-    private renderPopover(position: "auto" | Position, buttonLabel: string, popoverLabel: string, arrowLabel: string) {
-        const alignMessage =
-            arrowLabel === CENTER_LABEL ? (
+    private renderPopover(position: "auto" | Position, sideLabel: string, alignmentLabel?: string) {
+        const sideSpan = <span className={SIDE_LABEL_CLASS}>{sideLabel}</span>;
+
+        const buttonLabel =
+            alignmentLabel === undefined ? (
+                <>{sideSpan}</>
+            ) : (
                 <>
-                    Aligned at <code>(center)</code>.
+                    {sideSpan}_{<span className={ALIGNMENT_LABEL_CLASS}>{alignmentLabel}</span>}
+                </>
+            );
+
+        const popoverAlignmentSentence =
+            alignmentLabel === undefined ? (
+                <>
+                    Aligned at <code className={ALIGNMENT_LABEL_CLASS}>(center)</code>.
                 </>
             ) : (
                 <>
-                    Aligned on <code>{arrowLabel}</code> edge.
+                    Aligned on <code className={ALIGNMENT_LABEL_CLASS}>{alignmentLabel}</code> edge.
                 </>
             );
+
         const content = (
             <div>
-                Popover on <code>{popoverLabel}</code>.<br />
-                {alignMessage}
+                Popover on <code className={SIDE_LABEL_CLASS}>{sideLabel}</code>.<br />
+                {popoverAlignmentSentence}
             </div>
         );
+
         return (
             <Popover content={content} inline={true} position={position}>
-                <Button>{buttonLabel}</Button>
+                <Button className={BUTTON_CLASS}>{buttonLabel}</Button>
             </Popover>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -50,7 +50,7 @@ export class PopoverPositionExample extends BaseExample<{}> {
                     </td>
                     <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
                         <span className={INSTRUCTIONS_CLASS}>
-                            Button positions are flipped so that all popovers open inward.
+                            Button positions are flipped here so that all popovers open inward.
                         </span>
                     </td>
                     <td className={classNames(CELL_CLASS, CELL_RIGHT_CLASS)}>

--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as classNames from "classnames";
+import * as React from "react";
+
+import { Button, ButtonGroup, Classes, Popover, Position } from "@blueprintjs/core";
+import { BaseExample } from "@blueprintjs/docs";
+
+const CENTER_LABEL = "(center)";
+
+const EXAMPLE_CLASS = "docs-popover-position-example";
+
+const TABLE_CLASS = `${EXAMPLE_CLASS}-table`;
+const ROW_CLASS = `${EXAMPLE_CLASS}-row`;
+const CELL_CLASS = `${EXAMPLE_CLASS}-cell`;
+
+const CELL_LEFT_CLASS = `${CELL_CLASS}-left`;
+const CELL_CENTER_CLASS = `${CELL_CLASS}-center`;
+const CELL_RIGHT_CLASS = `${CELL_CLASS}-right`;
+
+const INSTRUCTIONS_CLASS = `${EXAMPLE_CLASS}-instructions`;
+
+export class PopoverPositionExample extends BaseExample<{}> {
+    protected className = EXAMPLE_CLASS;
+
+    protected renderExample() {
+        return (
+            <table className={TABLE_CLASS}>
+                <tr className={ROW_CLASS}>
+                    <td className={CELL_LEFT_CLASS} />
+                    <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
+                        {this.renderPopover(Position.BOTTOM_LEFT, "BOTTOM_LEFT", "BOTTOM", "LEFT")}
+                        {this.renderPopover(Position.BOTTOM, "BOTTOM", "BOTTOM", "(center)")}
+                        {this.renderPopover(Position.BOTTOM_RIGHT, "BOTTOM_RIGHT", "BOTTOM", "RIGHT")}
+                    </td>
+                    <td className={CELL_RIGHT_CLASS} />
+                </tr>
+                <tr className={ROW_CLASS}>
+                    <td className={classNames(CELL_CLASS, CELL_LEFT_CLASS)}>
+                        {this.renderPopover(Position.RIGHT_TOP, "RIGHT_TOP", "RIGHT", "TOP")}
+                        {this.renderPopover(Position.RIGHT, "RIGHT", "RIGHT", "(center)")}
+                        {this.renderPopover(Position.RIGHT_BOTTOM, "RIGHT_BOTTOM", "RIGHT", "BOTTOM")}
+                    </td>
+                    <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
+                        <span className={INSTRUCTIONS_CLASS}>
+                            Button positions are flipped so that all popovers open inward.
+                        </span>
+                    </td>
+                    <td className={classNames(CELL_CLASS, CELL_RIGHT_CLASS)}>
+                        {this.renderPopover(Position.LEFT_TOP, "LEFT_TOP", "LEFT", "TOP")}
+                        {this.renderPopover(Position.LEFT, "LEFT", "LEFT", "(center)")}
+                        {this.renderPopover(Position.LEFT_BOTTOM, "LEFT_BOTTOM", "LEFT", "BOTTOM")}
+                    </td>
+                </tr>
+                <tr className={ROW_CLASS}>
+                    <td className={CELL_LEFT_CLASS} />
+                    <td className={classNames(CELL_CLASS, CELL_CENTER_CLASS)}>
+                        {this.renderPopover(Position.TOP_LEFT, "TOP_LEFT", "TOP", "LEFT")}
+                        {this.renderPopover(Position.TOP, "TOP", "TOP", "(center)")}
+                        {this.renderPopover(Position.TOP_RIGHT, "TOP_RIGHT", "TOP", "RIGHT")}
+                    </td>
+                    <td className={CELL_RIGHT_CLASS} />
+                </tr>
+            </table>
+        );
+    }
+
+    private renderPopover(position: "auto" | Position, buttonLabel: string, popoverLabel: string, arrowLabel: string) {
+        const alignMessage =
+            arrowLabel === CENTER_LABEL ? (
+                <>
+                    Aligned at <code>(center)</code>.
+                </>
+            ) : (
+                <>
+                    Aligned on <code>{arrowLabel}</code> edge.
+                </>
+            );
+        const content = (
+            <div>
+                Popover on <code>{popoverLabel}</code>.<br />
+                {alignMessage}
+            </div>
+        );
+        return (
+            <Popover content={content} inline={true} position={position}>
+                <Button>{buttonLabel}</Button>
+            </Popover>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Button, Intent, IPopoverProps, Popover, Position } from "@blueprintjs/core";
+import { BaseExample } from "@blueprintjs/docs";
+import { FileMenu } from "./common/fileMenu";
+
+export class PopoverSizingExample extends BaseExample<{}> {
+    protected className = "docs-popover-sizing-example";
+
+    protected renderExample() {
+        return (
+            <div>
+                <Popover content={<FileMenu />} inline={true} position={Position.BOTTOM_LEFT}>
+                    <Button>Open...</Button>
+                </Popover>
+            </div>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, Intent, IPopoverProps, Popover, Position } from "@blueprintjs/core";
+import { Button, Popover, Position } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
 import { FileMenu } from "./common/fileMenu";
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -281,6 +281,59 @@
   }
 }
 
+.docs-popover-inline-example {
+  .docs-popover-inline-example-content {
+    display: flex;
+    flex: 1 1 auto;
+  }
+
+  .docs-popover-inline-example-scroll-container {
+    flex: 1 1 auto;
+    border: 1px solid $pt-divider-black;
+    border-radius: $pt-border-radius;
+    box-shadow: inset 0 1px 1px rgba($black, 0.05);
+    background: $light-gray4;
+    overflow-x: scroll;
+    overflow-y: hidden;
+
+    .pt-dark & {
+      border-color: $pt-dark-divider-black;
+      background: $dark-gray2;
+    }
+
+    &:first-child {
+      margin-right: $pt-grid-size;
+    }
+
+    &:last-child {
+      margin-left: $pt-grid-size;
+    }
+  }
+
+  .docs-popover-inline-example-scroll-content {
+    // can't compute this height easily using SCSS variables. instead of using
+    // JS to measure, just hardcode it since we have full control of all the
+    // example code.
+    $assumed-height-of-target-plus-popover: $pt-grid-size * 8.5;
+    $vertical-padding: $pt-grid-size * 2;
+
+    display: flex;
+    justify-content: center;
+    // wide enough to allow scrolling, but wide enough to let the popover target
+    // fully leave the viewport.
+    width: 200%;
+    height: $assumed-height-of-target-plus-popover + (2 * $vertical-padding);
+    padding-top: $vertical-padding;
+  }
+}
+
+.docs-popover-inline-example-popover {
+  .pt-popover-content {
+    padding: $pt-grid-size;
+    white-space: nowrap;
+  }
+}
+
 .docs-tooltip-example {
   > div {
     margin-bottom: $pt-grid-size;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -274,6 +274,13 @@
   }
 }
 
+.docs-popover-sizing-example {
+  .pt-popover-content {
+    max-height: $pt-grid-size * 15;
+    overflow-y: auto;
+  }
+}
+
 .docs-tooltip-example {
   > div {
     margin-bottom: $pt-grid-size;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -207,6 +207,60 @@
   }
 }
 
+.docs-popover-position-example {
+  .docs-popover-position-example-instructions {
+    display: inline-block;
+    max-width: 25 * $pt-grid-size;
+    color: $gray3;
+    font-style: italic;
+  }
+
+  .docs-popover-position-example-button {
+    font-family: $pt-font-family-monospace;
+  }
+
+  .docs-popover-position-example-table {
+    margin: 0 auto;
+  }
+
+  .docs-popover-position-example-cell-right,
+  .docs-popover-position-example-cell-left {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .docs-popover-position-example-cell-center {
+    text-align: center;
+  }
+
+  .docs-popover-position-example-cell-left {
+    align-items: flex-end;
+  }
+
+  .pt-popover-wrapper {
+    // Add a bit of space between borders of consecutive buttons.
+    margin: $pt-grid-size / 2;
+  }
+
+  .pt-popover-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    // big enough to make the shifting arrow position noticeable
+    width: 20 * $pt-grid-size;
+    height: 7 * $pt-grid-size;
+    padding: $pt-grid-size * 2;
+    text-align: center;
+    // increase line height to leave room between stacked <code> blocks.
+    line-height: $pt-line-height * 1.1;
+    white-space: nowrap;
+
+    code {
+      font-weight: 600;
+    }
+  }
+}
+
 .docs-tooltip-example {
   > div {
     margin-bottom: $pt-grid-size;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -261,6 +261,12 @@
   }
 }
 
+.docs-popover-minimal-example {
+  .pt-button:first-child {
+    margin-right: $pt-grid-size;
+  }
+}
+
 .docs-tooltip-example {
   > div {
     margin-bottom: $pt-grid-size;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -267,6 +267,13 @@
   }
 }
 
+.docs-popover-interaction-kind-example {
+  .pt-button {
+    margin-right: $pt-grid-size;
+    font-family: $pt-font-family-monospace;
+  }
+}
+
 .docs-tooltip-example {
   > div {
     margin-bottom: $pt-grid-size;

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -1,6 +1,8 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the terms of the LICENSE file distributed with this project.
 
+@import "~@blueprintjs/core/src/common/variables";
+
 // Generate a selector for a page ID by reference
 @function page($ref, $comparator: "=") {
   @return "[data-page-id#{$comparator}\"#{$ref}\"]";
@@ -267,5 +269,21 @@
   .docs-react-example {
     width: 100%;
     height: $pt-grid-size * 30;
+  }
+}
+
+#{page("popover")} {
+  .docs-popover-position-value-code-block {
+    text-align: center;
+    font-size: $pt-font-size-large;
+    font-weight: 600;
+  }
+
+  .docs-popover-position-label-side {
+    color: $cobalt3;
+  }
+
+  .docs-popover-position-label-alignment {
+    color: $forest3;
   }
 }

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -1,6 +1,11 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the terms of the LICENSE file distributed with this project.
 
+// Generate a selector for a page ID by reference
+@function page($ref, $comparator: "=") {
+  @return "[data-page-id#{$comparator}\"#{$ref}\"]";
+}
+
 // Generate a selector for a KSS example by reference
 @function reference($ref, $comparator: "=") {
   @return "[data-reference#{$comparator}\"#{$ref}\"]";
@@ -257,7 +262,7 @@
 }
 
 // give all Table examples a fixed height
-[data-page-id="table-js"] {
+#{page("table-js")} {
   .pt-table-container,
   .docs-react-example {
     width: 100%;


### PR DESCRIPTION
Lots of popover docs changes.

Best part IMO is the new `Position` docs, which feature (\*gasp\*) _color_:

![image](https://user-images.githubusercontent.com/443450/34187247-4cb8cb4e-e4e5-11e7-842c-ddedc2158b52.png)

But we also have several, more granular _examples_:

![2017-12-20 13 48 10](https://user-images.githubusercontent.com/443450/34230325-9325f528-e58c-11e7-9b19-7c23ec7bf1c8.gif)
![2017-12-20 13 47 46](https://user-images.githubusercontent.com/443450/34230326-933c72b2-e58c-11e7-913a-f1abaeea24ed.gif)
![2017-12-20 13 51 38](https://user-images.githubusercontent.com/443450/34230425-ef1c3090-e58c-11e7-8ed1-ef1cbc55bc26.gif)
![2017-12-20 17 53 19](https://user-images.githubusercontent.com/443450/34236923-b56596ee-e5ae-11e7-9d50-036c22e837a4.gif)
![2017-12-21 13 43 48](https://user-images.githubusercontent.com/443450/34276185-2a30f8d2-e655-11e7-8cf7-7bf09afc0caf.gif)



#### Next steps (in future PRs):
- [x] Add validation errors that old `Popover` used to throw (#1953)
- [x] Fix bugs with `ButtonGroup` + `Popover` composition

_Maybe_:
- [ ] Re-add `SVGPopover` and `SVGTooltip`? _Still lots of testing issues with this that I'd need to untangle._
- [x] `TagInput` tests (#1960)