### PR TITLE
3.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprintjs-monorepo",
-  "version": "2.3.0",
+  "version": "3.0.0-beta.1",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Core styles & components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/docs-theme",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Blueprint theme for documentalist",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -28,7 +28,7 @@
     "verify": "npm-run-all compile -p dist lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-beta.1",
     "@blueprintjs/select": "^3.0.0-beta.0",
     "classnames": "^2.2",
     "documentalist": "^1.3.2",

--- a/packages/docs-theme/src/components/baseExample.tsx
+++ b/packages/docs-theme/src/components/baseExample.tsx
@@ -8,6 +8,8 @@ import { Utils } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
+export const WARNING_BASE_EXAMPLE_DEPRECATED = `[Blueprint] BaseExample is deprecated and will be removed in the next beta. Compose new Example component instead of extending BaseExample.`;
+
 export interface IBaseExampleProps {
     id: string;
     themeName: string;
@@ -16,6 +18,7 @@ export interface IBaseExampleProps {
 /**
  * Starter class for all React example components.
  * Examples and options are rendered into separate containers.
+ * @deprecated
  */
 export class BaseExample<S> extends React.Component<IBaseExampleProps, S> {
     /** Define this prop to add a className to the example container */
@@ -44,6 +47,10 @@ export class BaseExample<S> extends React.Component<IBaseExampleProps, S> {
             this.hasDelayedBeforeInitialRender = true;
             this.forceUpdate();
         });
+    }
+
+    public componentDidMount() {
+        console.warn(WARNING_BASE_EXAMPLE_DEPRECATED);
     }
 
     public componentDidUpdate(_nextProps: IBaseExampleProps, _nextState: S) {


### PR DESCRIPTION
already published from `next` branch so it'll appear as the `@next` npm dist-tag.

`@blueprintjs/core@3.0.0-beta.1`
`@blueprintjs/docs-theme@3.0.0-beta.1`