### PR TITLE
[release/1.x] [table] measureTextContentWithExclusions

### DIFF
--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -191,7 +191,7 @@ export const Utils = {
      */
     measureElementTextContent(element: Element): TextMetrics {
         const context = document.createElement("canvas").getContext("2d");
-        const style = getComputedStyle(element);
+        const style = getComputedStyle(element, null);
         context.font = CSS_FONT_PROPERTIES.map(prop => style.getPropertyValue(prop)).join(" ");
         return measureTextContentWithExclusions(context, element);
     },

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -101,9 +101,7 @@ export class Locator implements ILocator {
 
     public getWidestVisibleCellInColumn(columnIndex: number): number {
         const columnCellSelector = this.getColumnCellSelector(columnIndex);
-        const columnHeaderAndBodyCells = this.tableElement.querySelectorAll(columnCellSelector) as NodeListOf<
-            HTMLElement
-        >;
+        const columnHeaderAndBodyCells = this.tableElement.querySelectorAll(columnCellSelector);
 
         let maxWidth = 0;
         for (let i = 0; i < columnHeaderAndBodyCells.length; i++) {

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -101,7 +101,9 @@ export class Locator implements ILocator {
 
     public getWidestVisibleCellInColumn(columnIndex: number): number {
         const columnCellSelector = this.getColumnCellSelector(columnIndex);
-        const columnHeaderAndBodyCells = this.tableElement.querySelectorAll(columnCellSelector);
+        const columnHeaderAndBodyCells = this.tableElement.querySelectorAll(columnCellSelector) as NodeListOf<
+            HTMLElement
+        >;
 
         let maxWidth = 0;
         for (let i = 0; i < columnHeaderAndBodyCells.length; i++) {


### PR DESCRIPTION
### Motivation

We'd like to add some text to our column headers (column descriptions) which should be shown in the header cell (as an affordance to users that they can click and view more details about the column) but not taken into account for double-click-to-resize interactions on the column.