### PR TITLE
[Dialog] Fix icon positioning in dialog header

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -145,7 +145,11 @@ $dialog-padding: $pt-grid-size * 2 !default;
 
   cursor: pointer;
   padding: $pt-grid-size;
-  padding-right: $dialog-padding;
+
+  .pt-icon-large,
+  .pt-icon {
+    margin: 0;
+  }
 }
 
 .pt-dialog-body {


### PR DESCRIPTION
- the cross on the right doesn't need padding, it's already properly sized
- there's a margin applied to all icons in the dialog header, should be disabled for the cross (it's only useful for the icon near the dialog title)