### PR TITLE
Checkbox renders SVG icons

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -64,11 +64,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     height: $control-indicator-size;
     line-height: $control-indicator-size;
     user-select: none;
-
-    &::before {
-      position: relative;
-      content: "";
-    }
   }
 
   input:checked ~ .pt-control-indicator {
@@ -151,11 +146,12 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       @extend input:checked;
     }
 
-    input:checked ~ .pt-control-indicator::before {
+    // CSS API support
+    input:checked ~ .pt-control-indicator:empty::before {
       content: $pt-icon-small-tick;
     }
 
-    input:indeterminate ~ .pt-control-indicator::before {
+    input:indeterminate ~ .pt-control-indicator:empty::before {
       content: $pt-icon-small-minus;
     }
   }
@@ -273,6 +269,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
       &::before {
         display: block;
+        position: relative;
         top: $switch-indicator-margin;
         left: $switch-indicator-margin;
         border-radius: $switch-height;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -115,10 +115,6 @@ export class Switch extends React.PureComponent<ISwitchProps> {
     public render() {
         return <Control {...this.props} type="checkbox" typeClassName={Classes.SWITCH} />;
     }
-
-    protected renderIndicator(): JSX.Element {
-        return null;
-    }
 }
 
 //

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -8,6 +8,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
+import { Icon } from "../../src";
 import { Checkbox, IControlProps, Radio, Switch } from "../../src/components/forms/controls";
 
 type ControlType = typeof Checkbox | typeof Radio | typeof Switch;
@@ -26,6 +27,28 @@ describe("Controls:", () => {
             it("default prop sets element state", () => {
                 mount(<Checkbox defaultIndeterminate={true} inputRef={handleInputRef} />);
                 assert.isTrue(input.indeterminate);
+            });
+        });
+
+        describe("indicator icon", () => {
+            it("default renders nothing", () => {
+                const icon = mount(<Checkbox />).find(Icon);
+                assert.isFalse(icon.exists());
+            });
+
+            it("checked renders tick", () => {
+                const icon = mount(<Checkbox checked={true} />).find(Icon);
+                assert.equal(icon.prop("icon"), "small-tick");
+            });
+
+            it("indeterminate renders minus", () => {
+                const icon = mount(<Checkbox indeterminate={true} />).find(Icon);
+                assert.equal(icon.prop("icon"), "small-minus");
+            });
+
+            it("checked overrides indeterminate", () => {
+                const icon = mount(<Checkbox checked={true} indeterminate={true} />).find(Icon);
+                assert.equal(icon.prop("icon"), "small-minus");
             });
         });
     });


### PR DESCRIPTION
#### Fixes #2312

#### Changes proposed in this pull request:

- `Checkbox` now renders `Icon`s instead of using CSS icons for checked and indeterminate
- refactor controls.tsx to support this, and to use composition instead of inheritance
