### PR TITLE
[Table] Call onVisibleCellsChange on scroll (in React 16.x)

### DIFF
--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -2066,9 +2066,8 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
     }
 
     private updateViewportRect = (nextViewportRect: Rect) => {
-        this.setState({ viewportRect: nextViewportRect });
-
         const { viewportRect } = this.state;
+        this.setState({ viewportRect: nextViewportRect });
 
         const didViewportChange =
             (viewportRect != null && !viewportRect.equals(nextViewportRect)) ||


### PR DESCRIPTION
#### Fixes #1974

#### Changes proposed in this pull request:
From: https://github.com/palantir/blueprint/issues/1974

The issues lies in updateViewportRect method in table.tsx.

Code below:
```
this.setState({ viewportRect: nextViewportRect });
const { viewportRect } = this.state;

const didViewportChange =
            (viewportRect != null && !viewportRect.equals(nextViewportRect)) ||
            (viewportRect == null && nextViewportRect != null);
```
is incorrect because viewportRect is destructured after the setState. React recent updates have changed the way setState is executed and state may be set immediately, thus causing didViewportChange to be false and the onVisibleCellsChange to not be invoked. Simply swapping the first two lines fixes the issue.

#### Reviewers should focus on:

`didViewportChange` working properly. The table performance perhaps improving via: https://github.com/palantir/blueprint/issues/1664
