### PR TITLE
[docs] fix regressions

### DIFF
--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -80,7 +80,7 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
 .pt-tree-node-caret-none {
   position: relative;
   min-width: $pt-grid-size * 3;
-  // override default icon styles, which appear first for some reason
+  // CSS API: override default icon styles, which appear first for some reason
   line-height: $tree-row-height !important; // stylelint-disable-line declaration-no-important
 }
 
@@ -98,6 +98,10 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
   // CSS API support
   &.pt-icon-standard::before {
     content: $pt-icon-caret-right;
+  }
+
+  .pt-icon {
+    margin: $tree-icon-spacing;
   }
 }
 

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -15,7 +15,7 @@ export function renderBlock(block: IBlock | undefined, tagRenderers: ITagRendere
     }
     return block.contents.map((node, i) => {
         if (typeof node === "string") {
-            return <div className="docs-section" dangerouslySetInnerHTML={{ __html: node }} key={i} />;
+            return <div className="docs-section pt-running-text" dangerouslySetInnerHTML={{ __html: node }} key={i} />;
         }
         try {
             const renderer = tagRenderers[node.tag];

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -12,7 +12,7 @@ export interface IModifierTableProps {
 
 export const ModifierTable: React.SFC<IModifierTableProps> = ({ children, title }) =>
     React.Children.count(children) > 0 ? (
-        <div className="docs-modifiers pt-running-text-small">
+        <div className="docs-modifiers-table">
             <table className="pt-html-table">
                 <thead>
                     <tr>

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -18,7 +18,7 @@ export interface IPageProps {
 export const Page: React.SFC<IPageProps> = ({ tagRenderers, page }) => {
     const pageContents = renderBlock(page, tagRenderers);
     return (
-        <div className="docs-page pt-running-text" data-page-id={page.reference}>
+        <div className="docs-page" data-page-id={page.reference}>
             {pageContents}
         </div>
     );

--- a/packages/docs-theme/src/styles/_api.scss
+++ b/packages/docs-theme/src/styles/_api.scss
@@ -13,20 +13,17 @@
     flex-direction: column;
     margin: 0;
     width: $content-width;
-
-    > * {
-      padding: $pt-grid-size ($pt-grid-size * 2);
-    }
   }
 
   .docs-interface-header {
     flex: 0 0 auto;
     margin: 0;
+    padding: $pt-grid-size ($pt-grid-size * 2);
   }
 
-  .docs-interface-table {
+  .docs-modifiers-table {
     overflow: auto;
-    padding-bottom: $pt-grid-size * 2;
+    padding: $pt-grid-size ($pt-grid-size * 2) ($pt-grid-size * 2);
   }
 }
 

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -107,22 +107,15 @@ $dark-example-background-color: $dark-content-background-color;
   vertical-align: top;
 
   > code {
+    display: inline-block;
     margin-bottom: $pt-grid-size;
+
+    &:empty {
+      display: none;
+    }
   }
 
   &[data-modifier="default"]:last-child > code {
-    display: none;
-  }
-}
-
-// modifier labels
-.docs-modifiers code,
-.docs-example > code {
-  display: inline-block;
-  line-height: 1.4;
-  white-space: nowrap;
-
-  &:empty {
     display: none;
   }
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:

Fix #2163: give ModifierTable its own class. stop reusing `.docs-modifiers`, which was the cause of this issue.

Fix #2194: tree caret icon rotation

Fix #2177: move pt-running-text back to docs-section. oof, preempts so many other tiny regressions!