### PR TITLE
Prepare Release v2.0.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprintjs-monorepo",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "workspaces": [
@@ -16,7 +16,7 @@
     "deploy": "gh-pages -d docs -b master",
     "dev:all": "lerna run dev --parallel --scope \"!@blueprintjs/{landing-app,table-dev-app}\"",
     "dev:core": "lerna run dev --parallel --scope \"@blueprintjs/{core,icons,docs-app}\"",
-    "dev:docs": "lerna run dev --parallel --scope \"@blueprintjs/{docs-app,docs-theme}\"",
+    "dev:docs": "lerna run dev --parallel --scope \"@blueprintjs/{core,docs-app,docs-theme}\"",
     "dev:datetime": "lerna run dev --parallel --scope \"@blueprintjs/{core,datetime,timezone,docs-app}\"",
     "dev:labs": "lerna run dev --parallel --scope \"@blueprintjs/{core,labs,select,docs-app}\"",
     "dev:landing": "lerna run dev --parallel --scope \"@blueprintjs/{core,landing-app}\"",


### PR DESCRIPTION
**Release notes for changes from 2.0.0-rc.3:**

### General

- 🌟 #2241 Run published CSS files through postcss to remove comments and run Autoprefixer.
- #2268 Copyright comments in files use `/*` comments only.
- #2269 Use `React.HTMLAttributes` instead of `React.HTMLProps` in components that support arbitrary HTML props.

### `@blueprintjs/core 2.0.0-rc.4`

- #2230 Publish the 2.0.0 upgrade script which renames most symbols.
  ```sh
  # the following script will now appear in your `npm bin` directory.
  # run it for full usage instructions.
  ./upgrade-blueprint-2.0.0-rename
  ```
- #2174 `NumericInput` supports continuous value change by holding down the button (:tophat: @reiv)
- #2231 `Tag` uses SVG `Icon` for remove button
- #2233 Fix `Toaster` layout regression (:tophat: @reiv)
- #2247 Upgrade Popper.js and react-popper for latest typings
- #2255 `blueprintPortalClassName` context key supports multiple classes
- #2256 Add `KeyCombo` `minimal` prop to render icon and text only
- #2251 Add `Tag` `interactive` modifier support (through `.pt-interactive` class)
- #2275 Fix `FileInput` default button shadow
- #2276 Add `Popover` `targetElementTag` prop a la `rootElementTag` (:tophat: @tgreen7)
- #2262 Fix `Overlay` React unique key warning
- #2280 Fix `Label` `helperText` to accept React nodes (:tophat: @will-stone)
- #2265 #2285 Fix `MenuItem` text clipping with alternate fonts and icon alignment (:tophat: @reiv)
- #2284 Hide `.pt-skeleton` nested content such as items (:tophat: @univerio)
- #2282 Fix input shadow clipping by removing `.pt-popover-target` styles

### `@blueprintjs/datetime 2.0.0-rc.4`

- :star2: #2151 `TimePicker` new `useAmPm` prop adds support for 12-hour format (:tophat: @colinbr96)
- #2271 Remove `TimePicker` outside padding

### `@blueprintjs/icons 2.0.0-rc.4`

- No changes since RC 3, just bumping version.


### `@blueprintjs/select 2.0.0-rc.4`

- :star2: #2252 Add `itemListRenderer` prop to all `select` components
  - Pull `initialContent`, `noResults`, `itemListRenderer` up to `QueryList` props (other components extend this shared interface)
  - `QueryList` `renderer` receives rendered `itemList` ReactNode.
  - `itemListRenderer` is now the only one with access to `items`/`itemsParentRef`/`renderItem` props.
  - The default `itemListRenderer` produces a `Menu` using `filteredItems` (to preserve arrow keys order).
  - New utility function `renderFilteredItems()` exported from package.
- #2213 Add `filteredItems` to `renderer` props
- #2245 Add `query` to `itemRenderer` props (:tophat: @reiv)

### `@blueprintjs/table 2.0.0-rc.4`

- #2228 `EditableCell` fix controlled mode to allow edits to be rejected
- #2267 Fix `onVisibleCellsChange` on scroll in React 16 (:tophat: @mmoutenot)

### `@blueprintjs/timezone 2.0.0-rc.4`

- No changes since RC 3, just bumping version.

### Documentation

- :star2: #2243 Refresh the left sidebar visuals for this major release!
- :star2: #2263 IE11 support for the docs site!
- Split Table section into 3 pages: main, features, API
- Resources page moved to top level (sibling of Core, etc)
- #2057 Add import statements for `icons` packages to usage examples
- #2261 Bring back some tooltip docs lost in the transition, particularly about composing with `Popover`
- #2286 Fix "Color aliases" table appearance
- #2283 Language edits to many docs sections