### PR TITLE
[Labs] Pass inputRef to <Suggest> & <MultiSelect>

### DIFF
--- a/packages/labs/src/components/select/multiSelect.tsx
+++ b/packages/labs/src/components/select/multiSelect.tsx
@@ -79,7 +79,17 @@ export class MultiSelect<T> extends React.Component<IMultiSelectProps<T>, IMulti
     private input: HTMLInputElement;
     private queryList: QueryList<T>;
     private refHandlers = {
-        input: (ref: HTMLInputElement) => (this.input = ref),
+        input: (ref: HTMLInputElement) => {
+            this.input = ref;
+
+            const { tagInputProps = {} } = this.props;
+            const inputProps: HTMLInputProps = tagInputProps.inputProps || {};
+            // can't use safeInvoke cuz inputProps.ref can be `string | function`
+            const refHandler = inputProps.ref;
+            if (Utils.isFunction(refHandler)) {
+                refHandler(ref);
+            }
+        },
         queryList: (ref: QueryList<T>) => (this.queryList = ref),
     };
 

--- a/packages/labs/src/components/select/suggest.tsx
+++ b/packages/labs/src/components/select/suggest.tsx
@@ -98,7 +98,12 @@ export class Suggest<T> extends React.Component<ISuggestProps<T>, ISuggestState<
     private TypedQueryList = QueryList.ofType<T>();
     private queryList: QueryList<T>;
     private refHandlers = {
-        input: (ref: HTMLInputElement) => (this.input = ref),
+        input: (ref: HTMLInputElement) => {
+            this.input = ref;
+
+            const { inputProps = {} } = this.props;
+            Utils.safeInvoke(inputProps.inputRef, ref);
+        },
         queryList: (ref: QueryList<T>) => (this.queryList = ref),
     };
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

1. Pass `inputProps.inputRef` prop to `Suggest` component, in same way as in `Select`.
1. Pass `tagInputProps.inputProps.ref` to `MultiSelect` component. (`inputProps` is passed to `TagInput`, that does not accept `inputRef`, because uses native `input` tag instead of `InputGroup`)

Passing custom ref handler to input will allow more flexible opportunity to build own extended components on top of blueprint components.