### PR TITLE
Don't open server in browser when running dev

### DIFF
--- a/packages/webpack-build-scripts/webpack.config.base.js
+++ b/packages/webpack-build-scripts/webpack.config.base.js
@@ -100,7 +100,7 @@ module.exports = {
         index: path.resolve(__dirname, "src/index.html"),
         inline: true,
         stats: "errors-only",
-        open: true,
+        open: false,
         overlay: {
             warnings: true,
             errors: true,


### PR DESCRIPTION
`localhost` reopens in the browser after every `dev` command. especially annoying when your default browser isn't your dev browser.

what do you think about going back to pre-2.0 behavior with this PR?
