### PR TITLE
IActionProps text accepts ReactNode

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -42,8 +42,8 @@ export interface IActionProps extends IIntentProps, IProps {
     /** Click event handler. */
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 
-    /** Action text. */
-    text?: string;
+    /** Action text. Can be any single React renderable. */
+    text?: React.ReactNode;
 }
 
 /** Interface for a link, with support for customizing target window. */

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -51,7 +51,7 @@ export interface IFileInputProps extends React.AllHTMLAttributes<HTMLLabelElemen
      * The text to display.
      * @default "Choose file..."
      */
-    text?: string;
+    text?: React.ReactNode;
 }
 
 // TODO: write tests (ignoring for now to get a build passing quickly)

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -20,7 +20,7 @@ import { Menu } from "./menu";
 export interface IMenuItemProps extends IActionProps, ILinkProps {
     // override from IActionProps to make it required
     /** Item text, required for usability. */
-    text: string;
+    text: React.ReactNode;
 
     /**
      * Right-aligned label content, useful for displaying hotkeys.

--- a/packages/core/test/collapsible-list/collapsibleListTests.tsx
+++ b/packages/core/test/collapsible-list/collapsibleListTests.tsx
@@ -105,7 +105,7 @@ describe("<CollapsibleList>", () => {
             renderCollapsibleList(7, { visibleItemRenderer, visibleItemCount: 3 });
             visibleItemRenderer.args.map(arg => {
                 const props: IMenuItemProps = arg[0];
-                const absoluteIndex = +props.text.slice(5); // "Item #"
+                const absoluteIndex = +props.text.toString().slice(5); // "Item #"
                 assert.equal(absoluteIndex, arg[1]);
             });
         });
@@ -115,7 +115,7 @@ describe("<CollapsibleList>", () => {
             renderCollapsibleList(6, { collapseFrom: CollapseFrom.END, visibleItemRenderer, visibleItemCount: 3 });
             visibleItemRenderer.args.map(arg => {
                 const props: IMenuItemProps = arg[0];
-                const absoluteIndex = +props.text.slice(5); // "Item #"
+                const absoluteIndex = +props.text.toString().slice(5); // "Item #"
                 assert.equal(absoluteIndex, arg[1]);
             });
         });

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -35,14 +35,14 @@ export class ToastExample extends BaseExample<IToasterProps> {
             action: {
                 href: "https://www.google.com/search?q=toast&source=lnms&tbm=isch",
                 target: "_blank",
-                text: "Yum",
+                text: <strong>Yum.</strong>,
             },
             button: "Procure toast",
             intent: Intent.PRIMARY,
             message: (
-                <span>
+                <>
                     One toast created. <em>Toasty.</em>
-                </span>
+                </>
             ),
         },
         {


### PR DESCRIPTION
#### Changes proposed in this pull request:

- `IActionProps` `text` accepts `React.ReactNode` (instead of only strings)
  - affects `Breadcrumb`, `Button`, `MenuItem`, `Toast`
- `FileInput` also accepts `React.ReactNode` text