### PR TITLE
[core] add support for more Alert props

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -9,8 +9,8 @@ const ns = "[Blueprint]";
 export const CLAMP_MIN_MAX = ns + ` clamp: max cannot be less than min`;
 
 export const ALERT_WARN_CANCEL_PROPS = ns + ` <Alert> cancelButtonText and onCancel should be set together.`;
-export const ALERT_WARN_CANCEL_ESCAPE_KEY = ns + ` <Alert> canEscapeKeyCancel enabled without onCancel handler.`;
-export const ALERT_WARN_CANCEL_OUTSIDE_CLICK = ns + ` <Alert> canOutsideClickCancel enbaled without onCancel handler.`;
+export const ALERT_WARN_CANCEL_ESCAPE_KEY = ns + ` <Alert> canEscapeKeyCancel enabled without onCancel or onClose handler.`;
+export const ALERT_WARN_CANCEL_OUTSIDE_CLICK = ns + ` <Alert> canOutsideClickCancel enbaled without onCancel or onClose handler.`;
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = ns + ` <CollapsibleList> children must be <MenuItem>s`;
 

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -9,6 +9,8 @@ const ns = "[Blueprint]";
 export const CLAMP_MIN_MAX = ns + ` clamp: max cannot be less than min`;
 
 export const ALERT_WARN_CANCEL_PROPS = ns + ` <Alert> cancelButtonText and onCancel should be set together.`;
+export const ALERT_WARN_CANCEL_ESCAPE_KEY = ns + ` <Alert> canEscapeKeyCancel enabled without onCancel handler.`;
+export const ALERT_WARN_CANCEL_OUTSIDE_CLICK = ns + ` <Alert> canOutsideClickCancel enbaled without onCancel handler.`;
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = ns + ` <CollapsibleList> children must be <MenuItem>s`;
 

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -9,8 +9,10 @@ const ns = "[Blueprint]";
 export const CLAMP_MIN_MAX = ns + ` clamp: max cannot be less than min`;
 
 export const ALERT_WARN_CANCEL_PROPS = ns + ` <Alert> cancelButtonText and onCancel should be set together.`;
-export const ALERT_WARN_CANCEL_ESCAPE_KEY = ns + ` <Alert> canEscapeKeyCancel enabled without onCancel or onClose handler.`;
-export const ALERT_WARN_CANCEL_OUTSIDE_CLICK = ns + ` <Alert> canOutsideClickCancel enbaled without onCancel or onClose handler.`;
+export const ALERT_WARN_CANCEL_ESCAPE_KEY =
+    ns + ` <Alert> canEscapeKeyCancel enabled without onCancel or onClose handler.`;
+export const ALERT_WARN_CANCEL_OUTSIDE_CLICK =
+    ns + ` <Alert> canOutsideClickCancel enbaled without onCancel or onClose handler.`;
 
 export const COLLAPSIBLE_LIST_INVALID_CHILD = ns + ` <CollapsibleList> children must be <MenuItem>s`;
 

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -8,19 +8,40 @@ import * as classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes, Intent, IProps } from "../../common";
-import { ALERT_WARN_CANCEL_PROPS } from "../../common/errors";
+import {
+    ALERT_WARN_CANCEL_ESCAPE_KEY,
+    ALERT_WARN_CANCEL_OUTSIDE_CLICK,
+    ALERT_WARN_CANCEL_PROPS,
+} from "../../common/errors";
+import { safeInvoke } from "../../common/utils";
 import { Button } from "../button/buttons";
 import { Dialog } from "../dialog/dialog";
 import { Icon, IconName } from "../icon/icon";
 
 export interface IAlertProps extends IProps {
     /**
+     * Whether pressing <kbd class="pt-key">escape</kbd> when focused on the Alert should cancel the alert.
+     * If this prop is enabled, then either `onCancel` or `onClose` must also be defined.
+     * @default false
+     */
+    canEscapeKeyCancel?: boolean;
+
+    /**
+     * Whether clicking outside the Alert should cancel the alert.
+     * If this prop is enabled, then either `onCancel` or `onClose` must also be defined.
+     * @default false
+     */
+    canOutsideClickCancel?: boolean;
+
+    /**
      * The text for the cancel button.
+     * If this prop is defined, then either `onCancel` or `onClose` must also be defined.
      */
     cancelButtonText?: string;
 
     /**
      * The text for the confirm (right-most) button.
+     * This button will always appear, and uses the value of the `intent` prop below.
      * @default "OK"
      */
     confirmButtonText?: string;
@@ -45,54 +66,93 @@ export interface IAlertProps extends IProps {
     style?: React.CSSProperties;
 
     /**
-     * Handler invoked when the cancel button is clicked.
+     * Indicates how long (in milliseconds) the overlay's enter/leave transition takes.
+     * This is used by React `CSSTransition` to know when a transition completes and must match
+     * the duration of the animation in CSS. Only set this prop if you override Blueprint's default
+     * transitions with new transitions of a different length.
+     * @default 300
      */
-    onCancel?(e: React.MouseEvent<HTMLButtonElement>): void;
+    transitionDuration?: number;
 
     /**
-     * Handler invoked when the confirm button is clicked.
+     * Handler invoked when the alert is canceled. Alerts can be **canceled** in the following ways:
+     * - clicking the cancel button (if `cancelButtonText` is defined)
+     * - pressing the escape key (if `canEscapeKeyCancel` is enabled)
+     * - clicking on the overlay backdrop (if `canOutsideClickCancel` is enabled)
+     *
+     * If any of the `cancel` props are defined, then either `onCancel` or `onClose` must be defined.
      */
-    onConfirm(e: React.MouseEvent<HTMLButtonElement>): void;
+    onCancel?(evt?: React.SyntheticEvent<HTMLElement>): void;
+
+    /**
+     * Handler invoked when the confirm button is clicked. Alerts can be **confirmed** in the following ways:
+     * - clicking the confirm button
+     * - focusing on the confirm button and pressing `enter` or `space`
+     */
+    onConfirm?(evt?: React.SyntheticEvent<HTMLElement>): void;
+
+    /**
+     * Handler invoked when the Alert is confirmed or canceled; see `onConfirm` and `onCancel` for more details.
+     * First argument is `true` if confirmed, `false` otherwise.
+     * This is an alternative to defining separate `onConfirm` and `onCancel` handlers.
+     */
+    onClose?(confirmed: boolean, evt?: React.SyntheticEvent<HTMLElement>): void;
 }
 
 export class Alert extends AbstractPureComponent<IAlertProps, {}> {
     public static defaultProps: IAlertProps = {
+        canEscapeKeyCancel: false,
+        canOutsideClickCancel: false,
         confirmButtonText: "OK",
         isOpen: false,
-        onConfirm: null,
     };
 
     public static displayName = "Blueprint2.Alert";
 
     public render() {
-        const { children, className, icon, intent, isOpen, confirmButtonText, onConfirm, style } = this.props;
+        const { children, className, icon, intent, cancelButtonText, confirmButtonText } = this.props;
         return (
-            <Dialog className={classNames(Classes.ALERT, className)} isOpen={isOpen} style={style}>
+            <Dialog
+                className={classNames(Classes.ALERT, className)}
+                canEscapeKeyClose={this.props.canEscapeKeyCancel}
+                canOutsideClickClose={this.props.canOutsideClickCancel}
+                isOpen={this.props.isOpen}
+                onClose={this.handleCancel}
+                style={this.props.style}
+                transitionDuration={this.props.transitionDuration}
+            >
                 <div className={Classes.ALERT_BODY}>
                     <Icon icon={icon} iconSize={40} intent={intent} />
                     <div className={Classes.ALERT_CONTENTS}>{children}</div>
                 </div>
                 <div className={Classes.ALERT_FOOTER}>
-                    <Button intent={intent} text={confirmButtonText} onClick={onConfirm} />
-                    {this.maybeRenderSecondaryAction()}
+                    <Button intent={intent} text={confirmButtonText} onClick={this.handleConfirm} />
+                    {cancelButtonText && <Button text={cancelButtonText} onClick={this.handleCancel} />}
                 </div>
             </Dialog>
         );
     }
 
     protected validateProps(props: IAlertProps) {
-        if (
-            (props.cancelButtonText != null && props.onCancel == null) ||
-            (props.cancelButtonText == null && props.onCancel != null)
-        ) {
+        if (props.onClose == null && (props.cancelButtonText == null) !== (props.onCancel == null)) {
             console.warn(ALERT_WARN_CANCEL_PROPS);
+        }
+
+        const hasCancelHandler = props.onCancel != null || props.onClose != null;
+        if (props.canEscapeKeyCancel && !hasCancelHandler) {
+            console.warn(ALERT_WARN_CANCEL_ESCAPE_KEY);
+        }
+        if (props.canOutsideClickCancel && !hasCancelHandler) {
+            console.warn(ALERT_WARN_CANCEL_OUTSIDE_CLICK);
         }
     }
 
-    private maybeRenderSecondaryAction() {
-        if (this.props.cancelButtonText != null) {
-            return <Button text={this.props.cancelButtonText} onClick={this.props.onCancel} />;
-        }
-        return undefined;
+    private handleCancel = (evt: React.SyntheticEvent<HTMLElement>) => this.internalHandleCallbacks(false, evt);
+    private handleConfirm = (evt: React.SyntheticEvent<HTMLElement>) => this.internalHandleCallbacks(true, evt);
+
+    private internalHandleCallbacks(confirmed: boolean, evt?: React.SyntheticEvent<HTMLElement>) {
+        const { onCancel, onClose, onConfirm } = this.props;
+        safeInvoke(confirmed ? onConfirm : onCancel, evt);
+        safeInvoke(onClose, confirmed, evt);
     }
 }

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -5,24 +5,23 @@
  */
 
 import { assert } from "chai";
-import { shallow, ShallowWrapper } from "enzyme";
+import { mount, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
-import { SinonSpy, spy } from "sinon";
+import { SinonStub, spy, stub } from "sinon";
 
-import { Alert, Button, Classes, Icon, Intent } from "../../src/index";
-
-const NOOP: () => any = () => undefined;
+import * as Errors from "../../src/common/errors";
+import { Alert, Button, Classes, IAlertProps, IButtonProps, Icon, Intent, Keys } from "../../src/index";
 
 describe("<Alert>", () => {
     it("renders its content correctly", () => {
+        const noop = () => true;
         const wrapper = shallow(
             <Alert
                 className="test-class"
                 isOpen={true}
                 confirmButtonText="Delete"
                 cancelButtonText="Cancel"
-                onConfirm={NOOP}
-                onCancel={NOOP}
+                onClose={noop}
             >
                 <p>Are you sure you want to delete this file?</p>
                 <p>There is no going back.</p>
@@ -37,7 +36,7 @@ describe("<Alert>", () => {
 
     it("renders the icon correctly", () => {
         const wrapper = shallow(
-            <Alert icon="warning-sign" isOpen={true} confirmButtonText="Delete" onConfirm={NOOP}>
+            <Alert icon="warning-sign" isOpen={true} confirmButtonText="Delete">
                 <p>Are you sure you want to delete this file?</p>
                 <p>There is no going back.</p>
             </Alert>,
@@ -47,11 +46,13 @@ describe("<Alert>", () => {
     });
 
     describe("confirm button", () => {
-        let wrapper: ShallowWrapper<any, any>;
-        let onConfirm: SinonSpy;
+        const onConfirm = spy();
+        const onClose = spy();
+        let wrapper: ShallowWrapper<IAlertProps, any>;
 
         beforeEach(() => {
-            onConfirm = spy();
+            onConfirm.resetHistory();
+            onClose.resetHistory();
             wrapper = shallow(
                 <Alert
                     icon="warning-sign"
@@ -59,12 +60,15 @@ describe("<Alert>", () => {
                     isOpen={true}
                     confirmButtonText="Delete"
                     onConfirm={onConfirm}
+                    onClose={onClose}
                 >
                     <p>Are you sure you want to delete this file?</p>
                     <p>There is no going back.</p>
                 </Alert>,
             );
         });
+
+        afterEach(() => wrapper.unmount());
 
         it("text is confirmButtonText", () => {
             assert.equal(wrapper.find(Button).prop("text"), "Delete");
@@ -74,19 +78,23 @@ describe("<Alert>", () => {
             assert.equal(wrapper.find(Button).prop("intent"), Intent.PRIMARY);
         });
 
-        it("onClick triggered on click", () => {
+        it("onConfirm and onClose triggered on click", () => {
             wrapper.find(Button).simulate("click");
             assert.isTrue(onConfirm.calledOnce);
+            assert.isTrue(onClose.calledOnce);
+            assert.strictEqual(onClose.args[0][0], true);
         });
     });
 
     describe("cancel button", () => {
-        let wrapper: ShallowWrapper<any, any>;
-        let onCancel: SinonSpy;
-        let cancelButton: ShallowWrapper<any, any>;
+        const onCancel = spy();
+        const onClose = spy();
+        let wrapper: ShallowWrapper<IAlertProps, any>;
+        let cancelButton: ShallowWrapper<IButtonProps, any>;
 
         beforeEach(() => {
-            onCancel = spy();
+            onCancel.resetHistory();
+            onClose.resetHistory();
             wrapper = shallow(
                 <Alert
                     icon="warning-sign"
@@ -95,7 +103,7 @@ describe("<Alert>", () => {
                     cancelButtonText="Cancel"
                     confirmButtonText="Delete"
                     onCancel={onCancel}
-                    onConfirm={NOOP}
+                    onClose={onClose}
                 >
                     <p>Are you sure you want to delete this file?</p>
                     <p>There is no going back.</p>
@@ -103,6 +111,8 @@ describe("<Alert>", () => {
             );
             cancelButton = wrapper.find(Button).last();
         });
+
+        afterEach(() => wrapper.unmount());
 
         it("text is cancelButtonText", () => {
             assert.equal(cancelButton.prop("text"), "Cancel");
@@ -112,9 +122,80 @@ describe("<Alert>", () => {
             assert.isUndefined(cancelButton.prop("intent"));
         });
 
-        it("onClick triggered on click", () => {
+        it("onCancel and onClose triggered on click", () => {
             cancelButton.simulate("click");
             assert.isTrue(onCancel.calledOnce);
+            assert.isTrue(onClose.calledOnce);
+            assert.strictEqual(onClose.args[0][0], false);
         });
+
+        it("canEscapeKeyCancel enables escape key", () => {
+            const alert = mount<IAlertProps>(
+                <Alert isOpen={true} cancelButtonText="Cancel" confirmButtonText="Delete" onCancel={onCancel}>
+                    <p>Are you sure you want to delete this file?</p>
+                    <p>There is no going back.</p>
+                </Alert>,
+            );
+            const overlay = alert.find(".pt-overlay").hostNodes();
+
+            overlay.simulate("keydown", { which: Keys.ESCAPE });
+            assert.isTrue(onCancel.notCalled);
+
+            alert.setProps({ canEscapeKeyCancel: true });
+            overlay.simulate("keydown", { which: Keys.ESCAPE });
+            assert.isTrue(onCancel.calledOnce);
+
+            alert.unmount();
+        });
+
+        it("canOutsideClickCancel enables outside click", () => {
+            const alert = mount<IAlertProps>(
+                <Alert isOpen={true} cancelButtonText="Cancel" confirmButtonText="Delete" onCancel={onCancel}>
+                    <p>Are you sure you want to delete this file?</p>
+                    <p>There is no going back.</p>
+                </Alert>,
+            );
+            const backdrop = alert.find(".pt-overlay-backdrop").hostNodes();
+
+            backdrop.simulate("mousedown");
+            assert.isTrue(onCancel.notCalled);
+
+            alert.setProps({ canOutsideClickCancel: true });
+            backdrop.simulate("mousedown");
+            assert.isTrue(onCancel.calledOnce);
+
+            alert.unmount();
+        });
+    });
+
+    describe("warnings", () => {
+        let warnSpy: SinonStub;
+        before(() => (warnSpy = stub(console, "warn")));
+        afterEach(() => warnSpy.resetHistory());
+        after(() => warnSpy.restore());
+
+        it("cancelButtonText without cancel handler", () => {
+            testWarn(<Alert cancelButtonText="cancel" isOpen={false} />, Errors.ALERT_WARN_CANCEL_PROPS);
+        });
+
+        it("canEscapeKeyCancel without cancel handler", () => {
+            testWarn(<Alert canEscapeKeyCancel={true} isOpen={false} />, Errors.ALERT_WARN_CANCEL_ESCAPE_KEY);
+        });
+
+        it("canOutsideClickCancel without cancel handler", () => {
+            testWarn(<Alert canOutsideClickCancel={true} isOpen={false} />, Errors.ALERT_WARN_CANCEL_OUTSIDE_CLICK);
+        });
+
+        function testWarn(alert: JSX.Element, warning: string) {
+            // one warning
+            const wrapper = shallow(alert);
+            assert.strictEqual(warnSpy.callCount, 1);
+            assert.isTrue(warnSpy.calledWithExactly(warning));
+            // no more warnings
+            wrapper
+                .setProps({ onClose: () => true })
+                .setProps({ cancelButtonText: "cancel", onCancel: () => true, onClose: undefined });
+            assert.strictEqual(warnSpy.callCount, 1);
+        }
     });
 });

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -6,47 +6,57 @@
 
 import * as React from "react";
 
-import { Alert, Button, Intent, IToaster, Toaster } from "@blueprintjs/core";
-import { BaseExample } from "@blueprintjs/docs-theme";
+import { Alert, Button, Intent, IToaster, Switch, Toaster } from "@blueprintjs/core";
+import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface IAlertExampleState {
-    isOpen?: boolean;
-    isOpenError?: boolean;
+    canEscapeKeyCancel: boolean;
+    canOutsideClickCancel: boolean;
+    isOpen: boolean;
+    isOpenError: boolean;
 }
 
 export class AlertExample extends BaseExample<{}> {
     public state: IAlertExampleState = {
+        canEscapeKeyCancel: false,
+        canOutsideClickCancel: false,
         isOpen: false,
         isOpenError: false,
     };
 
     private toaster: IToaster;
 
+    private handleEscapeKeyChange = handleBooleanChange(canEscapeKeyCancel => this.setState({ canEscapeKeyCancel }));
+    private handleOutsideClickChange = handleBooleanChange(click => this.setState({ canOutsideClickCancel: click }));
+
     protected renderExample() {
+        const { isOpen, isOpenError, ...switchProps } = this.state;
         return (
             <div>
-                <Button onClick={this.handleOpenError} text="Open file error alert" />
+                <Button onClick={this.handleErrorOpen} text="Open file error alert" />
                 <Alert
+                    {...switchProps}
                     className={this.props.themeName}
-                    isOpen={this.state.isOpenError}
                     confirmButtonText="Okay"
-                    onConfirm={this.handleCloseError}
+                    isOpen={isOpenError}
+                    onClose={this.handleErrorClose}
                 >
                     <p>
                         Couldn't create the file because the containing folder doesn't exist anymore. You will be
                         redirected to your user folder.
                     </p>
                 </Alert>
-                <Button onClick={this.handleOpen} text="Open file deletion alert" />
+                <Button onClick={this.handleMoveOpen} text="Open file deletion alert" />
                 <Alert
+                    {...switchProps}
                     className={this.props.themeName}
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Move to Trash"
                     icon="trash"
                     intent={Intent.PRIMARY}
-                    isOpen={this.state.isOpen}
-                    confirmButtonText="Move to Trash"
-                    cancelButtonText="Cancel"
-                    onConfirm={this.handleMoveClose}
-                    onCancel={this.handleClose}
+                    isOpen={isOpen}
+                    onCancel={this.handleMoveCancel}
+                    onConfirm={this.handleMoveConfirm}
                 >
                     <p>
                         Are you sure you want to move <b>filename</b> to Trash? You will be able to restore it later,
@@ -58,14 +68,34 @@ export class AlertExample extends BaseExample<{}> {
         );
     }
 
-    private handleOpenError = () => this.setState({ isOpenError: true });
-    private handleCloseError = () => this.setState({ isOpenError: false });
-    private handleOpen = () => this.setState({ isOpen: true });
-    private handleMoveClose = () => {
+    protected renderOptions() {
+        return [
+            [
+                <Switch
+                    checked={this.state.canEscapeKeyCancel}
+                    key="escape"
+                    label="Can escape key cancel"
+                    onChange={this.handleEscapeKeyChange}
+                />,
+                <Switch
+                    checked={this.state.canOutsideClickCancel}
+                    key="click"
+                    label="Can outside click cancel"
+                    onChange={this.handleOutsideClickChange}
+                />,
+            ],
+        ];
+    }
+
+    private handleErrorOpen = () => this.setState({ isOpenError: true });
+    private handleErrorClose = () => this.setState({ isOpenError: false });
+
+    private handleMoveOpen = () => this.setState({ isOpen: true });
+    private handleMoveConfirm = () => {
         this.setState({ isOpen: false });
         this.toaster.show({ className: this.props.themeName, message: TOAST_MESSAGE });
     };
-    private handleClose = () => this.setState({ isOpen: false });
+    private handleMoveCancel = () => this.setState({ isOpen: false });
 }
 
 const TOAST_MESSAGE = (


### PR DESCRIPTION
#### Fixes #517 

#### Changes proposed in this pull request:

- `Alert`: add `canEscapeKeyCancel`, `canOutsideClickCancel`, `onClose`, `transitionDuration` props
- `onClose` is single alternative to separate `onCancel`/`onConfirm` props
  - event handlers are all optional now, and handler-less usage is supported
- tweaked warnings, added warnings for new `can*Cancel` props
- __did not add `canEnterKeyConfirm`__ (see #517) because it's not easy to implement (key events require focus, blah blah), and is already supported by simply `tab`-ing onto a button and pressing `enter` or `space`
