### PR TITLE
revert-lerna-publish script to delete tags and commit

### DIFF
--- a/scripts/revert-lerna-publish
+++ b/scripts/revert-lerna-publish
@@ -4,7 +4,7 @@
 # and the "Publish" commit created by Lerna. Requires confirmation.
 
 read -p "⚠️  Delete lerna publish commit and tags? [y/N] " response
-if [[ $response =~ ^(no|n| ) ]] || [[ -z $response ]]; then
+if [[ ! $response =~ ^(yes|y)$ ]]; then
   exit
 fi
 

--- a/scripts/revert-lerna-publish
+++ b/scripts/revert-lerna-publish
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Run this script after a botched `lerna publish` to delete all tags
+# and the "Publish" commit created by Lerna. Requires confirmation.
+
+read -p "⚠️  Delete lerna publish commit and tags? [y/N] " response
+if [[ $response =~ ^(no|n| ) ]] || [[ -z $response ]]; then
+  exit
+fi
+
+# delete all tags created by Lerna
+for tag in $(git tag --points-at HEAD); do
+  git tag -d $tag
+done
+
+# undo Lerna commit
+git reset --hard HEAD^


### PR DESCRIPTION
sometimes (often) you botch the `lerna publish`. this script makes short work of resetting the repo state so you can try again.