### PR TITLE
Fix upgrade script's treatment of removed props

### DIFF
--- a/packages/core/scripts/upgrade-blueprint-2.0.0-rename
+++ b/packages/core/scripts/upgrade-blueprint-2.0.0-rename
@@ -103,7 +103,7 @@ function rename() {
     # Name parameters
     fromString=$1
     toString=$2
-    findRegexp=$3
+    findRegexp=${3:-$fromString}
     files=$(matchingFiles "$findRegexp")
 
     if [[ -z ${files// } ]]; then
@@ -127,7 +127,7 @@ function warn() {
     # Name parameters
     fromString=$1
     toString=$2
-    findRegexp=$3
+    findRegexp=${3:-$fromString}
     files=$(matchingFiles "$findRegexp")
 
     if [[ -z ${files// } ]]; then
@@ -136,7 +136,7 @@ function warn() {
         count=$(echo "$files" | wc -l | awk '{print $1}')
         echo ""
         echo -e "${RED}WARNING: Skipping ${BLUE}${fromString}${RESET} -> ${GREEN}${toString}${RESET}"
-        echo -e "${RED}Since ${BLUE}${fromString}${RED} is very common, you'll need to manually rename this string.${RESET}"
+        echo -e "${RED}Can't safely change ${BLUE}${fromString}${RED}, you'll need to manually rename/remove this string.${RESET}"
         echo -e "${RED}It was found in these files ${BLUE}${count}${RED} files:${RESET}"
         echo "$files"
     fi

--- a/packages/core/scripts/upgrade-blueprint-2.0.0-rename
+++ b/packages/core/scripts/upgrade-blueprint-2.0.0-rename
@@ -218,6 +218,6 @@ warnProp inline usePortal
 echo "
 
 Removed props"
-warn submenuViewportMargins REMOVED
-warn useSmartPositioning REMOVED
-warn popoverPosition REMOVED
+warnProp submenuViewportMargins REMOVED
+warnProp useSmartPositioning REMOVED
+warnProp popoverPosition REMOVED


### PR DESCRIPTION
#### Changes proposed in this pull request:

Previously, our checks for removed props, such as `warn submenuViewportMargins REMOVED`, worked incorrectly because they didn't provide a third argument to warn. This PR fixes that in two ways: `warn` now works as expected if it only has two arguments, and removed props now use the `warnProp` function which respects the `$PREFIX` variable.

This PR also slightly tweaks the error message shown for these warnings.