### PR TITLE
remove pt-popover-target styles to fix input shadow clipping

### DIFF
--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -107,24 +107,17 @@ $popover-width: $pt-grid-size * 35 !default;
   &.pt-popover-leave .pt-popover-content {
     pointer-events: none;
   }
+
+  // Popper.js applies this attribute when the target fully leaves boundaries
+  &[data-x-out-of-boundaries] {
+    display: none;
+  }
 }
 
 .pt-popover-wrapper {
   display: inline-block;
   position: relative;
   vertical-align: top;
-}
-
-.pt-popover-target {
-  display: inline-block;
-  position: relative;
-  vertical-align: top;
-
-  // avoid tether positioning bugs when nesting `display: inline` targets (BLUEPRINT-526)
-  // example: <Popover><Tooltip><button /></Tooltip></Popover>
-  > .pt-popover-target {
-    display: inline-block;
-  }
 
   // position the transition container using CSS when it is inline
   .pt-transition-container {
@@ -139,16 +132,6 @@ $popover-width: $pt-grid-size * 35 !default;
 }
 
 // fix positioning of popovers inside button groups (lots of extra nested elements)
-.pt-button-group {
-  &.pt-vertical .pt-popover-target {
-    display: block;
-  }
-
-  &:not(.pt-vertical) {
-    // make all containers float left to ensure proper sizing
-    .pt-popover-target,
-    .pt-tether-target {
-      float: left;
-    }
-  }
+.pt-button-group .pt-popover-target {
+  display: block;
 }

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -288,7 +288,7 @@ The backdrop element has the same opacity-fade transition as the `Dialog` backdr
 @### Portal rendering
 
 By default, popover contents are rendered in a [`Portal`](#core/components/portal) appended to `document.body`. This
-allows the the popover contents to "escape" the application DOM tree to avoid incompatible styles on ancestor elements.
+allows the popover contents to "escape" the application DOM tree to avoid incompatible styles on ancestor elements.
 (Incompatible styles typically include hidden `overflow` or complex `position` logic.) It also ensures that the popover
 will appear above all other content, as its container element appears after the application container in the DOM.
 


### PR DESCRIPTION
#### Fixes #2038
Part of #2266 

refactor popover styles a bit. remove `.pt-popover-target` _styles_ (the element still exists) to fix input shadow clipping -- all the popper logic still works great, in all examples.