### PR TITLE
change CSS namespace to `bp3`

### DIFF
--- a/packages/core/src/_reset.scss
+++ b/packages/core/src/_reset.scss
@@ -1,0 +1,31 @@
+// Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the terms of the LICENSE file distributed with this project.
+
+@import "common/variables";
+@import "common/mixins";
+
+// Style resets on top of Normalize.css
+
+
+body {
+  @include base-typography();
+  color: $pt-text-color;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: $pt-grid-size;
+}
+
+small {
+  font-size: $pt-font-size-small;
+}
+
+strong {
+  font-weight: 600;
+}
+
+// consistent cross-browser text selection
+::selection {
+  background: $pt-text-selection-color;
+}

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -7,30 +7,16 @@
 @import "common/mixins";
 @import "~@blueprintjs/icons/src/icons";
 
-// consistent cross-browser text selection
-::selection {
-  background: $pt-text-selection-color;
-}
-
-body {
-  @include base-typography();
-  color: $pt-text-color;
-}
-
-small {
-  font-size: $pt-font-size-small;
-}
-
 /*
 Headings
 
 Markup:
-<h1 class="pt-heading">H1 heading</h1>
-<h2 class="pt-heading">H2 heading</h2>
-<h3 class="pt-heading">H3 heading</h3>
-<h4 class="pt-heading">H4 heading</h4>
-<h5 class="pt-heading">H5 heading</h5>
-<h6 class="pt-heading">H6 heading</h6>
+<h1 class="@ns-heading">H1 heading</h1>
+<h2 class="@ns-heading">H2 heading</h2>
+<h3 class="@ns-heading">H3 heading</h3>
+<h4 class="@ns-heading">H4 heading</h4>
+<h5 class="@ns-heading">H5 heading</h5>
+<h6 class="@ns-heading">H6 heading</h6>
 
 Styleguide headings
 */

--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -10,6 +10,7 @@ Licensed under the terms of the LICENSE file distributed with this project.
 @import "common/variables";
 @import "common/colors";
 
+@import "reset";
 @import "typography";
 @import "accessibility";
 

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -5,7 +5,7 @@
 @import "mixins";
 
 // Namespace appended to the beginning of each CSS class: `.#{$ns}-button`.
-$ns: "pt" !default;
+$ns: "bp3" !default;
 
 // easily the most important variable, so it comes up top
 // (so other variables can use it to define themselves)

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -8,7 +8,7 @@ import { Elevation } from "../components/card/card";
 import { Alignment } from "./alignment";
 import { Intent } from "./intent";
 
-const NS = process.env.BLUEPRINT_NAMESPACE || "pt";
+const NS = process.env.BLUEPRINT_NAMESPACE || "bp3";
 
 // modifiers
 export const ACTIVE = `${NS}-active`;

--- a/packages/icons/src/_icons.scss
+++ b/packages/icons/src/_icons.scss
@@ -4,8 +4,7 @@
 @import "generated/icon-variables";
 @import "generated/icon-map";
 
-$pt-namespace: "pt" !default;
-$ns: $pt-namespace;
+$ns: "bp3" !default;
 
 $icon-classes: (
   ".#{$ns}-icon",


### PR DESCRIPTION
changing the CSS namespace prevents conflicts between Blueprint 1.x and 3.x elements.

add `_reset.scss` file for limited global resets: `body`, `p`, `strong`, `small`

TODO

- [x] remove top margin on `<p>` tags
- [x] fix `<h4>` tags in `Callout`, `Dialog`, `NIS` #2443, #2445 
- [x] standardize `<strong>` font weight to 600 (medium)