### PR TITLE
docs nits

### DIFF
--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -51,10 +51,8 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     {...spreadProps}
                     {...format}
                     defaultValue={new Date()}
-                    className="foofoofoo"
                     onChange={this.handleDateChange}
-                    popoverProps={{ popoverClassName: "barbarbar", position: Position.BOTTOM }}
-                    inputProps={{ className: "bazbazbaz" }}
+                    popoverProps={{ position: Position.BOTTOM }}
                 />
                 <div className="docs-date-range">
                     <MomentDate date={date} />

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -363,7 +363,6 @@
 .docs-date-range {
   @include pt-flex-container(row, $pt-grid-size / 2);
   align-items: center;
-  margin-left: $pt-grid-size;
 }
 
 .docs-wiggle {

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -365,6 +365,11 @@
   align-items: center;
 }
 
+// only for date input and date range input examples
+.pt-popover-wrapper + .docs-date-range {
+  margin-left: $pt-grid-size * 2;
+}
+
 .docs-wiggle {
   animation: docs-wiggle-rotate $pt-transition-duration $pt-transition-ease infinite;
 }

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -301,9 +301,3 @@
     }
   }
 }
-
-#{page("daterangeinput")} {
-  .docs-date-range {
-    margin-left: $pt-grid-size * 2;
-  }
-}

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -271,6 +271,11 @@
     width: 100%;
     height: $pt-grid-size * 30;
   }
+
+  // make all tables the same width
+  .pt-table-container {
+    width: 100%;
+  }
 }
 
 #{page("popover")} {
@@ -294,5 +299,11 @@
     .pt-dark & {
       color: $forest5;
     }
+  }
+}
+
+#{page("daterangeinput")} {
+  .docs-date-range {
+    margin-left: $pt-grid-size * 2;
   }
 }


### PR DESCRIPTION
- table examples now have nice consistent width across
- date picker docs date range tags only have a margin left in the date range picker example