### PR TITLE
Callout renders SVG Icon component

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -44,6 +44,7 @@ export const BUTTON = "pt-button";
 export const BUTTON_GROUP = "pt-button-group";
 
 export const CALLOUT = "pt-callout";
+export const CALLOUT_ICON = "pt-callout-icon";
 
 export const CARD = "pt-card";
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -28,24 +28,15 @@ Styleguide pt-callout
   background-color: rgba($gray3, 0.15);
   padding: $pt-grid-size ($pt-grid-size * 1.2) ($pt-grid-size * 0.9);
 
-  // apply class as modifier to adjust padding...
-  &.pt-callout-icon,
   &[class*="pt-icon-"] {
     padding-left: ($pt-grid-size * 2) + $pt-icon-size-large;
 
-    // ...and apply class to Icon for position
-    .pt-callout-icon,
     &::before {
+      @include pt-icon($pt-icon-size-large);
       position: absolute;
       top: $pt-grid-size;
       left: $pt-grid-size;
-      margin: 0;
       color: $pt-icon-color;
-    }
-
-    // CSS API support
-    &::before {
-      @include pt-icon($pt-icon-size-large);
     }
   }
 
@@ -88,4 +79,13 @@ Styleguide pt-callout
   .pt-running-text & {
     margin: ($pt-grid-size * 2) 0;
   }
+}
+
+// callout icon fills vertical space at left side, pushing title and content over.
+// note that CSS API `.pt-callout.pt-icon-[name]` is still supported.
+.pt-callout-icon {
+  float: left;
+  margin-right: $pt-grid-size;
+  height: 100%;
+  color: $pt-icon-color;
 }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -28,15 +28,24 @@ Styleguide pt-callout
   background-color: rgba($gray3, 0.15);
   padding: $pt-grid-size ($pt-grid-size * 1.2) ($pt-grid-size * 0.9);
 
+  // apply class as modifier to adjust padding...
+  &.pt-callout-icon,
   &[class*="pt-icon-"] {
     padding-left: ($pt-grid-size * 2) + $pt-icon-size-large;
 
+    // ...and apply class to Icon for position
+    .pt-callout-icon,
     &::before {
-      @include pt-icon($pt-icon-size-large);
       position: absolute;
       top: $pt-grid-size;
       left: $pt-grid-size;
+      margin: 0;
       color: $pt-icon-color;
+    }
+
+    // CSS API support
+    &::before {
+      @include pt-icon($pt-icon-size-large);
     }
   }
 
@@ -59,6 +68,7 @@ Styleguide pt-callout
       background-color: rgba($color, 0.15);
 
       &[class*="pt-icon-"]::before,
+      .pt-callout-icon,
       h5 {
         color: map-get($pt-intent-text-colors, $intent);
       }
@@ -67,6 +77,7 @@ Styleguide pt-callout
         background-color: rgba($color, 0.25);
 
         &[class*="pt-icon-"]::before,
+        .pt-callout-icon,
         h5 {
           color: map-get($pt-dark-intent-text-colors, $intent);
         }

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -2,6 +2,8 @@
 
 Callouts visually highlight important content for the user.
 
+@reactExample CalloutExample
+
 @## CSS API
 
 Callouts use the same visual intent modifier classes as buttons. If you need a
@@ -18,7 +20,13 @@ heading, use the `<h5>` element.
 The `Callout` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [general usage docs for JS components](#blueprint.usage).
 
-The component is a simple wrapper around the CSS API that provides props for modifiers and optional title element.
-Any additional HTML props will be spread to the rendered `<div>` element.
+The component is a simple wrapper around the CSS API that provides props for modifiers and the optional title
+element. Any additional HTML props will be spread to the rendered `<div>` element. It provides two additional
+useful features:
+
+1. Providing an `intent` will set use a default icon per intent, which can be overridden by supplying
+your own `iconName`.
+1. The React component renders an SVG `Icon` element for the `iconName` prop, instead of the `.pt-icon-*`
+CSS class.
 
 @interface ICalloutProps

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -7,12 +7,16 @@
 import * as classNames from "classnames";
 import * as React from "react";
 
-import { Classes, IIntentProps, IProps } from "../../common";
+import { Classes, IIntentProps, Intent, IProps } from "../../common";
+import { Icon } from "../../index";
 import { IconName } from "../icon/icon";
 
 /** This component also supports the full range of HTML `<div>` props. */
 export interface ICalloutProps extends IIntentProps, IProps {
-    /** Name of icon to render on left-hand side. */
+    /**
+     * Name of icon to render on left-hand side.
+     * If this prop is omitted, the `intent` prop will determine a default icon.
+     */
     iconName?: IconName;
 
     /**
@@ -26,18 +30,37 @@ export interface ICalloutProps extends IIntentProps, IProps {
 
 export class Callout extends React.PureComponent<ICalloutProps & React.HTMLAttributes<HTMLDivElement>, {}> {
     public render() {
-        const { className, children, iconName, intent, title, ...htmlProps } = this.props;
+        const { className, children, iconName: _nospread, intent, title, ...htmlProps } = this.props;
+        const iconName = this.getIconName();
         const classes = classNames(
             Classes.CALLOUT,
             Classes.intentClass(intent),
-            Classes.iconClass(iconName),
+            { [Classes.CALLOUT_ICON]: iconName != null },
             className,
         );
         return (
             <div className={classes} {...htmlProps}>
+                {iconName && <Icon className={Classes.CALLOUT_ICON} iconName={iconName} iconSize={Icon.SIZE_LARGE} />}
                 {title && <h5>{title}</h5>}
                 {children}
             </div>
         );
+    }
+
+    private getIconName(): IconName {
+        const { iconName, intent } = this.props;
+        if (iconName != null || intent === Intent.NONE) {
+            return iconName;
+        }
+        switch (intent) {
+            case Intent.DANGER:
+                return "error";
+            case Intent.PRIMARY:
+                return "info-sign";
+            case Intent.WARNING:
+                return "warning-sign";
+            case Intent.SUCCESS:
+                return "tick";
+        }
     }
 }

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -32,15 +32,14 @@ export class Callout extends React.PureComponent<ICalloutProps & React.HTMLAttri
     public render() {
         const { className, children, iconName: _nospread, intent, title, ...htmlProps } = this.props;
         const iconName = this.getIconName();
-        const classes = classNames(
-            Classes.CALLOUT,
-            Classes.intentClass(intent),
-            { [Classes.CALLOUT_ICON]: iconName != null },
-            className,
-        );
+        const classes = classNames(Classes.CALLOUT, Classes.intentClass(intent), className);
         return (
             <div className={classes} {...htmlProps}>
-                {iconName && <Icon className={Classes.CALLOUT_ICON} iconName={iconName} iconSize={Icon.SIZE_LARGE} />}
+                {iconName && (
+                    <span className={Classes.CALLOUT_ICON}>
+                        <Icon iconName={iconName} iconSize={Icon.SIZE_LARGE} />
+                    </span>
+                )}
                 {title && <h5>{title}</h5>}
                 {children}
             </div>

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -15,9 +15,11 @@ import { IconName } from "../icon/icon";
 export interface ICalloutProps extends IIntentProps, IProps {
     /**
      * Name of icon to render on left-hand side.
-     * If this prop is omitted, the `intent` prop will determine a default icon.
+     *
+     * If this prop is omitted or `undefined`, the `intent` prop will determine a default icon.
+     * If this prop is explicitly `null`, no icon will be displayed (regardless of `intent`).
      */
-    iconName?: IconName;
+    iconName?: IconName | null;
 
     /**
      * String content of optional title element.
@@ -46,9 +48,10 @@ export class Callout extends React.PureComponent<ICalloutProps & React.HTMLAttri
         );
     }
 
-    private getIconName(): IconName {
+    private getIconName(): IconName | undefined {
         const { iconName, intent } = this.props;
-        if (iconName != null || intent === Intent.NONE) {
+        // `iconName === null` overrides intent icon
+        if (iconName !== undefined) {
             return iconName;
         }
         switch (intent) {
@@ -60,6 +63,8 @@ export class Callout extends React.PureComponent<ICalloutProps & React.HTMLAttri
                 return "warning-sign";
             case Intent.SUCCESS:
                 return "tick";
+            default:
+                return undefined;
         }
     }
 }

--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -28,6 +28,16 @@ describe("<Callout>", () => {
         assert.isTrue(wrapper.hasClass(Classes.INTENT_DANGER));
     });
 
+    it("intent renders default icon", () => {
+        const wrapper = shallow(<Callout intent={Intent.PRIMARY} />);
+        assert.isTrue(wrapper.find(Icon).exists());
+    });
+
+    it("iconName=null removes intent icon", () => {
+        const wrapper = shallow(<Callout iconName={null} intent={Intent.PRIMARY} />);
+        assert.isFalse(wrapper.find(Icon).exists());
+    });
+
     it("renders optional title element", () => {
         const title = "I am the title";
         const wrapper = shallow(<Callout title={title} />);

--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -8,7 +8,7 @@ import { assert } from "chai";
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { Callout, Classes, Intent } from "../../src/index";
+import { Callout, Classes, Icon, Intent } from "../../src/index";
 
 describe("<Callout>", () => {
     it("supports className", () => {
@@ -20,7 +20,7 @@ describe("<Callout>", () => {
 
     it("supports icon", () => {
         const wrapper = shallow(<Callout iconName="graph" />);
-        assert.isTrue(wrapper.hasClass(Classes.iconClass("graph")));
+        assert.isTrue(wrapper.find(Icon).exists());
     });
 
     it("supports intent", () => {

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Callout, Intent, Switch } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+import { IconName } from "@blueprintjs/icons";
+import { IconSelect } from "./common/iconSelect";
+import { IntentSelect } from "./common/intentSelect";
+
+export interface ICalloutExampleState {
+    iconName?: IconName;
+    intent?: Intent;
+    showHeader: boolean;
+}
+
+export class CalloutExample extends BaseExample<ICalloutExampleState> {
+    public state: ICalloutExampleState = { showHeader: true };
+
+    protected renderExample() {
+        const { showHeader, ...calloutProps } = this.state;
+        return (
+            <Callout {...calloutProps} title={showHeader ? "Visually important content" : undefined}>
+                The component is a simple wrapper around the CSS API that provides props for modifiers and optional
+                title element. Any additional HTML props will be spread to the rendered <code>{"<div>"}</code> element.
+            </Callout>
+        );
+    }
+
+    protected renderOptions() {
+        const { iconName, intent, showHeader } = this.state;
+        return [
+            [
+                <IntentSelect key="intent" intent={intent} onChange={this.handleIntentChange} />,
+                <Switch key="header" checked={showHeader} label="Show header" onChange={this.handleHeaderChange} />,
+            ],
+            [<IconSelect key="icon-name" iconName={iconName} onChange={this.handleIconNameChange} />],
+        ];
+    }
+
+    // tslint:disable-next-line:member-ordering
+    private handleHeaderChange = handleBooleanChange((showHeader: boolean) => this.setState({ showHeader }));
+
+    private handleIconNameChange = (iconName: IconName) => this.setState({ iconName });
+
+    // tslint:disable-next-line:member-ordering
+    private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
+}

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -8,6 +8,7 @@ export * from "./alertExample";
 export * from "./buttonsExample";
 export * from "./buttonGroupExample";
 export * from "./buttonGroupPopoverExample";
+export * from "./calloutExample";
 export * from "./checkboxExample";
 export * from "./collapseExample";
 export * from "./cardExample";

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -130,7 +130,7 @@ describe("<ColumnHeaderCell>", () => {
             table.find(`.${Classes.TABLE_COLUMN_HEADERS}`).mouse("mousemove");
             table.find(`.${Classes.TABLE_TH_MENU} .${CoreClasses.POPOVER_TARGET}`).mouse("click");
             ElementHarness.document()
-                .find(".pt-icon-export")
+                .find('[data-icon="export"]')
                 .mouse("click");
             expect(menuClickSpy.called).to.be.true;
         }


### PR DESCRIPTION
- added `.pt-callout-icon` class to adjust padding & layout when icon is present
- existing CSS API is unchanged
- add Callout Example in docs
