### PR TITLE
[WiP] refactor docs to focus on React usage

### DIFF
--- a/packages/core/src/components/alert/alert.md
+++ b/packages/core/src/components/alert/alert.md
@@ -1,4 +1,4 @@
-@# Alerts
+@# `Alert`
 
 Alerts notify users of important information and force them to acknowledge the alert content before
 continuing.
@@ -13,7 +13,7 @@ to show the type of the alert.
 
 @reactExample AlertExample
 
-@## JavaScript API
+@## Props
 
 The `Alert` component is available in the __@blueprintjs/core__ package.
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -1,6 +1,17 @@
-@# Breadcrumbs
+@# `Breadcrumb`
 
 Breadcrumbs identify the current resource in an application.
+
+@## Props
+
+The `Breadcrumb` component is available in the __@blueprintjs/core__ package.
+Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
+
+The component renders an `a.@ns-breadcrumb`. You are responsible for constructing
+the `ul.@ns-breadcrumbs` list. [`CollapsibleList`](#core/components/collapsiblelist)
+works nicely with this component because its props are a subset of `IMenuItemProps`.
+
+@interface IBreadcrumbProps
 
 @## CSS API
 
@@ -17,16 +28,3 @@ user to that resource.
 containing breadcrumbs that are collapsed due to layout constraints.
 * When adding another element (such as a [tooltip](#core/components/tooltip) or
 [popover](#core/components/popover)) to a breadcrumb, wrap it around the contents of the `li`.
-
-@css breadcrumbs
-
-@## JavaScript API
-
-The `Breadcrumb` component is available in the __@blueprintjs/core__ package.
-Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
-
-The component renders an `a.@ns-breadcrumb`. You are responsible for constructing
-the `ul.@ns-breadcrumbs` list. [`CollapsibleList`](#core/components/collapsiblelist)
-works nicely with this component because its props are a subset of `IMenuItemProps`.
-
-@interface IBreadcrumbProps

--- a/packages/core/src/components/button/button-group.md
+++ b/packages/core/src/components/button/button-group.md
@@ -1,6 +1,54 @@
-@# Button groups
+@# `ButtonGroup`
 
 Button groups arrange multiple buttons in a horizontal or vertical group.
+
+@reactExample ButtonGroupExample
+
+@## JavaScript API
+
+The `ButtonGroup` component is available in the **@blueprintjs/core** package.
+Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
+
+This component is a simple wrapper that manages `className` to style itself and
+child buttons. It exposes shorthand props for CSS modifier classes and supports
+the full range of HTML props.
+
+```tsx
+<ButtonGroup minimal={true} large={false} onMouseEnter={...}>
+    <Button icon="database">Queries</Button>
+    <Button icon="function">Functions</Button>
+    <AnchorButton rightIcon="caret-down">Options</AnchorButton>
+</ButtonGroup>
+```
+
+@interface IButtonGroupProps
+
+@### Usage with Popovers
+
+`Button`s inside a `ButtonGroup` can optionally be wrapped with a
+[`Popover`](#core/components/popover). The following example demonstrates this
+composition:
+
+```tsx
+<ButtonGroup className={Classes.ALIGN_LEFT}>
+    <Popover content={...}>
+        <Button icon="document" rightIcon="caret-down" text="File" />
+    </Popover>
+    <Popover content={...}>
+        <Button icon="edit" rightIcon="caret-down" text="Edit" />
+    </Popover>
+    <Popover content={...}>
+        <Button icon="eye-open" rightIcon="caret-down" text="View" />
+    </Popover>
+</ButtonGroup>
+```
+
+@reactExample ButtonGroupPopoverExample
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    In vertical button groups, button content will be centered by default.
+    You can align button content to the left or right using `@ns-align-left` and `@ns-align-right`, respectively.
+</div>
 
 @## CSS API
 
@@ -35,47 +83,3 @@ left-align button text and icon and right-align `rightIcon`.
 You can also combine vertical groups with the `Classes.FILL` and `Classes.MINIMAL` class modifiers.
 
 @css button-group-vertical
-
-@## JavaScript API
-
-The `ButtonGroup` component is available in the **@blueprintjs/core** package.
-Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
-
-This component is a simple wrapper around the CSS API.
-It exposes shorthand props for CSS modifier classes and supports the full range of HTML props.
-
-```tsx
-<ButtonGroup minimal={true} large={false} onMouseEnter={...}>
-    <Button icon="database">Queries</Button>
-    <Button icon="function">Functions</Button>
-    <AnchorButton rightIcon="caret-down">Options</AnchorButton>
-</ButtonGroup>
-```
-
-@reactExample ButtonGroupExample
-
-@### Usage with Popovers
-
-`Button`s inside a `ButtonGroup` can optionally be wrapped with a [`Popover`](#core/components/popover). The following example demonstrates this composition:
-
-```tsx
-<ButtonGroup className={Classes.ALIGN_LEFT}>
-    <Popover content={...}>
-        <Button icon="document" rightIcon="caret-down" text="File" />
-    </Popover>
-    <Popover content={...}>
-        <Button icon="edit" rightIcon="caret-down" text="Edit" />
-    </Popover>
-    <Popover content={...}>
-        <Button icon="eye-open" rightIcon="caret-down" text="View" />
-    </Popover>
-</ButtonGroup>
-```
-
-@reactExample ButtonGroupPopoverExample
-
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    In vertical button groups, button content will be centered by default. You can align button content to the left or right using `@ns-align-left` and `@ns-align-right`, respectively.
-</div>
-
-@interface IButtonGroupProps

--- a/packages/core/src/components/button/button.md
+++ b/packages/core/src/components/button/button.md
@@ -1,6 +1,42 @@
-@# Buttons
+@# `Button`
 
 Buttons trigger actions when clicked.
+
+@reactExample ButtonsExample
+
+@## Props
+
+The `Button` and `AnchorButton` components are available in the **@blueprintjs/core** package.
+Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
+
+```tsx
+<Button icon="refresh" onClick={...} />
+// renders:
+<button class="@ns-button @ns-icon-refresh" type="button"></button>
+```
+
+```tsx
+<AnchorButton text="Click" onClick={...} />
+// renders:
+<a class="@ns-button" role="button" tabIndex={0}>Click</a>
+```
+
+You can provide your own props to these components as if they were regular JSX
+HTML elements. If you provide a `className` prop, the class names you provide
+will be merged with the Blueprint class name. Other attributes, such as a `role`
+for an `<AnchorButton>`, will override the defaults.
+
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">Interactions with disabled buttons</h4>
+    Use `AnchorButton` if you need mouse interaction events (such as hovering) on a disabled button.
+    This is because `Button` and `AnchorButton` handle the `disabled` prop differently: `Button` uses
+    the native `disabled` attribute on the `<button>` tag so the browser disables all interactions,
+    but `AnchorButton` uses the class `.@ns-disabled` because `<a>` tags do not support the `disabled`
+    attribute. As a result, the `AnchorButton` component will prevent *only* the `onClick` handler
+    when disabled but permit other events.
+</div>
+
+@interface IButtonProps
 
 @## CSS API
 
@@ -41,46 +77,3 @@ to any `.@ns-button`. `@ns-minimal` is compatible with all other button modifier
 except for `.@ns-fill` (due to lack of visual affordances).
 
 @css button-minimal
-
-@## JavaScript API
-
-The `Button` and `AnchorButton` components are available in the **@blueprintjs/core** package.
-Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
-
-Button components render buttons with Blueprint classes and attributes.
-See the [Buttons CSS docs](#core/components/button.css-api) for styling options.
-
-You can provide your own props to these components as if they were regular JSX HTML elements. If you
-provide a `className` prop, the class names you provide will be added alongside of the default
-Blueprint class name. If you specify other attributes that the component provides, such as a `role`
-for an `<AnchorButton>`, you'll overide the default value.
-
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">Interactions with disabled buttons</h4>
-    Use `AnchorButton` if you need mouse interaction events (such as hovering) on a disabled button.
-    This is because `Button` and `AnchorButton` handle the `disabled` prop differently: `Button` uses
-    the native `disabled` attribute on the `<button>` tag so the browser disables all interactions,
-    but `AnchorButton` uses the class `.@ns-disabled` because `<a>` tags do not support the `disabled`
-    attribute. As a result, the `AnchorButton` component will prevent *only* the `onClick` handler
-    when disabled but permit other events.
-</div>
-
-@reactExample ButtonsExample
-
-@### Anchor button
-
-```tsx
-<AnchorButton text="Click" />
-// renders:
-<a class="@ns-button" role="button" tabIndex={0}>Click</a>
-```
-
-@### Button
-
-```tsx
-<Button icon="refresh" />
-// renders:
-<button class="@ns-button @ns-icon-refresh" type="button"></button>
-```
-
-@interface IButtonProps

--- a/packages/docs-theme/src/common/utils.ts
+++ b/packages/docs-theme/src/common/utils.ts
@@ -9,6 +9,19 @@ import { IHeadingNode, IPageNode, isPageNode } from "documentalist/dist/client";
 import * as React from "react";
 
 /**
+ * Minimal markdown renderer that supports only backtick `code` elements and triple-backtick `pre` elements.
+ * Does not provide any syntax highlighting.
+ */
+export function markdownCode(text: string) {
+    return {
+        __html: text
+            .replace("<", "&lt;")
+            .replace(/```([^`]+)```/g, (_, code) => `<pre>${code}</pre>`)
+            .replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`),
+    };
+}
+
+/**
  * Removes leading indents from a template string without removing all leading whitespace.
  * Trims resulting string to remove blank first/last lines caused by ` location.
  */

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -8,6 +8,7 @@ import { Classes } from "@blueprintjs/core";
 import classNames from "classnames";
 import { IHeadingNode, IPageNode } from "documentalist/dist/client";
 import * as React from "react";
+import { markdownCode } from "../common/utils";
 
 export interface INavMenuItemProps {
     /** This element never receives `children`. */
@@ -36,7 +37,7 @@ export const NavMenuItem: React.SFC<INavMenuItemProps> = props => {
     const { className, isActive, isExpanded, section, ...htmlProps } = props;
     return (
         <a className={classNames(Classes.MENU_ITEM, className)} {...htmlProps}>
-            <span className={Classes.FILL}>{section.title}</span>
+            <span className={Classes.FILL} dangerouslySetInnerHTML={markdownCode(section.title)} />
         </a>
     );
 };

--- a/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
+++ b/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
@@ -6,6 +6,7 @@
 
 import { Intent, Tag } from "@blueprintjs/core";
 import * as React from "react";
+import { markdownCode } from "../../common/utils";
 
 export const DeprecatedTag: React.SFC<{ isDeprecated: boolean | string | undefined }> = ({ isDeprecated }) => {
     if (isDeprecated === true || typeof isDeprecated === "string") {
@@ -22,16 +23,3 @@ export const DeprecatedTag: React.SFC<{ isDeprecated: boolean | string | undefin
     return null;
 };
 DeprecatedTag.displayName = "Docs2.DeprecatedTag";
-
-/**
- * Minimal markdown renderer that supports only backtick `code` elements and triple-backtick `pre` elements.
- * Does not provide any syntax highlighting.
- */
-function markdownCode(text: string) {
-    return {
-        __html: text
-            .replace("<", "&lt;")
-            .replace(/```([^`]+)```/g, (_, code) => `<pre>${code}</pre>`)
-            .replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`),
-    };
-}

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -8,6 +8,7 @@ import { Classes, Icon } from "@blueprintjs/core";
 import classNames from "classnames";
 import { IHeadingTag } from "documentalist/dist/client";
 import * as React from "react";
+import { markdownCode } from "../common/utils";
 
 export const Heading: React.SFC<IHeadingTag> = ({ level, route, value }) =>
     // use createElement so we can dynamically choose tag based on depth
@@ -18,6 +19,6 @@ export const Heading: React.SFC<IHeadingTag> = ({ level, route, value }) =>
         <a className="docs-anchor-link" href={"#" + route} key="link">
             <Icon icon="link" />
         </a>,
-        value,
+        <span key="text" dangerouslySetInnerHTML={markdownCode(value)} />,
     );
 Heading.displayName = "Docs2.Heading";


### PR DESCRIPTION
#### Fixes #2465 

### 🚧  work in progress! 🚧 

Let's refactor the docs to promote React usage over the CSS API. This is a proposal for how to structure the docs. There are lots of little language bits that will need to be updated:

- where to put the "`Component` is available in __@blueprintjs/package__" messages?
- CSS API sections that demonstrate CSS modifiers that now have JS props (see button groups for many examples)