### PR TITLE
Update all component display names to "Blueprint2.X"

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -62,7 +62,7 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
         onConfirm: null,
     };
 
-    public static displayName = "Blueprint.Alert";
+    public static displayName = "Blueprint2.Alert";
 
     public render() {
         const { children, className, iconName, intent, isOpen, confirmButtonText, onConfirm, style } = this.props;

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -38,7 +38,7 @@ export interface IButtonGroupProps extends IProps, React.HTMLProps<HTMLDivElemen
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class ButtonGroup extends React.PureComponent<IButtonGroupProps, {}> {
-    public static displayName = "Blueprint.ButtonGroup";
+    public static displayName = "Blueprint2.ButtonGroup";
 
     public render() {
         const { className, fill, minimal, large, vertical, ...htmlProps } = this.props;

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -15,7 +15,7 @@ import { AbstractButton, IButtonProps } from "./abstractButton";
 export { IButtonProps };
 
 export class Button extends AbstractButton<HTMLButtonElement> {
-    public static displayName = "Blueprint.Button";
+    public static displayName = "Blueprint2.Button";
 
     public render() {
         return (
@@ -27,7 +27,7 @@ export class Button extends AbstractButton<HTMLButtonElement> {
 }
 
 export class AnchorButton extends AbstractButton<HTMLAnchorElement> {
-    public static displayName = "Blueprint.AnchorButton";
+    public static displayName = "Blueprint2.AnchorButton";
 
     public render() {
         const { href, tabIndex = 0 } = this.props;

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -54,7 +54,7 @@ const ELEVATION_CLASSES = [
 ];
 
 export class Card extends React.PureComponent<ICardProps, {}> {
-    public static displayName = "Blueprint.Card";
+    public static displayName = "Blueprint2.Card";
     public static defaultProps: ICardProps = {
         elevation: Elevation.ZERO,
         interactive: false,

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -84,7 +84,7 @@ export enum AnimationStates {
  * These are all animated.
  */
 export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseState> {
-    public static displayName = "Blueprint.Collapse";
+    public static displayName = "Blueprint2.Collapse";
 
     public static defaultProps: ICollapseProps = {
         component: "div",

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -58,7 +58,7 @@ export interface ICollapsibleListProps extends IProps {
 }
 
 export class CollapsibleList extends React.Component<ICollapsibleListProps, {}> {
-    public static displayName = "Blueprint.CollapsibleList";
+    public static displayName = "Blueprint2.CollapsibleList";
 
     public static defaultProps: ICollapsibleListProps = {
         collapseFrom: CollapseFrom.START,

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -68,7 +68,7 @@ export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
         isOpen: false,
     };
 
-    public static displayName = "Blueprint.Dialog";
+    public static displayName = "Blueprint2.Dialog";
 
     public render() {
         return (

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -24,7 +24,7 @@ export interface IControlGroupProps extends React.AllHTMLAttributes<HTMLDivEleme
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class ControlGroup extends React.PureComponent<IControlGroupProps, {}> {
-    public static displayName = "Blueprint.ControlGroup";
+    public static displayName = "Blueprint2.ControlGroup";
 
     public render() {
         const { children, className, fill, vertical, ...htmlProps } = this.props;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -104,7 +104,7 @@ export interface ICheckboxProps extends IControlProps {
 }
 
 export class Checkbox extends Control<ICheckboxProps> {
-    public static displayName = "Blueprint.Checkbox";
+    public static displayName = "Blueprint2.Checkbox";
 
     // must maintain internal reference for `indeterminate` support
     private input: HTMLInputElement;
@@ -139,7 +139,7 @@ export class Checkbox extends Control<ICheckboxProps> {
 export interface ISwitchProps extends IControlProps {}
 
 export class Switch extends Control<ISwitchProps> {
-    public static displayName = "Blueprint.Switch";
+    public static displayName = "Blueprint2.Switch";
 
     public render() {
         return this.renderControl("checkbox", "pt-switch");
@@ -149,7 +149,7 @@ export class Switch extends Control<ISwitchProps> {
 export interface IRadioProps extends IControlProps {}
 
 export class Radio extends Control<IRadioProps> {
-    public static displayName = "Blueprint.Radio";
+    public static displayName = "Blueprint2.Radio";
 
     public render() {
         return this.renderControl("radio", "pt-radio");

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -57,7 +57,7 @@ export interface IFileInputProps extends React.AllHTMLAttributes<HTMLLabelElemen
 // TODO: write tests (ignoring for now to get a build passing quickly)
 /* istanbul ignore next */
 export class FileInput extends React.Component<IFileInputProps, {}> {
-    public static displayName = "Blueprint.FileInput";
+    public static displayName = "Blueprint2.FileInput";
 
     public static defaultProps: IFileInputProps = {
         inputProps: {},

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -46,7 +46,7 @@ export interface IInputGroupState {
 }
 
 export class InputGroup extends React.PureComponent<HTMLInputProps & IInputGroupProps, IInputGroupState> {
-    public static displayName = "Blueprint.InputGroup";
+    public static displayName = "Blueprint2.InputGroup";
 
     public state: IInputGroupState = {
         rightElementWidth: 30,

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -26,7 +26,7 @@ export interface ILabelProps extends React.AllHTMLAttributes<HTMLDivElement>, IP
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class Label extends React.PureComponent<ILabelProps, {}> {
-    public static displayName = "Blueprint.Label";
+    public static displayName = "Blueprint2.Label";
 
     public render() {
         const { children, className, disabled, helperText, text, ...htmlProps } = this.props;

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -129,7 +129,7 @@ enum IncrementDirection {
 }
 
 export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumericInputProps, INumericInputState> {
-    public static displayName = "Blueprint.NumericInput";
+    public static displayName = "Blueprint2.NumericInput";
 
     public static VALUE_EMPTY = "";
     public static VALUE_ZERO = "0";

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -57,7 +57,7 @@ function nextName() {
 }
 
 export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
-    public static displayName = "Blueprint.RadioGroup";
+    public static displayName = "Blueprint2.RadioGroup";
 
     // a unique name for this group, which can be overridden by `name` prop.
     private autoGroupName = nextName();

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -24,7 +24,7 @@ export interface ITextAreaProps extends React.AllHTMLAttributes<HTMLTextAreaElem
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
-    public static displayName = "Blueprint.TextArea";
+    public static displayName = "Blueprint2.TextArea";
 
     public render() {
         const { className, fill, intent, large, ...htmlProps } = this.props;

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -31,7 +31,7 @@ export interface IIconProps extends IIntentProps, IProps {
 }
 
 export class Icon extends React.PureComponent<IIconProps & React.HTMLAttributes<HTMLSpanElement>, never> {
-    public static displayName = "Blueprint.Icon";
+    public static displayName = "Blueprint2.Icon";
 
     public static readonly SIZE_STANDARD = 16 as 16;
     public static readonly SIZE_LARGE = 20 as 20;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -16,7 +16,7 @@ export interface IMenuProps extends IProps {
 }
 
 export class Menu extends React.Component<IMenuProps, {}> {
-    public static displayName = "Blueprint.Menu";
+    public static displayName = "Blueprint2.Menu";
 
     public render() {
         return (

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -16,7 +16,7 @@ export interface IMenuDividerProps extends IProps {
 }
 
 export class MenuDivider extends React.Component<IMenuDividerProps, {}> {
-    public static displayName = "Blueprint.MenuDivider";
+    public static displayName = "Blueprint2.MenuDivider";
 
     public render() {
         const { className, title } = this.props;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -83,7 +83,7 @@ export class MenuItem extends AbstractPureComponent<IMenuItemProps, IMenuItemSta
         text: "",
         useSmartPositioning: true,
     };
-    public static displayName = "Blueprint.MenuItem";
+    public static displayName = "Blueprint2.MenuItem";
 
     public static contextTypes = REACT_CONTEXT_TYPES;
     public static childContextTypes = REACT_CONTEXT_TYPES;

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -23,7 +23,7 @@ export interface INavbarProps extends React.HTMLProps<HTMLDivElement>, IProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class Navbar extends React.PureComponent<INavbarProps, {}> {
-    public static displayName = "Blueprint.Navbar";
+    public static displayName = "Blueprint2.Navbar";
 
     public static Divider = NavbarDivider;
     public static Group = NavbarGroup;

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -18,7 +18,7 @@ export interface INavbarDividerProps extends React.HTMLProps<HTMLDivElement>, IP
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarDivider extends React.PureComponent<INavbarDividerProps, {}> {
-    public static displayName = "Blueprint.NavbarDivider";
+    public static displayName = "Blueprint2.NavbarDivider";
 
     public render() {
         const { className, ...htmlProps } = this.props;

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -20,7 +20,7 @@ export interface INavbarGroupProps extends React.HTMLProps<HTMLDivElement>, IPro
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarGroup extends React.PureComponent<INavbarGroupProps, {}> {
-    public static displayName = "Blueprint.NavbarGroup";
+    public static displayName = "Blueprint2.NavbarGroup";
 
     public static defaultProps: INavbarGroupProps = {
         align: "left",

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -18,7 +18,7 @@ export interface INavbarHeadingProps extends React.HTMLProps<HTMLDivElement>, IP
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarHeading extends React.PureComponent<React.HTMLProps<HTMLDivElement>, {}> {
-    public static displayName = "Blueprint.NavbarHeading";
+    public static displayName = "Blueprint2.NavbarHeading";
 
     public render() {
         const { children, className, ...htmlProps } = this.props;

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -118,7 +118,7 @@ export interface IOverlayState {
 }
 
 export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
-    public static displayName = "Blueprint.Overlay";
+    public static displayName = "Blueprint2.Overlay";
 
     public static defaultProps: IOverlayProps = {
         autoFocus: true,

--- a/packages/core/src/components/popover/arrow.tsx
+++ b/packages/core/src/components/popover/arrow.tsx
@@ -43,4 +43,4 @@ export const PopoverArrow: React.SFC<{ angle: number }> = ({ angle }) => (
         </svg>
     </Arrow>
 );
-PopoverArrow.displayName = "Blueprint.PopoverArrow";
+PopoverArrow.displayName = "Blueprint2.PopoverArrow";

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -192,7 +192,7 @@ export interface IPopoverState {
 }
 
 export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState> {
-    public static displayName = "Blueprint.Popover";
+    public static displayName = "Blueprint2.Popover";
 
     public static defaultProps: IPopoverProps = {
         defaultIsOpen: false,

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -50,7 +50,7 @@ const REACT_CONTEXT_TYPES: React.ValidationMap<IPortalContext> = {
  * Any class names passed to this element will be propagated to the new container element on document.body.
  */
 export class Portal extends React.Component<IPortalProps, IPortalState> {
-    public static displayName = "Blueprint.Portal";
+    public static displayName = "Blueprint2.Portal";
     public static contextTypes = REACT_CONTEXT_TYPES;
 
     public context: IPortalContext;

--- a/packages/core/src/components/progress/progressBar.tsx
+++ b/packages/core/src/components/progress/progressBar.tsx
@@ -21,7 +21,7 @@ export interface IProgressBarProps extends IProps, IIntentProps {
 }
 
 export class ProgressBar extends React.PureComponent<IProgressBarProps, {}> {
-    public static displayName = "Blueprint.ProgressBar";
+    public static displayName = "Blueprint2.ProgressBar";
 
     public render() {
         const { className, intent, value } = this.props;

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -38,7 +38,7 @@ export interface IHandleState {
 const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"];
 
 export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
-    public static displayName = "Blueprint.SliderHandle";
+    public static displayName = "Blueprint2.SliderHandle";
 
     public state = {
         isMoving: false,

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -46,7 +46,7 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
         vertical: false,
     };
 
-    public static displayName = "Blueprint.RangeSlider";
+    public static displayName = "Blueprint2.RangeSlider";
     public className = classNames(Classes.SLIDER, Classes.RANGE_SLIDER);
 
     private handles: Handle[] = [];

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -29,7 +29,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
 }
 
 export class Spinner extends React.PureComponent<ISpinnerProps, {}> {
-    public static displayName = "Blueprint.Spinner";
+    public static displayName = "Blueprint2.Spinner";
 
     public render() {
         const { className, intent, value } = this.props;

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -44,7 +44,7 @@ export class Tab extends React.PureComponent<ITabProps, {}> {
         id: undefined,
     };
 
-    public static displayName = "Blueprint.Tab";
+    public static displayName = "Blueprint2.Tab";
 
     // this component is never rendered directly; see Tabs#renderTabPanel()
     /* istanbul ignore next */

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -22,7 +22,7 @@ export interface ITabTitleProps extends ITabProps {
 }
 
 export class TabTitle extends React.PureComponent<ITabTitleProps, {}> {
-    public static displayName = "Blueprint.TabTitle";
+    public static displayName = "Blueprint2.TabTitle";
 
     public render() {
         const { disabled, id, parentId, selected } = this.props;

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -96,7 +96,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
         vertical: false,
     };
 
-    public static displayName = "Blueprint.Tabs";
+    public static displayName = "Blueprint2.Tabs";
 
     private tablistElement: HTMLDivElement;
     private refHandlers = {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -151,7 +151,7 @@ export interface ITagInputState {
 const NONE = -1;
 
 export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputState> {
-    public static displayName = "Blueprint.TagInput";
+    public static displayName = "Blueprint2.TagInput";
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         inputProps: {},

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -28,7 +28,7 @@ export interface ITagProps extends IProps, IIntentProps, React.HTMLAttributes<HT
 }
 
 export class Tag extends React.PureComponent<ITagProps, {}> {
-    public static displayName = "Blueprint.Tag";
+    public static displayName = "Blueprint2.Tag";
 
     public render() {
         const { active, className, intent, onRemove } = this.props;

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -50,7 +50,7 @@ export class Toast extends AbstractPureComponent<IToastProps, {}> {
         timeout: 5000,
     };
 
-    public static displayName = "Blueprint.Toast";
+    public static displayName = "Blueprint2.Toast";
 
     public render(): JSX.Element {
         const { className, iconName, intent, message } = this.props;

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -124,7 +124,7 @@ export interface ITooltipProps extends IProps, IIntentProps {
 }
 
 export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
-    public static displayName = "Blueprint.Tooltip";
+    public static displayName = "Blueprint2.Tooltip";
 
     public static defaultProps: Partial<ITooltipProps> = {
         defaultIsOpen: false,

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -68,36 +68,28 @@ describe("<NumericInput>", () => {
     });
 
     describe("Button position", () => {
+        const BUTTON_GROUP_SELECTOR = `.${Classes.BUTTON_GROUP}`;
+
         it("renders the buttons on the right when buttonPosition == Position.RIGHT", () => {
             const component = mount(<NumericInput buttonPosition={Position.RIGHT} />);
-            const inputGroup = component.find(InputGroup);
-            expect(inputGroup.name()).to.equal("Blueprint.InputGroup");
+            const buttonGroup = component.children().childAt(1);
+            expect(buttonGroup.is(BUTTON_GROUP_SELECTOR)).to.be.true;
         });
 
         it("renders the buttons on the left when buttonPosition == Position.LEFT", () => {
             const component = mount(<NumericInput buttonPosition={Position.LEFT} />);
-            const inputGroup = component.find(InputGroup);
-            expect(inputGroup.name()).to.equal("Blueprint.InputGroup");
+            const buttonGroup = component.children().childAt(0);
+            expect(buttonGroup.is(BUTTON_GROUP_SELECTOR)).to.be.true;
         });
 
         it('does not render the buttons when buttonPosition == "none"', () => {
-            const component = mount(<NumericInput buttonPosition={"none"} />);
-
-            const inputGroup = component.find(InputGroup);
-            const numChildren = component.children().length;
-
-            expect(inputGroup.name()).to.equal("Blueprint.InputGroup");
-            expect(numChildren).to.equal(1);
+            const component = mount(<NumericInput buttonPosition="none" />);
+            expect(component.find(BUTTON_GROUP_SELECTOR).exists()).to.be.false;
         });
 
         it("does not render the buttons when buttonPosition is null", () => {
             const component = mount(<NumericInput buttonPosition={null} />);
-
-            const inputGroup = component.find(InputGroup);
-            const numChildren = component.children().length;
-
-            expect(inputGroup.name()).to.equal("Blueprint.InputGroup");
-            expect(numChildren).to.equal(1);
+            expect(component.find(BUTTON_GROUP_SELECTOR).exists()).to.be.false;
         });
 
         it(`renders the children in a ${Classes.CONTROL_GROUP} when buttons are visible`, () => {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -173,7 +173,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         timePickerProps: {},
     };
 
-    public static displayName = "Blueprint.DateInput";
+    public static displayName = "Blueprint2.DateInput";
 
     public constructor(props?: IDateInputProps, context?: any) {
         super(props, context);

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -77,7 +77,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         showActionsBar: false,
     };
 
-    public static displayName = "Blueprint.DatePicker";
+    public static displayName = "Blueprint2.DatePicker";
 
     private ignoreNextMonthChange = false;
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -235,7 +235,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         startInputProps: {},
     };
 
-    public static displayName = "Blueprint.DateRangeInput";
+    public static displayName = "Blueprint2.DateRangeInput";
 
     private startInputRef: HTMLInputElement;
     private endInputRef: HTMLInputElement;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -123,7 +123,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         shortcuts: true,
     };
 
-    public static displayName = "Blueprint.DateRangePicker";
+    public static displayName = "Blueprint2.DateRangePicker";
 
     private get isControlled() {
         return this.props.value != null;

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -63,7 +63,7 @@ export class DateTimePicker extends AbstractPureComponent<IDateTimePickerProps, 
         defaultValue: new Date(),
     };
 
-    public static displayName = "Blueprint.DateTimePicker";
+    public static displayName = "Blueprint2.DateTimePicker";
 
     public constructor(props?: IDateTimePickerProps, context?: any) {
         super(props, context);

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -107,7 +107,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         showArrowButtons: false,
     };
 
-    public static displayName = "Blueprint.TimePicker";
+    public static displayName = "Blueprint2.TimePicker";
 
     public constructor(props?: ITimePickerProps, context?: any) {
         super(props, context);

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -46,7 +46,7 @@ export const NavMenuItem: React.SFC<INavMenuItemProps & { children?: React.React
         </li>
     );
 };
-NavMenuItem.displayName = "Docs.NavMenuItem";
+NavMenuItem.displayName = "Docs2.NavMenuItem";
 
 export const NavMenu: React.SFC<INavMenuProps> = props => {
     const menu = props.items.map(section => {
@@ -70,7 +70,7 @@ export const NavMenu: React.SFC<INavMenuProps> = props => {
     const classes = classNames("docs-nav-menu", "pt-list-unstyled", props.className);
     return <ul className={classes}>{menu}</ul>;
 };
-NavMenu.displayName = "Docs.NavMenu";
+NavMenu.displayName = "Docs2.NavMenu";
 
 function isParentOfRoute(parent: string, route: string) {
     return route.indexOf(parent + "/") === 0 || route.indexOf(parent + ".") === 0;

--- a/packages/docs-theme/src/components/typescript/apiHeader.tsx
+++ b/packages/docs-theme/src/components/typescript/apiHeader.tsx
@@ -10,7 +10,7 @@ import { DocumentationContextTypes, IDocumentationContext } from "../../common/c
 
 export class ApiHeader extends React.PureComponent<ITsDocBase> {
     public static contextTypes = DocumentationContextTypes;
-    public static displayName = "Docs.ApiHeader";
+    public static displayName = "Docs2.ApiHeader";
 
     public context: IDocumentationContext;
 

--- a/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
+++ b/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
@@ -21,7 +21,7 @@ export const DeprecatedTag: React.SFC<{ isDeprecated: boolean | string | undefin
     }
     return null;
 };
-DeprecatedTag.displayName = "Docs.DeprecatedTag";
+DeprecatedTag.displayName = "Docs2.DeprecatedTag";
 
 /**
  * Minimal markdown renderer that supports only backtick `code` elements and triple-backtick `pre` elements.

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -19,7 +19,7 @@ export interface IEnumTableProps {
 
 export class EnumTable extends React.PureComponent<IEnumTableProps> {
     public static contextTypes = DocumentationContextTypes;
-    public static displayName = "Docs.EnumTable";
+    public static displayName = "Docs2.EnumTable";
 
     public context: IDocumentationContext;
 

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -21,7 +21,7 @@ export interface IInterfaceTableProps {
 
 export class InterfaceTable extends React.PureComponent<IInterfaceTableProps> {
     public static contextTypes = DocumentationContextTypes;
-    public static displayName = "Docs.InterfaceTable";
+    public static displayName = "Docs2.InterfaceTable";
 
     public context: IDocumentationContext;
 

--- a/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
+++ b/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
@@ -15,7 +15,7 @@ export interface ITypeAliasTableProps {
 
 export class TypeAliasTable extends React.PureComponent<ITypeAliasTableProps> {
     public static contextTypes = DocumentationContextTypes;
-    public static displayName = "Docs.TypeAliasTable";
+    public static displayName = "Docs2.TypeAliasTable";
 
     public context: IDocumentationContext;
 

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -11,7 +11,7 @@ import { ModifierTable } from "../components/modifierTable";
 
 export class CssExample extends React.PureComponent<ITag> {
     public static contextTypes = DocumentationContextTypes;
-    public static displayName = "Docs.CssExample";
+    public static displayName = "Docs2.CssExample";
 
     public context: IDocumentationContext;
 

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -19,4 +19,4 @@ export const Heading: React.SFC<IHeadingTag> = ({ level, route, value }) =>
         </a>,
         value,
     );
-Heading.displayName = "Docs.Heading";
+Heading.displayName = "Docs2.Heading";

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -32,7 +32,7 @@ export const ReactExample: React.SFC<IExampleProps> = props => (
         </a>
     </div>
 );
-ReactExample.displayName = "Docs.ReactExample";
+ReactExample.displayName = "Docs2.ReactExample";
 
 export class ReactExampleTagRenderer {
     constructor(private examples: IExampleMap) {}

--- a/packages/docs-theme/src/tags/typescript.tsx
+++ b/packages/docs-theme/src/tags/typescript.tsx
@@ -37,4 +37,4 @@ export const TypescriptExample: React.SFC<ITag> = ({ value }, { getDocsData }: I
     }
 };
 TypescriptExample.contextTypes = DocumentationContextTypes;
-TypescriptExample.displayName = "Docs.TypescriptExample";
+TypescriptExample.displayName = "Docs2.TypescriptExample";

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -72,7 +72,7 @@ export interface IOmnibarState<T> extends IOverlayableProps, IBackdropProps {
 }
 
 export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarState<T>> {
-    public static displayName = "Blueprint.Omnibar";
+    public static displayName = "Blueprint2.Omnibar";
 
     public static ofType<T>() {
         return (Omnibar as any) as new () => Omnibar<T>;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -139,7 +139,7 @@ export interface IQueryListState<T> {
 }
 
 export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryListState<T>> {
-    public static displayName = "Blueprint.QueryList";
+    public static displayName = "Blueprint2.QueryList";
 
     public static ofType<T>() {
         return QueryList as new (props: IQueryListProps<T>) => QueryList<T>;

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -63,7 +63,7 @@ export interface IMultiSelectState<T> {
 }
 
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
-    public static displayName = "Blueprint.MultiSelect";
+    public static displayName = "Blueprint2.MultiSelect";
 
     public static ofType<T>() {
         return (MultiSelect as any) as new () => MultiSelect<T>;

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -85,7 +85,7 @@ export interface ISelectState<T> {
 }
 
 export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState<T>> {
-    public static displayName = "Blueprint.Select";
+    public static displayName = "Blueprint2.Select";
 
     public static ofType<T>() {
         return Select as new () => Select<T>;

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -60,7 +60,7 @@ export interface ISuggestState<T> {
 }
 
 export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestState<T>> {
-    public static displayName = "Blueprint.Suggest";
+    public static displayName = "Blueprint2.Suggest";
 
     public static ofType<T>() {
         return (Suggest as any) as new () => Suggest<T>;

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -101,7 +101,7 @@ export interface ITimezonePickerState {
 const TypedSelect = Select.ofType<ITimezoneItem>();
 
 export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, ITimezonePickerState> {
-    public static displayName = "Blueprint.TimezonePicker";
+    public static displayName = "Blueprint2.TimezonePicker";
 
     public static defaultProps: Partial<ITimezonePickerProps> = {
         disabled: false,


### PR DESCRIPTION
#### Fixes #2049 

- [x] `docs-theme` uses `Docs.X` display names. Should I a) make those `Docs2.X` ~~or b) `Blueprint2.X`?~~