### PR TITLE
invoke Portal onChildrenMount _after_ children mount

### DIFF
--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -10,7 +10,6 @@ import * as ReactDOM from "react-dom";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { HTMLDivProps, IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
 
 export interface IPortalProps extends IProps, HTMLDivProps {
     /**

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -65,8 +65,7 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
     public componentDidMount() {
         this.portalElement = this.createContainerElement();
         document.body.appendChild(this.portalElement);
-        safeInvoke(this.props.onChildrenMount);
-        this.setState({ hasMounted: true });
+        this.setState({ hasMounted: true }, this.props.onChildrenMount);
     }
 
     public componentDidUpdate(prevProps: IPortalProps) {

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -65,4 +65,17 @@ describe("<Portal>", () => {
         const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);
         assert.isTrue(portalElement.classList.contains(Classes.PORTAL));
     });
+
+    it("children mount before onChildrenMount invoked", done => {
+        function spy() {
+            // can't use `portal` in here as `mount()` has not finished, so query DOM directly
+            assert.exists(document.querySelector("p"));
+            done();
+        }
+        portal = mount(
+            <Portal onChildrenMount={spy}>
+                <p>test</p>
+            </Portal>,
+        );
+    });
 });


### PR DESCRIPTION
#### Fixes #2351

#### Changes proposed in this pull request:

invoke `Portal` `onChildrenMount` _after_ children mount.

this was super easy to verify fixed with the added unit test! failed hard at first, now it'll be green.