### PR TITLE
[Common] Adding 'round' to the INVALID_PROPS list

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -108,6 +108,7 @@ const INVALID_PROPS = [
     "popoverProps",
     "rightElement",
     "rightIcon",
+    "round",
     "small",
     "text",
 ];

--- a/packages/core/test/common/propsTests.ts
+++ b/packages/core/test/common/propsTests.ts
@@ -21,6 +21,7 @@ describe("Props", () => {
                 elementRef: true,
                 icon: true,
                 intent: true,
+                round: true,
                 text: true,
             };
         });
@@ -40,6 +41,7 @@ describe("Props", () => {
                 elementRef: true,
                 icon: true,
                 intent: true,
+                round: true,
                 text: true,
             });
         });


### PR DESCRIPTION
#### Fixes #2508

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests

#### Changes proposed in this pull request:

Add `"round"` to the list of invalid html props, this will prevent the `round` prop being passed through to the the HTML Input element [here](https://github.com/palantir/blueprint/blob/develop/packages/core/src/components/forms/inputGroup.tsx#L92).

#### Reviewers should focus on:

I've incorporated this prop into the existing tests for this utility function, but not for the InputGroup component itself.

Round does not appear to be a valid html attribute so adding it to this list should be fine
* https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes


