### PR TITLE
[2.0.1] React peer dependency 16.2 for fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprintjs-monorepo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
+    "react": "^16.2.0",
     "react-dom": "^16.0.0",
     "react-transition-group": "^2.2.1"
   },

--- a/packages/docs-app/src/whats-new.md
+++ b/packages/docs-app/src/whats-new.md
@@ -8,8 +8,10 @@ Blueprint 2.0 features JavaScript API refactors, smaller & more modular packages
 - The minimum version of TypeScript for the declaration files is now 2.3.
 - `Portal` now uses React 16's built-in Portal functionality instead of `ReactDOM.unstable_renderSubtreeIntoContainer`.
 - `Icon` now renders SVG elements and is used in all Blueprint components.
-  - This also means that you can _provide your own SVG icons for all components_.
-  - Support for the icon font remains, but will be removed in the next major version.
+    - This also means that you can _provide your own SVG icons for all components_.
+    - Support for the icon font remains, but will be removed in the next major version.
+- Icon styles and fonts have moved to a new **@blueprintjs/icons** package
+    - Core depends on this package, so you will have to import its CSS alongside `blueprint.css`
 - `Popover2` is now the default `Popover`. It uses [Popper.js](https://popper.js.org/) instead of [Tether](http://tether.io/), which provides much better auto-positioning capabilities and solves a number of outstanding bugs out-of-the-box.
 - All Labs components (in `@blueprintjs/labs`) have been moved into separate packages so that you no longer have to deal with the `0.x` version range for many components that are used widely in production.
 

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -18,7 +18,7 @@
     "enzyme-adapter-react-16": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.2.0"
   },
   "devDependencies": {
     "react": "^16.2.0",


### PR DESCRIPTION
#### Fixes #2315 

- add note about new icons package in "What's new in 2.0" section
- Prepare release v2.0.1