### PR TITLE
refactor: removes <Label /> helperText span element when the helperTe…

### DIFF
--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -42,7 +42,7 @@ export class Label extends React.PureComponent<ILabelProps, {}> {
         return (
             <label {...htmlProps} className={rootClasses}>
                 {text}
-                <span className={classNames(Classes.TEXT_MUTED)}>{helperText ? " " + helperText : ""}</span>
+                {helperText && <span className={classNames(Classes.TEXT_MUTED)}>{" " + helperText}</span>}
                 {children}
             </label>
         );


### PR DESCRIPTION
#### Changes proposed in this pull request:

A refactor of PR #2180

For Label component, the span element for helperText is removed when helperText is not defined.