### PR TITLE
[core] Add Icon `title` prop

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -45,6 +45,14 @@ export interface IIconProps extends IIntentProps, IProps {
 
     /** CSS style properties. */
     style?: React.CSSProperties;
+
+    /**
+     * Description string.
+     * Browsers usually render this as a tooltip on hover, whereas screen
+     * readers will use it for aural feedback.
+     * By default, this is set to the icon's name for accessibility.
+     */
+    title?: string | false | null;
 }
 
 export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<SVGElement>> {
@@ -54,7 +62,7 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
     public static readonly SIZE_LARGE = 20;
 
     public render() {
-        const { className, icon, iconSize = Icon.SIZE_STANDARD, intent, ...svgProps } = this.props;
+        const { className, icon, iconSize = Icon.SIZE_STANDARD, intent, title = icon, ...svgProps } = this.props;
         if (icon == null) {
             return null;
         } else if (typeof icon !== "string") {
@@ -79,7 +87,7 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
                 height={iconSize}
                 viewBox={viewBox}
             >
-                <title>{icon}</title>
+                {title ? <title>{title}</title> : null}
                 {paths}
             </svg>
         );

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -44,6 +44,16 @@ describe("<Icon>", () => {
         assert.isTrue(icon.isEmptyRender());
     });
 
+    it("title sets content of <title> element", () => {
+        const icon = shallow(<Icon icon="airplane" title="bird" />);
+        assert.equal(icon.find("title").text(), "bird");
+    });
+
+    it("title defaults to icon name", () => {
+        const icon = shallow(<Icon icon="airplane" />);
+        assert.equal(icon.find("title").text(), "airplane");
+    });
+
     /** Asserts that rendered icon has given className. */
     function assertIcon(icon: React.ReactElement<IIconProps>, iconName: IconName) {
         assert.strictEqual(shallow(icon).text(), iconName);


### PR DESCRIPTION
#### Fixes #2160

#### Changes proposed in this pull request:

Adds a `title` prop to `Icon`, allowing consumers to override or disable the hover text.