### PR TITLE
Fix default value doc for resetOnSelect

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -36,7 +36,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
      * Whether the filtering state should be reset to initial when an item is selected
      * (immediately before `onItemSelect` is invoked), or when the popover closes.
      * The query will become the empty string and the first item will be made active.
-     * @default true
+     * @default false
      */
     resetOnSelect?: boolean;
 


### PR DESCRIPTION
This fixes the docs for `MultiSelect`'s `resetOnSelect` prop.  The default is documented as being `true`, but it is actually `false`.  Whether the default is intended to be true, changing the actual default value would be a potential functionality break.