### PR TITLE
Pasting in newline separated values for tag input

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -420,13 +420,10 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         // we don't want it to show up in the input since we're directly adding the terms
         event.preventDefault();
         const { onChange, values } = this.props;
-        const clipboardText = event.clipboardData.getData("text")
-        const newValues = [].concat(...clipboardText.split(/\n|\r/).map((s) => this.getValues(s)))
-            
-       
+        const clipboardText = event.clipboardData.getData("text");
+        const newValues = [].concat(...clipboardText.split(/\n|\r/).map(s => this.getValues(s)));
         if (Utils.isFunction(onChange)) {
-           onChange([...values, ...newValues]);
+            onChange([...values, ...newValues]);
         }
-    }
-
+    };
 }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -232,6 +232,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
                         onChange={this.handleInputChange}
                         onKeyDown={this.handleInputKeyDown}
                         onKeyUp={this.handleInputKeyUp}
+                        onPaste={this.handlePaste}
                         placeholder={resolvedPlaceholder}
                         ref={this.refHandlers.input}
                         className={classNames(Classes.INPUT_GHOST, inputProps.className)}
@@ -414,4 +415,18 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     private isValidIndex(index: number) {
         return index !== NONE && index < this.props.values.length;
     }
+
+    private handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+        // we don't want it to show up in the input since we're directly adding the terms
+        event.preventDefault();
+        const { onChange, values } = this.props;
+        const clipboardText = event.clipboardData.getData("text")
+        const newValues = [].concat(...clipboardText.split(/\n|\r/).map((s) => this.getValues(s)))
+            
+       
+        if (Utils.isFunction(onChange)) {
+           onChange([...values, ...newValues]);
+        }
+    }
+
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:

Adding onPaste handler to TagInput so that pasted-in newline separated lists of values (e.g. from excel) will be split into separate tags (and within lines, split on the separator)

