### PR TITLE
MultiRangeSlider component

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -191,8 +191,12 @@ export const SKELETON = "pt-skeleton";
 export const SLIDER = "pt-slider";
 export const SLIDER_HANDLE = "pt-slider-handle";
 export const SLIDER_LABEL = "pt-slider-label";
+export const SLIDER_TRACK = "pt-slider-track";
 export const SLIDER_PROGRESS = "pt-slider-progress";
 export const RANGE_SLIDER = "pt-range-slider";
+export const MULTI_RANGE_SLIDER = "pt-multi-range-slider";
+export const LOWER = "pt-lower";
+export const UPPER = "pt-upper";
 
 export const SPINNER = "pt-spinner";
 export const SPINNER_HEAD = "pt-spinner-head";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -50,6 +50,7 @@ export * from "./text/text";
 export * from "./popover/popover";
 export * from "./portal/portal";
 export * from "./progress/progressBar";
+export * from "./slider/multiRangeSlider";
 export * from "./slider/rangeSlider";
 export * from "./slider/slider";
 export * from "./spinner/spinner";

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -37,11 +37,7 @@ $track-height: $track-size !default;
   }
 }
 
-.pt-slider-track,
-.pt-slider-progress {
-  @include slider-track-orientation($handle-size, $track-size, $vertical: false);
-  position: absolute;
-  border-radius: $pt-border-radius;
+.pt-slider-track:first-child {
   background: rgba($gray1, 0.2);
 
   .pt-dark & {
@@ -49,9 +45,40 @@ $track-height: $track-size !default;
   }
 }
 
+.pt-slider-track,
+.pt-slider-progress {
+  @include slider-track-orientation($handle-size, $track-size, $vertical: false);
+  position: absolute;
+  border-radius: $pt-border-radius;
+}
+
 .pt-slider-progress,
 .pt-dark .pt-slider-progress {
-  background: $pt-intent-primary;
+  &.pt-lower {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  &.pt-upper {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &.pt-intent-primary {
+    background: $pt-intent-primary;
+  }
+
+  &.pt-intent-success {
+    background: $pt-intent-success;
+  }
+
+  &.pt-intent-warning {
+    background: $pt-intent-warning;
+  }
+
+  &.pt-intent-danger {
+    background: $pt-intent-danger;
+  }
 }
 
 .pt-slider-handle {
@@ -126,6 +153,25 @@ $track-height: $track-size !default;
       box-shadow: none;
     }
   }
+
+  &.pt-lower, &.pt-upper {
+    width: $handle-size / 2;
+  }
+
+  &.pt-lower {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &.pt-upper {
+    margin-left: $handle-size / 2;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+
+    .pt-slider-label {
+      margin-left: 0;
+    }
+  }
 }
 
 .pt-slider-label {
@@ -136,31 +182,6 @@ $track-height: $track-size !default;
   vertical-align: top;
   line-height: 1;
   font-size: $pt-font-size-small;
-}
-
-.pt-range-slider {
-  .pt-slider-handle {
-    width: $handle-size / 2;
-
-    &:first-of-type {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-
-    &:last-of-type {
-      margin-left: $handle-size / 2;
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-
-      .pt-slider-label {
-        margin-left: 0;
-      }
-    }
-  }
-
-  .pt-slider-progress {
-    border-radius: 0;
-  }
 }
 
 .pt-slider.pt-vertical {
@@ -186,20 +207,14 @@ $track-height: $track-size !default;
       margin-top: -$handle-size / 2;
       margin-left: 0;
     }
-  }
-}
 
-.pt-range-slider.pt-vertical {
-  .pt-slider-handle {
-    margin-left: 0;
-    width: $handle-size;
-    height: $handle-size / 2;
-
-    .pt-slider-label {
+    &.pt-upper, &.pt-lower {
       margin-left: 0;
+      width: $handle-size;
+      height: $handle-size / 2;
     }
 
-    &:first-of-type {
+    &.pt-lower {
       border-top-left-radius: 0;
       border-bottom-right-radius: $pt-border-radius;
 
@@ -208,7 +223,7 @@ $track-height: $track-size !default;
       }
     }
 
-    &:last-of-type {
+    &.pt-upper {
       margin-bottom: $handle-size / 2;
       border-top-left-radius: $pt-border-radius;
       border-bottom-left-radius: 0;

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -154,7 +154,8 @@ $track-height: $track-size !default;
     }
   }
 
-  &.pt-lower, &.pt-upper {
+  &.pt-lower,
+  &.pt-upper {
     width: $handle-size / 2;
   }
 
@@ -208,7 +209,8 @@ $track-height: $track-size !default;
       margin-left: 0;
     }
 
-    &.pt-upper, &.pt-lower {
+    &.pt-upper,
+    &.pt-lower {
       margin-left: 0;
       width: $handle-size;
       height: $handle-size / 2;

--- a/packages/core/src/components/slider/coreSlider.tsx
+++ b/packages/core/src/components/slider/coreSlider.tsx
@@ -111,7 +111,7 @@ export abstract class CoreSlider<P extends ICoreSliderProps> extends AbstractPur
         );
         return (
             <div className={classes} onMouseDown={this.maybeHandleTrackClick} onTouchStart={this.maybeHandleTrackTouch}>
-                <div className={`${Classes.SLIDER}-track`} ref={this.refHandlers.track} />
+                <div className={Classes.SLIDER_TRACK} ref={this.refHandlers.track} />
                 {this.maybeRenderFill()}
                 {this.maybeRenderAxis()}
                 {this.renderHandles()}

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -48,7 +48,10 @@ export class Handle extends AbstractPureComponent<IHandleProps, IHandleState> {
 
     private handleElement: HTMLElement;
     private refHandlers = {
-        handle: (el: HTMLSpanElement) => (this.handleElement = el),
+        handle: (el: HTMLSpanElement) => {
+            this.handleElement = el;
+            this.forceUpdate();
+        },
     };
 
     public render() {

--- a/packages/core/src/components/slider/multiRangeSlider.tsx
+++ b/packages/core/src/components/slider/multiRangeSlider.tsx
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+
+import { Classes, Intent } from "../../common";
+import { intentClass } from "../../common/classes";
+import { isFunction } from "../../common/utils";
+import { CoreSlider, formatPercentage, ICoreSliderProps } from "./coreSlider";
+import { Handle } from "./handle";
+
+export type SliderHandleType = "full" | "lower" | "upper";
+
+export interface ISliderHandleProps {
+    value: number;
+    trackIntentAbove?: Intent;
+    trackIntentBelow?: Intent;
+    type?: SliderHandleType;
+}
+
+export interface IMultiRangeSliderProps extends ICoreSliderProps {
+    handles: ISliderHandleProps[];
+    defaultTrackIntent?: Intent;
+    onChange?(values: number[]): void;
+    onRelease?(values: number[]): void;
+}
+
+export class MultiRangeSlider extends CoreSlider<IMultiRangeSliderProps> {
+    public static defaultProps: IMultiRangeSliderProps = {
+        disabled: false,
+        handles: [],
+        labelStepSize: 1,
+        max: 10,
+        min: 0,
+        showTrackFill: true,
+        stepSize: 1,
+        vertical: false,
+    };
+
+    public static displayName = "Blueprint2.MultiRangeSlider";
+    public className = classNames(Classes.SLIDER, Classes.MULTI_RANGE_SLIDER);
+
+    private handles: Handle[] = [];
+
+    public componentWillReceiveProps(nextProps: IMultiRangeSliderProps & { children: React.ReactNode }) {
+        super.componentWillReceiveProps(nextProps);
+        if (nextProps.handles.length !== this.props.handles.length) {
+            this.handles = [];
+        }
+    }
+
+    protected renderFill() {
+        const minHandle: ISliderHandleProps = { value: this.props.min };
+        const maxHandle: ISliderHandleProps = { value: this.props.max };
+        const expandedHandles = [minHandle, ...this.getSortedHandles(), maxHandle];
+
+        const tracks: Array<JSX.Element | null> = [];
+
+        for (let index = 0; index < expandedHandles.length - 1; index++) {
+            const left = expandedHandles[index];
+            const right = expandedHandles[index + 1];
+            const fillIntentPriorities = [
+                left.trackIntentAbove,
+                right.trackIntentBelow,
+                this.props.defaultTrackIntent,
+                Intent.NONE,
+            ];
+            const fillIntent = fillIntentPriorities.filter(intent => intent != null)[0];
+            tracks.push(this.renderTrackFill(index, left, right, fillIntent));
+        }
+
+        return <div className={Classes.SLIDER_TRACK}>{tracks}</div>;
+    }
+
+    protected renderHandles() {
+        const { disabled, max, min, stepSize, vertical, onRelease } = this.props;
+        return this.getSortedHandles().map(({ value, type }, index) => (
+            <Handle
+                className={classNames({
+                    [Classes.LOWER]: type === "lower",
+                    [Classes.UPPER]: type === "upper",
+                })}
+                disabled={disabled}
+                key={`${index}-${this.props.handles.length}`}
+                label={this.formatLabel(value)}
+                max={max}
+                min={min}
+                onChange={this.getHandlerForIndex(index, this.handleChange)}
+                onRelease={this.getHandlerForIndex(index, onRelease)}
+                ref={this.addHandleRef}
+                stepSize={stepSize}
+                tickSize={this.state.tickSize}
+                tickSizeRatio={this.state.tickSizeRatio}
+                value={value}
+                vertical={vertical}
+            />
+        ));
+    }
+
+    protected handleTrackClick(event: React.MouseEvent<HTMLElement>) {
+        const foundHandle = this.nearestHandleForValue(this.handles, handle => handle.mouseEventClientOffset(event));
+        if (foundHandle) {
+            foundHandle.beginHandleMovement(event);
+        }
+    }
+
+    protected handleTrackTouch(event: React.TouchEvent<HTMLElement>) {
+        const foundHandle = this.nearestHandleForValue(this.handles, handle => handle.touchEventClientOffset(event));
+        if (foundHandle) {
+            foundHandle.beginHandleTouchMovement(event);
+        }
+    }
+
+    private renderTrackFill(index: number, left: ISliderHandleProps, right: ISliderHandleProps, intent: Intent) {
+        const { tickSizeRatio } = this.state;
+        const lowerValue = left.value;
+        const upperValue = right.value;
+
+        if (intent === Intent.NONE || lowerValue === upperValue) {
+            return undefined;
+        }
+
+        let lowerOffsetRatio = this.getOffsetRatio(lowerValue, tickSizeRatio);
+        let upperOffsetRatio = this.getOffsetRatio(upperValue, tickSizeRatio);
+
+        if (lowerOffsetRatio > upperOffsetRatio) {
+            const temp = upperOffsetRatio;
+            upperOffsetRatio = lowerOffsetRatio;
+            lowerOffsetRatio = temp;
+        }
+
+        const lowerOffset = formatPercentage(lowerOffsetRatio);
+        const upperOffset = formatPercentage(1 - upperOffsetRatio);
+
+        const style: React.CSSProperties = this.props.vertical
+            ? { bottom: lowerOffset, top: upperOffset, left: 0 }
+            : { left: lowerOffset, right: upperOffset, top: 0 };
+
+        const classes = classNames(Classes.SLIDER_PROGRESS, intentClass(intent), {
+            [Classes.LOWER]: left.type === "lower",
+            [Classes.UPPER]: right.type === "upper",
+        });
+
+        return <div key={`track-${index}`} className={classes} style={style} />;
+    }
+
+    private getOffsetRatio(value: number, tickSizeRatio: number) {
+        return (value - this.props.min) * tickSizeRatio;
+    }
+
+    private nearestHandleForValue(handles: Handle[], getOffset: (handle: Handle) => number): Handle | undefined {
+        return argMin(handles, handle => {
+            const offset = getOffset(handle);
+            const offsetValue = handle.clientToValue(offset);
+            const handleValue = handle.props.value!;
+            return Math.abs(offsetValue - handleValue);
+        });
+    }
+
+    private addHandleRef = (ref: Handle) => {
+        if (ref != null) {
+            this.handles.push(ref);
+        }
+    };
+
+    private getHandlerForIndex = (index: number, callback?: (values: number[]) => void) => {
+        return (newValue: number) => {
+            if (isFunction(callback)) {
+                const values = this.props.handles.map(handle => handle.value);
+                const start = values.slice(0, index);
+                const end = values.slice(index + 1);
+                const newValues = [...start, newValue, ...end];
+                newValues.sort();
+                callback(newValues);
+            }
+        };
+    };
+
+    private handleChange = (values: number[]) => {
+        const oldValues = this.getSortedHandles().map(handle => handle.value);
+        const newValues = values.slice().sort(compare);
+        if (!areValuesEqual(newValues, oldValues) && isFunction(this.props.onChange)) {
+            this.props.onChange(newValues);
+        }
+    };
+
+    private getSortedHandles(): ISliderHandleProps[] {
+        const handlesCopy = this.props.handles.slice();
+        return handlesCopy.sort((left, right) => compare(left.value, right.value));
+    }
+}
+
+function compare(left: number, right: number) {
+    if (left < right) {
+        return -1;
+    } else if (left > right) {
+        return 1;
+    }
+    return 0;
+}
+
+function areValuesEqual(left: number[], right: number[]) {
+    if (left.length !== right.length) {
+        return false;
+    }
+    for (let index = 0; index < left.length; index++) {
+        if (left[index] !== right[index]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function argMin<T>(values: T[], argFn: (value: T) => any): T | undefined {
+    if (values.length === 0) {
+        return undefined;
+    }
+
+    let minValue = values[0];
+    let minArg = argFn(minValue);
+
+    for (let index = 1; index < values.length; index++) {
+        const value = values[index];
+        const arg = argFn(value);
+        if (arg < minArg) {
+            minValue = value;
+            minArg = arg;
+        }
+    }
+
+    return minValue;
+}

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -80,6 +80,10 @@ export class RangeSlider extends CoreSlider<IRangeSliderProps> {
         const { disabled, max, min, onRelease, stepSize, value, vertical } = this.props;
         return value.map((val, index) => (
             <Handle
+                className={classNames({
+                    [Classes.LOWER]: index === RangeIndex.START,
+                    [Classes.UPPER]: index === RangeIndex.END,
+                })}
                 disabled={disabled}
                 key={index}
                 label={this.formatLabel(val)}


### PR DESCRIPTION
#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

---

#### Changes proposed in this pull request:

This adds a very general `MultiRangeSlider` component that ultimately should be able to subsume the `Slider` and `RangeSlider` components.

Notes about the component API:
- Instead of taking a value/values the component takes a list of handles specified by props. Each handle has:
 - `value` - where it gets placed on the slider
 - `type` - specifies how the slider handle should be displayed
   - `"full"` - handle appears like it does in a `Slider` (default)
   - `"lower"` - handle appears like the first slider in a `RangeSlider`
   - `"upper"` - handle appears like the second slider in a `RangeSlider`
 - `trackIntent{Above,Below}` specifies the color of the track fill above and below (numerically) of the given handle.

Handles are always displayed in ascending numeric order and the values that are returned by `onChange` and `onRelease` are always sorted.

In addition, `MultiRangeSlider` takes a `defaultTrackIntent` prop which is used in the resolution of how to render the color of the track between two given handles. The way that this is resolved is as follows (and is one of my concerns about the API).

- If the left handle has an above intent, use that
- If the right handle has a below intent, use that
- If the component has a default intent, use that
- Otherwise don't color that section

**Important:** Note that there is a difference between the `NONE` intent and the absence of an intent entirely. The former will render a gray track between the two handles and the latter will fall-through to the next color in the hierarchy above.

I previously allowed the specification of colors instead of intents but that didn't seem very blueprint-y.

---

#### Reviewers should focus on:

I have explicitly **not** written tests/docs for this yet, as I would first like to iterate on the API as I'm not convinced what I've written is particularly nice (worked for our use case but don't know if it generalizes well). Once we've iterated and nailed down an API I will gladly write tests and docs for this component.

I've written some questions in the code, but one additional question I have is should this component live in `labs` first to incubate before moving into `core`?

---

#### Not addressed in this PR (requires follow-up):

To keep this PR simple(r) and easy(er) to review, I have not made many changes to the existing slider components but in 1-2 follow up PRs I would like to:

1. Refactor `Slider` and `RangeSlider` to be simple wrappers around `MultiRangeSlider`
2. Remove `CoreSlider` and refactor into `MultiRangeSlider`

The second one is questionable, especially if there are plans to add a slider that does not fit into the multi range slider model.

---

#### Screenshots

Two tailed slider:

![screen shot 2018-04-19 at 10 43 24 am](https://user-images.githubusercontent.com/993321/39000287-9e078b26-43c1-11e8-85c6-96e59d1fb92e.png)

Disabled:

![screen shot 2018-04-19 at 11 09 44 am](https://user-images.githubusercontent.com/993321/39000519-3b62b3c8-43c2-11e8-8e72-7547d5091e40.png)

One tailed:

![screen shot 2018-04-19 at 11 10 39 am](https://user-images.githubusercontent.com/993321/39000675-95658c1a-43c2-11e8-9b40-3ae00692dc0b.png)

Weird:

![screen shot 2018-04-19 at 11 12 27 am](https://user-images.githubusercontent.com/993321/39000684-9aeaa030-43c2-11e8-8205-f2ce51258d93.png)

Vertical:

![screen shot 2018-04-19 at 11 14 13 am](https://user-images.githubusercontent.com/993321/39000784-d548f65a-43c2-11e8-9a2a-a5ab891a71dc.png)

In action:

![mulit-range-slider](https://user-images.githubusercontent.com/993321/39000291-a34d7cf8-43c1-11e8-8e2b-7feaf81f3413.gif)

