### PR TITLE
[select] Add items prop to Omnibar isotest

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -57,7 +57,7 @@ export function renderFilteredItems(
     noResults?: React.ReactNode,
     initialContent?: React.ReactNode | null,
 ): React.ReactNode {
-    if (props.query.length === 0 && initialContent !== undefined) {
+    if (props.query.length === 0 && initialContent != null) {
         return initialContent;
     }
     const items = props.filteredItems.map(props.renderItem).filter(item => item != null);

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -57,7 +57,7 @@ export function renderFilteredItems(
     noResults?: React.ReactNode,
     initialContent?: React.ReactNode | null,
 ): React.ReactNode {
-    if (props.query.length === 0 && initialContent != null) {
+    if (props.query.length === 0 && initialContent !== undefined) {
         return initialContent;
     }
     const items = props.filteredItems.map(props.renderItem).filter(item => item != null);

--- a/packages/select/test/isotest.js
+++ b/packages/select/test/isotest.js
@@ -27,6 +27,9 @@ const customProps = {
     },
     Suggest: {
         items: [],
+    },
+    Omnibar: {
+        items: [],
     }
 };
 


### PR DESCRIPTION
Does not f𝗂x #2336 ([whoops](https://github.com/palantir/blueprint/pull/2337#issuecomment-377514514)).

The addition of `items` to the Omnibar SSR test case might still prevent other build errors down the line.