### PR TITLE
fixes: helperText no longer accepting React nodes

### DIFF
--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -42,7 +42,7 @@ export class Label extends React.PureComponent<ILabelProps, {}> {
         return (
             <label {...htmlProps} className={rootClasses}>
                 {text}
-                {helperText && <span className={Classes.TEXT_MUTED}>{" "}{helperText}</span>}
+                {helperText && <span className={Classes.TEXT_MUTED}> {helperText}</span>}
                 {children}
             </label>
         );

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -42,7 +42,7 @@ export class Label extends React.PureComponent<ILabelProps, {}> {
         return (
             <label {...htmlProps} className={rootClasses}>
                 {text}
-                {helperText && <span className={classNames(Classes.TEXT_MUTED)}>{" " + helperText}</span>}
+                {helperText && <span className={classNames(Classes.TEXT_MUTED)}>{" "}{helperText}</span>}
                 {children}
             </label>
         );

--- a/packages/core/src/components/forms/label.tsx
+++ b/packages/core/src/components/forms/label.tsx
@@ -42,7 +42,7 @@ export class Label extends React.PureComponent<ILabelProps, {}> {
         return (
             <label {...htmlProps} className={rootClasses}>
                 {text}
-                {helperText && <span className={classNames(Classes.TEXT_MUTED)}>{" "}{helperText}</span>}
+                {helperText && <span className={Classes.TEXT_MUTED}>{" "}{helperText}</span>}
                 {children}
             </label>
         );


### PR DESCRIPTION
#### Fixes #2279

#### Changes proposed in this pull request:

The current implementation of helperText on Label only allows for text, this fixes the regression and allows for React nodes again.

#### Reviewers should focus on:

Adding React nodes as helperText
