### PR TITLE
Toaster.create throws error if used within lifecycle method

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -66,6 +66,10 @@ export const SLIDER_ZERO_STEP = ns + ` <Slider> stepSize must be greater than ze
 export const SLIDER_ZERO_LABEL_STEP = ns + ` <Slider> labelStepSize must be greater than zero.`;
 export const RANGESLIDER_NULL_VALUE = ns + ` <RangeSlider> value prop must be an array of two non-null numbers.`;
 
+export const TOASTER_CREATE_NULL =
+    ns +
+    ` Toaster.create() is not supported inside React lifecycle methods in React 16.` +
+    ` See usage example on the docs site.`;
 export const TOASTER_WARN_INLINE = ns + ` Toaster.create() ignores inline prop as it always creates a new element.`;
 
 export const DIALOG_WARN_NO_HEADER_ICON = ns + ` <Dialog> iconName is ignored if title is omitted.`;

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -65,12 +65,18 @@ has a collection of methods to show and hide toasts in its given container.
 Toaster.create(props?: IToasterProps, container = document.body): IToaster
 ```
 
-
-The `Toaster` will be rendered into a new element appended to the given `container`. The `container` determines which element toasts are positioned relative to; the default value of `<body>` allows them to use the entire viewport.
+The `Toaster` will be rendered into a new element appended to the given `container`.
+The `container` determines which element toasts are positioned relative to; the default value of `<body>` allows them to use the entire viewport.
 
 Note that the return type is `IToaster`, which is a minimal interface that exposes only the instance
 methods detailed below. It can be thought of as `Toaster` minus the `React.Component` methods,
 because the `Toaster` should not be treated as a normal React component.
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h4 class="@ns-heading">React 16 usage</h4>
+    `Toaster.create()` will throw an error if invoked inside a component lifecycle method in React 16, as `ReactDOM.render()` will return
+    `null` resulting in an inaccessible toaster instance. See the second bullet point on the [React 16 release notes](https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes) for more information.
+</div>
 
 @interface IToaster
 

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -10,7 +10,7 @@ import * as ReactDOM from "react-dom";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
-import { TOASTER_WARN_INLINE } from "../../common/errors";
+import { TOASTER_CREATE_NULL, TOASTER_WARN_INLINE } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
@@ -107,7 +107,11 @@ export class Toaster extends AbstractPureComponent<IToasterProps, IToasterState>
         }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
-        return ReactDOM.render(<Toaster {...props} usePortal={false} />, containerElement) as Toaster;
+        const toaster = ReactDOM.render(<Toaster {...props} usePortal={false} />, containerElement) as Toaster;
+        if (toaster == null) {
+            throw new Error(TOASTER_CREATE_NULL);
+        }
+        return toaster;
     }
 
     public state = {

--- a/packages/core/test/toast/toasterTests.ts
+++ b/packages/core/test/toast/toasterTests.ts
@@ -5,10 +5,13 @@
  */
 
 import { assert } from "chai";
+import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { spy } from "sinon";
 
+import { mount } from "enzyme";
 import * as Classes from "../../src/common/classes";
+import { TOASTER_CREATE_NULL } from "../../src/common/errors";
 import { IToaster, Toaster } from "../../src/index";
 
 describe("Toaster", () => {
@@ -136,5 +139,22 @@ describe("Toaster", () => {
                 done();
             }, 10);
         });
+    });
+
+    it("throws an error if used within a React lifecycle method", () => {
+        class LifecycleToaster extends React.Component {
+            public render() {
+                return React.createElement("div");
+            }
+
+            public componentDidMount() {
+                try {
+                    Toaster.create();
+                } catch (err) {
+                    assert.equal(err.message, TOASTER_CREATE_NULL);
+                }
+            }
+        }
+        mount(React.createElement(LifecycleToaster));
     });
 });


### PR DESCRIPTION
to avoid breaking change in React 16.
https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes