### PR TITLE
[select] Add query to itemRenderer props

### DIFF
--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -151,7 +151,7 @@ function highlightText(text: string, query: string) {
     const words = query
         .split(/\s+/)
         .filter(word => word.length > 0)
-        .map(regexEscape);
+        .map(escapeRegExpChars);
     if (words.length === 0) {
         return [text];
     }
@@ -167,7 +167,7 @@ function highlightText(text: string, query: string) {
         if (before.length > 0) {
             tokens.push(before);
         }
-        tokens.push(<span style={{ fontWeight: "bold" }}>{match[0]}</span>);
+        tokens.push(<strong>{match[0]}</strong>);
         lastIndex = regexp.lastIndex;
     }
     const rest = text.slice(lastIndex);
@@ -177,7 +177,7 @@ function highlightText(text: string, query: string) {
     return tokens;
 }
 
-function regexEscape(text: string) {
+function escapeRegExpChars(text: string) {
     return text.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
 }
 

--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -122,7 +122,7 @@ export const TOP_100_FILMS: IFilm[] = [
     { title: "Monty Python and the Holy Grail", year: 1975 },
 ].map((m, index) => ({ ...m, rank: index + 1 }));
 
-export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, modifiers }) => {
+export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, modifiers, query }) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }
@@ -130,13 +130,14 @@ export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, modifiers }
         [Classes.ACTIVE]: modifiers.active,
         [Classes.INTENT_PRIMARY]: modifiers.active,
     });
+    const text = `${film.rank}. ${film.title}`;
     return (
         <MenuItem
             className={classes}
             label={film.year.toString()}
             key={film.rank}
             onClick={handleClick}
-            text={`${film.rank}. ${film.title}`}
+            text={highlightText(text, query)}
         />
     );
 };
@@ -144,6 +145,41 @@ export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, modifiers }
 export const filterFilm: ItemPredicate<IFilm> = (query, film) => {
     return `${film.rank}. ${film.title.toLowerCase()} ${film.year}`.indexOf(query.toLowerCase()) >= 0;
 };
+
+function highlightText(text: string, query: string) {
+    let lastIndex = 0;
+    const words = query
+        .split(/\s+/)
+        .filter(word => word.length > 0)
+        .map(regexEscape);
+    if (words.length === 0) {
+        return [text];
+    }
+    const regexp = new RegExp(words.join("|"), "gi");
+    const tokens: React.ReactNode[] = [];
+    while (true) {
+        const match = regexp.exec(text);
+        if (!match) {
+            break;
+        }
+        const length = match[0].length;
+        const before = text.slice(lastIndex, regexp.lastIndex - length);
+        if (before.length > 0) {
+            tokens.push(before);
+        }
+        tokens.push(<span style={{ fontWeight: "bold" }}>{match[0]}</span>);
+        lastIndex = regexp.lastIndex;
+    }
+    const rest = text.slice(lastIndex);
+    if (rest.length > 0) {
+        tokens.push(rest);
+    }
+    return tokens;
+}
+
+function regexEscape(text: string) {
+    return text.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+}
 
 export const filmSelectProps = {
     itemPredicate: filterFilm,

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -29,6 +29,9 @@ export interface IItemRendererProps {
 
     /** Modifiers that describe how to render this item, such as `active` or `disabled`. */
     modifiers: IItemModifiers;
+
+    /** The current query string used to filter the items. */
+    query: string;
 }
 
 /** Type alias for a function that receives an item and props and renders a JSX element (or `null`). */

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -310,6 +310,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             handleClick: e => this.handleItemSelect(item, e),
             index,
             modifiers,
+            query,
         });
     };
 }


### PR DESCRIPTION
#### Fixes #2239

#### Changes proposed in this pull request:

This PR adds `query` to the props passed to `itemRenderer`, making it possible to implement text highlighting. The `Select` docs example now makes use of this.

#### Screenshot

![starwars](https://user-images.githubusercontent.com/205631/37449546-e76245ac-282a-11e8-8a28-dd786cd87d31.png)