### PR TITLE
Graduate Labs to Core: Stop using rAF in componentDidMount; change 1,2 => Left,Right

### DIFF
--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -28,15 +28,8 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
     };
 
     public componentDidMount() {
-        // if we don't requestAnimationFrame, this function apparently executes
-        // before styles are applied to the page, so the centering is way off.
-        requestAnimationFrame(this.recenter);
-        // likewise, Popper.js doesn't handle controlled, non-inline popovers
-        // properly if rendered with isOpen={true} on initial mount: popovers
-        // won't follow the target when scrolled. to fix, defer opening.
-        requestAnimationFrame(() => {
-            this.setState({ hasMounted: true });
-        });
+        this.recenter();
+        this.setState({ hasMounted: true });
     }
 
     protected renderExample() {

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -20,11 +20,11 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
 
     protected className = "docs-popover-inline-example";
 
-    private scrollContainer1Ref: HTMLDivElement;
-    private scrollContainer2Ref: HTMLDivElement;
+    private scrollContainerLeftRef: HTMLDivElement;
+    private scrollContainerRightRef: HTMLDivElement;
     private refHandlers = {
-        scrollContainer1: (ref: HTMLDivElement) => (this.scrollContainer1Ref = ref),
-        scrollContainer2: (ref: HTMLDivElement) => (this.scrollContainer2Ref = ref),
+        scrollContainerLeft: (ref: HTMLDivElement) => (this.scrollContainerLeftRef = ref),
+        scrollContainerRight: (ref: HTMLDivElement) => (this.scrollContainerRightRef = ref),
     };
 
     public componentDidMount() {
@@ -50,8 +50,8 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
             <div className="docs-popover-inline-example-content">
                 <div
                     className="docs-popover-inline-example-scroll-container"
-                    ref={this.refHandlers.scrollContainer1}
-                    onScroll={this.syncScroll1}
+                    ref={this.refHandlers.scrollContainerLeft}
+                    onScroll={this.syncScrollLeft}
                 >
                     <div className="docs-popover-inline-example-scroll-content">
                         <Popover {...popoverBaseProps} content="I am a default popover." inline={false}>
@@ -63,8 +63,8 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
                 </div>
                 <div
                     className="docs-popover-inline-example-scroll-container"
-                    ref={this.refHandlers.scrollContainer2}
-                    onScroll={this.syncScroll2}
+                    ref={this.refHandlers.scrollContainerRight}
+                    onScroll={this.syncScrollRight}
                 >
                     <div className="docs-popover-inline-example-scroll-content">
                         <Popover {...popoverBaseProps} content="I am an inline popover." inline={true}>
@@ -92,8 +92,8 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
     }
 
     private recenter = () => {
-        this.scrollToCenter(this.scrollContainer1Ref);
-        this.scrollToCenter(this.scrollContainer2Ref);
+        this.scrollToCenter(this.scrollContainerLeftRef);
+        this.scrollToCenter(this.scrollContainerRightRef);
     };
 
     private scrollToCenter = (scrollContainer?: HTMLDivElement) => {
@@ -103,13 +103,13 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
         }
     };
 
-    private syncScroll1 = () => {
+    private syncScrollLeft = () => {
         // use rAF to throttle scroll-sync calculations; otherwise, scrolling is noticeably choppy.
-        return requestAnimationFrame(() => this.syncScroll(this.scrollContainer1Ref, this.scrollContainer2Ref));
+        return requestAnimationFrame(() => this.syncScroll(this.scrollContainerLeftRef, this.scrollContainerRightRef));
     };
 
-    private syncScroll2 = () => {
-        return requestAnimationFrame(() => this.syncScroll(this.scrollContainer2Ref, this.scrollContainer1Ref));
+    private syncScrollRight = () => {
+        return requestAnimationFrame(() => this.syncScroll(this.scrollContainerRightRef, this.scrollContainerLeftRef));
     };
 
     private syncScroll(sourceContainer: HTMLDivElement, otherContainer: HTMLDivElement) {


### PR DESCRIPTION
- Stop using `requestAnimationFrame` in `PopoverInlineExample.componentDidMount`.
    - Assume prod mode will fix the flashes of unstyled content that led to my using these in the first place.
- (From a commit I failed to push before) Change:
    - `scrollSync{1,2}` to `scrollSync{Left,Right}`
    - `scrollContainer{1,2}Ref` to `scrollContainer{Left,Right}Ref`