### PR TITLE
[menu] fix large menu items

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -33,7 +33,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
 // setting modifier to "" will generally apply it as default styles due to & selectors
 @mixin menu-item($disabled-selector: ".pt-disabled", $hover-selector: ":hover") {
   @include pt-flex-container(row, $menu-item-padding);
-  align-items: center;
+  align-items: flex-start;
   border-radius: $menu-item-border-radius;
   padding: $menu-item-padding-vertical $menu-item-padding;
   text-decoration: none;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -97,6 +97,11 @@ Styleguide pt-menu
   .pt-large & {
     @include menu-item-large();
 
+    .pt-icon {
+      // SVG icons remain standard size when menu is large
+      margin-top: ($menu-item-line-height-large - $pt-icon-size-standard) / 2;
+    }
+
     &::before {
       @include pt-icon($pt-icon-size-large);
       margin-top: ($menu-item-line-height-large - $pt-icon-size-large) / 2;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -60,13 +60,11 @@ Styleguide pt-menu
 
   &::before,
   .pt-icon {
-    align-self: flex-start;
     margin-top: ($menu-item-line-height - $pt-icon-size-standard) / 2;
     color: $pt-icon-color;
   }
 
   .pt-menu-item-label {
-    align-self: flex-start;
     color: $pt-text-color-muted;
   }
 


### PR DESCRIPTION
#### Fixes #2281, follow up from #2265 

#### Changes proposed in this pull request:

- menu items align all children to flex-start
- fix top margin for SVG icons in large menu item

cc @reiv 