### PR TITLE
[docs] add spacing around site for narrow widths

### DIFF
--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -49,6 +49,8 @@ Page layout elements
 
 .docs-nav-wrapper {
   flex-basis: $sidebar-width;
+  position: relative;
+  z-index: $pt-z-index-content;
   margin-left: $sidebar-padding * 2;
 }
 

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -49,6 +49,7 @@ Page layout elements
 
 .docs-nav-wrapper {
   flex-basis: $sidebar-width;
+  margin-left: $sidebar-padding * 2;
 }
 
 .docs-nav {
@@ -83,6 +84,7 @@ Page layout elements
   align-items: flex-start;
   outline: none;
   background-color: $content-background-color;
+  padding-right: $sidebar-padding * 2;
 
   .pt-dark & {
     background-color: $dark-content-background-color;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/199754/37843828-3f859fdc-2e83-11e8-8cec-01523b9444b2.png)

After:
![image](https://user-images.githubusercontent.com/199754/37843807-33bbf714-2e83-11e8-8bf7-deff02c54a07.png)
