### PR TITLE
Graduate Labs Components: Fix/Improve Popover Examples

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -42,8 +42,8 @@ export const NUMERIC_INPUT_STEP_SIZE_NULL = ns + ` <NumericInput> requires stepS
 // TODO (clewis): Migrate old Popover validation errors to the component formerly known as Popover2.
 // See: https://github.com/palantir/blueprint/issues/1940
 export const POPOVER_REQUIRES_TARGET = ns + ` <Popover> requires target prop or at least one child element.`;
-export const POPOVER_MODAL_INTERACTION =
-    ns + ` <Popover isModal={true}> requires interactionKind={PopoverInteractionKind.CLICK}.`;
+export const POPOVER_HAS_BACKDROP_INTERACTION =
+    ns + ` <Popover hasBackdrop={true}> requires interactionKind={PopoverInteractionKind.CLICK}.`;
 export const POPOVER_WARN_TOO_MANY_CHILDREN =
     ns +
     ` <Popover> supports one or two children; additional children are ignored.` +
@@ -53,7 +53,7 @@ export const POPOVER_WARN_DOUBLE_CONTENT =
 export const POPOVER_WARN_DOUBLE_TARGET =
     ns + ` <Popover> with children ignores target prop; use either prop or children.`;
 export const POPOVER_WARN_EMPTY_CONTENT = ns + ` Disabling <Popover> with empty/whitespace content...`;
-export const POPOVER_WARN_MODAL_INLINE = ns + ` <Popover inline={true}> ignores isModal`;
+export const POPOVER_WARN_HAS_BACKDROP_INLINE = ns + ` <Popover inline={true}> ignores hasBackdrop`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 
 export const PORTAL_CONTEXT_CLASS_NAME_STRING = ns + ` <Portal> context blueprintPortalClassName must be string`;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -358,10 +358,10 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
             console.warn(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
         }
         if (props.hasBackdrop && props.inline) {
-            console.warn(Errors.POPOVER_WARN_MODAL_INLINE);
+            console.warn(Errors.POPOVER_WARN_HAS_BACKDROP_INLINE);
         }
         if (props.hasBackdrop && props.interactionKind !== PopoverInteractionKind.CLICK) {
-            throw new Error(Errors.POPOVER_MODAL_INTERACTION);
+            throw new Error(Errors.POPOVER_HAS_BACKDROP_INTERACTION);
         }
 
         const childrenCount = React.Children.count(props.children);

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -103,7 +103,7 @@ describe("<Popover>", () => {
                     {"content"}
                 </Popover>,
             );
-            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_MODAL_INLINE));
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_HAS_BACKDROP_INLINE));
             warnSpy.restore();
         });
 
@@ -123,7 +123,7 @@ describe("<Popover>", () => {
                     expectPropValidationError(
                         Popover,
                         { hasBackdrop: true, interactionKind: PopoverInteractionKind[interactionKindKey] },
-                        Errors.POPOVER_MODAL_INTERACTION,
+                        Errors.POPOVER_HAS_BACKDROP_INTERACTION,
                     );
                 });
             }

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -271,9 +271,13 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
 
     private centerScroll = (div: HTMLDivElement) => {
         if (div != null) {
-            const container = div.parentElement;
-            container.scrollTop = div.clientHeight / 4;
-            container.scrollLeft = div.clientWidth / 4;
+            // if we don't requestAnimationFrame, this function apparently executes
+            // before styles are applied to the page, so the centering is way off.
+            requestAnimationFrame(() => {
+                const container = div.parentElement;
+                container.scrollTop = div.clientHeight / 4;
+                container.scrollLeft = div.clientWidth / 4;
+            });
         }
     };
 }

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, Popover, Position } from "@blueprintjs/core";
+import { Button, IPopoverProps, Popover, Position } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
 
 export class PopoverInlineExample extends BaseExample<{}> {
@@ -24,18 +24,20 @@ export class PopoverInlineExample extends BaseExample<{}> {
     }
 
     protected renderExample() {
+        const popoverBaseProps: IPopoverProps = {
+            enforceFocus: false,
+            isOpen: true,
+            // prevent-overflow functionality is irrelevant to this example
+            modifiers: { preventOverflow: { enabled: false } },
+            popoverClassName: "docs-popover-inline-example-popover",
+            position: Position.BOTTOM,
+        };
+
         return (
             <div className="docs-popover-inline-example-content">
                 <div className="docs-popover-inline-example-scroll-container" ref={this.refHandlers.scrollContainer1}>
                     <div className="docs-popover-inline-example-scroll-content">
-                        <Popover
-                            content="I am a default popover."
-                            inline={false}
-                            isOpen={true}
-                            modifiers={{ preventOverflow: { boundariesElement: "window" } }}
-                            popoverClassName="docs-popover-inline-example-popover"
-                            position={Position.BOTTOM}
-                        >
+                        <Popover {...popoverBaseProps} content="I am a default popover." inline={false}>
                             <Button>
                                 <code>{`inline={false}`}</code>
                             </Button>
@@ -44,14 +46,7 @@ export class PopoverInlineExample extends BaseExample<{}> {
                 </div>
                 <div className="docs-popover-inline-example-scroll-container" ref={this.refHandlers.scrollContainer2}>
                     <div className="docs-popover-inline-example-scroll-content">
-                        <Popover
-                            content="I am an inline popover."
-                            inline={true}
-                            isOpen={true}
-                            modifiers={{ preventOverflow: { boundariesElement: "window" } }}
-                            popoverClassName="docs-popover-inline-example-popover"
-                            position={Position.BOTTOM}
-                        >
+                        <Popover {...popoverBaseProps} content="I am an inline popover." inline={true}>
                             <Button>
                                 <code>{`inline={true}`}</code>
                             </Button>

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -20,7 +20,9 @@ export class PopoverInlineExample extends BaseExample<{}> {
     };
 
     public componentDidMount() {
-        this.recenter();
+        // if we don't requestAnimationFrame, this function apparently executes
+        // before styles are applied to the page, so the centering is way off.
+        requestAnimationFrame(this.recenter);
     }
 
     protected renderExample() {

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -46,8 +46,9 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
             // `keepTogether` functionality apparently doesn't work once you
             // render an open popover in a portal on mount.
             isOpen: this.state.hasMounted ? true : false,
-            // prevent-overflow functionality is irrelevant to this example
-            modifiers: { preventOverflow: { enabled: false } },
+            // not relevant to this example, but required in order for default
+            // modifiers to work (e.g. `hide`).
+            modifiers: { preventOverflow: { boundariesElement: "window" } },
             popoverClassName: "docs-popover-inline-example-popover",
             position: Position.BOTTOM,
         };

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -57,7 +57,6 @@ export class PopoverInteractionKindExample extends BaseExample<{}> {
             <Popover
                 {...popoverProps}
                 content={<FileMenu shouldDismissPopover={false} />}
-                inline={true}
                 position={Position.BOTTOM_LEFT}
                 interactionKind={interactionKind}
             >

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -6,26 +6,12 @@
 
 import * as React from "react";
 
-import {
-    Button,
-    IButtonProps,
-    Intent,
-    IPopoverProps,
-    Popover,
-    PopoverInteractionKind,
-    Position,
-    Toaster,
-} from "@blueprintjs/core";
+import { Button, Intent, Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
 import { FileMenu } from "./common/fileMenu";
 
 export class PopoverInteractionKindExample extends BaseExample<{}> {
     protected className = "docs-popover-interaction-kind-example";
-
-    private toaster: Toaster;
-    private refHandlers = {
-        toaster: (ref: Toaster) => (this.toaster = ref),
-    };
 
     protected renderExample() {
         return (
@@ -33,55 +19,24 @@ export class PopoverInteractionKindExample extends BaseExample<{}> {
                 {this.renderPopover("HOVER", PopoverInteractionKind.HOVER)}
                 {this.renderPopover("HOVER_TARGET_ONLY", PopoverInteractionKind.HOVER_TARGET_ONLY)}
                 {this.renderPopover("CLICK", PopoverInteractionKind.CLICK)}
-                {this.renderPopover(
-                    "CLICK_TARGET_ONLY",
-                    PopoverInteractionKind.CLICK_TARGET_ONLY,
-                    { onClick: this.handleClickTargetOnlyButtonClick },
-                    { popoverWillClose: this.handleClickTargetOnlyPopoverWillClose },
-                )}
-                <Toaster {...this.state} ref={this.refHandlers.toaster} />
+                {this.renderPopover("CLICK_TARGET_ONLY", PopoverInteractionKind.CLICK_TARGET_ONLY)}
             </div>
         );
     }
 
-    private renderPopover(
-        buttonLabel: string,
-        interactionKind: PopoverInteractionKind,
-        buttonProps?: IButtonProps,
-        popoverProps?: IPopoverProps,
-    ) {
+    private renderPopover(buttonLabel: string, interactionKind: PopoverInteractionKind) {
         // MenuItem's default shouldDismissPopover={true} behavior is confusing
         // in this example, since it introduces an additional way popovers can
         // close. set it to false here for clarity.
         return (
             <Popover
-                {...popoverProps}
                 content={<FileMenu shouldDismissPopover={false} />}
+                enforceFocus={false}
                 position={Position.BOTTOM_LEFT}
                 interactionKind={interactionKind}
             >
-                <Button intent={Intent.PRIMARY} {...buttonProps}>
-                    {buttonLabel}
-                </Button>
+                <Button intent={Intent.PRIMARY}>{buttonLabel}</Button>
             </Popover>
         );
     }
-
-    private handleClickTargetOnlyButtonClick = () => {
-        this.toaster.show({
-            iconName: "info-sign",
-            intent: Intent.PRIMARY,
-            message: (
-                <>
-                    Click the <code>CLICK_TARGET_ONLY</code> button again to close the popover and regain interactivity
-                    in the rest of the app.
-                </>
-            ),
-            timeout: -1,
-        });
-    };
-
-    private handleClickTargetOnlyPopoverWillClose = () => {
-        this.toaster.clear();
-    };
 }

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -6,12 +6,26 @@
 
 import * as React from "react";
 
-import { Button, Intent, Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
+import {
+    Button,
+    IButtonProps,
+    Intent,
+    IPopoverProps,
+    Popover,
+    PopoverInteractionKind,
+    Position,
+    Toaster,
+} from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs";
 import { FileMenu } from "./common/fileMenu";
 
 export class PopoverInteractionKindExample extends BaseExample<{}> {
     protected className = "docs-popover-interaction-kind-example";
+
+    private toaster: Toaster;
+    private refHandlers = {
+        toaster: (ref: Toaster) => (this.toaster = ref),
+    };
 
     protected renderExample() {
         return (
@@ -19,23 +33,56 @@ export class PopoverInteractionKindExample extends BaseExample<{}> {
                 {this.renderPopover("HOVER", PopoverInteractionKind.HOVER)}
                 {this.renderPopover("HOVER_TARGET_ONLY", PopoverInteractionKind.HOVER_TARGET_ONLY)}
                 {this.renderPopover("CLICK", PopoverInteractionKind.CLICK)}
-                {this.renderPopover("CLICK_TARGET_ONLY", PopoverInteractionKind.CLICK_TARGET_ONLY)}
+                {this.renderPopover(
+                    "CLICK_TARGET_ONLY",
+                    PopoverInteractionKind.CLICK_TARGET_ONLY,
+                    { onClick: this.handleClickTargetOnlyButtonClick },
+                    { popoverWillClose: this.handleClickTargetOnlyPopoverWillClose },
+                )}
+                <Toaster {...this.state} ref={this.refHandlers.toaster} />
             </div>
         );
     }
 
-    private renderPopover(buttonLabel: string, interactionKind: PopoverInteractionKind) {
+    private renderPopover(
+        buttonLabel: string,
+        interactionKind: PopoverInteractionKind,
+        buttonProps?: IButtonProps,
+        popoverProps?: IPopoverProps,
+    ) {
         // MenuItem's default shouldDismissPopover={true} behavior is confusing
         // in this example, since it introduces an additional way popovers can
         // close. set it to false here for clarity.
         return (
             <Popover
+                {...popoverProps}
                 content={<FileMenu shouldDismissPopover={false} />}
+                inline={true}
                 position={Position.BOTTOM_LEFT}
                 interactionKind={interactionKind}
             >
-                <Button intent={Intent.PRIMARY}>{buttonLabel}</Button>
+                <Button intent={Intent.PRIMARY} {...buttonProps}>
+                    {buttonLabel}
+                </Button>
             </Popover>
         );
     }
+
+    private handleClickTargetOnlyButtonClick = () => {
+        this.toaster.show({
+            iconName: "info-sign",
+            intent: Intent.PRIMARY,
+            message: (
+                <>
+                    Click the <code>CLICK_TARGET_ONLY</code> button again to close the popover and regain interactivity
+                    in the rest of the app.
+                </>
+            ),
+            timeout: -1,
+        });
+    };
+
+    private handleClickTargetOnlyPopoverWillClose = () => {
+        this.toaster.clear();
+    };
 }


### PR DESCRIPTION
- Fix docs-app scroll-jumping issue on the `PopoverInlineExample` by setting `enforceFocus={false}`
- Fix issue where `PopoverInlineExample` scroll containers weren't being centered on mount.
- Fix issue where `PopoverInlineExample` non-inline popover wasn't tracking the target.
- Set `enforceFocus={false}` on the `CLICK_TARGET_ONLY` example, so user can still click on things in the rest of the docs app. 
- Remove mentions of old props in Popover error-message constants.