### PR TITLE
📦 move react-transition-group to regular dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,12 +44,12 @@
     "normalize.css": "^8.0.0",
     "popper.js": "^1.14.1",
     "react-popper": "^0.8.2",
+    "react-transition-group": "^2.2.1",
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
     "react": "^15.3.0 || 16",
-    "react-dom": "^15.3.0 || 16",
-    "react-transition-group": "^2.2.1"
+    "react-dom": "^15.3.0 || 16"
   },
   "devDependencies": {
     "@blueprintjs/karma-build-scripts": "^0.6.1",
@@ -62,7 +62,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -49,7 +49,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -22,7 +22,7 @@ The `main` module exports all symbols from all modules so you don't have to impo
 1. If you see `UNMET PEER DEPENDENCY` errors, you should manually install React (v15.3 or greater):
 
     ```sh
-    yarn add react react-dom react-transition-group
+    yarn add react react-dom
     ```
 
 1. After installation, you'll be able to import the React components in your application:
@@ -137,7 +137,7 @@ install typings for Blueprint's dependencies before you can consume it:
 
 ```sh
 # required for all @blueprintjs packages:
-npm install --save @types/react @types/react-dom @types/react-transition-group
+npm install --save @types/react @types/react-dom
 
 # @blueprintjs/timezone requires:
 npm install --save @types/moment-timezone

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -41,7 +41,6 @@
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -45,7 +45,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -47,7 +47,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -19,8 +19,7 @@
     "@blueprintjs/core": "^3.0.0-beta.0",
     "classnames": "^2.2.5",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-transition-group": "^2.2.1"
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "@blueprintjs/webpack-build-scripts": "^0.5.2",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -47,7 +47,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -22,8 +22,7 @@
     "dom4": "^2.0.1",
     "normalize.css": "^8.0.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-transition-group": "^2.2.1"
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "@blueprintjs/webpack-build-scripts": "^0.5.2",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -49,7 +49,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.1"

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -50,7 +50,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "react-transition-group": "^2.2.1",
     "typescript": "~2.7.2",
     "webpack": "^3.10.0"
   },


### PR DESCRIPTION
- it's been a peer dependency forever but I don't think this is correct, and is often a source of upgrade pain to users
- most libraries declare react and react-dom as peer deps (r-t-g does this too) so it seems reasonable for that to be the minimal set of peer deps
- r-t-g is not exposed in our APIs so it can be a normal dependency
    - maaaybe `transitionName/Duration` but those use basic types so not really "exposing"
    - also the official recommendation: https://github.com/reactjs/react-transition-group/issues/32