### PR TITLE
Allow edits to be rejected for EditableCell

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -96,7 +96,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
 
     public componentWillReceiveProps(nextProps: IEditableCellProps) {
         const { value } = nextProps;
-        if (value !== this.props.value) {
+        if (value != null) {
             this.setState({ savedValue: value, dirtyValue: value });
         }
     }

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -62,7 +62,7 @@ describe("<EditableCell>", () => {
         expect(onConfirm.called).to.be.true;
     });
 
-    it("doesn't change edited value on non-value prop changes", () => {
+    it("changes value state on non-value prop changes", () => {
         const onCancel = sinon.spy();
         const onChange = sinon.spy();
         const onConfirm = sinon.spy();
@@ -83,16 +83,17 @@ describe("<EditableCell>", () => {
         expect(onConfirm.called).to.be.false;
         expect(elem.find(`.${Classes.TABLE_EDITABLE_TEXT} .pt-editable-content`).text()).to.equal("new-text");
 
-        // set non-value prop
-        elem.setProps({ onChange: null });
-
-        // value stays the same
-        expect(elem.find(`.${Classes.TABLE_EDITABLE_TEXT} .pt-editable-content`).text()).to.equal("new-text");
-
         // confirm
         input.simulate("blur");
         expect(onCancel.called).to.be.false;
         expect(onConfirm.called).to.be.true;
+        // cell shows user-entered text until re-render
+        expect(elem.find(`.${Classes.TABLE_EDITABLE_TEXT}`).text()).to.equal("new-text");
+
+        // set non-value prop, forces EditableCell update
+        elem.setProps({ onChange: null });
+        // value resets to prop
+        expect(elem.find(`.${Classes.TABLE_EDITABLE_TEXT}`).text()).to.equal("test-value-5000");
     });
 
     it("passes index prop to callbacks if index was provided", () => {


### PR DESCRIPTION
(reboot of #2192, cc @maclockard)

> Currently, if I don't change the controlled `value` as the result of a `onConfirm`, this check prevents the original value from overriding the `savedValue`. This is useful in a case where input to the `EditableCell` is being validated, and if it doesn't pass validation, the value of the cell shouldn't change.

In this PR, if `EditableCell` is controlled, then `value` prop will always update state fields on re-render.