### PR TITLE
Add missing text class constants

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -28,7 +28,15 @@ export const ROUND = "pt-round";
 // text utilities
 export const TEXT_MUTED = "pt-text-muted";
 export const TEXT_OVERFLOW_ELLIPSIS = "pt-text-overflow-ellipsis";
+export const UI_TEXT = "pt-ui-text";
 export const UI_TEXT_LARGE = "pt-ui-text-large";
+export const RUNNING_TEXT = "pt-running-text";
+export const RUNNING_TEXT_SMALL = "pt-running-text-small";
+export const MONOSPACE_TEXT = "pt-monospace-text";
+
+// lists
+export const LIST = "pt-list";
+export const LIST_UNSTYLED = "pt-list-unstyled";
 
 // components
 export const ALERT = "pt-alert";


### PR DESCRIPTION
#### Fixes #2047 

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)

#### Changes proposed in this pull request:

Added a number of classes to constants that were not previously there:
- pt-running-text
- pt-running-text-small
- pt-monospace-text
- pt-list
- pt-list-unstyled

#### Reviewers should focus on:

The need to replace used class strings with new constants.

#### Other info

I stumbled upon #2047 and thought i could contribute here. Seemed easy enough for a good first PR so i can start diggin the project.

Let me know if i am missing anything.