### PR TITLE
copyright comments use /* only

### DIFF
--- a/packages/core/src/common/alignment.ts
+++ b/packages/core/src/common/alignment.ts
@@ -1,8 +1,8 @@
 /*
-* Copyright 2018 Palantir Technologies, Inc. All rights reserved.
-*
-* Licensed under the terms of the LICENSE file distributed with this project.
-*/
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
 
 /** Alignment along the horizontal axis. */
 export enum Alignment {

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -1,6 +1,4 @@
-/*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
- */
+// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
 @import "../../common/variables";
 @import "../../common/mixins";

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/test/forms/fileInputTests.tsx
+++ b/packages/core/test/forms/fileInputTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/datetime/karma.conf.js
+++ b/packages/datetime/karma.conf.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/datetime/src/common/timeUnit.ts
+++ b/packages/datetime/src/common/timeUnit.ts
@@ -1,8 +1,8 @@
 /*
-* Copyright 2018 Palantir Technologies, Inc. All rights reserved.
-*
-* Licensed under the terms of the LICENSE file distributed with this project.
-*/
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
 
 import * as Classes from "./classes";
 import { get12HourFrom24Hour, get24HourFrom12Hour } from "./dateUtils";

--- a/packages/datetime/test/common/dateFormat.ts
+++ b/packages/datetime/test/common/dateFormat.ts
@@ -1,8 +1,8 @@
 /*
-* Copyright 2018 Palantir Technologies, Inc. All rights reserved.
-*
-* Licensed under the terms of the LICENSE file distributed with this project.
-*/
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
 
 import { IDateFormatProps } from "../../src/dateFormat";
 

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/docs-app/src/examples/datetime-examples/index.ts
+++ b/packages/docs-app/src/examples/datetime-examples/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/docs-app/src/examples/select-examples/index.ts
+++ b/packages/docs-app/src/examples/select-examples/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/docs-app/src/examples/table-examples/index.ts
+++ b/packages/docs-app/src/examples/table-examples/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/docs-app/src/examples/timezone-examples/index.ts
+++ b/packages/docs-app/src/examples/timezone-examples/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/docs-app/webpack.config.js
+++ b/packages/docs-app/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/docs-data/compile-docs-data
+++ b/packages/docs-data/compile-docs-data
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * @license Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Generates data for packages/docs-app
  */
 

--- a/packages/docs-data/docsUtils.js
+++ b/packages/docs-data/docsUtils.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -8,6 +8,8 @@ $banner-height: $pt-grid-size * 4;
 
 // banner along top of screen linking to v2 docs
 .docs-banner {
+  flex: 0 0 auto;
+
   position: fixed;
   top: 0;
   right: 0;

--- a/packages/docs-theme/webpack.config.js
+++ b/packages/docs-theme/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/icons/webpack.config.js
+++ b/packages/icons/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/karma-build-scripts/createKarmaConfig.js
+++ b/packages/karma-build-scripts/createKarmaConfig.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/karma-build-scripts/index.js
+++ b/packages/karma-build-scripts/index.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/labs/karma.conf.js
+++ b/packages/labs/karma.conf.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/labs/webpack.config.js
+++ b/packages/labs/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/landing-app/scripts/dedupe-svg-ids.js
+++ b/packages/landing-app/scripts/dedupe-svg-ids.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/landing-app/src/index.tsx
+++ b/packages/landing-app/src/index.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/landing-app/src/svgs.ts
+++ b/packages/landing-app/src/svgs.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/landing-app/webpack.config.js
+++ b/packages/landing-app/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/node-build-scripts/assert-package-layout
+++ b/packages/node-build-scripts/assert-package-layout
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * @license Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Asserts that all library packages adhere to the layout spec.
  */
 

--- a/packages/node-build-scripts/generate-css-variables
+++ b/packages/node-build-scripts/generate-css-variables
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * @license Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Asserts that all library packages adhere to the layout spec.
  */
 

--- a/packages/node-build-scripts/generate-icons-source
+++ b/packages/node-build-scripts/generate-icons-source
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * @license Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Generates icons Sass and TypeScript source code from JSON metadata about icons.
  */
 

--- a/packages/select/karma.conf.js
+++ b/packages/select/karma.conf.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/select/src/common/predicate.ts
+++ b/packages/select/src/common/predicate.ts
@@ -1,8 +1,8 @@
 /*
-* Copyright 2018 Palantir Technologies, Inc. All rights reserved.
-*
-* Licensed under the terms of the LICENSE file distributed with this project.
-*/
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
 
 /**
  * Customize querying of entire `items` array. Return new list of items.

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/select/webpack.config.js
+++ b/packages/select/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/table-dev-app/src/denseGridMutableStore.ts
+++ b/packages/table-dev-app/src/denseGridMutableStore.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table-dev-app/src/index.tsx
+++ b/packages/table-dev-app/src/index.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table-dev-app/src/localStore.ts
+++ b/packages/table-dev-app/src/localStore.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table-dev-app/src/nav.tsx
+++ b/packages/table-dev-app/src/nav.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/table-dev-app/src/slowLayoutStack.tsx
+++ b/packages/table-dev-app/src/slowLayoutStack.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table-dev-app/src/sparseGridMutableStore.ts
+++ b/packages/table-dev-app/src/sparseGridMutableStore.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/karma.conf.js
+++ b/packages/table/karma.conf.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/batcher.ts
+++ b/packages/table/src/common/batcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/clipboard.ts
+++ b/packages/table/src/common/clipboard.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/context.ts
+++ b/packages/table/src/common/context.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/table/src/common/contextMenuTargetWrapper.tsx
+++ b/packages/table/src/common/contextMenuTargetWrapper.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/direction.ts
+++ b/packages/table/src/common/direction.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/index.ts
+++ b/packages/table/src/common/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/internal/directionUtils.ts
+++ b/packages/table/src/common/internal/directionUtils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/internal/scrollUtils.ts
+++ b/packages/table/src/common/internal/scrollUtils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/loadableContent.tsx
+++ b/packages/table/src/common/loadableContent.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/movementDelta.ts
+++ b/packages/table/src/common/movementDelta.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/rect.ts
+++ b/packages/table/src/common/rect.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/renderMode.ts
+++ b/packages/table/src/common/renderMode.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/requestIdleCallback.ts
+++ b/packages/table/src/common/requestIdleCallback.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/dragEvents.ts
+++ b/packages/table/src/interactions/dragEvents.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/menus/index.ts
+++ b/packages/table/src/interactions/menus/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/resizeSensor.ts
+++ b/packages/table/src/interactions/resizeSensor.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/batcherTests.tsx
+++ b/packages/table/test/batcherTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/cellTestUtils.ts
+++ b/packages/table/test/cellTestUtils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/cellTests.tsx
+++ b/packages/table/test/cellTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/clipboardTests.ts
+++ b/packages/table/test/clipboardTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/common/internal/directionUtilsTests.ts
+++ b/packages/table/test/common/internal/directionUtilsTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/common/internal/focusedCellUtilsTests.ts
+++ b/packages/table/test/common/internal/focusedCellUtilsTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/common/internal/index.ts
+++ b/packages/table/test/common/internal/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/common/internal/platformUtilsTests.ts
+++ b/packages/table/test/common/internal/platformUtilsTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/common/internal/scrollUtilsTests.tsx
+++ b/packages/table/test/common/internal/scrollUtilsTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/common/internal/selectionUtilsTests.ts
+++ b/packages/table/test/common/internal/selectionUtilsTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/editableNameTests.tsx
+++ b/packages/table/test/editableNameTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/formatsTests.tsx
+++ b/packages/table/test/formatsTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/guidesTests.tsx
+++ b/packages/table/test/guidesTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/index.ts
+++ b/packages/table/test/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/loadableContentTests.tsx
+++ b/packages/table/test/loadableContentTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/loadingOptionsTests.tsx
+++ b/packages/table/test/loadingOptionsTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/menusTests.tsx
+++ b/packages/table/test/menusTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/mocks/table.tsx
+++ b/packages/table/test/mocks/table.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/quadrants/tableQuadrantTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/rectTests.ts
+++ b/packages/table/test/rectTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/regionsTests.ts
+++ b/packages/table/test/regionsTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/resizableTests.tsx
+++ b/packages/table/test/resizableTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.

--- a/packages/table/webpack.config.js
+++ b/packages/table/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*\
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/test-commons/src/generateIsomorphicTests.ts
+++ b/packages/test-commons/src/generateIsomorphicTests.ts
@@ -1,6 +1,7 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
- * @fileoverview Generates isomorphic tests for React components
+ *
+ * Generates isomorphic tests for React components
  */
 
 // TODO: make this an executable script that takes configuration from CLI arguments so we don't need

--- a/packages/timezone/karma.conf.js
+++ b/packages/timezone/karma.conf.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/timezone/webpack.config.js
+++ b/packages/timezone/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/tslint-config/index.js
+++ b/packages/tslint-config/index.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/webpack-build-scripts/index.js
+++ b/packages/webpack-build-scripts/index.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/webpack-build-scripts/utils.js
+++ b/packages/webpack-build-scripts/utils.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/packages/webpack-build-scripts/webpack.config.base.js
+++ b/packages/webpack-build-scripts/webpack.config.base.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/webpack-build-scripts/webpack.config.karma.js
+++ b/packages/webpack-build-scripts/webpack.config.karma.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 

--- a/scripts/get-publishable-paths-from-semver-tags
+++ b/scripts/get-publishable-paths-from-semver-tags
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * @license Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Finds the subset of packages which are ready to be published based on the latest Lerna publish commit.
  */
 


### PR DESCRIPTION
part of #2266 

fixes some issues where entities would have the copyright statement as their documentation.

### why?

`/** `is a **JSDoc comment**, meaning it contains useful user-facing documentation. Tools like VS Code and Typedoc will pick up `/**` comments and display them in tooltips etc.

`/*` is a simple block comment, meaning it contains a comment about some code and can span multiple lines.

&rArr; These copyright blocks should be block comments as they are _not_ documentation.
