### PR TITLE
Allow edits to be rejected for EditableCell

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -96,9 +96,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
 
     public componentWillReceiveProps(nextProps: IEditableCellProps) {
         const { value } = nextProps;
-        if (value !== this.props.value) {
-            this.setState({ savedValue: value, dirtyValue: value });
-        }
+        this.setState({ savedValue: value, dirtyValue: value });
     }
 
     public render() {

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -62,7 +62,7 @@ describe("<EditableCell>", () => {
         expect(onConfirm.called).to.be.true;
     });
 
-    it("doesn't change edited value on non-value prop changes", () => {
+    it("does change edited value on non-value prop changes", () => {
         const onCancel = sinon.spy();
         const onChange = sinon.spy();
         const onConfirm = sinon.spy();
@@ -87,7 +87,7 @@ describe("<EditableCell>", () => {
         elem.setProps({ onChange: null });
 
         // value stays the same
-        expect(elem.find(`.${Classes.TABLE_EDITABLE_TEXT} .pt-editable-content`).text()).to.equal("new-text");
+        expect(elem.find(`.${Classes.TABLE_EDITABLE_TEXT} .pt-editable-content`).text()).to.equal("test-value-5000");
 
         // confirm
         input.simulate("blur");


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:
Currently, if I don't change the controlled value as the result of a `onConfirm`, this check prevents the original value from overriding the savedValue. This is useful in a case where input to the `EditableCell` is being validated, and if it doesn't pass validation, the value of the cell shouldn't change.
