### PR TITLE
Fix #2095: Ensure elements are compared to proxied component type

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -37,7 +37,7 @@ export function getDisplayName(ComponentClass: React.ComponentClass | INamed) {
 
 export function isElementOfType<P = {}>(
     element: any,
-    ComponentClass: React.ComponentClass<P>
+    ComponentClass: React.ComponentClass<P>,
 ): element is React.ReactElement<P> {
     return element != null && element.type === React.createElement(ComponentClass).type;
 }

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -4,6 +4,8 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+import * as React from "react";
+
 import { CLAMP_MIN_MAX } from "./errors";
 
 export * from "./utils/compareUtils";
@@ -31,6 +33,10 @@ export interface INamed {
 
 export function getDisplayName(ComponentClass: React.ComponentClass | INamed) {
     return (ComponentClass as React.ComponentClass).displayName || (ComponentClass as INamed).name || "Unknown";
+}
+
+export function isElementType(element: JSX.Element, ComponentClass: React.ComponentClass) {
+    return element.type === React.createElement(ComponentClass).type;
 }
 
 /**

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -35,8 +35,11 @@ export function getDisplayName(ComponentClass: React.ComponentClass | INamed) {
     return (ComponentClass as React.ComponentClass).displayName || (ComponentClass as INamed).name || "Unknown";
 }
 
-export function isElementType(element: JSX.Element, ComponentClass: React.ComponentClass) {
-    return element.type === React.createElement(ComponentClass).type;
+export function isElementOfType<P = {}>(
+    element: any,
+    ComponentClass: React.ComponentClass<P>
+): element is React.ReactElement<P> {
+    return element != null && element.type === React.createElement(ComponentClass).type;
 }
 
 /**

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -11,7 +11,7 @@ import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
-import { isElementType } from "../../common/utils";
+import { isElementOfType } from "../../common/utils";
 import { Menu } from "../menu/menu";
 import { IMenuItemProps, MenuItem } from "../menu/menuItem";
 import { IPopoverProps, Popover } from "../popover/popover";
@@ -118,10 +118,10 @@ export class CollapsibleList extends React.Component<ICollapsibleListProps, {}> 
             return [[], []];
         }
         const childrenArray = React.Children.map(this.props.children, (child: JSX.Element, index: number) => {
-            if (!isElementType(child, MenuItem)) {
+            if (!isElementOfType(child, MenuItem)) {
                 throw new Error(Errors.COLLAPSIBLE_LIST_INVALID_CHILD);
             }
-            return React.cloneElement(child, { key: `visible-${index}` });
+            return React.cloneElement(child as JSX.Element, { key: `visible-${index}` });
         });
         if (this.props.collapseFrom === CollapseFrom.START) {
             // reverse START list so we can always slice visible items from the front of the list

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -118,7 +118,7 @@ export class CollapsibleList extends React.Component<ICollapsibleListProps, {}> 
             return [[], []];
         }
         const childrenArray = React.Children.map(this.props.children, (child: JSX.Element, index: number) => {
-            if (isElementType(child, MenuItem)) {
+            if (!isElementType(child, MenuItem)) {
                 throw new Error(Errors.COLLAPSIBLE_LIST_INVALID_CHILD);
             }
             return React.cloneElement(child, { key: `visible-${index}` });

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -11,6 +11,7 @@ import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
+import { isElementType } from "../../common/utils";
 import { Menu } from "../menu/menu";
 import { IMenuItemProps, MenuItem } from "../menu/menuItem";
 import { IPopoverProps, Popover } from "../popover/popover";
@@ -117,7 +118,7 @@ export class CollapsibleList extends React.Component<ICollapsibleListProps, {}> 
             return [[], []];
         }
         const childrenArray = React.Children.map(this.props.children, (child: JSX.Element, index: number) => {
-            if (child.type !== MenuItem) {
+            if (isElementType(child, MenuItem)) {
                 throw new Error(Errors.COLLAPSIBLE_LIST_INVALID_CHILD);
             }
             return React.cloneElement(child, { key: `visible-${index}` });

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -11,7 +11,7 @@ import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { IOptionProps, IProps } from "../../common/props";
 import { isElementOfType } from "../../common/utils";
-import { Radio, IRadioProps } from "./controls";
+import { IRadioProps, Radio } from "./controls";
 
 export interface IRadioGroupProps extends IProps {
     /**

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -10,6 +10,7 @@ import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { IOptionProps, IProps } from "../../common/props";
+import { isElementType } from "../../common/utils";
 import { Radio } from "./controls";
 
 export interface IRadioGroupProps extends IProps {
@@ -108,5 +109,5 @@ export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
 }
 
 function isRadio(child: any): child is JSX.Element {
-    return child != null && (child as JSX.Element).type === Radio;
+    return child != null && isElementType(child as JSX.Element, Radio);
 }

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -10,8 +10,8 @@ import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { IOptionProps, IProps } from "../../common/props";
-import { isElementType } from "../../common/utils";
-import { Radio } from "./controls";
+import { isElementOfType } from "../../common/utils";
+import { Radio, IRadioProps } from "./controls";
 
 export interface IRadioGroupProps extends IProps {
     /**
@@ -81,8 +81,8 @@ export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
 
     private renderChildren() {
         return React.Children.map(this.props.children, child => {
-            if (isRadio(child)) {
-                return React.cloneElement(child, this.getRadioProps(child.props));
+            if (isElementOfType(child, Radio)) {
+                return React.cloneElement(child, this.getRadioProps(child.props as IOptionProps));
             } else {
                 return child;
             }
@@ -95,7 +95,7 @@ export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
         ));
     }
 
-    private getRadioProps(optionProps: IOptionProps) {
+    private getRadioProps(optionProps: IOptionProps): IRadioProps {
         const { name } = this.props;
         const { value, disabled } = optionProps;
         return {
@@ -106,8 +106,4 @@ export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
             onChange: this.props.onChange,
         };
     }
-}
-
-function isRadio(child: any): child is JSX.Element {
-    return child != null && isElementType(child as JSX.Element, Radio);
 }

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -8,6 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, IProps } from "../../common";
+import { isElementType } from "../../common/utils";
 import { KeyCombo } from "./keyCombo";
 
 export interface IHotkeyProps extends IProps {
@@ -83,7 +84,7 @@ export class Hotkey extends AbstractPureComponent<IHotkeyProps, {}> {
     };
 
     public static isInstance(element: any): element is React.ReactElement<IHotkeyProps> {
-        return element != null && (element as JSX.Element).type === Hotkey;
+        return element != null && isElementType(element as JSX.Element, Hotkey);
     }
 
     public render() {

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -8,7 +8,6 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, IProps } from "../../common";
-import { isElementType } from "../../common/utils";
 import { KeyCombo } from "./keyCombo";
 
 export interface IHotkeyProps extends IProps {
@@ -82,10 +81,6 @@ export class Hotkey extends AbstractPureComponent<IHotkeyProps, {}> {
         preventDefault: false,
         stopPropagation: false,
     };
-
-    public static isInstance(element: any): element is React.ReactElement<IHotkeyProps> {
-        return element != null && isElementType(element as JSX.Element, Hotkey);
-    }
 
     public render() {
         const { label, className, ...spreadableProps } = this.props;

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import * as classNames from "classnames";
 import { AbstractPureComponent, IProps } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
+import { isElementType } from "../../common/utils";
 import { Hotkey, IHotkeyProps } from "./hotkey";
 
 export { Hotkey, IHotkeyProps } from "./hotkey";
@@ -70,8 +71,8 @@ export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}> {
     }
 
     protected validateProps(props: IHotkeysProps & { children: React.ReactNode }) {
-        React.Children.forEach(props.children, child => {
-            if (!Hotkey.isInstance(child)) {
+        React.Children.forEach(props.children, (child: JSX.Element) => {
+            if (!isElementType(child, Hotkey)) {
                 throw new Error(HOTKEYS_HOTKEY_CHILDREN);
             }
         });

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import * as classNames from "classnames";
 import { AbstractPureComponent, IProps } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
-import { isElementType } from "../../common/utils";
+import { isElementOfType } from "../../common/utils";
 import { Hotkey, IHotkeyProps } from "./hotkey";
 
 export { Hotkey, IHotkeyProps } from "./hotkey";
@@ -72,7 +72,7 @@ export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}> {
 
     protected validateProps(props: IHotkeysProps & { children: React.ReactNode }) {
         React.Children.forEach(props.children, (child: JSX.Element) => {
-            if (!isElementType(child, Hotkey)) {
+            if (!isElementOfType(child, Hotkey)) {
                 throw new Error(HOTKEYS_HOTKEY_CHILDREN);
             }
         });

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -5,7 +5,7 @@
  */
 
 import { Children, ReactElement, ReactNode } from "react";
-import { safeInvoke, isElementOfType } from "../../common/utils";
+import { isElementOfType, safeInvoke } from "../../common/utils";
 
 import { Hotkey, IHotkeyProps } from "./hotkey";
 import { comboMatches, getKeyCombo, IKeyCombo, parseKeyCombo } from "./hotkeyParser";

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -5,7 +5,7 @@
  */
 
 import { Children, ReactElement, ReactNode } from "react";
-import { safeInvoke } from "../../common/utils";
+import { safeInvoke, isElementOfType } from "../../common/utils";
 
 import { Hotkey, IHotkeyProps } from "./hotkey";
 import { comboMatches, getKeyCombo, IKeyCombo, parseKeyCombo } from "./hotkeyParser";
@@ -40,7 +40,7 @@ export class HotkeysEvents {
     public setHotkeys(props: IHotkeysProps & { children?: ReactNode }) {
         const actions = [] as IHotkeyAction[];
         Children.forEach(props.children, (child: ReactElement<any>) => {
-            if (Hotkey.isInstance(child) && this.isScope(child.props)) {
+            if (isElementOfType(child, Hotkey) && this.isScope(child.props)) {
                 actions.push({
                     combo: parseKeyCombo(child.props.combo),
                     props: child.props,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -291,7 +291,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
                 [Classes.ACTIVE]: isOpen && !isHoverInteractionKind,
             }),
             // force disable single Tooltip child when popover is open (BLUEPRINT-552)
-            disabled: isOpen && children.target.type === Tooltip ? true : children.target.props.disabled,
+            disabled: isOpen && Utils.isElementType(children.target, Tooltip) ? true : children.target.props.disabled,
             tabIndex: targetTabIndex,
         });
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -291,7 +291,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
                 [Classes.ACTIVE]: isOpen && !isHoverInteractionKind,
             }),
             // force disable single Tooltip child when popover is open (BLUEPRINT-552)
-            disabled: isOpen && Utils.isElementType(children.target, Tooltip) ? true : children.target.props.disabled,
+            disabled: isOpen && Utils.isElementOfType(children.target, Tooltip) ? true : children.target.props.disabled,
             tabIndex: targetTabIndex,
         });
 

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -316,5 +316,5 @@ function isEventKeyCode(e: React.KeyboardEvent<HTMLElement>, ...codes: number[])
 }
 
 function isTab(child: React.ReactChild): child is TabElement {
-    return child != null && (child as JSX.Element).type === Tab;
+    return child != null && Utils.isElementType(child as JSX.Element, Tab);
 }

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -114,7 +114,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
 
         const tabTitles = React.Children.map(
             this.props.children,
-            child => (isTab(child) ? this.renderTabTitle(child) : child),
+            child => (Utils.isElementOfType(child, Tab) ? this.renderTabTitle(child as TabElement) : child),
         );
 
         const tabPanels = this.getTabChildren()
@@ -208,7 +208,9 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
 
     /** Filters children to only `<Tab>`s */
     private getTabChildren(props: ITabsProps & { children?: React.ReactNode } = this.props) {
-        return React.Children.toArray(props.children).filter(isTab) as TabElement[];
+        return React.Children.toArray(props.children).filter((child) => {
+            return Utils.isElementOfType(child, Tab);
+        }) as TabElement[];
     }
 
     /** Queries root HTML element for all `.pt-tab`s with optional filter selector */
@@ -313,8 +315,4 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
 
 function isEventKeyCode(e: React.KeyboardEvent<HTMLElement>, ...codes: number[]) {
     return codes.indexOf(e.which) >= 0;
-}
-
-function isTab(child: React.ReactChild): child is TabElement {
-    return child != null && Utils.isElementType(child as JSX.Element, Tab);
 }

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -208,7 +208,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
 
     /** Filters children to only `<Tab>`s */
     private getTabChildren(props: ITabsProps & { children?: React.ReactNode } = this.props) {
-        return React.Children.toArray(props.children).filter((child) => {
+        return React.Children.toArray(props.children).filter(child => {
             return Utils.isElementOfType(child, Tab);
         }) as TabElement[];
     }


### PR DESCRIPTION
#### Fixes #2095 

#### Changes proposed in this pull request:

Since components end up proxied when using `react-hot-loader`, comparing to `React.createElement(Component).type` rather than `Component` should be a better solution to check if a component is of the right type (e.g. a `Hotkey`) 🙂 

#### Reviewers should focus on:

Whether the components changed still behave as normal: Collapsible List, Radio Group, Hotkeys, Popover and Tabs.