### PR TITLE
fix docs site on Firefox ESR

### DIFF
--- a/packages/docs-theme/src/components/scrollbar.ts
+++ b/packages/docs-theme/src/components/scrollbar.ts
@@ -12,8 +12,8 @@
 export function addScrollbarStyle() {
     const width = getScrollbarWidth();
     const stylesheet = createStyleSheet();
-    stylesheet.insertRule(`.pt-overlay-open .docs-root { padding-right: ${width}px }`);
-    stylesheet.insertRule(`.pt-overlay-open .docs-banner { padding-right: ${20 + width}px; }`);
+    stylesheet.insertRule(`.pt-overlay-open .docs-banner { padding-right: ${20 + width}px; }`, 0);
+    stylesheet.insertRule(`.pt-overlay-open .docs-root { padding-right: ${width}px }`, 0);
 }
 
 function createStyleSheet() {


### PR DESCRIPTION
#### Fixes #2380

Always provide `index` argument:
![image](https://user-images.githubusercontent.com/464822/38841094-91b0907e-4197-11e8-814b-1856de44a1cd.png)
https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule
