### PR TITLE
Add 'alignText' to invalid HTML props

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -91,6 +91,7 @@ export interface IOptionProps extends IProps {
 /** A collection of curated prop keys used across our Components which are not valid HTMLElement props. */
 const INVALID_PROPS = [
     "active",
+    "alignText",
     "containerRef",
     "elementRef",
     "fill",


### PR DESCRIPTION
This fixes warnings being spewed when using `alignText` on `Button` components.

eg:
<img width="990" alt="screen shot 2018-03-30 at 11 50 37 am" src="https://user-images.githubusercontent.com/992244/38149805-f0524b20-3410-11e8-9f41-286dee74ea00.png">
