### PR TITLE
[Docs] Add consistent H5s to each example options

### DIFF
--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -15,8 +15,8 @@ export interface IButtonGroupProps extends IProps, HTMLDivProps {
      * Text alignment of button contents.
      * This prop only has an effect if buttons are wider than their default widths.
      *
-     * `align={Alignment.LEFT}` will left-align button text and push `rightIcon` to right side.
-     * `align={Alignment.RIGHT}` right-aligns text and pushes `icon` to left side.
+     * `Alignment.LEFT` will left-align button text and push `rightIcon` to right side.
+     * `Alignment.RIGHT` right-aligns text and pushes `icon` to left side.
      */
     alignText?: Alignment;
 

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Alert, Button, Intent, IToaster, Switch, Toaster } from "@blueprintjs/core";
+import { Alert, Button, H5, Intent, IToaster, Switch, Toaster } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IBlueprintExampleData } from "../../tags/reactExamples";
 
@@ -34,6 +34,7 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
         const { isOpen, isOpenError, ...alertProps } = this.state;
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch
                     checked={this.state.canEscapeKeyCancel}
                     label="Can escape key cancel"

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Alignment, AnchorButton, Button, ButtonGroup, Switch } from "@blueprintjs/core";
+import { Alignment, AnchorButton, Button, ButtonGroup, H5, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { AlignmentSelect } from "./common/alignmentSelect";
 
@@ -39,12 +39,14 @@ export class ButtonGroupExample extends React.PureComponent<IExampleProps, IButt
         const { iconOnly, ...bgProps } = this.state;
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch checked={this.state.fill} label="Fill" onChange={this.handleFillChange} />
                 <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
                 <Switch checked={this.state.minimal} label="Minimal" onChange={this.handleMinimalChange} />
                 <Switch checked={this.state.vertical} label="Vertical" onChange={this.handleVerticalChange} />
-                <Switch checked={this.state.iconOnly} label="Icons only" onChange={this.handleIconOnlyChange} />
                 <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />
+                <H5>Example</H5>
+                <Switch checked={this.state.iconOnly} label="Icons only" onChange={this.handleIconOnlyChange} />
             </>
         );
         // have the container take up the full-width if `fill` is true;

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Alignment, Button, ButtonGroup, IconName, Intent, Popover, Position, Switch } from "@blueprintjs/core";
+import { Alignment, Button, ButtonGroup, H5, IconName, Intent, Popover, Position, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 
@@ -38,10 +38,12 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
         const { intent, ...bgProps } = this.state;
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
                 <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />
+                <H5>Button props</H5>
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
             </>
         );

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { AnchorButton, Button, Code, Intent, Switch } from "@blueprintjs/core";
+import { AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -53,12 +53,14 @@ export class ButtonsExample extends React.PureComponent<IExampleProps, IButtonsE
 
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch label="Active" checked={this.state.active} onChange={this.handleActiveChange} />
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Loading" checked={this.state.loading} onChange={this.handleLoadingChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
+                <H5>Example</H5>
                 <Switch label="Icons only" checked={this.state.iconOnly} onChange={this.handleIconOnlyChange} />
             </>
         );

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Callout, Code, Intent, Switch } from "@blueprintjs/core";
+import { Callout, Code, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IDocsExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 import { IconSelect } from "./common/iconSelect";
@@ -28,9 +28,11 @@ export class CalloutExample extends React.PureComponent<IDocsExampleProps, ICall
         const { showHeader, ...calloutProps } = this.state;
         const options = (
             <>
+                <H5>Props</H5>
                 <IntentSelect intent={calloutProps.intent} onChange={this.handleIntentChange} />
-                <Switch checked={showHeader} label="Show header" onChange={this.handleHeaderChange} />
                 <IconSelect iconName={calloutProps.icon} onChange={this.handleIconNameChange} />
+                <H5>Example</H5>
+                <Switch checked={showHeader} label="Show header" onChange={this.handleHeaderChange} />
             </>
         );
         return (

--- a/packages/docs-app/src/examples/core-examples/cardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardExample.tsx
@@ -23,14 +23,16 @@ export class CardExample extends React.PureComponent<IExampleProps, ICardExample
     public render() {
         const options = (
             <>
-                <Label text="Elevation" />
-                <Slider
-                    max={4}
-                    showTrackFill={false}
-                    value={this.state.elevation}
-                    onChange={this.handleElevationChange}
-                />
+                <H5>Props</H5>
                 <Switch checked={this.state.interactive} label="Interactive" onChange={this.handleInteractiveChange} />
+                <Label text="Elevation">
+                    <Slider
+                        max={4}
+                        showTrackFill={false}
+                        value={this.state.elevation}
+                        onChange={this.handleElevationChange}
+                    />
+                </Label>
             </>
         );
 

--- a/packages/docs-app/src/examples/core-examples/collapseExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapseExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, Collapse, Pre, Switch } from "@blueprintjs/core";
+import { Button, Collapse, H5, Pre, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ICollapseExampleState {
@@ -26,11 +26,14 @@ export class CollapseExample extends React.PureComponent<IExampleProps, ICollaps
 
     public render() {
         const options = (
-            <Switch
-                checked={this.state.keepChildrenMounted}
-                label="Keep children mounted"
-                onChange={this.handleChildrenMountedChange}
-            />
+            <>
+                <H5>Props</H5>
+                <Switch
+                    checked={this.state.keepChildrenMounted}
+                    label="Keep children mounted"
+                    onChange={this.handleChildrenMountedChange}
+                />
+            </>
         );
 
         return (

--- a/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
@@ -11,6 +11,7 @@ import {
     Classes,
     CollapseFrom,
     CollapsibleList,
+    H5,
     IMenuItemProps,
     Label,
     MenuItem,
@@ -40,6 +41,7 @@ export class CollapsibleListExample extends React.PureComponent<IExampleProps, I
     public render() {
         const options = (
             <>
+                <H5>Props</H5>
                 <Label text="Visible items" />
                 <Slider
                     max={6}

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -4,8 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Intent } from "@blueprintjs/core";
-import classNames from "classnames";
+import { Classes, Intent, Label } from "@blueprintjs/core";
 import * as React from "react";
 
 const INTENTS = [
@@ -23,8 +22,7 @@ export interface IIntentSelectProps {
 }
 
 export const IntentSelect: React.SFC<IIntentSelectProps> = props => (
-    <label className={classNames(Classes.LABEL, { [Classes.INLINE]: props.inline })}>
-        Intent
+    <Label text="Intent">
         <div className={Classes.SELECT}>
             <select value={props.intent} onChange={props.onChange}>
                 {INTENTS.map((opt, i) => (
@@ -34,5 +32,5 @@ export const IntentSelect: React.SFC<IIntentSelectProps> = props => (
                 ))}
             </select>
         </div>
-    </label>
+    </Label>
 );

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Classes, Intent } from "@blueprintjs/core";
+import classNames from "classnames";
 import * as React from "react";
 
 const INTENTS = [
@@ -16,12 +17,13 @@ const INTENTS = [
 ];
 
 export interface IIntentSelectProps {
+    inline?: boolean;
     intent: Intent;
     onChange: React.FormEventHandler<HTMLSelectElement>;
 }
 
 export const IntentSelect: React.SFC<IIntentSelectProps> = props => (
-    <label className={Classes.LABEL}>
+    <label className={classNames(Classes.LABEL, { [Classes.INLINE]: props.inline })}>
         Intent
         <div className={Classes.SELECT}>
             <select value={props.intent} onChange={props.onChange}>

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { AnchorButton, Button, Classes, Code, Dialog, Intent, Switch, Tooltip } from "@blueprintjs/core";
+import { AnchorButton, Button, Classes, Code, Dialog, H5, Intent, Switch, Tooltip } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IBlueprintExampleData } from "../../tags/reactExamples";
 
@@ -96,6 +96,7 @@ export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintE
         const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, usePortal } = this.state;
         return (
             <>
+                <H5>Props</H5>
                 <Switch checked={autoFocus} label="Auto focus" onChange={this.handleAutoFocusChange} />
                 <Switch checked={enforceFocus} label="Enforce focus" onChange={this.handleEnforceFocusChange} />
                 <Switch checked={usePortal} onChange={this.handleUsePortalChange}>

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Classes, EditableText, FormGroup, H1, Intent, NumericInput, Switch } from "@blueprintjs/core";
+import { Classes, EditableText, FormGroup, H1, H5, Intent, NumericInput, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -62,6 +62,7 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
     private renderOptions() {
         return (
             <>
+                <H5>Props</H5>
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <FormGroup label="Max length" labelFor={INPUT_ID}>
                     <NumericInput

--- a/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
@@ -162,7 +162,11 @@ export class HotkeyPiano extends React.PureComponent<IExampleProps, IHotkeyPiano
 
         if (AUDIO_CONTEXT == null) {
             return (
-                <div tabIndex={0}>Oops! This browser does not support the WebAudio API needed for this example.</div>
+                <Example options={false} {...this.props}>
+                    <div tabIndex={0}>
+                        Oops! This browser does not support the WebAudio API needed for this example.
+                    </div>
+                </Example>
             );
         }
 

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Icon, Label, Slider } from "@blueprintjs/core";
+import { H5, Icon, Label, Slider } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 import { IconSelect } from "./common/iconSelect";
@@ -27,6 +27,7 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
 
         const options = (
             <>
+                <H5>Props</H5>
                 <IconSelect iconName={icon} onChange={this.handleIconNameChange} />
                 <Label text="Icon size" />
                 <Slider

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import {
     Button,
     Classes,
+    H5,
     InputGroup,
     Intent,
     Menu,
@@ -121,6 +122,7 @@ export class InputGroupExample extends React.PureComponent<IExampleProps, IInput
         const { disabled, large } = this.state;
         return (
             <>
+                <H5>Props</H5>
                 <Switch label="Disabled" onChange={this.handleDisabledChange} checked={disabled} />
                 <Switch label="Large" onChange={this.handleLargeChange} checked={large} />
             </>

--- a/packages/docs-app/src/examples/core-examples/navbarExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/navbarExample.tsx
@@ -10,6 +10,7 @@ import {
     Alignment,
     Button,
     Classes,
+    H5,
     Navbar,
     NavbarDivider,
     NavbarGroup,
@@ -31,7 +32,12 @@ export class NavbarExample extends React.PureComponent<IExampleProps, INavbarExa
 
     public render() {
         const { alignRight } = this.state;
-        const options = <Switch checked={alignRight} label="Align right" onChange={this.handleAlignRightChange} />;
+        const options = (
+            <>
+                <H5>Props</H5>
+                <Switch checked={alignRight} label="Align right" onChange={this.handleAlignRightChange} />
+            </>
+        );
         return (
             <Example options={options} {...this.props}>
                 <Navbar>

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Classes, InputGroup, NonIdealState, Switch } from "@blueprintjs/core";
+import { Classes, H5, InputGroup, NonIdealState, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface INonIdealStateExampleState {
@@ -29,6 +29,7 @@ export class NonIdealStateExample extends React.PureComponent<IExampleProps, INo
     public render() {
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch label="Show icon" checked={this.state.icon} onChange={this.toggleIcon} />
                 <Switch label="Show description" checked={this.state.description} onChange={this.toggleDescription} />
                 <Switch label="Show action" checked={this.state.action} onChange={this.toggleAction} />

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -6,7 +6,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Button, Classes, Code, H3, Intent, Overlay, Switch } from "@blueprintjs/core";
+import { Button, Classes, Code, H3, H5, Intent, Overlay, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IBlueprintExampleData } from "../../tags/reactExamples";
 
@@ -82,6 +82,7 @@ export class OverlayExample extends React.PureComponent<IExampleProps<IBlueprint
         const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, hasBackdrop, usePortal } = this.state;
         return (
             <>
+                <H5>Props</H5>
                 <Switch checked={autoFocus} label="Auto focus" onChange={this.handleAutoFocusChange} />
                 <Switch checked={enforceFocus} label="Enforce focus" onChange={this.handleEnforceFocusChange} />
                 <Switch checked={usePortal} onChange={this.handleUsePortalChange}>

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, Code, IPopoverProps, Popover, Position, Switch } from "@blueprintjs/core";
+import { Button, Code, H5, IPopoverProps, Popover, Position, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface IPopoverPortalExampleState {
@@ -34,7 +34,9 @@ export class PopoverPortalExample extends React.PureComponent<IExampleProps, IPo
 
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch label="Open" checked={isOpen} onChange={this.handleOpen} />
+                <H5>Example</H5>
                 <Button text="Re-center" icon="alignment-vertical-center" onClick={this.recenter} />
             </>
         );

--- a/packages/docs-app/src/examples/core-examples/progressExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/progressExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Intent, ProgressBar, Slider, Switch } from "@blueprintjs/core";
+import { H5, Intent, ProgressBar, Slider, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -31,7 +31,9 @@ export class ProgressExample extends React.PureComponent<IExampleProps, IProgres
 
         const options = (
             <>
-                <Switch checked={hasValue} label="Known Value" onChange={this.handleIndeterminateChange} />
+                <H5>Props</H5>
+                <IntentSelect intent={intent} onChange={this.handleModifierChange} />
+                <Switch checked={hasValue} label="Known value" onChange={this.handleIndeterminateChange} />
                 <Slider
                     disabled={!hasValue}
                     labelStepSize={1}
@@ -43,7 +45,6 @@ export class ProgressExample extends React.PureComponent<IExampleProps, IProgres
                     showTrackFill={false}
                     value={value}
                 />
-                <IntentSelect intent={intent} onChange={this.handleModifierChange} />
             </>
         );
 

--- a/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { NumberRange, RangeSlider, Switch } from "@blueprintjs/core";
+import { H5, NumberRange, RangeSlider, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface IRangeSliderExampleState {
@@ -24,7 +24,12 @@ export class RangeSliderExample extends React.PureComponent<IExampleProps, IRang
 
     public render() {
         const { range, vertical } = this.state;
-        const options = <Switch label="Vertical" checked={vertical} onChange={this.toggleVertical} />;
+        const options = (
+            <>
+                <H5>Props</H5>
+                <Switch label="Vertical" checked={vertical} onChange={this.toggleVertical} />
+            </>
+        );
 
         return (
             <Example options={options} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Slider, Switch } from "@blueprintjs/core";
+import { H5, Slider, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ISliderExampleState {
@@ -28,7 +28,12 @@ export class SliderExample extends React.PureComponent<IExampleProps, ISliderExa
 
     public render() {
         const { vertical } = this.state;
-        const options = <Switch checked={vertical} label="Vertical" key="vertical" onChange={this.toggleVertical} />;
+        const options = (
+            <>
+                <H5>Props</H5>
+                <Switch checked={vertical} label="Vertical" key="vertical" onChange={this.toggleVertical} />
+            </>
+        );
 
         return (
             <Example options={options} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Classes, Intent, Label, Slider, Spinner, Switch } from "@blueprintjs/core";
+import { Classes, H5, Intent, Label, Slider, Spinner, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IntentSelect } from "./common/intentSelect";
 
@@ -52,7 +52,16 @@ export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerE
         const { size, hasValue, intent, value } = this.state;
         return (
             <>
-                <Switch checked={hasValue} label="Known Value" onChange={this.handleIndeterminateChange} />
+                <H5>Props</H5>
+                <IntentSelect intent={intent} onChange={this.handleModifierChange} />
+                <Label text="Size">
+                    <div className={Classes.SELECT}>
+                        <select value={size} onChange={this.handleSizeChange}>
+                            {SIZES.map((opt, i) => <option key={i} {...opt} />)}
+                        </select>
+                    </div>
+                </Label>
+                <Switch checked={hasValue} label="Known value" onChange={this.handleIndeterminateChange} />
                 <Slider
                     disabled={!hasValue}
                     labelStepSize={1}
@@ -64,14 +73,6 @@ export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerE
                     showTrackFill={false}
                     value={value}
                 />
-                <IntentSelect intent={intent} onChange={this.handleModifierChange} />
-                <Label text="Size">
-                    <div className={Classes.SELECT}>
-                        <select value={size} onChange={this.handleSizeChange}>
-                            {SIZES.map((opt, i) => <option key={i} {...opt} />)}
-                        </select>
-                    </div>
-                </Label>
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Alignment, Classes, H3, InputGroup, Navbar, Switch, Tab, TabId, Tabs } from "@blueprintjs/core";
+import { Alignment, Classes, H3, H5, InputGroup, Navbar, Switch, Tab, TabId, Tabs } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ITabsExampleState {
@@ -31,6 +31,7 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
     public render() {
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch checked={this.state.animate} label="Animate indicator" onChange={this.toggleAnimate} />
                 <Switch checked={this.state.vertical} label="Use vertical tabs" onChange={this.toggleVertical} />
                 <Switch

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, Intent, Switch, Tag } from "@blueprintjs/core";
+import { Button, H5, Intent, Switch, Tag } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IntentSelect } from "./common/intentSelect";
 
@@ -56,11 +56,13 @@ export class TagExample extends React.PureComponent<IExampleProps, ITagExampleSt
         const { intent, interactive, large, minimal, removable } = this.state;
         return (
             <>
+                <H5>Props</H5>
                 <Switch label="Large" checked={large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Interactive" checked={interactive} onChange={this.handleInteractiveChange} />
                 <Switch label="Removable" checked={removable} onChange={this.handleRemovableChange} />
                 <IntentSelect intent={intent} onChange={this.handleIntentChange} />
+                <H5>Example</H5>
                 <Button icon="refresh" text="Reset tags" onClick={this.resetTags} />
             </>
         );

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -92,11 +92,12 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
     private renderOptions() {
         return (
             <>
+                <H5>Props</H5>
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />
-                <H5>Tag props</H5>
+                <H5>Example</H5>
                 <Switch label="Use minimal tags" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Cycle through intents" checked={this.state.intent} onChange={this.handleIntentChange} />
             </>

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -97,7 +97,7 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />
-                <H5>Example</H5>
+                <H5>Tag props</H5>
                 <Switch label="Use minimal tags" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Cycle through intents" checked={this.state.intent} onChange={this.handleIntentChange} />
             </>

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import {
     Button,
     Classes,
+    H5,
     Intent,
     IToasterProps,
     IToastProps,
@@ -109,7 +110,8 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
         const { autoFocus, canEscapeKeyClear, position } = this.state;
         return (
             <>
-                <Label text="Toast position">
+                <H5>Props</H5>
+                <Label text="Position">
                     <div className={Classes.SELECT}>
                         <select value={position.toString()} onChange={this.handlePositionChange}>
                             <option value={Position.TOP_LEFT.toString()}>Top left</option>

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Position, Switch } from "@blueprintjs/core";
+import { H5, Position, Switch } from "@blueprintjs/core";
 import { DateInput, IDateFormatProps, TimePickerPrecision } from "@blueprintjs/datetime";
 import { Example, handleBooleanChange, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
@@ -59,12 +59,13 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
         const { closeOnSelection, disabled, reverseMonthAndYearMenus: reverse, format, timePrecision } = this.state;
         return (
             <>
+                <H5>Props</H5>
                 <Switch label="Close on selection" checked={closeOnSelection} onChange={this.toggleSelection} />
                 <Switch label="Disabled" checked={disabled} onChange={this.toggleDisabled} />
                 <Switch label="Reverse month and year menus" checked={reverse} onChange={this.toggleReverseMenus} />
                 <FormatSelect format={format} onChange={this.handleFormatChange} />
                 <PrecisionSelect
-                    label="Time Precision"
+                    label="Time precision"
                     allowEmpty={true}
                     value={timePrecision}
                     onChange={this.toggleTimePrecision}

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Switch } from "@blueprintjs/core";
+import { Classes, H5, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 
@@ -32,6 +32,7 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
 
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch checked={showActionsBar} label="Show actions bar" onChange={this.toggleActionsBar} />
                 <Switch
                     checked={reverseMenus}

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, IPopoverProps, Label, Switch } from "@blueprintjs/core";
+import { Classes, H5, IPopoverProps, Switch } from "@blueprintjs/core";
 import { DateRange, DateRangeInput, IDateFormatProps } from "@blueprintjs/datetime";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
@@ -71,7 +71,7 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
     protected renderOptions() {
         return (
             <>
-                <Label text="Modifiers" />
+                <H5>Props</H5>
                 <Switch
                     checked={this.state.allowSingleDayRange}
                     label="Allow single day range"

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -120,7 +120,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                     />
                 </div>
                 <div>
-                    <H5 />
                     {this.renderSelectMenu(
                         "Minimum date",
                         this.state.minDateIndex,

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Label, Switch } from "@blueprintjs/core";
+import { Classes, H5, Label, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
 import moment from "moment";
 import * as React from "react";
@@ -101,6 +101,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
         return (
             <>
                 <div>
+                    <H5>Props</H5>
                     <Switch
                         checked={this.state.allowSingleDayRange}
                         label="Allow single day range"
@@ -119,6 +120,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                     />
                 </div>
                 <div>
+                    <H5 />
                     {this.renderSelectMenu(
                         "Minimum date",
                         this.state.minDateIndex,

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Switch } from "@blueprintjs/core";
+import { Classes, H5, Switch } from "@blueprintjs/core";
 import { Example, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 import { PrecisionSelect } from "./common/precisionSelect";
@@ -57,6 +57,7 @@ export class TimePickerExample extends React.PureComponent<IExampleProps, ITimeP
     protected renderOptions() {
         return (
             <>
+                <H5>Props</H5>
                 <Switch
                     checked={this.state.selectAllOnFocus}
                     label="Select all on focus"

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -96,7 +96,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     checked={this.state.hasInitialContent}
                     onChange={this.handleInitialContentChange}
                 />
-                <H5>Example</H5>
+                <H5>Tag props</H5>
                 <Switch
                     label="Minimal tag style"
                     checked={this.state.tagMinimal}
@@ -107,6 +107,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     checked={this.state.intent}
                     onChange={this.handleIntentChange}
                 />
+                <H5>Popover props</H5>
                 <Switch
                     label="Minimal popover style"
                     checked={this.state.popoverMinimal}

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 
 import {
     Button,
+    H5,
     Hotkey,
     Hotkeys,
     HotkeysTarget,
@@ -58,7 +59,10 @@ export class OmnibarExample extends React.PureComponent<IExampleProps, IOmnibarE
 
     public render() {
         const options = (
-            <Switch label="Reset on select" checked={this.state.resetOnSelect} onChange={this.handleResetChange} />
+            <>
+                <H5>Props</H5>
+                <Switch label="Reset on select" checked={this.state.resetOnSelect} onChange={this.handleResetChange} />
+            </>
         );
 
         return (

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -88,7 +88,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     checked={this.state.hasInitialContent}
                     onChange={this.handleInitialContentChange}
                 />
-                <H5>Example</H5>
+                <H5>Popover props</H5>
                 <Switch
                     label="Minimal popover style"
                     checked={this.state.minimal}

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, MenuItem, Switch } from "@blueprintjs/core";
+import { Button, H5, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Select } from "@blueprintjs/select";
 import { filmSelectProps, IFilm, TOP_100_FILMS } from "./films";
@@ -70,6 +70,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
     protected renderOptions() {
         return (
             <>
+                <H5>Props</H5>
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Filterable" checked={this.state.filterable} onChange={this.handleFilterableChange} />
                 <Switch
@@ -83,14 +84,15 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     onChange={this.handleResetOnSelectChange}
                 />
                 <Switch
-                    label="Minimal popover style"
-                    checked={this.state.minimal}
-                    onChange={this.handleMinimalChange}
-                />
-                <Switch
                     label="Use initial content"
                     checked={this.state.hasInitialContent}
                     onChange={this.handleInitialContentChange}
+                />
+                <H5>Example</H5>
+                <Switch
+                    label="Minimal popover style"
+                    checked={this.state.minimal}
+                    onChange={this.handleMinimalChange}
                 />
             </>
         );

--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { MenuItem, Switch } from "@blueprintjs/core";
+import { H5, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Suggest } from "@blueprintjs/select";
 import { filmSelectProps, IFilm, TOP_100_FILMS } from "./films";
@@ -51,6 +51,7 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
     protected renderOptions() {
         return (
             <>
+                <H5>Props</H5>
                 <Switch
                     label="Close on select"
                     checked={this.state.closeOnSelect}
@@ -61,6 +62,7 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
                     checked={this.state.openOnKeyDown}
                     onChange={this.handleOpenOnKeyDownChange}
                 />
+                <H5>Popover props</H5>
                 <Switch
                     label="Minimal popover style"
                     checked={this.state.minimal}

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import { H5, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { TimezoneDisplayFormat, TimezonePicker } from "@blueprintjs/timezone";
 
@@ -36,6 +36,7 @@ export class TimezonePickerExample extends React.PureComponent<IExampleProps, IT
 
         const options = (
             <>
+                <H5>Props</H5>
                 <Switch checked={showLocalTimezone} label="Show local timezone" onChange={this.handleShowLocalChange} />
                 <Switch checked={disabled} label="Disabled" onChange={this.handleDisabledChange} />
                 <RadioGroup


### PR DESCRIPTION
Still a few rough edges:
![screen shot 2018-05-16 at 3 20 18 pm](https://user-images.githubusercontent.com/199754/40148268-0352019e-5922-11e8-9970-970c3bace2c1.png)
![screen shot 2018-05-16 at 3 47 32 pm](https://user-images.githubusercontent.com/199754/40148269-036b8dc6-5922-11e8-8757-7615e22e59c4.png)
![screen shot 2018-05-16 at 3 48 27 pm](https://user-images.githubusercontent.com/199754/40148270-0381a0b6-5922-11e8-8bad-00f29bb8c904.png)
![screen shot 2018-05-16 at 3 48 45 pm](https://user-images.githubusercontent.com/199754/40148271-039ceeb6-5922-11e8-981b-e790ff0e9bf4.png)
![screen shot 2018-05-16 at 3 52 54 pm](https://user-images.githubusercontent.com/199754/40148272-03ba86a6-5922-11e8-9b2d-999a23d75e13.png)



They're due to `core` spacing bugs. Good thing we're building a sidebar-style form options container, I've discovered a ton of form controls issues thanks to that!!