### PR TITLE
enable strict mode in select package

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -32,7 +32,7 @@ export interface IButtonProps extends IActionProps {
     alignText?: Alignment;
 
     /** A ref handler that receives the native HTML element backing this component. */
-    elementRef?: (ref: HTMLElement) => any;
+    elementRef?: (ref: HTMLElement | null) => any;
 
     /**
      * If set to `true`, the button will display a centered loading spinner instead of its contents.

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -34,7 +34,7 @@ export interface IControlProps extends IProps, HTMLInputProps {
     disabled?: boolean;
 
     /** Ref handler that receives HTML `<input>` element backing this component. */
-    inputRef?: (ref: HTMLInputElement) => any;
+    inputRef?: (ref: HTMLInputElement | null) => any;
 
     /** Whether the control is inline. */
     inline?: boolean;

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -20,7 +20,7 @@ export interface IInputGroupProps extends IControlledProps, IIntentProps, IProps
     disabled?: boolean;
 
     /** Ref handler that receives HTML `<input>` element backing this component. */
-    inputRef?: (ref: HTMLInputElement) => any;
+    inputRef?: (ref: HTMLInputElement | null) => any;
 
     /**
      * Name of a Blueprint UI icon (or an icon element) to render on the left side of the input group,

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -12,7 +12,7 @@ import { IProps } from "../../common/props";
 
 export interface IMenuProps extends IProps {
     /** Ref handler that receives the HTML `<ul>` element backing this component. */
-    ulRef?: (ref: HTMLUListElement) => any;
+    ulRef?: (ref: HTMLUListElement | null) => any;
 }
 
 export class Menu extends React.Component<IMenuProps, {}> {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -140,7 +140,7 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     /**
      * Ref supplied to the `pt-popover` element.
      */
-    popoverRef?: (ref: HTMLDivElement) => void;
+    popoverRef?: (ref: HTMLDivElement | null) => void;
 
     /**
      * Callback invoked when a popover begins to close.

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -18,7 +18,7 @@ export interface IPortalProps extends IProps, React.HTMLProps<HTMLDivElement> {
      * As this component renders its contents into a separate container, the result of the `ref`
      * prop is not backed by a DOM node. Hence this callback is necessary to get the real DOM node.
      */
-    containerRef?: (ref: HTMLDivElement) => void;
+    containerRef?: (ref: HTMLDivElement | null) => void;
 
     /**
      * Callback invoked when the children of this `Portal` have been added to the DOM.

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -31,7 +31,7 @@ export interface ITagInputProps extends IProps {
     inputProps?: HTMLInputProps;
 
     /** Ref handler for the `<input>` element. */
-    inputRef?: (input: HTMLInputElement) => void;
+    inputRef?: (input: HTMLInputElement | null) => void;
 
     /** Controlled value of the `<input>` element. This is shorthand for `inputProps={{ value }}`. */
     inputValue?: string;

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -49,11 +49,7 @@ const VALID_POSITIONS: Array<Position | "auto"> = [
     Position.LEFT_BOTTOM,
 ];
 
-const POSITION_OPTIONS = VALID_POSITIONS.map((p: Position) => (
-    <option key={p} value={p}>
-        {p}
-    </option>
-));
+const POSITION_OPTIONS = VALID_POSITIONS.map(p => <option key={p} value={p} children={p} />);
 
 const POPPER_DOCS = "https://popper.js.org/popper-documentation.html#modifiers";
 
@@ -153,6 +149,7 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                 <h5 key="app">Appearance</h5>,
                 <FormGroup
                     helperText="May be overridden to prevent overflow"
+                    key="position"
                     label="Position when opened"
                     labelFor="position"
                 >

--- a/packages/select/src/common/predicate.ts
+++ b/packages/select/src/common/predicate.ts
@@ -20,4 +20,4 @@ export type ItemListPredicate<T> = (query: string, items: T[]) => T[];
  *
  * If defined with `itemListPredicate`, this prop will be ignored.
  */
-export type ItemPredicate<T> = (query: string, item: T, index: number) => boolean;
+export type ItemPredicate<T> = (query: string, item: T, index?: number) => boolean;

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -68,7 +68,7 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
 
 export interface IOmnibarState<T> extends IOverlayableProps, IBackdropProps {
     activeItem?: T;
-    query?: string;
+    query: string;
 }
 
 export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarState<T>> {
@@ -168,9 +168,9 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
 
     private isQueryEmpty = () => this.state.query.length === 0;
 
-    private handleActiveItemChange = (activeItem: T) => this.setState({ activeItem });
+    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
 
-    private handleItemSelect = (item: T, event: React.SyntheticEvent<HTMLElement>) => {
+    private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         if (!this.isQueryEmpty()) {
             Utils.safeInvoke(this.props.onItemSelect, item, event);
         }

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -83,9 +83,9 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
     };
 
     private TypedQueryList = QueryList.ofType<T>();
-    private queryList: QueryList<T>;
+    private queryList: QueryList<T> | null;
     private refHandlers = {
-        queryList: (ref: QueryList<T>) => (this.queryList = ref),
+        queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };
 
     public render() {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -126,7 +126,7 @@ export interface IQueryListRendererProps<T> extends IProps {
      * A ref handler that should be applied to the HTML element that contains the rendererd items.
      * This is required for the `QueryList` to scroll the active item into view automatically.
      */
-    itemsParentRef: (ref: HTMLElement) => void;
+    itemsParentRef: (ref: HTMLElement | null) => void;
 
     /**
      * Controlled query string. Attach an `onChange` handler to the relevant
@@ -146,9 +146,9 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         return QueryList as new (props: IQueryListProps<T>) => QueryList<T>;
     }
 
-    private itemsParentRef: HTMLElement;
+    private itemsParentRef: HTMLElement | null;
     private refHandlers = {
-        itemsParent: (ref: HTMLElement) => (this.itemsParentRef = ref),
+        itemsParent: (ref: HTMLElement | null) => (this.itemsParentRef = ref),
     };
 
     /**
@@ -244,7 +244,8 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     private getItemsParentPadding() {
-        const { paddingTop, paddingBottom } = getComputedStyle(this.itemsParentRef);
+        // assert ref exists because it was checked before calling
+        const { paddingTop, paddingBottom } = getComputedStyle(this.itemsParentRef!);
         return {
             paddingBottom: pxToNumber(paddingBottom),
             paddingTop: pxToNumber(paddingTop),

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -95,7 +95,7 @@ export interface IQueryListRendererProps<T> extends IProps {
      * Selection handler that should be invoked when a new item has been chosen,
      * perhaps because the user clicked it.
      */
-    handleItemSelect: (item: T | undefined, event?: React.SyntheticEvent<HTMLElement>) => void;
+    handleItemSelect: (item: T, event?: React.SyntheticEvent<HTMLElement>) => void;
 
     /**
      * Keyboard handler for up/down arrow keys to shift the active item.
@@ -114,7 +114,7 @@ export interface IQueryListRendererProps<T> extends IProps {
      * `QueryList` will retrieve modifiers for the item and delegate to `itemRenderer` prop for the actual rendering.
      * The second parameter `index` is optional here; if provided, it will be passed through `itemRenderer` props.
      */
-    renderItem: (item: T, index?: number) => JSX.Element;
+    renderItem: (item: T, index?: number) => JSX.Element | null;
 
     /**
      * Array of all (unfiltered) items in the list.
@@ -136,7 +136,7 @@ export interface IQueryListRendererProps<T> extends IProps {
 }
 
 export interface IQueryListState<T> {
-    filteredItems?: T[];
+    filteredItems: T[];
 }
 
 export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryListState<T>> {
@@ -238,8 +238,9 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     private getActiveIndex() {
+        const { activeItem } = this.props;
         // NOTE: this operation is O(n) so it should be avoided in render(). safe for events though.
-        return this.state.filteredItems.indexOf(this.props.activeItem);
+        return activeItem == null ? -1 : this.state.filteredItems.indexOf(activeItem);
     }
 
     private getItemsParentPadding() {
@@ -250,7 +251,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         };
     }
 
-    private handleItemSelect = (item: T, event: React.SyntheticEvent<HTMLElement>) => {
+    private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         Utils.safeInvoke(this.props.onActiveItemChange, item);
         Utils.safeInvoke(this.props.onItemSelect, item, event);
     };
@@ -276,7 +277,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         // using keyup for enter to play nice with Button's keyboard clicking.
         // if we were to process enter on keydown, then Button would click itself on keyup
         // and the popvoer would re-open out of our control :(.
-        if (event.keyCode === Keys.ENTER) {
+        if (event.keyCode === Keys.ENTER && activeItem != null) {
             event.preventDefault();
             Utils.safeInvoke(onItemSelect, activeItem, event);
         }
@@ -311,8 +312,8 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     };
 }
 
-function pxToNumber(value: string) {
-    return parseInt(value.slice(0, -2), 10);
+function pxToNumber(value: string | null) {
+    return value == null ? 0 : parseInt(value.slice(0, -2), 10);
 }
 
 function getFilteredItems<T>({ items, itemPredicate, itemListPredicate, query }: IQueryListProps<T>) {

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -173,7 +173,9 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
     };
 
     private handleItemSelect = (item: T, evt?: React.SyntheticEvent<HTMLElement>) => {
-        this.input && this.input.focus();
+        if (this.input != null) {
+            this.input.focus();
+        }
         // make sure the query is valid by checking if activeItem is defined
         if (this.state.activeItem != null) {
             if (this.props.resetOnSelect && !this.isQueryEmpty()) {
@@ -233,7 +235,9 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             if (which === Keys.ESCAPE || which === Keys.TAB) {
                 // By default the escape key will not trigger a blur on the
                 // input element. It must be done explicitly.
-                this.input && this.input.blur();
+                if (this.input != null) {
+                    this.input.blur();
+                }
                 this.setState({
                     activeItem: resetOnSelect ? this.props.items[0] : this.state.activeItem,
                     isOpen: false,

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -75,11 +75,11 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
     };
 
     private TypedQueryList = QueryList.ofType<T>();
-    private input: HTMLInputElement;
-    private queryList: QueryList<T>;
+    private input: HTMLInputElement | null;
+    private queryList: QueryList<T> | null;
     private refHandlers = {
-        input: (ref: HTMLInputElement) => (this.input = ref),
-        queryList: (ref: QueryList<T>) => (this.queryList = ref),
+        input: (ref: HTMLInputElement | null) => (this.input = ref),
+        queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };
 
     public render() {
@@ -173,7 +173,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
     };
 
     private handleItemSelect = (item: T, evt?: React.SyntheticEvent<HTMLElement>) => {
-        this.input.focus();
+        this.input && this.input.focus();
         // make sure the query is valid by checking if activeItem is defined
         if (this.state.activeItem != null) {
             if (this.props.resetOnSelect && !this.isQueryEmpty()) {
@@ -233,7 +233,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             if (which === Keys.ESCAPE || which === Keys.TAB) {
                 // By default the escape key will not trigger a blur on the
                 // input element. It must be done explicitly.
-                this.input.blur();
+                this.input && this.input.blur();
                 this.setState({
                     activeItem: resetOnSelect ? this.props.items[0] : this.state.activeItem,
                     isOpen: false,

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -58,8 +58,8 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
 
 export interface IMultiSelectState<T> {
     activeItem?: T;
-    isOpen?: boolean;
-    query?: string;
+    isOpen: boolean;
+    query: string;
 }
 
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
@@ -162,17 +162,17 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
 
     private isQueryEmpty = () => this.state.query.length === 0;
 
-    private handleQueryChange = (e: React.FormEvent<HTMLInputElement>) => {
+    private handleQueryChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
         const { tagInputProps = {}, openOnKeyDown } = this.props;
-        const query = e.currentTarget.value;
+        const query = evt.currentTarget.value;
         this.setState({ query, isOpen: !this.isQueryEmpty() || !openOnKeyDown });
 
         if (tagInputProps.inputProps != null) {
-            Utils.safeInvoke(tagInputProps.inputProps.onChange, e);
+            Utils.safeInvoke(tagInputProps.inputProps.onChange, evt);
         }
     };
 
-    private handleItemSelect = (item: T, e: React.SyntheticEvent<HTMLElement>) => {
+    private handleItemSelect = (item: T, evt?: React.SyntheticEvent<HTMLElement>) => {
         this.input.focus();
         // make sure the query is valid by checking if activeItem is defined
         if (this.state.activeItem != null) {
@@ -182,7 +182,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                     query: "",
                 });
             }
-            Utils.safeInvoke(this.props.onItemSelect, item, e);
+            Utils.safeInvoke(this.props.onItemSelect, item, evt);
         }
     };
 
@@ -221,9 +221,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         Utils.safeInvoke(popoverProps.popoverDidOpen);
     };
 
-    private handleActiveItemChange = (activeItem: T) => {
-        this.setState({ activeItem });
-    };
+    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
 
     private getTargetKeyDownHandler = (
         handleQueryListKeyDown: React.EventHandler<React.KeyboardEvent<HTMLElement>>,

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -80,8 +80,8 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
 
 export interface ISelectState<T> {
     activeItem?: T;
-    isOpen?: boolean;
-    query?: string;
+    isOpen: boolean;
+    query: string;
 }
 
 export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState<T>> {
@@ -91,26 +91,24 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         return Select as new () => Select<T>;
     }
 
-    public state: ISelectState<T> = { isOpen: false, query: "" };
-
-    private input: HTMLInputElement;
     private TypedQueryList = QueryList.ofType<T>();
-    private list: QueryList<T>;
+    private input: HTMLInputElement | null;
+    private list: QueryList<T> | null;
+    private previousFocusedElement: HTMLElement | undefined;
     private refHandlers = {
-        input: (ref: HTMLInputElement) => {
+        input: (ref: HTMLInputElement | null) => {
             this.input = ref;
 
             const { inputProps = {} } = this.props;
             Utils.safeInvoke(inputProps.inputRef, ref);
         },
-        queryList: (ref: QueryList<T>) => (this.list = ref),
+        queryList: (ref: QueryList<T> | null) => (this.list = ref),
     };
-    private previousFocusedElement: HTMLElement;
 
     constructor(props?: ISelectProps<T>, context?: any) {
         super(props, context);
-
-        const query = props && props.inputProps && props.inputProps.value !== undefined ? props.inputProps.value : "";
+        const { inputProps = {} } = props;
+        const query = inputProps.value == null ? "" : inputProps.value.toString();
         this.state = { isOpen: false, query };
     }
 
@@ -134,7 +132,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
     public componentWillReceiveProps(nextProps: ISelectProps<T>) {
         const { inputProps: nextInputProps = {} } = nextProps;
         if (nextInputProps.value !== undefined && this.state.query !== nextInputProps.value) {
-            this.setState({ query: nextInputProps.value });
+            this.setState({ query: nextInputProps.value.toString() });
         }
     }
 
@@ -210,7 +208,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
 
     private isQueryEmpty = () => this.state.query.length === 0;
 
-    private handleActiveItemChange = (activeItem: T) => this.setState({ activeItem });
+    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
 
     private handleTargetKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
         // open popover when arrow key pressed on target while closed
@@ -219,7 +217,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         }
     };
 
-    private handleItemSelect = (item: T, event: React.SyntheticEvent<HTMLElement>) => {
+    private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isOpen: false });
         if (this.props.resetOnSelect) {
             this.resetQuery();

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -78,17 +78,16 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         query: "",
     };
 
-    private input: HTMLInputElement;
     private TypedQueryList = QueryList.ofType<T>();
-    private queryList: QueryList<T>;
+    private input: HTMLInputElement | null;
+    private queryList: QueryList<T> | null;
     private refHandlers = {
-        input: (ref: HTMLInputElement) => {
+        input: (ref: HTMLInputElement | null) => {
             this.input = ref;
-
             const { inputProps = {} } = this.props;
             Utils.safeInvoke(inputProps.inputRef, ref);
         },
-        queryList: (ref: QueryList<T>) => (this.queryList = ref),
+        queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };
 
     public render() {
@@ -156,10 +155,12 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     }
 
     private selectText = () => {
-        if (this.input != null) {
-            // wait until the input is properly focused to select the text inside of it
-            requestAnimationFrame(() => this.input.setSelectionRange(0, this.input.value.length));
-        }
+        // wait until the input is properly focused to select the text inside of it
+        requestAnimationFrame(() => {
+            if (this.input != null) {
+                this.input.setSelectionRange(0, this.input.value.length);
+            }
+        });
     };
 
     private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -179,11 +180,15 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         let nextOpenState: boolean;
         if (!this.props.closeOnSelect) {
-            this.input.focus();
+            if (this.input != null) {
+                this.input.focus();
+            }
             this.selectText();
             nextOpenState = true;
         } else {
-            this.input.blur();
+            if (this.input != null) {
+                this.input.blur();
+            }
             nextOpenState = false;
         }
 
@@ -254,7 +259,9 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             const { inputProps = {}, openOnKeyDown } = this.props;
 
             if (which === Keys.ESCAPE || which === Keys.TAB) {
-                this.input.blur();
+                if (this.input != null) {
+                    this.input.blur();
+                }
                 this.setState({
                     isOpen: false,
                     selectedItem: isTyping ? undefined : selectedItem,

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -62,6 +62,12 @@ export interface ISuggestState<T> {
 export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestState<T>> {
     public static displayName = "Blueprint2.Suggest";
 
+    // Note: can't use <T> in static members, so this remains dynamically typed.
+    public static defaultProps = {
+        closeOnSelect: true,
+        openOnKeyDown: false,
+    };
+
     public static ofType<T>() {
         return Suggest as new (props: ISuggestProps<T>) => Suggest<T>;
     }
@@ -70,16 +76,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         isOpen: false,
         isTyping: false,
         query: "",
-    };
-
-    // not using defaultProps, because they're hard to type with generics (can't
-    // use <T> on static members). but we still want to keep default values in
-    // one, necessarily non-`static` place. note that Partial is necessary to
-    // avoid having to define all required props, and all of these values must
-    // be referenced manually in code.
-    private DEFAULT_PROPS = {
-        closeOnSelect: true,
-        openOnKeyDown: false,
     };
 
     private input: HTMLInputElement;
@@ -162,7 +158,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     };
 
     private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-        const { openOnKeyDown = this.DEFAULT_PROPS.openOnKeyDown, inputProps = {} } = this.props;
+        const { openOnKeyDown, inputProps = {} } = this.props;
 
         this.selectText();
 
@@ -176,9 +172,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
-        const { closeOnSelect = this.DEFAULT_PROPS.closeOnSelect } = this.props;
         let nextOpenState: boolean;
-        if (!closeOnSelect) {
+        if (!this.props.closeOnSelect) {
             this.input.focus();
             this.selectText();
             nextOpenState = true;
@@ -251,7 +246,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         return (evt: React.KeyboardEvent<HTMLInputElement>) => {
             const { which } = evt;
             const { isTyping, selectedItem } = this.state;
-            const { inputProps = {}, openOnKeyDown = this.DEFAULT_PROPS.openOnKeyDown } = this.props;
+            const { inputProps = {}, openOnKeyDown } = this.props;
 
             if (which === Keys.ESCAPE || which === Keys.TAB) {
                 this.input.blur();

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -53,9 +53,9 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 
 export interface ISuggestState<T> {
     activeItem?: T;
-    isOpen?: boolean;
-    isTyping?: boolean;
-    query?: string;
+    isOpen: boolean;
+    isTyping: boolean;
+    query: string;
     selectedItem?: T;
 }
 
@@ -77,11 +77,9 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     // one, necessarily non-`static` place. note that Partial is necessary to
     // avoid having to define all required props, and all of these values must
     // be referenced manually in code.
-    private DEFAULT_PROPS: Partial<ISuggestProps<T>> = {
+    private DEFAULT_PROPS = {
         closeOnSelect: true,
-        inputProps: {},
         openOnKeyDown: false,
-        popoverProps: {},
     };
 
     private input: HTMLInputElement;
@@ -116,11 +114,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const {
-            inputValueRenderer,
-            inputProps = this.DEFAULT_PROPS.inputProps,
-            popoverProps = this.DEFAULT_PROPS.popoverProps,
-        } = this.props;
+        const { inputValueRenderer, inputProps = {}, popoverProps = {} } = this.props;
         const { isTyping, selectedItem, query } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
         const inputValue: string = isTyping ? query : selectedItem ? inputValueRenderer(selectedItem) : "";
@@ -167,11 +161,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         }
     };
 
-    private handleInputFocus = (event: React.SyntheticEvent<HTMLInputElement>) => {
-        const {
-            openOnKeyDown = this.DEFAULT_PROPS.openOnKeyDown,
-            inputProps = this.DEFAULT_PROPS.inputProps,
-        } = this.props;
+    private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+        const { openOnKeyDown = this.DEFAULT_PROPS.openOnKeyDown, inputProps = {} } = this.props;
 
         this.selectText();
 
@@ -182,9 +173,9 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(inputProps.onFocus, event);
     };
 
-    private handleActiveItemChange = (activeItem: T) => this.setState({ activeItem });
+    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
 
-    private handleItemSelect = (item: T, event: React.SyntheticEvent<HTMLElement>) => {
+    private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         const { closeOnSelect = this.DEFAULT_PROPS.closeOnSelect } = this.props;
         let nextOpenState: boolean;
         if (!closeOnSelect) {
@@ -244,7 +235,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     };
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
-        const { inputProps = this.DEFAULT_PROPS.inputProps } = this.props;
+        const { inputProps = {} } = this.props;
 
         this.setState({
             isTyping: true,
@@ -257,13 +248,10 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     private getTargetKeyDownHandler = (
         handleQueryListKeyDown: React.EventHandler<React.KeyboardEvent<HTMLElement>>,
     ) => {
-        return (e: React.KeyboardEvent<HTMLElement>) => {
-            const { which } = e;
+        return (evt: React.KeyboardEvent<HTMLInputElement>) => {
+            const { which } = evt;
             const { isTyping, selectedItem } = this.state;
-            const {
-                inputProps = this.DEFAULT_PROPS.inputProps,
-                openOnKeyDown = this.DEFAULT_PROPS.openOnKeyDown,
-            } = this.props;
+            const { inputProps = {}, openOnKeyDown = this.DEFAULT_PROPS.openOnKeyDown } = this.props;
 
             if (which === Keys.ESCAPE || which === Keys.TAB) {
                 this.input.blur();
@@ -281,20 +269,20 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             }
 
             if (this.state.isOpen) {
-                Utils.safeInvoke(handleQueryListKeyDown, e);
+                Utils.safeInvoke(handleQueryListKeyDown, evt);
             }
 
-            Utils.safeInvoke(inputProps.onKeyDown, e);
+            Utils.safeInvoke(inputProps.onKeyDown, evt);
         };
     };
 
     private getTargetKeyUpHandler = (handleQueryListKeyUp: React.EventHandler<React.KeyboardEvent<HTMLElement>>) => {
-        return (e: React.KeyboardEvent<HTMLElement>) => {
-            const { inputProps = this.DEFAULT_PROPS.inputProps } = this.props;
+        return (evt: React.KeyboardEvent<HTMLInputElement>) => {
+            const { inputProps = {} } = this.props;
             if (this.state.isOpen) {
-                Utils.safeInvoke(handleQueryListKeyUp, e);
+                Utils.safeInvoke(handleQueryListKeyUp, evt);
             }
-            Utils.safeInvoke(inputProps.onKeyUp, e);
+            Utils.safeInvoke(inputProps.onKeyUp, evt);
         };
     };
 }

--- a/packages/select/src/tsconfig.json
+++ b/packages/select/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
-        "outDir": "../lib/esm"
+        "outDir": "../lib/esm",
+        "strict": true
     }
 }

--- a/packages/select/test/tsconfig.json
+++ b/packages/select/test/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
         "declaration": false,
-        "noEmit": true
+        "noEmit": true,
+        "strict": true
     }
 }

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -86,7 +86,7 @@ export interface ICellProps extends IIntentProps, IProps {
     /**
      * A ref handle to capture the outer div of this cell. Used internally.
      */
-    cellRef?: (ref: HTMLElement) => void;
+    cellRef?: (ref: HTMLElement | null) => void;
 }
 
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -38,7 +38,7 @@ export interface IColumnHeaderProps extends IHeaderProps, IColumnWidths, IColumn
      * Ref handler that receives the HTML element that should be measured to
      * indicate the fluid height of the column header.
      */
-    measurableElementRef?: (ref: HTMLElement) => void;
+    measurableElementRef?: (ref: HTMLElement | null) => void;
 
     /**
      * A callback invoked when user is done resizing the column

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -40,7 +40,7 @@ export interface ITableQuadrantProps extends IProps {
      * A callback that receives a `ref` to the quadrant's body-wrapping element. Will need to be
      * provided only for the MAIN quadrant, because that quadrant contains the main table body.
      */
-    bodyRef?: React.Ref<HTMLElement>;
+    bodyRef?: (ref: HTMLElement | null) => any;
 
     /**
      * The grid computes sizes of cells, rows, or columns from the
@@ -71,7 +71,7 @@ export interface ITableQuadrantProps extends IProps {
     /**
      * A callback that receives a `ref` to the quadrant's outermost element.
      */
-    quadrantRef?: React.Ref<HTMLElement>;
+    quadrantRef?: (ref: HTMLElement | null) => any;
 
     /**
      * The quadrant type. Informs the values of the parameters that will be passed to the
@@ -106,7 +106,7 @@ export interface ITableQuadrantProps extends IProps {
     /**
      * A callback that receives a `ref` to the quadrant's scroll-container element.
      */
-    scrollContainerRef?: React.Ref<HTMLElement>;
+    scrollContainerRef?: (ref: HTMLElement | null) => any;
 
     /**
      * CSS styles to apply to the quadrant's outermost element.

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -31,12 +31,12 @@ export interface ITableQuadrantStackProps extends IProps {
     /**
      * A callback that receives a `ref` to the main quadrant's table-body element.
      */
-    bodyRef?: React.Ref<HTMLElement>;
+    bodyRef?: (ref: HTMLElement | null) => any;
 
     /**
      * A callback that receives a `ref` to the main quadrant's column-header container.
      */
-    columnHeaderRef?: (ref: HTMLElement) => void;
+    columnHeaderRef?: (ref: HTMLElement | null) => void;
 
     /**
      * The grid computes sizes of cells, rows, or columns from the
@@ -138,7 +138,7 @@ export interface ITableQuadrantStackProps extends IProps {
     /**
      * A callback that receives a `ref` to the main-quadrant element.
      */
-    quadrantRef?: (ref: HTMLElement) => void;
+    quadrantRef?: (ref: HTMLElement | null) => void;
 
     /**
      * A callback that renders either all of or just frozen sections of the table body.
@@ -177,12 +177,12 @@ export interface ITableQuadrantStackProps extends IProps {
     /**
      * A callback that receives a `ref` to the main quadrant's row-header container.
      */
-    rowHeaderRef?: (ref: HTMLElement) => void;
+    rowHeaderRef?: (ref: HTMLElement | null) => any;
 
     /**
      * A callback that receives a `ref` to the main quadrant's scroll-container element.
      */
-    scrollContainerRef?: (ref: HTMLElement) => void;
+    scrollContainerRef?: (ref: HTMLElement | null) => any;
 
     /**
      * Whether "scroll" and "wheel" events should be throttled using


### PR DESCRIPTION
also add `| null` type to all ref props in all packages (for compatibility)
and fix a React warning in Popover example