### PR TITLE
[Portal] SSR support, one fewer element in Overlay

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -8,6 +8,7 @@ import * as classNames from "classnames";
 import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
+import { findDOMNode } from "react-dom";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IProps } from "../../common/props";
@@ -144,7 +145,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
     // an HTMLElement that contains the backdrop and any children, to query for focus target
     public containerElement: HTMLElement;
     private refHandlers = {
-        container: (ref: HTMLDivElement) => (this.containerElement = ref),
+        container: (ref: React.ReactInstance) => (this.containerElement = findDOMNode(ref) as HTMLElement),
     };
 
     public constructor(props?: IOverlayProps, context?: any) {
@@ -178,13 +179,6 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             );
         });
 
-        const transitionGroup = (
-            <TransitionGroup appear={true}>
-                {this.maybeRenderBackdrop()}
-                {isOpen ? childrenWithTransitions : null}
-            </TransitionGroup>
-        );
-
         const mergedClassName = classNames(
             Classes.OVERLAY,
             {
@@ -199,22 +193,16 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             onKeyDown: this.handleKeyDown,
         };
 
+        const transitionGroup = (
+            <TransitionGroup appear={true} {...elementProps} ref={this.refHandlers.container}>
+                {this.maybeRenderBackdrop()}
+                {isOpen ? childrenWithTransitions : null}
+            </TransitionGroup>
+        );
         if (usePortal) {
-            return (
-                <Portal
-                    {...elementProps}
-                    containerRef={this.refHandlers.container}
-                    onChildrenMount={this.handleContentMount}
-                >
-                    {transitionGroup}
-                </Portal>
-            );
+            return <Portal onChildrenMount={this.handleContentMount}>{transitionGroup}</Portal>;
         } else {
-            return (
-                <span {...elementProps} ref={this.refHandlers.container}>
-                    {transitionGroup}
-                </span>
-            );
+            return transitionGroup;
         }
     }
 
@@ -289,7 +277,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
                 </CSSTransition>
             );
         } else {
-            return undefined;
+            return null;
         }
     }
 

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -71,7 +71,7 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
         // update className prop on portal DOM element
         if (this.portalElement != null && prevProps.className !== this.props.className) {
             this.portalElement.classList.remove(prevProps.className);
-            this.portalElement.classList.add(this.props.className);
+            maybeAddClass(this.portalElement.classList, this.props.className);
         }
     }
 
@@ -83,10 +83,17 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
 
     private createElement() {
         const container = document.createElement("div");
-        container.classList.add(Classes.PORTAL, this.props.className);
-        if (this.context && this.context.blueprintPortalClassName != null) {
-            container.classList.add(this.context.blueprintPortalClassName);
+        container.classList.add(Classes.PORTAL);
+        maybeAddClass(container.classList, this.props.className);
+        if (this.context != null) {
+            maybeAddClass(container.classList, this.context.blueprintPortalClassName);
         }
         return container;
+    }
+}
+
+function maybeAddClass(classList: DOMTokenList, className?: string) {
+    if (className != null && className !== "") {
+        classList.add(className);
     }
 }

--- a/packages/core/test/isotest.js
+++ b/packages/core/test/isotest.js
@@ -32,10 +32,6 @@ const customChildren = {
     Toaster: React.createElement(Core.Toast, { message: "Toast" }),
 };
 
-const skipList = [
-    "Portal", // doesn't render any DOM inline
-]
-
 describe("Core isomorphic rendering", () => {
-    generateIsomorphicTests(Core, customProps, customChildren, skipList);
+    generateIsomorphicTests(Core, customProps, customChildren);
 });

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -30,7 +30,7 @@ describe("<Portal>", () => {
         assert.lengthOf(document.getElementsByClassName(CLASS_TO_TEST), 1);
     });
 
-    it("propagates class names", () => {
+    it("propagates className to portal element", () => {
         const CLASS_TO_TEST = "bp-test-klass";
         portal = mount(
             <Portal className={CLASS_TO_TEST}>
@@ -38,8 +38,19 @@ describe("<Portal>", () => {
             </Portal>,
         );
 
-        const portalChild = document.querySelector(`.${CLASS_TO_TEST}`);
-        assert.strictEqual(portalChild.parentElement.className, Classes.PORTAL);
+        const portalChild = document.querySelector(`.${Classes.PORTAL}.${CLASS_TO_TEST}`);
+        assert.exists(portalChild);
+    });
+
+    it("updates className on portal element", () => {
+        portal = mount(
+            <Portal className="class-one">
+                <p>test</p>
+            </Portal>,
+        );
+        assert.exists(portal.find(".class-one"));
+        portal.setProps({ className: "class-two" });
+        assert.exists(portal.find(".class-two"));
     });
 
     it("respects blueprintPortalClassName on context", () => {


### PR DESCRIPTION
#### Fixes #2191 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

(ok sorry there are some breaking changes here, but I promise they're worth it)

- refactor `Portal` to support SSR by checking for browser environment and creating element in `DidMount()` instead of constructor
- 🔥 the DOM element created by `Portal` is now treated as its root, so `className` is applied to this element. this also means that no dummy element is created inside the portal, making it one level shallower.
  - `containerRef` prop has been removed as it no longer makes sense. users can simply apply refs to the elements they render in the portal.
- refactor `Overlay` to not use `containerRef
  - using `TransitionGroup` as the wrapper element removes one empty element from the DOM tree:
     __before__: 
    <img width="560" alt="overlay-before" src="https://user-images.githubusercontent.com/464822/37054639-40dfff82-2134-11e8-854d-533b45e80ada.png">
    __after__: 
    <img width="548" alt="overlay-after" src="https://user-images.githubusercontent.com/464822/37054649-435491b0-2134-11e8-83fd-f808262c692c.png">
