### PR TITLE
📦 upgrade documentalist

### DIFF
--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.0.0-beta.0",
     "@blueprintjs/docs-theme": "^3.0.0-beta.0",
-    "documentalist": "^1.2.0",
+    "documentalist": "^1.3.2",
     "glob": "^7.1.2",
     "highlights": "^3.1.1",
     "marked": "^0.3.6",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -31,7 +31,7 @@
     "@blueprintjs/core": "^3.0.0-beta.0",
     "@blueprintjs/select": "^3.0.0-beta.0",
     "classnames": "^2.2",
-    "documentalist": "^1.2.0",
+    "documentalist": "^1.3.2",
     "fuzzaldrin-plus": "^0.5.0",
     "tslib": "^1.9.0"
   },

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -128,7 +128,10 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         return {
             getDocsData: () => docs,
             renderBlock: block => renderBlock(block, this.props.tagRenderers),
-            renderType: this.renderType,
+            renderType: hasTypescriptData(docs)
+                ? type =>
+                      linkify(type, docs.typescript, (name, _d, idx) => <ApiLink key={`${name}-${idx}`} name={name} />)
+                : type => type,
             renderViewSourceLinkText: Utils.isFunction(renderViewSourceLinkText)
                 ? renderViewSourceLinkText
                 : () => "View source",
@@ -235,14 +238,6 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
 
         Utils.safeInvoke(this.props.onComponentUpdate, activePageId);
     }
-
-    private renderType = (type: string) => {
-        const { docs } = this.props;
-        let index = 0;
-        return hasTypescriptData(docs)
-            ? linkify(type, docs.typescript, name => <ApiLink key={`${name}-${index++}`} name={name} />)
-            : type;
-    };
 
     private updateHash() {
         // update state based on current hash location

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,9 +2111,9 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-documentalist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/documentalist/-/documentalist-1.2.0.tgz#0c543d812e27e15ba665b76cf0bb143b36d3acce"
+documentalist@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/documentalist/-/documentalist-1.3.2.tgz#26f9a053c00e918d02c3f6865c8b314487427c71"
   dependencies:
     "@types/kss" "^3.0.0"
     glob "^7.1.1"


### PR DESCRIPTION
- upgrade to latest documentalist 1.3.2 for `const/type` support and `index` param in `linkify()` util.
    - this will unblock #2484
- include `index` in `renderType` to avoid duplicate keys