### PR TITLE
[Slider] Use percentage values in slider styles

### DIFF
--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -78,6 +78,8 @@ export interface ISliderState {
     labelPrecision?: number;
     /** the client size, in pixels, of one tick */
     tickSize?: number;
+    /** the size of one tick as a ratio of the component's client size */
+    tickSizeRatio?: number;
 }
 
 export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPureComponent<P, ISliderState> {
@@ -93,6 +95,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
         this.state = {
             labelPrecision: this.getLabelPrecision(props),
             tickSize: 0,
+            tickSizeRatio: 0,
         };
     }
 
@@ -175,11 +178,17 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
             return undefined;
         }
 
-        const stepSize = Math.round(this.state.tickSize * labelStepSize);
+        // const stepSize = Math.round(this.state.tickSize * labelStepSize);
+        const stepSizeRatio = this.state.tickSizeRatio * labelStepSize;
         const labels: JSX.Element[] = [];
         // tslint:disable-next-line:one-variable-per-declaration ban-comma-operator
-        for (let i = min, offset = 0; i < max || approxEqual(i, max); i += labelStepSize, offset += stepSize) {
-            const style = this.props.vertical ? { bottom: offset } : { left: offset };
+        for (
+            let i = min, offsetRatio = 0;
+            i < max || approxEqual(i, max);
+            i += labelStepSize, offsetRatio += stepSizeRatio
+        ) {
+            const offsetPercent = `${offsetRatio * 100}%`;
+            const style = this.props.vertical ? { bottom: offsetPercent } : { left: offsetPercent };
             labels.push(
                 <div className={`${Classes.SLIDER}-label`} key={i} style={style}>
                     {this.formatLabel(i)}
@@ -222,8 +231,9 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
     private updateTickSize() {
         if (this.trackElement != null) {
             const trackSize = this.props.vertical ? this.trackElement.clientHeight : this.trackElement.clientWidth;
-            const tickSize = trackSize / ((this.props.max as number) - (this.props.min as number));
-            this.setState({ tickSize });
+            const tickSizeRatio = 1 / (this.props.max as number) - (this.props.min as number);
+            const tickSize = trackSize * tickSizeRatio;
+            this.setState({ tickSize, tickSizeRatio });
         }
     }
 }

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -230,7 +230,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
     private updateTickSize() {
         if (this.trackElement != null) {
             const trackSize = this.props.vertical ? this.trackElement.clientHeight : this.trackElement.clientWidth;
-            const tickSizeRatio = 1 / (this.props.max as number) - (this.props.min as number);
+            const tickSizeRatio = 1 / ((this.props.max as number) - (this.props.min as number));
             const tickSize = trackSize * tickSizeRatio;
             this.setState({ tickSize, tickSizeRatio });
         }

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -186,7 +186,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
             i < max || approxEqual(i, max);
             i += labelStepSize, offsetRatio += stepSizeRatio
         ) {
-            const offsetPercentage = `${(offsetRatio * 100).toFixed(2)}%`;
+            const offsetPercentage = formatPercentage(offsetRatio);
             const style = this.props.vertical ? { bottom: offsetPercentage } : { left: offsetPercentage };
             labels.push(
                 <div className={`${Classes.SLIDER}-label`} key={i} style={style}>
@@ -235,4 +235,9 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
             this.setState({ tickSize, tickSizeRatio });
         }
     }
+}
+
+/** Helper function for formatting ratios as CSS percentage values. */
+export function formatPercentage(ratio: number) {
+    return `${(ratio * 100).toFixed(2)}%`;
 }

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -178,7 +178,6 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
             return undefined;
         }
 
-        // const stepSize = Math.round(this.state.tickSize * labelStepSize);
         const stepSizeRatio = this.state.tickSizeRatio * labelStepSize;
         const labels: JSX.Element[] = [];
         // tslint:disable-next-line:one-variable-per-declaration ban-comma-operator

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -186,7 +186,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
             i < max || approxEqual(i, max);
             i += labelStepSize, offsetRatio += stepSizeRatio
         ) {
-            const offsetPercent = `${offsetRatio * 100}%`;
+            const offsetPercent = `${(offsetRatio * 100).toFixed(2)}%`;
             const style = this.props.vertical ? { bottom: offsetPercent } : { left: offsetPercent };
             labels.push(
                 <div className={`${Classes.SLIDER}-label`} key={i} style={style}>

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -186,8 +186,8 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
             i < max || approxEqual(i, max);
             i += labelStepSize, offsetRatio += stepSizeRatio
         ) {
-            const offsetPercent = `${(offsetRatio * 100).toFixed(2)}%`;
-            const style = this.props.vertical ? { bottom: offsetPercent } : { left: offsetPercent };
+            const offsetPercentage = `${(offsetRatio * 100).toFixed(2)}%`;
+            const style = this.props.vertical ? { bottom: offsetPercentage } : { left: offsetPercentage };
             labels.push(
                 <div className={`${Classes.SLIDER}-label`} key={i} style={style}>
                     {this.formatLabel(i)}

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -12,6 +12,7 @@ import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IProps } from "../../common/props";
 import { clamp, safeInvoke } from "../../common/utils";
+import { formatPercentage } from "./coreSlider";
 
 /**
  * N.B. some properties need to be optional for spread in slider.tsx to work
@@ -61,7 +62,7 @@ export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
         // margin).
         const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement, true);
         const offsetRatio = (value - min) * tickSizeRatio;
-        const offsetCalc = `calc(${(offsetRatio * 100).toFixed(2)}% - ${handleMidpoint}px)`;
+        const offsetCalc = `calc(${formatPercentage(offsetRatio)} - ${handleMidpoint}px)`;
         const style: React.CSSProperties = vertical ? { bottom: offsetCalc } : { left: offsetCalc };
 
         return (

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -54,7 +54,7 @@ export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
         const { className, disabled, label, min, tickSizeRatio, value, vertical } = this.props;
         const { isMoving } = this.state;
 
-        const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement, true);
+        const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement);
         const offsetRatio = (value - min) * tickSizeRatio;
         const offsetCalc = `calc(${offsetRatio * 100}% - ${handleMidpoint}px)`;
         const style: React.CSSProperties = vertical ? { bottom: offsetCalc } : { left: offsetCalc };

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -25,6 +25,7 @@ export interface IHandleProps extends IProps {
     onRelease?: (newValue: number) => void;
     stepSize?: number;
     tickSize?: number;
+    tickSizeRatio?: number;
     value?: number;
     vertical?: boolean;
 }
@@ -50,12 +51,13 @@ export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
     };
 
     public render() {
-        const { className, disabled, label, min, tickSize, value, vertical } = this.props;
+        const { className, disabled, label, min, tickSizeRatio, value, vertical } = this.props;
         const { isMoving } = this.state;
 
         const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement, true);
-        const offset = Math.round((value - min) * tickSize - handleMidpoint);
-        const style: React.CSSProperties = vertical ? { bottom: offset } : { left: offset };
+        const offsetRatio = (value - min) * tickSizeRatio;
+        const offsetCalc = `calc(${offsetRatio * 100}% - ${handleMidpoint}px)`;
+        const style: React.CSSProperties = vertical ? { bottom: offsetCalc } : { left: offsetCalc };
 
         return (
             <span

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -61,7 +61,7 @@ export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
         // margin).
         const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement, true);
         const offsetRatio = (value - min) * tickSizeRatio;
-        const offsetCalc = `calc(${offsetRatio * 100}% - ${handleMidpoint}px)`;
+        const offsetCalc = `calc(${(offsetRatio * 100).toFixed(2)}% - ${handleMidpoint}px)`;
         const style: React.CSSProperties = vertical ? { bottom: offsetCalc } : { left: offsetCalc };
 
         return (

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -54,7 +54,12 @@ export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
         const { className, disabled, label, min, tickSizeRatio, value, vertical } = this.props;
         const { isMoving } = this.state;
 
-        const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement);
+        // The handle midpoint of RangeSlider is actually shifted by a margin to
+        // be on the edge of the visible handle element. Because the midpoint
+        // calculation does not take this margin into account, we instead
+        // measure the long side (which is equal to the short side plus the
+        // margin).
+        const { handleMidpoint } = this.getHandleMidpointAndOffset(this.handleElement, true);
         const offsetRatio = (value - min) * tickSizeRatio;
         const offsetCalc = `calc(${offsetRatio * 100}% - ${handleMidpoint}px)`;
         const style: React.CSSProperties = vertical ? { bottom: offsetCalc } : { left: offsetCalc };

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -52,23 +52,26 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
     private handles: Handle[] = [];
 
     protected renderFill() {
-        const { tickSize } = this.state;
+        const { tickSizeRatio } = this.state;
         const [startValue, endValue] = this.props.value;
         if (startValue === endValue) {
             return undefined;
         }
-        // expand by 1px in each direction so it sits under the handle border
-        let offset = Math.round((startValue - this.props.min) * tickSize) - 1;
-        let size = Math.round((endValue - startValue) * tickSize) + 2;
+        let offsetRatio = (startValue - this.props.min) * tickSizeRatio;
+        let sizeRatio = (endValue - startValue) * tickSizeRatio;
 
-        if (size < 0) {
-            offset += size;
-            size = Math.abs(size);
+        if (sizeRatio < 0) {
+            offsetRatio += sizeRatio;
+            sizeRatio = Math.abs(sizeRatio);
         }
 
+        // expand by 1px in each direction so it sits under the handle border
+        const offsetCalc = `calc(${offsetRatio * 100}% - 1px)`;
+        const sizeCalc = `calc(${sizeRatio * 100}% + 2px)`;
+
         const style: React.CSSProperties = this.props.vertical
-            ? { bottom: offset, height: size }
-            : { left: offset, width: size };
+            ? { bottom: offsetCalc, height: sizeCalc }
+            : { left: offsetCalc, width: sizeCalc };
 
         return <div className={`${Classes.SLIDER}-progress`} style={style} />;
     }
@@ -87,6 +90,7 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
                 ref={this.addHandleRef}
                 stepSize={stepSize}
                 tickSize={this.state.tickSize}
+                tickSizeRatio={this.state.tickSizeRatio}
                 value={val}
                 vertical={vertical}
             />

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { isFunction } from "../../common/utils";
-import { CoreSlider, ICoreSliderProps } from "./coreSlider";
+import { CoreSlider, formatPercentage, ICoreSliderProps } from "./coreSlider";
 import { Handle } from "./handle";
 
 export type NumberRange = [number, number];
@@ -66,8 +66,8 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
         }
 
         // expand by 1px in each direction so it sits under the handle border
-        const offsetCalc = `calc(${(offsetRatio * 100).toFixed(2)}% - 1px)`;
-        const sizeCalc = `calc(${(sizeRatio * 100).toFixed(2)}% + 2px)`;
+        const offsetCalc = `calc(${formatPercentage(offsetRatio)} - 1px)`;
+        const sizeCalc = `calc(${formatPercentage(sizeRatio)} + 2px)`;
 
         const style: React.CSSProperties = this.props.vertical
             ? { bottom: offsetCalc, height: sizeCalc }

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -66,8 +66,8 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
         }
 
         // expand by 1px in each direction so it sits under the handle border
-        const offsetCalc = `calc(${offsetRatio * 100}% - 1px)`;
-        const sizeCalc = `calc(${sizeRatio * 100}% + 2px)`;
+        const offsetCalc = `calc(${(offsetRatio * 100).toFixed(2)}% - 1px)`;
+        const sizeCalc = `calc(${(sizeRatio * 100).toFixed(2)}% + 2px)`;
 
         const style: React.CSSProperties = this.props.vertical
             ? { bottom: offsetCalc, height: sizeCalc }

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -49,20 +49,25 @@ export class Slider extends CoreSlider<ISliderProps> {
     private handle: Handle;
 
     protected renderFill() {
-        const { tickSize } = this.state;
+        const { tickSizeRatio } = this.state;
         const initialValue = clamp(this.props.initialValue, this.props.min, this.props.max);
 
-        let offset = Math.round((initialValue - this.props.min) * tickSize);
-        let size = Math.round((this.props.value - initialValue) * tickSize);
+        // let offset = Math.round((initialValue - this.props.min) * tickSize);
+        // let size = Math.round((this.props.value - initialValue) * tickSize);
+        let offset = (initialValue - this.props.min) * tickSizeRatio;
+        let size = (this.props.value - initialValue) * tickSizeRatio;
 
         if (size < 0) {
             offset += size;
             size = Math.abs(size);
         }
 
+        const offsetPercentage = `${offset * 100}%`;
+        const sizePercentage = `${size * 100}%`;
+
         const style: React.CSSProperties = this.props.vertical
-            ? { bottom: offset, height: size }
-            : { left: offset, width: size };
+            ? { bottom: offsetPercentage, height: sizePercentage }
+            : { left: offsetPercentage, width: sizePercentage };
 
         return <div className={`${Classes.SLIDER}-progress`} style={style} />;
     }

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -60,8 +60,8 @@ export class Slider extends CoreSlider<ISliderProps> {
             size = Math.abs(size);
         }
 
-        const offsetPercentage = `${offset * 100}%`;
-        const sizePercentage = `${size * 100}%`;
+        const offsetPercentage = `${(offset * 100).toFixed(2)}%`;
+        const sizePercentage = `${(size * 100).toFixed(2)}%`;
 
         const style: React.CSSProperties = this.props.vertical
             ? { bottom: offsetPercentage, height: sizePercentage }

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -52,8 +52,6 @@ export class Slider extends CoreSlider<ISliderProps> {
         const { tickSizeRatio } = this.state;
         const initialValue = clamp(this.props.initialValue, this.props.min, this.props.max);
 
-        // let offset = Math.round((initialValue - this.props.min) * tickSize);
-        // let size = Math.round((this.props.value - initialValue) * tickSize);
         let offset = (initialValue - this.props.min) * tickSizeRatio;
         let size = (this.props.value - initialValue) * tickSizeRatio;
 

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -52,16 +52,16 @@ export class Slider extends CoreSlider<ISliderProps> {
         const { tickSizeRatio } = this.state;
         const initialValue = clamp(this.props.initialValue, this.props.min, this.props.max);
 
-        let offset = (initialValue - this.props.min) * tickSizeRatio;
-        let size = (this.props.value - initialValue) * tickSizeRatio;
+        let offsetRatio = (initialValue - this.props.min) * tickSizeRatio;
+        let sizeRatio = (this.props.value - initialValue) * tickSizeRatio;
 
-        if (size < 0) {
-            offset += size;
-            size = Math.abs(size);
+        if (sizeRatio < 0) {
+            offsetRatio += sizeRatio;
+            sizeRatio = Math.abs(sizeRatio);
         }
 
-        const offsetPercentage = formatPercentage(offset);
-        const sizePercentage = formatPercentage(size);
+        const offsetPercentage = formatPercentage(offsetRatio);
+        const sizePercentage = formatPercentage(sizeRatio);
 
         const style: React.CSSProperties = this.props.vertical
             ? { bottom: offsetPercentage, height: sizePercentage }

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -8,7 +8,7 @@ import * as React from "react";
 
 import * as Classes from "../../common/classes";
 import { clamp } from "../../common/utils";
-import { CoreSlider, ICoreSliderProps } from "./coreSlider";
+import { CoreSlider, formatPercentage, ICoreSliderProps } from "./coreSlider";
 import { Handle } from "./handle";
 
 export interface ISliderProps extends ICoreSliderProps {
@@ -60,8 +60,8 @@ export class Slider extends CoreSlider<ISliderProps> {
             size = Math.abs(size);
         }
 
-        const offsetPercentage = `${(offset * 100).toFixed(2)}%`;
-        const sizePercentage = `${(size * 100).toFixed(2)}%`;
+        const offsetPercentage = formatPercentage(offset);
+        const sizePercentage = formatPercentage(size);
 
         const style: React.CSSProperties = this.props.vertical
             ? { bottom: offsetPercentage, height: sizePercentage }

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -193,7 +193,7 @@ describe("<Slider>", () => {
         const style = renderSlider(<Slider initialValue={-10} min={0} value={5} />)
             .find("." + Classes.SLIDER_PROGRESS)
             .prop("style") as React.CSSProperties;
-        assert.strictEqual(style.left, 0);
+        assert.strictEqual(style.left, "0%");
     });
 
     describe("vertical orientation", () => {

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -193,7 +193,7 @@ describe("<Slider>", () => {
         const style = renderSlider(<Slider initialValue={-10} min={0} value={5} />)
             .find("." + Classes.SLIDER_PROGRESS)
             .prop("style") as React.CSSProperties;
-        assert.strictEqual(style.left, "0%");
+        assert.strictEqual(style.left, "0.00%");
     });
 
     describe("vertical orientation", () => {


### PR DESCRIPTION
#### Fixes #2338

#### Changes proposed in this pull request:

This PR changes the slider styles to use percentages instead of absolute pixel values. This should allow the slider to be freely resized without requiring a forced re-render.

#### Screenshot

This recording shows the slider being resized (`width` is being set in the inspector).

![2018-03-30_18-58-56](https://user-images.githubusercontent.com/205631/38147557-28436324-3453-11e8-98d9-5c2ce10b69b8.gif)

