### PR TITLE
Add ITreeNode.nodeData property

### DIFF
--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -49,15 +49,9 @@ export interface ITreeProps<T = {}> extends IProps {
 }
 
 export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
-
-    constructor(props?: ITreeProps<T>, context?: any) {
-        super(props, context);
-    }
-
     public static ofType<T>() {
         return Tree as new () => Tree<T>;
     }
-
 
     public static nodeFromPath(path: number[], treeNodes: ITreeNode[]): ITreeNode {
         if (path.length === 1) {
@@ -65,6 +59,10 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
         } else {
             return Tree.nodeFromPath(path.slice(1), treeNodes[path[0]].childNodes);
         }
+    }
+
+    constructor(props?: ITreeProps<T>, context?: any) {
+        super(props, context);
     }
 
     private nodeRefs: { [nodeId: string]: HTMLElement } = {};

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -18,7 +18,7 @@ export interface ITreeProps<T = {}> extends IProps {
     /**
      * The data specifying the contents and appearance of the tree.
      */
-    contents: ITreeNode<T>[];
+    contents: Array<ITreeNode<T>>;
 
     /**
      * Invoked when a node is clicked anywhere other than the caret for expanding/collapsing the node.

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -14,11 +14,11 @@ import { ITreeNode, TreeNode } from "./treeNode";
 
 export type TreeEventHandler = (node: ITreeNode, nodePath: number[], e: React.MouseEvent<HTMLElement>) => void;
 
-export interface ITreeProps extends IProps {
+export interface ITreeProps<T = {}> extends IProps {
     /**
      * The data specifying the contents and appearance of the tree.
      */
-    contents: ITreeNode[];
+    contents: ITreeNode<T>[];
 
     /**
      * Invoked when a node is clicked anywhere other than the caret for expanding/collapsing the node.
@@ -48,7 +48,17 @@ export interface ITreeProps extends IProps {
     onNodeExpand?: TreeEventHandler;
 }
 
-export class Tree extends React.Component<ITreeProps, {}> {
+export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
+
+    constructor(props?: ITreeProps<T>, context?: any) {
+        super(props, context);
+    }
+
+    public static ofType<T>() {
+        return Tree as new () => Tree<T>;
+    }
+
+
     public static nodeFromPath(path: number[], treeNodes: ITreeNode[]): ITreeNode {
         if (path.length === 1) {
             return treeNodes[path[0]];

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -61,11 +61,11 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
         }
     }
 
+    private nodeRefs: { [nodeId: string]: HTMLElement } = {};
+
     constructor(props?: ITreeProps<T>, context?: any) {
         super(props, context);
     }
-
-    private nodeRefs: { [nodeId: string]: HTMLElement } = {};
 
     public render() {
         return (

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -106,7 +106,7 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
                 >
                     {this.renderNodes(node.childNodes, elementPath)}
                 </TreeNode>
-                 );
+            );
         });
 
         return <ul className={classNames(Classes.TREE_NODE_LIST, className)}>{nodeItems}</ul>;

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -58,7 +58,9 @@ export interface ITreeNode<T = {}> extends IProps {
     secondaryLabel?: string | JSX.Element;
 
     /**
-     * An optional custom user object to associate with the node. This property can then be used in the onClick, onContextMenu and onDoubleClick event handlers for doing custom logic per node.
+     * An optional custom user object to associate with the node. 
+     * This property can then be used in the `onClick`, `onContextMenu` and `onDoubleClick` 
+     * event handlers for doing custom logic per node.
      */
     nodeData?: T;
 }

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -13,7 +13,7 @@ import { safeInvoke } from "../../common/utils";
 import { Collapse } from "../collapse/collapse";
 import { Icon, IconName } from "../icon/icon";
 
-export interface ITreeNode <T = {}> extends IProps {
+export interface ITreeNode<T = {}> extends IProps {
     /**
      * Child tree nodes of this node.
      */
@@ -63,7 +63,7 @@ export interface ITreeNode <T = {}> extends IProps {
     nodeData?: T;
 }
 
-export interface ITreeNodeProps <T = {}> extends ITreeNode<T> {
+export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
     children?: React.ReactNode;
     contentRef?: (node: TreeNode, element: HTMLDivElement | null) => void;
     depth: number;
@@ -76,7 +76,7 @@ export interface ITreeNodeProps <T = {}> extends ITreeNode<T> {
     path: number[];
 }
 
-export class TreeNode <T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
+export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
     public render() {
         const { children, className, hasCaret, icon, isExpanded, isSelected, label } = this.props;
 

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -79,6 +79,15 @@ export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
 }
 
 export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
+
+    public static ofType<T>() {
+        return TreeNode as new () => TreeNode<T>;
+    }
+
+    constructor(props?: ITreeNodeProps<T>, context?: any) {
+        super(props, context);
+    }
+
     public render() {
         const { children, className, hasCaret, icon, isExpanded, isSelected, label } = this.props;
 

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -79,7 +79,6 @@ export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
 }
 
 export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
-
     public static ofType<T>() {
         return TreeNode as new () => TreeNode<T>;
     }

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -13,7 +13,7 @@ import { safeInvoke } from "../../common/utils";
 import { Collapse } from "../collapse/collapse";
 import { Icon, IconName } from "../icon/icon";
 
-export interface ITreeNode extends IProps {
+export interface ITreeNode <T = {}> extends IProps {
     /**
      * Child tree nodes of this node.
      */
@@ -56,9 +56,14 @@ export interface ITreeNode extends IProps {
      * A secondary label/component that is displayed at the right side of the node.
      */
     secondaryLabel?: string | JSX.Element;
+
+    /**
+     * An optional custom user object to associate with the node. This property can then be used in the onClick, onContextMenu and onDoubleClick event handlers for doing custom logic per node.
+     */
+    nodeData?: T;
 }
 
-export interface ITreeNodeProps extends ITreeNode {
+export interface ITreeNodeProps <T = {}> extends ITreeNode<T> {
     children?: React.ReactNode;
     contentRef?: (node: TreeNode, element: HTMLDivElement | null) => void;
     depth: number;
@@ -71,7 +76,7 @@ export interface ITreeNodeProps extends ITreeNode {
     path: number[];
 }
 
-export class TreeNode extends React.Component<ITreeNodeProps, {}> {
+export class TreeNode <T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
     public render() {
         const { children, className, hasCaret, icon, isExpanded, isSelected, label } = this.props;
 

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -58,8 +58,8 @@ export interface ITreeNode<T = {}> extends IProps {
     secondaryLabel?: string | JSX.Element;
 
     /**
-     * An optional custom user object to associate with the node. 
-     * This property can then be used in the `onClick`, `onContextMenu` and `onDoubleClick` 
+     * An optional custom user object to associate with the node.
+     * This property can then be used in the `onClick`, `onContextMenu` and `onDoubleClick`
      * event handlers for doing custom logic per node.
      */
     nodeData?: T;


### PR DESCRIPTION
#### Fixes #1989 
This feature add a new generics type prop for ITreeNode called 'nodeData'.
The user can use this property to store custom user data, object reference, etc.

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

<!-- fill this out -->

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
