### PR TITLE
Close dateinput popover

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -215,11 +215,10 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             // dom elements for the updated month is not available when
             // onMonthChange is called. setTimeout is necessary to wait
             // for the updated month to be rendered
-            onMonthChange: (month: Date) =>
-                setTimeout(() => {
-                    Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, month);
-                    this.registerPopoverBlurHandler();
-                }, 0),
+            onMonthChange: (month: Date) => {
+                Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, month);
+                this.setTimeout(this.registerPopoverBlurHandler);
+            },
         };
 
         const popoverContent =
@@ -479,8 +478,11 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         this.safeInvokeInputProp("onKeyDown", e);
     };
 
+    // blur DOM event listener (not React event)
+    private handlePopoverBlur = () => this.handleClosePopover();
+
     private registerPopoverBlurHandler = () => {
-        if (this.contentRef) {
+        if (this.contentRef != null) {
             // Popover contents are well structured, but the selector will need
             // to be updated if more focusable components are added in the future
             const tabbableElements = this.contentRef.querySelectorAll("input, [tabindex]:not([tabindex='-1'])");
@@ -490,7 +492,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
                 if (this.lastPopoverElement !== lastPopoverElement) {
                     this.unregisterPopoverBlurHandler();
                     this.lastPopoverElement = lastPopoverElement;
-                    this.lastPopoverElement.addEventListener("blur", (this.handleClosePopover as any) as EventListener);
+                    this.lastPopoverElement.addEventListener("blur", this.handlePopoverBlur);
                 }
             }
         }
@@ -498,7 +500,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     private unregisterPopoverBlurHandler = () => {
         if (this.lastPopoverElement) {
-            this.lastPopoverElement.removeEventListener("blur", (this.handleClosePopover as any) as EventListener);
+            this.lastPopoverElement.removeEventListener("blur", this.handlePopoverBlur);
         }
     };
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -215,10 +215,11 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             // dom elements for the updated month is not available when
             // onMonthChange is called. setTimeout is necessary to wait
             // for the updated month to be rendered
-            onMonthChange: (month: Date) => setTimeout(() => {
-                Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, month);
-                this.registerPopoverBlurHandler();
-            }, 0),
+            onMonthChange: (month: Date) =>
+                setTimeout(() => {
+                    Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, month);
+                    this.registerPopoverBlurHandler();
+                }, 0),
         };
 
         const popoverContent =
@@ -479,16 +480,18 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     };
 
     private registerPopoverBlurHandler = () => {
-        // Popover contents are well structured, but the selector will need
-        // to be updated if more focusable components are added in the future
-        const tabbableElements = this.contentRef.querySelectorAll("input, [tabindex]:not([tabindex='-1'])");
-        const numOfElements = tabbableElements.length;
-        if (numOfElements > 0) {
-            const lastPopoverElement = tabbableElements[numOfElements - 1] as HTMLElement;
-            if (this.lastPopoverElement !== lastPopoverElement) {
-                this.unregisterPopoverBlurHandler();
-                this.lastPopoverElement = lastPopoverElement;
-                this.lastPopoverElement.addEventListener("blur", (this.handleClosePopover as any) as EventListener);
+        if (this.contentRef) {
+            // Popover contents are well structured, but the selector will need
+            // to be updated if more focusable components are added in the future
+            const tabbableElements = this.contentRef.querySelectorAll("input, [tabindex]:not([tabindex='-1'])");
+            const numOfElements = tabbableElements.length;
+            if (numOfElements > 0) {
+                const lastPopoverElement = tabbableElements[numOfElements - 1] as HTMLElement;
+                if (this.lastPopoverElement !== lastPopoverElement) {
+                    this.unregisterPopoverBlurHandler();
+                    this.lastPopoverElement = lastPopoverElement;
+                    this.lastPopoverElement.addEventListener("blur", (this.handleClosePopover as any) as EventListener);
+                }
             }
         }
     };

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -478,10 +478,10 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         this.safeInvokeInputProp("onKeyDown", e);
     };
 
-    // keyboard DOM event listener (not React event)
-    private handlePopoverBlur = (e: KeyboardEvent) => {
-        if (e.which === Keys.TAB && !e.shiftKey) {
-            e.target.dispatchEvent(new FocusEvent("blur"));
+    // focus DOM event listener (not React event)
+    private handlePopoverBlur = (e: FocusEvent) => {
+        const relatedTarget = e.relatedTarget as HTMLElement;
+        if (relatedTarget == null || !this.contentRef.contains(relatedTarget)) {
             this.handleClosePopover();
         }
     };
@@ -494,14 +494,14 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             const numOfElements = tabbableElements.length;
             if (numOfElements > 0) {
                 // Keep track of the last focusable element in popover and add
-                // a keydown handler, so that:
-                // * popover closes when the user tabs to the next element
-                // * or focus moves to previous element if shift+tab
+                // a blur handler, so that when:
+                // * user tabs to the next element, popover closes
+                // * focus moves to element within popover, popover stays open
                 const lastElement = tabbableElements[numOfElements - 1] as HTMLElement;
                 if (this.lastElementInPopover !== lastElement) {
                     this.unregisterPopoverBlurHandler();
                     this.lastElementInPopover = lastElement;
-                    this.lastElementInPopover.addEventListener("keydown", this.handlePopoverBlur);
+                    this.lastElementInPopover.addEventListener("blur", this.handlePopoverBlur);
                 }
             }
         }
@@ -509,7 +509,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     private unregisterPopoverBlurHandler = () => {
         if (this.lastElementInPopover != null) {
-            this.lastElementInPopover.removeEventListener("keydown", this.handlePopoverBlur);
+            this.lastElementInPopover.removeEventListener("blur", this.handlePopoverBlur);
         }
     };
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -447,6 +447,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             // the page. tabbing forward should *not* close the popover, because
             // focus will be moving into the popover itself.
             this.setState({ isOpen: false });
+        } else if (e.which === Keys.ESCAPE) {
+            this.setState({ isOpen: false });
+            this.inputRef.blur();
         }
         this.safeInvokeInputProp("onKeyDown", e);
     };

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -478,7 +478,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
         this.safeInvokeInputProp("onKeyDown", e);
     };
 
-    // blur DOM event listener (not React event)
+    // keyboard DOM event listener (not React event)
     private handlePopoverBlur = (e: KeyboardEvent) => {
         if (e.which === Keys.TAB && !e.shiftKey) {
             e.target.dispatchEvent(new FocusEvent("blur"));
@@ -494,8 +494,9 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             const numOfElements = tabbableElements.length;
             if (numOfElements > 0) {
                 // Keep track of the last focusable element in popover and add
-                // a blur handler, so that popover closes when the user
-                // moves to the next element
+                // a keydown handler, so that:
+                // * popover closes when the user tabs to the next element
+                // * or focus moves to previous element if shift+tab
                 const lastElement = tabbableElements[numOfElements - 1] as HTMLElement;
                 if (this.lastElementInPopover !== lastElement) {
                     this.unregisterPopoverBlurHandler();

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -185,7 +185,7 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
 
     private inputRef: HTMLElement = null;
     private contentRef: HTMLElement = null;
-    private lastPopoverElement: HTMLElement = null;
+    private lastElementInPopover: HTMLElement = null;
 
     public constructor(props?: IDateInputProps, context?: any) {
         super(props, context);
@@ -479,7 +479,12 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
     };
 
     // blur DOM event listener (not React event)
-    private handlePopoverBlur = () => this.handleClosePopover();
+    private handlePopoverBlur = (e: KeyboardEvent) => {
+        if (e.which === Keys.TAB && !e.shiftKey) {
+            e.target.dispatchEvent(new FocusEvent("blur"));
+            this.handleClosePopover();
+        }
+    };
 
     private registerPopoverBlurHandler = () => {
         if (this.contentRef != null) {
@@ -488,19 +493,22 @@ export class DateInput extends AbstractComponent<IDateInputProps, IDateInputStat
             const tabbableElements = this.contentRef.querySelectorAll("input, [tabindex]:not([tabindex='-1'])");
             const numOfElements = tabbableElements.length;
             if (numOfElements > 0) {
-                const lastPopoverElement = tabbableElements[numOfElements - 1] as HTMLElement;
-                if (this.lastPopoverElement !== lastPopoverElement) {
+                // Keep track of the last focusable element in popover and add
+                // a blur handler, so that popover closes when the user
+                // moves to the next element
+                const lastElement = tabbableElements[numOfElements - 1] as HTMLElement;
+                if (this.lastElementInPopover !== lastElement) {
                     this.unregisterPopoverBlurHandler();
-                    this.lastPopoverElement = lastPopoverElement;
-                    this.lastPopoverElement.addEventListener("blur", this.handlePopoverBlur);
+                    this.lastElementInPopover = lastElement;
+                    this.lastElementInPopover.addEventListener("keydown", this.handlePopoverBlur);
                 }
             }
         }
     };
 
     private unregisterPopoverBlurHandler = () => {
-        if (this.lastPopoverElement) {
-            this.lastPopoverElement.removeEventListener("blur", this.handlePopoverBlur);
+        if (this.lastElementInPopover != null) {
+            this.lastElementInPopover.removeEventListener("keydown", this.handlePopoverBlur);
         }
     };
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -63,6 +63,31 @@ describe("<DateInput>", () => {
         assert.isFalse(wrapper.find(Popover).prop("isOpen"));
     });
 
+    it("Popover closes when ESC key pressed", () => {
+        const wrapper = mount(<DateInput openOnFocus={true} />);
+        const input = wrapper.find("input");
+        input.simulate("focus");
+        const popover = wrapper.find(Popover);
+        assert.isTrue(popover.prop("isOpen"));
+        input.simulate("keydown", { which: Keys.ESCAPE });
+        assert.isFalse(popover.prop("isOpen"));
+    });
+
+    it("Popover closes when last tabbable component is blurred", () => {
+        const wrapper = mount(<DateInput openOnFocus={true} />);
+        const input = wrapper.find("input");
+        input.simulate("focus");
+        const popover = wrapper.find(Popover);
+        assert.isTrue(popover.prop("isOpen"));
+        input.simulate("blur");
+        const lastTabbable = popover
+            .find(".DayPicker-Day--outside")
+            .last()
+            .getDOMNode() as HTMLElement;
+        lastTabbable.dispatchEvent(new Event("blur"));
+        assert.isFalse(popover.prop("isOpen"));
+    });
+
     it("setting timePrecision renders a TimePicker", () => {
         const wrapper = mount(<DateInput timePrecision={TimePickerPrecision.SECOND} />).setState({ isOpen: true });
         // assert TimePicker appears

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -75,12 +75,13 @@ describe("<DateInput>", () => {
 
     it("Popover closes when last tabbable component is blurred", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
-        const wrapper = mount(<DateInput openOnFocus={true} defaultValue={defaultValue} />);
-        const input = wrapper.find("input");
-        input.simulate("focus");
+        const wrapper = mount(<DateInput defaultValue={defaultValue} />);
+        wrapper.setState({ isOpen: true });
+        wrapper
+            .find("input")
+            .simulate("focus")
+            .simulate("blur");
         const popover = wrapper.find(Popover);
-        assert.isTrue(popover.prop("isOpen"));
-        input.simulate("blur");
         // We need to use classname selector since enzyme doesn't
         // support tabindex selector
         const tabbables = popover.find(".DayPicker-Day--outside");
@@ -91,7 +92,8 @@ describe("<DateInput>", () => {
 
     it("Popover should not close if focus moves to previous date", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
-        const wrapper = mount(<DateInput openOnFocus={true} defaultValue={defaultValue} />);
+        const wrapper = mount(<DateInput defaultValue={defaultValue} />);
+        wrapper.setState({ isOpen: true });
         wrapper
             .find("input")
             .simulate("focus")
@@ -101,6 +103,30 @@ describe("<DateInput>", () => {
         const relatedTarget = tabbables.at(tabbables.length - 1).getDOMNode();
         const event = createFocusEvent("blur", relatedTarget);
         lastTabbable.dispatchEvent(event);
+        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+    });
+
+    it("Popover should not close if focus moves to month select", () => {
+        const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
+        const wrapper = mount(<DateInput defaultValue={defaultValue} />);
+        wrapper.setState({ isOpen: true });
+        wrapper
+            .find("input")
+            .simulate("focus")
+            .simulate("blur");
+        wrapper.find(".pt-datepicker-month-select").simulate("change", { value: Months.FEBRUARY.toString() });
+        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+    });
+
+    it("Popover should not close if focus moves to year select", () => {
+        const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
+        const wrapper = mount(<DateInput defaultValue={defaultValue} />);
+        wrapper.setState({ isOpen: true });
+        wrapper
+            .find("input")
+            .simulate("focus")
+            .simulate("blur");
+        wrapper.find(".pt-datepicker-year-select").simulate("change", { value: "2016" });
         assert.isTrue(wrapper.find(Popover).prop("isOpen"));
     });
 


### PR DESCRIPTION
#### Changes proposed in this pull request:
This PR enables the dateinput popover to be closed:
* after tabbing out of the last tabbable element inside the date popover
* clicking ESC key

Currently, shift tabbing out of the dateinput will close the date popover, however, tabbing through the popover elements do not close the popover after tabbing out of the last tabbable element. ESC also does not have any effect.

#### Reviewers should focus on:
<!-- fill this out -->
Is there a better way to implement this feature?

#### Screenshot
![feb-05-2018 21-41-13](https://user-images.githubusercontent.com/16532/35843521-80faf924-0abd-11e8-843b-2f58713cf729.gif)
