### PR TITLE
[dev] Fix missing types from node_modules with at-loader on Windows

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -24,6 +24,7 @@
         "removeComments": false,
         "sourceMap": false,
         "stripInternal": true,
-        "target": "es5"
+        "target": "es5",
+        "typeRoots": ["../node_modules/@types"]
     }
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:
This PR fixes a bug that affects `at-loader` on Windows: typings from `node_modules` aren't loaded automatically as they are in other environments, resulting in many errors during compilation, primarily when running unit tests. For example, running `yarn test` in the `core` package produces 836 errors, because the namespace for Mocha isn't loaded:

```
ERROR in [at-loader] ./test/alert/alertTests.tsx:15:1
    TS2304: Cannot find name 'describe'.

ERROR in [at-loader] ./test/alert/alertTests.tsx:16:5
    TS2304: Cannot find name 'it'.

...
```
(Note that `tsc` still emits correct code, but the type-checking process fails).

The fix is to explicitly instruct `tsc` to look in `node_modules/@types` for type declarations, which is something it [should already be doing by default](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).
