### PR TITLE
Fix default import for older webpack versions

### DIFF
--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -7,7 +7,11 @@
 import { AbstractComponent, Button, IProps, Utils } from "@blueprintjs/core";
 import * as classNames from "classnames";
 import * as React from "react";
-import * as ReactDayPicker from "react-day-picker";
+import ReactDayPicker, {
+    CaptionElementProps as ReactDayPickerCaptionElementProps,
+    DayModifiers as ReactDayPickerDayModifiers,
+    Props as ReactDayPickerProps,
+} from "react-day-picker";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -31,7 +35,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
      * `canChangeMonth`, `captionElement`, `fromMonth` (use `minDate`), `month` (use
      * `initialMonth`), `toMonth` (use `maxDate`).
      */
-    dayPickerProps?: ReactDayPicker.Props;
+    dayPickerProps?: ReactDayPickerProps;
 
     /**
      * Initial day the calendar will display as selected.
@@ -128,11 +132,10 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
             showActionsBar,
         } = this.props;
         const { displayMonth, displayYear } = this.state;
-        const ReactDayPickerComponent = ReactDayPicker.default;
 
         return (
             <div className={classNames(Classes.DATEPICKER, className)}>
-                <ReactDayPickerComponent
+                <ReactDayPicker
                     enableOutsideDays={true}
                     locale={locale}
                     localeUtils={localeUtils}
@@ -199,7 +202,7 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
         return Array.isArray(disabledDays) ? [this.disabledDays, ...disabledDays] : [this.disabledDays, disabledDays];
     };
 
-    private renderCaption = (props: ReactDayPicker.CaptionElementProps) => (
+    private renderCaption = (props: ReactDayPickerCaptionElementProps) => (
         <DatePickerCaption
             {...props}
             maxDate={this.props.maxDate}
@@ -229,7 +232,7 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
 
     private handleDayClick = (
         day: Date,
-        modifiers: ReactDayPicker.DayModifiers,
+        modifiers: ReactDayPickerDayModifiers,
         e: React.MouseEvent<HTMLDivElement>,
     ) => {
         Utils.safeInvoke(this.props.dayPickerProps.onDayClick, day, modifiers, e);

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -128,10 +128,11 @@ export class DatePicker extends AbstractComponent<IDatePickerProps, IDatePickerS
             showActionsBar,
         } = this.props;
         const { displayMonth, displayYear } = this.state;
+        const ReactDayPickerComponent = ReactDayPicker.default;
 
         return (
             <div className={classNames(Classes.DATEPICKER, className)}>
-                <ReactDayPicker
+                <ReactDayPickerComponent
                     enableOutsideDays={true}
                     locale={locale}
                     localeUtils={localeUtils}


### PR DESCRIPTION
#### Fixes #2100 

#### Changes proposed in this pull request:

Use `.default` import from react-day-picker explicitly. This should not change behavior for webpack 2 and above, but enable DatePicker to properly show in Gatsby (and possibly other webpack 1 apps).