### PR TITLE
Fixed broken DateInput close feature due to bumping react-day-select

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -400,27 +400,38 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         const relatedTarget = e.relatedTarget as HTMLElement;
         if (relatedTarget == null || !this.popoverContentEl.contains(relatedTarget)) {
             this.handleClosePopover();
+        } else if (relatedTarget != null) {
+            this.unregisterPopoverBlurHandler();
+            this.lastElementInPopover = relatedTarget;
+            this.lastElementInPopover.addEventListener("blur", this.handlePopoverBlur);
         }
     };
 
     private registerPopoverBlurHandler = () => {
         if (this.popoverContentEl != null) {
+            // If current activeElement exists inside popover content, a month
+            // change has triggered and this element should be lastTabbableElement
+            let lastTabbableElement = this.popoverContentEl.contains(document.activeElement)
+                ? document.activeElement
+                : undefined;
             // Popover contents are well structured, but the selector will need
             // to be updated if more focusable components are added in the future
-            const tabbableElements = this.popoverContentEl.querySelectorAll("input, [tabindex]:not([tabindex='-1'])");
-            const numOfElements = tabbableElements.length;
-            if (numOfElements > 0) {
-                // Keep track of the last focusable element in popover and add
-                // a blur handler, so that when:
-                // * user tabs to the next element, popover closes
-                // * focus moves to element within popover, popover stays open
-                const lastElement = tabbableElements[numOfElements - 1] as HTMLElement;
-                if (this.lastElementInPopover !== lastElement) {
-                    this.unregisterPopoverBlurHandler();
-                    this.lastElementInPopover = lastElement;
-                    this.lastElementInPopover.addEventListener("blur", this.handlePopoverBlur);
+            if (!lastTabbableElement) {
+                const tabbableElements = this.popoverContentEl.querySelectorAll(
+                    "input, [tabindex]:not([tabindex='-1'])",
+                );
+                const numOfElements = tabbableElements.length;
+                if (numOfElements > 0) {
+                    // Keep track of the last focusable element in popover and add
+                    // a blur handler, so that when:
+                    // * user tabs to the next element, popover closes
+                    // * focus moves to element within popover, popover stays open
+                    lastTabbableElement = tabbableElements[numOfElements - 1];
                 }
             }
+            this.unregisterPopoverBlurHandler();
+            this.lastElementInPopover = lastTabbableElement as HTMLElement;
+            this.lastElementInPopover.addEventListener("blur", this.handlePopoverBlur);
         }
     };
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -416,7 +416,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
                 : undefined;
             // Popover contents are well structured, but the selector will need
             // to be updated if more focusable components are added in the future
-            if (!lastTabbableElement) {
+            if (lastTabbableElement == null) {
                 const tabbableElements = this.popoverContentEl.querySelectorAll(
                     "input, [tabindex]:not([tabindex='-1'])",
                 );


### PR DESCRIPTION
#### Fixes #2155 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->
- [x] Include tests

#### Changes proposed in this pull request:
<!-- fill this out -->
Fixed issue caused by bumping react-day-select.

#### Reviewers should focus on:
<!-- fill this out -->
The update in react-day-select caused a slight change in behavior. Tabbing inside the date select popover will tab through the month, year selectors, then prev/next month arrow, then the first day of the current month. Prior version focused on the prev and next month's dates ie. days with `DayPicker-Day--outside` class. Now, after tabbing out of the first day of the current month, the popover will close.

Additionally, once the first day is focused, users can move the focused day by using the arrow keys. This PR adds changes which will allow the user to move the focused day and still close the popover by pressing tab anytime.

#### Screenshot
![feb-19-2018 20-24-49](https://user-images.githubusercontent.com/16532/36407382-06bf7eae-15b3-11e8-8a11-d72afe0ee1cf.gif)

