### PR TITLE
[Docs] Fix table bugs

### DIFF
--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -40,11 +40,7 @@ export class TableEditableExample extends BaseExample<ITableEditableExampleState
                 <Column key={index} cellRenderer={this.renderCell} columnHeaderCellRenderer={this.renderColumnHeader} />
             );
         });
-        return (
-            <Table numRows={7} enableColumnInteractionBar={true}>
-                {columns}
-            </Table>
-        );
+        return <Table numRows={7}>{columns}</Table>;
     }
 
     public renderCell = (rowIndex: number, columnIndex: number) => {

--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -34,7 +34,7 @@ export class TableEditableExample extends BaseExample<ITableEditableExampleState
         sparseColumnIntents: [],
     };
 
-    public render() {
+    public renderExample() {
         const columns = this.state.columnNames.map((_: string, index: number) => {
             return (
                 <Column key={index} cellRenderer={this.renderCell} columnHeaderCellRenderer={this.renderColumnHeader} />

--- a/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
@@ -79,7 +79,7 @@ export class TableFormatsExample extends BaseExample<{}> {
     private data = TIME_ZONES;
     private date = new Date();
 
-    public render() {
+    public renderExample() {
         return (
             <Table enableRowResizing={true} numRows={this.data.length}>
                 <Column name="Timezone" cellRenderer={this.renderTimezone} />

--- a/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
@@ -20,7 +20,7 @@ const NUM_FROZEN_ROWS = 2;
 const NUM_FROZEN_COLUMNS = 1;
 
 export class TableFreezingExample extends BaseExample<ITableFreezingExampleState> {
-    public render() {
+    public renderExample() {
         return (
             <Table numRows={NUM_ROWS} numFrozenRows={NUM_FROZEN_ROWS} numFrozenColumns={NUM_FROZEN_COLUMNS}>
                 {this.renderColumns()}

--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { BaseExample, handleBooleanChange, IBaseExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table, Utils } from "@blueprintjs/table";
 
 export interface ITableReorderableExampleState {
@@ -45,7 +45,9 @@ export class TableReorderableExample extends BaseExample<ITableReorderableExampl
         this.setState({ columns });
     }
 
-    public componentDidUpdate(_nextProps: {}, nextState: ITableReorderableExampleState) {
+    public componentDidUpdate(nextProps: IBaseExampleProps, nextState: ITableReorderableExampleState) {
+        super.componentDidUpdate(nextProps, nextState);
+
         const { enableColumnInteractionBar } = this.state;
         if (nextState.enableColumnInteractionBar !== enableColumnInteractionBar) {
             const nextColumns = React.Children.map(this.state.columns, (column: JSX.Element) => {

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -193,7 +193,7 @@ export class TableSortableExample extends BaseExample<{}> {
         sortedIndexMap: [] as number[],
     };
 
-    public render() {
+    public renderExample() {
         const numRows = this.state.data.length;
         const columns = this.state.columns.map(col => col.getColumn(this.getCellData, this.sortColumn));
         return (

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -266,7 +266,6 @@
 // give all Table examples a fixed height
 #{page("table")},
 #{page("features")} {
-  .pt-table-container,
   .docs-react-example {
     width: 100%;
     height: $pt-grid-size * 30;

--- a/packages/docs-theme/src/components/baseExample.tsx
+++ b/packages/docs-theme/src/components/baseExample.tsx
@@ -46,7 +46,7 @@ export class BaseExample<S> extends React.Component<IBaseExampleProps, S> {
         });
     }
 
-    public componentDidUpdate() {
+    public componentDidUpdate(_nextProps: IBaseExampleProps, _nextState: S) {
         // HACKHACK: Initial render happens as an *update* due to our requestAnimationFrame shenanigans, not as a mount.
         // Once we've rendered initially, set this flag so that shouldComponentUpdate logic will return to its normal
         // PureComponent-style logic, ignoring these flags henceforth.

--- a/packages/docs-theme/src/components/baseExample.tsx
+++ b/packages/docs-theme/src/components/baseExample.tsx
@@ -4,6 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+import { Utils } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -16,11 +17,50 @@ export interface IBaseExampleProps {
  * Starter class for all React example components.
  * Examples and options are rendered into separate containers.
  */
-export class BaseExample<S> extends React.PureComponent<IBaseExampleProps, S> {
+export class BaseExample<S> extends React.Component<IBaseExampleProps, S> {
     /** Define this prop to add a className to the example container */
     protected className: string;
 
+    // Can't put this in state, because the state typing is generic.
+    private hasDelayedBeforeInitialRender = false;
+    private hasCompletedInitialRender = false;
+
+    public shouldComponentUpdate(nextProps: IBaseExampleProps, nextState: S & object) {
+        return (
+            // HACKHACK: Permit one redundant re-render after the inital delay. (This will be the first proper render of
+            // the component.)
+            (this.hasDelayedBeforeInitialRender && !this.hasCompletedInitialRender) ||
+            // Now, mimic PureComponent shouldComponentUpdate behavior:
+            !Utils.shallowCompareKeys(this.props, nextProps) ||
+            !Utils.shallowCompareKeys(this.state, nextState)
+        );
+    }
+
+    public componentWillMount() {
+        // HACKHACK: The docs app suffers from a Flash of Unstyled Content that causes some 'width: 100%' examples to
+        // render incorrectly, because they mis-measure the horizontal space available to them. Until that bug is squashed,
+        // this is the workaround: delay initial render with a requestAnimationFrame.
+        requestAnimationFrame(() => {
+            this.hasDelayedBeforeInitialRender = true;
+            this.forceUpdate();
+        });
+    }
+
+    public componentDidUpdate() {
+        // HACKHACK: Initial render happens as an *update* due to our requestAnimationFrame shenanigans, not as a mount.
+        // Once we've rendered initially, set this flag so that shouldComponentUpdate logic will return to its normal
+        // PureComponent-style logic, ignoring these flags henceforth.
+        if (!this.hasCompletedInitialRender) {
+            this.hasCompletedInitialRender = true;
+        }
+    }
+
     public render() {
+        // HACKHACK: This is the other required piece. Don't let any React nodes into the DOM until the
+        // requestAnimationFrame delay has elapsed. This prevents shouldComponentUpdate snafus at lower levels.
+        if (!this.hasDelayedBeforeInitialRender) {
+            return null;
+        }
         return (
             <div className={classNames("docs-example", this.className)} data-example-id={this.props.id}>
                 <div className="docs-react-example">{this.renderExample()}</div>


### PR DESCRIPTION
#### Addresses table bugs in https://github.com/palantir/blueprint/issues/2266

## Changes proposed in this pull request:

- **`HACKHACK`**: `BaseExample` now defers initial render with a `requestAnimationFrame`. See the code comments for explanations (hopefully they're clear).
    - This was motivated by [this](https://github.com/palantir/blueprint/issues/2266#issuecomment-375030766) rendering bug with table examples.
    - 🤔 **Need to figure out why the docs site suffers from a Flash of Unstyled Content.**
- Removed the interaction bar in the table-editing example. Wasn't necessary, and fixes the incorrect-header-sizing issue that seems to only appear on the docs site:
![image](https://user-images.githubusercontent.com/443450/37731408-3c0f5990-2cff-11e8-9acf-439a47c48b73.png)
- Fixed padding beneath table examples by using `renderExample` instead of `render`:
![image](https://user-images.githubusercontent.com/443450/37731601-d526d766-2cff-11e8-9248-4c2e837c8aaf.png)

