### PR TITLE
add react and react-dom as peer dependency for v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
     "stylelint-scss": "^2.5.0",
     "typescript": "~2.7.2"
   },
+  "peerDependencies": {
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
+  },
   "engines": {
     "node": ">=6.1"
   },


### PR DESCRIPTION
If by any chances someone dumb like me skips this page "http://blueprintjs.com/docs/v2/#blueprint/whats-new" and still uses react 16.0.0, they have a nice way to know to upgrade to 16.2.0 when doing "npm install"

#### Changes proposed in this pull request:

add peerDependency in package.json

