### PR TITLE
[button] fix large CSS-icon-only button width

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -29,7 +29,9 @@ Styleguide button
   @include pt-button-height($pt-button-height);
 
   &:empty {
-    padding: 0;
+    // override padding from other modifiers (for CSS icon support)
+    // stylelint-disable-next-line declaration-no-important
+    padding: 0 !important;
   }
 
   &:disabled,


### PR DESCRIPTION
ensure no padding on empty buttons (CSS icons only support)