### PR TITLE
Add Popover targetElementTag prop

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -186,6 +186,12 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     targetClassName?: string;
 
     /**
+     * Component element of the popover target.
+     * @default "div"
+     */
+    targetComponent?: string;
+
+    /**
      * Whether the popover should be rendered inside a `Portal` attached to `document.body`.
      * Rendering content inside a `Portal` allows the popover content to escape the physical bounds of its
      * parent while still being positioned correctly relative to its target.
@@ -221,6 +227,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         openOnTargetFocus: true,
         position: "auto",
         rootElementTag: "span",
+        targetComponent: "div",
         transitionDuration: 300,
         usePortal: true,
     };
@@ -259,7 +266,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     }
 
     public render() {
-        const { className, disabled, hasBackdrop, targetClassName } = this.props;
+        const { className, disabled, hasBackdrop, targetClassName, targetComponent } = this.props;
         const { isOpen } = this.state;
         const isHoverInteractionKind = this.isHoverInteractionKind();
 
@@ -305,7 +312,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
         return (
             <Manager tag={this.props.rootElementTag} className={classNames(Classes.POPOVER_WRAPPER, className)}>
-                <Target {...targetProps} innerRef={this.refHandlers.target}>
+                <Target {...targetProps} component={targetComponent} innerRef={this.refHandlers.target}>
                     {target}
                 </Target>
                 <Overlay

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -186,10 +186,10 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     targetClassName?: string;
 
     /**
-     * Component element of the popover target.
+     * The name of the HTML tag to use when rendering the popover target element.
      * @default "div"
      */
-    targetComponent?: string;
+    targetElementTag?: string;
 
     /**
      * Whether the popover should be rendered inside a `Portal` attached to `document.body`.
@@ -227,7 +227,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         openOnTargetFocus: true,
         position: "auto",
         rootElementTag: "span",
-        targetComponent: "div",
+        targetElementTag: "div",
         transitionDuration: 300,
         usePortal: true,
     };
@@ -266,7 +266,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     }
 
     public render() {
-        const { className, disabled, hasBackdrop, targetClassName, targetComponent } = this.props;
+        const { className, disabled, hasBackdrop, targetClassName, targetElementTag } = this.props;
         const { isOpen } = this.state;
         const isHoverInteractionKind = this.isHoverInteractionKind();
 
@@ -312,7 +312,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
         return (
             <Manager tag={this.props.rootElementTag} className={classNames(Classes.POPOVER_WRAPPER, className)}>
-                <Target {...targetProps} component={targetComponent} innerRef={this.refHandlers.target}>
+                <Target {...targetProps} component={targetElementTag} innerRef={this.refHandlers.target}>
                     {target}
                 </Target>
                 <Overlay

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -101,6 +101,12 @@ export interface ITooltipProps extends IProps, IIntentProps {
     rootElementTag?: string;
 
     /**
+     * Component element of the popover target.
+     * @default "div"
+     */
+    targetComponent?: string;
+
+    /**
      * A space-delimited string of class names that are applied to the tooltip.
      */
     tooltipClassName?: string;

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -101,10 +101,10 @@ export interface ITooltipProps extends IProps, IIntentProps {
     rootElementTag?: string;
 
     /**
-     * Component element of the popover target.
+     * The name of the HTML tag to use when rendering the popover target element.
      * @default "div"
      */
-    targetComponent?: string;
+    targetElementTag?: string;
 
     /**
      * A space-delimited string of class names that are applied to the tooltip.


### PR DESCRIPTION
#### Fixes #2240

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Update documentation

#### Changes proposed in this pull request:

With the `targetElementTag` prop passed to `Popover` or `Tooltip` you can change the component from a `<div>` to a `<g>` (or anything). This makes Tooltips work inside `<svg>`. The `targetComponent` prop is passed to react-popper <Target> as the component prop.

#### Reviewers should focus on:

`Popover` `targetElementTag`. This should be able to be a `string` or an `JSX.Element` see https://github.com/souporserious/react-popper/issues/107 but I was not sure how to get typescript to allow both.

NEED HELP: adding tests and fixing prop types to allow JSX.Element. As is solves issue #2250 
