### PR TITLE
Add filteredItems to queryList

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -92,6 +92,11 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
 /** Interface for object passed to `QueryList` `renderer` function. */
 export interface IQueryListRendererProps<T> extends IProps {
     /**
+     * Array of filteredItems filtered by itemListPredicate or itemPredicate
+     */
+    filteredItems: T[];
+
+    /**
      * Selection handler that should be invoked when a new item has been chosen,
      * perhaps because the user clicked it.
      */
@@ -159,8 +164,10 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     public render() {
         const { className, items, renderer, query } = this.props;
+        const { filteredItems } = this.state;
         return renderer({
             className,
+            filteredItems,
             handleItemSelect: this.handleItemSelect,
             handleKeyDown: this.handleKeyDown,
             handleKeyUp: this.handleKeyUp,


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add filtered items to the queryList rendered callback
- Biggest issue without exposing it, is that if you implement `itemListPredicate` that changes the sortOrder, than you will be unable to use the raw `items` because those are un-sorted. So rendering will not match arrow-up / arrow-down
- I don't know how to best solve this for select... if some implements a `itemListPredicate` that changes order for Select it will be broken. We could change the select to use `filteredItems` instead of items for their `itemRenderer` however that would limit people who want to do something with items that do not match the filter
- @giladgray for SA

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
