### PR TITLE
Add 3.0 upgrade script; improve 2.0 script

### DIFF
--- a/packages/core/scripts/upgrade-blueprint-2.0.0-rename
+++ b/packages/core/scripts/upgrade-blueprint-2.0.0-rename
@@ -202,7 +202,8 @@ renameProp leftIconName leftIcon
 renameProp rightIconName rightIcon
 renameProp iconName icon
 renameString "icon=\{IconClasses" "icon={IconNames" # prop usage (previous line renames icon prop)
-renameString IconClasses "Classes.iconClass(IconNames"  # assuming user wanted class name
+renameString "visual=\{IconClasses" "visual={IconNames" # NonIdealState prop usage (previous line renames icon prop)
+warn IconClasses "Classes.iconClass(IconName.SOME_ICON)"  # assuming user wanted class name
 renameString FileUpload FileInput
 renameString fileUpload fileInput
 renameString "pt-file-upload(?!-)" pt-file-input # only rename full classname, not partial classname like pt-file-upload-input

--- a/packages/core/scripts/upgrade-blueprint-3.0.0-rename
+++ b/packages/core/scripts/upgrade-blueprint-3.0.0-rename
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+function usage() {
+    cat << EOF
+
+Blueprint 3.0.0 Upgrade Script
+
+Usage
+
+    $0 [--path=path] [--include=glob] [--exclude=glob] [--prefix=regexp]
+
+Description
+
+    This script finds instances of various renamed methods and properties and
+    replaces them in place. This includes renames for React props, css classes,
+    and enum constants.
+
+Options
+
+    -h,--help
+
+        Display this message and exit.
+
+    --path=.
+
+        The path where the recursive search begins, relative to the current
+        working directory.
+
+    --include=*.{ts,tsx,scss,less}
+
+        A glob string to match specific file extensions in the search path.
+
+    --exclude={dist,build,coverage,node_modules}
+
+        A glob string to omit specific directories from the search path.
+
+    --prefix=(?!(?<=public )|(?<=protected )|(?<=abstract )|(?<=private )|(?<=this\.))
+
+        A regexp prefix for each find/replace prop string. The default includes
+        groups of non-capturing negative lookbehinds. This helps limit the
+        renames to props and not class methods. If you are applying this script
+        to files other than typescript (e.g. markdown), you should probably set
+        this to ''.
+
+EOF
+}
+
+# Arguments
+for i in "$@" ; do
+    case $i in
+        --path=*)
+        SEARCH_PATH="${i#*=}"
+        shift
+        ;;
+        --include=*)
+        INCLUDE_GLOB="${i#*=}"
+        shift
+        ;;
+        --exclude=*)
+        EXCLUDE_GLOB="${i#*=}"
+        shift
+        ;;
+        --prefix=*)
+        PREFIX="${i#*=}"
+        shift
+        ;;
+        -h|--help)
+        usage
+        exit 1
+        ;;
+        *)
+        ;;
+    esac
+done
+
+# Default argument values
+SEARCH_PATH=${SEARCH_PATH:-'.'}
+INCLUDE_GLOB=${INCLUDE_GLOB:-'*.{ts,tsx,scss,less}'}
+EXCLUDE_GLOB=${EXCLUDE_GLOB:-'{dist,build,node_modules}'}
+PREFIX=${PREFIX:-'(?!(?<=public )|(?<=protected )|(?<=abstract )|(?<=private )|(?<=this\.))'}
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RESET='\033[0m'
+
+function matchingFiles() {
+    # Find all files containing regexp. Use grep's glob syntax for
+    # include/exclude paths. Use perl's regexp syntax.
+    cmd="grep \
+        --recursive \
+        --files-with-matches \
+        --include=$INCLUDE_GLOB \
+        --exclude-dir=$EXCLUDE_GLOB \
+        . \
+        ${SEARCH_PATH} \
+        | xargs perl -lne 'if (/$1/) { print \$ARGV; close ARGV }'
+    "
+    echo "$(eval $cmd)"
+}
+
+function rename() {
+    # Name parameters
+    fromString=$1
+    toString=$2
+    findRegexp=${3:-$fromString}
+    files=$(matchingFiles "$findRegexp")
+
+    if [[ -z ${files// } ]]; then
+        echo -e "No files contain ${BLUE}${fromString}${RESET}"
+    else
+        count=$(echo "$files" | wc -l | awk '{print $1}')
+        echo -e "Renaming ${BLUE}${fromString}${RESET} -> ${GREEN}${toString}${RESET} in ${BLUE}${count}${RESET} files"
+
+        # Iterate and search&replace
+        echo "$files" | while read -r file ; do
+            echo -n "$file ... "
+
+            # Search&replace in place with perl
+            perl -p -i -e "s/$findRegexp/$toString/g" "$file"
+            echo -e "${GREEN}done${RESET}"
+        done
+    fi
+}
+
+function warn() {
+    # Name parameters
+    fromString=$1
+    toString=$2
+    findRegexp=${3:-$fromString}
+    files=$(matchingFiles "$findRegexp")
+
+    if [[ -z ${files// } ]]; then
+        echo -e "No files contain ${BLUE}${fromString}${RESET}"
+    else
+        count=$(echo "$files" | wc -l | awk '{print $1}')
+        echo ""
+        echo -e "${RED}WARNING: Skipping ${BLUE}${fromString}${RESET} -> ${GREEN}${toString}${RESET}"
+        echo -e "${RED}Can't safely change ${BLUE}${fromString}${RED}, you'll need to manually rename/remove this string.${RESET}"
+        echo -e "${RED}It was found in these files ${BLUE}${count}${RED} files:${RESET}"
+        echo "$files"
+    fi
+}
+
+function renameProp() {
+    # Add prefix and word boundaries to search string
+    rename $1 $2 "$PREFIX\\b$1\\b"
+}
+
+function warnProp() {
+    warn $1 $2 "$PREFIX\\b$1\\b"
+}
+
+function renamePartialClass() {
+    # Don't add word boundary so that partial css classnames rename
+    rename $1 $2 "\\b$1"
+}
+
+function renameString() {
+    # Add simple word boundaries
+    rename $1 $2 "\\b$1\\b"
+}
+
+echo "
+
+Renames for @blueprintjs/core"
+renameProp visual icon
+renameString "Classes\.CALLOUT_TITLE" "Classes.HEADING" 
+renameString "Classes\.DIALOG_TITLE" "Classes.HEADING" 
+renameString "Classes\.HOTKEY_GROUP" "Classes.HEADING" 
+renameString "Classes\.NON_IDEAL_STATE_TITLE" "Classes.HEADING" 


### PR DESCRIPTION
#### Changes proposed in this pull request:

**Changes to 2.0 script**:
* rename `IconClasses` when used in a NIS `visual`
* only warn about remaining uses of `IconClasses`, trying to replace it with invalid TS just ends badly

**New 3.0 script**:
* Same functions and help docs as 2.0. (Sidenote: I think we should've just done these in node.js instead of bash for more cross-platform compat, but too late now)
* Handles NIS `visual` -> `icon`
* Renames classes to `Classes.HEADING`

