### PR TITLE
Fix "color" property of <Icon>

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -62,7 +62,7 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
     public static readonly SIZE_LARGE = 20;
 
     public render() {
-        const { className, icon, iconSize = Icon.SIZE_STANDARD, intent, title = icon, ...svgProps } = this.props;
+        const { className, color, icon, iconSize = Icon.SIZE_STANDARD, intent, title = icon, ...svgProps } = this.props;
         if (icon == null) {
             return null;
         } else if (typeof icon !== "string") {
@@ -78,10 +78,19 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
 
         const classes = classNames(Classes.ICON, Classes.intentClass(intent), className);
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
+
+        let style = svgProps.style || {};
+
+        // ".pt-icon" will overwrite "fill" in svg attribute, put "fill: color" into style to make it work.
+        if (color) {
+            style = { ...style, fill: color };
+        }
+
         return (
             <svg
                 {...svgProps}
                 className={classes}
+                style={style}
                 data-icon={icon}
                 width={iconSize}
                 height={iconSize}

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -62,7 +62,8 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
     public static readonly SIZE_LARGE = 20;
 
     public render() {
-        const { className, color, icon, iconSize = Icon.SIZE_STANDARD, intent, style = {}, title = icon, ...svgProps } = this.props;
+        const { className, color, icon, iconSize = Icon.SIZE_STANDARD, intent, title = icon, ...svgProps } = this.props;
+
         if (icon == null) {
             return null;
         } else if (typeof icon !== "string") {
@@ -80,6 +81,7 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
 
         // ".pt-icon" will apply a "fill" CSS style, so we need to inject an inline style to override it
+        let { style = {} } = this.props;
         if (color != null) {
             style = { ...style, fill: color };
         }

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -62,7 +62,7 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
     public static readonly SIZE_LARGE = 20;
 
     public render() {
-        const { className, color, icon, iconSize = Icon.SIZE_STANDARD, intent, title = icon, ...svgProps } = this.props;
+        const { className, color, icon, iconSize = Icon.SIZE_STANDARD, intent, style = {}, title = icon, ...svgProps } = this.props;
         if (icon == null) {
             return null;
         } else if (typeof icon !== "string") {
@@ -79,10 +79,8 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
         const classes = classNames(Classes.ICON, Classes.intentClass(intent), className);
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
 
-        let style = svgProps.style || {};
-
-        // ".pt-icon" will overwrite "fill" in svg attribute, put "fill: color" into style to make it work.
-        if (color) {
+        // ".pt-icon" will apply a "fill" CSS style, so we need to inject an inline style to override it
+        if (color != null) {
             style = { ...style, fill: color };
         }
 

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -24,6 +24,8 @@ describe("<Icon>", () => {
 
     it("renders icon name", () => assertIcon(<Icon icon="calendar" />, "calendar"));
 
+    it("renders icon color", () => assertIconColor(<Icon icon="add" color="red" />, "red"));
+
     it("prefixed icon renders nothing", () => {
         // @ts-ignore invalid icon
         const icon = shallow(<Icon icon={Classes.iconClass("airplane")} />);
@@ -64,5 +66,10 @@ describe("<Icon>", () => {
         const wrapper = shallow(icon);
         assert.strictEqual(wrapper.prop("width"), size);
         assert.strictEqual(wrapper.prop("height"), size);
+    }
+
+    /** Asserts that rendered icon has color equal to color. */
+    function assertIconColor(icon: React.ReactElement<IIconProps>, color: string) {
+        assert.deepEqual(shallow(icon).prop("style"), { fill: color });
     }
 });


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [CircleCI](https://circleci.com/gh/micooz/blueprint/tree/develop)
- [x] Include tests
- [ ] Update documentation

#### Issues before change:

`color` is not handled in `<Icon>` because:

https://github.com/palantir/blueprint/blob/6cc104e5c8b4711d3aa314768ee505ba9bf71a23/packages/core/src/components/icon/icon.tsx#L19-L24

https://github.com/palantir/blueprint/blob/6cc104e5c8b4711d3aa314768ee505ba9bf71a23/packages/core/src/components/icon/icon.tsx#L64-L68

#### Changes proposed in this pull request:

This PR fixed a issue that `color` property doesn't work on `<Icon>`:

```js
<Icon icon="add" color="red"/> // icon is now "red".
```

#### Reviewers should focus on:

If user also pass a `style` to the component, final `style` should includes user defined properties:

```js
<Icon icon="add" color="red" style={{ color: "blue", border: "1px solid green" }}/> // icon is "red" with a green border.
```

#### Screenshot

<img width="684" alt="20180309111015" src="https://user-images.githubusercontent.com/8897063/37188506-7f497778-238a-11e8-8ee1-41d1d6f04a38.png">
