### PR TITLE
[docs] new Example component makes more legible examples

### DIFF
--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -8,7 +8,7 @@ import * as React from "react";
 
 import { Alert, Button, Intent, IToaster, Switch, Toaster } from "@blueprintjs/core";
 import { Example, handleBooleanChange } from "@blueprintjs/docs-theme";
-import { IReactExampleProps } from "../../tags/reactExamples";
+import { IBlueprintExampleProps } from "../../tags/reactExamples";
 
 export interface IAlertExampleState {
     canEscapeKeyCancel: boolean;
@@ -17,7 +17,7 @@ export interface IAlertExampleState {
     isOpenError: boolean;
 }
 
-export class AlertExample extends React.PureComponent<IReactExampleProps, IAlertExampleState> {
+export class AlertExample extends React.PureComponent<IBlueprintExampleProps, IAlertExampleState> {
     public state: IAlertExampleState = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -7,7 +7,8 @@
 import * as React from "react";
 
 import { Alert, Button, Intent, IToaster, Switch, Toaster } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { IReactExampleProps } from "../../tags/reactExamples";
 
 export interface IAlertExampleState {
     canEscapeKeyCancel: boolean;
@@ -16,7 +17,7 @@ export interface IAlertExampleState {
     isOpenError: boolean;
 }
 
-export class AlertExample extends BaseExample<{}> {
+export class AlertExample extends React.PureComponent<IReactExampleProps, IAlertExampleState> {
     public state: IAlertExampleState = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,
@@ -29,13 +30,27 @@ export class AlertExample extends BaseExample<{}> {
     private handleEscapeKeyChange = handleBooleanChange(canEscapeKeyCancel => this.setState({ canEscapeKeyCancel }));
     private handleOutsideClickChange = handleBooleanChange(click => this.setState({ canOutsideClickCancel: click }));
 
-    protected renderExample() {
-        const { isOpen, isOpenError, ...switchProps } = this.state;
-        return (
+    public render() {
+        const { isOpen, isOpenError, ...alertProps } = this.state;
+        const options = (
             <>
+                <Switch
+                    checked={this.state.canEscapeKeyCancel}
+                    label="Can escape key cancel"
+                    onChange={this.handleEscapeKeyChange}
+                />
+                <Switch
+                    checked={this.state.canOutsideClickCancel}
+                    label="Can outside click cancel"
+                    onChange={this.handleOutsideClickChange}
+                />
+            </>
+        );
+        return (
+            <Example options={options} {...this.props}>
                 <Button onClick={this.handleErrorOpen} text="Open file error alert" />
                 <Alert
-                    {...switchProps}
+                    {...alertProps}
                     className={this.props.themeName}
                     confirmButtonText="Okay"
                     isOpen={isOpenError}
@@ -46,9 +61,10 @@ export class AlertExample extends BaseExample<{}> {
                         redirected to your user folder.
                     </p>
                 </Alert>
+
                 <Button onClick={this.handleMoveOpen} text="Open file deletion alert" />
                 <Alert
-                    {...switchProps}
+                    {...alertProps}
                     className={this.props.themeName}
                     cancelButtonText="Cancel"
                     confirmButtonText="Move to Trash"
@@ -63,28 +79,10 @@ export class AlertExample extends BaseExample<{}> {
                         but it will become private to you.
                     </p>
                 </Alert>
-                <Toaster ref={ref => (this.toaster = ref)} />
-            </>
-        );
-    }
 
-    protected renderOptions() {
-        return [
-            [
-                <Switch
-                    checked={this.state.canEscapeKeyCancel}
-                    key="escape"
-                    label="Can escape key cancel"
-                    onChange={this.handleEscapeKeyChange}
-                />,
-                <Switch
-                    checked={this.state.canOutsideClickCancel}
-                    key="click"
-                    label="Can outside click cancel"
-                    onChange={this.handleOutsideClickChange}
-                />,
-            ],
-        ];
+                <Toaster ref={ref => (this.toaster = ref)} />
+            </Example>
+        );
     }
 
     private handleErrorOpen = () => this.setState({ isOpenError: true });

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { Alignment, AnchorButton, Button, ButtonGroup, Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export interface IButtonGroupExampleState {
@@ -19,7 +19,7 @@ export interface IButtonGroupExampleState {
     vertical: boolean;
 }
 
-export class ButtonGroupExample extends BaseExample<IButtonGroupExampleState> {
+export class ButtonGroupExample extends React.PureComponent<IExampleProps, IButtonGroupExampleState> {
     public state: IButtonGroupExampleState = {
         alignText: Alignment.CENTER,
         fill: false,
@@ -35,49 +35,33 @@ export class ButtonGroupExample extends BaseExample<IButtonGroupExampleState> {
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
-    protected renderExample() {
+    public render() {
         const { iconOnly, ...bgProps } = this.state;
+        const options = (
+            <>
+                <Switch checked={this.state.fill} label="Fill" onChange={this.handleFillChange} />
+                <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
+                <Switch checked={this.state.minimal} label="Minimal" onChange={this.handleMinimalChange} />
+                <Switch checked={this.state.vertical} label="Vertical" onChange={this.handleVerticalChange} />
+                <Switch checked={this.state.iconOnly} label="Icons only" onChange={this.handleIconOnlyChange} />
+                <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />
+            </>
+        );
         // have the container take up the full-width if `fill` is true;
         // otherwise, disable full-width styles to keep a vertical button group
         // from taking up the full width.
         const style: React.CSSProperties = { minWidth: 200, flexGrow: this.state.fill ? 1 : undefined };
         return (
-            <ButtonGroup style={style} {...bgProps}>
-                <Button icon="database">{!iconOnly && "Queries"}</Button>
-                <Button icon="function">{!iconOnly && "Functions"}</Button>
-                <AnchorButton icon="cog" rightIcon="caret-down">
-                    {!iconOnly && "Options"}
-                </AnchorButton>
-            </ButtonGroup>
+            <Example options={options} {...this.props}>
+                <ButtonGroup style={style} {...bgProps}>
+                    <Button icon="database">{!iconOnly && "Queries"}</Button>
+                    <Button icon="function">{!iconOnly && "Functions"}</Button>
+                    <AnchorButton icon="cog" rightIcon="caret-down">
+                        {!iconOnly && "Options"}
+                    </AnchorButton>
+                </ButtonGroup>
+            </Example>
         );
-    }
-
-    protected renderOptions() {
-        return [
-            [
-                <Switch checked={this.state.fill} key="fill" label="Fill" onChange={this.handleFillChange} />,
-                <Switch checked={this.state.large} key="large" label="Large" onChange={this.handleLargeChange} />,
-                <Switch
-                    checked={this.state.minimal}
-                    key="minimal"
-                    label="Minimal"
-                    onChange={this.handleMinimalChange}
-                />,
-                <Switch
-                    checked={this.state.vertical}
-                    key="vertical"
-                    label="Vertical"
-                    onChange={this.handleVerticalChange}
-                />,
-                <Switch
-                    checked={this.state.iconOnly}
-                    key="icon"
-                    label="Icons only"
-                    onChange={this.handleIconOnlyChange}
-                />,
-            ],
-            [<AlignmentSelect key="align" align={this.state.alignText} onChange={this.handleAlignChange} />],
-        ];
     }
 
     private handleAlignChange = (alignText: Alignment) => this.setState({ alignText });

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Alignment, Button, ButtonGroup, IconName, Intent, Popover, Position, Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 
 import { AlignmentSelect } from "./common/alignmentSelect";
@@ -20,7 +20,7 @@ export interface IButtonGroupPopoverExampleState {
     vertical: boolean;
 }
 
-export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverExampleState> {
+export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps, IButtonGroupPopoverExampleState> {
     public state: IButtonGroupPopoverExampleState = {
         alignText: Alignment.CENTER,
         intent: Intent.NONE,
@@ -38,37 +38,24 @@ export class ButtonGroupPopoverExample extends BaseExample<IButtonGroupPopoverEx
 
     protected renderExample() {
         const { intent, ...bgProps } = this.state;
-
-        return (
-            <ButtonGroup {...bgProps} style={{ minWidth: 120 }}>
-                {this.renderButton("File", "document")}
-                {this.renderButton("Edit", "edit")}
-                {this.renderButton("View", "eye-open")}
-            </ButtonGroup>
+        const options = (
+            <>
+                <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
+                <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
+                <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
+                <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />
+                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
+            </>
         );
-    }
-
-    protected renderOptions() {
-        const { alignText } = this.state;
-        return [
-            [
-                <Switch key="large" checked={this.state.large} onChange={this.handleLargeChange} label="Large" />,
-                <Switch
-                    key="minimal"
-                    checked={this.state.minimal}
-                    onChange={this.handleMinimalChange}
-                    label="Minimal"
-                />,
-                <Switch
-                    key="vertical"
-                    checked={this.state.vertical}
-                    onChange={this.handleVerticalChange}
-                    label="Vertical"
-                />,
-            ],
-            [<AlignmentSelect key="align" align={alignText} onChange={this.handleAlignChange} />],
-            [<IntentSelect key="intent" intent={this.state.intent} onChange={this.handleIntentChange} />],
-        ];
+        return (
+            <Example options={options} {...this.props}>
+                <ButtonGroup {...bgProps} style={{ minWidth: 120 }}>
+                    {this.renderButton("File", "document")}
+                    {this.renderButton("Edit", "edit")}
+                    {this.renderButton("View", "eye-open")}
+                </ButtonGroup>
+            </Example>
+        );
     }
 
     private renderButton(text: string, iconName: IconName) {

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { AnchorButton, Button, Code, Intent, Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -22,7 +22,7 @@ export interface IButtonsExampleState {
     wiggling: boolean;
 }
 
-export class ButtonsExample extends BaseExample<IButtonsExampleState> {
+export class ButtonsExample extends React.PureComponent<IExampleProps, IButtonsExampleState> {
     public state: IButtonsExampleState = {
         active: false,
         disabled: false,
@@ -48,12 +48,24 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
         window.clearTimeout(this.wiggleTimeoutId);
     }
 
-    protected renderExample() {
+    public render() {
         const { iconOnly, wiggling, ...buttonProps } = this.state;
 
-        return (
+        const options = (
             <>
-                <div className="docs-react-example-column">
+                <Switch label="Active" checked={this.state.active} onChange={this.handleActiveChange} />
+                <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
+                <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
+                <Switch label="Loading" checked={this.state.loading} onChange={this.handleLoadingChange} />
+                <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
+                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
+                <Switch label="Icons only" checked={this.state.iconOnly} onChange={this.handleIconOnlyChange} />
+            </>
+        );
+
+        return (
+            <Example options={options} {...this.props}>
+                <div>
                     <p>
                         <Code>Button</Code>
                     </p>
@@ -66,7 +78,7 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                         {!iconOnly && "Click to wiggle"}
                     </Button>
                 </div>
-                <div className="docs-react-example-column">
+                <div>
                     <p>
                         <Code>AnchorButton</Code>
                     </p>
@@ -79,44 +91,8 @@ export class ButtonsExample extends BaseExample<IButtonsExampleState> {
                         {...buttonProps}
                     />
                 </div>
-            </>
+            </Example>
         );
-    }
-
-    protected renderOptions() {
-        return [
-            [
-                <Switch checked={this.state.active} key="active" label="Active" onChange={this.handleActiveChange} />,
-                <Switch
-                    checked={this.state.disabled}
-                    key="disabled"
-                    label="Disabled"
-                    onChange={this.handleDisabledChange}
-                />,
-                <Switch checked={this.state.large} key="large" label="Large" onChange={this.handleLargeChange} />,
-                <Switch
-                    checked={this.state.loading}
-                    key="loading"
-                    label="Loading"
-                    onChange={this.handleLoadingChange}
-                />,
-                <Switch
-                    checked={this.state.minimal}
-                    key="minimal"
-                    label="Minimal"
-                    onChange={this.handleMinimalChange}
-                />,
-            ],
-            [
-                <IntentSelect intent={this.state.intent} key="intent" onChange={this.handleIntentChange} />,
-                <Switch
-                    checked={this.state.iconOnly}
-                    key="icon"
-                    label="Icons only"
-                    onChange={this.handleIconOnlyChange}
-                />,
-            ],
-        ];
     }
 
     private beginWiggling = () => {

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { Callout, Code, Intent, Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleStringChange, IDocsExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 import { IconSelect } from "./common/iconSelect";
 import { IntentSelect } from "./common/intentSelect";
@@ -18,35 +18,31 @@ export interface ICalloutExampleState {
     showHeader: boolean;
 }
 
-export class CalloutExample extends BaseExample<ICalloutExampleState> {
+export class CalloutExample extends React.PureComponent<IDocsExampleProps, ICalloutExampleState> {
     public state: ICalloutExampleState = { showHeader: true };
 
-    protected renderExample() {
+    private handleHeaderChange = handleBooleanChange((showHeader: boolean) => this.setState({ showHeader }));
+    private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
+
+    public render() {
         const { showHeader, ...calloutProps } = this.state;
+        const options = (
+            <>
+                <IntentSelect intent={calloutProps.intent} onChange={this.handleIntentChange} />
+                <Switch checked={showHeader} label="Show header" onChange={this.handleHeaderChange} />
+                <IconSelect iconName={calloutProps.icon} onChange={this.handleIconNameChange} />
+            </>
+        );
         return (
-            <Callout {...calloutProps} title={showHeader ? "Visually important content" : undefined}>
-                The component is a simple wrapper around the CSS API that provides props for modifiers and optional
-                title element. Any additional HTML props will be spread to the rendered <Code>{"<div>"}</Code> element.
-            </Callout>
+            <Example options={options} {...this.props}>
+                <Callout {...calloutProps} title={showHeader ? "Visually important content" : undefined}>
+                    The component is a simple wrapper around the CSS API that provides props for modifiers and optional
+                    title element. Any additional HTML props will be spread to the rendered <Code>{"<div>"}</Code>{" "}
+                    element.
+                </Callout>
+            </Example>
         );
     }
 
-    protected renderOptions() {
-        const { icon, intent, showHeader } = this.state;
-        return [
-            [
-                <IntentSelect key="intent" intent={intent} onChange={this.handleIntentChange} />,
-                <Switch key="header" checked={showHeader} label="Show header" onChange={this.handleHeaderChange} />,
-            ],
-            [<IconSelect key="icon-name" iconName={icon} onChange={this.handleIconNameChange} />],
-        ];
-    }
-
-    // tslint:disable-next-line:member-ordering
-    private handleHeaderChange = handleBooleanChange((showHeader: boolean) => this.setState({ showHeader }));
-
     private handleIconNameChange = (icon: IconName) => this.setState({ icon });
-
-    // tslint:disable-next-line:member-ordering
-    private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
 }

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -6,7 +6,7 @@
 import * as React from "react";
 
 import { RadioGroup } from "@blueprintjs/core";
-import { BaseExample, handleStringChange } from "@blueprintjs/docs-theme";
+import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnHeaderCell, RowHeaderCell, Table } from "@blueprintjs/table";
 
 interface IBigSpaceRock {
@@ -38,7 +38,7 @@ export interface ICellLoadingExampleState {
     randomNumbers?: number[];
 }
 
-export class CellLoadingExample extends BaseExample<ICellLoadingExampleState> {
+export class CellLoadingExample extends React.PureComponent<IExampleProps, ICellLoadingExampleState> {
     public state: ICellLoadingExampleState = {
         configuration: CellsLoadingConfiguration.ALL,
     };
@@ -58,26 +58,25 @@ export class CellLoadingExample extends BaseExample<ICellLoadingExampleState> {
         this.setState({ configuration: configuration as CellsLoadingConfiguration });
     });
 
-    public renderExample() {
-        return (
-            <Table
-                numRows={bigSpaceRocks.length}
-                rowHeaderCellRenderer={this.renderRowHeaderCell}
-                enableColumnInteractionBar={true}
-            >
-                {this.renderColumns()}
-            </Table>
-        );
-    }
-
-    protected renderOptions() {
-        return (
+    public render() {
+        const options = (
             <RadioGroup
                 label="Example cell loading configurations"
                 selectedValue={this.state.configuration}
                 options={CONFIGURATIONS}
                 onChange={this.handleConfigurationChange}
             />
+        );
+        return (
+            <Example options={options} {...this.props}>
+                <Table
+                    numRows={bigSpaceRocks.length}
+                    rowHeaderCellRenderer={this.renderRowHeaderCell}
+                    enableColumnInteractionBar={true}
+                >
+                    {this.renderColumns()}
+                </Table>
+            </Example>
         );
     }
 

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -6,8 +6,8 @@
 
 import * as React from "react";
 
-import { Classes } from "@blueprintjs/core";
-import { BaseExample, handleNumberChange } from "@blueprintjs/docs-theme";
+import { Classes, Label } from "@blueprintjs/core";
+import { Example, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnLoadingOption, Table } from "@blueprintjs/table";
 
 interface IBigSpaceRock {
@@ -21,7 +21,7 @@ export interface IColumnLoadingExampleState {
     loadingColumn?: number;
 }
 
-export class ColumnLoadingExample extends BaseExample<IColumnLoadingExampleState> {
+export class ColumnLoadingExample extends React.PureComponent<IExampleProps, IColumnLoadingExampleState> {
     public state: IColumnLoadingExampleState = {
         loadingColumn: 1,
     };
@@ -30,8 +30,12 @@ export class ColumnLoadingExample extends BaseExample<IColumnLoadingExampleState
 
     private handleLoadingColumnChange = handleNumberChange(loadingColumn => this.setState({ loadingColumn }));
 
-    public renderExample() {
-        return <Table numRows={bigSpaceRocks.length}>{this.renderColumns()}</Table>;
+    public render() {
+        return (
+            <Example options={this.renderOptions()} {...this.props}>
+                <Table numRows={bigSpaceRocks.length}>{this.renderColumns()}</Table>
+            </Example>
+        );
     }
 
     protected renderOptions() {
@@ -39,21 +43,17 @@ export class ColumnLoadingExample extends BaseExample<IColumnLoadingExampleState
         const numColumns = Object.keys(firstSpaceRock).length;
         const options: JSX.Element[] = [];
         for (let i = 0; i < numColumns; i++) {
-            options.push(
-                <option key={i} value={i}>
-                    {this.formatColumnName(Object.keys(firstSpaceRock)[i])}
-                </option>,
-            );
+            const label = this.formatColumnName(Object.keys(firstSpaceRock)[i]);
+            options.push(<option key={i} value={i} label={label} />);
         }
         return (
-            <label className={Classes.LABEL}>
-                Loading column
+            <Label text="Loading column">
                 <div className={Classes.SELECT}>
                     <select value={this.state.loadingColumn} onChange={this.handleLoadingColumnChange}>
                         {options}
                     </select>
                 </div>
-            </label>
+            </Label>
         );
     }
 

--- a/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { BaseExample } from "@blueprintjs/docs-theme";
+import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, JSONFormat, Table, TruncatedFormat } from "@blueprintjs/table";
 
 interface ITimezone {
@@ -75,18 +75,20 @@ const FORMAT_OPTIONS = {
     year: "numeric",
 };
 
-export class TableFormatsExample extends BaseExample<{}> {
+export class TableFormatsExample extends React.PureComponent<IExampleProps, {}> {
     private data = TIME_ZONES;
     private date = new Date();
 
-    public renderExample() {
+    public render() {
         return (
-            <Table enableRowResizing={true} numRows={this.data.length}>
-                <Column name="Timezone" cellRenderer={this.renderTimezone} />
-                <Column name="UTC Offset" cellRenderer={this.renderOffset} />
-                <Column name="Local Time" cellRenderer={this.renderLocalTime} />
-                <Column name="Timezone JSON" cellRenderer={this.renderJSON} />
-            </Table>
+            <Example options={false} {...this.props}>
+                <Table enableRowResizing={true} numRows={this.data.length}>
+                    <Column name="Timezone" cellRenderer={this.renderTimezone} />
+                    <Column name="UTC Offset" cellRenderer={this.renderOffset} />
+                    <Column name="Local Time" cellRenderer={this.renderLocalTime} />
+                    <Column name="Timezone JSON" cellRenderer={this.renderJSON} />
+                </Table>
+            </Example>
         );
     }
 

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -17,7 +17,9 @@ import { getTheme } from "../components/blueprintDocs";
 
 const SRC_HREF_BASE = "https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples";
 
+/** Extend the library type with additional app-specific fields. */
 export interface IReactExampleProps extends IExampleProps {
+    /** CSS theme like `Classes.DARK` */
     themeName: string;
 }
 

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -18,14 +18,14 @@ import { getTheme } from "../components/blueprintDocs";
 const SRC_HREF_BASE = "https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples";
 
 /** Extend the library type with additional app-specific fields. */
-export interface IReactExampleProps extends IExampleProps {
+export interface IBlueprintExampleProps extends IExampleProps {
     /** CSS theme like `Classes.DARK` */
     themeName: string;
 }
 
 function getPackageExamples(
     packageName: string,
-    packageExamples: { [name: string]: React.ComponentClass<IReactExampleProps> },
+    packageExamples: { [name: string]: React.ComponentClass<IBlueprintExampleProps> },
 ) {
     const ret: IExampleMap = {};
     for (const exampleName of Object.keys(packageExamples)) {

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { IBaseExampleProps, IExampleMap } from "@blueprintjs/docs-theme";
+import { IExampleMap, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 
 import * as CoreExamples from "../examples/core-examples";
@@ -17,9 +17,13 @@ import { getTheme } from "../components/blueprintDocs";
 
 const SRC_HREF_BASE = "https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples";
 
+export interface IReactExampleProps extends IExampleProps {
+    themeName: string;
+}
+
 function getPackageExamples(
     packageName: string,
-    packageExamples: { [name: string]: React.ComponentClass<IBaseExampleProps> },
+    packageExamples: { [name: string]: React.ComponentClass<IReactExampleProps> },
 ) {
     const ret: IExampleMap = {};
     for (const exampleName of Object.keys(packageExamples)) {

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { IProps } from "@blueprintjs/core";
+import classNames from "classnames";
+import React from "react";
+
+export interface IExampleProps extends IProps {
+    id: string;
+}
+
+export interface IDocsExampleProps extends IExampleProps {
+    options: React.ReactNode;
+}
+
+/**
+ * Container for an example and its options.
+ *
+ * ```tsx
+ * import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+ * // use IExampleProps as your props type,
+ * // then spread it to <Example> below
+ * export class MyExample extends React.PureComponent<IExampleProps, [your state]> {
+ *     public render() {
+ *         const options = (
+ *             <>
+ *                  --- render options here ---
+ *             </>
+ *         );
+ *         return (
+ *             <Example options={options} {...this.props}>
+ *                 --- render examples here ---
+ *             </Example>
+ *         );
+ *     }
+ * ```
+ */
+export class Example extends React.Component<IDocsExampleProps> {
+    // Can't put this in state, because the state typing is generic.
+    private hasDelayedBeforeInitialRender = false;
+    private hasCompletedInitialRender = false;
+
+    public render() {
+        // HACKHACK: This is the other required piece. Don't let any React nodes into the DOM until the
+        // requestAnimationFrame delay has elapsed. This prevents shouldComponentUpdate snafus at lower levels.
+        if (!this.hasDelayedBeforeInitialRender) {
+            return null;
+        }
+        return (
+            <div className={classNames("docs-example-frame", this.props.className)} data-example-id={this.props.id}>
+                <div className="docs-example">{this.props.children}</div>
+                <div className="docs-example-options">{this.props.options}</div>
+            </div>
+        );
+    }
+
+    public componentWillMount() {
+        // HACKHACK: The docs app suffers from a Flash of Unstyled Content that causes some 'width: 100%' examples to
+        // render incorrectly, because they mis-measure the horizontal space available to them. Until that bug is squashed,
+        // this is the workaround: delay initial render with a requestAnimationFrame.
+        requestAnimationFrame(() => {
+            this.hasDelayedBeforeInitialRender = true;
+            this.forceUpdate();
+        });
+    }
+
+    public componentDidUpdate() {
+        // HACKHACK: Initial render happens as an *update* due to our requestAnimationFrame shenanigans, not as a mount.
+        // Once we've rendered initially, set this flag so that shouldComponentUpdate logic will return to its normal
+        // PureComponent-style logic, ignoring these flags henceforth.
+        if (!this.hasCompletedInitialRender) {
+            this.hasCompletedInitialRender = true;
+        }
+    }
+}

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -13,7 +13,18 @@ export interface IExampleProps extends IProps {
 }
 
 export interface IDocsExampleProps extends IExampleProps {
+    /**
+     * Options for the example, which will appear in a narrow column to the right of the example.
+     */
     options: React.ReactNode;
+
+    /**
+     * HTML markup for the example, which will be directly injected into the
+     * example container using `dangerouslySetInnerHTML`.
+     *
+     * This prop is mutually exclusive with and takes priority over `children`.
+     */
+    html?: string;
 }
 
 /**
@@ -49,10 +60,18 @@ export class Example extends React.PureComponent<IDocsExampleProps> {
             return null;
         }
 
+        const { children, className, html, id, options } = this.props;
+        const example =
+            html == null ? (
+                <div className="docs-example">{children}</div>
+            ) : (
+                <div className="docs-example" dangerouslySetInnerHTML={{ __html: html }} />
+            );
+
         return (
-            <div className={classNames("docs-example-frame", this.props.className)} data-example-id={this.props.id}>
-                <div className="docs-example">{this.props.children}</div>
-                <div className="docs-example-options">{this.props.options}</div>
+            <div className={classNames("docs-example-frame", className)} data-example-id={id}>
+                {example}
+                <div className="docs-example-options">{options}</div>
             </div>
         );
     }

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -38,17 +38,17 @@ export interface IDocsExampleProps extends IExampleProps {
  *     }
  * ```
  */
-export class Example extends React.Component<IDocsExampleProps> {
-    // Can't put this in state, because the state typing is generic.
+export class Example extends React.PureComponent<IDocsExampleProps> {
     private hasDelayedBeforeInitialRender = false;
-    private hasCompletedInitialRender = false;
 
     public render() {
-        // HACKHACK: This is the other required piece. Don't let any React nodes into the DOM until the
-        // requestAnimationFrame delay has elapsed. This prevents shouldComponentUpdate snafus at lower levels.
+        // HACKHACK: This is the other required piece. Don't let any React nodes
+        // into the DOM until the requestAnimationFrame delay has elapsed. This
+        // prevents shouldComponentUpdate snafus at lower levels.
         if (!this.hasDelayedBeforeInitialRender) {
             return null;
         }
+
         return (
             <div className={classNames("docs-example-frame", this.props.className)} data-example-id={this.props.id}>
                 <div className="docs-example">{this.props.children}</div>
@@ -57,22 +57,14 @@ export class Example extends React.Component<IDocsExampleProps> {
         );
     }
 
-    public componentWillMount() {
-        // HACKHACK: The docs app suffers from a Flash of Unstyled Content that causes some 'width: 100%' examples to
-        // render incorrectly, because they mis-measure the horizontal space available to them. Until that bug is squashed,
-        // this is the workaround: delay initial render with a requestAnimationFrame.
+    public componentDidMount() {
+        // HACKHACK: The docs app suffers from a Flash of Unstyled Content that
+        // causes some 'width: 100%' examples to mis-measure the horizontal
+        // space available to them. Until that bug is squashed, we must delay
+        // initial render till the DOM loads with a requestAnimationFrame.
         requestAnimationFrame(() => {
             this.hasDelayedBeforeInitialRender = true;
             this.forceUpdate();
         });
-    }
-
-    public componentDidUpdate() {
-        // HACKHACK: Initial render happens as an *update* due to our requestAnimationFrame shenanigans, not as a mount.
-        // Once we've rendered initially, set this flag so that shouldComponentUpdate logic will return to its normal
-        // PureComponent-style logic, ignoring these flags henceforth.
-        if (!this.hasCompletedInitialRender) {
-            this.hasCompletedInitialRender = true;
-        }
     }
 }

--- a/packages/docs-theme/src/index.ts
+++ b/packages/docs-theme/src/index.ts
@@ -7,6 +7,7 @@
 export * from "./components/banner";
 export * from "./components/baseExample";
 export * from "./components/documentation";
+export * from "./components/example";
 export * from "./components/navMenuItem";
 export * from "./components/navButton";
 export * from "./common";

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -9,6 +9,7 @@ import classNames from "classnames";
 import { IKssPluginData, ITag } from "documentalist/dist/client";
 import * as React from "react";
 import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
+import { Example } from "../components/example";
 
 export interface ICssExampleState {
     modifiers: Set<string>;
@@ -40,10 +41,9 @@ export class CssExample extends React.PureComponent<ITag> {
         ));
         return (
             <>
-                <div className="docs-example-frame" data-reference={reference}>
-                    <div className="docs-example" dangerouslySetInnerHTML={this.renderExample(markup)} />
-                    <div className="docs-example-options">{options}</div>
-                </div>
+                <Example id={reference} options={options}>
+                    <div dangerouslySetInnerHTML={this.renderExample(markup)} />
+                </Example>
                 <div
                     className={classNames("docs-example-markup", Classes.RUNNING_TEXT)}
                     dangerouslySetInnerHTML={{ __html: markupHtml }}

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -41,9 +41,7 @@ export class CssExample extends React.PureComponent<ITag> {
         ));
         return (
             <>
-                <Example id={reference} options={options}>
-                    <div dangerouslySetInnerHTML={this.renderExample(markup)} />
-                </Example>
+                <Example id={reference} options={options} html={this.renderExample(markup)} />
                 <div
                     className={classNames("docs-example-markup", Classes.RUNNING_TEXT)}
                     dangerouslySetInnerHTML={{ __html: markupHtml }}
@@ -67,7 +65,7 @@ export class CssExample extends React.PureComponent<ITag> {
     private renderExample(markup: string) {
         const classes = this.getModifiers(".");
         const attrs = this.getModifiers(":");
-        return { __html: markup.replace(MODIFIER_ATTR_REGEXP, attrs).replace(MODIFIER_CLASS_REGEXP, classes) };
+        return markup.replace(MODIFIER_ATTR_REGEXP, attrs).replace(MODIFIER_CLASS_REGEXP, classes);
     }
 
     private getModifiers(prefix: "." | ":") {

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -7,10 +7,11 @@
 import { AnchorButton, Intent } from "@blueprintjs/core";
 import { ITag } from "documentalist/dist/client";
 import * as React from "react";
+import { IExampleProps } from "../components/example";
 
 export interface IExample {
     sourceUrl: string;
-    render: (props: { id: string }) => JSX.Element | undefined;
+    render: (props: IExampleProps) => JSX.Element | undefined;
 }
 
 // construct a map of package name to all examples defined in that package.
@@ -18,28 +19,6 @@ export interface IExample {
 export interface IExampleMap {
     [componentName: string]: IExample;
 }
-
-export interface IExampleProps {
-    example: IExample;
-    name: string;
-}
-
-export const ReactExample: React.SFC<IExampleProps> = props => (
-    <>
-        {props.example.render({ id: props.name })}
-        <AnchorButton
-            className="docs-example-view-source"
-            fill={true}
-            href={props.example.sourceUrl}
-            icon="code"
-            intent={Intent.PRIMARY}
-            minimal={true}
-            target="_blank"
-            text="View source on GitHub"
-        />
-    </>
-);
-ReactExample.displayName = "Docs2.ReactExample";
 
 export class ReactExampleTagRenderer {
     constructor(private examples: IExampleMap) {}
@@ -58,6 +37,20 @@ export class ReactExampleTagRenderer {
         if (example == null) {
             throw new Error(`Unknown @example component: ${exampleName}`);
         }
-        return <ReactExample example={example} name={exampleName} />;
+        return (
+            <>
+                {example.render({ id: exampleName })}
+                <AnchorButton
+                    className="docs-example-view-source"
+                    fill={true}
+                    href={example.sourceUrl}
+                    icon="code"
+                    intent={Intent.PRIMARY}
+                    minimal={true}
+                    target="_blank"
+                    text="View source on GitHub"
+                />
+            </>
+        );
     };
 }


### PR DESCRIPTION
- new `Example` component will eventually replace `BaseExample` as _the way_ to author docs examples.
   - composition instead of inheritance is just so much more legible and less magical! 
   - examples using `Example` simply implement `render()` like any other React component and can define their options as a single fragment. this is much friendlier to newcomers than the previous situation where we extended some inscrutable `BaseExample<S>` class and implemented `renderExample()` and `renderOptions()`.
   - `BaseExample` still exists -- this PR is purely additive. we'll remove it once all examples are converted.
- refactor a handful of examples to demonstrate the new API.
   - i don't want to do _all of them_ in this PR as it'll be overwhelming and its very rote--we can easily parallelize after this merges.

#### New typical usage:
```tsx
import { Example, IExampleProps } from "@blueprintjs/docs-theme";

// use IExampleProps as your props type,
// then spread it to <Example> below
export class MyExample extends React.PureComponent<IExampleProps, [your state]> {
    public render() {
        const options = (
            <>
                 --- render options here ---
            </>
        );
        return (
            <Example options={options} {...this.props}>
                --- render examples here ---
            </Example>
        );
    }
```

#### How to convert old examples to new ones:
1. `extends BaseExample<` => `extends React.PureComponent<IExampleProps, `
1. import `IExampleProps` from docs-theme (use editor auto-suggest)
1. change `BaseExample` import to `Example`
1. `protected renderExample()` => `public render()`
1. wrap returned element in `<Example options={this.renderOptions()} {...this.props}>` `</Example>`
1. convert options nested arrays to one fragment. remove `key` props!! delete commas and braces (they'll appear as text once you convert to fragment)
1. move this fragment into `render()` function as `const options` (this step is optional, leave as separate function if options are long or complex)