### PR TITLE
HTMLInputProps without ref or key

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -9,7 +9,7 @@ import * as React from "react";
 import { IconName } from "@blueprintjs/icons";
 import { Intent } from "./intent";
 
-export type HTMLInputProps = React.HTMLProps<HTMLInputElement>;
+export type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 /**
  * A shared base interface for all Blueprint component props.

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -9,6 +9,10 @@ import * as React from "react";
 import { IconName } from "@blueprintjs/icons";
 import { Intent } from "./intent";
 
+/**
+ * Alias for all valid HTML props for `<input>` element.
+ * Does not include React's `ref` or `key`.
+ */
 export type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 /**

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -24,8 +24,14 @@ export interface ITagInputProps extends IProps {
      */
     disabled?: boolean;
 
-    /** React props to pass to the `<input>` element. */
+    /**
+     * React props to pass to the `<input>` element.
+     * Note that `ref` and `key` are not supported here; use `inputRef` below.
+     */
     inputProps?: HTMLInputProps;
+
+    /** Ref handler for the `<input>` element. */
+    inputRef?: (input: HTMLInputElement) => void;
 
     /** Controlled value of the `<input>` element. This is shorthand for `inputProps={{ value }}`. */
     inputValue?: string;
@@ -163,11 +169,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     private refHandlers = {
         input: (ref: HTMLInputElement) => {
             this.inputElement = ref;
-            // can't use safeInvoke cuz inputProps.ref can be `string | function`
-            const refHandler = this.props.inputProps.ref;
-            if (Utils.isFunction(refHandler)) {
-                refHandler(ref);
-            }
+            Utils.safeInvoke(this.props.inputRef, ref);
         },
     };
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -208,8 +208,6 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
             );
         // assign default empty object here to prevent mutation
         const { inputProps = {}, popoverProps = {}, format } = this.props;
-        // exclude ref (comes from HTMLInputProps typings, not InputGroup)
-        const { ref, ...htmlInputProps } = inputProps;
 
         const inputClasses = classNames(
             {
@@ -237,7 +235,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
                     autoComplete="off"
                     placeholder={placeholder}
                     rightElement={this.props.rightElement}
-                    {...htmlInputProps}
+                    {...inputProps}
                     className={inputClasses}
                     disabled={this.props.disabled}
                     type="text"

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -359,24 +359,18 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
     private renderInputGroup = (boundary: DateRangeBoundary) => {
         const inputProps = this.getInputProps(boundary);
 
-        // don't include `ref` in the returned HTML props, because passing it to the InputGroup
-        // leads to TS typing errors.
-        const { ref, ...htmlProps } = inputProps;
-
         const handleInputEvent =
             boundary === DateRangeBoundary.START ? this.handleStartInputEvent : this.handleEndInputEvent;
 
         const classes = classNames(
-            {
-                [Classes.INTENT_DANGER]: this.isInputInErrorState(boundary),
-            },
+            { [Classes.INTENT_DANGER]: this.isInputInErrorState(boundary) },
             inputProps.className,
         );
 
         return (
             <InputGroup
                 autoComplete="off"
-                {...htmlProps}
+                {...inputProps}
                 className={classes}
                 disabled={this.props.disabled}
                 inputRef={this.getInputRef(boundary)}

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -125,7 +125,6 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { inputProps = {}, isOpen, overlayProps = {} } = this.props;
-        const { ref, ...htmlInputProps } = inputProps;
         const { handleKeyDown, handleKeyUp } = listProps;
         const handlers = isOpen && !this.isQueryEmpty() ? { onKeyDown: handleKeyDown, onKeyUp: handleKeyUp } : {};
 
@@ -144,7 +143,7 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
                         leftIconName="search"
                         placeholder="Search..."
                         value={listProps.query}
-                        {...htmlInputProps}
+                        {...inputProps}
                         onChange={this.handleQueryChange}
                     />
                     {this.maybeRenderMenu(listProps)}

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -124,7 +124,6 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             ...tagInputProps.inputProps,
             // tslint:disable-next-line:object-literal-sort-keys
             onChange: this.handleQueryChange,
-            ref: this.refHandlers.input,
             value: query,
         };
 
@@ -149,6 +148,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                     <TagInput
                         {...tagInputProps}
                         inputProps={defaultInputProps}
+                        inputRef={this.refHandlers.input}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         values={selectedItems.map(this.props.tagRenderer)}
                     />

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -183,7 +183,6 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
         const { filterable = true, disabled = false, inputProps = {}, popoverProps = {} } = this.props;
 
-        const { ref, ...htmlInputProps } = inputProps;
         const input = (
             <InputGroup
                 autoFocus={true}
@@ -191,7 +190,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
                 placeholder="Filter..."
                 rightElement={this.maybeRenderInputClearButton()}
                 value={listProps.query}
-                {...htmlInputProps}
+                {...inputProps}
                 inputRef={this.refHandlers.input}
                 onChange={this.handleQueryChange}
             />

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -130,7 +130,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             popoverProps = this.DEFAULT_PROPS.popoverProps,
         } = this.props;
         const { isTyping, selectedItem, query } = this.state;
-        const { ref, ...htmlInputProps } = inputProps;
         const { handleKeyDown, handleKeyUp } = listProps;
         const inputValue: string = isTyping ? query : selectedItem ? inputValueRenderer(selectedItem) : "";
 
@@ -150,7 +149,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 <InputGroup
                     placeholder="Search..."
                     value={inputValue}
-                    {...htmlInputProps}
+                    {...inputProps}
                     inputRef={this.refHandlers.input}
                     onChange={this.handleQueryChange}
                     onFocus={this.handleInputFocus}


### PR DESCRIPTION
#### Fixes #943

#### Changes proposed in this pull request:

- `HTMLInputProps` alias uses `InputHTMLAttributes` instead of `HTMLProps` (does not include `ref` or `key`)
- remove `const { ref, ...htmlInputProps } = inputProps` workaround!!
- add `TagInput` `inputRef` prop because `inputProps` does not expose it anymore.