### PR TITLE
Fix file input button shadow

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -21,14 +21,18 @@ CSS `border` property issues:
 
 `box-shadow` doesn't have these issues, we're using it instead of `border`.
 */
-$button-box-shadow: inset 0 0 0 $button-border-width rgba($black, 0.2),
-                    inset 0 (-$button-border-width) 0 rgba($black, 0.1) !default;
-$button-box-shadow-active: inset 0 0 0 $button-border-width rgba($black, 0.2),
-                           inset 0 1px 2px rgba($black, 0.2) !default;
-$button-intent-box-shadow: inset 0 0 0 $button-border-width rgba($black, 0.4),
-                           inset 0 (-$button-border-width) 0 rgba($black, 0.2) !default;
-$button-intent-box-shadow-active: inset 0 0 0 $button-border-width rgba($black, 0.4),
-                                  inset 0 1px 2px rgba($black, 0.2) !default;
+$button-box-shadow:
+  inset 0 0 0 $button-border-width rgba($black, 0.2),
+  inset 0 (-$button-border-width) 0 rgba($black, 0.1) !default;
+$button-box-shadow-active:
+  inset 0 0 0 $button-border-width rgba($black, 0.2),
+  inset 0 1px 2px rgba($black, 0.2) !default;
+$button-intent-box-shadow:
+  inset 0 0 0 $button-border-width rgba($black, 0.4),
+  inset 0 (-$button-border-width) 0 rgba($black, 0.2) !default;
+$button-intent-box-shadow-active:
+  inset 0 0 0 $button-border-width rgba($black, 0.4),
+  inset 0 1px 2px rgba($black, 0.2) !default;
 
 /*
 Overlay shadows are used for default buttons
@@ -36,17 +40,23 @@ floating on top of other elements. This way, the
 shadows blend with the colors beneath it.
 Switches and slider handles both use these variables.
 */
-$button-box-shadow-overlay: 0 0 0 $button-border-width rgba($black, 0.2),
-                            0 1px 1px rgba($black, 0.2) !default;
-$button-box-shadow-overlay-active: 0 0 0 $button-border-width rgba($black, 0.2),
-                                   inset 0 1px 1px rgba($black, 0.1) !default;
+$button-box-shadow-overlay:
+  0 0 0 $button-border-width rgba($black, 0.2),
+  0 1px 1px rgba($black, 0.2) !default;
+$button-box-shadow-overlay-active:
+  0 0 0 $button-border-width rgba($black, 0.2),
+  inset 0 1px 1px rgba($black, 0.1) !default;
 
-$dark-button-box-shadow: 0 0 0 $button-border-width rgba($black, 0.4) !default;
-$dark-button-box-shadow-active: 0 0 0 $button-border-width rgba($black, 0.6),
-                                inset 0 1px 2px rgba($black, 0.2) !default;
-$dark-button-intent-box-shadow: 0 0 0 $button-border-width rgba($black, 0.4) !default;
-$dark-button-intent-box-shadow-active: 0 0 0 $button-border-width rgba($black, 0.4),
-                                       inset 0 1px 2px rgba($black, 0.2) !default;
+$dark-button-box-shadow:
+  0 0 0 $button-border-width rgba($black, 0.4) !default;
+$dark-button-box-shadow-active:
+  0 0 0 $button-border-width rgba($black, 0.6),
+  inset 0 1px 2px rgba($black, 0.2) !default;
+$dark-button-intent-box-shadow:
+  0 0 0 $button-border-width rgba($black, 0.4) !default;
+$dark-button-intent-box-shadow-active:
+  0 0 0 $button-border-width rgba($black, 0.4),
+  inset 0 1px 2px rgba($black, 0.2) !default;
 
 $button-gradient: linear-gradient(to bottom, rgba($white, 0.8), rgba($white, 0)) !default;
 $button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -21,18 +21,14 @@ CSS `border` property issues:
 
 `box-shadow` doesn't have these issues, we're using it instead of `border`.
 */
-$button-box-shadow:
-  inset 0 0 0 $button-border-width rgba($black, 0.2),
-  inset 0 (-$button-border-width) 0 rgba($black, 0.1) !default;
-$button-box-shadow-active:
-  inset 0 0 0 $button-border-width rgba($black, 0.2),
-  inset 0 1px 2px rgba($black, 0.2) !default;
-$button-intent-box-shadow:
-  inset 0 0 0 $button-border-width rgba($black, 0.4),
-  inset 0 (-$button-border-width) 0 rgba($black, 0.2) !default;
-$button-intent-box-shadow-active:
-  inset 0 0 0 $button-border-width rgba($black, 0.4),
-  inset 0 1px 2px rgba($black, 0.2) !default;
+$button-box-shadow: inset 0 0 0 $button-border-width rgba($black, 0.2),
+                    inset 0 (-$button-border-width) 0 rgba($black, 0.1) !default;
+$button-box-shadow-active: inset 0 0 0 $button-border-width rgba($black, 0.2),
+                           inset 0 1px 2px rgba($black, 0.2) !default;
+$button-intent-box-shadow: inset 0 0 0 $button-border-width rgba($black, 0.4),
+                           inset 0 (-$button-border-width) 0 rgba($black, 0.2) !default;
+$button-intent-box-shadow-active: inset 0 0 0 $button-border-width rgba($black, 0.4),
+                                  inset 0 1px 2px rgba($black, 0.2) !default;
 
 /*
 Overlay shadows are used for default buttons
@@ -40,23 +36,17 @@ floating on top of other elements. This way, the
 shadows blend with the colors beneath it.
 Switches and slider handles both use these variables.
 */
-$button-box-shadow-overlay:
-  0 0 0 $button-border-width rgba($black, 0.2),
-  0 1px 1px rgba($black, 0.2) !default;
-$button-box-shadow-overlay-active:
-  0 0 0 $button-border-width rgba($black, 0.2),
-  inset 0 1px 1px rgba($black, 0.1) !default;
+$button-box-shadow-overlay: 0 0 0 $button-border-width rgba($black, 0.2),
+                            0 1px 1px rgba($black, 0.2) !default;
+$button-box-shadow-overlay-active: 0 0 0 $button-border-width rgba($black, 0.2),
+                                   inset 0 1px 1px rgba($black, 0.1) !default;
 
-$dark-button-box-shadow:
-  0 0 0 $button-border-width rgba($black, 0.4) !default;
-$dark-button-box-shadow-active:
-  0 0 0 $button-border-width rgba($black, 0.6),
-  inset 0 1px 2px rgba($black, 0.2) !default;
-$dark-button-intent-box-shadow:
-  0 0 0 $button-border-width rgba($black, 0.4) !default;
-$dark-button-intent-box-shadow-active:
-  0 0 0 $button-border-width rgba($black, 0.4),
-  inset 0 1px 2px rgba($black, 0.2) !default;
+$dark-button-box-shadow: 0 0 0 $button-border-width rgba($black, 0.4) !default;
+$dark-button-box-shadow-active: 0 0 0 $button-border-width rgba($black, 0.6),
+                                inset 0 1px 2px rgba($black, 0.2) !default;
+$dark-button-intent-box-shadow: 0 0 0 $button-border-width rgba($black, 0.4) !default;
+$dark-button-intent-box-shadow-active: 0 0 0 $button-border-width rgba($black, 0.4),
+                                       inset 0 1px 2px rgba($black, 0.2) !default;
 
 $button-gradient: linear-gradient(to bottom, rgba($white, 0.8), rgba($white, 0)) !default;
 $button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -86,7 +86,6 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) /
     right: 0;
     margin: $file-input-button-padding;
     border-radius: $pt-border-radius;
-    box-shadow: $button-box-shadow;
     width: $file-input-button-width;
     text-align: center;
     line-height: $pt-button-height-small;
@@ -130,3 +129,9 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) /
     }
   }
 }
+
+// hack to force the button shadow to display since
+// it doesn't render correct via the `pt-button` mixin
+// stylelint-disable-next-line
+.pt-file-upload-input::after { box-shadow: $button-box-shadow; }
+// stylelint-enable

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -86,7 +86,7 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) /
     right: 0;
     margin: $file-input-button-padding;
     border-radius: $pt-border-radius;
-    box-shadow: $pt-input-box-shadow;
+    box-shadow: $button-box-shadow;
     width: $file-input-button-width;
     text-align: center;
     line-height: $pt-button-height-small;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -86,6 +86,7 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) /
     right: 0;
     margin: $file-input-button-padding;
     border-radius: $pt-border-radius;
+    box-shadow: $pt-input-box-shadow;
     width: $file-input-button-width;
     text-align: center;
     line-height: $pt-button-height-small;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -134,4 +134,3 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) /
 // it doesn't render correct via the `pt-button` mixin
 // stylelint-disable-next-line
 .pt-file-upload-input::after { box-shadow: $button-box-shadow; }
-// stylelint-enable


### PR DESCRIPTION
That shadow actually works fine locally without this change, but not on the docs website (the `::after` has no `box-shadow` rule). This PR explicitly adds a `box-shadow` rule to the `::after` without relying on the mixin