### PR TITLE
docs edits

### DIFF
--- a/packages/core/src/components/context-menu/context-menu.md
+++ b/packages/core/src/components/context-menu/context-menu.md
@@ -4,14 +4,14 @@ Context menus present the user with a custom list of actions upon right-click.
 
 You can create context menus in either of the following ways:
 
-- by adding the `@ContextMenuTarget` [decorator](#core/components/context-menu.javascript-api--decorator)
+- by adding the `@ContextMenuTarget` [decorator](#core/components/context-menu.decorator-api)
   to a React component that implements `renderContextMenu(): JSX.Element`.
-- via the [imperative](#core/components/context-menu.javascript-api--imperative) `ContextMenu.show`
+- via the [imperative](#core/components/context-menu.imperative-api) `ContextMenu.show`
   and `ContextMenu.hide` API methods, ideal for non-React-based applications.
 
 @reactExample ContextMenuExample
 
-@## JavaScript API: decorator
+@## Decorator API
 
 The `ContextMenuTarget` decorator is available in the __@blueprintjs/core__ package.
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
@@ -63,7 +63,7 @@ class RightClickMe extends React.Component<{}, {}> {
 [ts-decorator]: https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Decorators.md
 [wiki-cm]: https://en.wikipedia.org/wiki/Context_menu
 
-@## JavaScript API: imperative
+@## Imperative API
 
 The `ContextMenu` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).

--- a/packages/datetime/src/dateinput.md
+++ b/packages/datetime/src/dateinput.md
@@ -1,14 +1,11 @@
 @# Date input
 
-The `DateInput` component is an [input group](#core/components/forms/input-group) that shows a [`DatePicker`](#datetime/datepicker) in a [`Popover`](#core/components/popover) on focus.
+The `DateInput` component is an [input group](#core/components/forms/input-group) that shows a [`DatePicker`](#datetime/datepicker) in a [`Popover`](#core/components/popover) on focus. Use it in forms where the user must enter a date.
 
-Use the `onChange` function to listen for changes to the selected date. Use `onError` to listen for
-invalid entered dates.
-
-You can control the selected date by setting the `value` prop, or use the component in uncontrolled
-mode and specify an initial date by setting `defaultValue`.
-
-Use this component in forms where the user must enter a date.
+Customize the date format with `formatDate` and `parseDate` callbacks.
+Attach an `onChange` handler to listen for changes to the selected date.
+Use `onError` to listen for invalid entered dates.
+Control the selected date by setting the `value` prop, or use the component in uncontrolled mode and specify an initial date with `defaultValue`.
 
 @reactExample DateInputExample
 
@@ -18,6 +15,8 @@ Use this component in forms where the user must enter a date.
 
 - `formatDate(date, locale?)` receives the current `Date` and returns a string representation of it. The result of this function becomes the input value when it is not being edited.
 - `parseDate(str, locale?)` receives text inputted by the user and converts it to a `Date` object. The returned `Date` becomes the next value of the component.
+
+The optional `locale` argument is the value of the `locale` prop.
 
 A simple implementation using built-in browser methods could look like this:
 
@@ -61,7 +60,13 @@ Make sure to review the [getting started docs for installation info](#blueprint/
 ```tsx
 import { DateInput } from "@blueprintjs/datetime";
 
-<DateInput value={this.state.date} onChange={this.handleDateChange} />
+<DateInput
+    formatDate={date => date.toLocaleString()}
+    onChange={this.handleDateChange}
+    parseDate={str => new Date(str)}
+    placeholder={"M/D/YYYY"}
+    value={this.state.date}
+/>
 ```
 
 @interface IDateInputProps

--- a/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInlineExample.tsx
@@ -6,16 +6,16 @@
 
 import * as React from "react";
 
-import { Button, IPopoverProps, Popover, Position } from "@blueprintjs/core";
+import { Button, IPopoverProps, Popover, Position, Switch } from "@blueprintjs/core";
 import { BaseExample } from "@blueprintjs/docs-theme";
 
 export interface IPopoverInlineExampleState {
-    hasMounted?: boolean;
+    isOpen: boolean;
 }
 
 export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState> {
     public state: IPopoverInlineExampleState = {
-        hasMounted: false,
+        isOpen: false,
     };
 
     protected className = "docs-popover-inline-example";
@@ -29,23 +29,10 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
 
     public componentDidMount() {
         this.recenter();
-        this.setState({ hasMounted: true });
     }
 
     protected renderExample() {
-        const popoverBaseProps: IPopoverProps = {
-            enforceFocus: false,
-            // set to true after the initial mount, because Popper.js's
-            // `keepTogether` functionality apparently doesn't work once you
-            // render an open popover in a portal on mount.
-            isOpen: this.state.hasMounted ? true : false,
-            // not relevant to this example, but required in order for default
-            // modifiers to work (e.g. `hide`).
-            modifiers: { preventOverflow: { boundariesElement: "window" } },
-            popoverClassName: "docs-popover-inline-example-popover",
-            position: Position.BOTTOM,
-        };
-
+        const { isOpen } = this.state;
         return (
             <div className="docs-popover-inline-example-content">
                 <div
@@ -54,7 +41,12 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
                     onScroll={this.syncScrollLeft}
                 >
                     <div className="docs-popover-inline-example-scroll-content">
-                        <Popover {...popoverBaseProps} content="I am in a Portal (default)." usePortal={true}>
+                        <Popover
+                            {...POPOVER_PROPS}
+                            content="I am in a Portal (default)."
+                            isOpen={isOpen}
+                            usePortal={true}
+                        >
                             <code>{`usePortal={true}`}</code>
                         </Popover>
                     </div>
@@ -65,7 +57,7 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
                     onScroll={this.syncScrollRight}
                 >
                     <div className="docs-popover-inline-example-scroll-content">
-                        <Popover {...popoverBaseProps} content="I am an inline popover." usePortal={false}>
+                        <Popover {...POPOVER_PROPS} content="I am an inline popover." isOpen={isOpen} usePortal={false}>
                             <code>{`usePortal={false}`}</code>
                         </Popover>
                     </div>
@@ -75,8 +67,15 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
     }
 
     protected renderOptions() {
-        return [[<Button key="recenter" text="Re-center" icon="alignment-vertical-center" onClick={this.recenter} />]];
+        return [
+            [
+                <Switch key="open" checked={this.state.isOpen} label="Open" onChange={this.handleOpen} />,
+                <Button key="recenter" text="Re-center" icon="alignment-vertical-center" onClick={this.recenter} />,
+            ],
+        ];
     }
+
+    private handleOpen = () => this.setState({ isOpen: !this.state.isOpen });
 
     private recenter = () => {
         this.scrollToCenter(this.scrollContainerLeftRef);
@@ -105,3 +104,12 @@ export class PopoverInlineExample extends BaseExample<IPopoverInlineExampleState
         }
     }
 }
+
+const POPOVER_PROPS: IPopoverProps = {
+    enforceFocus: false,
+    // not relevant to this example, but required in order for default
+    // modifiers to work (e.g. `hide`).
+    modifiers: { preventOverflow: { boundariesElement: "window" } },
+    popoverClassName: "docs-popover-inline-example-popover",
+    position: Position.BOTTOM,
+};

--- a/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
@@ -15,13 +15,9 @@ const FORMAT = "dddd, LL";
 export const MomentDate: React.SFC<{ date: Date; format?: string }> = ({ date, format = FORMAT }) => {
     const m = moment(date);
     if (m.isValid()) {
-        return (
-            <Tag className={Classes.LARGE} intent={Intent.PRIMARY}>
-                {m.format(format)}
-            </Tag>
-        );
+        return <Tag intent={Intent.PRIMARY}>{m.format(format)}</Tag>;
     } else {
-        return <Tag className={classNames(Classes.LARGE, Classes.MINIMAL)}>no date</Tag>;
+        return <Tag className={Classes.MINIMAL}>no date</Tag>;
     }
 };
 

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -46,7 +46,7 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
     protected renderExample() {
         const { date, format, ...spreadProps } = this.state;
         return (
-            <div>
+            <>
                 <DateInput
                     {...spreadProps}
                     {...format}
@@ -56,10 +56,10 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     popoverProps={{ popoverClassName: "barbarbar", position: Position.BOTTOM }}
                     inputProps={{ className: "bazbazbaz" }}
                 />
-                <div className="docs-date-range pt-inline">
+                <div className="docs-date-range">
                     <MomentDate date={date} />
                 </div>
-            </div>
+            </>
         );
     }
 

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -57,7 +57,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
     protected renderExample() {
         const { format, range, ...spreadProps } = this.state;
         return (
-            <div>
+            <>
                 <DateRangeInput
                     {...spreadProps}
                     {...format}
@@ -65,7 +65,7 @@ export class DateRangeInputExample extends BaseExample<IDateRangeInputExampleSta
                     popoverProps={this.popoverProps}
                 />
                 <MomentDateRange className={this.state.isPopoverOpen ? Classes.INLINE : ""} range={range} />
-            </div>
+            </>
         );
     }
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -363,14 +363,7 @@
 .docs-date-range {
   @include pt-flex-container(row, $pt-grid-size / 2);
   align-items: center;
-  margin-top: $pt-grid-size;
-
-  // move inline when popover opens (for Date*Input)
-  &.pt-inline {
-    display: inline-flex;
-    margin: 0;
-    margin-left: $pt-grid-size;
-  }
+  margin-left: $pt-grid-size;
 }
 
 .docs-wiggle {


### PR DESCRIPTION
for #2266 

- fix alignment of date tags in datetime examples (and make them normal size)
- docs language updates to dateinput
- rename context-menu sections so they don't wrap lines
- PopoverInlineExample now has an "Open" switch as auto-opening causes auto-scroll and breaks the portal'ed popover