### PR TITLE
[HTML Table] Nicer interactive styles (hover + active)

### DIFF
--- a/packages/core/src/components/table/_table.scss
+++ b/packages/core/src/components/table/_table.scss
@@ -75,6 +75,26 @@ $dark-table-border-color: $pt-dark-divider-white !default;
       box-shadow: inset 0 $table-border-width 0 0 $table-border-color;
     }
   }
+
+  // a bunch of deep compound selectors ahead, but there's not really a better way to do this right now
+  // stylelint-disable selector-max-compound-selectors
+  .#{$ns}-dark & {
+    th {
+      color: $pt-dark-heading-color;
+    }
+
+    td {
+      color: $pt-dark-text-color;
+    }
+
+    tbody tr:first-child {
+      th,
+      td {
+        box-shadow: inset 0 $table-border-width 0 0 $dark-table-border-color;
+      }
+    }
+  }
+  // stylelint-enable selector-max-compound-selectors
 }
 
 table.#{$ns}-html-table {
@@ -135,25 +155,7 @@ table.#{$ns}-html-table {
   }
 
   .#{$ns}-dark & {
-    // a bunch of deep compound selectors ahead, but there's not really a better way to do this right now
     // stylelint-disable selector-max-compound-selectors
-
-    th {
-      color: $pt-dark-heading-color;
-    }
-
-    td {
-      color: $pt-dark-text-color;
-    }
-
-
-    tbody tr:first-child {
-      th,
-      td {
-        box-shadow: inset 0 $table-border-width 0 0 $dark-table-border-color;
-      }
-    }
-
     &.#{$ns}-html-table-striped {
       tbody tr:nth-child(odd) td {
         background: rgba($gray1, 0.15);
@@ -199,5 +201,6 @@ table.#{$ns}-html-table {
         }
       }
     }
+    // stylelint-enable selector-max-compound-selectors
   }
 }

--- a/packages/core/src/components/table/_table.scss
+++ b/packages/core/src/components/table/_table.scss
@@ -35,9 +35,9 @@ Markup:
 </table>
 
 .#{$ns}-small - Small, condensed appearance
-.#{$ns}-html-table-striped   - Striped appearance
-.#{$ns}-html-table-bordered  - Bordered appearance
-.#{$ns}-interactive  - Enables hover styles on rows
+.#{$ns}-html-table-striped - Striped appearance
+.#{$ns}-html-table-bordered - Bordered appearance
+.#{$ns}-interactive - Enables hover styles on rows
 
 Styleguide html-table
 */
@@ -92,7 +92,7 @@ table.#{$ns}-html-table {
 
   &.#{$ns}-html-table-striped {
     tbody tr:nth-child(odd) td {
-      background: rgba($gray5, 0.2);
+      background: rgba($gray5, 0.15);
     }
   }
 
@@ -122,9 +122,15 @@ table.#{$ns}-html-table {
   }
 
   &.#{$ns}-interactive {
-    tbody tr:hover td {
-      background-color: rgba($gray5, 0.4);
-      cursor: pointer;
+    tbody tr {
+      &:hover td {
+        background-color: rgba($gray5, 0.3);
+        cursor: pointer;
+      }
+
+      &:active td {
+        background-color: rgba($gray5, 0.4);
+      }
     }
   }
 
@@ -182,9 +188,15 @@ table.#{$ns}-html-table {
     }
 
     &.#{$ns}-interactive {
-      tbody tr:hover td {
-        background-color: rgba($gray1, 0.3);
-        cursor: pointer;
+      tbody tr {
+        &:hover td {
+          background-color: rgba($gray1, 0.3);
+          cursor: pointer;
+        }
+
+        &:active td {
+          background-color: rgba($gray1, 0.4);
+        }
       }
     }
   }


### PR DESCRIPTION
- nicer hover/active effects with `.pt-interactive`
- move some colors to the Sass placeholder so they work in dark theme

<img width="773" alt="image" src="https://user-images.githubusercontent.com/199754/39973111-5f7de6c6-56d0-11e8-9bd2-8840adbaa3ed.png">

before:
<img width="866" alt="screen shot 2018-05-13 at 6 39 50 pm" src="https://user-images.githubusercontent.com/199754/39974378-0b720370-56dd-11e8-818a-bb6b0ac81c56.png">

after:
<img width="739" alt="screen shot 2018-05-13 at 6 38 32 pm" src="https://user-images.githubusercontent.com/199754/39974325-e845c76a-56dc-11e8-8319-e27d39f6c6b6.png">


