### PR TITLE
fix warnings in tests

### DIFF
--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -13,7 +13,7 @@ import { Callout, Classes, Intent } from "../../src/index";
 describe("<Callout>", () => {
     it("supports className", () => {
         const wrapper = shallow(<Callout className="foo" />);
-        assert.isTrue(wrapper.find("h5").isEmpty(), "expected no h5");
+        assert.isFalse(wrapper.find("h5").exists(), "expected no h5");
         assert.isTrue(wrapper.hasClass(Classes.CALLOUT));
         assert.isTrue(wrapper.hasClass("foo"));
     });

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -210,7 +210,7 @@ describe("<NumericInput>", () => {
             incrementButton.simulate("click");
             expect(onButtonClickSpy.calledOnce).to.be.true;
             expect(onButtonClickSpy.firstCall.args).to.deep.equal([1, "1"]);
-            onButtonClickSpy.reset();
+            onButtonClickSpy.resetHistory();
 
             // decrementing from 1 now
             decrementButton.simulate("click");

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -7,8 +7,9 @@
 import { assert } from "chai";
 import { EnzymePropSelector, mount, ReactWrapper } from "enzyme";
 import * as React from "react";
-import { spy } from "sinon";
+import { spy, stub } from "sinon";
 
+import { RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX } from "../../src/common/errors";
 import { IOptionProps, Radio, RadioGroup } from "../../src/index";
 
 describe("<RadioGroup>", () => {
@@ -61,13 +62,16 @@ describe("<RadioGroup>", () => {
         assert.isTrue(findInput(group, { value: "c" }).prop("disabled"), "radio c not disabled");
     });
 
-    it("uses options if given both options and children", () => {
+    it("uses options if given both options and children (with conosle warning)", () => {
+        const warnSpy = stub(console, "warn");
         const group = mount(
             <RadioGroup onChange={emptyHandler} options={[]}>
                 <Radio value="one" />
             </RadioGroup>,
         );
         assert.lengthOf(group.find(Radio), 0);
+        assert.isTrue(warnSpy.alwaysCalledWith(RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX));
+        warnSpy.restore();
     });
 
     it("renders non-Radio children too", () => {

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -75,6 +75,7 @@ describe("MenuItem", () => {
         const submenu = findSubmenu(wrapper);
         assert.lengthOf(submenu.props.children, 2);
         assert.isTrue(warnSpy.alwaysCalledWith(MENU_WARN_CHILDREN_SUBMENU_MUTEX));
+        warnSpy.restore();
     });
 
     it("Clicking MenuItem triggers onClick prop", () => {

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -9,8 +9,9 @@ import { mount, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
-import { spy } from "sinon";
+import { spy, stub } from "sinon";
 
+import { MENU_WARN_CHILDREN_SUBMENU_MUTEX } from "../../src/common/errors";
 import {
     Classes,
     IMenuItemProps,
@@ -64,6 +65,7 @@ describe("MenuItem", () => {
     });
 
     it("renders children if given children and submenu", () => {
+        const warnSpy = stub(console, "warn");
         const wrapper = shallow(
             <MenuItem iconName="style" text="Style" submenu={[{ text: "foo" }]}>
                 <MenuItem text="one" />
@@ -72,6 +74,7 @@ describe("MenuItem", () => {
         );
         const submenu = findSubmenu(wrapper);
         assert.lengthOf(submenu.props.children, 2);
+        assert.isTrue(warnSpy.alwaysCalledWith(MENU_WARN_CHILDREN_SUBMENU_MUTEX));
     });
 
     it("Clicking MenuItem triggers onClick prop", () => {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -16,7 +16,6 @@ import * as Classes from "../../src/common/classes";
 import * as Errors from "../../src/common/errors";
 import * as Keys from "../../src/common/keys";
 import { Position } from "../../src/common/position";
-import * as Utils from "../../src/common/utils";
 import { Overlay } from "../../src/components/overlay/overlay";
 import { IPopoverProps, IPopoverState, Popover, PopoverInteractionKind } from "../../src/components/popover/popover";
 import { Tooltip } from "../../src/components/tooltip/tooltip";
@@ -27,17 +26,13 @@ describe("<Popover>", () => {
     let wrapper: IPopoverWrapper;
     let onInteractionSpy: sinon.SinonSpy;
 
-    before(() => {
-        onInteractionSpy = sinon.spy();
-    });
-
     beforeEach(() => {
+        onInteractionSpy = sinon.spy();
         testsContainerElement = document.createElement("div");
         document.body.appendChild(testsContainerElement);
     });
 
     afterEach(() => {
-        onInteractionSpy.reset();
         if (wrapper !== undefined) {
             // clean up wrapper to remove Portal element from DOM
             wrapper.detach();
@@ -505,15 +500,12 @@ describe("<Popover>", () => {
                 .assertIsOpen(false);
         });
 
-        it("HOVER_TARGET_ONLY works properly", () => {
+        it("HOVER_TARGET_ONLY works properly", done => {
             renderPopover({ inline: false, interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                 .simulateTarget("mouseenter")
                 .assertIsOpen()
                 .simulateTarget("mouseleave")
-                .then(popover => {
-                    // Popover defers popover closing, so need to defer this check
-                    popover.assertIsOpen(false);
-                });
+                .then(popover => popover.assertIsOpen(false), done);
         });
 
         it("inline HOVER_TARGET_ONLY works properly when openOnTargetFocus={false}", () => {
@@ -685,7 +677,7 @@ describe("<Popover>", () => {
         simulateTarget(eventName: string): this;
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
         sendEscapeKey(): this;
-        then(next: (wrap: IPopoverWrapper) => void, done?: MochaDone): void;
+        then(next: (wrap: IPopoverWrapper) => void, done: MochaDone): void;
     }
 
     function renderPopover(props: Partial<IPopoverProps> = {}, content?: any) {
@@ -719,8 +711,9 @@ describe("<Popover>", () => {
         };
         wrapper.then = (next, done) => {
             setTimeout(() => {
+                wrapper.update();
                 next(wrapper);
-                Utils.safeInvoke(done);
+                done();
             });
         };
         return wrapper;

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -24,10 +24,9 @@ import { Portal } from "../../src/index";
 describe("<Popover>", () => {
     let testsContainerElement: HTMLElement;
     let wrapper: IPopoverWrapper;
-    let onInteractionSpy: sinon.SinonSpy;
+    const onInteractionSpy = sinon.spy();
 
     beforeEach(() => {
-        onInteractionSpy = sinon.spy();
         testsContainerElement = document.createElement("div");
         document.body.appendChild(testsContainerElement);
     });
@@ -39,6 +38,7 @@ describe("<Popover>", () => {
             wrapper = undefined;
         }
         testsContainerElement.remove();
+        onInteractionSpy.resetHistory();
     });
 
     describe("validation:", () => {

--- a/packages/core/test/slider/rangeSliderTests.tsx
+++ b/packages/core/test/slider/rangeSliderTests.tsx
@@ -204,7 +204,7 @@ describe("<RangeSlider>", () => {
         slider.find(`.${Classes.SLIDER}`).simulate("mousedown", { clientX: tickSize * NEXT_LOW_VALUE });
         assert.equal(changeSpy.callCount, 1, "lower handle invokes onChange");
         assert.deepEqual(changeSpy.firstCall.args[0], [NEXT_LOW_VALUE, VALUE], "lower handle moves");
-        changeSpy.reset();
+        changeSpy.resetHistory();
 
         slider.find(`.${Classes.SLIDER}`).simulate("mousedown", { clientX: tickSize * NEXT_HIGH_VALUE });
         assert.equal(changeSpy.callCount, 1, "higher handle invokes onChange");
@@ -212,17 +212,12 @@ describe("<RangeSlider>", () => {
     });
 
     describe("vertical orientation", () => {
-        let changeSpy: sinon.SinonSpy;
-        let releaseSpy: sinon.SinonSpy;
-
-        before(() => {
-            changeSpy = sinon.spy();
-            releaseSpy = sinon.spy();
-        });
+        const changeSpy = sinon.spy();
+        const releaseSpy = sinon.spy();
 
         afterEach(() => {
-            changeSpy.reset();
-            releaseSpy.reset();
+            changeSpy.resetHistory();
+            releaseSpy.resetHistory();
         });
 
         it("moving mouse on bottom handle updates first value in range", () => {

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -197,17 +197,12 @@ describe("<Slider>", () => {
     });
 
     describe("vertical orientation", () => {
-        let changeSpy: sinon.SinonSpy;
-        let releaseSpy: sinon.SinonSpy;
-
-        before(() => {
-            changeSpy = sinon.spy();
-            releaseSpy = sinon.spy();
-        });
+        const changeSpy = sinon.spy();
+        const releaseSpy = sinon.spy();
 
         afterEach(() => {
-            changeSpy.reset();
-            releaseSpy.reset();
+            changeSpy.resetHistory();
+            releaseSpy.resetHistory();
         });
 
         it("moving mouse calls onChange with nearest value", () => {

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -419,7 +419,7 @@ describe("<TagInput>", () => {
         });
 
         it("prop changes are reflected in state", () => {
-            const wrapper = mount(<TagInput values={VALUES} />);
+            const wrapper = mount(<TagInput inputValue="" values={VALUES} />);
             wrapper.setProps({ inputValue: "a" });
             expect(wrapper.state().inputValue).to.equal("a");
             wrapper.setProps({ inputValue: "b" });

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -8,7 +8,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 import { Target } from "react-popper";
-import { spy } from "sinon";
+import { spy, stub } from "sinon";
 
 import { Classes, ITooltipProps, Overlay, Popover, Tooltip } from "../../src/index";
 
@@ -55,14 +55,14 @@ describe("<Tooltip>", () => {
         });
 
         it("empty content disables Popover and warns", () => {
-            const warnSpy = spy(console, "warn");
+            const warnSpy = stub(console, "warn");
             const tooltip = renderTooltip({ isOpen: true });
 
             function assertDisabledPopover(content?: string) {
                 tooltip.setProps({ content });
                 assert.isFalse(tooltip.find(Overlay).prop("isOpen"), `"${content}"`);
                 assert.isTrue(warnSpy.calledOnce, "spy not called once");
-                warnSpy.reset();
+                warnSpy.resetHistory();
             }
 
             assertDisabledPopover("");
@@ -90,7 +90,7 @@ describe("<Tooltip>", () => {
         });
 
         it("empty content disables Popover and warns", () => {
-            const warnSpy = spy(console, "warn");
+            const warnSpy = stub(console, "warn");
             const tooltip = renderTooltip({ content: "", isOpen: true });
             assert.isFalse(tooltip.find(Overlay).prop("isOpen"));
             assert.isTrue(warnSpy.calledOnce);

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -69,11 +69,18 @@ describe("<Tree>", () => {
                 hasCaret: true,
                 id: 1,
                 isExpanded: false,
-                label: "",
+                label: "c0",
             },
-            { id: 0, className: "c1", hasCaret: true, isExpanded: true, label: "" },
-            { id: 2, className: "c2", hasCaret: true, isExpanded: false, label: "" },
-            { id: 3, className: "c3", hasCaret: true, isExpanded: true, label: "", childNodes: [{ id: 5, label: "" }] },
+            { id: 0, className: "c1", hasCaret: true, isExpanded: true, label: "c1" },
+            { id: 2, className: "c2", hasCaret: true, isExpanded: false, label: "c2" },
+            {
+                childNodes: [{ id: 5, label: "c4" }],
+                className: "c3",
+                hasCaret: true,
+                id: 3,
+                isExpanded: true,
+                label: "c3",
+            },
         ];
 
         const tree = renderTree({ contents });

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -25,9 +25,9 @@ describe("<QueryList>", () => {
     };
 
     beforeEach(() => {
-        testProps.onActiveItemChange.reset();
-        testProps.onItemSelect.reset();
-        testProps.renderer.reset();
+        testProps.onActiveItemChange.resetHistory();
+        testProps.onItemSelect.resetHistory();
+        testProps.renderer.resetHistory();
     });
 
     describe("filtering", () => {

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -112,7 +112,7 @@ describe("<Select>", () => {
         // Select defines its own popoverWillOpen so this ensures that the passthrough happens
         const popoverWillOpen = sinon.spy();
         const modifiers = {}; // our own instance
-        const wrapper = select({ popoverProps: { isOpen: undefined, popoverWillOpen, modifiers } });
+        const wrapper = select({ popoverProps: { popoverWillOpen, modifiers } });
         wrapper.find("table").simulate("click");
         assert.strictEqual(wrapper.find(Popover).prop("modifiers"), modifiers);
         assert.isTrue(popoverWillOpen.calledOnce);

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -245,7 +245,7 @@ describe("Suggest", () => {
         const popoverWillOpen = sinon.spy();
 
         afterEach(() => {
-            popoverWillOpen.reset();
+            popoverWillOpen.resetHistory();
         });
 
         it("popover can be controlled with popoverProps", () => {

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -554,7 +554,7 @@ describe("TableQuadrantStack", () => {
 
         afterEach(() => {
             ReactDOM.unmountComponentAtNode(container);
-            onScroll.reset();
+            onScroll.resetHistory();
         });
 
         describe("onScroll", () => {

--- a/packages/table/test/quadrants/tableQuadrantTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantTests.tsx
@@ -36,7 +36,7 @@ describe("TableQuadrant", () => {
     });
 
     afterEach(() => {
-        bodyRenderer.reset();
+        bodyRenderer.resetHistory();
     });
 
     describe("Event callbacks", () => {
@@ -55,7 +55,7 @@ describe("TableQuadrant", () => {
         });
 
         it("prints a console warning if onScroll is provided when quadrantType != MAIN", () => {
-            const consoleWarn = sinon.spy(console, "warn");
+            const consoleWarn = sinon.stub(console, "warn");
             mountTableQuadrant({ onScroll: sinon.spy(), quadrantType: QuadrantType.LEFT });
             expect(consoleWarn.calledOnce);
             expect(consoleWarn.firstCall.args[0]).to.equal(Errors.QUADRANT_ON_SCROLL_UNNECESSARILY_DEFINED);

--- a/packages/table/test/resizableTests.tsx
+++ b/packages/table/test/resizableTests.tsx
@@ -104,10 +104,10 @@ describe("Resizable", () => {
         expect(onDoubleClick.called).to.be.false;
         expect(resizable.find(".resizable-div").bounds().width).to.equal(110);
 
-        onDoubleClick.reset();
-        onLayoutLock.reset();
-        onResizeEnd.reset();
-        onSizeChanged.reset();
+        onDoubleClick.resetHistory();
+        onLayoutLock.resetHistory();
+        onResizeEnd.resetHistory();
+        onSizeChanged.resetHistory();
 
         // double click the resize handle
         target

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -39,14 +39,14 @@ describe("DragSelectable", () => {
     afterEach(() => {
         harness.unmount();
 
-        onSelection.reset();
-        onFocusedCell.reset();
+        onSelection.resetHistory();
+        onFocusedCell.resetHistory();
 
         locateClick.returns(undefined);
         locateDrag.returns(undefined);
 
-        locateClick.reset();
-        locateDrag.reset();
+        locateClick.resetHistory();
+        locateDrag.resetHistory();
     });
 
     after(() => {

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -87,7 +87,7 @@ describe("Selection", () => {
             .mouse("mouseup");
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
-        onSelection.reset();
+        onSelection.resetHistory();
 
         table
             .find(`.${Classes.rowCellIndexClass(1)}.${Classes.columnCellIndexClass(1)}`)
@@ -107,7 +107,7 @@ describe("Selection", () => {
             .find(COLUMN_TH_SELECTOR)
             .mouse("mousedown")
             .mouse("mouseup");
-        onSelection.reset();
+        onSelection.resetHistory();
 
         // select a row
         table
@@ -116,7 +116,7 @@ describe("Selection", () => {
             .mouse("mouseup");
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.row(0)]]);
-        onSelection.reset();
+        onSelection.resetHistory();
 
         // deselects on cmd+click
         table
@@ -126,7 +126,7 @@ describe("Selection", () => {
         expect(onSelection.called).to.equal(true, "cmd+click to deselect");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[]]);
-        onSelection.reset();
+        onSelection.resetHistory();
     });
 
     it("Column selection works when enabled", () => {
@@ -141,7 +141,7 @@ describe("Selection", () => {
         expect(onSelection.called).to.equal(true, "first select");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
-        onSelection.reset();
+        onSelection.resetHistory();
 
         // deselects on cmd+click
         table
@@ -151,7 +151,7 @@ describe("Selection", () => {
         expect(onSelection.called).to.equal(true, "cmd+click to deselect");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[]]);
-        onSelection.reset();
+        onSelection.resetHistory();
 
         // re-select
         table
@@ -159,7 +159,7 @@ describe("Selection", () => {
             .mouse("mousedown")
             .mouse("mouseup");
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]], "second select");
-        onSelection.reset();
+        onSelection.resetHistory();
 
         // clears even with meta key
         const isMetaKeyDown = true;
@@ -240,7 +240,7 @@ describe("Selection", () => {
         expect(onSelection.called).to.equal(true, "first select called");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
-        onSelection.reset();
+        onSelection.resetHistory();
 
         const isMetaKeyDown = true;
         table

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -112,9 +112,9 @@ describe("TableBody", () => {
         const bodyContextMenuRenderer = sinon.stub().returns(<div />);
 
         afterEach(() => {
-            onFocusedCell.reset();
-            onSelection.reset();
-            bodyContextMenuRenderer.reset();
+            onFocusedCell.resetHistory();
+            onSelection.resetHistory();
+            bodyContextMenuRenderer.resetHistory();
         });
 
         describe("on right-click", () => {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -371,8 +371,8 @@ describe("<Table>", () => {
         const onSelection = sinon.spy();
 
         afterEach(() => {
-            onFocusedCell.reset();
-            onSelection.reset();
+            onFocusedCell.resetHistory();
+            onSelection.resetHistory();
         });
 
         it("Selects all and moves focus cell to (0, 0) on click of upper-left corner", () => {
@@ -545,7 +545,7 @@ describe("<Table>", () => {
         let consoleWarn: sinon.SinonSpy;
 
         before(() => (consoleWarn = sinon.stub(console, "warn")));
-        afterEach(() => consoleWarn.reset());
+        afterEach(() => consoleWarn.resetHistory());
         after(() => consoleWarn.restore());
 
         it("prints a warning and clamps out-of-bounds numFrozenColumns if > number of columns", () => {
@@ -815,9 +815,9 @@ describe("<Table>", () => {
         const onSelection = sinon.spy();
 
         afterEach(() => {
-            onColumnsReordered.reset();
-            onRowsReordered.reset();
-            onSelection.reset();
+            onColumnsReordered.resetHistory();
+            onRowsReordered.resetHistory();
+            onSelection.resetHistory();
         });
 
         it("Shows preview guide and invokes callback when selected columns reordered", () => {
@@ -1566,19 +1566,10 @@ describe("<Table>", () => {
             });
 
             describe("warnings", () => {
-                let consoleWarn: sinon.SinonSpy;
-
-                before(() => {
-                    consoleWarn = sinon.spy(console, "warn");
-                });
-
-                afterEach(() => {
-                    consoleWarn.reset();
-                });
-
-                after(() => {
-                    consoleWarn.restore();
-                });
+                let consoleWarn: sinon.SinonStub;
+                before(() => (consoleWarn = sinon.stub(console, "warn")));
+                afterEach(() => consoleWarn.resetHistory());
+                after(() => consoleWarn.restore());
 
                 it("should print a warning when numFrozenRows > numRows", () => {
                     const table = mount(<Table numRows={1} numFrozenRows={2} />);
@@ -1824,7 +1815,7 @@ describe("<Table>", () => {
             pressKeyWithShiftKey(component, Keys.ARROW_RIGHT);
             expect(onSelection.calledOnce).to.be.true;
             expect(onSelection.firstCall.args).to.deep.equal([expectedSelectedRegions]);
-            onSelection.reset();
+            onSelection.resetHistory();
 
             // pretend the selection change persisted
             component.setProps({ selectedRegions: expectedSelectedRegions });


### PR DESCRIPTION
#### Fixes #1908 

#### Changes proposed in this pull request:

see commits for individual strategies to address warnings.
a few warning messages remain, namely that `NaN ... left` one in PopoverArrow, which I suspect is coming from Popper due to Phantom being a weird environment.

also includes (what I think is the) fix for Popover flakes, from https://github.com/palantir/blueprint/pull/2028/commits/1089e6e0c42329926067157b164451e6e7ad92f1 in #2028