### PR TITLE
Prepare release v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprintjs-monorepo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "workspaces": [

--- a/packages/core/src/components/card/card.md
+++ b/packages/core/src/components/card/card.md
@@ -4,19 +4,19 @@ A card is a bounded unit of UI content with a solid background color.
 
 @## CSS API
 
-Start with `.@ns-card` and add an elevation modifier class to apply a drop shadow that simulates
-height in the UI.
+Start with `.@ns-card` and add an elevation modifier class to apply a drop
+shadow that simulates height in the UI.
 
-You can also use the `.@ns-elevation-*` classes by themselves to apply shadows to any arbitrary
-element.
+You can also use the `.@ns-elevation-*` classes by themselves to apply shadows
+to any arbitrary element.
 
 @css card
 
 @### Interactive cards
 
-Add the `.@ns-interactive` modifier class to make a `.@ns-card` respond to user interactions. When you
-hover over cards with this class applied, the mouse changes to a pointer and the elevation shadow on
-the card increases to the maximum level.
+Add the `.@ns-interactive` modifier class to make a `.@ns-card` respond to user
+interactions. When you hover over cards with this class applied, the mouse
+changes to a pointer and increases the elevation shadow on the card.
 
 Users expect an interactive card to be a single clickable unit.
 

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -21,7 +21,7 @@ export interface ICardProps extends IProps, HTMLDivProps {
 
     /**
      * Whether the card should respond to user interactions. If set to `true`,
-     * hovering over the card will increase the card's elevation to the maximum
+     * hovering over the card will increase the card's elevation
      * and change the mouse cursor to a pointer.
      *
      * Recommended when `onClick` is also defined.


### PR DESCRIPTION
🎆 **Highlights:** customize CSS namespace, percentage-based `Slider`, Blueprint TSLint rules!

### General

- ⭐️ #2325 Support for customizing the CSS class namespace `pt-`
    - in the upcoming 3.0 release, we will change this namespace to `bp3-` to avoid style conflicts with previous versions of Blueprint on the same page
    - added a new docs page about [Classes]() to encourage use of the forward-compatible `Classes` constants
- #2328 Fix Webpack externals so `*.bundle.js` files are as light as possible
- #2367 Fix TypeScript bundling with `at-loader` on Windows (🎩 @reiv 

### `@blueprintjs/core 2.2.0`

- ⭐️ #2341 `Slider` now uses percentages instead of pixels for layout, resulting in effortless resizes! (🎩 @reiv)
![2018-03-30_18-58-56](https://user-images.githubusercontent.com/205631/38147557-28436324-3453-11e8-98d9-5c2ce10b69b8.gif)
- 📦 #2362 Upgrade to Normalize.css 8.0.0 to fix `font-family` issues on some components (🎩 @reiv)
- #2399 Added `Overlay` `didClose` and `Popover` `popoverDidClose` lifecycle props!
    - now possible with `react-transition-group` `onExited` method (did not exist in 1.0)
- #2131  `ContextMenu` now re-creates its DOM element when it closes, allowing it to be used in other overlays like `Dialog`
- #2344 `InputGroup` now supports `.pt-fill` modifier (🎩 @qcz)
- #1861 `InputGroup` now has default right padding when `rightElement` is omitted
- #2382 `Popover` improved focus event handling, particularly when switching tabs (🎩 @reiv)
- #2400 Fix `Callout` icon positioning
- #2377 Fix `Checkbox` `onChange` 😨 (🎩 @js-um)
- #803 Fix `ContextMenu` so it will remain inside the viewport
- #1188 Fix `Overlay` outside click logic when `hasBackdrop=false`
- #2401 Fix `Portal` `onChildrenMount` so it is invoked _after_ children mount
- #2365 Fix large `TagInput` tag-remove button size
- #2409 File input Sass variables now have `!default`

### `@blueprintjs/table 2.1.0`

- #2390 Fix hot reload support (🎩 @dan-katz)
- #2118 Fix scroll syncing when widths/heights change (🎩  @mcintyret)

### `@blueprintjs/tslint-config 1.2.0`

- ⭐️ #2394 Add a new lint rule `blueprint-classes-constants` to enforce use of `Classes.*` constants instead of `"pt-prefixed-strings"`. This rule is enabled by default.
  - Also added `blueprint-icon-components` rule to enforce JSX component _or_ string literal usage for `icon` props. This rule is disabled by default and has little practical purpose until we ship individual components for the icons #2193 
- removed `file-header` configuration as it mentioned Palantir

### Documentation

- #2385 Example options flex responsively
- #2396 Fix site on older browsers