### PR TITLE
[docs] Example prop to show options below example

### DIFF
--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -4,8 +4,8 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs-theme";
+import { Classes, Label, Switch } from "@blueprintjs/core";
+import { Example, handleBooleanChange, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
 import moment from "moment";
 import * as React from "react";
 
@@ -53,7 +53,7 @@ const MAX_DATE_OPTIONS: ISelectOption[] = [
     },
 ];
 
-export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleState> {
+export class DateRangePickerExample extends React.PureComponent<IExampleProps, IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,
@@ -76,12 +76,49 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
         this.setState({ contiguousCalendarMonths });
     });
 
-    protected renderExample() {
+    public render() {
         const minDate = MIN_DATE_OPTIONS[this.state.minDateIndex].value;
         const maxDate = MAX_DATE_OPTIONS[this.state.maxDateIndex].value;
 
+        const options = (
+            <>
+                <div>
+                    <Switch
+                        checked={this.state.allowSingleDayRange}
+                        label="Allow single day range"
+                        onChange={this.toggleSingleDay}
+                    />
+                    <Switch
+                        checked={this.state.contiguousCalendarMonths}
+                        label="Constrain to contiguous months"
+                        onChange={this.toggleContiguousCalendarMonths}
+                    />
+                    <Switch checked={this.state.shortcuts} label="Show shortcuts" onChange={this.toggleShortcuts} />
+                    <Switch
+                        checked={this.state.reverseMonthAndYearMenus}
+                        label="Reverse month and year menus"
+                        onChange={this.toggleReverseMonthAndYearMenus}
+                    />
+                </div>
+                <div>
+                    {this.renderSelectMenu(
+                        "Minimum date",
+                        this.state.minDateIndex,
+                        MIN_DATE_OPTIONS,
+                        this.handleMinDateIndexChange,
+                    )}
+                    {this.renderSelectMenu(
+                        "Maximum date",
+                        this.state.maxDateIndex,
+                        MAX_DATE_OPTIONS,
+                        this.handleMaxDateIndexChange,
+                    )}
+                </div>
+            </>
+        );
+
         return (
-            <div className="docs-datetime-example">
+            <Example options={options} showOptionsBelowExample={true} {...this.props}>
                 <DateRangePicker
                     allowSingleDayRange={this.state.allowSingleDayRange}
                     contiguousCalendarMonths={this.state.contiguousCalendarMonths}
@@ -93,55 +130,8 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
                     shortcuts={this.state.shortcuts}
                 />
                 <MomentDateRange range={this.state.dateRange} />
-            </div>
+            </Example>
         );
-    }
-
-    protected renderOptions() {
-        return [
-            [
-                <Switch
-                    checked={this.state.allowSingleDayRange}
-                    key="SingleDay"
-                    label="Allow single day range"
-                    onChange={this.toggleSingleDay}
-                />,
-                <Switch
-                    checked={this.state.contiguousCalendarMonths}
-                    key="Contiguous"
-                    label="Constrain to contiguous months"
-                    onChange={this.toggleContiguousCalendarMonths}
-                />,
-                <Switch
-                    checked={this.state.shortcuts}
-                    key="Shortcuts"
-                    label="Show shortcuts"
-                    onChange={this.toggleShortcuts}
-                />,
-                <Switch
-                    checked={this.state.reverseMonthAndYearMenus}
-                    label="Reverse month and year menus"
-                    key="Reverse month and year menus"
-                    onChange={this.toggleReverseMonthAndYearMenus}
-                />,
-            ],
-            [
-                this.renderSelectMenu(
-                    "Minimum date",
-                    this.state.minDateIndex,
-                    MIN_DATE_OPTIONS,
-                    this.handleMinDateIndexChange,
-                ),
-            ],
-            [
-                this.renderSelectMenu(
-                    "Maximum date",
-                    this.state.maxDateIndex,
-                    MAX_DATE_OPTIONS,
-                    this.handleMaxDateIndexChange,
-                ),
-            ],
-        ];
     }
 
     private handleDateChange = (dateRange: DateRange) => this.setState({ dateRange });
@@ -152,25 +142,15 @@ export class DateRangePickerExample extends BaseExample<IDateRangePickerExampleS
         options: ISelectOption[],
         onChange: React.FormEventHandler<HTMLElement>,
     ) {
+        const optionElements = options.map((opt, i) => <option key={i} value={i} label={opt.label} />);
         return (
-            <label className={Classes.LABEL} key={label}>
-                {label}
+            <Label text={label}>
                 <div className={Classes.SELECT}>
                     <select value={selectedValue} onChange={onChange}>
-                        {this.renderSelectMenuOptions(options)}
+                        {optionElements}
                     </select>
                 </div>
-            </label>
+            </Label>
         );
-    }
-
-    private renderSelectMenuOptions(options: ISelectOption[]) {
-        return options.map((option, index) => {
-            return (
-                <option key={index} value={index}>
-                    {option.label}
-                </option>
-            );
-        });
     }
 }

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -80,7 +80,25 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
         const minDate = MIN_DATE_OPTIONS[this.state.minDateIndex].value;
         const maxDate = MAX_DATE_OPTIONS[this.state.maxDateIndex].value;
 
-        const options = (
+        return (
+            <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
+                <DateRangePicker
+                    allowSingleDayRange={this.state.allowSingleDayRange}
+                    contiguousCalendarMonths={this.state.contiguousCalendarMonths}
+                    className={Classes.ELEVATION_1}
+                    maxDate={maxDate}
+                    minDate={minDate}
+                    onChange={this.handleDateChange}
+                    reverseMonthAndYearMenus={this.state.reverseMonthAndYearMenus}
+                    shortcuts={this.state.shortcuts}
+                />
+                <MomentDateRange range={this.state.dateRange} />
+            </Example>
+        );
+    }
+    
+    private renderOptions() {
+        return (
             <>
                 <div>
                     <Switch
@@ -115,22 +133,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                     )}
                 </div>
             </>
-        );
-
-        return (
-            <Example options={options} showOptionsBelowExample={true} {...this.props}>
-                <DateRangePicker
-                    allowSingleDayRange={this.state.allowSingleDayRange}
-                    contiguousCalendarMonths={this.state.contiguousCalendarMonths}
-                    className={Classes.ELEVATION_1}
-                    maxDate={maxDate}
-                    minDate={minDate}
-                    onChange={this.handleDateChange}
-                    reverseMonthAndYearMenus={this.state.reverseMonthAndYearMenus}
-                    shortcuts={this.state.shortcuts}
-                />
-                <MomentDateRange range={this.state.dateRange} />
-            </Example>
         );
     }
 

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -96,7 +96,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
             </Example>
         );
     }
-    
+
     private renderOptions() {
         return (
             <>

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -68,7 +68,7 @@ export class CellLoadingExample extends React.PureComponent<IExampleProps, ICell
             />
         );
         return (
-            <Example options={options} {...this.props}>
+            <Example options={options} showOptionsBelowExample={true} {...this.props}>
                 <Table
                     numRows={bigSpaceRocks.length}
                     rowHeaderCellRenderer={this.renderRowHeaderCell}

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -32,7 +32,7 @@ export class ColumnLoadingExample extends React.PureComponent<IExampleProps, ICo
 
     public render() {
         return (
-            <Example options={this.renderOptions()} {...this.props}>
+            <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
                 <Table numRows={bigSpaceRocks.length}>{this.renderColumns()}</Table>
             </Example>
         );

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -6,16 +6,18 @@
 
 import * as React from "react";
 
-import { BaseExample } from "@blueprintjs/docs-theme";
+import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table } from "@blueprintjs/table";
 
-export class TableDollarExample extends BaseExample<{}> {
-    public renderExample() {
+export class TableDollarExample extends React.PureComponent<IExampleProps> {
+    public render() {
         const cellRenderer = (rowIndex: number) => <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>;
         return (
-            <Table numRows={10}>
-                <Column name="Dollars" cellRenderer={cellRenderer} />
-            </Table>
+            <Example options={false} showOptionsBelowExample={true} {...this.props}>
+                <Table numRows={10}>
+                    <Column name="Dollars" cellRenderer={cellRenderer} />
+                </Table>
+            </Example>
         );
     }
 }

--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { Intent } from "@blueprintjs/core";
-import { BaseExample } from "@blueprintjs/docs-theme";
+import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Column, ColumnHeaderCell, EditableCell, EditableName, Table } from "@blueprintjs/table";
 
 export interface ITableEditableExampleState {
@@ -17,7 +17,7 @@ export interface ITableEditableExampleState {
     sparseColumnIntents?: Intent[];
 }
 
-export class TableEditableExample extends BaseExample<ITableEditableExampleState> {
+export class TableEditableExample extends React.PureComponent<IExampleProps, ITableEditableExampleState> {
     public static dataKey = (rowIndex: number, columnIndex: number) => {
         return `${rowIndex}-${columnIndex}`;
     };
@@ -34,13 +34,17 @@ export class TableEditableExample extends BaseExample<ITableEditableExampleState
         sparseColumnIntents: [],
     };
 
-    public renderExample() {
+    public render() {
         const columns = this.state.columnNames.map((_: string, index: number) => {
             return (
                 <Column key={index} cellRenderer={this.renderCell} columnHeaderCellRenderer={this.renderColumnHeader} />
             );
         });
-        return <Table numRows={7}>{columns}</Table>;
+        return (
+            <Example options={false} showOptionsBelowExample={true} {...this.props}>
+                <Table numRows={7}>{columns}</Table>
+            </Example>
+        );
     }
 
     public renderCell = (rowIndex: number, columnIndex: number) => {

--- a/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
@@ -81,7 +81,7 @@ export class TableFormatsExample extends React.PureComponent<IExampleProps, {}> 
 
     public render() {
         return (
-            <Example options={false} {...this.props}>
+            <Example options={false} showOptionsBelowExample={true} {...this.props}>
                 <Table enableRowResizing={true} numRows={this.data.length}>
                     <Column name="Timezone" cellRenderer={this.renderTimezone} />
                     <Column name="UTC Offset" cellRenderer={this.renderOffset} />

--- a/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { BaseExample } from "@blueprintjs/docs-theme";
+import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table, Utils } from "@blueprintjs/table";
 
 export interface ITableFreezingExampleState {
@@ -19,12 +19,14 @@ const NUM_COLUMNS = 20;
 const NUM_FROZEN_ROWS = 2;
 const NUM_FROZEN_COLUMNS = 1;
 
-export class TableFreezingExample extends BaseExample<ITableFreezingExampleState> {
-    public renderExample() {
+export class TableFreezingExample extends React.PureComponent<IExampleProps, ITableFreezingExampleState> {
+    public render() {
         return (
-            <Table numRows={NUM_ROWS} numFrozenRows={NUM_FROZEN_ROWS} numFrozenColumns={NUM_FROZEN_COLUMNS}>
-                {this.renderColumns()}
-            </Table>
+            <Example options={false} showOptionsBelowExample={true} {...this.props}>
+                <Table numRows={NUM_ROWS} numFrozenRows={NUM_FROZEN_ROWS} numFrozenColumns={NUM_FROZEN_COLUMNS}>
+                    {this.renderColumns()}
+                </Table>
+            </Example>
         );
     }
 

--- a/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table, TableLoadingOption } from "@blueprintjs/table";
 
 interface IBigSpaceRock {
@@ -23,7 +23,7 @@ export interface ITableLoadingExampleState {
     rowHeadersLoading?: boolean;
 }
 
-export class TableLoadingExample extends BaseExample<ITableLoadingExampleState> {
+export class TableLoadingExample extends React.PureComponent<IExampleProps, ITableLoadingExampleState> {
     public state: ITableLoadingExampleState = {
         cellsLoading: true,
         columnHeadersLoading: true,
@@ -38,60 +38,35 @@ export class TableLoadingExample extends BaseExample<ITableLoadingExampleState> 
 
     private handleRowHeadersLoading = handleBooleanChange(rowHeadersLoading => this.setState({ rowHeadersLoading }));
 
-    public renderExample() {
-        const loadingOptions: TableLoadingOption[] = [];
-        if (this.state.cellsLoading) {
-            loadingOptions.push(TableLoadingOption.CELLS);
-        }
-        if (this.state.columnHeadersLoading) {
-            loadingOptions.push(TableLoadingOption.COLUMN_HEADERS);
-        }
-        if (this.state.rowHeadersLoading) {
-            loadingOptions.push(TableLoadingOption.ROW_HEADERS);
-        }
-
+    public render() {
+        const columns = Object.keys(bigSpaceRocks[0]).map((columnName, index) => (
+            <Column key={index} name={this.formatColumnName(columnName)} cellRenderer={this.renderCell} />
+        ));
         return (
-            <Table numRows={bigSpaceRocks.length} loadingOptions={loadingOptions}>
-                {this.renderColumns()}
-            </Table>
+            <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
+                <Table numRows={bigSpaceRocks.length} loadingOptions={this.getLoadingOptions()}>
+                    {columns}
+                </Table>
+            </Example>
         );
     }
 
     protected renderOptions() {
-        return [
-            [
-                <Switch
-                    checked={this.state.cellsLoading}
-                    label="Cells"
-                    key="cells"
-                    onChange={this.handleCellsLoading}
-                />,
+        return (
+            <>
+                <Switch checked={this.state.cellsLoading} label="Cells" onChange={this.handleCellsLoading} />
                 <Switch
                     checked={this.state.columnHeadersLoading}
                     label="Column headers"
-                    key="columnheaders"
                     onChange={this.handleColumnHeadersLoading}
-                />,
+                />
                 <Switch
                     checked={this.state.rowHeadersLoading}
                     label="Row headers"
-                    key="rowheaders"
                     onChange={this.handleRowHeadersLoading}
-                />,
-            ],
-        ];
-    }
-
-    private renderColumns() {
-        const columns: JSX.Element[] = [];
-
-        Object.keys(bigSpaceRocks[0]).forEach((columnName, index) => {
-            columns.push(
-                <Column key={index} name={this.formatColumnName(columnName)} cellRenderer={this.renderCell} />,
-            );
-        });
-
-        return columns;
+                />
+            </>
+        );
     }
 
     private renderCell = (rowIndex: number, columnIndex: number) => {
@@ -102,4 +77,18 @@ export class TableLoadingExample extends BaseExample<ITableLoadingExampleState> 
     private formatColumnName = (columnName: string) => {
         return columnName.replace(/([A-Z])/g, " $1").replace(/^./, firstCharacter => firstCharacter.toUpperCase());
     };
+
+    private getLoadingOptions() {
+        const loadingOptions: TableLoadingOption[] = [];
+        if (this.state.cellsLoading) {
+            loadingOptions.push(TableLoadingOption.CELLS);
+        }
+        if (this.state.columnHeadersLoading) {
+            loadingOptions.push(TableLoadingOption.COLUMN_HEADERS);
+        }
+        if (this.state.rowHeadersLoading) {
+            loadingOptions.push(TableLoadingOption.ROW_HEADERS);
+        }
+        return loadingOptions;
+    }
 }

--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { BaseExample, handleBooleanChange, IBaseExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, IBaseExampleProps, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table, Utils } from "@blueprintjs/table";
 
 export interface ITableReorderableExampleState {
@@ -24,8 +24,16 @@ const REORDERABLE_TABLE_DATA = [
     ["E", "Eggplant", "Elk", "Eritrea", "El Paso"],
 ].map(([letter, fruit, animal, country, city]) => ({ letter, fruit, animal, country, city }));
 
-export class TableReorderableExample extends BaseExample<ITableReorderableExampleState> {
+export class TableReorderableExample extends React.PureComponent<IExampleProps, ITableReorderableExampleState> {
     public state: ITableReorderableExampleState = {
+        columns: [
+            // these cellRenderers are only created once and then cloned on updates
+            <Column key="1" name="Letter" cellRenderer={this.getCellRenderer("letter")} />,
+            <Column key="2" name="Fruit" cellRenderer={this.getCellRenderer("fruit")} />,
+            <Column key="3" name="Animal" cellRenderer={this.getCellRenderer("animal")} />,
+            <Column key="4" name="Country" cellRenderer={this.getCellRenderer("country")} />,
+            <Column key="5" name="City" cellRenderer={this.getCellRenderer("city")} />,
+        ],
         data: REORDERABLE_TABLE_DATA,
         enableColumnInteractionBar: false,
     };
@@ -34,20 +42,7 @@ export class TableReorderableExample extends BaseExample<ITableReorderableExampl
         this.setState({ enableColumnInteractionBar }),
     );
 
-    public componentDidMount() {
-        const columns = [
-            <Column key="1" name="Letter" cellRenderer={this.renderLetterCell} />,
-            <Column key="2" name="Fruit" cellRenderer={this.renderFruitCell} />,
-            <Column key="3" name="Animal" cellRenderer={this.renderAnimalCell} />,
-            <Column key="4" name="Country" cellRenderer={this.renderCountryCell} />,
-            <Column key="5" name="City" cellRenderer={this.renderCityCell} />,
-        ];
-        this.setState({ columns });
-    }
-
-    public componentDidUpdate(nextProps: IBaseExampleProps, nextState: ITableReorderableExampleState) {
-        super.componentDidUpdate(nextProps, nextState);
-
+    public componentDidUpdate(_nextProps: IBaseExampleProps, nextState: ITableReorderableExampleState) {
         const { enableColumnInteractionBar } = this.state;
         if (nextState.enableColumnInteractionBar !== enableColumnInteractionBar) {
             const nextColumns = React.Children.map(this.state.columns, (column: JSX.Element) => {
@@ -57,39 +52,36 @@ export class TableReorderableExample extends BaseExample<ITableReorderableExampl
         }
     }
 
-    public renderExample() {
+    public render() {
         const { enableColumnInteractionBar } = this.state;
-        return (
-            <Table
-                enableColumnReordering={true}
-                enableColumnResizing={false}
-                enableRowReordering={true}
-                enableRowResizing={false}
-                numRows={this.state.data.length}
-                onColumnsReordered={this.handleColumnsReordered}
-                onRowsReordered={this.handleRowsReordered}
-                enableColumnInteractionBar={enableColumnInteractionBar}
-            >
-                {this.state.columns}
-            </Table>
-        );
-    }
-
-    protected renderOptions() {
-        return (
+        const options = (
             <Switch
-                checked={this.state.enableColumnInteractionBar}
+                checked={enableColumnInteractionBar}
                 label="Interaction bar"
                 onChange={this.toggleUseInteractionBar}
             />
         );
+        return (
+            <Example options={options} showOptionsBelowExample={true} {...this.props}>
+                <Table
+                    enableColumnReordering={true}
+                    enableColumnResizing={false}
+                    enableRowReordering={true}
+                    enableRowResizing={false}
+                    numRows={this.state.data.length}
+                    onColumnsReordered={this.handleColumnsReordered}
+                    onRowsReordered={this.handleRowsReordered}
+                    enableColumnInteractionBar={enableColumnInteractionBar}
+                >
+                    {this.state.columns}
+                </Table>
+            </Example>
+        );
     }
 
-    private renderLetterCell = (row: number) => <Cell>{this.state.data[row].letter}</Cell>;
-    private renderFruitCell = (row: number) => <Cell>{this.state.data[row].fruit}</Cell>;
-    private renderAnimalCell = (row: number) => <Cell>{this.state.data[row].animal}</Cell>;
-    private renderCountryCell = (row: number) => <Cell>{this.state.data[row].country}</Cell>;
-    private renderCityCell = (row: number) => <Cell>{this.state.data[row].city}</Cell>;
+    private getCellRenderer(key: string) {
+        return (row: number) => <Cell>{this.state.data[row][key]}</Cell>;
+    }
 
     private handleColumnsReordered = (oldIndex: number, newIndex: number, length: number) => {
         if (oldIndex === newIndex) {

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -9,7 +9,7 @@
 import * as React from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
-import { BaseExample } from "@blueprintjs/docs-theme";
+import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import {
     Cell,
     Column,
@@ -172,7 +172,7 @@ class RecordSortableColumn extends AbstractSortableColumn {
     }
 }
 
-export class TableSortableExample extends BaseExample<{}> {
+export class TableSortableExample extends React.PureComponent<IExampleProps> {
     public state = {
         columns: [
             new TextSortableColumn("Rikishi", 0),
@@ -193,17 +193,19 @@ export class TableSortableExample extends BaseExample<{}> {
         sortedIndexMap: [] as number[],
     };
 
-    public renderExample() {
+    public render() {
         const numRows = this.state.data.length;
         const columns = this.state.columns.map(col => col.getColumn(this.getCellData, this.sortColumn));
         return (
-            <Table
-                bodyContextMenuRenderer={this.renderBodyContextMenu}
-                numRows={numRows}
-                selectionModes={SelectionModes.COLUMNS_AND_CELLS}
-            >
-                {columns}
-            </Table>
+            <Example options={false} showOptionsBelowExample={true} {...this.props}>
+                <Table
+                    bodyContextMenuRenderer={this.renderBodyContextMenu}
+                    numRows={numRows}
+                    selectionModes={SelectionModes.COLUMNS_AND_CELLS}
+                >
+                    {columns}
+                </Table>
+            </Example>
         );
     }
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -424,16 +424,6 @@
 // DATETIME
 //
 
-#{example("DateRangePickerExample")} {
-  flex-direction: column;
-
-  .docs-example-options {
-    margin-top: $pt-grid-size;
-    margin-left: 0;
-    max-width: unset;
-  }
-}
-
 .docs-datetime-example {
   display: flex;
   flex-direction: column;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -455,14 +455,8 @@
     height: $pt-grid-size * 36;
   }
 
-  // options appear below table (so tables can occupy full width)
-  .docs-example-frame {
-    flex-direction: column;
-  }
-
-  .docs-example-options {
-    margin-top: $pt-grid-size;
-    margin-left: 0;
-    max-width: unset;
+  // reduce example container padding
+  .docs-example {
+    padding: 0;
   }
 }

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -14,9 +14,19 @@ export interface IExampleProps extends IProps {
 
 export interface IDocsExampleProps extends IExampleProps {
     /**
-     * Options for the example, which will appear in a narrow column to the right of the example.
+     * Options for the example, which will typically appear in a narrow column
+     * to the right of the example.
      */
     options: React.ReactNode;
+
+    /**
+     * Whether options should appear in a full-width row below the example
+     * container. By default, options appear in a single column to the right of
+     * the example. If this prop is enabled, then the options container becomes
+     * a flex row; group options into columns by wrapping them in a `<div>`.
+     * @default false
+     */
+    showOptionsBelowExample?: boolean;
 
     /**
      * HTML markup for the example, which will be directly injected into the
@@ -60,7 +70,12 @@ export class Example extends React.PureComponent<IDocsExampleProps> {
             return null;
         }
 
-        const { children, className, html, id, options } = this.props;
+        const { children, className, html, id, options, showOptionsBelowExample = false } = this.props;
+        const classes = classNames(
+            "docs-example-frame",
+            showOptionsBelowExample ? "docs-example-frame-column" : "docs-example-frame-row",
+            className,
+        );
         const example =
             html == null ? (
                 <div className="docs-example">{children}</div>
@@ -69,7 +84,7 @@ export class Example extends React.PureComponent<IDocsExampleProps> {
             );
 
         return (
-            <div className={classNames("docs-example-frame", className)} data-example-id={id}>
+            <div className={classes} data-example-id={id}>
                 {example}
                 <div className="docs-example-options">{options}</div>
             </div>

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -17,13 +17,37 @@ $dark-options-background-color: $dark-gray5;
 
 // full-bleed wrapper for example
 .docs-example-frame {
-  @include pt-flex-container(row, $fill: ".docs-example");
   position: relative;
   margin-top: $content-padding * 2;
   width: 100%;
 
   &:empty {
     display: none;
+  }
+}
+
+// options to the right of example in same row
+.docs-example-frame-row {
+  @include pt-flex-container(row, $pt-grid-size, $fill: ".docs-example");
+
+  // option elements arranged vertically. use headings for grouping.
+  .docs-example-options {
+    @include pt-flex-container(column, $pt-grid-size);
+    max-width: $pt-grid-size * 30;
+  }
+}
+
+// options below example in its own row.
+.docs-example-frame-column {
+  @include pt-flex-container(column, $pt-grid-size, $fill: ".docs-example");
+
+  // option elements arranged horizontally. group controls into columns.
+  .docs-example-options {
+    @include pt-flex-container(row, $pt-grid-size * 4);
+    justify-content: center;
+    margin-top: $pt-grid-size;
+    margin-left: 0;
+    max-width: unset;
   }
 }
 
@@ -50,12 +74,9 @@ $dark-options-background-color: $dark-gray5;
 }
 
 .docs-example-options {
-  @include pt-flex-container(column, $pt-grid-size);
   flex: 0 0 auto;
-  margin-left: $example-frame-spacing;
   border-radius: $example-frame-border-radius;
   background-color: $options-background-color;
-  max-width: $pt-grid-size * 30;
   padding: $pt-grid-size * 2;
   text-align: left;
 


### PR DESCRIPTION
`Example` `showOptionsBelowExample` changes layout so options are in a row below the example.

Refactor `DRP` example (see screenshot) and all Table examples to use new API.

![image](https://user-images.githubusercontent.com/464822/40084759-0c4b1126-584d-11e8-988d-b986cafab3b5.png)
