### PR TITLE
[Select] fixes #2135 - Adds a blur explicitly when escape key is pressed

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -233,6 +233,9 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             const { resetOnSelect } = this.props;
 
             if (which === Keys.ESCAPE || which === Keys.TAB) {
+                // By default the escape key will not trigger a blur on the
+                // input element. It must be done explicitly.
+                this.input.blur();
                 this.setState({
                     activeItem: resetOnSelect ? this.props.items[0] : this.state.activeItem,
                     isOpen: false,


### PR DESCRIPTION
#### Fixes #2135

#### Changes proposed in this pull request:

Pressing the escape key will now close the MultiSelect Popover when it is open and the input field is focused.  An escape keypress will also now blur the input field.


