### PR TITLE
[docs] move infra packages into submenu in releases dropdown

### DIFF
--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -11,6 +11,9 @@
 
     > .pt-popover-target {
       display: inherit;
+      // override very specific selector for popovers in button groups
+      // stylelint-disable-next-line declaration-no-important
+      float: none !important;
 
       > .pt-menu-item {
         padding-right: $pt-icon-size-standard + $pt-grid-size;

--- a/packages/docs-app/src/components/navbarActions.tsx
+++ b/packages/docs-app/src/components/navbarActions.tsx
@@ -10,6 +10,7 @@ import {
     Hotkey,
     Hotkeys,
     HotkeysTarget,
+    Icon,
     Menu,
     MenuDivider,
     MenuItem,
@@ -33,7 +34,12 @@ export class NavbarActions extends React.PureComponent<INavbarActionsProps, {}> 
         return (
             <div className={classNames(Classes.BUTTON_GROUP, Classes.MINIMAL)}>
                 <AnchorButton href="https://github.com/palantir/blueprint" target="_blank" text="GitHub" />
-                <Popover inline={true} content={this.renderReleasesMenu()} position={Position.BOTTOM_RIGHT}>
+                <Popover
+                    inline={true}
+                    className="docs-releases-menu"
+                    content={this.renderReleasesMenu()}
+                    position={Position.BOTTOM_RIGHT}
+                >
                     <AnchorButton rightIconName="caret-down" text="Releases" />
                 </Popover>
                 <AnchorButton
@@ -79,17 +85,17 @@ export class NavbarActions extends React.PureComponent<INavbarActionsProps, {}> 
         const libs = releases.filter(({ name }) => COMPONENT_PACKAGES.indexOf(name) >= 0).map(renderItem);
         const tooling = releases.filter(({ name }) => COMPONENT_PACKAGES.indexOf(name) === -1).map(renderItem);
         return (
-            <Menu className="docs-releases-menu">
+            <Menu>
                 <MenuItem
                     href="https://github.com/palantir/blueprint/releases"
                     iconName="book"
                     target="_blank"
                     text="Release notes"
                 />
-                <MenuDivider title="Components" />
+                <MenuDivider title="Component packages" />
                 {libs}
-                <MenuDivider title="Tooling" />
-                {tooling}
+                <MenuDivider />
+                <MenuItem text="Infrastructure packages">{tooling}</MenuItem>
             </Menu>
         );
     }

--- a/packages/docs-app/src/components/navbarActions.tsx
+++ b/packages/docs-app/src/components/navbarActions.tsx
@@ -10,7 +10,6 @@ import {
     Hotkey,
     Hotkeys,
     HotkeysTarget,
-    Icon,
     Menu,
     MenuDivider,
     MenuItem,
@@ -92,10 +91,10 @@ export class NavbarActions extends React.PureComponent<INavbarActionsProps, {}> 
                     target="_blank"
                     text="Release notes"
                 />
-                <MenuDivider title="Component packages" />
+                <MenuDivider title="Components" />
                 {libs}
                 <MenuDivider />
-                <MenuItem text="Infrastructure packages">{tooling}</MenuItem>
+                <MenuItem text="Build tooling">{tooling}</MenuItem>
             </Menu>
         );
     }

--- a/packages/docs-app/src/index.scss
+++ b/packages/docs-app/src/index.scss
@@ -28,6 +28,6 @@
   background-image: url("./assets/blueprint-logo.svg");
 }
 
-.docs-releases-menu {
+.docs-releases-menu .pt-menu {
   width: 320px;
 }


### PR DESCRIPTION
#### Fixes #1969 

#### Changes proposed in this pull request:

- move infrastructure packages into submenu in releases dropdown
- 🐛  fix CSS issue with submenu in popover on button in button group (yuck)

