### PR TITLE
[Popover] Improved focus event handling

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -249,6 +249,10 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     // now that mouseleave is triggered when you cross the gap between the two.
     private isMouseInTargetOrPopover = false;
 
+    // a flag that indicates whether the target previously lost focus to another
+    // element on the same page.
+    private lostFocusOnSamePage = true;
+
     private refHandlers = {
         popover: (ref: HTMLDivElement) => {
             this.popoverElement = ref;
@@ -501,6 +505,11 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
     private handleTargetFocus = (e?: React.FocusEvent<HTMLElement>) => {
         if (this.props.openOnTargetFocus && this.isHoverInteractionKind()) {
+            if (e.relatedTarget == null && !this.lostFocusOnSamePage) {
+                // ignore this focus event -- the target was already focused but the page itself
+                // lost focus (e.g. due to switching tabs).
+                return;
+            }
             this.handleMouseEnter(e);
         }
     };
@@ -510,9 +519,10 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
             // if the next element to receive focus is within the popover, we'll want to leave the
             // popover open.
             if (!this.isElementInPopover(e.relatedTarget as HTMLElement)) {
-                    this.handleMouseLeave(e);
-                }
+                this.handleMouseLeave(e);
+            }
         }
+        this.lostFocusOnSamePage = e.relatedTarget != null;
     };
 
     private handleMouseEnter = (e: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -499,22 +499,19 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         }
     };
 
-    private handleTargetFocus = (e?: React.FormEvent<HTMLElement>) => {
+    private handleTargetFocus = (e?: React.FocusEvent<HTMLElement>) => {
         if (this.props.openOnTargetFocus && this.isHoverInteractionKind()) {
             this.handleMouseEnter(e);
         }
     };
 
-    private handleTargetBlur = (e?: React.FormEvent<HTMLElement>) => {
+    private handleTargetBlur = (e?: React.FocusEvent<HTMLElement>) => {
         if (this.props.openOnTargetFocus && this.isHoverInteractionKind()) {
             // if the next element to receive focus is within the popover, we'll want to leave the
-            // popover open. we must do this check *after* the next element focuses, so we use a
-            // timeout of 0 to flush the rest of the event queue before proceeding.
-            this.setTimeout(() => {
-                if (!this.isElementInPopover(document.activeElement)) {
+            // popover open.
+            if (!this.isElementInPopover(e.relatedTarget as HTMLElement)) {
                     this.handleMouseLeave(e);
                 }
-            });
         }
     };
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -503,7 +503,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         }
     };
 
-    private handleTargetFocus = (e?: React.FocusEvent<HTMLElement>) => {
+    private handleTargetFocus = (e: React.FocusEvent<HTMLElement>) => {
         if (this.props.openOnTargetFocus && this.isHoverInteractionKind()) {
             if (e.relatedTarget == null && !this.lostFocusOnSamePage) {
                 // ignore this focus event -- the target was already focused but the page itself
@@ -514,7 +514,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         }
     };
 
-    private handleTargetBlur = (e?: React.FocusEvent<HTMLElement>) => {
+    private handleTargetBlur = (e: React.FocusEvent<HTMLElement>) => {
         if (this.props.openOnTargetFocus && this.isHoverInteractionKind()) {
             // if the next element to receive focus is within the popover, we'll want to leave the
             // popover open.


### PR DESCRIPTION
#### Fixes #2373

#### Changes proposed in this pull request:

This PR makes two changes to the way `Popover` handles focus events.

1. Use [`FocusEvent.relatedTarget`](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent)¹ instead of wrapping `document.activeElement` in a timeout to accomplish the same.
2. Check if the target gained focus when it was already previously focused but the *page itself* lost focus (e.g. due to tabbing out) -- in this case the popover won't open again.

___________

<sup>[1] MDN says this is "experimental technology", but it seems to be available in all browsers save for IE < 9.</sup>

