### PR TITLE
flex tag input

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -170,7 +170,8 @@ export const TAG_REMOVABLE = "pt-tag-removable";
 export const TAG_REMOVE = "pt-tag-remove";
 
 export const TAG_INPUT = "pt-tag-input";
-export const TAG_INPUT_ICON = `${TAG_INPUT}-icon`;
+export const TAG_INPUT_ICON = "pt-tag-input-icon";
+export const TAG_INPUT_VALUES = "pt-tag-input-values";
 
 export const TOAST = "pt-toast";
 export const TOAST_CONTAINER = "pt-toast-container";

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -200,12 +200,12 @@ Styleguide pt-button
 
   &.pt-large,
   .pt-large & {
-    @include pt-button-large();
+    @include pt-button-height-large();
   }
 
   &.pt-small,
   .pt-small & {
-    @include pt-button-small();
+    @include pt-button-height-small();
   }
 }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -112,6 +112,23 @@ $button-intents: (
   min-height: $height;
 }
 
+@mixin pt-button-height-large() {
+  @include pt-button-height($pt-button-height-large);
+  @include pt-flex-margin(row, $button-icon-spacing-large);
+  padding: $button-padding-large;
+  font-size: $pt-font-size-large;
+}
+
+@mixin pt-button-height-default() {
+  @include pt-button-height($pt-button-height);
+  padding: $button-padding;
+}
+
+@mixin pt-button-height-small() {
+  @include pt-button-height($pt-button-height-small);
+  padding: $button-padding-small;
+}
+
 @mixin pt-button() {
   box-shadow: $button-box-shadow;
   background-color: $button-background-color;
@@ -431,14 +448,3 @@ $button-intents: (
   }
 }
 
-@mixin pt-button-large() {
-  @include pt-button-height($pt-button-height-large);
-  @include pt-flex-margin(row, $button-icon-spacing-large);
-  padding: $button-padding-large;
-  font-size: $pt-font-size-large;
-}
-
-@mixin pt-button-small() {
-  @include pt-button-height($pt-button-height-small);
-  padding: $button-padding-small;
-}

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -6,25 +6,23 @@
 @import "../tag/common";
 
 $ti-padding: ($pt-input-height - $tag-height) / 2;
-$ti-padding-right: ($pt-input-height - $pt-button-height-small) / 2;
-$ti-padding-right-large: ($pt-input-height-large - $pt-button-height-small) / 2;
 
 $ti-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
 $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
 
 .pt-tag-input {
-  @include pt-flex-container(row, $ti-icon-padding, $fill: ".pt-tag-input-values");
-  align-items: center;
+  @include pt-flex-container(row, $fill: ".pt-tag-input-values");
+  align-items: flex-start;
   cursor: text;
   height: auto;
   min-height: $pt-input-height;
-  padding-right: $ti-padding-right;
+  padding-right: 0;
   padding-left: $ti-padding;
 
   .pt-tag-input-icon {
-    align-self: flex-start;
     // margins to center icon in one-line input
     margin-top: $ti-icon-padding;
+    margin-right: $ti-icon-padding;
     margin-left: $ti-icon-padding - $ti-padding;
     color: $pt-icon-color;
   }
@@ -33,8 +31,10 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
     @include pt-flex-container(row, $ti-padding);
     flex-wrap: wrap;
     align-items: center;
+    // fill vertical height
     align-self: stretch;
     margin-top: $ti-padding;
+    margin-right: $ti-icon-padding;
 
     > * {
       margin-bottom: $ti-padding;
@@ -59,15 +59,26 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
     }
   }
 
+  .pt-button {
+    @include pt-button-height($pt-button-height-small);
+    margin: ($pt-input-height - $pt-button-height-small) / 2;
+    margin-left: 0;
+  }
+
   &.pt-large {
     @include pt-flex-margin(row, $ti-icon-padding-large);
     height: auto;
     min-height: $pt-input-height-large;
-    padding-right: $ti-padding-right-large;
 
     .pt-tag-input-icon {
       margin-top: $ti-icon-padding-large;
       margin-left: $ti-icon-padding-large - $ti-padding;
+    }
+
+    .pt-button {
+      @include pt-button-height($pt-button-height);
+      margin: ($pt-input-height-large - $pt-button-height) / 2;
+      margin-left: 0;
     }
   }
 

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -7,27 +7,41 @@
 
 $ti-padding: ($pt-input-height - $tag-height) / 2;
 $ti-padding-right: ($pt-input-height - $pt-button-height-small) / 2;
-$ti-large-padding-right: ($pt-input-height-large - $pt-button-height-small) / 2;
+$ti-padding-right-large: ($pt-input-height-large - $pt-button-height-small) / 2;
 
 $ti-icon-padding: ($pt-input-height - $pt-icon-size-standard) / 2;
-$ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
+$ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
 
 .pt-tag-input {
-  display: flex;
-  flex-wrap: wrap;
+  @include pt-flex-container(row, $ti-icon-padding, $fill: ".pt-tag-input-values");
   align-items: center;
   cursor: text;
   height: auto;
-  padding: $ti-padding $ti-padding-right 0 0;
+  min-height: $pt-input-height;
+  padding-right: $ti-padding-right;
+  padding-left: $ti-padding;
 
   .pt-tag-input-icon {
-    // stylelint-disable-next-line max-line-length
-    margin: 0 ($ti-icon-padding - $ti-padding) $ti-padding $ti-icon-padding;
+    align-self: flex-start;
+    // margins to center icon in one-line input
+    margin-top: $ti-icon-padding;
+    margin-left: $ti-icon-padding - $ti-padding;
     color: $pt-icon-color;
   }
 
+  .pt-tag-input-values {
+    @include pt-flex-container(row, $ti-padding);
+    flex-wrap: wrap;
+    align-items: center;
+    align-self: stretch;
+    margin-top: $ti-padding;
+
+    > * {
+      margin-bottom: $ti-padding;
+    }
+  }
+
   .pt-tag {
-    margin: 0 0 $ti-padding $ti-padding;
     // NOTE: in order to wrap long words, you must set explicit width on TagInput,
     // or use .pt-fill CSS class modifier.
     overflow-wrap: break-word;
@@ -36,38 +50,24 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
   .pt-input-ghost {
     // input fills remaining line
     flex: 1 1 auto;
-    margin-bottom: $ti-padding;
     // essentially a min-width, cuz flex allows it to grow or shrink:
-    width: $pt-grid-size * 10;
-    line-height: $tag-height;
-
-    // match padding of other input elements iff no tags are selected
-    &:not(:first-child) {
-      padding: 0 ($input-padding-horizontal - $ti-padding);
-    }
+    width: $pt-grid-size * 8;
 
     &:disabled,
     &.pt-disabled {
       cursor: not-allowed;
     }
-
-    ~ * {
-      // shift right element up (to ignore top padding) so flex box will center it correctly
-      margin-top: -$ti-padding;
-    }
   }
 
   &.pt-large {
+    @include pt-flex-margin(row, $ti-icon-padding-large);
     height: auto;
-    padding-right: $ti-large-padding-right;
+    min-height: $pt-input-height-large;
+    padding-right: $ti-padding-right-large;
 
     .pt-tag-input-icon {
-      // stylelint-disable-next-line max-line-length
-      margin: 0 ($ti-icon-padding-large - $ti-padding) $ti-padding $ti-icon-padding-large;
-    }
-
-    .pt-input-ghost {
-      line-height: $tag-height-large;
+      margin-top: $ti-icon-padding-large;
+      margin-left: $ti-icon-padding-large - $ti-padding;
     }
   }
 
@@ -104,7 +104,7 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-standard) / 2;
   border: none;
   box-shadow: none;
   background: none;
-  padding: 0 $input-padding-horizontal;
+  padding: 0;
 
   &:focus {
     // remove focus state too

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -52,6 +52,7 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
     flex: 1 1 auto;
     // essentially a min-width, cuz flex allows it to grow or shrink:
     width: $pt-grid-size * 8;
+    line-height: $tag-height;
 
     &:disabled,
     &.pt-disabled {
@@ -59,10 +60,14 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
     }
   }
 
-  .pt-button {
-    @include pt-button-height($pt-button-height-small);
+  .pt-button,
+  .pt-spinner {
     margin: ($pt-input-height - $pt-button-height-small) / 2;
     margin-left: 0;
+  }
+
+  .pt-button {
+    @include pt-button-height-small();
   }
 
   &.pt-large {
@@ -75,9 +80,18 @@ $ti-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 2;
       margin-left: $ti-icon-padding-large - $ti-padding;
     }
 
+    .pt-input-ghost {
+      line-height: $tag-height-large;
+    }
+
     .pt-button {
-      @include pt-button-height($pt-button-height);
+      @include pt-button-height-default();
       margin: ($pt-input-height-large - $pt-button-height) / 2;
+      margin-left: 0;
+    }
+
+    .pt-spinner {
+      margin: ($pt-input-height-large - $pt-button-height-small) / 2;
       margin-left: 0;
     }
   }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -109,7 +109,7 @@ export interface ITagInputProps extends IProps {
 
     /**
      * Element to render on right side of input.
-     * For best results, use a small minimal button, tag, or spinner.
+     * For best results, use a minimal button, tag, or spinner.
      */
     rightElement?: JSX.Element;
 

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -206,19 +206,22 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
                     iconName={leftIconName}
                     iconSize={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD}
                 />
-                {values.map(this.maybeRenderTag)}
-                <input
-                    value={this.state.inputValue}
-                    {...inputProps}
-                    onFocus={this.handleInputFocus}
-                    onChange={this.handleInputChange}
-                    onKeyDown={this.handleInputKeyDown}
-                    onKeyUp={this.handleInputKeyUp}
-                    placeholder={resolvedPlaceholder}
-                    ref={this.refHandlers.input}
-                    className={classNames(Classes.INPUT_GHOST, inputProps.className)}
-                    disabled={this.props.disabled}
-                />
+                <div className={Classes.TAG_INPUT_VALUES}>
+                    {values.map(this.maybeRenderTag)}
+                    {this.props.children}
+                    <input
+                        value={this.state.inputValue}
+                        {...inputProps}
+                        onFocus={this.handleInputFocus}
+                        onChange={this.handleInputChange}
+                        onKeyDown={this.handleInputKeyDown}
+                        onKeyUp={this.handleInputKeyUp}
+                        placeholder={resolvedPlaceholder}
+                        ref={this.refHandlers.input}
+                        className={classNames(Classes.INPUT_GHOST, inputProps.className)}
+                        disabled={this.props.disabled}
+                    />
+                </div>
                 {this.props.rightElement}
             </div>
         );

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -109,7 +109,8 @@ export interface ITagInputProps extends IProps {
 
     /**
      * Element to render on right side of input.
-     * For best results, use a minimal button, tag, or spinner.
+     * For best results, use a small spinner or minimal button (button height will adjust if `TagInput` use `.pt-large`).
+     * Other elements will likely require custom styles for correct positioning.
      */
     rightElement?: JSX.Element;
 

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -58,7 +58,7 @@ export class TagInputExample extends BaseExample<ITagInputExampleState> {
 
         const clearButton = (
             <Button
-                className={classNames(Classes.MINIMAL, Classes.SMALL)}
+                className={Classes.MINIMAL}
                 disabled={disabled}
                 iconName={values.length > 1 ? "cross" : "refresh"}
                 onClick={this.handleClear}


### PR DESCRIPTION
#### Fixes #1425 (last remaining TODO)

- actually three-column layout, with tags (and children) in center container
- `rightElement` supports buttons and spinners out of the box, but other elements will likely need custom CSS

#### Thoughts

- ⚠️  aligning the `rightElement` is basically impossible to generalize 😢 . any thoughts about how to handle this?
  - the left icon and values are easy to center because they're owned by TagInput: we know size, position, etc about those.
    - check out the margins on the left icon — they’re very specific to center it properly
and they change when large
  - but `rightElement?: React.ReactNode` we know _nothing_ about!
in the docs example it’s a small button but it could be _anything_, from a large button to an entire app-in-a-box
    - the `align-items: flex-start` fucks it all up cuz i don’t know what kind of margins to apply to “center” the element in the one-line case
  

<img width="764" alt="tag-input-flex" src="https://user-images.githubusercontent.com/464822/35832429-22436f28-0a82-11e8-9cb9-59c10f446aff.png">

