### PR TITLE
[Overlay] Support nested overlays

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -6,6 +6,7 @@
 
 import * as classNames from "classnames";
 import * as React from "react";
+import { findDOMNode } from "react-dom";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import * as Classes from "../../common/classes";
@@ -348,8 +349,18 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
     private handleDocumentClick = (e: MouseEvent) => {
         const { isOpen, onClose } = this.props;
         const eventTarget = e.target as HTMLElement;
+
+        const { openStack } = Overlay;
+        const stackIndex = openStack.indexOf(this);
+
+        const isClickInDescendantOverlay = openStack
+            .slice(stackIndex)
+            .map(findDOMNode)
+            .some(elem => elem && elem.contains && elem.contains(eventTarget));
+
         const isClickInOverlay = this.containerElement != null && this.containerElement.contains(eventTarget);
-        if (isOpen && this.props.canOutsideClickClose && !isClickInOverlay) {
+
+        if (isOpen && this.props.canOutsideClickClose && !isClickInOverlay && !isClickInDescendantOverlay) {
             // casting to any because this is a native event
             safeInvoke(onClose, e as any);
         }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -6,7 +6,6 @@
 
 import * as classNames from "classnames";
 import * as React from "react";
-import { findDOMNode } from "react-dom";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import * as Classes from "../../common/classes";
@@ -139,7 +138,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
     private static getLastOpened = () => Overlay.openStack[Overlay.openStack.length - 1];
 
     // an HTMLElement that contains the backdrop and any children, to query for focus target
-    private containerElement: HTMLElement;
+    public containerElement: HTMLElement;
     private refHandlers = {
         container: (ref: HTMLDivElement) => (this.containerElement = ref),
     };
@@ -347,20 +346,17 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
     };
 
     private handleDocumentClick = (e: MouseEvent) => {
-        const { isOpen, onClose } = this.props;
+        const { canOutsideClickClose, isOpen, onClose } = this.props;
         const eventTarget = e.target as HTMLElement;
 
         const { openStack } = Overlay;
         const stackIndex = openStack.indexOf(this);
 
-        const isClickInDescendantOverlay = openStack
+        const isClickInThisOverlayOrDescendant = openStack
             .slice(stackIndex)
-            .map(findDOMNode)
-            .some(elem => elem && elem.contains && elem.contains(eventTarget));
+            .some(({ containerElement }) => containerElement && containerElement.contains(eventTarget));
 
-        const isClickInOverlay = this.containerElement != null && this.containerElement.contains(eventTarget);
-
-        if (isOpen && this.props.canOutsideClickClose && !isClickInOverlay && !isClickInDescendantOverlay) {
+        if (isOpen && canOutsideClickClose && !isClickInThisOverlayOrDescendant) {
             // casting to any because this is a native event
             safeInvoke(onClose, e as any);
         }

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -129,6 +129,23 @@ describe("<Overlay>", () => {
             assert.isTrue(onClose.notCalled);
         });
 
+        it("not invoked on click of inner overlay", () => {
+            const onClose = spy();
+            mount(
+                <Overlay isOpen={true} onClose={onClose}>
+                    <div>
+                        {createOverlayContents()}
+                        <Overlay isOpen={true}>
+                            <div id="inner-element">
+                                {createOverlayContents()}
+                            </div>
+                        </Overlay>
+                    </div>
+                </Overlay>,
+            ).find("#inner-element").simulate("mousedown");
+            assert.isTrue(onClose.notCalled);
+        });
+
         it("invoked on escape key", () => {
             const onClose = spy();
             mount(

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -136,13 +136,13 @@ describe("<Overlay>", () => {
                     <div>
                         {createOverlayContents()}
                         <Overlay isOpen={true}>
-                            <div id="inner-element">
-                                {createOverlayContents()}
-                            </div>
+                            <div id="inner-element">{createOverlayContents()}</div>
                         </Overlay>
                     </div>
                 </Overlay>,
-            ).find("#inner-element").simulate("mousedown");
+            )
+                .find("#inner-element")
+                .simulate("mousedown");
             assert.isTrue(onClose.notCalled);
         });
 

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -129,7 +129,7 @@ describe("<Overlay>", () => {
             assert.isTrue(onClose.notCalled);
         });
 
-        it("not invoked on click of inner overlay", () => {
+        it("not invoked on click of a nested overlay", () => {
             const onClose = spy();
             mount(
                 <Overlay isOpen={true} onClose={onClose}>


### PR DESCRIPTION
#### Fixes #2030

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests

#### Changes proposed in this pull request:

Uses `Overlay.openStack` to test if a document click is in a descendant overlay. Children overlays _should_ always be after the parent's index, so I think this should work for most cases.

This PR does not handle the case of having a non-`Overlay` `Blueprint.Portal` or `ReactDOM.createPortal`.