### PR TITLE
refactor NonIdealState: fewer classes, simple styles

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -152,10 +152,6 @@ export const NAVBAR_HEADING = `${NAVBAR}-heading`;
 export const NAVBAR_DIVIDER = `${NAVBAR}-divider`;
 
 export const NON_IDEAL_STATE = `${NS}-non-ideal-state`;
-export const NON_IDEAL_STATE_ACTION = `${NON_IDEAL_STATE}-action`;
-export const NON_IDEAL_STATE_DESCRIPTION = `${NON_IDEAL_STATE}-description`;
-export const NON_IDEAL_STATE_ICON = `${NON_IDEAL_STATE}-icon`;
-export const NON_IDEAL_STATE_TITLE = `${NON_IDEAL_STATE}-title`;
 export const NON_IDEAL_STATE_VISUAL = `${NON_IDEAL_STATE}-visual`;
 
 export const NUMERIC_INPUT = `${NS}-numeric-input`;

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -25,6 +25,22 @@ export function isFunction(value: any): value is Function {
 }
 
 /**
+ * Converts a React child to an element: non-empty strings or numbers are wrapped in `<span>`;
+ * empty strings are discarded.
+ */
+export function ensureElement(child: React.ReactChild | undefined, tagName: keyof JSX.IntrinsicElements = "span") {
+    // wrap text in a <span> so children are always elements
+    if (typeof child === "string") {
+        // cull whitespace strings
+        return child.trim().length > 0 ? React.createElement(tagName, {}, child) : undefined;
+    } else if (typeof child === "number") {
+        return React.createElement(tagName, {}, child);
+    } else {
+        return child;
+    }
+}
+
+/**
  * Represents anything that has a `name` property such as Functions.
  */
 export interface INamed {

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -27,6 +27,7 @@ Styleguide non-ideal-state
   width: 100%;
   max-width: $pt-grid-size * 40;
   height: 100%;
+  text-align: center;
 }
 
 .#{$ns}-non-ideal-state-visual {

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -9,21 +9,18 @@ Non-ideal state
 
 Markup:
 <div class="#{$ns}-non-ideal-state">
-  <div class="#{$ns}-non-ideal-state-visual #{$ns}-non-ideal-state-icon">
+  <div class="#{$ns}-non-ideal-state-visual">
     <span class="#{$ns}-icon #{$ns}-icon-folder-open"></span>
   </div>
-  <h4 class="#{$ns}-non-ideal-state-title">This folder is empty</h4>
-  <div class="#{$ns}-non-ideal-state-description">
-    Create a new file to populate the folder.
-  </div>
+  <h4 class="#{$ns}-heading">This folder is empty</h4>
+  <div>Create a new file to populate the folder.</div>
 </div>
 
 Styleguide non-ideal-state
 */
 
 .#{$ns}-non-ideal-state {
-  display: flex;
-  flex-direction: column;
+  @include pt-flex-container(column, $pt-grid-size * 2);
   align-items: center;
   justify-content: center;
   margin: 0 auto;
@@ -32,21 +29,11 @@ Styleguide non-ideal-state
   height: 100%;
 }
 
-.#{$ns}-non-ideal-state > :not(:last-child) {
-  margin-bottom: $pt-grid-size * 2;
-}
-
-.#{$ns}-non-ideal-state-icon .#{$ns}-icon {
+.#{$ns}-non-ideal-state-visual {
   color: $pt-icon-color-disabled;
   font-size: $pt-icon-size-large * 3;
 
   .#{$ns}-dark & {
     color: $pt-dark-icon-color-disabled;
   }
-}
-
-.#{$ns}-non-ideal-state-title,
-.#{$ns}-non-ideal-state-description {
-  max-width: 100%; // for Internet Explorer (https://github.com/palantir/blueprint/issues/1193)
-  text-align: center;
 }

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -9,63 +9,56 @@ import * as React from "react";
 
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
+import { ensureElement } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 
 export interface INonIdealStateProps extends IProps {
-    /** An action to resolve the non-ideal state which appears last (after `description`). */
+    /** An action to resolve the non-ideal state which appears after `description`. */
     action?: JSX.Element;
 
-    /** React children will appear immediately after `description` in the same container. */
+    /**
+     * Advanced usage: React `children` will appear last (after `action`).
+     * Avoid passing raw strings as they will not receive margins and disrupt the layout flow.
+     */
     children?: React.ReactNode;
 
-    /** A longer description of the non-ideal state. */
-    description?: React.ReactNode;
+    /**
+     * A longer description of the non-ideal state.
+     * A string or number value will be wrapped in a `<div>` to preserve margins.
+     */
+    description?: React.ReactChild;
+
+    /** The name of a Blueprint icon or a JSX Element (such as `<Spinner/>`) to render above the title. */
+    icon?: IconName | JSX.Element;
 
     /** The title of the non-ideal state. */
     title?: React.ReactNode;
-
-    /** The name of a Blueprint icon or a JSX Element (such as `<Spinner/>`) to render above the title. */
-    visual?: IconName | JSX.Element;
 }
 
 export class NonIdealState extends React.PureComponent<INonIdealStateProps, {}> {
     public render() {
-        const { action, className, title } = this.props;
+        const { action, children, className, description, title } = this.props;
         return (
             <div className={classNames(Classes.NON_IDEAL_STATE, className)}>
                 {this.maybeRenderVisual()}
-                {title && <h4 className={Classes.NON_IDEAL_STATE_TITLE}>{title}</h4>}
-                {this.maybeRenderDescription()}
-                {action && <div className={Classes.NON_IDEAL_STATE_ACTION}>{action}</div>}
-            </div>
-        );
-    }
-
-    private maybeRenderDescription() {
-        const { children, description } = this.props;
-        if (children == null && description == null) {
-            return null;
-        }
-        return (
-            <div className={Classes.NON_IDEAL_STATE_DESCRIPTION}>
-                {description}
+                {title && <h4 className={Classes.HEADING}>{title}</h4>}
+                {description && ensureElement(description, "div")}
+                {action}
                 {children}
             </div>
         );
     }
 
     private maybeRenderVisual() {
-        const { visual } = this.props;
-        if (visual == null) {
+        const { icon } = this.props;
+        if (icon == null) {
             return null;
-        } else if (typeof visual === "string") {
+        } else {
             return (
-                <div className={classNames(Classes.NON_IDEAL_STATE_VISUAL, Classes.NON_IDEAL_STATE_ICON)}>
-                    <Icon icon={visual} iconSize={Icon.SIZE_LARGE * 3} />
+                <div className={Classes.NON_IDEAL_STATE_VISUAL}>
+                    <Icon icon={icon} iconSize={Icon.SIZE_LARGE * 3} />
                 </div>
             );
-        } else {
-            return <div className={Classes.NON_IDEAL_STATE_VISUAL}>{visual}</div>;
         }
     }
 }

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -15,7 +15,6 @@ import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
 import { HTMLDivProps, IProps } from "../../common/props";
 import * as Utils from "../../common/utils";
-import { ensureElement } from '../../common/utils';
 import { IOverlayableProps, Overlay } from "../overlay/overlay";
 import { Tooltip } from "../tooltip/tooltip";
 import { getArrowAngle, PopoverArrow } from "./arrow";
@@ -488,8 +487,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         // #validateProps asserts that 1 <= children.length <= 2 so content is optional
         const [targetChild, contentChild] = React.Children.toArray(children);
         return {
-            content: ensureElement(contentChild == null ? contentProp : contentChild),
-            target: ensureElement(targetChild == null ? targetProp : targetChild),
+            content: Utils.ensureElement(contentChild == null ? contentProp : contentChild),
+            target: Utils.ensureElement(targetChild == null ? targetProp : targetChild),
         };
     }
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -15,6 +15,7 @@ import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
 import { HTMLDivProps, IProps } from "../../common/props";
 import * as Utils from "../../common/utils";
+import { ensureElement } from '../../common/utils';
 import { IOverlayableProps, Overlay } from "../overlay/overlay";
 import { Tooltip } from "../tooltip/tooltip";
 import { getArrowAngle, PopoverArrow } from "./arrow";
@@ -632,20 +633,4 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         });
         return data;
     };
-}
-
-/**
- * Converts a react child to an element: non-empty strings or numbers are wrapped in `<span>`;
- * empty strings are discarded.
- */
-function ensureElement(child: React.ReactChild | undefined) {
-    // wrap text in a <span> so children are always elements
-    if (typeof child === "string") {
-        // cull whitespace strings
-        return child.trim().length > 0 ? <span>{child}</span> : undefined;
-    } else if (typeof child === "number") {
-        return <span>{child}</span>;
-    } else {
-        return child;
-    }
 }

--- a/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
+++ b/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
@@ -8,12 +8,10 @@ import { assert } from "chai";
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { Classes, NonIdealState, Spinner } from "../../src/index";
+import { Classes, NonIdealState } from "../../src/index";
 
 describe("<NonIdealState>", () => {
     it("renders its contents", () => {
-        assert.lengthOf(document.getElementsByClassName(Classes.NON_IDEAL_STATE), 0);
-
         const wrapper = shallow(
             <NonIdealState
                 action={<p>More text!</p>}
@@ -22,20 +20,15 @@ describe("<NonIdealState>", () => {
                 icon="folder-close"
             />,
         );
-        [Classes.HEADING, Classes.ICON, Classes.NON_IDEAL_STATE_VISUAL, Classes.NON_IDEAL_STATE].forEach(className => {
+        [Classes.HEADING, Classes.NON_IDEAL_STATE_VISUAL, Classes.NON_IDEAL_STATE].forEach(className => {
             assert.lengthOf(wrapper.find(`.${className}`), 1, `missing ${className}`);
         });
     });
 
     it("ensures description is wrapped in an element", () => {
-        const wrapper = shallow(<NonIdealState description="foo" />);
-        assert.lengthOf(wrapper.find("div"), 1);
-        assert.strictEqual(wrapper.find("div").text(), "foo");
-    });
-
-    it("can render a JSX visual", () => {
-        const wrapper = shallow(<NonIdealState description="foo" title="bar" icon={<Spinner />} />);
-        assert.lengthOf(wrapper.find(Spinner), 1);
-        assert.lengthOf(wrapper.find(`.${Classes.ICON}`), 0);
+        const wrapper = shallow(<NonIdealState action={<strong />} description="foo" />);
+        const div = wrapper.children().find("div");
+        assert.lengthOf(div, 1);
+        assert.strictEqual(div.text(), "foo");
     });
 });

--- a/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
+++ b/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
@@ -19,24 +19,23 @@ describe("<NonIdealState>", () => {
                 action={<p>More text!</p>}
                 description="An error occured."
                 title="ERROR"
-                visual="folder-close"
+                icon="folder-close"
             />,
         );
-        [
-            Classes.NON_IDEAL_STATE,
-            Classes.NON_IDEAL_STATE_VISUAL,
-            Classes.NON_IDEAL_STATE_ICON,
-            Classes.NON_IDEAL_STATE_TITLE,
-            Classes.NON_IDEAL_STATE_DESCRIPTION,
-            Classes.NON_IDEAL_STATE_ACTION,
-        ].forEach(className => {
+        [Classes.HEADING, Classes.ICON, Classes.NON_IDEAL_STATE_VISUAL, Classes.NON_IDEAL_STATE].forEach(className => {
             assert.lengthOf(wrapper.find(`.${className}`), 1, `missing ${className}`);
         });
     });
 
+    it("ensures description is wrapped in an element", () => {
+        const wrapper = shallow(<NonIdealState description="foo" />);
+        assert.lengthOf(wrapper.find("div"), 1);
+        assert.strictEqual(wrapper.find("div").text(), "foo");
+    });
+
     it("can render a JSX visual", () => {
-        const wrapper = shallow(<NonIdealState description="foo" title="bar" visual={<Spinner />} />);
+        const wrapper = shallow(<NonIdealState description="foo" title="bar" icon={<Spinner />} />);
         assert.lengthOf(wrapper.find(Spinner), 1);
-        assert.lengthOf(wrapper.find(`.${Classes.NON_IDEAL_STATE_ICON}`), 0);
+        assert.lengthOf(wrapper.find(`.${Classes.ICON}`), 0);
     });
 });

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -94,7 +94,7 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
     }
 
     private renderZeroState() {
-        return <NonIdealState className={Classes.TEXT_MUTED} visual="zoom-out" description="No icons found" />;
+        return <NonIdealState className={Classes.TEXT_MUTED} icon="zoom-out" description="No icons found" />;
     }
 
     private handleFilterChange = (e: React.SyntheticEvent<HTMLInputElement>) => {

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -17,12 +17,15 @@ export class NonIdealStateExample extends BaseExample<{}> {
             </span>
         );
         return (
-            <NonIdealState
-                visual="search"
-                title="No search results"
-                description={description}
-                action={<InputGroup className={Classes.ROUND} leftIcon="search" placeholder="Search..." />}
-            />
+            // empty wrapper div to cancel parent flexbox styles
+            <div style={{ margin: "auto" }}>
+                <NonIdealState
+                    icon="search"
+                    title="No search results"
+                    description={description}
+                    action={<InputGroup className={Classes.ROUND} leftIcon="search" placeholder="Search..." />}
+                />
+            </div>
         );
     }
 }


### PR DESCRIPTION
- :fire: `visual` &rArr; `icon` to match other components
- :fire: replace most of the `NIS` classes constants with flex layout and rhythm
- use `Classes.HEADING` on the `<h4>`.
- use `pt-flex-container()` to ensure margin between all children and centering.
- move `ensureElement()` from `Popover` to `common/utils`