### PR TITLE
Fix querylist classname regression

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -158,8 +158,9 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     private shouldCheckActiveItemInViewport: boolean;
 
     public render() {
-        const { items, renderer, query } = this.props;
+        const { className, items, renderer, query } = this.props;
         return renderer({
+            className,
             handleItemSelect: this.handleItemSelect,
             handleKeyDown: this.handleKeyDown,
             handleKeyUp: this.handleKeyUp,


### PR DESCRIPTION
#### Fixes #0000

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

- There is a regression in 2.x where the classname passed to a Select, which is then passed into a QueryList is not passed back to the Select.renderer to be attached on the popover
- Accidentally closed  https://github.com/palantir/blueprint/pull/2211


#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
