### PR TITLE
[docs] better flex layout for options

### DIFF
--- a/packages/core/src/docs/colors.md
+++ b/packages/core/src/docs/colors.md
@@ -10,6 +10,7 @@ the main UI frame: containers, headers, sections, boxes, etc.
 If you need to call attention to a particular element (buttons, icons, tooltips, etc.),
 use one of the [core colors](#colors.core-colors).
 
+@reactDocs BlackWhitePalette
 @reactDocs GrayscalePalette
 
 @## Core colors

--- a/packages/docs-app/src/components/colorPalettes.tsx
+++ b/packages/docs-app/src/components/colorPalettes.tsx
@@ -97,8 +97,10 @@ function createPaletteBook(palettes: string[][], className?: string): React.SFC<
     );
 }
 
+export const BlackWhitePalette = createPaletteBook([["black"], ["white"]]);
+
 export const GrayscalePalette = createPaletteBook(
-    [["black"], ["white"], expand("dark-gray"), expand("gray"), expand("light-gray")],
+    [expand("dark-gray"), expand("gray"), expand("light-gray")],
     "docs-color-book-grayscale",
 );
 

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -66,10 +66,8 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
                     label="Vertical"
                 />,
             ],
-            [
-                <IntentSelect key="intent" intent={this.state.intent} onChange={this.handleIntentChange} />,
-                <AlignmentSelect align={alignText} onChange={this.handleAlignChange} />,
-            ],
+            [<AlignmentSelect align={alignText} onChange={this.handleAlignChange} />],
+            [<IntentSelect key="intent" intent={this.state.intent} onChange={this.handleIntentChange} />],
         ];
     }
 

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -54,9 +54,9 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         return (
             <div className="docs-react-example-row">
                 <div className="docs-react-example-column">
-                    <code>Button</code>
-                    <br />
-                    <br />
+                    <p>
+                        <code>Button</code>
+                    </p>
                     <Button
                         className={this.state.wiggling ? "docs-wiggle" : ""}
                         icon="refresh"
@@ -67,9 +67,9 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                     </Button>
                 </div>
                 <div className="docs-react-example-column">
-                    <code>AnchorButton</code>
-                    <br />
-                    <br />
+                    <p>
+                        <code>AnchorButton</code>
+                    </p>
                     <AnchorButton
                         href="./#core/components/button.javascript-api"
                         icon="duplicate"

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -61,8 +61,8 @@ export class EditableTextExample extends BaseExample<IEditableTextExampleState> 
 
     protected renderOptions() {
         return [
+            [<IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />],
             [
-                <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
                 <div className={Classes.FORM_GROUP} key="maxlength">
                     <label className={Classes.LABEL} htmlFor={INPUT_ID}>
                         Max length

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -225,6 +225,7 @@ export class PopoverExample extends BaseExample<IPopoverExampleState> {
                     key="preventOverflow"
                     onChange={this.getModifierChangeHandler("preventOverflow")}
                 >
+                    <br />
                     <div className={Classes.SELECT} style={{ marginTop: 5 }}>
                         <select
                             disabled={!preventOverflow.enabled}

--- a/packages/docs-app/src/examples/core-examples/progressExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/progressExample.tsx
@@ -55,8 +55,8 @@ export class ProgressExample extends BaseExample<IProgressExampleState> {
                     showTrackFill={false}
                     value={this.state.value}
                 />,
-                <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleModifierChange} />,
             ],
+            [<IntentSelect intent={this.state.intent} key="intent" onChange={this.handleModifierChange} />],
         ];
     }
 

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -26,7 +26,7 @@ export class SpinnerExample extends ProgressExample {
 
     protected renderOptions() {
         const options = super.renderOptions();
-        options[0].push(
+        options.push([
             <label className={Classes.LABEL} key="size">
                 Size (via <code>className</code>)
                 <div className={Classes.SELECT}>
@@ -39,7 +39,7 @@ export class SpinnerExample extends ProgressExample {
                     </select>
                 </div>
             </label>,
-        );
+        ]);
         return options;
     }
 }

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -56,7 +56,6 @@ export class TagExample extends BaseExample<ITagExampleState> {
             [
                 <Switch key="large" label="Large" checked={large} onChange={this.handleLargeChange} />,
                 <Switch key="minimal" label="Minimal" checked={minimal} onChange={this.handleMinimalChange} />,
-                <Switch key="removable" label="Removable" checked={removable} onChange={this.handleRemovableChange} />,
                 <Switch
                     key="interactive"
                     label="Interactive"
@@ -65,7 +64,10 @@ export class TagExample extends BaseExample<ITagExampleState> {
                 />,
             ],
             [<IntentSelect key="intent" intent={intent} onChange={this.handleIntentChange} />],
-            [<Button key="reset" text="Reset tags" onClick={this.resetTags} />],
+            [
+                <Switch key="removable" label="Removable" checked={removable} onChange={this.handleRemovableChange} />,
+                <Button key="reset" text="Reset tags" onClick={this.resetTags} />,
+            ],
         ];
     }
 

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -119,6 +119,8 @@ export class ToastExample extends BaseExample<IToasterProps> {
                         </select>
                     </div>
                 </label>,
+            ],
+            [
                 <Switch
                     checked={this.state.autoFocus}
                     label="Auto focus"

--- a/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
@@ -34,7 +34,7 @@ export interface IPrecisionSelectProps {
 
 export const PrecisionSelect: React.SFC<IPrecisionSelectProps> = props => (
     <label className={Classes.LABEL}>
-        {props.label == null ? props.label : "Precision"}
+        {props.label || "Precision"}
         <div className={Classes.SELECT}>
             <select value={props.value} onChange={props.onChange}>
                 {props.allowEmpty ? <option value="-1">None</option> : undefined}

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -77,6 +77,9 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     key="Reverse month and year menus"
                     onChange={this.toggleReverseMonthAndYearMenus}
                 />,
+            ],
+            [<FormatSelect key="Format" format={this.state.format} onChange={this.handleFormatChange} />],
+            [
                 <PrecisionSelect
                     label="Time Precision"
                     key="precision"
@@ -85,7 +88,6 @@ export class DateInputExample extends BaseExample<IDateInputExampleState> {
                     onChange={this.toggleTimePrecision}
                 />,
             ],
-            [<FormatSelect key="Format" format={this.state.format} onChange={this.handleFormatChange} />],
         ];
     }
 

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -53,7 +53,6 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
     protected renderOptions() {
         return [
             [
-                <PrecisionSelect value={this.state.precision} onChange={this.handlePrecisionChange} key="precision" />,
                 <Switch
                     checked={this.state.selectAllOnFocus}
                     label="Select all on focus"
@@ -69,6 +68,7 @@ export class TimePickerExample extends BaseExample<ITimePickerExampleState> {
                 <Switch checked={this.state.disabled} label="Disabled" key="disabled" onChange={this.toggleDisabled} />,
                 <Switch checked={this.state.useAmPm} label="Use AM/PM" key="ampm" onChange={this.toggleUseAmPm} />,
             ],
+            [<PrecisionSelect value={this.state.precision} onChange={this.handlePrecisionChange} key="precision" />],
             [
                 <label key={0} className={Classes.LABEL}>
                     Minimum time

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -13,7 +13,7 @@ $swatch-hover-message: "Click to copy hex code";
 $swatch-copied-message: "#{$pt-icon-tick} Copied to clipboard";
 
 @function palette-width($columns) {
-  @return ($content-width - $content-padding * 2 - $palette-spacing * ($columns - 1)) / $columns;
+  @return (102% - 2% * $columns) / $columns;
 }
 
 .docs-clipboard {
@@ -115,7 +115,7 @@ label.docs-color-scheme-label { margin: ($pt-grid-size * 2) 0; }
   margin-bottom: $palette-spacing;
   cursor: pointer;
 
-  .docs-color-book-grayscale &:not(.docs-color-palette-single) {
+  .docs-color-book-grayscale & {
     flex-basis: palette-width(3);
   }
 

--- a/packages/docs-app/src/styles/_sections.scss
+++ b/packages/docs-app/src/styles/_sections.scss
@@ -257,13 +257,6 @@
   }
 }
 
-#{example("PopoverExample")} {
-  // wider lines for this example so labels wrap less
-  .pt-label {
-    width: $pt-grid-size * 21;
-  }
-}
-
 // give all Table examples a fixed height
 #{page("table")},
 #{page("features")} {

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -6,8 +6,7 @@
 .docs-react-example,
 .docs-react-example-row,
 .docs-react-options, {
-  display: flex;
-  flex-direction: row;
+  @include pt-flex-container(row, $pt-grid-size * 5);
 }
 
 .docs-react-options {
@@ -20,25 +19,8 @@
   }
 }
 
-.docs-react-example-column,
-.docs-react-options-column {
-  margin-right: $options-margin * 2;
-
-  &:last-child {
-    margin: 0;
-  }
-}
-
-.docs-react-options-column {
-  flex: 0 0 $options-width;
-
-  .pt-control:not(.pt-inline) {
-    margin-right: 0;
-  }
-}
-
-.docs-react-example-column {
-  flex: 0 0 auto;
+.docs-react-options-column .pt-control:not(.pt-inline) {
+  margin-right: 0;
 }
 
 .docs-inline-example {

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -172,7 +172,8 @@ Lefthand navigation menu
 .docs-examples-only {
   .docs-markup,
   .docs-modifiers,
-  .docs-section {
+  .docs-title,
+  .docs-section > .pt-running-text {
     display: none;
   }
 }


### PR DESCRIPTION
use `pt-flex-container()` mixin for example options. columns now take up as much space as needed, resulting in minimal line wrapping and more compact controls.