### PR TITLE
always unmount Overlay in tests -- fixes flakes!

### DIFF
--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -16,20 +16,33 @@ import { Classes, IOverlayProps, Overlay, Portal, Utils } from "../../src/index"
 
 const BACKDROP_SELECTOR = `.${Classes.OVERLAY_BACKDROP}`;
 
+/*
+IMPORTANT NOTE: It is critical that every <Overlay> wrapper be unmounted after the test, to avoid
+polluting the DOM with leftover overlay elements. This was the cause of the Overlay test flakes of
+late 2017/early 2018 and was resolved by ensuring that every wrapper is unmounted.
+
+The `wrapper` variable below and the `mountWrapper` method should be used for full enzyme mounts.
+For shallow mounts, be sure to call `shallowWrapper.unmount()` after the assertions.
+*/
 describe("<Overlay>", () => {
-    /**
-     * Assign mounted wrappers to this variable to automatically clean them up after the test.
-     *
-     * **Always assign the result of `mount(<Overlay>)` to avoid leaving dangling Overlays,** which
-     * can interfere with other tests through the Overlay stack.
-     *
-     * Shallow renders do not need to be cleaned up in the same way.
-     */
     let wrapper: ReactWrapper<IOverlayProps, any>;
+    const testsContainerElement = document.createElement("div");
+    document.documentElement.appendChild(testsContainerElement);
+
+    /**
+     * Mount the `content` into `testsContainerElement` and assign to local `wrapper` variable.
+     * Use this method in this suite instead of Enzyme's `mount` method.
+     */
+    function mountWrapper(content: JSX.Element) {
+        wrapper = mount(content, { attachTo: testsContainerElement });
+        return wrapper;
+    }
 
     afterEach(() => {
+        // clean up wrapper after each test, if it was used
         if (wrapper != null) {
             wrapper.unmount();
+            wrapper.detach();
             wrapper = null;
         }
     });
@@ -42,6 +55,7 @@ describe("<Overlay>", () => {
         );
         assert.lengthOf(overlay.find("h1"), 1);
         assert.lengthOf(overlay.find(BACKDROP_SELECTOR), 1);
+        overlay.unmount();
     });
 
     it("supports non-element children", () => {
@@ -50,7 +64,7 @@ describe("<Overlay>", () => {
                 <Overlay inline={true} isOpen={true}>
                     {null} {undefined}
                 </Overlay>,
-            ),
+            ).unmount(),
         );
     });
 
@@ -62,11 +76,12 @@ describe("<Overlay>", () => {
         );
         assert.lengthOf(overlay.find("h1"), 1);
         assert.lengthOf(overlay.find(BACKDROP_SELECTOR), 0);
+        overlay.unmount();
     });
 
     it("invokes didOpen when Overlay is opened", () => {
         const didOpen = spy();
-        wrapper = mount(
+        mountWrapper(
             <Overlay didOpen={didOpen} isOpen={false}>
                 {createOverlayContents()}
             </Overlay>,
@@ -79,7 +94,7 @@ describe("<Overlay>", () => {
 
     it("invokes didOpen when inline Overlay is opened", () => {
         const didOpen = spy();
-        wrapper = mount(
+        mountWrapper(
             <Overlay didOpen={didOpen} inline={true} isOpen={false}>
                 {createOverlayContents()}
             </Overlay>,
@@ -91,7 +106,7 @@ describe("<Overlay>", () => {
     });
 
     it("renders portal attached to body when not inline after first opened", () => {
-        wrapper = mount(<Overlay isOpen={false}>{createOverlayContents()}</Overlay>);
+        mountWrapper(<Overlay isOpen={false}>{createOverlayContents()}</Overlay>);
         assert.lengthOf(wrapper.find(Portal), 0, "unexpected Portal");
         wrapper.setProps({ isOpen: true });
         assert.lengthOf(wrapper.find(Portal), 1, "expected Portal");
@@ -100,32 +115,32 @@ describe("<Overlay>", () => {
     describe("onClose", () => {
         it("invoked on backdrop mousedown when canOutsideClickClose=true", () => {
             const onClose = spy();
-            shallow(
+            const overlay = shallow(
                 <Overlay canOutsideClickClose={true} inline={true} isOpen={true} onClose={onClose}>
                     {createOverlayContents()}
                 </Overlay>,
-            )
-                .find(BACKDROP_SELECTOR)
-                .simulate("mousedown");
+            );
+            overlay.find(BACKDROP_SELECTOR).simulate("mousedown");
             assert.isTrue(onClose.calledOnce);
+            overlay.unmount();
         });
 
         it("not invoked on backdrop mousedown when canOutsideClickClose=false", () => {
             const onClose = spy();
-            shallow(
+            const overlay = shallow(
                 <Overlay canOutsideClickClose={false} inline={true} isOpen={true} onClose={onClose}>
                     {createOverlayContents()}
                 </Overlay>,
-            )
-                .find(BACKDROP_SELECTOR)
-                .simulate("mousedown");
+            );
+            overlay.find(BACKDROP_SELECTOR).simulate("mousedown");
             assert.isTrue(onClose.notCalled);
+            overlay.unmount();
         });
 
         it("invoked on document mousedown when hasBackdrop=false", () => {
             const onClose = spy();
             // mounting cuz we need document events + lifecycle
-            wrapper = mount(
+            mountWrapper(
                 <Overlay hasBackdrop={false} inline={true} isOpen={true} onClose={onClose}>
                     {createOverlayContents()}
                 </Overlay>,
@@ -137,7 +152,7 @@ describe("<Overlay>", () => {
 
         it("not invoked on document mousedown when hasBackdrop=false and canOutsideClickClose=false", () => {
             const onClose = spy();
-            wrapper = mount(
+            mountWrapper(
                 <Overlay canOutsideClickClose={false} hasBackdrop={false} inline={true} isOpen={true} onClose={onClose}>
                     {createOverlayContents()}
                 </Overlay>,
@@ -149,7 +164,7 @@ describe("<Overlay>", () => {
 
         it("not invoked on click of a nested overlay", () => {
             const onClose = spy();
-            wrapper = mount(
+            mountWrapper(
                 <Overlay isOpen={true} onClose={onClose}>
                     <div>
                         {createOverlayContents()}
@@ -165,7 +180,7 @@ describe("<Overlay>", () => {
 
         it("invoked on escape key", () => {
             const onClose = spy();
-            wrapper = mount(
+            mountWrapper(
                 <Overlay inline={true} isOpen={true} onClose={onClose}>
                     {createOverlayContents()}
                 </Overlay>,
@@ -176,48 +191,47 @@ describe("<Overlay>", () => {
 
         it("not invoked on escape key when canEscapeKeyClose=false", () => {
             const onClose = spy();
-            shallow(
+            const overlay = shallow(
                 <Overlay canEscapeKeyClose={false} inline={true} isOpen={true} onClose={onClose}>
                     {createOverlayContents()}
                 </Overlay>,
-            ).simulate("keydown", { which: Keys.ESCAPE });
+            );
+            overlay.simulate("keydown", { which: Keys.ESCAPE });
             assert.isTrue(onClose.notCalled);
+            overlay.unmount();
         });
 
         it("renders portal attached to body when not inline", () => {
-            const portal = shallow(
+            const overlay = shallow(
                 <Overlay inline={false} isOpen={true}>
                     {createOverlayContents()}
                 </Overlay>,
-            ).find(Portal);
-            assert.lengthOf(portal, 1, "missing Portal");
+            );
+            const portal = overlay.find(Portal);
+            assert.isTrue(portal.exists(), "missing Portal");
             assert.lengthOf(portal.find("h1"), 1, "missing h1");
+            overlay.unmount();
         });
     });
 
     describe("Focus management", () => {
-        const testsContainerElement = document.createElement("div");
-        document.documentElement.appendChild(testsContainerElement);
-
         it("brings focus to overlay if autoFocus=true", done => {
-            wrapper = mount(
+            mountWrapper(
                 <Overlay autoFocus={true} inline={false} isOpen={true}>
                     <input type="text" />
                 </Overlay>,
-                { attachTo: testsContainerElement },
             );
             assertFocus(".pt-overlay-backdrop", done);
         });
 
         it("does not bring focus to overlay if autoFocus=false", done => {
-            wrapper = mount(
+            mountWrapper(
                 <div>
                     <button>something outside overlay for browser to focus on</button>
                     <Overlay autoFocus={false} inline={false} isOpen={true}>
                         <input type="text" />
                     </Overlay>
                 </div>,
-                { attachTo: testsContainerElement },
             );
             assertFocus("body", done);
         });
@@ -225,11 +239,10 @@ describe("<Overlay>", () => {
         // React implements autoFocus itself so our `[autofocus]` logic never fires.
         // Still, worth testing we can control where the focus goes.
         it("autoFocus element inside overlay gets the focus", done => {
-            wrapper = mount(
+            mountWrapper(
                 <Overlay inline={false} isOpen={true}>
                     <input autoFocus={true} type="text" />
                 </Overlay>,
-                { attachTo: testsContainerElement },
             );
             assertFocus("input", done);
         });
@@ -237,14 +250,13 @@ describe("<Overlay>", () => {
         it("returns focus to overlay if enforceFocus=true", done => {
             let buttonRef: HTMLElement;
             let inputRef: HTMLElement;
-            wrapper = mount(
+            mountWrapper(
                 <div>
                     <button ref={ref => (buttonRef = ref)} />
                     <Overlay enforceFocus={true} inline={false} isOpen={true}>
                         <input autoFocus={true} ref={ref => (inputRef = ref)} />
                     </Overlay>
                 </div>,
-                { attachTo: testsContainerElement },
             );
             assert.strictEqual(document.activeElement, inputRef);
             buttonRef.focus();
@@ -255,11 +267,10 @@ describe("<Overlay>", () => {
         });
 
         it("returns focus to overlay after clicking the backdrop if enforceFocus=true", done => {
-            wrapper = mount(
+            mountWrapper(
                 <Overlay enforceFocus={true} canOutsideClickClose={false} inline={true} isOpen={true}>
                     {createOverlayContents()}
                 </Overlay>,
-                { attachTo: testsContainerElement },
             );
             wrapper.find(BACKDROP_SELECTOR).simulate("mousedown");
             assertFocus(`.${Classes.OVERLAY_CONTENT}`, done);
@@ -275,11 +286,10 @@ describe("<Overlay>", () => {
                 { attachTo: anotherContainer },
             );
 
-            wrapper = mount(
+            mountWrapper(
                 <Overlay enforceFocus={true} inline={true} isOpen={false}>
                     <input id="inputId" type="text" />
                 </Overlay>,
-                { attachTo: testsContainerElement },
             );
             // ES6 class property vs prototype, see: https://github.com/airbnb/enzyme/issues/365
             const bringFocusSpy = spy(wrapper.instance() as Overlay, "bringFocusInsideOverlay");
@@ -302,36 +312,33 @@ describe("<Overlay>", () => {
                 done();
             };
 
-            wrapper = mount(
+            mountWrapper(
                 <div>
                     <button ref={ref => (buttonRef = ref)} />
                     <Overlay enforceFocus={false} inline={false} isOpen={true}>
                         <input ref={ref => ref && setTimeout(focusBtnAndAssert)} />
                     </Overlay>
                 </div>,
-                { attachTo: testsContainerElement },
             );
         });
 
         it("doesn't focus overlay if focus is already inside overlay", done => {
             let textarea: HTMLTextAreaElement;
-            wrapper = mount(
+            mountWrapper(
                 <Overlay inline={false} isOpen={true}>
                     <textarea ref={ref => (textarea = ref)} />
                 </Overlay>,
-                { attachTo: testsContainerElement },
             );
             textarea.focus();
             assertFocus("textarea", done);
         });
 
         it("does not focus overlay when closed", done => {
-            wrapper = mount(
+            mountWrapper(
                 <div>
                     <button ref={ref => ref && ref.focus()} />
                     <Overlay inline={false} isOpen={false} />
                 </div>,
-                { attachTo: testsContainerElement },
             );
             assertFocus("button", done);
         });
@@ -339,17 +346,17 @@ describe("<Overlay>", () => {
         function assertFocus(selector: string | (() => void), done: MochaDone) {
             // the behavior being tested relies on requestAnimationFrame.
             // to avoid flakiness, use nested setTimeouts to delay execution until the *next* frame.
+            // setTimeout(() => {
             setTimeout(() => {
-                setTimeout(() => {
-                    wrapper.update();
-                    if (Utils.isFunction(selector)) {
-                        selector();
-                    } else {
-                        assert.strictEqual(document.querySelector(selector), document.activeElement);
-                    }
-                    done();
-                }, 1);
-            }, 1);
+                wrapper.update();
+                if (Utils.isFunction(selector)) {
+                    selector();
+                } else {
+                    assert.strictEqual(document.querySelector(selector), document.activeElement);
+                }
+                done();
+            }, 100);
+            // }, 1);
         }
     });
 
@@ -361,51 +368,51 @@ describe("<Overlay>", () => {
         });
 
         it("disables document scrolling by default", done => {
-            wrapper = mountOverlay(undefined, undefined);
+            wrapper = mountWrapper(renderSimpleOverlay(undefined, undefined));
             assertBodyScrollingDisabled(true, done);
         });
 
         it("disables document scrolling if inline=false and hasBackdrop=true", done => {
-            wrapper = mountOverlay(false, true);
+            wrapper = mountWrapper(renderSimpleOverlay(false, true));
             assertBodyScrollingDisabled(true, done);
         });
 
         it("does not disable document scrolling if inline=false and hasBackdrop=false", done => {
-            wrapper = mountOverlay(false, false);
+            wrapper = mountWrapper(renderSimpleOverlay(false, false));
             assertBodyScrollingDisabled(false, done);
         });
 
         it("does not disable document scrolling if inline=true and hasBackdrop=true", done => {
-            wrapper = mountOverlay(true, true);
+            wrapper = mountWrapper(renderSimpleOverlay(true, true));
             assertBodyScrollingDisabled(false, done);
         });
 
         it("does not disable document scrolling if inline=true and hasBackdrop=false", done => {
-            wrapper = mountOverlay(true, false);
+            wrapper = mountWrapper(renderSimpleOverlay(true, false));
             assertBodyScrollingDisabled(false, done);
         });
 
         it("keeps scrolling disabled if hasBackdrop=true overlay exists following unmount", done => {
-            const backdropOverlay = mountOverlay(false, true);
-            wrapper = mountOverlay(false, true);
+            const backdropOverlay = mount(renderSimpleOverlay(false, true));
+            wrapper = mountWrapper(renderSimpleOverlay(false, true));
             backdropOverlay.unmount();
 
             assertBodyScrollingDisabled(true, done);
         });
 
         it("doesn't keep scrolling disabled if no hasBackdrop=true overlay exists following unmount", done => {
-            const backdropOverlay = mountOverlay(false, true);
-            wrapper = mountOverlay(false, false);
+            const backdropOverlay = mount(renderSimpleOverlay(false, true));
+            wrapper = mountWrapper(renderSimpleOverlay(false, false));
             backdropOverlay.unmount();
 
             assertBodyScrollingDisabled(false, done);
         });
 
-        function mountOverlay(inline: boolean, hasBackdrop: boolean) {
-            return mount(
+        function renderSimpleOverlay(inline: boolean, hasBackdrop: boolean) {
+            return (
                 <Overlay hasBackdrop={hasBackdrop} inline={inline} isOpen={true}>
                     <div>Some overlay content</div>
-                </Overlay>,
+                </Overlay>
             );
         }
 

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -344,9 +344,7 @@ describe("<Overlay>", () => {
         });
 
         function assertFocus(selector: string | (() => void), done: MochaDone) {
-            // the behavior being tested relies on requestAnimationFrame.
-            // to avoid flakiness, use nested setTimeouts to delay execution until the *next* frame.
-            // setTimeout(() => {
+            // the behavior being tested relies on requestAnimationFrame. use setTimeout to delay till after rAF.
             setTimeout(() => {
                 wrapper.update();
                 if (Utils.isFunction(selector)) {
@@ -355,8 +353,7 @@ describe("<Overlay>", () => {
                     assert.strictEqual(document.querySelector(selector), document.activeElement);
                 }
                 done();
-            }, 100);
-            // }, 1);
+            });
         }
     });
 

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -344,15 +344,18 @@ describe("<Overlay>", () => {
         });
 
         function assertFocus(selector: string | (() => void), done: MochaDone) {
-            // the behavior being tested relies on requestAnimationFrame. use setTimeout to delay till after rAF.
+            // the behavior being tested relies on requestAnimationFrame.
+            // use nested setTimeouts to delay till end of next frame.
             setTimeout(() => {
-                wrapper.update();
-                if (Utils.isFunction(selector)) {
-                    selector();
-                } else {
-                    assert.strictEqual(document.querySelector(selector), document.activeElement);
-                }
-                done();
+                setTimeout(() => {
+                    wrapper.update();
+                    if (Utils.isFunction(selector)) {
+                        selector();
+                    } else {
+                        assert.strictEqual(document.querySelector(selector), document.activeElement);
+                    }
+                    done();
+                });
             });
         }
     });


### PR DESCRIPTION
#### Fixes #1951 for real real

Don't know of a way to assert that enzyme wrappers are unmounted before tests.

https://github.com/airbnb/enzyme/issues/911 captures the heart of this discussion: it's up to the consumer to ensure their tests clean up after themselves. enzyme does not automatically unmount, or provide a `cleanup()` method. There's actually a [**Note** to this effect](https://github.com/airbnb/enzyme/blob/master/docs/api/mount.md#full-rendering-api-mount) on the `.mount()` docs.