### PR TITLE
remove global styles

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -35,18 +35,24 @@ small {
 Headings
 
 Markup:
-<h1>H1 heading</h1>
-<h2>H2 heading</h2>
-<h3>H3 heading</h3>
-<h4>H4 heading</h4>
-<h5>H5 heading</h5>
-<h6>H6 heading</h6>
+<h1 class="pt-heading">H1 heading</h1>
+<h2 class="pt-heading">H2 heading</h2>
+<h3 class="pt-heading">H3 heading</h3>
+<h4 class="pt-heading">H4 heading</h4>
+<h5 class="pt-heading">H5 heading</h5>
+<h6 class="pt-heading">H6 heading</h6>
 
 Styleguide headings
 */
 
+.pt-heading {
+  @include heading-typography();
+  margin: 0 0 $pt-grid-size;
+  padding: 0;
+}
+
 // tag: (font-size, line-height)
-$headers: (
+$headings: (
   "h1": (36px, 40px),
   "h2": (28px, 32px),
   "h3": (22px, 25px),
@@ -55,13 +61,14 @@ $headers: (
   "h6": (14px, 16px)
 );
 
-@each $header, $props in $headers {
-  #{$header} {
-    @include header-typography();
-    margin: 0 0 $pt-grid-size;
-    padding: 0;
+@each $tag, $props in $headings {
+  %#{$tag} {
     line-height: nth($props, 2);
     font-size: nth($props, 1);
+  }
+
+  #{$tag}.pt-heading {
+    @extend %#{$tag};
   }
 }
 
@@ -133,8 +140,10 @@ Styleguide pt-running-text
 .pt-running-text {
   @include running-typography();
 
-  @each $header, $props in $headers {
-    #{$header} {
+  @each $tag, $props in $headings {
+    #{$tag} {
+      @extend %#{$tag};
+      @include heading-typography();
       margin-top: $pt-grid-size * 4;
       margin-bottom: $pt-grid-size * 2;
     }
@@ -409,10 +418,4 @@ Styleguide pt-rtl
 
 .pt-dark {
   color: $pt-dark-text-color;
-
-  @each $header, $props in $headers {
-    #{$header} {
-      color: $pt-dark-heading-color;
-    }
-  }
 }

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -174,12 +174,13 @@ Styleguide pt-running-text
 
   pre {
     @extend %code-block;
+  }
 
-    > code {
-      // undo
+  ul,
+  ol {
+    @extend %list;
     }
   }
-}
 
 /*
 Links

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -110,8 +110,8 @@ Markup:
 <div class="pt-running-text {{.modifier}}">
   <blockquote>
     <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </p>
     <ul>
       <li>Item the <code>first</code>.</li>
@@ -119,7 +119,10 @@ Markup:
       <li>Item the <a href="#core/typography.running-text">third</a>.</li>
     </ul>
     <h3>New section</h3>
-    <p>And another paragraph.</p>
+    <p>
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+      nisi ut aliquip ex ea commodo consequat.
+    </p>
   </blockquote>
 </div>
 
@@ -299,10 +302,10 @@ Block quotes
 Markup:
 <blockquote class="pt-blockquote">
   <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+    ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+    ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   </p>
 </blockquote>
 
@@ -339,7 +342,7 @@ Markup:
   </li>
 </ol>
 
-.pt-list - Comfortable margins and padding. Note that this modifier must be applied to each nested `ul` or `ol` element.
+.pt-list - Comfortable margins and padding.
 .pt-list-unstyled - Remove list item decorators and all margins and padding.
 
 Styleguide lists

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -7,16 +7,6 @@
 @import "common/mixins";
 @import "~@blueprintjs/icons/src/icons";
 
-hr {
-  margin: ($pt-grid-size * 2) 0;
-  border: none;
-  border-bottom: 1px solid $pt-divider-black;
-
-  .pt-dark & {
-    border-color: $pt-dark-divider-white;
-  }
-}
-
 // consistent cross-browser text selection
 ::selection {
   background: $pt-text-selection-color;
@@ -80,11 +70,12 @@ Markup:
   Blueprint components react overlay date picker. Breadcrumbs dialog progress non-ideal state.
 </div>
 
-.pt-ui-text - Default Blueprint font styles.
-.pt-ui-text-large - Larger font styles.
+.pt-ui-text - Default Blueprint font styles, applied to the `<body>` tag and available as a class for nested resets.
 .pt-monospace-text - Use a monospace font (ideal for code).
-.pt-text-muted - Changes text color to a gentler gray.
-.pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
+.pt-running-text - Increase line height ideal for longform text. See [Running text](#core/typography.running-text) below for additional features.
+.pt-text-large - Use a larger font size.
+.pt-text-muted - Change text color to a gentler gray.
+.pt-text-overflow-ellipsis - Truncate a single line of text with an ellipsis if it overflows its
   container.
 
 Styleguide pt-ui-text
@@ -94,14 +85,11 @@ Styleguide pt-ui-text
   @include base-typography();
 }
 
-.pt-ui-text-large {
-  line-height: 1.25;
-  font-size: $pt-font-size-large;
-}
-
 .pt-monospace-text {
   @include monospace-typography();
 }
+
+// NOTE: .pt-text-large defined below after .pt-running-text
 
 .pt-text-muted {
   color: $pt-text-color-muted;
@@ -132,7 +120,7 @@ elements:</p>
   <p>And another paragraph.</p>
 </div>
 
-.pt-running-text - Apply larger font size and additional spacing.
+.pt-text-large - Use larger font size.
 
 Styleguide pt-running-text
 */
@@ -181,6 +169,11 @@ Styleguide pt-running-text
     @extend %list;
     }
   }
+
+// NOTE: this must be defined after .pt-running-text in order to override font-size.
+.pt-text-large {
+  font-size: $pt-font-size-large;
+}
 
 /*
 Links

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -132,15 +132,37 @@ Styleguide pt-running-text
       margin-bottom: $pt-grid-size * 2;
     }
   }
-}
 
-.pt-running-text-small {
-  @include running-typography-small();
-}
+  hr {
+    margin: ($pt-grid-size * 2) 0;
+    border: none;
+    border-bottom: 1px solid $pt-divider-black;
 
-p {
-  margin: 0 0 $pt-grid-size;
-  padding: 0;
+    .pt-dark & {
+      border-color: $pt-dark-divider-white;
+    }
+  }
+
+  p {
+    margin: 0 0 $pt-grid-size;
+    padding: 0;
+  }
+
+  blockquote {
+    @extend %blockquote;
+  }
+
+  code {
+    @extend %code;
+  }
+
+  pre {
+    @extend %code-block;
+
+    > code {
+      // undo
+    }
+  }
 }
 
 /*
@@ -210,12 +232,9 @@ Markup:
 Styleguide preformatted
 */
 
-pre,
-code {
+%code {
   @include monospace-typography();
-}
 
-code {
   border-radius: $pt-border-radius;
   box-shadow: inset border-shadow(0.2);
   background: $pt-code-background-color;
@@ -229,7 +248,9 @@ code {
   }
 }
 
-pre {
+%code-block {
+  @include monospace-typography();
+
   display: block;
   margin: $pt-grid-size 0;
   border-radius: $pt-border-radius;
@@ -242,26 +263,27 @@ pre {
   word-break: break-all;
   word-wrap: break-word;
 
-  > code {
-    border-radius: 0;
-    box-shadow: none;
-    background: transparent;
-    padding: 0;
-    white-space: pre-wrap;
-    color: inherit;
-    font-size: inherit;
-  }
-
   .pt-dark & {
     box-shadow: inset 0 0 0 1px $pt-dark-divider-black;
     background: $pt-dark-code-background-color;
     color: $pt-dark-text-color;
-
-    > code {
-      box-shadow: none;
-      background: transparent;
-    }
   }
+
+  > code {
+    box-shadow: none;
+    background: none;
+    padding: 0;
+    color: inherit;
+    font-size: inherit;
+  }
+}
+
+.pt-code {
+  @extend %code;
+}
+
+.pt-code-block {
+  @extend %code-block;
 }
 
 /*
@@ -286,19 +308,18 @@ Markup:
 Styleguide blockquote
 */
 
-blockquote {
-  @include running-typography();
+%blockquote {
   margin: 0 0 $pt-grid-size;
   border-left: solid 4px rgba($gray4, 0.5);
   padding: 0 ($pt-grid-size * 2);
 
-  p:last-child {
-    margin-bottom: 0;
-  }
-
   .pt-dark & {
     border-color: rgba($gray2, 0.5);
   }
+}
+
+.pt-blockquote {
+  @extend %blockquote;
 }
 
 /*
@@ -322,28 +343,23 @@ Markup:
 Styleguide lists
 */
 
-ol,
-ul {
+%list {
   margin: $pt-grid-size 0;
   padding-left: $pt-grid-size * 4;
-}
 
-.pt-list,
-.pt-running-text ul,
-.pt-running-text ol {
   li:not(:last-child) {
-    padding-bottom: $pt-grid-size / 2;
+    margin-bottom: $pt-grid-size / 2;
   }
 
-  // remove bottom margin on final element in list item because list items put their own spacing
-  li :last-child {
-    margin-bottom: 0;
-  }
-
+  // nested lists
   ol,
   ul {
     margin-top: $pt-grid-size / 2;
   }
+}
+
+.pt-list {
+  @extend %list;
 }
 
 .pt-list-unstyled {

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -42,10 +42,6 @@ Markup:
 Styleguide fonts
 */
 
-.pt-monospace-text {
-  @include monospace-typography();
-}
-
 /*
 Headings
 
@@ -84,10 +80,16 @@ $headers: (
 UI text
 
 Markup:
-<div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
+<div class="{{.modifier}}">
+  Blueprint components react overlay date picker. Breadcrumbs dialog progress non-ideal state.
+</div>
 
-.pt-ui-text - Default UI text. This is applied to the document body as part of core styles.
-.pt-ui-text-large - Larger UI text.
+.pt-ui-text - Default Blueprint font styles.
+.pt-ui-text-large - Larger font styles.
+.pt-monospace-text - Use a monospace font (ideal for code).
+.pt-text-muted - Changes text color to a gentler gray.
+.pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
+  container.
 
 Styleguide pt-ui-text
 */
@@ -99,6 +101,22 @@ Styleguide pt-ui-text
 .pt-ui-text-large {
   line-height: 1.25;
   font-size: $pt-font-size-large;
+}
+
+.pt-monospace-text {
+  @include monospace-typography();
+}
+
+.pt-text-muted {
+  color: $pt-text-color-muted;
+
+  .pt-dark & {
+    color: $pt-dark-text-color-muted;
+  }
+}
+
+.pt-text-overflow-ellipsis {
+  @include overflow-ellipsis();
 }
 
 /*
@@ -370,33 +388,6 @@ Styleguide lists
   li {
     padding: 0;
   }
-}
-
-/*
-Text utilities
-
-Markup:
-<div class="{{.modifier}}" style="width: 320px;">
-  Blueprint components react overlay date picker. Breadcrumbs dialog progress non-ideal state.
-</div>
-
-.pt-text-muted - Changes text color to a gentler gray.
-.pt-text-overflow-ellipsis - Truncates a single line of text with an ellipsis if it overflows its
-  container.
-
-Styleguide utilities
-*/
-
-.pt-text-muted {
-  color: $pt-text-color-muted;
-
-  .pt-dark & {
-    color: $pt-dark-text-color-muted;
-  }
-}
-
-.pt-text-overflow-ellipsis {
-  @include overflow-ellipsis();
 }
 
 /*

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -107,17 +107,20 @@ Styleguide pt-ui-text
 Running text
 
 Markup:
-<div class="{{.modifier}}">
-  <p>Longform text, such as rendered Markdown documents, benefit from additional spacing and slightly
-large font size. Apply <code>.pt-running-text</code> to the parent element to adjust spacing for the following
-elements:</p>
-  <ul>
-    <li><code>&lt;p></code> tags have increased line-height and font size.</li>
-    <li><code>&lt;h*></code> tag margins are adjusted to provide clear separation between sections in a document.</li>
-    <li><code>&lt;ul></code> and <code>&lt;ol></code> tags receive [`.pt-list`](#typography.lists) styles for legibility.</li>
-  </ul>
-  <h3>New section</h3>
-  <p>And another paragraph.</p>
+<div class="pt-running-text {{.modifier}}">
+  <blockquote>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    </p>
+    <ul>
+      <li>Item the <code>first</code>.</li>
+      <li>Item the <strong>second</strong></code>.</li>
+      <li>Item the <a href="#core/typography.running-text">third</a>.</li>
+    </ul>
+    <h3>New section</h3>
+    <p>And another paragraph.</p>
+  </blockquote>
 </div>
 
 .pt-text-large - Use larger font size.
@@ -167,12 +170,13 @@ Styleguide pt-running-text
   ul,
   ol {
     @extend %list;
-    }
   }
+}
 
 // NOTE: this must be defined after .pt-running-text in order to override font-size.
 .pt-text-large {
   font-size: $pt-font-size-large;
+  // line-height comes from .pt-(ui|running)-text
 }
 
 /*
@@ -219,13 +223,8 @@ a {
 Preformatted text
 
 Markup:
-<p>
-  The <code class="pt-code">Portal</code> component functions like a declarative
-  <code class="pt-code">appendChild()</code>, or jQuery's <code class="pt-code">$.fn.appendTo()</code>.
-</p>
-<div class="pt-running-text">
-  <pre>The children of a <code>Portal</code> component are appended to the <code>&lt;body></code> element.</pre>
-</div>
+<p>Use the <code class="pt-code">&lt;code></code> tag for snippets of code.</p>
+<pre class="pt-code-block">Use the &lt;pre> tag for blocks of code.</pre>
 <pre class="pt-code-block"><code>// code sample
 export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.SyntaxKind[]) {
   if (modifiers == null || modifierKinds == null) {
@@ -247,6 +246,7 @@ Styleguide preformatted
   background: $pt-code-background-color;
   padding: 2px 5px;
   color: $pt-code-text-color;
+  font-size: $pt-font-size-small;
 
   .pt-dark & {
     box-shadow: inset border-shadow(0.4);
@@ -305,16 +305,6 @@ Markup:
     voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   </p>
 </blockquote>
-<div class="pt-running-text">
-  <blockquote>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-      labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-      laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-      voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-    </p>
-  </blockquote>
-</div>
 
 Styleguide blockquote
 */
@@ -337,31 +327,27 @@ Styleguide blockquote
 Lists
 
 Markup:
-<ol class="pt-list">
+<ol class="{{.modifier}}">
   <li>Item the first</li>
   <li>Item the second</li>
   <li>
     Item the third
-    <ol>
+    <ol class="{{.modifier}}">
       <li>Item the fourth</li>
       <li>Item the fifth</li>
     </ol>
   </li>
 </ol>
-<div class="pt-running-text">
-  <ul>
-  <li>Item the first</li>
-  <li>Item the second</li>
-  <li>Item the third</li>
-  </ul>
-</div>
+
+.pt-list - Comfortable margins and padding. Note that this modifier must be applied to each nested `ul` or `ol` element.
+.pt-list-unstyled - Remove list item decorators and all margins and padding.
 
 Styleguide lists
 */
 
 %list {
   margin: $pt-grid-size 0;
-  padding-left: $pt-grid-size * 4;
+  padding-left: $pt-grid-size * 3;
 
   li:not(:last-child) {
     margin-bottom: $pt-grid-size / 2;

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -32,17 +32,6 @@ small {
 }
 
 /*
-Fonts
-
-Markup:
-<div class="{{.modifier}}">Blueprint components react overlay date picker.</div>
-
-.pt-monospace-text - Use a monospace font (ideal for code)
-
-Styleguide fonts
-*/
-
-/*
 Headings
 
 Markup:
@@ -227,24 +216,21 @@ a {
 Preformatted text
 
 Markup:
-<code>$ npm install</code>
-<pre>
-%pt-select {
-  @include pt-button();
-  border-radius: $pt-border-radius;
-  height: $pt-button-height;
-  padding: 0 ($input-padding-horizontal * 3) 0 $input-padding-horizontal;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-}
-</pre>
-<pre><code>export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.SyntaxKind[]) {
-    if (modifiers == null || modifierKinds == null) {
-        return false;
-    }
-    return modifiers.some((m) => {
-        return modifierKinds.some((k) => m.kind === k);
-    });
+<p>
+  The <code class="pt-code">Portal</code> component functions like a declarative
+  <code class="pt-code">appendChild()</code>, or jQuery's <code class="pt-code">$.fn.appendTo()</code>.
+</p>
+<div class="pt-running-text">
+  <pre>The children of a <code>Portal</code> component are appended to the <code>&lt;body></code> element.</pre>
+</div>
+<pre class="pt-code-block"><code>// code sample
+export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.SyntaxKind[]) {
+  if (modifiers == null || modifierKinds == null) {
+    return false;
+  }
+  return modifiers.some((m) => {
+    return modifierKinds.some((k) => m.kind === k);
+  });
 }</code></pre>
 
 Styleguide preformatted
@@ -308,13 +294,7 @@ Styleguide preformatted
 Block quotes
 
 Markup:
-<blockquote>
-  <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-  </p>
+<blockquote class="pt-blockquote">
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
     labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
@@ -322,6 +302,16 @@ Markup:
     voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   </p>
 </blockquote>
+<div class="pt-running-text">
+  <blockquote>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+      labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+      laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+      voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    </p>
+  </blockquote>
+</div>
 
 Styleguide blockquote
 */
@@ -344,19 +334,24 @@ Styleguide blockquote
 Lists
 
 Markup:
-<ul class="{{.modifier}}">
+<ol class="pt-list">
   <li>Item the first</li>
   <li>Item the second</li>
-  <li>Item the third</li>
-</ul>
-<ol class="{{.modifier}}">
-  <li>Item the first</li>
-  <li>Item the second</li>
-  <li>Item the third</li>
+  <li>
+    Item the third
+    <ol>
+      <li>Item the fourth</li>
+      <li>Item the fifth</li>
+    </ol>
+  </li>
 </ol>
-
-.pt-list - Add a little spacing between items for readability.
-.pt-list-unstyled - Remove all list styling (including indicators) so you can add your own.
+<div class="pt-running-text">
+  <ul>
+  <li>Item the first</li>
+  <li>Item the second</li>
+  <li>Item the third</li>
+  </ul>
+</div>
 
 Styleguide lists
 */

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -52,9 +52,13 @@ $pt-dark-intent-text-colors: (
   font-size: $pt-font-size;
 }
 
-@mixin header-typography() {
+@mixin heading-typography() {
   color: $pt-heading-color;
   font-weight: 600;
+
+  .pt-dark & {
+    color: $pt-dark-heading-color;
+  }
 }
 
 @mixin monospace-typography() {

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -44,11 +44,6 @@ $pt-dark-intent-text-colors: (
 
 @mixin running-typography() {
   line-height: 1.5;
-  font-size: $pt-font-size-large;
-}
-
-@mixin running-typography-small() {
-  line-height: 1.5;
   font-size: $pt-font-size;
 }
 
@@ -64,7 +59,6 @@ $pt-dark-intent-text-colors: (
 @mixin monospace-typography() {
   text-transform: none;
   font-family: $pt-font-family-monospace;
-  font-size: smaller;
 }
 
 @mixin overflow-ellipsis() {
@@ -78,6 +72,26 @@ $pt-dark-intent-text-colors: (
   outline: rgba($blue3, 0.5) auto 2px;
   outline-offset: $offset;
   -moz-outline-radius: 6px;
+}
+
+@function border-shadow($alpha, $color: $black, $size: 1px) {
+  @return 0 0 0 $size rgba($color, $alpha);
+}
+
+// returns the padding necessary to center text in a container of the given height.
+// default line-height is that of base typography, 18px assuming 14px font-size.
+@function centered-text($height, $line-height: floor($pt-font-size * $pt-line-height)) {
+  @return floor(($height - $line-height) / 2);
+}
+
+// Removes the unit from a Sass numeric value (if present): `strip-unit(12px) => 12`
+// @see https://css-tricks.com/snippets/sass/strip-unit-function/
+@function strip-unit($number) {
+  @if type-of($number) == "number" and not unitless($number) {
+    @return $number / ($number * 0 + 1);
+  }
+
+  @return $number;
 }
 
 @mixin force-hardware-acceleration() {
@@ -106,24 +120,4 @@ $pt-dark-intent-text-colors: (
 @mixin new-render-layer() {
   // a semantic rename of the mixin above for when you just want to isolate z-indices
   @include force-hardware-acceleration();
-}
-
-@function border-shadow($alpha, $color: $black, $size: 1px) {
-  @return 0 0 0 $size rgba($color, $alpha);
-}
-
-// returns the padding necessary to center text in a container of the given height.
-// default line-height is that of base typography, 18px assuming 14px font-size.
-@function centered-text($height, $line-height: floor($pt-font-size * $pt-line-height)) {
-  @return floor(($height - $line-height) / 2);
-}
-
-// Removes the unit from a Sass numeric value (if present): `strip-unit(12px) => 12`
-// @see https://css-tricks.com/snippets/sass/strip-unit-function/
-@function strip-unit($number) {
-  @if type-of($number) == "number" and not unitless($number) {
-    @return $number / ($number * 0 + 1);
-  }
-
-  @return $number;
 }

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -39,15 +39,17 @@ export const INTENT_WARNING = intentClass(Intent.WARNING);
 export const INTENT_DANGER = intentClass(Intent.DANGER);
 
 // text utilities
+export const UI_TEXT = "pt-ui-text";
+export const RUNNING_TEXT = "pt-running-text";
+export const MONOSPACE_TEXT = "pt-monospace-text";
 export const TEXT_MUTED = "pt-text-muted";
 export const TEXT_OVERFLOW_ELLIPSIS = "pt-text-overflow-ellipsis";
-export const UI_TEXT = "pt-ui-text";
-export const UI_TEXT_LARGE = "pt-ui-text-large";
-export const RUNNING_TEXT = "pt-running-text";
-export const RUNNING_TEXT_SMALL = "pt-running-text-small";
-export const MONOSPACE_TEXT = "pt-monospace-text";
 
-// lists
+// textual elements
+export const BLOCKQUOTE = "pt-blockquote";
+export const CODE = "pt-code";
+export const CODE_BLOCK = "pt-code-block";
+export const HEADING = "pt-heading";
 export const LIST = "pt-list";
 export const LIST_UNSTYLED = "pt-list-unstyled";
 

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -42,6 +42,7 @@ export const INTENT_DANGER = intentClass(Intent.DANGER);
 export const UI_TEXT = "pt-ui-text";
 export const RUNNING_TEXT = "pt-running-text";
 export const MONOSPACE_TEXT = "pt-monospace-text";
+export const TEXT_LARGE = "pt-text-large";
 export const TEXT_MUTED = "pt-text-muted";
 export const TEXT_OVERFLOW_ELLIPSIS = "pt-text-overflow-ellipsis";
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -22,7 +22,7 @@ Styleguide pt-callout
 */
 
 .pt-callout {
-  @include running-typography-small();
+  @include running-typography();
   position: relative;
   border-radius: $pt-border-radius;
   background-color: rgba($gray3, 0.15);

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -151,7 +151,7 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
 }
 
 @mixin menu-heading() {
-  @include header-typography();
+  @include heading-typography();
   @include overflow-ellipsis();
   margin: 0;
   padding: $pt-grid-size $menu-item-padding 0 1px;

--- a/packages/core/src/docs/typography.md
+++ b/packages/core/src/docs/typography.md
@@ -14,32 +14,34 @@ Instead, reference the classes and variables we provide in Blueprint (`.pt-ui-te
 
 @## UI text
 
-Blueprint's default text styles are applied via `.pt-ui-text` or `.pt-ui-text-large`. A handful
-of other utility classes can be combined freely to further customize a block of text.
-
-Blueprint does not include any fonts of its own; it will use the default sans-serif operating system
-font. We provide a class to use the default monospace font instead.
+Blueprint does not include any fonts of its own; it will use the default sans-serif operating system font.
+A handful of utility CSS classes can be combined freely to further customize a block of text.
 
 The base font size for Blueprint web applications is 14px. This should be the default type size
 for most short strings of text which are not headings or titles. If you wish to reset some
 element's font size and line height to the default base styles, use the `.pt-ui-text` class.
-For longer running text, see [running text styles](#core/typography.running-text).
+
+For longer blocks of running text, such as articles or documents, see [running text styles](#core/typography.running-text).
 
 @css pt-ui-text
 
-@## Headings
-
-@css headings
-
 @## Running text
 
-Longform text, such as rendered Markdown documents, benefit from increased spacing and support for unclassed textual elements. Apply `.pt-running-text` to the parent element to apply the following styles to all children:
+Longform text, such as rendered Markdown documents, benefit from increased spacing and support for unclassed textual elements.
+Apply `.pt-running-text` to the parent element to apply the following styles to all children:
 
 - `<h*>`, `<ul>`, `<ol>`, `<blockquote>`, `<code>`, `<pre>` do not require additional CSS classes for styles. This is great for rendered Markdown documents.
 - `<h*>` tag margins are adjusted to provide clear separation between sections in a document.
 - `<ul>` and `<ol>` tags receive [`.pt-list`](#core/typography.lists) styles for legibility.
 
 @css pt-running-text
+
+@## Headings
+
+Apply the `.pt-heading` class to one of the six `<h*>` tags (or nest them inside a `.pt-running-text` container)
+to adjust font size and line height.
+
+@css headings
 
 @## Links
 
@@ -50,32 +52,32 @@ Putting an icon inside a link will cause it to inherit the link's text color.
 
 @## Preformatted text
 
-Use `<pre>` for code blocks, and `<code>` for inline code. Note that `<pre>` blocks will
-retain _all_ whitespace so you'll have to format the content accordingly.
+Use `.pt-code` for inline code elements (typically with the `<code>` tag).
+Use `.pt-code-block` for mulitline blocks of code (typically on a `<pre>` tag).
+Note that `<pre>` blocks will retain _all_ whitespace so you'll have to format the content accordingly.
+
+When nested inside a `.pt-running-text` container, use the `<pre>` or `<code>` tags directly without CSS classes.
 
 @css preformatted
 
 @## Block quotes
 
-Block quotes are treated as running text.
+Block quotes receive a left border and padding to distinguish them from body text.
+
+Use the `.pt-blockquote` class or nest a `<blockquote>` element inside a `.pt-running-text` container.
 
 @css blockquote
 
 @## Lists
 
-Blueprint provides a small amount of global styling and a few modifier classes for list elements.
+Use `.pt-list` to adjust list margins and padding to match Blueprint's grid. `<ul>` and `<ol>` elements inside a
+`.pt-running-text` container will automatically assume these styles to promote readability.
 
-`<ul>` and `<ol>` elements in blocks with the `.pt-running-text` modifier class will
-automatically assume the `.pt-list` styles to promote readability.
+Use `.pt-list-unstyled` to remove list item decorations and margins and padding.
+
+Note that these classes must be applied to each nested `<ul>` or `<ol>` element in a tree.
 
 @css lists
-
-@## Text utilities
-
-Blueprint provides a small handful of class-based text utilities which can applied to any element
-that contains text.
-
-@css utilities
 
 @## Internationalization
 

--- a/packages/core/src/docs/typography.md
+++ b/packages/core/src/docs/typography.md
@@ -12,19 +12,13 @@ proper contrast.
 Instead, reference the classes and variables we provide in Blueprint (`.pt-ui-text`,
 `$pt-font-size-large`, etc.).
 
-@## Fonts
+@## UI text
+
+Blueprint's default text styles are applied via `.pt-ui-text` or `.pt-ui-text-large`. A handful
+of other utility classes can be combined freely to further customize a block of text.
 
 Blueprint does not include any fonts of its own; it will use the default sans-serif operating system
 font. We provide a class to use the default monospace font instead.
-
-
-@css fonts
-
-@## Headings
-
-@css headings
-
-@## UI text
 
 The base font size for Blueprint web applications is 14px. This should be the default type size
 for most short strings of text which are not headings or titles. If you wish to reset some
@@ -33,13 +27,15 @@ For longer running text, see [running text styles](#core/typography.running-text
 
 @css pt-ui-text
 
+@## Headings
+
+@css headings
+
 @## Running text
 
-Longform text, such as rendered Markdown documents, benefit from additional spacing and slightly
-large font size. Apply `.pt-running-text` to the parent element to adjust spacing for the following
-elements:
+Longform text, such as rendered Markdown documents, benefit from increased spacing and support for unclassed textual elements. Apply `.pt-running-text` to the parent element to apply the following styles to all children:
 
-- `<p>` tags have increased line-height and font size.
+- `<h*>`, `<ul>`, `<ol>`, `<blockquote>`, `<code>`, `<pre>` do not require additional CSS classes for styles. This is great for rendered Markdown documents.
 - `<h*>` tag margins are adjusted to provide clear separation between sections in a document.
 - `<ul>` and `<ol>` tags receive [`.pt-list`](#core/typography.lists) styles for legibility.
 

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -30,7 +30,9 @@
 // (Default styles give flex-basis of 100% to each example.)
 @mixin examples-per-row($amount) {
   .docs-example {
-    flex-basis: floor(100% / $amount);
+    $width: floor(100% / $amount);
+    flex-basis: $width;
+    width: $width;
     padding-right: $pt-grid-size * 2;
 
     &[data-modifier=".pt-fill"] {
@@ -42,6 +44,8 @@
 
 // CSS examples
 
+#{reference("pt-ui-text")},
+#{reference("pt-running-text")},
 #{reference("pt-file-input")},
 #{reference("pt-label")},
 #{reference("pt-menu")},
@@ -52,6 +56,7 @@
   @include examples-per-row(2);
 }
 
+#{reference("lists")},
 #{reference-all("pt-input")},
 #{reference("pt-button")},
 #{reference("pt-button.pt-minimal")},

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -4,6 +4,8 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+import { Classes } from "@blueprintjs/core";
+import classNames from "classnames";
 import { IBlock } from "documentalist/dist/client";
 import * as React from "react";
 import { ITagRendererMap } from "../tags";
@@ -19,9 +21,10 @@ export function renderBlock(
     if (block === undefined) {
         return null;
     }
+    const textClasses = classNames(Classes.RUNNING_TEXT, textClassName);
     const contents = block.contents.map((node, i) => {
         if (typeof node === "string") {
-            return <div className={textClassName} key={i} dangerouslySetInnerHTML={{ __html: node }} />;
+            return <div className={textClasses} key={i} dangerouslySetInnerHTML={{ __html: node }} />;
         }
         try {
             const renderer = tagRenderers[node.tag];
@@ -33,7 +36,7 @@ export function renderBlock(
             console.error(ex.message);
             return (
                 <h3 key={`__error-${i}`}>
-                    <code>{ex.message}</code>
+                    <code className={Classes.CODE}>{ex.message}</code>
                 </h3>
             );
         }

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -121,7 +121,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         const { docs, renderViewSourceLinkText } = this.props;
         return {
             getDocsData: () => docs,
-            renderBlock: block => renderBlock(block, this.props.tagRenderers, Classes.RUNNING_TEXT_SMALL),
+            renderBlock: block => renderBlock(block, this.props.tagRenderers),
             renderType: hasTypescriptData(docs)
                 ? type => linkify(type, docs.typescript, name => <ApiLink key={name} name={name} />)
                 : type => type,

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Classes } from "@blueprintjs/core";
+import classNames from "classnames";
 import * as React from "react";
 
 export interface IModifierTableProps {
@@ -16,7 +17,7 @@ export interface IModifierTableProps {
 }
 
 export const ModifierTable: React.SFC<IModifierTableProps> = ({ children, emptyMessage, title }) => (
-    <div className="docs-modifiers-table">
+    <div className={classNames("docs-modifiers-table", Classes.RUNNING_TEXT)}>
         <table className={Classes.HTML_TABLE}>
             <thead>
                 <tr>

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -18,7 +18,7 @@ export interface IPageProps {
 
 export const Page: React.SFC<IPageProps> = ({ tagRenderers, page }) => {
     // apply running text styles to blocks in pages (but not on blocks in examples)
-    const pageContents = renderBlock(page, tagRenderers, Classes.RUNNING_TEXT);
+    const pageContents = renderBlock(page, tagRenderers, Classes.TEXT_LARGE);
     return (
         <div className="docs-page" data-page-id={page.reference}>
             {pageContents}

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -73,7 +73,7 @@ $dark-example-background-color: $dark-content-background-color;
   justify-content: space-between;
 
   position: relative;
-  margin-top: $content-padding;
+  margin-top: $content-padding * 2;
 
   &:empty {
     display: none;

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -4,6 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+import { Classes } from "@blueprintjs/core";
 import { IKssPluginData, ITag } from "documentalist/dist/client";
 import * as React from "react";
 import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
@@ -25,9 +26,9 @@ export class CssExample extends React.PureComponent<ITag> {
         const examples = modifiers.map(modifier => (
             <tr key={modifier.name}>
                 <td data-modifier={modifier.name}>
-                    <code>{modifier.name}</code>
+                    <code className={Classes.CODE}>{modifier.name}</code>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: modifier.documentation }} />
+                <td className="docs-prop-description" dangerouslySetInnerHTML={{ __html: modifier.documentation }} />
             </tr>
         ));
         return (
@@ -37,7 +38,7 @@ export class CssExample extends React.PureComponent<ITag> {
                     {this.renderMarkupExample(markup)}
                     {modifiers.map(mod => this.renderMarkupExample(markup, mod.name))}
                 </div>
-                <div className="docs-markup" dangerouslySetInnerHTML={{ __html: markupHtml }} />
+                <div className={Classes.RUNNING_TEXT} dangerouslySetInnerHTML={{ __html: markupHtml }} />
             </div>
         );
     }
@@ -45,7 +46,7 @@ export class CssExample extends React.PureComponent<ITag> {
     private renderMarkupExample(markup: string, modifierName = "default") {
         return (
             <div className="docs-example" data-modifier={modifierName} key={modifierName}>
-                <code>{modifierName}</code>
+                <code className={Classes.CODE}>{modifierName}</code>
                 {this.renderMarkupForModifier(markup, modifierName)}
             </div>
         );

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -4,7 +4,8 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Icon } from "@blueprintjs/core";
+import { Classes, Icon } from "@blueprintjs/core";
+import classNames from "classnames";
 import { IHeadingTag } from "documentalist/dist/client";
 import * as React from "react";
 
@@ -12,7 +13,7 @@ export const Heading: React.SFC<IHeadingTag> = ({ level, route, value }) =>
     // use createElement so we can dynamically choose tag based on depth
     React.createElement(
         `h${level}`,
-        { className: "docs-title" },
+        { className: classNames(Classes.HEADING, "docs-title") },
         <a className="docs-anchor" data-route={route} key="anchor" />,
         <a className="docs-anchor-link" href={"#" + route} key="link">
             <Icon icon="link" />


### PR DESCRIPTION
#### Fixes #244 

#### Changes proposed in this pull request:

So we had global styles for a bunch of elements (conveniently all in `_typography.scss`). This PR refactors global styles for the checked items below so they're guarded by a class (typically `.pt-<tag>`).

- [x] `h1`-`h6` 
- [x] `blockquote`
- [x] `code`
- [x] `hr`
- [x] `ol`
- [x] `p`
- [x] `pre`
- [x] `ul`
- [ ] `html` - sets `box-sizing` on all elements
- [ ] `body` - sets default typography. removing this would require adding a class to the `<body>` element as part of basic Blueprint usage.
- [ ] `small` - adjusted to match default typography. other formatting tags like `<em>` and `<strong>` already work properly.
- [ ] `a` - i could be convinced to change this

### 🔥  Breaks

- clearly **all the global style removals** are API breaks, though if you're using `.pt-running-text` like you're supposed to then you may not notice.
- `.pt-ui-text-large` has been removed, replaced with `.pt-ui-text.pt-text-large`
- `.pt-running-text-large` has been removed, replaced with `.pt-running-text.pt-text-large`

### Other changes

- added `.pt-text-large` modifier that simply sets `$pt-font-size-large`. this can be combined with other `.pt-text-` classes (like ui-text and muted).
- added `Classes` constants for all new classes

### ❓ Questions

- [ ] `.pt-text-muted` and `.pt-ui-text` are inconsistent. how can we unify them? `.pt-text-ui` feels awkward...
- [ ] any remaining global styles that should be non-globalized?