### PR TITLE
Add missing default props to MultiSelect

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -56,6 +56,11 @@ export interface IMultiSelectState<T> {
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
     public static displayName = "Blueprint2.MultiSelect";
 
+    public static defaultProps = {
+        openOnKeyDown: false,
+        resetOnSelect: true,
+    };
+
     public static ofType<T>() {
         return MultiSelect as new (props: IMultiSelectProps<T>) => MultiSelect<T>;
     }

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -56,7 +56,7 @@ export interface IMultiSelectState<T> {
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
     public static displayName = "Blueprint2.MultiSelect";
 
-    public static defaultProps = {
+    public static defaultProps: Partial<IMultiSelectProps<any>> = {
         openOnKeyDown: false,
         resetOnSelect: true,
     };


### PR DESCRIPTION
In [docs](http://blueprintjs.com/docs/v2/#select/multi-select) defaults are specified, but missed in code