### PR TITLE
Hide nested content for .pt-skeleton, e.g. icons

### DIFF
--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -13,7 +13,7 @@ Markup:
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eget tortor felis.
     Fusce dapibus metus in dapibus mollis. Quisque eget ex diam.
   </p>
-  <button type="button" class="pt-button {{.modifier}}" tabindex="-1">Submit</button>
+  <button type="button" class="pt-button pt-icon-add {{.modifier}}" tabindex="-1">Submit</button>
 </div>
 
 .pt-skeleton - Render this element as a skeleton, an outline of its true self.
@@ -52,5 +52,12 @@ Styleguide pt-skeleton
   animation: $skeleton-animation;
   pointer-events: none;
   user-select: none;
+
+  // Make pseudo-elements and children invisible
+  &::before,  // e.g. .pt-icon-*
+  &::after,  // e.g. .pt-select
+  * {  // e.g. SVG icons
+    visibility: hidden !important;
+  }
 }
 /* stylelint-enable declaration-no-important */


### PR DESCRIPTION
#### Fixes #2176

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Hide all descendants of `.pt-skeleton`, including `::before` and `::after`. The main motivation behind it is to hide icons.

#### Reviewers should focus on:

Whether the scope of this change is too broad or not.

#### Screenshot

![image](https://user-images.githubusercontent.com/1037172/36619792-f40fc3e6-18a4-11e8-9d4d-0da73fe3af63.png)

