### PR TITLE
Graduate Labs Components - Part 4: Popover validation

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -54,8 +54,6 @@ export const POPOVER_WARN_DOUBLE_TARGET =
     ns + ` <Popover> with children ignores target prop; use either prop or children.`;
 export const POPOVER_WARN_EMPTY_CONTENT = ns + ` Disabling <Popover> with empty/whitespace content...`;
 export const POPOVER_WARN_MODAL_INLINE = ns + ` <Popover inline={true}> ignores isModal`;
-export const POPOVER_WARN_DEPRECATED_CONSTRAINTS =
-    ns + ` <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 
 export const PORTAL_CONTEXT_CLASS_NAME_STRING = ns + ` <Portal> context blueprintPortalClassName must be string`;

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -56,8 +56,6 @@ export const POPOVER_WARN_EMPTY_CONTENT = ns + ` Disabling <Popover> with empty/
 export const POPOVER_WARN_MODAL_INLINE = ns + ` <Popover inline={true}> ignores isModal`;
 export const POPOVER_WARN_DEPRECATED_CONSTRAINTS =
     ns + ` <Popover> constraints and useSmartPositioning are deprecated. Use tetherOptions directly.`;
-export const POPOVER_WARN_INLINE_NO_TETHER =
-    ns + ` <Popover inline={true}> ignores tetherOptions, constraints, and useSmartPositioning.`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 
 export const PORTAL_CONTEXT_CLASS_NAME_STRING = ns + ` <Portal> context blueprintPortalClassName must be string`;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -14,6 +14,7 @@ type Placement = PopperJS.Placement;
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
+import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
 import * as Utils from "../../common/utils";
@@ -299,7 +300,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
         const isContentEmpty = children.content == null;
         if (isContentEmpty && !disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
-            console.warn("[Blueprint] Disabling <Popover> with empty/whitespace content...");
+            console.warn(Errors.POPOVER_WARN_EMPTY_CONTENT);
         }
 
         return (

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -299,6 +299,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         });
 
         const isContentEmpty = children.content == null;
+        // need to do this check in render(), because `isOpen` is derived from
+        // state, and state can't necessarily be accessed in validateProps.
         if (isContentEmpty && !disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
             console.warn(Errors.POPOVER_WARN_EMPTY_CONTENT);
         }
@@ -370,6 +372,35 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
     public componentWillUnmount() {
         super.componentWillUnmount();
+    }
+
+    protected validateProps(props: IPopoverProps & { children?: React.ReactNode }) {
+        if (props.isOpen == null && props.onInteraction != null) {
+            console.warn(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
+        }
+        if (props.hasBackdrop && props.inline) {
+            console.warn(Errors.POPOVER_WARN_MODAL_INLINE);
+        }
+        if (props.hasBackdrop && props.interactionKind !== PopoverInteractionKind.CLICK) {
+            throw new Error(Errors.POPOVER_MODAL_INTERACTION);
+        }
+
+        const childrenCount = React.Children.count(props.children);
+        const hasContentProp = props.content !== undefined;
+        const hasTargetProp = props.target !== undefined;
+
+        if (childrenCount === 0 && !hasTargetProp) {
+            throw new Error(Errors.POPOVER_REQUIRES_TARGET);
+        }
+        if (childrenCount > 2) {
+            console.warn(Errors.POPOVER_WARN_TOO_MANY_CHILDREN);
+        }
+        if (childrenCount > 0 && hasTargetProp) {
+            console.warn(Errors.POPOVER_WARN_DOUBLE_TARGET);
+        }
+        if (childrenCount === 2 && hasContentProp) {
+            console.warn(Errors.POPOVER_WARN_DOUBLE_CONTENT);
+        }
     }
 
     private updateDarkParent() {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -326,10 +326,9 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
         if (nextProps.isOpen != null && nextIsOpen !== this.state.isOpen) {
             this.setOpenState(nextIsOpen);
-            if (nextProps.isOpen != null) {
-                // setOpenState only calls setState if isOpen is not controlled.
-                this.setState({ isOpen: nextIsOpen });
-            }
+            // tricky: setOpenState calls setState only if this.props.isOpen is
+            // not controlled, so we need to invoke setState manually here.
+            this.setState({ isOpen: nextIsOpen });
         } else if (this.state.isOpen && nextProps.isOpen == null && nextProps.disabled) {
             // special case: close an uncontrolled popover when disabled is set to true
             this.setOpenState(false);
@@ -462,7 +461,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
     private getIsOpen(props?: IPopoverProps) {
         // disabled popovers should never be allowed to open.
-        if (props.disabled) {
+        if (props == null || props.disabled) {
             return false;
         } else if (props.isOpen != null) {
             return props.isOpen;

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -243,8 +243,8 @@ describe("<Popover>", () => {
     });
 
     it("rootElementTag prop renders the right elements", () => {
-        wrapper = renderPopover({ isOpen: true, rootElementTag: "g" });
-        assert.isNotNull(wrapper.find("g"));
+        wrapper = renderPopover({ isOpen: true, rootElementTag: "article" });
+        assert.isNotNull(wrapper.find("article"));
     });
 
     describe("openOnTargetFocus", () => {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -76,6 +76,17 @@ describe("<Popover>", () => {
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_CONTENT));
             warnSpy.restore();
         });
+
+        it("warns if attempting to open a popover with empty content", () => {
+            const warnSpy = sinon.spy(console, "warn");
+            shallow(
+                <Popover content={null} isOpen={true}>
+                    {"target"}
+                </Popover>,
+            );
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_EMPTY_CONTENT));
+            warnSpy.restore();
+        });
     });
 
     it("propagates class names correctly", () => {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -52,7 +52,7 @@ describe("<Popover>", () => {
         });
 
         it("warns if given > 2 target elements", () => {
-            // use sinon.stub to prevent warnings from appearing the test logs
+            // use sinon.stub to prevent warnings from appearing in the test logs
             const warnSpy = sinon.stub(console, "warn");
             shallow(
                 <Popover>
@@ -108,9 +108,9 @@ describe("<Popover>", () => {
         });
 
         describe("throws error if backdrop enabled with non-CLICK interactionKind", () => {
-            runErrorTest("HOVER", PopoverInteractionKind.HOVER);
-            runErrorTest("HOVER_TARGET_ONLY", PopoverInteractionKind.HOVER_TARGET_ONLY);
-            runErrorTest("CLICK_TARGET_ONLY", PopoverInteractionKind.CLICK_TARGET_ONLY);
+            runErrorTest("HOVER");
+            runErrorTest("HOVER_TARGET_ONLY");
+            runErrorTest("CLICK_TARGET_ONLY");
 
             it("doesn't throw error for CLICK", () => {
                 assert.doesNotThrow(() => (
@@ -118,11 +118,11 @@ describe("<Popover>", () => {
                 ));
             });
 
-            function runErrorTest(testName: string, interactionKind: PopoverInteractionKind) {
-                it(testName, () => {
+            function runErrorTest(interactionKindKey: keyof typeof PopoverInteractionKind) {
+                it(interactionKindKey, () => {
                     expectPropValidationError(
                         Popover,
-                        { hasBackdrop: true, interactionKind },
+                        { hasBackdrop: true, interactionKind: PopoverInteractionKind[interactionKindKey] },
                         Errors.POPOVER_MODAL_INTERACTION,
                     );
                 });


### PR DESCRIPTION
- Handle all the validation errors that old `Popover` used to handle.
- Fix interaction between `Popover`'s `disabled` prop and `isOpen` prop.
    - `disabled=true` overrides `isOpen=true`, keeping the popover closed.
    - Invoke `onInteraction` whenever the `this.state.isOpen` changes as a result of changing the `disabled` prop.
- Write tests.

