### PR TITLE
remove dividers from minimal button groups

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -99,30 +99,15 @@ Styleguide pt-button-group
   &:not(.pt-minimal) {
     > .pt-popover-wrapper:not(:first-child) .pt-popover-target .pt-button,
     > .pt-button:not(:first-child) {
-      border-radius: 0 $pt-border-radius $pt-border-radius 0;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
     }
 
     > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
     > .pt-button:not(:last-child) {
       margin-right: -$button-border-width;
-      border-radius: $pt-border-radius 0 0 $pt-border-radius;
-    }
-
-    &.pt-vertical {
-      > .pt-popover-wrapper:first-child .pt-popover-target .pt-button,
-      > .pt-button:first-child {
-        border-radius: $pt-border-radius $pt-border-radius 0 0;
-      }
-
-      > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
-      > .pt-button:last-child {
-        border-radius: 0 0 $pt-border-radius $pt-border-radius;
-      }
-
-      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
-      > .pt-button:not(:last-child) {
-        margin-bottom: -$button-border-width;
-      }
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
     }
   }
 
@@ -198,6 +183,23 @@ Styleguide pt-button-group
       // needed to ensure buttons take up the full width when wrapped in a Popover:
       width: 100%;
     }
+
+    &:not(.pt-minimal) {
+      > .pt-popover-wrapper:first-child .pt-popover-target .pt-button,
+      > .pt-button:first-child {
+        border-radius: $pt-border-radius $pt-border-radius 0 0;
+      }
+
+      > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
+      > .pt-button:last-child {
+        border-radius: 0 0 $pt-border-radius $pt-border-radius;
+      }
+
+      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
+      > .pt-button:not(:last-child) {
+        margin-bottom: -$button-border-width;
+      }
+    }
   }
 
   &.pt-align-left .pt-button {
@@ -207,13 +209,14 @@ Styleguide pt-button-group
   .pt-dark & {
     // support wrapping buttons in a Blueprint.Tooltip, which adds a wrapper element
     // in dark theme, we adjust the spacing between buttons for best visual results
-
-    // deeply nested selector necessary to target the appropriate popover
-    // wrapper, yet ensure we only style buttons within the target.
-    // stylelint-disable-next-line selector-max-compound-selectors
-    > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
-    > .pt-button:not(:last-child) {
-      margin-right: $button-border-width;
+    &:not(.pt-minimal) {
+      // deeply nested selector necessary to target the appropriate popover
+      // wrapper, yet ensure we only style buttons within the target.
+      // stylelint-disable-next-line selector-max-compound-selectors
+      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
+      > .pt-button:not(:last-child) {
+        margin-right: $button-border-width;
+      }
     }
 
     &.pt-vertical {

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -95,23 +95,34 @@ Styleguide pt-button-group
     }
   }
 
-  > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
-  > .pt-button:not(:last-child) {
-    margin-right: -$button-border-width;
-  }
-
   // support wrapping buttons in a tooltip, which adds a wrapper element
   &:not(.pt-minimal) {
     > .pt-popover-wrapper:not(:first-child) .pt-popover-target .pt-button,
     > .pt-button:not(:first-child) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+      border-radius: 0 $pt-border-radius $pt-border-radius 0;
     }
 
     > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
     > .pt-button:not(:last-child) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
+      margin-right: -$button-border-width;
+      border-radius: $pt-border-radius 0 0 $pt-border-radius;
+    }
+
+    &.pt-vertical {
+      > .pt-popover-wrapper:first-child .pt-popover-target .pt-button,
+      > .pt-button:first-child {
+        border-radius: $pt-border-radius $pt-border-radius 0 0;
+      }
+
+      > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
+      > .pt-button:last-child {
+        border-radius: 0 0 $pt-border-radius $pt-border-radius;
+      }
+
+      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
+      > .pt-button:not(:last-child) {
+        margin-bottom: -$button-border-width;
+      }
     }
   }
 
@@ -186,21 +197,6 @@ Styleguide pt-button-group
       margin-right: 0 !important; // stylelint-disable-line declaration-no-important
       // needed to ensure buttons take up the full width when wrapped in a Popover:
       width: 100%;
-    }
-
-    > .pt-popover-wrapper:first-child .pt-popover-target .pt-button,
-    > .pt-button:first-child {
-      border-radius: $pt-border-radius $pt-border-radius 0 0;
-    }
-
-    > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
-    > .pt-button:last-child {
-      border-radius: 0 0 $pt-border-radius $pt-border-radius;
-    }
-
-    > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
-    > .pt-button:not(:last-child) {
-      margin-bottom: -$button-border-width;
     }
   }
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -35,8 +35,7 @@ Markup:
 </div>
 
 .pt-large - Use large buttons
-.pt-minimal - Use minimal buttons. Note that these minimal buttons will not automatically
-              truncate text in an ellipsis because of the divider line added in CSS.
+.pt-minimal - Use minimal buttons
 
 Styleguide pt-button-group
 */
@@ -96,6 +95,11 @@ Styleguide pt-button-group
     }
   }
 
+  > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
+  > .pt-button:not(:last-child) {
+    margin-right: -$button-border-width;
+  }
+
   // support wrapping buttons in a tooltip, which adds a wrapper element
   &:not(.pt-minimal) {
     > .pt-popover-wrapper:not(:first-child) .pt-popover-target .pt-button,
@@ -106,7 +110,6 @@ Styleguide pt-button-group
 
     > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
     > .pt-button:not(:last-child) {
-      margin-right: -$button-border-width;
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }
@@ -115,37 +118,6 @@ Styleguide pt-button-group
   &.pt-minimal {
     .pt-button {
       @include pt-button-minimal();
-      margin-right: $pt-grid-size + $minimal-button-divider-width;
-      // always round the borders on minimal buttons
-      // stylelint-disable-next-line declaration-no-important
-      border-radius: $pt-border-radius !important;
-      // so the ::after divider is visible outside bounds of button
-      // however, this prevents ellipsizing of button text :(
-      overflow: visible;
-
-      &:focus {
-        // ensure outline is always a rectangle, instead of contouring to bounding box
-        outline-style: solid;
-      }
-
-      &::after {
-        @include pt-button-minimal-divider();
-        display: inline-block;
-        position: absolute;
-        top: 10%;
-        bottom: 10%;
-        left: 100%;
-        content: "";
-      }
-    }
-
-    > .pt-popover-wrapper:last-child .pt-popover-target .pt-button,
-    > .pt-button:last-child {
-      margin-right: 0;
-
-      &::after {
-        display: none;
-      }
     }
   }
 
@@ -230,25 +202,6 @@ Styleguide pt-button-group
     > .pt-button:not(:last-child) {
       margin-bottom: -$button-border-width;
     }
-
-    &.pt-minimal {
-      // apply the margin and divider to the .pt-popover-wrapper so that the
-      // popover arrow remains centered on the button.
-      > .pt-popover-wrapper:not(:last-child),
-      > .pt-button:not(:last-child) {
-        margin-bottom: $pt-grid-size + $minimal-button-divider-width;
-      }
-
-      > .pt-popover-wrapper .pt-popover-target .pt-button::after,
-      > .pt-button::after {
-        top: 100%;
-        right: 0;
-        bottom: auto;
-        left: 0;
-        width: auto;
-        height: $minimal-button-divider-width;
-      }
-    }
   }
 
   &.pt-align-left .pt-button {
@@ -258,14 +211,13 @@ Styleguide pt-button-group
   .pt-dark & {
     // support wrapping buttons in a Blueprint.Tooltip, which adds a wrapper element
     // in dark theme, we adjust the spacing between buttons for best visual results
-    &:not(.pt-minimal) {
-      // deeply nested selector necessary to target the appropriate popover
-      // wrapper, yet ensure we only style buttons within the target.
-      // stylelint-disable-next-line selector-max-compound-selectors
-      > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
-      > .pt-button:not(:last-child) {
-        margin-right: $button-border-width;
-      }
+
+    // deeply nested selector necessary to target the appropriate popover
+    // wrapper, yet ensure we only style buttons within the target.
+    // stylelint-disable-next-line selector-max-compound-selectors
+    > .pt-popover-wrapper:not(:last-child) .pt-popover-target .pt-button,
+    > .pt-button:not(:last-child) {
+      margin-right: $button-border-width;
     }
 
     &.pt-vertical {


### PR DESCRIPTION
huge deletions

> `    [     default ]  [ active ] [ hover ]`:

<img width="319" alt="minimal-button-group-no-dividers" src="https://user-images.githubusercontent.com/464822/35892268-81308cce-0b5d-11e8-9227-053164e6f660.png">
