### PR TITLE
Adding input-level props to tagInput

### DIFF
--- a/packages/labs/src/components/tag-input/tag-input.md
+++ b/packages/labs/src/components/tag-input/tag-input.md
@@ -18,7 +18,7 @@
 
 `TagInput` provides granular `onAdd` and `onRemove` **event props**, which are passed the added or removed items in response to the user interactions above. It also provides `onChange`, which combines both events and is passed the updated `values` array, with new items appended to the end and removed items filtered away.
 
-`inputValue` allows for direct manipulation of the `<input>` element's text. Use `onInputChange` to respond to changes to the `<input>` text. Additional properties (such as custom event handlers) can be applied to the `<input>` element via `inputProps`.
+The `<input>` element can be controlled directly via the `inputValue` and `onInputChange` props. Additional properties (such as custom event handlers) can be applied to the input via `inputProps`.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
     <h5>Handling long words</h5>

--- a/packages/labs/src/components/tag-input/tag-input.md
+++ b/packages/labs/src/components/tag-input/tag-input.md
@@ -16,7 +16,9 @@
 
 **`Tag` appearance can be customized** with `tagProps`: supply an object to apply the same props to every tag, or supply a callback to apply dynamic props per tag. Tag `values` must be an array of strings so you may need a transformation step between your state and these props.
 
-`TagInput` provides granular `onAdd` and `onRemove` **event props**, which are passed the added or removed items in response to the user interactions above. It also provides `onChange`, which combines both events and is passed the updated `values` array, with new items appended to the end and removed items filtered away. Supply `inputProps` to customize the `<input>` element or add your own event handlers.
+`TagInput` provides granular `onAdd` and `onRemove` **event props**, which are passed the added or removed items in response to the user interactions above. It also provides `onChange`, which combines both events and is passed the updated `values` array, with new items appended to the end and removed items filtered away.
+
+`inputValue` allows for direct manipulation of the `<input>` element's text. Use `onInputChange` to respond to changes to the `<input>` text. Additional properties (such as custom event handlers) can be applied to the `<input>` element via `inputProps`.
 
 <div class="pt-callout pt-intent-primary pt-icon-info-sign">
     <h5>Handling long words</h5>

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -31,10 +31,10 @@ export interface ITagInputProps extends IProps {
      */
     disabled?: boolean;
 
-    /** React props to pass to the `<input>` element */
+    /** React props to pass to the `<input>` element. */
     inputProps?: HTMLInputProps;
 
-    /** Controlled value of the `<input>` element */
+    /** Controlled value of the `<input>` element. This is shorthand for inputProps={{ value }}. */
     inputValue?: string;
 
     /** Name of the icon (the part after `pt-icon-`) to render on left side of input. */
@@ -51,7 +51,10 @@ export interface ITagInputProps extends IProps {
      */
     onAdd?: (values: string[]) => boolean | void;
 
-    /** Callback invoked when the value of `<input>` element is changed */
+    /**
+     * Callback invoked when the value of `<input>` element is changed.
+     * This is shorthand for inputProps={{ onChange }}.
+     */
     onInputChange?: React.FormEventHandler<HTMLInputElement>;
 
     /**
@@ -154,7 +157,6 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         inputProps: {},
-        inputValue: "",
         separator: ",",
         tagProps: {},
     };
@@ -304,6 +306,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
     private handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.setState({ activeIndex: NONE, inputValue: event.currentTarget.value });
         Utils.safeInvoke(this.props.onInputChange, event);
+        Utils.safeInvoke(this.props.inputProps.onChange, event);
     };
 
     private handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -34,6 +34,9 @@ export interface ITagInputProps extends IProps {
     /** React props to pass to the `<input>` element */
     inputProps?: HTMLInputProps;
 
+    /** Controlled value of the `<input>` element */
+    inputValue?: string;
+
     /** Name of the icon (the part after `pt-icon-`) to render on left side of input. */
     leftIconName?: IconName;
 
@@ -47,6 +50,9 @@ export interface ITagInputProps extends IProps {
      * not be added as a tag.
      */
     onAdd?: (values: string[]) => boolean | void;
+
+    /** Callback invoked when the value of `<input>` element is changed */
+    onInputChange?: React.FormEventHandler<HTMLInputElement>;
 
     /**
      * Callback invoked when new tags are added or removed. Receives the updated list of `values`:
@@ -148,13 +154,14 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         inputProps: {},
+        inputValue: "",
         separator: ",",
         tagProps: {},
     };
 
     public state: ITagInputState = {
         activeIndex: NONE,
-        inputValue: "",
+        inputValue: this.props.inputValue,
         isInputFocused: false,
     };
 
@@ -169,6 +176,14 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
             }
         },
     };
+
+    public componentWillReceiveProps(nextProps: HTMLInputProps & ITagInputProps) {
+        super.componentWillReceiveProps(nextProps);
+
+        if (nextProps.inputValue !== this.props.inputValue) {
+            this.setState({ inputValue: nextProps.inputValue });
+        }
+    }
 
     public render() {
         const { className, inputProps, leftIconName, placeholder, values } = this.props;
@@ -288,7 +303,7 @@ export class TagInput extends AbstractComponent<ITagInputProps, ITagInputState> 
 
     private handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.setState({ activeIndex: NONE, inputValue: event.currentTarget.value });
-        Utils.safeInvoke(this.props.inputProps.onChange, event);
+        Utils.safeInvoke(this.props.onInputChange, event);
     };
 
     private handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/labs/src/components/tag-input/tagInput.tsx
+++ b/packages/labs/src/components/tag-input/tagInput.tsx
@@ -34,7 +34,7 @@ export interface ITagInputProps extends IProps {
     /** React props to pass to the `<input>` element. */
     inputProps?: HTMLInputProps;
 
-    /** Controlled value of the `<input>` element. This is shorthand for inputProps={{ value }}. */
+    /** Controlled value of the `<input>` element. This is shorthand for `inputProps={{ value }}`. */
     inputValue?: string;
 
     /** Name of the icon (the part after `pt-icon-`) to render on left side of input. */
@@ -50,12 +50,6 @@ export interface ITagInputProps extends IProps {
      * not be added as a tag.
      */
     onAdd?: (values: string[]) => boolean | void;
-
-    /**
-     * Callback invoked when the value of `<input>` element is changed.
-     * This is shorthand for inputProps={{ onChange }}.
-     */
-    onInputChange?: React.FormEventHandler<HTMLInputElement>;
 
     /**
      * Callback invoked when new tags are added or removed. Receives the updated list of `values`:
@@ -77,6 +71,12 @@ export interface ITagInputProps extends IProps {
      * ```
      */
     onChange?: (values: React.ReactNode[]) => boolean | void;
+
+    /**
+     * Callback invoked when the value of `<input>` element is changed.
+     * This is shorthand for `inputProps={{ onChange }}`.
+     */
+    onInputChange?: React.FormEventHandler<HTMLInputElement>;
 
     /**
      * Callback invoked when the user depresses a keyboard key.

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -397,7 +397,7 @@ describe("<TagInput>", () => {
         const NEW_VALUE = "new item";
         it("passes initial inputValue to input element", () => {
             const input = shallow(<TagInput values={VALUES} inputValue={NEW_VALUE} />).find("input");
-            assert.isTrue(input.prop("value") === NEW_VALUE);
+            expect(input.prop("value")).to.equal(NEW_VALUE);
             expect(input.prop("value")).to.equal(NEW_VALUE);
         });
 

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -398,9 +398,10 @@ describe("<TagInput>", () => {
         it("passes initial inputValue to input element", () => {
             const input = shallow(<TagInput values={VALUES} inputValue={NEW_VALUE} />).find("input");
             assert.isTrue(input.prop("value") === NEW_VALUE);
+            expect(input.prop("value")).to.equal(NEW_VALUE);
         });
 
-        it("accepts successive input value changes", () => {
+        it("prop changes are reflected in state", () => {
             const wrapper = mount(<TagInput values={VALUES} />);
             wrapper.setProps({ inputValue: "a" });
             expect(wrapper.state().inputValue).to.equal("a");
@@ -412,11 +413,10 @@ describe("<TagInput>", () => {
 
         it("Updating inputValue updates input element", () => {
             const wrapper = mount(<TagInput values={VALUES} />);
-            const input = wrapper.find("input");
             wrapper.setProps({
                 inputValue: NEW_VALUE,
             });
-            assert.isTrue(input.prop("value") === NEW_VALUE);
+            expect(wrapper.find("input").prop("value")).to.equal(NEW_VALUE);
         });
     });
 

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -403,7 +403,6 @@ describe("<TagInput>", () => {
         it("accepts successive input value changes", () => {
             const wrapper = mount(<TagInput values={VALUES} />);
             wrapper.setProps({ inputValue: "a" });
-            console.log(wrapper.state());
             expect(wrapper.state().inputValue).to.equal("a");
             wrapper.setProps({ inputValue: "b" });
             expect(wrapper.state().inputValue).to.equal("b");

--- a/packages/labs/test/tagInputTests.tsx
+++ b/packages/labs/test/tagInputTests.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import { mount, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
@@ -373,6 +373,51 @@ describe("<TagInput>", () => {
         );
         wrapper.find(Tag).forEach(tag => {
             assert.isFalse(tag.hasClass("pt-tag-removeable"), ".pt-tag should not have .pt-tag-removable applied");
+        });
+    });
+
+    describe("onInputChange", () => {
+        it("is not invoked on enter when input is empty", () => {
+            const onInputChange = sinon.stub();
+            const wrapper = shallow(<TagInput onInputChange={onInputChange} values={VALUES} />);
+            pressEnterInInput(wrapper, "");
+            assert.isTrue(onInputChange.notCalled);
+        });
+
+        it("is invoked when input text changes", () => {
+            const changeSpy: any = sinon.spy();
+            const wrapper = shallow(<TagInput onInputChange={changeSpy} values={VALUES} />);
+            wrapper.find("input").simulate("change", { currentTarget: { value: "hello" } });
+            assert.isTrue(changeSpy.calledOnce, "onChange called");
+            assert.equal("hello", changeSpy.args[0][0].currentTarget.value);
+        });
+    });
+
+    describe("inputValue", () => {
+        const NEW_VALUE = "new item";
+        it("passes initial inputValue to input element", () => {
+            const input = shallow(<TagInput values={VALUES} inputValue={NEW_VALUE} />).find("input");
+            assert.isTrue(input.prop("value") === NEW_VALUE);
+        });
+
+        it("accepts successive input value changes", () => {
+            const wrapper = mount(<TagInput values={VALUES} />);
+            wrapper.setProps({ inputValue: "a" });
+            console.log(wrapper.state());
+            expect(wrapper.state().inputValue).to.equal("a");
+            wrapper.setProps({ inputValue: "b" });
+            expect(wrapper.state().inputValue).to.equal("b");
+            wrapper.setProps({ inputValue: "c" });
+            expect(wrapper.state().inputValue).to.equal("c");
+        });
+
+        it("Updating inputValue updates input element", () => {
+            const wrapper = mount(<TagInput values={VALUES} />);
+            const input = wrapper.find("input");
+            wrapper.setProps({
+                inputValue: NEW_VALUE,
+            });
+            assert.isTrue(input.prop("value") === NEW_VALUE);
         });
     });
 


### PR DESCRIPTION
#### Fixes #1412 bullet 1

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

inputValue, onInputChange props to listen/control input without resorting to inputProps

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
