### PR TITLE
Add scrollParent prop to Documentation component

### DIFF
--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -74,7 +74,7 @@ export interface IDocumentationProps extends IProps {
     renderNavMenuItem?: (props: INavMenuItemProps) => JSX.Element;
 
     /**
-     * HTML element to use as the scroll parent. By default document.documentElement is assumed to be the scroll container.
+     * HTML element to use as the scroll parent. By default `document.documentElement` is assumed to be the scroll container.
      * @default document.documentElement
      */
     scrollParent?: HTMLElement;

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -73,6 +73,12 @@ export interface IDocumentationProps extends IProps {
      */
     renderNavMenuItem?: (props: INavMenuItemProps) => JSX.Element;
 
+    /**
+     * Element to use as the scroll parent. By default document.documentElement is assumed to be the scroll container.
+     * @default document.documentElement
+     */
+    scrollParent?: HTMLElement;
+
     /** Tag renderer functions. Unknown tags will log console errors. */
     tagRenderers: ITagRendererMap;
 }
@@ -87,6 +93,10 @@ export interface IDocumentationState {
 
 @HotkeysTarget
 export class Documentation extends React.PureComponent<IDocumentationProps, IDocumentationState> {
+    public static defaultProps: Partial<IDocumentationProps> = {
+        scrollParent: document.documentElement,
+    };
+
     public static childContextTypes = DocumentationContextTypes;
 
     /** Map of section route to containing page reference. */
@@ -262,7 +272,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
     private handlePreviousSection = () => this.shiftSection(-1);
 
     private handleScroll = () => {
-        const activeSectionId = getScrolledReference(100, document.documentElement);
+        const activeSectionId = getScrolledReference(100, this.props.scrollParent);
         if (activeSectionId == null) {
             return;
         }
@@ -284,7 +294,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
 
     private scrollToActiveSection() {
         if (this.contentElement != null) {
-            scrollToReference(this.state.activeSectionId, document.documentElement);
+            scrollToReference(this.state.activeSectionId, this.props.scrollParent);
         }
     }
 

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -93,10 +93,6 @@ export interface IDocumentationState {
 
 @HotkeysTarget
 export class Documentation extends React.PureComponent<IDocumentationProps, IDocumentationState> {
-    public static defaultProps: Partial<IDocumentationProps> = {
-        scrollParent: document.documentElement,
-    };
-
     public static childContextTypes = DocumentationContextTypes;
 
     /** Map of section route to containing page reference. */
@@ -323,7 +319,7 @@ function queryHTMLElement(parent: Element, selector: string) {
 /**
  * Returns the reference of the closest section within `offset` pixels of the top of the viewport.
  */
-function getScrolledReference(offset: number, scrollContainer: HTMLElement) {
+function getScrolledReference(offset: number, scrollContainer: HTMLElement = document.documentElement) {
     const headings = Array.from(scrollContainer.querySelectorAll(".docs-title"));
     while (headings.length > 0) {
         // iterating in reverse order (popping from end / bottom of page)
@@ -340,7 +336,7 @@ function getScrolledReference(offset: number, scrollContainer: HTMLElement) {
 /**
  * Scroll the scroll container such that the reference heading appears at the top of the viewport.
  */
-function scrollToReference(reference: string, scrollContainer: HTMLElement) {
+function scrollToReference(reference: string, scrollContainer: HTMLElement = document.documentElement) {
     // without rAF, on initial load this would scroll to the bottom because the CSS had not been applied.
     // with rAF, CSS is applied before updating scroll positions so all elements are in their correct places.
     requestAnimationFrame(() => {

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -74,7 +74,7 @@ export interface IDocumentationProps extends IProps {
     renderNavMenuItem?: (props: INavMenuItemProps) => JSX.Element;
 
     /**
-     * Element to use as the scroll parent. By default document.documentElement is assumed to be the scroll container.
+     * HTML element to use as the scroll parent. By default document.documentElement is assumed to be the scroll container.
      * @default document.documentElement
      */
     scrollParent?: HTMLElement;


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

the `Documentation` component assumes that the scroll parent is `document.documentElement` - this is not necessarily always the case, so I added a `scrollParent` prop that lets consumers override this. By default `scrollParent` is just `document.documentElement`
