### PR TITLE
Upgrade to normalize.css 8.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "@types/dom4": "^2.0.0",
     "classnames": "^2.2",
     "dom4": "^2.0.1",
-    "normalize.css": "^7.0.0",
+    "normalize.css": "^8.0.0",
     "popper.js": "^1.14.1",
     "react-popper": "^0.8.2",
     "tslib": "^1.9.0"

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -103,7 +103,6 @@ $button-intents: (
   cursor: pointer;
   padding: $button-padding;
   text-align: left;
-  font-family: inherit;
   font-size: $pt-font-size;
 }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -91,7 +91,6 @@ $control-group-stack: (
   vertical-align: middle;
   line-height: $pt-input-height;
   color: $input-color;
-  font-family: inherit;
   font-size: $pt-font-size;
   font-weight: $input-font-weight;
   transition: $input-transition;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -115,7 +115,6 @@ button.pt-menu-item {
   background: none;
   width: 100%;
   text-align: left;
-  font-family: inherit;
 }
 
 /*

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -31,7 +31,7 @@
     "classnames": "^2.2.5",
     "dom4": "^2.0.1",
     "moment": "^2.18.1",
-    "normalize.css": "^7.0.0",
+    "normalize.css": "^8.0.0",
     "popper.js": "^1.14.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -20,7 +20,7 @@
     "@blueprintjs/table": "^2.0.0",
     "classnames": "^2.2.5",
     "dom4": "^2.0.1",
-    "normalize.css": "^7.0.0",
+    "normalize.css": "^8.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-transition-group": "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5343,9 +5343,9 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-normalize.css@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-7.0.0.tgz#abfb1dd82470674e0322b53ceb1aaf412938e4bf"
+normalize.css@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.0.tgz#14ac5e461612538a4ce9be90a7da23f86e718493"
 
 npm-run-all@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
Split off from #2357.

[Changelog](https://github.com/necolas/normalize.css/blob/master/CHANGELOG.md#800-february-2-2018):
> Remove support for older browsers Android 4, lte IE 9, lte Safari 7.
> Don't remove search input cancel button in Chrome/Safari.
> Form inputs inherit font-family.
> Fix text decoration in Safari 8+.


This PR also removes some redundant `font-family: inherit` rules that are already handled by normalize.css.