### PR TITLE
Support for 12-hour clock (AM/PM) for TimePicker component

### DIFF
--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -75,7 +75,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
   }
 
   .pt-timepicker-ampm-select {
-    margin-left: 2px;
+    margin-left: $pt-grid-size / 2;
   }
 
   &.pt-disabled {

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -44,6 +44,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     background: $input-background-color;
     height: $timepicker-input-row-height;
     padding: $timepicker-row-padding;
+    vertical-align: middle;
     line-height: $timepicker-input-row-inner-height;
   }
 
@@ -71,6 +72,10 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     &:focus {
       box-shadow: input-transition-shadow($input-shadow-color-focus, true);
     }
+  }
+
+  .pt-timepicker-ampm-select {
+    margin-left: 2px;
   }
 
   &.pt-disabled {

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -35,3 +35,4 @@ export const TIMEPICKER_INPUT_ROW = "pt-timepicker-input-row";
 export const TIMEPICKER_MILLISECOND = "pt-timepicker-millisecond";
 export const TIMEPICKER_MINUTE = "pt-timepicker-minute";
 export const TIMEPICKER_SECOND = "pt-timepicker-second";
+export const TIMEPICKER_AMPM_SELECT = "pt-timepicker-ampm-select";

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -210,10 +210,7 @@ export function convert24HourMeridiem(hour: number, toAm: boolean): number {
     if (hour < 0 || hour > 23) {
         throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
     }
-    if (toAm) {
-        return hour % 12;
-    }
-    return hour % 12 + 12;
+    return toAm ? hour % 12 : hour % 12 + 12;
 }
 
 export function getIsPmFrom24Hour(hour: number): boolean {
@@ -227,24 +224,14 @@ export function get12HourFrom24Hour(hour: number): number {
     if (hour < 0 || hour > 23) {
         throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
     }
-    hour = hour % 12;
-    if (hour === 0) {
-        hour = 12;
-    }
-    return hour;
+    const newHour = hour % 12;
+    return newHour === 0 ? 12 : newHour;
 }
 
 export function get24HourFrom12Hour(hour: number, isPm: boolean): number {
     if (hour < 1 || hour > 12) {
-        throw new Error(`hour must be between [0,12] inclusive: got ${hour}`);
+        throw new Error(`hour must be between [1,12] inclusive: got ${hour}`);
     }
-    if (isPm) {
-        hour = hour + 12;
-        if (hour === 24) {
-            hour = 12;
-        }
-    } else if (hour === 12) {
-        hour = 0;
-    }
-    return hour;
+    const newHour = hour === 12 ? 0 : hour;
+    return isPm ? newHour + 12 : newHour;
 }

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -218,6 +218,10 @@ export function convertHourMeridiem(hour: number, toAm: boolean): number {
     return hour;
 }
 
+export function getIsPmFrom24Hour(hour: number): boolean {
+    return hour >= 12;
+}
+
 export function get12HourFrom24Hour(hour: number): number {
     hour = hour % 12;
     if (hour === 0) hour = 12;

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -209,11 +209,11 @@ export function getDateNextMonth(date: Date): Date {
 export function convert12HourMeridiem(hour: number, toAm: boolean): number {
     if (toAm && hour == 12) {
         hour = 0;
-    }
-    else if (!toAm) {
+    } else if (!toAm) {
         hour += 12;
-        if (hour == 24)
+        if (hour == 24) {
             hour = 0;
+        }
     }
     return hour;
 }
@@ -224,16 +224,20 @@ export function getIsPmFrom24Hour(hour: number): boolean {
 
 export function get12HourFrom24Hour(hour: number): number {
     hour = hour % 12;
-    if (hour === 0) hour = 12;
+    if (hour === 0) {
+        hour = 12;
+    }
     return hour;
 }
 
 export function get24HourFrom12Hour(hour: number, isPm: boolean): number {
     if (isPm) {
         hour = hour + 12;
-        if (hour === 24) hour = 12;
-    }
-    else if (hour === 12)
+        if (hour === 24) {
+            hour = 12;
+        }
+    } else if (hour === 12) {
         hour = 0;
+    }
     return hour;
 }

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -206,11 +206,11 @@ export function getDateNextMonth(date: Date): Date {
     }
 }
 
-export function convert24HourMeridiem(hour: number, toAm: boolean): number {
+export function convert24HourMeridiem(hour: number, toPm: boolean): number {
     if (hour < 0 || hour > 23) {
         throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
     }
-    return toAm ? hour % 12 : hour % 12 + 12;
+    return toPm ? hour % 12 + 12 : hour % 12;
 }
 
 export function getIsPmFrom24Hour(hour: number): boolean {

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -206,11 +206,11 @@ export function getDateNextMonth(date: Date): Date {
     }
 }
 
-export function convertHourMeridiem(hour: number, toAm: boolean): number {
+export function convert12HourMeridiem(hour: number, toAm: boolean): number {
     if (toAm && hour == 12) {
         hour = 0;
     }
-    else {
+    else if (!toAm) {
         hour += 12;
         if (hour == 24)
             hour = 0;

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -205,3 +205,31 @@ export function getDateNextMonth(date: Date): Date {
         return new Date(date.getFullYear(), date.getMonth() + 1);
     }
 }
+
+export function convertHourMeridiem(hour: number, toAm: boolean): number {
+    if (toAm && hour == 12) {
+        hour = 0;
+    }
+    else {
+        hour += 12;
+        if (hour == 24)
+            hour = 0;
+    }
+    return hour;
+}
+
+export function get12HourFrom24Hour(hour: number): number {
+    hour = hour % 12;
+    if (hour === 0) hour = 12;
+    return hour;
+}
+
+export function get24HourFrom12Hour(hour: number, isPm: boolean): number {
+    if (isPm) {
+        hour = hour + 12;
+        if (hour === 24) hour = 12;
+    }
+    else if (hour === 12)
+        hour = 0;
+    return hour;
+}

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -206,23 +206,27 @@ export function getDateNextMonth(date: Date): Date {
     }
 }
 
-export function convert12HourMeridiem(hour: number, toAm: boolean): number {
-    if (toAm && hour == 12) {
-        hour = 0;
-    } else if (!toAm) {
-        hour += 12;
-        if (hour == 24) {
-            hour = 0;
-        }
+export function convert24HourMeridiem(hour: number, toAm: boolean): number {
+    if (hour < 0 || hour > 23) {
+        throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
     }
-    return hour;
+    if (toAm) {
+        return hour % 12;
+    }
+    return hour % 12 + 12;
 }
 
 export function getIsPmFrom24Hour(hour: number): boolean {
+    if (hour < 0 || hour > 23) {
+        throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
+    }
     return hour >= 12;
 }
 
 export function get12HourFrom24Hour(hour: number): number {
+    if (hour < 0 || hour > 23) {
+        throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
+    }
     hour = hour % 12;
     if (hour === 0) {
         hour = 12;
@@ -231,6 +235,9 @@ export function get12HourFrom24Hour(hour: number): number {
 }
 
 export function get24HourFrom12Hour(hour: number, isPm: boolean): number {
+    if (hour < 1 || hour > 12) {
+        throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
+    }
     if (isPm) {
         hour = hour + 12;
         if (hour === 24) {

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -236,7 +236,7 @@ export function get12HourFrom24Hour(hour: number): number {
 
 export function get24HourFrom12Hour(hour: number, isPm: boolean): number {
     if (hour < 1 || hour > 12) {
-        throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
+        throw new Error(`hour must be between [0,12] inclusive: got ${hour}`);
     }
     if (isPm) {
         hour = hour + 12;

--- a/packages/datetime/src/common/timeUnit.ts
+++ b/packages/datetime/src/common/timeUnit.ts
@@ -5,10 +5,12 @@
 */
 
 import * as Classes from "./classes";
+import { get12HourFrom24Hour, get24HourFrom12Hour } from "./dateUtils";
 
 /** describes a component of time. `H:MM:SS.MS` */
 export enum TimeUnit {
-    HOUR = "hour",
+    HOUR_24 = "24hour",
+    HOUR_12 = "12hour",
     MINUTE = "minute",
     SECOND = "second",
     MS = "ms",
@@ -17,8 +19,10 @@ export enum TimeUnit {
 /** Returns the given time unit component of the date. */
 export function getTimeUnit(unit: TimeUnit, date: Date) {
     switch (unit) {
-        case TimeUnit.HOUR:
+        case TimeUnit.HOUR_24:
             return date.getHours();
+        case TimeUnit.HOUR_12:
+            return get12HourFrom24Hour(date.getHours());
         case TimeUnit.MINUTE:
             return date.getMinutes();
         case TimeUnit.SECOND:
@@ -31,10 +35,13 @@ export function getTimeUnit(unit: TimeUnit, date: Date) {
 }
 
 /** Sets the given time unit to the given time in date object. Modifies given `date` object and returns it. */
-export function setTimeUnit(unit: TimeUnit, time: number, date: Date) {
+export function setTimeUnit(unit: TimeUnit, time: number, date: Date, isPm: boolean) {
     switch (unit) {
-        case TimeUnit.HOUR:
+        case TimeUnit.HOUR_24:
             date.setHours(time);
+            break;
+        case TimeUnit.HOUR_12:
+            date.setHours(get24HourFrom12Hour(time, isPm));
             break;
         case TimeUnit.MINUTE:
             date.setMinutes(time);
@@ -96,11 +103,13 @@ interface ITimeUnitMetadata {
 }
 
 const DEFAULT_MIN_HOUR = 0;
+const MERIDIEM_MIN_HOUR = 1;
 const DEFAULT_MIN_MINUTE = 0;
 const DEFAULT_MIN_SECOND = 0;
 const DEFAULT_MIN_MILLISECOND = 0;
 
 const DEFAULT_MAX_HOUR = 23;
+const MERIDIEM_MAX_HOUR = 12;
 const DEFAULT_MAX_MINUTE = 59;
 const DEFAULT_MAX_SECOND = 59;
 const DEFAULT_MAX_MILLISECOND = 999;
@@ -110,10 +119,15 @@ const DEFAULT_MAX_MILLISECOND = 999;
  * Use the `get*` methods above to access these fields.
  */
 const TimeUnitMetadata: Record<TimeUnit, ITimeUnitMetadata> = {
-    [TimeUnit.HOUR]: {
+    [TimeUnit.HOUR_24]: {
         className: Classes.TIMEPICKER_HOUR,
         max: DEFAULT_MAX_HOUR,
         min: DEFAULT_MIN_HOUR,
+    },
+    [TimeUnit.HOUR_12]: {
+        className: Classes.TIMEPICKER_HOUR,
+        max: MERIDIEM_MAX_HOUR,
+        min: MERIDIEM_MIN_HOUR,
     },
     [TimeUnit.MINUTE]: {
         className: Classes.TIMEPICKER_MINUTE,

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -23,4 +23,4 @@ export { IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
 export { DateRangeInput } from "./dateRangeInput";
 export { DateRangePicker, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
-export { ITimePickerProps, TimePicker, TimePickerPrecision } from "./timePicker";
+export { ITimePickerProps, TimePicker, TimePickerPrecision, TimePickerHourFormat } from "./timePicker";

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -23,4 +23,4 @@ export { IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
 export { DateRangeInput } from "./dateRangeInput";
 export { DateRangePicker, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
-export { ITimePickerProps, TimePicker, TimePickerPrecision, TimePickerHourFormat } from "./timePicker";
+export { ITimePickerProps, TimePicker, TimePickerPrecision } from "./timePicker";

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -121,18 +121,13 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         super(props, context);
 
         let value = props.minTime;
-        let useAmPm = TimePicker.defaultProps.useAmPm;
-
         if (props.value != null) {
             value = props.value;
         } else if (props.defaultValue != null) {
             value = props.defaultValue;
         }
-        if (props.useAmPm != null) {
-            useAmPm = props.useAmPm;
-        }
 
-        this.state = this.getFullStateFromValue(value, useAmPm);
+        this.state = this.getFullStateFromValue(value, props.useAmPm);
     }
 
     public render() {
@@ -182,7 +177,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         const didUseAmPmChange = nextProps.useAmPm !== this.props.useAmPm;
 
         let value = this.state.value;
-        let useAmPm = this.props.useAmPm || TimePicker.defaultProps.useAmPm;
+        let useAmPm = this.props.useAmPm;
 
         if (didBoundsChange) {
             value = DateUtils.getTimeInRange(this.state.value, nextProps.minTime, nextProps.maxTime);

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -245,8 +245,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
             if (changeToAm !== this.state.isPm) {
                 return;
             }
-            let hour = DateUtils.get12HourFrom24Hour(this.state.value.getHours());
-            hour = DateUtils.convert12HourMeridiem(hour, changeToAm);
+            const hour = DateUtils.convert24HourMeridiem(this.state.value.getHours(), changeToAm);
 
             this.setState({ isPm: !changeToAm }, () => {
                 this.updateTime(hour, TimeUnit.HOUR_24);

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -112,12 +112,12 @@ export interface ITimePickerState {
 export class TimePicker extends React.Component<ITimePickerProps, ITimePickerState> {
     public static defaultProps: ITimePickerProps = {
         disabled: false,
+        hourFormat: TimePickerHourFormat.HOUR_24,
         maxTime: getDefaultMaxTime(),
         minTime: getDefaultMinTime(),
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
-        hourFormat: TimePickerHourFormat.HOUR_24,
     };
 
     public static displayName = "Blueprint2.TimePicker";
@@ -189,12 +189,15 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         let value = this.state.value;
         let hourFormat = this.props.hourFormat || TimePicker.defaultProps.hourFormat;
 
-        if (didBoundsChange)
+        if (didBoundsChange) {
             value = DateUtils.getTimeInRange(this.state.value, nextProps.minTime, nextProps.maxTime);
-        if (nextProps.value != null && !DateUtils.areSameTime(nextProps.value, this.props.value))
+        }
+        if (nextProps.value != null && !DateUtils.areSameTime(nextProps.value, this.props.value)) {
             value = nextProps.value;
-        if (didHourFormatChange)
+        }
+        if (didHourFormatChange) {
             hourFormat = nextProps.hourFormat;
+        }
 
         this.setState(this.getFullStateFromValue(value, hourFormat));
     }
@@ -239,13 +242,13 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
 
         const onChange = (amPm: string) => {
             const changeToAm = amPm === "am";
-            if (changeToAm !== this.state.isPm)
+            if (changeToAm !== this.state.isPm) {
                 return;
-
+            }
             let hour = DateUtils.get12HourFrom24Hour(this.state.value.getHours());
             hour = DateUtils.convert12HourMeridiem(hour, changeToAm);
 
-            this.setState({isPm: !changeToAm}, () => {
+            this.setState({ isPm: !changeToAm }, () => {
                 this.updateTime(hour, TimeUnit.HOUR_24);
             });
         };

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -65,7 +65,7 @@ export interface ITimePickerProps extends IProps {
     showArrowButtons?: boolean;
 
     /**
-     * Whether to choose from a 12 hour format with an AM/PM dropdown.
+     * Whether to use a 12 hour format with an AM/PM dropdown.
      * @default false
      */
     useAmPm?: boolean;
@@ -174,22 +174,16 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         const didMinTimeChange = nextProps.minTime !== this.props.minTime;
         const didMaxTimeChange = nextProps.maxTime !== this.props.maxTime;
         const didBoundsChange = didMinTimeChange || didMaxTimeChange;
-        const didUseAmPmChange = nextProps.useAmPm !== this.props.useAmPm;
 
         let value = this.state.value;
-        let useAmPm = this.props.useAmPm;
-
         if (didBoundsChange) {
             value = DateUtils.getTimeInRange(this.state.value, nextProps.minTime, nextProps.maxTime);
         }
         if (nextProps.value != null && !DateUtils.areSameTime(nextProps.value, this.props.value)) {
             value = nextProps.value;
         }
-        if (didUseAmPmChange) {
-            useAmPm = nextProps.useAmPm;
-        }
 
-        this.setState(this.getFullStateFromValue(value, useAmPm));
+        this.setState(this.getFullStateFromValue(value, nextProps.useAmPm));
     }
 
     // begin method definitions: rendering
@@ -236,8 +230,8 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                     onChange={this.handleAmPmChange}
                     disabled={this.props.disabled}
                 >
-                    <option value={"am"}>AM</option>
-                    <option value={"pm"}>PM</option>
+                    <option value="am">AM</option>
+                    <option value="pm">PM</option>
                 </select>
             </div>
         );

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -167,8 +167,8 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                     {shouldRenderMilliseconds && this.renderDivider(".")}
                     {shouldRenderMilliseconds &&
                         this.renderInput(Classes.TIMEPICKER_MILLISECOND, TimeUnit.MS, this.state.millisecondText)}
-                    {this.maybeRenderMeridiem()}
                 </div>
+                {this.maybeRenderAmPm()}
                 <div className={Classes.TIMEPICKER_ARROW_ROW}>
                     {this.maybeRenderArrowButton(false, hourUnit)}
                     {this.maybeRenderArrowButton(false, TimeUnit.MINUTE)}
@@ -232,24 +232,39 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         );
     }
 
-    private maybeRenderMeridiem() {
+    private maybeRenderAmPm() {
         if (this.props.hourFormat !== TimePickerHourFormat.HOUR_12) {
             return null;
         }
 
-        const onClick = () => {
-            let hour = this.state.value.getHours();
-            hour = DateUtils.convertHourMeridiem(hour, this.state.isPm);
+        const onChange = (amPm: string) => {
+            const isPm = amPm === "pm";
+            if (isPm === this.state.isPm)
+                return;
 
-            this.setState({isPm: !this.state.isPm}, () => {
+            let hour = this.state.value.getHours();
+            hour = DateUtils.convertHourMeridiem(hour, isPm);
+
+            this.setState({isPm: isPm}, () => {
                 this.updateTime(hour, TimeUnit.HOUR_24);
             });
         };
 
         return (
-            <span onClick={onClick}>
-                {this.state.isPm ? "PM" : "AM"}
-            </span>
+            <div className={classNames(CoreClasses.SELECT, Classes.TIMEPICKER_AMPM_SELECT)}>
+                <select
+                    value={this.state.isPm ? "pm" : "am"}
+                    onChange={handleStringChange(onChange)}
+                    disabled={this.props.disabled}
+                >
+                    <option key={0} value={"am"}>
+                        AM
+                    </option>
+                    <option key={1} value={"pm"}>
+                        PM
+                    </option>
+                </select>
+            </div>
         );
     }
 
@@ -426,4 +441,9 @@ function handleKeyEvent(e: React.KeyboardEvent<HTMLInputElement>, actions: IKeyE
             actions[key]();
         }
     }
+}
+
+/** Event handler that exposes the target element's value as a string. */
+function handleStringChange(handler: (value: string) => void) {
+    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
 }

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -238,14 +238,14 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         }
 
         const onChange = (amPm: string) => {
-            const isPm = amPm === "pm";
-            if (isPm === this.state.isPm)
+            const changeToAm = amPm === "am";
+            if (changeToAm !== this.state.isPm)
                 return;
 
-            let hour = this.state.value.getHours();
-            hour = DateUtils.convertHourMeridiem(hour, isPm);
+            let hour = DateUtils.get12HourFrom24Hour(this.state.value.getHours());
+            hour = DateUtils.convert12HourMeridiem(hour, changeToAm);
 
-            this.setState({isPm: isPm}, () => {
+            this.setState({isPm: !changeToAm}, () => {
                 this.updateTime(hour, TimeUnit.HOUR_24);
             });
         };

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -234,32 +234,15 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         if (!this.props.useAmPm) {
             return null;
         }
-
-        const onChange = (amPm: string) => {
-            const changeToAm = amPm === "am";
-            if (changeToAm !== this.state.isPm) {
-                return;
-            }
-            const hour = DateUtils.convert24HourMeridiem(this.state.value.getHours(), changeToAm);
-
-            this.setState({ isPm: !changeToAm }, () => {
-                this.updateTime(hour, TimeUnit.HOUR_24);
-            });
-        };
-
         return (
             <div className={classNames(CoreClasses.SELECT, Classes.TIMEPICKER_AMPM_SELECT)}>
                 <select
                     value={this.state.isPm ? "pm" : "am"}
-                    onChange={handleStringChange(onChange)}
+                    onChange={this.handleAmPmChange}
                     disabled={this.props.disabled}
                 >
-                    <option key={0} value={"am"}>
-                        AM
-                    </option>
-                    <option key={1} value={"pm"}>
-                        PM
-                    </option>
+                    <option value={"am"}>AM</option>
+                    <option value={"pm"}>PM</option>
                 </select>
             </div>
         );
@@ -327,6 +310,18 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         if (this.props.selectAllOnFocus) {
             e.currentTarget.select();
         }
+    };
+
+    private handleAmPmChange = (e: React.SyntheticEvent<HTMLSelectElement>) => {
+        const changeToAm = e.currentTarget.value === "am";
+        if (changeToAm !== this.state.isPm) {
+            return;
+        }
+        const hour = DateUtils.convert24HourMeridiem(this.state.value.getHours(), changeToAm);
+
+        this.setState({ isPm: !changeToAm }, () => {
+            this.updateTime(hour, TimeUnit.HOUR_24);
+        });
     };
 
     // begin method definitions: state modification
@@ -438,9 +433,4 @@ function handleKeyEvent(e: React.KeyboardEvent<HTMLInputElement>, actions: IKeyE
             actions[key]();
         }
     }
-}
-
-/** Event handler that exposes the target element's value as a string. */
-function handleStringChange(handler: (value: string) => void) {
-    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
 }

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -308,15 +308,11 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     };
 
     private handleAmPmChange = (e: React.SyntheticEvent<HTMLSelectElement>) => {
-        const changeToAm = e.currentTarget.value === "am";
-        if (changeToAm !== this.state.isPm) {
-            return;
+        const isNextPm = e.currentTarget.value === "pm";
+        if (isNextPm !== this.state.isPm) {
+            const hour = DateUtils.convert24HourMeridiem(this.state.value.getHours(), isNextPm);
+            this.setState({ isPm: isNextPm }, () => this.updateTime(hour, TimeUnit.HOUR_24));
         }
-        const hour = DateUtils.convert24HourMeridiem(this.state.value.getHours(), changeToAm);
-
-        this.setState({ isPm: !changeToAm }, () => {
-            this.updateTime(hour, TimeUnit.HOUR_24);
-        });
     };
 
     // begin method definitions: state modification

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -223,36 +223,32 @@ describe("dateUtils", () => {
     });
 
     describe("convert24HourMeridiem", () => {
-        it("returns given hour, if hour is AM and toAm", () => {
-            for (let hour = 0; hour <= 11; hour++) {
-                expect(DateUtils.convert24HourMeridiem(hour, true)).to.equal(hour);
-            }
+        it("returns given hour, if hour is PM and toPm", () => {
+            expect(DateUtils.convert24HourMeridiem(12, true)).to.equal(12);
+            expect(DateUtils.convert24HourMeridiem(13, true)).to.equal(13);
+            expect(DateUtils.convert24HourMeridiem(22, true)).to.equal(22);
+            expect(DateUtils.convert24HourMeridiem(23, true)).to.equal(23);
         });
 
-        it("returns given hour in PM, if hour is AM and not toAm", () => {
-            const pmHours = [];
-            for (let i = 12; i <= 23; i++) {
-                pmHours.push(i);
-            }
-            for (let amHour = 0; amHour <= 11; amHour++) {
-                expect(DateUtils.convert24HourMeridiem(amHour, false)).to.equal(pmHours[amHour]);
-            }
+        it("returns given hour in AM, if hour is PM and not toPm", () => {
+            expect(DateUtils.convert24HourMeridiem(12, false)).to.equal(0);
+            expect(DateUtils.convert24HourMeridiem(13, false)).to.equal(1);
+            expect(DateUtils.convert24HourMeridiem(22, false)).to.equal(10);
+            expect(DateUtils.convert24HourMeridiem(23, false)).to.equal(11);
         });
 
-        it("returns given hour, if hour is PM and not toAm", () => {
-            for (let hour = 12; hour <= 23; hour++) {
-                expect(DateUtils.convert24HourMeridiem(hour, false)).to.equal(hour);
-            }
+        it("returns given hour, if hour is AM and not toPm", () => {
+            expect(DateUtils.convert24HourMeridiem(0, false)).to.equal(0);
+            expect(DateUtils.convert24HourMeridiem(1, false)).to.equal(1);
+            expect(DateUtils.convert24HourMeridiem(10, false)).to.equal(10);
+            expect(DateUtils.convert24HourMeridiem(11, false)).to.equal(11);
         });
 
-        it("returns given hour in AM, if hour is PM and toAm", () => {
-            const pmHours = [];
-            for (let i = 12; i <= 23; i++) {
-                pmHours.push(i);
-            }
-            for (let amHour = 0; amHour <= 11; amHour++) {
-                expect(DateUtils.convert24HourMeridiem(pmHours[amHour], true)).to.equal(amHour);
-            }
+        it("returns given hour in PM, if hour is AM and toPm", () => {
+            expect(DateUtils.convert24HourMeridiem(0, true)).to.equal(12);
+            expect(DateUtils.convert24HourMeridiem(1, true)).to.equal(13);
+            expect(DateUtils.convert24HourMeridiem(10, true)).to.equal(22);
+            expect(DateUtils.convert24HourMeridiem(11, true)).to.equal(23);
         });
 
         it("throws an error only for invalid hours", () => {

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -221,4 +221,45 @@ describe("dateUtils", () => {
             assertTimeIs(time, 11, 20);
         });
     });
+
+    describe("convert24HourMeridiem", () => {
+        it("returns given hour, if hour is AM and toAm", () => {
+            for (let hour = 0; hour <= 11; hour++) {
+                expect(DateUtils.convert24HourMeridiem(hour, true)).to.equal(hour);
+            }
+        });
+
+        it("returns given hour in PM, if hour is AM and not toAm", () => {
+            const pmHours = [];
+            for (let i = 12; i <= 23; i++) {
+                pmHours.push(i);
+            }
+            for (let amHour = 0; amHour <= 11; amHour++) {
+                expect(DateUtils.convert24HourMeridiem(amHour, false)).to.equal(pmHours[amHour]);
+            }
+        });
+
+        it("returns given hour, if hour is PM and not toAm", () => {
+            for (let hour = 12; hour <= 23; hour++) {
+                expect(DateUtils.convert24HourMeridiem(hour, false)).to.equal(hour);
+            }
+        });
+
+        it("returns given hour in AM, if hour is PM and toAm", () => {
+            const pmHours = [];
+            for (let i = 12; i <= 23; i++) {
+                pmHours.push(i);
+            }
+            for (let amHour = 0; amHour <= 11; amHour++) {
+                expect(DateUtils.convert24HourMeridiem(pmHours[amHour], true)).to.equal(amHour);
+            }
+        });
+
+        it("throws an error only for invalid hours", () => {
+            expect(() => DateUtils.convert24HourMeridiem(-1, true)).to.throw();
+            expect(() => DateUtils.convert24HourMeridiem(24, true)).to.throw();
+            expect(() => DateUtils.convert24HourMeridiem(0, true)).to.not.throw();
+            expect(() => DateUtils.convert24HourMeridiem(23, true)).to.not.throw();
+        });
+    });
 });

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -262,20 +262,18 @@ describe("dateUtils", () => {
     describe("getIsPmFrom24Hour", () => {
         it("returns true, if hour (in 24 range) is PM", () => {
             expect(DateUtils.getIsPmFrom24Hour(12)).to.equal(true);
+            expect(DateUtils.getIsPmFrom24Hour(13)).to.equal(true);
+            expect(DateUtils.getIsPmFrom24Hour(17)).to.equal(true);
+            expect(DateUtils.getIsPmFrom24Hour(22)).to.equal(true);
             expect(DateUtils.getIsPmFrom24Hour(23)).to.equal(true);
-
-            for (let hour = 12; hour <= 23; hour++) {
-                expect(DateUtils.getIsPmFrom24Hour(hour)).to.equal(true);
-            }
         });
 
         it("returns false, if hour (in 24 range) is AM", () => {
             expect(DateUtils.getIsPmFrom24Hour(0)).to.equal(false);
+            expect(DateUtils.getIsPmFrom24Hour(1)).to.equal(false);
+            expect(DateUtils.getIsPmFrom24Hour(5)).to.equal(false);
+            expect(DateUtils.getIsPmFrom24Hour(10)).to.equal(false);
             expect(DateUtils.getIsPmFrom24Hour(11)).to.equal(false);
-
-            for (let hour = 0; hour <= 11; hour++) {
-                expect(DateUtils.getIsPmFrom24Hour(hour)).to.equal(false);
-            }
         });
 
         it("throws an error only for invalid hours", () => {
@@ -289,14 +287,11 @@ describe("dateUtils", () => {
     describe("get12HourFrom24Hour", () => {
         it("returns correct 12-hour format from 24-hour format", () => {
             expect(DateUtils.get12HourFrom24Hour(0)).to.equal(12);
+            expect(DateUtils.get12HourFrom24Hour(5)).to.equal(5);
             expect(DateUtils.get12HourFrom24Hour(11)).to.equal(11);
             expect(DateUtils.get12HourFrom24Hour(12)).to.equal(12);
+            expect(DateUtils.get12HourFrom24Hour(18)).to.equal(6);
             expect(DateUtils.get12HourFrom24Hour(23)).to.equal(11);
-
-            const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-            for (let hour24 = 0; hour24 <= 23; hour24++) {
-                expect(DateUtils.get12HourFrom24Hour(hour24)).to.equal(hours12[hour24]);
-            }
         });
 
         it("throws an error only for invalid 24-hours", () => {
@@ -310,24 +305,16 @@ describe("dateUtils", () => {
     describe("get24HourFrom12Hour", () => {
         it("returns correct 24-hour format from 12-hour format, if isPm", () => {
             expect(DateUtils.get24HourFrom12Hour(1, true)).to.equal(13);
+            expect(DateUtils.get24HourFrom12Hour(7, true)).to.equal(19);
             expect(DateUtils.get24HourFrom12Hour(11, true)).to.equal(23);
             expect(DateUtils.get24HourFrom12Hour(12, true)).to.equal(12);
-
-            const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-            for (let hour24 = 12; hour24 <= 23; hour24++) {
-                expect(DateUtils.get24HourFrom12Hour(hours12[hour24 - 12], true)).to.equal(hour24);
-            }
         });
 
         it("returns correct 24-hour format from 12-hour format, if not isPm", () => {
             expect(DateUtils.get24HourFrom12Hour(1, false)).to.equal(1);
+            expect(DateUtils.get24HourFrom12Hour(4, false)).to.equal(4);
             expect(DateUtils.get24HourFrom12Hour(11, false)).to.equal(11);
             expect(DateUtils.get24HourFrom12Hour(12, false)).to.equal(0);
-
-            const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-            for (let hour24 = 0; hour24 <= 11; hour24++) {
-                expect(DateUtils.get24HourFrom12Hour(hours12[hour24], false)).to.equal(hour24);
-            }
         });
 
         it("throws an error only for invalid 12-hours", () => {

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -265,21 +265,19 @@ describe("dateUtils", () => {
 
     describe("getIsPmFrom24Hour", () => {
         it("returns true, if hour (in 24 range) is PM", () => {
-            const pmHours = [];
-            for (let i = 12; i <= 23; i++) {
-                pmHours.push(i);
-            }
-            for (const hour of pmHours) {
+            expect(DateUtils.getIsPmFrom24Hour(12)).to.equal(true);
+            expect(DateUtils.getIsPmFrom24Hour(23)).to.equal(true);
+
+            for (let hour = 12; hour <= 23; hour++) {
                 expect(DateUtils.getIsPmFrom24Hour(hour)).to.equal(true);
             }
         });
 
         it("returns false, if hour (in 24 range) is AM", () => {
-            const amHours = [];
-            for (let i = 0; i <= 11; i++) {
-                amHours.push(i);
-            }
-            for (const hour of amHours) {
+            expect(DateUtils.getIsPmFrom24Hour(0)).to.equal(false);
+            expect(DateUtils.getIsPmFrom24Hour(11)).to.equal(false);
+
+            for (let hour = 0; hour <= 11; hour++) {
                 expect(DateUtils.getIsPmFrom24Hour(hour)).to.equal(false);
             }
         });
@@ -294,6 +292,11 @@ describe("dateUtils", () => {
 
     describe("get12HourFrom24Hour", () => {
         it("returns correct 12-hour format from 24-hour format", () => {
+            expect(DateUtils.get12HourFrom24Hour(0)).to.equal(12);
+            expect(DateUtils.get12HourFrom24Hour(11)).to.equal(11);
+            expect(DateUtils.get12HourFrom24Hour(12)).to.equal(12);
+            expect(DateUtils.get12HourFrom24Hour(23)).to.equal(11);
+
             const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
             for (let hour24 = 0; hour24 <= 23; hour24++) {
                 expect(DateUtils.get12HourFrom24Hour(hour24)).to.equal(hours12[hour24]);
@@ -310,20 +313,22 @@ describe("dateUtils", () => {
 
     describe("get24HourFrom12Hour", () => {
         it("returns correct 24-hour format from 12-hour format, if isPm", () => {
-            const hours12 = [12];
-            for (let i = 1; i <= 11; i++) {
-                hours12.push(i);
-            }
+            expect(DateUtils.get24HourFrom12Hour(1, true)).to.equal(13);
+            expect(DateUtils.get24HourFrom12Hour(11, true)).to.equal(23);
+            expect(DateUtils.get24HourFrom12Hour(12, true)).to.equal(12);
+
+            const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
             for (let hour24 = 12; hour24 <= 23; hour24++) {
                 expect(DateUtils.get24HourFrom12Hour(hours12[hour24 - 12], true)).to.equal(hour24);
             }
         });
 
         it("returns correct 24-hour format from 12-hour format, if not isPm", () => {
-            const hours12 = [12];
-            for (let i = 1; i <= 11; i++) {
-                hours12.push(i);
-            }
+            expect(DateUtils.get24HourFrom12Hour(1, false)).to.equal(1);
+            expect(DateUtils.get24HourFrom12Hour(11, false)).to.equal(11);
+            expect(DateUtils.get24HourFrom12Hour(12, false)).to.equal(0);
+
+            const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
             for (let hour24 = 0; hour24 <= 11; hour24++) {
                 expect(DateUtils.get24HourFrom12Hour(hours12[hour24], false)).to.equal(hour24);
             }

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -262,4 +262,78 @@ describe("dateUtils", () => {
             expect(() => DateUtils.convert24HourMeridiem(23, true)).to.not.throw();
         });
     });
+
+    describe("getIsPmFrom24Hour", () => {
+        it("returns true, if hour (in 24 range) is PM", () => {
+            const pmHours = [];
+            for (let i = 12; i <= 23; i++) {
+                pmHours.push(i);
+            }
+            for (const hour of pmHours) {
+                expect(DateUtils.getIsPmFrom24Hour(hour)).to.equal(true);
+            }
+        });
+
+        it("returns false, if hour (in 24 range) is AM", () => {
+            const amHours = [];
+            for (let i = 0; i <= 11; i++) {
+                amHours.push(i);
+            }
+            for (const hour of amHours) {
+                expect(DateUtils.getIsPmFrom24Hour(hour)).to.equal(false);
+            }
+        });
+
+        it("throws an error only for invalid hours", () => {
+            expect(() => DateUtils.getIsPmFrom24Hour(-1)).to.throw();
+            expect(() => DateUtils.getIsPmFrom24Hour(24)).to.throw();
+            expect(() => DateUtils.getIsPmFrom24Hour(0)).to.not.throw();
+            expect(() => DateUtils.getIsPmFrom24Hour(23)).to.not.throw();
+        });
+    });
+
+    describe("get12HourFrom24Hour", () => {
+        it("returns correct 12-hour format from 24-hour format", () => {
+            const hours12 = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+            for (let hour24 = 0; hour24 <= 23; hour24++) {
+                expect(DateUtils.get12HourFrom24Hour(hour24)).to.equal(hours12[hour24]);
+            }
+        });
+
+        it("throws an error only for invalid 24-hours", () => {
+            expect(() => DateUtils.get12HourFrom24Hour(-1)).to.throw();
+            expect(() => DateUtils.get12HourFrom24Hour(24)).to.throw();
+            expect(() => DateUtils.get12HourFrom24Hour(0)).to.not.throw();
+            expect(() => DateUtils.get12HourFrom24Hour(23)).to.not.throw();
+        });
+    });
+
+    describe("get24HourFrom12Hour", () => {
+        it("returns correct 24-hour format from 12-hour format, if isPm", () => {
+            const hours12 = [12];
+            for (let i = 1; i <= 11; i++) {
+                hours12.push(i);
+            }
+            for (let hour24 = 12; hour24 <= 23; hour24++) {
+                expect(DateUtils.get24HourFrom12Hour(hours12[hour24 - 12], true)).to.equal(hour24);
+            }
+        });
+
+        it("returns correct 24-hour format from 12-hour format, if not isPm", () => {
+            const hours12 = [12];
+            for (let i = 1; i <= 11; i++) {
+                hours12.push(i);
+            }
+            for (let hour24 = 0; hour24 <= 11; hour24++) {
+                expect(DateUtils.get24HourFrom12Hour(hours12[hour24], false)).to.equal(hour24);
+            }
+        });
+
+        it("throws an error only for invalid 12-hours", () => {
+            expect(() => DateUtils.get24HourFrom12Hour(0, true)).to.throw();
+            expect(() => DateUtils.get24HourFrom12Hour(13, true)).to.throw();
+            expect(() => DateUtils.get24HourFrom12Hour(1, true)).to.not.throw();
+            expect(() => DateUtils.get24HourFrom12Hour(12, true)).to.not.throw();
+        });
+    });
 });

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -9,7 +9,7 @@ import { BaseExample, handleNumberChange } from "@blueprintjs/docs-theme";
 import * as React from "react";
 import { PrecisionSelect } from "./common/precisionSelect";
 
-import { TimePicker, TimePickerPrecision } from "@blueprintjs/datetime";
+import { TimePicker, TimePickerPrecision, TimePickerHourFormat } from "@blueprintjs/datetime";
 // tslint:disable-next-line:no-submodule-imports
 import { getDefaultMaxTime, getDefaultMinTime } from "@blueprintjs/datetime/lib/esm/common/timeUnit";
 
@@ -20,6 +20,7 @@ export interface ITimePickerExampleState {
     disabled?: boolean;
     minTime?: Date;
     maxTime?: Date;
+    hourFormat?: TimePickerHourFormat;
 }
 
 enum MinimumHours {
@@ -40,6 +41,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
+        hourFormat: TimePickerHourFormat.HOUR_24,
     };
 
     private handlePrecisionChange = handleNumberChange(precision => this.setState({ precision }));
@@ -65,6 +67,12 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                     onChange={this.toggleShowArrowButtons}
                 />,
                 <Switch checked={this.state.disabled} label="Disabled" key="disabled" onChange={this.toggleDisabled} />,
+                <Switch
+                    checked={this.state.hourFormat === TimePickerHourFormat.HOUR_12}
+                    label="Use AM/PM"
+                    key="ampm"
+                    onChange={this.toggleUseAmPm}
+                />,
             ],
             [
                 <label key={0} className={Classes.LABEL}>
@@ -113,6 +121,14 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
 
     private toggleDisabled = () => {
         this.setState({ disabled: !this.state.disabled });
+    };
+
+    private toggleUseAmPm = () => {
+        let newHourFormat = (this.state.hourFormat === TimePickerHourFormat.HOUR_24) ?
+            TimePickerHourFormat.HOUR_12 :
+            TimePickerHourFormat.HOUR_24;
+
+        this.setState({ hourFormat: newHourFormat });
     };
 
     private changeMinHour = (hour: MinimumHours) => {

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -9,7 +9,7 @@ import { BaseExample, handleNumberChange } from "@blueprintjs/docs-theme";
 import * as React from "react";
 import { PrecisionSelect } from "./common/precisionSelect";
 
-import { TimePicker, TimePickerHourFormat, TimePickerPrecision } from "@blueprintjs/datetime";
+import { TimePicker, TimePickerPrecision } from "@blueprintjs/datetime";
 // tslint:disable-next-line:no-submodule-imports
 import { getDefaultMaxTime, getDefaultMinTime } from "@blueprintjs/datetime/lib/esm/common/timeUnit";
 
@@ -20,7 +20,7 @@ export interface ITimePickerExampleState {
     disabled?: boolean;
     minTime?: Date;
     maxTime?: Date;
-    hourFormat?: TimePickerHourFormat;
+    useAmPm?: boolean;
 }
 
 enum MinimumHours {
@@ -38,7 +38,7 @@ enum MaximumHours {
 export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     public state = {
         disabled: false,
-        hourFormat: TimePickerHourFormat.HOUR_24,
+        useAmPm: false,
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
@@ -68,7 +68,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                 />,
                 <Switch checked={this.state.disabled} label="Disabled" key="disabled" onChange={this.toggleDisabled} />,
                 <Switch
-                    checked={this.state.hourFormat === TimePickerHourFormat.HOUR_12}
+                    checked={this.state.useAmPm}
                     label="Use AM/PM"
                     key="ampm"
                     onChange={this.toggleUseAmPm}
@@ -124,12 +124,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     };
 
     private toggleUseAmPm = () => {
-        const newHourFormat =
-            this.state.hourFormat === TimePickerHourFormat.HOUR_24
-                ? TimePickerHourFormat.HOUR_12
-                : TimePickerHourFormat.HOUR_24;
-
-        this.setState({ hourFormat: newHourFormat });
+        this.setState({ useAmPm: !this.state.useAmPm });
     };
 
     private changeMinHour = (hour: MinimumHours) => {

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -38,10 +38,10 @@ enum MaximumHours {
 export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     public state = {
         disabled: false,
-        useAmPm: false,
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
+        useAmPm: false,
     };
 
     private handlePrecisionChange = handleNumberChange(precision => this.setState({ precision }));
@@ -67,12 +67,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                     onChange={this.toggleShowArrowButtons}
                 />,
                 <Switch checked={this.state.disabled} label="Disabled" key="disabled" onChange={this.toggleDisabled} />,
-                <Switch
-                    checked={this.state.useAmPm}
-                    label="Use AM/PM"
-                    key="ampm"
-                    onChange={this.toggleUseAmPm}
-                />,
+                <Switch checked={this.state.useAmPm} label="Use AM/PM" key="ampm" onChange={this.toggleUseAmPm} />,
             ],
             [
                 <label key={0} className={Classes.LABEL}>

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -9,7 +9,7 @@ import { BaseExample, handleNumberChange } from "@blueprintjs/docs-theme";
 import * as React from "react";
 import { PrecisionSelect } from "./common/precisionSelect";
 
-import { TimePicker, TimePickerPrecision, TimePickerHourFormat } from "@blueprintjs/datetime";
+import { TimePicker, TimePickerHourFormat, TimePickerPrecision } from "@blueprintjs/datetime";
 // tslint:disable-next-line:no-submodule-imports
 import { getDefaultMaxTime, getDefaultMinTime } from "@blueprintjs/datetime/lib/esm/common/timeUnit";
 
@@ -38,10 +38,10 @@ enum MaximumHours {
 export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     public state = {
         disabled: false,
+        hourFormat: TimePickerHourFormat.HOUR_24,
         precision: TimePickerPrecision.MINUTE,
         selectAllOnFocus: false,
         showArrowButtons: false,
-        hourFormat: TimePickerHourFormat.HOUR_24,
     };
 
     private handlePrecisionChange = handleNumberChange(precision => this.setState({ precision }));
@@ -124,9 +124,10 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     };
 
     private toggleUseAmPm = () => {
-        let newHourFormat = (this.state.hourFormat === TimePickerHourFormat.HOUR_24) ?
-            TimePickerHourFormat.HOUR_12 :
-            TimePickerHourFormat.HOUR_24;
+        const newHourFormat =
+            this.state.hourFormat === TimePickerHourFormat.HOUR_24
+                ? TimePickerHourFormat.HOUR_12
+                : TimePickerHourFormat.HOUR_24;
 
         this.setState({ hourFormat: newHourFormat });
     };


### PR DESCRIPTION
#### Fixes #1409 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Adding an additional prop ~~`hourFormat`~~ `useAmPm` to the TimePicker component to support a 12-hour clock and AM/PM switcher. ~~`hourFormat` can be set to either of the two strings `"12hour"` or `"24hour"` to toggle the AM/PM switcher and type of hour unit being used.~~ `useAmPm` is a boolean which defaults to `false` (using the 24-hour clock by default to maintain backwards compatibility) and can be set to `true` to set the hour range to 12-hours and display an AM/PM dropdown.

I also added a switch to the TimePicker documentation page to set the example component's `hourFormat`.

#### Reviewers should focus on:

<!-- fill this out -->

#### Video Demo

https://media.giphy.com/media/39m89EvdXoQFbCPKYk/giphy.gif
