### PR TITLE
[Core/Datetime] remove usePortal={false} where not documented

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -150,7 +150,6 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
                 interactionKind={PopoverInteractionKind.HOVER}
                 modifiers={SUBMENU_POPOVER_MODIFIERS}
                 position={Position.RIGHT_TOP}
-                usePortal={false}
                 {...popoverProps}
                 content={<Menu>{children}</Menu>}
                 minimal={true}

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -203,7 +203,6 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         return (
             <Popover
                 isOpen={this.state.isOpen && !this.props.disabled}
-                usePortal={false}
                 {...popoverProps}
                 autoFocus={false}
                 className={classNames(popoverProps.className, this.props.className)}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -278,7 +278,6 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             <Popover
                 isOpen={this.state.isOpen}
                 position={Position.BOTTOM_LEFT}
-                usePortal={false}
                 {...this.props.popoverProps}
                 autoFocus={false}
                 className={popoverClassName}

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -15,6 +15,9 @@ import { Classes, DateInput, IDateInputProps, TimePicker, TimePrecision } from "
 import { DATE_FORMAT } from "./common/dateFormat";
 import * as DateTestUtils from "./common/dateTestUtils";
 
+// Change the default for testability
+DateInput.defaultProps.popoverProps = { usePortal: false };
+
 describe("<DateInput>", () => {
     it("handles null inputs without crashing", () => {
         assert.doesNotThrow(() => mount(<DateInput {...DATE_FORMAT} value={null} />));
@@ -29,7 +32,9 @@ describe("<DateInput>", () => {
         const CLASS_1 = "foo";
         const CLASS_2 = "bar";
 
-        const wrapper = mount(<DateInput {...DATE_FORMAT} className={CLASS_1} popoverProps={{ className: CLASS_2 }} />);
+        const wrapper = mount(
+            <DateInput {...DATE_FORMAT} className={CLASS_1} popoverProps={{ className: CLASS_2, usePortal: false }} />,
+        );
         wrapper.setState({ isOpen: true });
 
         const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_WRAPPER}`).hostNodes();

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -43,6 +43,9 @@ type InvalidDateTestFunction = (
     otherInputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
 ) => void;
 
+// Change the default for testability
+DateRangeInput.defaultProps.popoverProps = { usePortal: false };
+
 describe("<DateRangeInput>", () => {
     const START_DAY = 22;
     const START_DATE = new Date(2017, Months.JANUARY, START_DAY);
@@ -91,7 +94,11 @@ describe("<DateRangeInput>", () => {
         const CLASS_2 = "bar";
 
         const wrapper = mount(
-            <DateRangeInput {...DATE_FORMAT} className={CLASS_1} popoverProps={{ className: CLASS_2 }} />,
+            <DateRangeInput
+                {...DATE_FORMAT}
+                className={CLASS_1}
+                popoverProps={{ className: CLASS_2, usePortal: false }}
+            />,
         );
         wrapper.setState({ isOpen: true });
 
@@ -360,6 +367,7 @@ describe("<DateRangeInput>", () => {
                 popoverWillClose: sinon.spy(),
                 popoverWillOpen: sinon.spy(),
                 position: Position.TOP_LEFT,
+                usePortal: false,
             };
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />);
 
@@ -380,6 +388,7 @@ describe("<DateRangeInput>", () => {
                 autoFocus: true,
                 content: CUSTOM_CONTENT,
                 enforceFocus: true,
+                usePortal: false,
             };
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />);
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/2505

- removed default `usePortal={false}` in `MenuItem`, `DateInput`, `DateRangeInput`