### PR TITLE
TypeScript 2.7 + esModuleInterop

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,7 +1,9 @@
 {
-    "version": "2.6.2",
+    "version": "2.7.2",
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
         "declaration": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "importHelpers": true,
         "jsx": "react",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react-dom": "^16.0.3",
     "@types/react-transition-group": "^2.0.6",
     "@types/sinon": "^4.1.2",
-    "@types/webpack": "^3.8.2",
+    "@types/webpack": "^3.8.8",
     "better-handlebars": "github:wmeldon/better-handlebars",
     "chai": "^4.1.2",
     "cross-env": "^5.1.3",
@@ -62,7 +62,7 @@
     "stylelint-config-palantir": "^2.1.0",
     "stylelint-config-standard": "^18.0.0",
     "stylelint-scss": "^2.2.0",
-    "typescript": "~2.6.2"
+    "typescript": "~2.7.2"
   },
   "engines": {
     "node": ">=6.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "normalize.css": "^7.0.0",
     "popper.js": "^1.12.6",
     "react-popper": "~0.7.4",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "peerDependencies": {
     "react": "^16.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes, Intent, IProps } from "../../common";

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Alignment } from "../../common/alignment";

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, IIntentProps, Intent, IProps } from "../../common";

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -10,7 +10,7 @@
 // we need some empty interfaces to show up in docs
 // tslint:disable no-empty-interface
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import { Utils } from "../../common";
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IIntentProps, IProps } from "../../common/props";

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { IconName } from "@blueprintjs/icons";

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IIntentProps, IProps } from "../../common/props";

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, IProps } from "../../common";

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import { AbstractPureComponent, IProps } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
 import { isElementOfType } from "../../common/utils";

--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import { IProps } from "../../common";
 import { Icon, IconName } from "../icon/icon";

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { IconName, IconSvgPaths16, IconSvgPaths20 } from "@blueprintjs/icons";

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import PopperJS from "popper.js";
 import * as React from "react";
 import { Manager, Popper, Target } from "react-popper";

--- a/packages/core/src/components/progress/progressBar.tsx
+++ b/packages/core/src/components/progress/progressBar.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -140,7 +140,8 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
         if (labelRenderer === false) {
             return undefined;
         } else if (isFunction(labelRenderer)) {
-            return labelRenderer(value);
+            // TODO: TS 2.7 might have a type narrowing issue?
+            return (labelRenderer as (value: number) => React.ReactChild)(value);
         } else {
             return value.toFixed(this.state.labelPrecision);
         }

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/spinner/svgSpinner.tsx
+++ b/packages/core/src/components/spinner/svgSpinner.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Utils } from "../../common";

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import PopperJS from "popper.js";
 import * as React from "react";
 

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -48,7 +48,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -33,7 +33,7 @@
     "@blueprintjs/core": "^2.0.0-rc.2",
     "classnames": "^2.2",
     "react-day-picker": "^7.0.7",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/karma-build-scripts": "^0.5.0",

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import { DayPickerProps } from "react-day-picker/types/props";
 

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -5,7 +5,7 @@
  */
 
 import { AbstractPureComponent, Button, IProps, Utils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import ReactDayPicker from "react-day-picker";
 import { DayModifiers } from "react-day-picker/types/common";

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import DayPicker from "react-day-picker";
 import { DayPickerProps } from "react-day-picker/types/props";

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -5,7 +5,7 @@
  */
 
 import { AbstractPureComponent, Classes, IProps, Menu, MenuItem, Utils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import ReactDayPicker from "react-day-picker";
 import { DayModifiers } from "react-day-picker/types/common";

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, IProps, Utils } from "@blueprintjs/core";

--- a/packages/datetime/src/dateinput.md
+++ b/packages/datetime/src/dateinput.md
@@ -38,7 +38,7 @@ An implementation using `moment.js` could look like this:
 
 ```tsx
 import { DateInput, IDateFormatProps } from "@blueprintjs/datetime";
-import * as moment from "moment";
+import moment from "moment";
 
 function getMomentFormatter(format: string): IDateFormatProps {
     // note that locale argument comes from locale prop and may be undefined

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Classes as CoreClasses, Icon, IProps, Keys, Utils as BlueprintUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "./common/classes";

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -36,7 +36,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-transition-group": "^2.2.1",
-    "tslib": "^1.7.1"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/node-build-scripts": "^0.5.0",

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { IProps, Keys, removeNonHTMLProps, Utils } from "@blueprintjs/core";

--- a/packages/docs-app/src/components/colorPalettes.tsx
+++ b/packages/docs-app/src/components/colorPalettes.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Colors } from "@blueprintjs/core";

--- a/packages/docs-app/src/components/colorSchemes.tsx
+++ b/packages/docs-app/src/components/colorSchemes.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as chroma from "chroma-js";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Keys, RadioGroup } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { AnchorButton, Button, Classes, Intent, Switch } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -7,7 +7,7 @@
 import { Button, Classes, MenuItem } from "@blueprintjs/core";
 import { IconName, IconNames } from "@blueprintjs/icons";
 import { ItemRenderer, Select } from "@blueprintjs/select";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 export interface IIconSelectProps {

--- a/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
@@ -6,7 +6,7 @@
 
 // tslint:disable max-classes-per-file
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { ContextMenu, ContextMenuTarget, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, EditableText, Intent, NumericInput, Switch } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
@@ -6,7 +6,7 @@
 
 // tslint:disable max-classes-per-file
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -3,7 +3,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Intent, NumericInput, Position, Switch } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -3,7 +3,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Button, Classes, Intent, Overlay, Switch } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import PopperJS from "popper.js";
 import * as React from "react";
 

--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Button, Popover, Position } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Slider, Switch } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Switch, Tab, TabId, Tabs } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Button, Classes, Intent, ITagProps, Switch, TagInput } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Text } from "@blueprintjs/core";

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/docs-app/src/examples/datetime-examples/common/formatSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/formatSelect.tsx
@@ -7,7 +7,7 @@
 import { Radio, RadioGroup } from "@blueprintjs/core";
 import { IDateFormatProps } from "@blueprintjs/datetime";
 import { handleNumberChange } from "@blueprintjs/docs-theme";
-import * as moment from "moment";
+import moment from "moment";
 import * as React from "react";
 
 export interface IFormatSelectProps {

--- a/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
@@ -6,8 +6,8 @@
 
 import { Classes, Icon, Intent, IProps, Tag } from "@blueprintjs/core";
 import { DateRange } from "@blueprintjs/datetime";
-import * as classNames from "classnames";
-import * as moment from "moment";
+import classNames from "classnames";
+import moment from "moment";
 import * as React from "react";
 
 const FORMAT = "dddd, LL";

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -7,7 +7,7 @@
 import { Classes, Intent, Switch, Tag } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
 import classNames from "classnames";
-import * as moment from "moment";
+import moment from "moment";
 import * as React from "react";
 
 import { DatePicker } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -6,7 +6,7 @@
 
 import { Classes, Intent, Switch, Tag } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as moment from "moment";
 import * as React from "react";
 

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -6,7 +6,7 @@
 
 import { Classes, Icon, Switch } from "@blueprintjs/core";
 import { BaseExample, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs-theme";
-import * as moment from "moment";
+import moment from "moment";
 import * as React from "react";
 
 import { DateRange, DateRangePicker } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -6,7 +6,7 @@
 
 import { Classes, MenuItem } from "@blueprintjs/core";
 import { ItemPredicate, ItemRenderer } from "@blueprintjs/select";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 export interface IFilm {

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Intent, ITagProps, MenuItem, Switch } from "@blueprintjs/core";

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@blueprintjs/docs-theme": "^2.0.0-rc.2",
-    "documentalist": "^1.0.0",
+    "documentalist": "^1.1.0",
     "glob": "^7.1.2",
     "highlights": "^3.1.1",
     "marked": "^0.3.6",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -29,7 +29,7 @@
     "classnames": "^2.2",
     "documentalist": "^1.1.0",
     "fuzzaldrin-plus": "^0.5.0",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/node-build-scripts": "^0.5.0",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@blueprintjs/core": "^2.0.0-rc.2",
     "classnames": "^2.2",
-    "documentalist": "^1.0.0",
+    "documentalist": "^1.1.0",
     "fuzzaldrin-plus": "^0.5.0",
     "tslib": "^1.5.0"
   },

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/docs-theme/src/components/banner.tsx
+++ b/packages/docs-theme/src/components/banner.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Classes, Intent, IProps } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 export interface IBannerProps extends IProps {

--- a/packages/docs-theme/src/components/baseExample.tsx
+++ b/packages/docs-theme/src/components/baseExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 export interface IBaseExampleProps {

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import { isPageNode, ITsDocBase, linkify } from "documentalist/dist/client";
 import * as React from "react";
 

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Classes, IProps } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { IHeadingNode, IPageNode, isPageNode } from "documentalist/dist/client";

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -7,7 +7,7 @@
 import { Classes, Hotkey, Hotkeys, HotkeysTarget, InputGroup, Keys, Popover, Position, Utils } from "@blueprintjs/core";
 import { IconContents } from "@blueprintjs/icons";
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import { IHeadingNode, IPageNode } from "documentalist/dist/client";
 import { filter } from "fuzzaldrin-plus";
 import * as React from "react";

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import { ITsEnum, ITsEnumMember } from "documentalist/dist/client";
 import * as React from "react";
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Classes, Intent, Tag } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import { isTsProperty, ITsClass, ITsInterface, ITsMethod, ITsProperty, ITsSignature } from "documentalist/dist/client";
 import * as React from "react";
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "classnames": "^2.2",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/node-build-scripts": "^0.5.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -44,7 +44,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -33,7 +33,7 @@
     "@blueprintjs/select": "^2.0.0-rc.1",
     "@blueprintjs/timezone": "^2.0.0-rc.1",
     "classnames": "^2.2",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/node-build-scripts": "^0.5.0",

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -46,7 +46,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -46,7 +46,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@blueprintjs/core": "^2.0.0-rc.2",
     "classnames": "^2.2",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/karma-build-scripts": "^0.5.0",

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -83,7 +83,7 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
     };
 
     private TypedQueryList = QueryList.ofType<T>();
-    private queryList: QueryList<T> | null;
+    private queryList?: QueryList<T> | null;
     private refHandlers = {
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -146,7 +146,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         return QueryList as new (props: IQueryListProps<T>) => QueryList<T>;
     }
 
-    private itemsParentRef: HTMLElement | null;
+    private itemsParentRef?: HTMLElement | null;
     private refHandlers = {
         itemsParent: (ref: HTMLElement | null) => (this.itemsParentRef = ref),
     };
@@ -155,7 +155,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
      * flag indicating that we should check whether selected item is in viewport after rendering,
      * typically because of keyboard change.
      */
-    private shouldCheckActiveItemInViewport: boolean;
+    private shouldCheckActiveItemInViewport: boolean = false;
 
     public render() {
         const { className, items, renderer, query } = this.props;

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -75,8 +75,8 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
     };
 
     private TypedQueryList = QueryList.ofType<T>();
-    private input: HTMLInputElement | null;
-    private queryList: QueryList<T> | null;
+    private input?: HTMLInputElement | null;
+    private queryList?: QueryList<T> | null;
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {
             this.input = ref;

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -3,7 +3,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -92,8 +92,8 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
     }
 
     private TypedQueryList = QueryList.ofType<T>();
-    private input: HTMLInputElement | null;
-    private list: QueryList<T> | null;
+    private input?: HTMLInputElement | null;
+    private list?: QueryList<T> | null;
     private previousFocusedElement: HTMLElement | undefined;
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -79,8 +79,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     };
 
     private TypedQueryList = QueryList.ofType<T>();
-    private input: HTMLInputElement | null;
-    private queryList: QueryList<T> | null;
+    private input?: HTMLInputElement | null;
+    private queryList?: QueryList<T> | null;
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {
             this.input = ref;

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -15,7 +15,7 @@ import {
     MenuItem,
     Switch,
 } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -33,7 +33,7 @@
     "@blueprintjs/core": "^2.0.0-rc.2",
     "classnames": "^2.2",
     "prop-types": "^15.6.0",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/node-build-scripts": "^0.5.0",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -48,7 +48,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.10.1"
   },

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -3,7 +3,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../common/classes";
 

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -3,7 +3,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { EditableText, Hotkey, Hotkeys, HotkeysTarget, Utils as CoreUtils } from "@blueprintjs/core";

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { ITruncatedFormatProps, TruncatedFormat, TruncatedPopoverMode } from "./truncatedFormat";

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Icon, IProps, Popover, Position } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -5,7 +5,7 @@
  */
 
 import { EditableText, IIntentProps, IProps, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../common/classes";
 

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Icon, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Grid } from "../common";

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes as CoreClasses, ContextMenuTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -5,7 +5,7 @@
  */
 
 import { IProps } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -5,7 +5,7 @@
  */
 
 import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -5,7 +5,7 @@
  */
 
 import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../common/classes";
 import { QuadrantType } from "../quadrants/tableQuadrant";

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -5,7 +5,7 @@
  */
 
 import { AbstractComponent, IProps, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -5,7 +5,7 @@
  */
 
 import { AbstractComponent, Hotkey, Hotkeys, HotkeysTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { ICellProps } from "./cell/cell";

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { ICellCoordinates } from "./common/cell";

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -5,7 +5,7 @@
  */
 
 import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import { emptyCellRenderer, ICellRenderer } from "./cell/cell";

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "react": "^16.2.0",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2"
+    "typescript": "~2.7.2"
   },
   "repository": {
     "type": "git",

--- a/packages/test-commons/src/generateIsomorphicTests.ts
+++ b/packages/test-commons/src/generateIsomorphicTests.ts
@@ -7,10 +7,10 @@
 // to use the `mocha` CLI and write an isotest.js file in every project
 
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
+import React16Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
-Enzyme.configure({ adapter: new Adapter() });
+Enzyme.configure({ adapter: new React16Adapter() });
 
 /**
  * Determines if the passed Component is a React Class or not

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -49,7 +49,7 @@
     "react-test-renderer": "^16.2.0",
     "react-transition-group": "^2.2.1",
     "tslint": "^5.9.0",
-    "typescript": "~2.6.2",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2",
     "moment": "^2.14.1",
     "moment-timezone": "^0.5.13",
-    "tslib": "^1.5.0"
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@blueprintjs/node-build-scripts": "^0.5.0",

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import * as classNames from "classnames";
+import classNames from "classnames";
 import * as React from "react";
 
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8253,9 +8253,13 @@ trough@^1.0.0:
   dependencies:
     glob "^6.0.4"
 
-tslib@^1.5.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
+tslib@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
 tslint-config-prettier@^1.6.0:
   version "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,13 +124,14 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/webpack@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-3.8.2.tgz#489276aa101b8364fa444f358e7c220a65c2cc66"
+"@types/webpack@^3.8.8":
+  version "3.8.8"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-3.8.8.tgz#fd9483edf2d6935eaab52aa530b1f737c188cd9a"
   dependencies:
     "@types/node" "*"
     "@types/tapable" "*"
     "@types/uglify-js" "*"
+    source-map "^0.6.0"
 
 JSONStream@^0.8.4:
   version "0.8.4"
@@ -7505,7 +7506,7 @@ source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -8352,9 +8353,9 @@ typescript@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
-typescript@~2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@~2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,9 +35,13 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/fs-extra@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/fs-extra@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.0.tgz#d3e225b35eb5c6d3a5a782c28219df365c781413"
   dependencies:
     "@types/node" "*"
 
@@ -45,29 +49,37 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@types/fuzzaldrin-plus/-/fuzzaldrin-plus-0.0.1.tgz#bfe5e25bc5b4066848171baf7a8aaf30e267d30a"
 
-"@types/handlebars@4.0.31":
-  version "4.0.31"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.31.tgz#a7fba66fafe42713aee88eeca8db91192efe6e72"
+"@types/glob@*":
+  version "5.0.35"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
 
-"@types/highlight.js@9.1.8":
-  version "9.1.8"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.8.tgz#d227f18bcb8f3f187e16965f2444859a04689758"
+"@types/handlebars@4.0.36":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
+
+"@types/highlight.js@9.12.2":
+  version "9.12.2"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.2.tgz#6ee7cd395effe5ec80b515d3ff1699068cd0cd1d"
 
 "@types/kss@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/kss/-/kss-3.0.0.tgz#8456ebcaccfd70fb7396033d9416bda710e56b95"
 
-"@types/lodash@4.14.74":
-  version "4.14.74"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
+"@types/lodash@4.14.99":
+  version "4.14.99"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.99.tgz#e6e10c0a4cc16c7409b3181f1e66880d2fb7d4dc"
 
 "@types/marked@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
 
-"@types/minimatch@2.0.29":
-  version "2.0.29"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
+"@types/minimatch@*", "@types/minimatch@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
 "@types/mocha@^2.2.46":
   version "2.2.46"
@@ -104,10 +116,11 @@
   version "16.0.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.34.tgz#7a8f795afd8a404a9c4af9539b24c75d3996914e"
 
-"@types/shelljs@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.0.tgz#229c157c6bc1e67d6b990e6c5e18dbd2ff58cff0"
+"@types/shelljs@0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.7.tgz#1f7bfa28947661afea06365db9b1135bbc903ec4"
   dependencies:
+    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/sinon@^4.1.2":
@@ -2134,16 +2147,16 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-documentalist@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/documentalist/-/documentalist-1.0.0.tgz#920fdcc9a8b20e179b201912811e8f4f9ae72201"
+documentalist@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/documentalist/-/documentalist-1.1.0.tgz#2e6f833750691b5a0aee2c31173d58f334b79d9f"
   dependencies:
     "@types/kss" "^3.0.0"
     glob "^7.1.1"
     js-yaml "^3.10.0"
     kss "^3.0.0-beta.18"
     marked "^0.3.7"
-    typedoc "^0.9.0"
+    typedoc "^0.10.0"
     yargs "^10.0.3"
 
 doiuse@^2.4.1:
@@ -3079,9 +3092,17 @@ fs-extra@^2.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^4.0.0, fs-extra@^4.0.1, fs-extra@^4.0.2:
+fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -4891,7 +4912,7 @@ marked-terminal@^2.0.0:
     lodash.assign "^4.2.0"
     node-emoji "^1.4.1"
 
-marked@^0.3.12, marked@^0.3.5, marked@^0.3.6, marked@^0.3.7:
+marked@^0.3.12, marked@^0.3.6, marked@^0.3.7:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
 
@@ -7313,9 +7334,9 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.0:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+shelljs@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -8327,31 +8348,31 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
-typedoc@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.9.0.tgz#159bff7c7784ce5b91d86f3e4cc8928e62040957"
+typedoc@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.10.0.tgz#898b447248dabf68ecbde9d5ccf5141fda8aa166"
   dependencies:
-    "@types/fs-extra" "4.0.0"
-    "@types/handlebars" "4.0.31"
-    "@types/highlight.js" "9.1.8"
-    "@types/lodash" "4.14.74"
+    "@types/fs-extra" "5.0.0"
+    "@types/handlebars" "4.0.36"
+    "@types/highlight.js" "9.12.2"
+    "@types/lodash" "4.14.99"
     "@types/marked" "0.3.0"
-    "@types/minimatch" "2.0.29"
-    "@types/shelljs" "0.7.0"
-    fs-extra "^4.0.0"
+    "@types/minimatch" "3.0.3"
+    "@types/shelljs" "0.7.7"
+    fs-extra "^5.0.0"
     handlebars "^4.0.6"
     highlight.js "^9.0.0"
     lodash "^4.13.1"
-    marked "^0.3.5"
+    marked "^0.3.12"
     minimatch "^3.0.0"
     progress "^2.0.0"
-    shelljs "^0.7.0"
+    shelljs "^0.8.1"
     typedoc-default-themes "^0.5.0"
-    typescript "2.4.1"
+    typescript "2.7.1"
 
-typescript@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+typescript@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 typescript@~2.7.2:
   version "2.7.2"


### PR DESCRIPTION
#### Fixes #2144

- [ ] verify compiled files work

#### Changes proposed in this pull request:

- typescript 2.7 and enable `esModuleInterop` and `allowSyntheticDefaultImports`
- documentalist 1.1.0 for latest typedoc with 2.7 support
- tslib 1.9.0 for new helpers
  - ⚠️ dependency bump in all packages, 1.5 => 1.9