### PR TITLE
Add Yesterday and Today shortcuts when allowSingleDayRange enabled

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -343,7 +343,11 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             return undefined;
         }
 
-        const shortcuts = typeof propsShortcuts === "boolean" ? createDefaultShortcuts() : propsShortcuts;
+        const shortcuts =
+            typeof propsShortcuts === "boolean"
+                ? createDefaultShortcuts(this.props.allowSingleDayRange)
+                : propsShortcuts;
+
         const shortcutElements = shortcuts.map((s, i) => {
             return (
                 <MenuItem
@@ -664,7 +668,7 @@ function createShortcut(label: string, dateRange: DateRange): IDateRangeShortcut
     return { dateRange, label };
 }
 
-function createDefaultShortcuts() {
+function createDefaultShortcuts(allowSingleDayRange: boolean) {
     const today = new Date();
     const makeDate = (action: (d: Date) => void) => {
         const returnVal = DateUtils.clone(today);
@@ -673,6 +677,7 @@ function createDefaultShortcuts() {
         return returnVal;
     };
 
+    const yesterday = makeDate(d => d.setDate(d.getDate() - 2));
     const oneWeekAgo = makeDate(d => d.setDate(d.getDate() - 7));
     const oneMonthAgo = makeDate(d => d.setMonth(d.getMonth() - 1));
     const threeMonthsAgo = makeDate(d => d.setMonth(d.getMonth() - 3));
@@ -680,7 +685,12 @@ function createDefaultShortcuts() {
     const oneYearAgo = makeDate(d => d.setFullYear(d.getFullYear() - 1));
     const twoYearsAgo = makeDate(d => d.setFullYear(d.getFullYear() - 2));
 
+    const singleDayShortcuts = allowSingleDayRange
+        ? [createShortcut("Today", [today, today]), createShortcut("Yesterday", [yesterday, yesterday])]
+        : [];
+
     return [
+        ...singleDayShortcuts,
         createShortcut("Past week", [oneWeekAgo, today]),
         createShortcut("Past month", [oneMonthAgo, today]),
         createShortcut("Past 3 months", [threeMonthsAgo, today]),

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -925,6 +925,17 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(today, onDateRangePickerChangeSpy.args[0][0][1]));
         });
 
+        it("shortcuts fire onChange with correct values when single day range enabled", () => {
+            renderDateRangePicker({ allowSingleDayRange: true });
+            clickFirstShortcut();
+
+            const today = new Date();
+
+            assert.isTrue(onDateRangePickerChangeSpy.calledOnce);
+            assert.isTrue(DateUtils.areSameDay(today, onDateRangePickerChangeSpy.args[0][0][0]));
+            assert.isTrue(DateUtils.areSameDay(today, onDateRangePickerChangeSpy.args[0][0][1]));
+        });
+
         it("custom shortcuts select the correct values", () => {
             const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)] as DateRange;
             renderDateRangePicker({


### PR DESCRIPTION

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Adding a "Today" and "Yesterday" shortcut to the date range selector. These only show up when allowSingleDayRange is enabled (since it wouldn't really work otherwise).

#### Screenshot

![image](https://user-images.githubusercontent.com/1369884/35274496-b13fdc66-0055-11e8-8f91-d0256d4d4ae4.png)

