### PR TITLE
[core] Add space in between Label 'text' and 'helperText'.

### DIFF
--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -42,7 +42,7 @@ export class Label extends React.PureComponent<ILabelProps, {}> {
         return (
             <label {...htmlProps} className={rootClasses}>
                 {text}
-                <span className={classNames(Classes.TEXT_MUTED)}>{helperText}</span>
+                <span className={classNames(Classes.TEXT_MUTED)}>{helperText ? " " + helperText : ""}</span>
                 {children}
             </label>
         );

--- a/packages/core/test/forms/labelTests.tsx
+++ b/packages/core/test/forms/labelTests.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { assert } from "chai";
+import { shallow } from "enzyme";
+import * as React from "react";
+import { Label } from "../../src/index";
+
+describe("<Label>", () => {
+    it("renders a space between text and helperText", () => {
+        const wrapper = shallow(
+            <Label text="Username" helperText="(blah blah)">
+                <input autoFocus={true} className="pt-input" type="text" />
+            </Label>,
+        );
+        assert.strictEqual(wrapper.text(), "Username (blah blah)");
+    });
+
+    it("does not have an extra space after text when helperText is not defined", () => {
+        const wrapper = shallow(
+            <Label text="Username">
+                <input autoFocus={true} className="pt-input" type="text" />
+            </Label>,
+        );
+        assert.strictEqual(wrapper.text(), "Username");
+    });
+});

--- a/packages/core/test/forms/labelTests.tsx
+++ b/packages/core/test/forms/labelTests.tsx
@@ -19,7 +19,7 @@ describe("<Label>", () => {
         assert.strictEqual(wrapper.text(), "Username (blah blah)");
     });
 
-    it("does not have an extra space after text when helperText is not defined", () => {
+    it("does not put an extra space after text when helperText is not defined", () => {
         const wrapper = shallow(
             <Label text="Username">
                 <input autoFocus={true} className="pt-input" type="text" />

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -24,6 +24,7 @@ import "./dialog/dialogTests";
 import "./editable-text/editableTextTests";
 import "./forms/fileInputTests";
 import "./forms/formGroupTests";
+import "./forms/labelTests";
 import "./hotkeys/hotkeysTests";
 import "./icon/iconTests";
 import "./menu/menuItemTests";


### PR DESCRIPTION
#### Fixes #2175

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/gh/danielbh/blueprint)
- [x] Include tests
- [x] Update documentation (not need, its a bugfix)

#### Changes proposed in this pull request:

Adds a space in between `text` and `helperText` for the Label component

#### Reviewers should focus on:

The updated `Label` component and new tests

#### Screenshot

`Before`

<img width="218" alt="screen shot 2018-02-23 at 10 05 46 pm" src="https://user-images.githubusercontent.com/6653234/36625163-257a093a-18e8-11e8-8ad7-ef3258516f2e.png">

`After`

<img width="209" alt="screen shot 2018-02-23 at 11 15 07 pm" src="https://user-images.githubusercontent.com/6653234/36625542-72e7f45a-18ef-11e8-9b30-327972288a9a.png">
