### PR TITLE
[1.x] Toaster.create errors if ReactDOM.render returns null

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -70,6 +70,10 @@ export const TABS_WARN_DEPRECATED =
     ` <Tabs> is deprecated since v1.11.0; consider upgrading to <Tabs2>.` +
     " https://blueprintjs.com/#components.tabs.js";
 
+export const TOASTER_CREATE_NULL =
+    ns +
+    ` Toaster.create() is not supported inside React lifecycle methods in React 16.` +
+    ` See usage example on the docs site.`;
 export const TOASTER_WARN_INLINE = ns + ` Toaster.create() ignores inline prop as it always creates a new element.`;
 export const TOASTER_WARN_LEFT_RIGHT = ns + ` Toaster does not support LEFT or RIGHT positions.`;
 

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -104,15 +104,12 @@ import { Button, Position, Toaster } from "@blueprintjs/core";
 
 class MyComponent extends React.Component<{}, {}> {
     private toaster: Toaster;
-    private refHandlers = {
-        toaster: (ref: Toaster) => this.toaster = ref,
-    };
 
     public render() {
         return (
             <div>
                 <Button onClick={this.addToast} text="Procure toast" />
-                <Toaster position={Position.TOP_RIGHT} ref={this.refHandlers.toaster} />
+                <Toaster position={Position.TOP_RIGHT} ref={ref => this.toaster = ref} />
             </div>
         )
     }

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -11,7 +11,7 @@ import * as ReactDOM from "react-dom";
 
 import { AbstractComponent } from "../../common/abstractComponent";
 import * as Classes from "../../common/classes";
-import { TOASTER_WARN_INLINE, TOASTER_WARN_LEFT_RIGHT } from "../../common/errors";
+import { TOASTER_CREATE_NULL, TOASTER_WARN_INLINE, TOASTER_WARN_LEFT_RIGHT } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
@@ -97,7 +97,11 @@ export class Toaster extends AbstractComponent<IToasterProps, IToasterState> imp
         }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
-        return ReactDOM.render(<Toaster {...props} inline={true} />, containerElement) as Toaster;
+        const toaster = ReactDOM.render(<Toaster {...props} inline={true} />, containerElement) as Toaster;
+        if (toaster == null) {
+            throw new Error(TOASTER_CREATE_NULL);
+        }
+        return toaster;
     }
 
     public state = {


### PR DESCRIPTION
to avoid breaking change in React 16.
https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes