### PR TITLE
#2422 Add value parameter to onEdit callback

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -85,7 +85,7 @@ export interface IEditableTextProps extends IIntentProps, IProps {
     onConfirm?(value: string): void;
 
     /** Callback invoked after the user enters edit mode. */
-    onEdit?(): void;
+    onEdit?(value: string): void;
 }
 
 export interface IEditableTextState {
@@ -196,7 +196,7 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
 
     public componentDidUpdate(_: IEditableTextProps, prevState: IEditableTextState) {
         if (this.state.isEditing && !prevState.isEditing) {
-            safeInvoke(this.props.onEdit);
+            safeInvoke(this.props.onEdit, prevState.value);
         }
         this.updateInputDimensions();
     }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -196,7 +196,7 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
 
     public componentDidUpdate(_: IEditableTextProps, prevState: IEditableTextState) {
         if (this.state.isEditing && !prevState.isEditing) {
-            safeInvoke(this.props.onEdit, prevState.value);
+            safeInvoke(this.props.onEdit, this.state.value);
         }
         this.updateInputDimensions();
     }

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -136,12 +136,16 @@ describe("<EditableText>", () => {
             assert.isTrue(confirmSpy.calledWith(OLD_VALUE), `unexpected argument "${confirmSpy.args[0][0]}"`);
         });
 
-        it("calls onEdit when entering edit mode", () => {
+        it("calls onEdit when entering edit mode and passes the initial value to the callback", () => {
             const editSpy = spy();
-            mount(<EditableText onEdit={editSpy} />)
+            
+            const INIT_VALUE = "hello";
+            
+            mount(<EditableText onEdit={editSpy} defaultValue={INIT_VALUE} />)
                 .find("div")
                 .simulate("focus");
             assert.isTrue(editSpy.calledOnce, "onEdit called once");
+            assert.isTrue(editSpy.calledWith(INIT_VALUE), `unexpected argument "${editSpy.args[0][0]}"`);
         });
 
         it("stops editing when disabled", () => {

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -139,7 +139,6 @@ describe("<EditableText>", () => {
         it("calls onEdit when entering edit mode and passes the initial value to the callback", () => {
             const editSpy = spy();
             const INIT_VALUE = "hello";
-            
             mount(<EditableText onEdit={editSpy} defaultValue={INIT_VALUE} />)
                 .find("div")
                 .simulate("focus");

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -138,7 +138,6 @@ describe("<EditableText>", () => {
 
         it("calls onEdit when entering edit mode and passes the initial value to the callback", () => {
             const editSpy = spy();
-            
             const INIT_VALUE = "hello";
             
             mount(<EditableText onEdit={editSpy} defaultValue={INIT_VALUE} />)


### PR DESCRIPTION
#### Fixes #2422 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] Add value parameter to onEdit callback
- [x] Include tests

#### Changes proposed in this pull request:

Make the `onEdit` event pass the initial value of Editable text component before it gets modified.

#### Reviewers should focus on:

I've made the changes that I see they will implement the needed feature in #2422, so I'm not sure if there're other changes that need to be made.
