### PR TITLE
Date range calendars order

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -182,6 +182,11 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
             initialMonth = props.initialMonth;
         } else if (value[0] != null) {
             initialMonth = DateUtils.clone(value[0]);
+        } else if (value[1] != null) {
+            initialMonth = DateUtils.clone(value[1]);
+            if (!DateUtils.areSameMonth(initialMonth, props.minDate)) {
+                initialMonth.setMonth(initialMonth.getMonth() - 1);
+            }
         } else if (DateUtils.isDayInRange(today, [props.minDate, props.maxDate])) {
             initialMonth = today;
         } else {
@@ -200,10 +205,11 @@ export class DateRangePicker extends AbstractComponent<IDateRangePickerProps, ID
 
         // show the selected end date's encompassing month in the right view if
         // the calendars don't have to be contiguous.
+        // if left view and right view months are the same, show next month in the right view.
         const leftView = MonthAndYear.fromDate(initialMonth);
         const rightDate = value[1];
         const rightView =
-            !props.contiguousCalendarMonths && rightDate != null
+            !props.contiguousCalendarMonths && rightDate != null && !DateUtils.areSameMonth(initialMonth, rightDate)
                 ? MonthAndYear.fromDate(rightDate)
                 : leftView.getNextMonth();
         this.state = { leftView, rightView, value, hoverValue: [null, null] };

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -334,6 +334,21 @@ describe("<DateRangePicker>", () => {
             assert.equal(dateRangePicker.state.leftView.getMonth(), Months.APRIL);
         });
 
+        it("is (endDate - 1 month) if only endDate is set", () => {
+            const value = [null, new Date(2007, Months.APRIL, 4)] as DateRange;
+            renderDateRangePicker({ value });
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2007);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.MARCH);
+        });
+
+        it("is endDate if only endDate is set and endDate === minDate month", () => {
+            const minDate = new Date(2007, Months.APRIL);
+            const value = [null, new Date(2007, Months.APRIL, 4)] as DateRange;
+            renderDateRangePicker({ minDate, value });
+            assert.equal(dateRangePicker.state.leftView.getYear(), 2007);
+            assert.equal(dateRangePicker.state.leftView.getMonth(), Months.APRIL);
+        });
+
         it("is today if only maxDate/minDate set and today is in date range", () => {
             const maxDate = new Date(2020, Months.JANUARY);
             const minDate = new Date(2000, Months.JANUARY);
@@ -543,6 +558,13 @@ describe("<DateRangePicker>", () => {
             const endDate = new Date(2017, Months.JULY, 5);
             renderDateRangePicker({ contiguousCalendarMonths: false, value: [startDate, endDate] });
             assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JULY);
+        });
+
+        it("right calendar shows the month immediately after the left view if startDate === endDate month", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.MAY, 15);
+            renderDateRangePicker({ contiguousCalendarMonths: false, value: [startDate, endDate] });
+            assert.equal(dateRangePicker.state.rightView.getMonth(), Months.JUNE);
         });
     });
 


### PR DESCRIPTION
#### Checklist:

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests

#### Changes proposed in this pull request:

This PR should fix couple small bugs in `DateRangePicker`:

1) When `minDate` === `startDate` === `endDate` month, both left and right calendar shows that month, but right calendar month selector shows the next month (see screenshot 1). 
**Cause:** `fromMonth` which is passed to right `ReactDayPicker` is after `rightView` date which is passed as `month`.
**Fix:** Now right calendar shows month immediately after left calendar month if `startDate` === `endDate` month. (I'm assuming that a desirable behaviour was calendars to never show the same month since right and left calendar `fromMonth` and `toMonth` are different).

2) When calculating `initialMonth`, `endDate` isn't taken in account. This could result in left calendar month being after right calendar month, if only `endDate` defined (see screenshot 2). 
**Fix:** if neither `initialMonth` nor `startDate` wasn't provided, but `endDate` was, set `initialMonth` one month before `endDate` month.

#### Screenshots:

1)
<img width="461" alt="screen shot 2018-02-13 at 4 03 24 pm" src="https://user-images.githubusercontent.com/15594382/36219852-98162e92-116d-11e8-8ac4-d336072006da.png">

2)
<img width="462" alt="screen shot 2018-02-13 at 4 08 22 pm" src="https://user-images.githubusercontent.com/15594382/36219883-acdd2b5a-116d-11e8-83b6-71300efdd753.png">
