### PR TITLE
[Callout] Add first-child to only target callout icon

### DIFF
--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -45,7 +45,7 @@ Styleguide callout
   &.#{$ns}-callout-icon {
     padding-left: ($pt-grid-size * 2) + $pt-icon-size-large;
 
-    .#{$ns}-icon {
+    > .#{$ns}-icon:first-child {
       position: absolute;
       top: $pt-grid-size;
       left: $pt-grid-size;
@@ -72,7 +72,7 @@ Styleguide callout
       background-color: rgba($color, 0.15);
 
       &[class*="#{$ns}-icon-"]::before,
-      .#{$ns}-icon,
+      > .#{$ns}-icon:first-child,
       .#{$ns}-heading {
         color: map-get($pt-intent-text-colors, $intent);
       }
@@ -81,7 +81,7 @@ Styleguide callout
         background-color: rgba($color, 0.25);
 
         &[class*="#{$ns}-icon-"]::before,
-        .#{$ns}-callout-icon,
+        > .#{$ns}-icon:first-child,
         .#{$ns}-heading {
           color: map-get($pt-dark-intent-text-colors, $intent);
         }


### PR DESCRIPTION
fixes #2472

![image](https://user-images.githubusercontent.com/199754/40387094-8120d986-5dc0-11e8-85e0-ac1a808164cc.png)
![image](https://user-images.githubusercontent.com/199754/40387104-8ae92608-5dc0-11e8-8acc-334daadf3316.png)
