### PR TITLE
docs regressions

### DIFF
--- a/packages/core/src/components/forms/select-forms.md
+++ b/packages/core/src/components/forms/select-forms.md
@@ -1,11 +1,12 @@
 @# Selects
 
-Styling `<select>` tags requires a wrapper element to customize the dropdown caret. Put class
-modifiers on the wrapper and attribute modifiers directly on the `<select>`.
+Styling HTML `<select>` tags requires a wrapper element to customize the dropdown caret.
+Put class modifiers on the wrapper and attribute modifiers directly on the `<select>`.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    Check out [dropdown menus](#core/components/menu.dropdown-menus) for a simple JavaScript
-    alternative to the `<select>` tag.
+<div class="@ns-callout @ns-intent-success @ns-icon-info-sign">
+    The [`Select`](#select/multi-select) component in the [**@blueprintjs/select**](#select) package provides a
+    React [dropdown menu](#core/components/menu.dropdown-menus) instead of using the native HTML `<select>`
+    tag. It supports filtering and custom item rendering.
 </div>
 
 @css select

--- a/packages/core/src/components/tag-input/tag-input.md
+++ b/packages/core/src/components/tag-input/tag-input.md
@@ -2,12 +2,6 @@
 
 Tag inputs render [`Tag`](#core/components/tag)s inside an input, followed by an actual text input. The container is merely styled to look like a Blueprint input; the actual editable element appears after the last tag. Clicking anywhere on the container will focus the text input for seamless interaction.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-callout-title">Disabling a tag input</h4>
-    <p>Disabling this component requires setting the `disabled` prop to `true` and separately disabling the component's `rightElement` as appropriate (because `TagInput` accepts any `JSX.Element` as its `rightElement`).</p>
-    <p>In the example below, when you slide the `Disabled` toggle switch on, the result becomes `<TagInput ... disabled={true} rightElement={<Button ... disabled={true} />} />`</p>
-</div>
-
 @reactExample TagInputExample
 
 **`TagInput` must be controlled,** meaning the `values` prop is required and event handlers are strongly suggested. Typing in the input and pressing <kbd class="@ns-key">enter</kbd> will **add new items** by invoking callbacks. If `addOnBlur` is set to true, clicking out of the component will also trigger the callback to add new items. A `separator` prop is supported to allow multiple items to be added at once; the default splits on commas.
@@ -20,9 +14,20 @@ Tag inputs render [`Tag`](#core/components/tag)s inside an input, followed by an
 
 The `<input>` element can be controlled directly via the `inputValue` and `onInputChange` props. Additional properties (such as custom event handlers) can be applied to the input via `inputProps`.
 
+<div class="@ns-callout @ns-intent-success @ns-icon-info-sign">
+    <h4 class="@ns-callout-title">Looking for a dropdown menu?</h4>
+    [`MultiSelect`](#select/multi-select) from the **@blueprintjs/select** package composes this component with a dropdopwn menu of suggestions.
+</div>
+
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-callout-title">Handling long words</h4>
     Set an explicit `width` on `.@ns-tag-input` to cause long words to wrap onto multiple lines. Either supply a specific pixel value, or use `<TagInput className="@ns-fill">` to fill its container's width (try this in the example above).
+</div>
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    <h4 class="@ns-callout-title">Disabling a tag input</h4>
+    <p>Disabling this component requires setting the `disabled` prop to `true` and separately disabling the component's `rightElement` as appropriate (because `TagInput` accepts any `JSX.Element` as its `rightElement`).</p>
+    <p>In the example below, when you slide the `Disabled` toggle switch on, the result becomes `<TagInput ... disabled={true} rightElement={<Button ... disabled={true} />} />`</p>
 </div>
 
 @interface ITagInputProps

--- a/packages/core/src/components/text/text.md
+++ b/packages/core/src/components/text/text.md
@@ -3,6 +3,8 @@
 The `Text` component adds accessible overflow behavior to a line of text by
 conditionally adding the title attribute and truncating with an ellipsis when content overflows its container.
 
+@reactExample TextExample
+
 @## JavaScript API
 
 The `Text` component is available in the __@blueprintjs/core__ package.
@@ -11,5 +13,3 @@ Make sure to review the [getting started docs for installation info](#blueprint/
 `Text` accepts and renders arbitrary children. It is intended that these children render as text.
 
 @interface ITextProps
-
-@reactExample TextExample

--- a/packages/core/src/components/tree/tree.md
+++ b/packages/core/src/components/tree/tree.md
@@ -2,6 +2,8 @@
 
 Trees display hierarchical data.
 
+@reactExample TreeExample
+
 @## CSS API
 
 See below for the [JavaScript API](#core/components/tree.javascript-api) for the `Tree` React component. However, you
@@ -28,8 +30,6 @@ parameter `nodePath`, which is an array of numbers representing a node's positio
 example, `[2, 0]` represents the first child (`0`) of the third top-level node (`2`).
 
 @interface ITreeProps
-
-@reactExample TreeExample
 
 @### Instance methods
 

--- a/packages/docs-app/src/components/colorPalettes.tsx
+++ b/packages/docs-app/src/components/colorPalettes.tsx
@@ -48,8 +48,8 @@ const ColorSwatch: React.SFC<{ colorName: string; hexCode: string }> = ({ colorN
     };
     return (
         <ClickToCopy className="docs-color-swatch" style={style} value={hexCode}>
-            <div className="docs-color-swatch-trigger docs-clipboard-message" data-message={hexCode}>
-                <span>@{colorName}</span>
+            <div className="docs-color-swatch-trigger docs-clipboard-message" data-message={`@${colorName}`}>
+                <span>{hexCode}</span>
             </div>
         </ClickToCopy>
     );

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -76,7 +76,7 @@ export class ButtonGroupExample extends BaseExample<IButtonGroupExampleState> {
                     onChange={this.handleIconOnlyChange}
                 />,
             ],
-            [<AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />],
+            [<AlignmentSelect key="align" align={this.state.alignText} onChange={this.handleAlignChange} />],
         ];
     }
 

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -66,7 +66,7 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
                     label="Vertical"
                 />,
             ],
-            [<AlignmentSelect align={alignText} onChange={this.handleAlignChange} />],
+            [<AlignmentSelect key="align" align={alignText} onChange={this.handleAlignChange} />],
             [<IntentSelect key="intent" intent={this.state.intent} onChange={this.handleIntentChange} />],
         ];
     }

--- a/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
@@ -12,7 +12,7 @@ import { DateTimePicker, TimePickerPrecision } from "@blueprintjs/datetime";
 import { MomentDate } from "./common/momentDate";
 
 export class DateTimePickerExample extends BaseExample<{ date: Date }> {
-    public state = { date: null as Date };
+    public state = { date: new Date() };
 
     protected renderExample() {
         const timeProps = { precision: TimePickerPrecision.SECOND };
@@ -20,6 +20,7 @@ export class DateTimePickerExample extends BaseExample<{ date: Date }> {
             <div className="docs-datetime-example">
                 <DateTimePicker
                     className={Classes.ELEVATION_1}
+                    value={this.state.date}
                     timePickerProps={timeProps}
                     onChange={this.handleDateChange}
                 />

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -52,7 +52,10 @@ export class MultiSelectExample extends BaseExample<IMultiSelectExampleState> {
 
         const initialContent = this.state.hasInitialContent ? (
             <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} />
-        ) : null;
+        ) : (
+            // explicit undefined (not null) for default behavior (show full list)
+            undefined
+        );
 
         const clearButton = films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : null;
 

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -144,6 +144,7 @@ label.docs-color-scheme-label { margin: ($pt-grid-size * 2) 0; }
   border-top-width: 0;
   border-bottom-width: 0;
   height: $swatch-height;
+  font-family: $pt-font-family-monospace;
 
   &:first-child {
     border-top-width: 1px;
@@ -202,6 +203,9 @@ label.docs-color-scheme-label { margin: ($pt-grid-size * 2) 0; }
   white-space: nowrap;
   font-size: $pt-font-size-small;
   transition: all $pt-transition-duration $pt-transition-ease;
+
+  // ClickToCopy uses ::after element for variable name so we re-order in flexbox
+  span { order: 1; }
 }
 
 .docs-color-bar-swatches {

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -100,7 +100,6 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         const defaultInputProps: HTMLInputProps = {
             placeholder: "Search...",
             ...tagInputProps.inputProps,
-            // tslint:disable-next-line:object-literal-sort-keys
             onChange: this.handleQueryChange,
             value: query,
         };


### PR DESCRIPTION
#### Changes proposed in this pull request:

- 🌟  docs Color Palettes replace variable name with 'click to copy' text 
![image](https://user-images.githubusercontent.com/464822/39074166-2f90035a-44a5-11e8-8b45-e90848ea5ce5.png)
- move Text and Tree examples to top
- HTML Selects and Tag Inputs link to select package
- fix some missing keys
- `DateTimePicker` example is controlled so it shows initial date
- fix `MultiSelectExample` initial content
