### PR TITLE
[Core] Buttons are directly children of align-(left|right) parents

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -233,8 +233,8 @@ a.#{$ns}-button {
   flex: 0 1 auto;
 
   // when alignment is set, grow to fill and inherit `text-align` set on `.#{$ns}-button`
-  .#{$ns}-align-left &,
-  .#{$ns}-align-right & {
+  .#{$ns}-align-left > &,
+  .#{$ns}-align-right > & {
     flex: 1 1 auto;
   }
 }


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/2358

#### Screenshot

Before:
<img width="571" alt="screen shot 2018-05-22 at 1 23 16 pm" src="https://user-images.githubusercontent.com/199754/40388211-b496a3c4-5dc3-11e8-8281-28811e977534.png">

After:
<img width="479" alt="screen shot 2018-05-22 at 1 24 41 pm" src="https://user-images.githubusercontent.com/199754/40388208-b2f6bd24-5dc3-11e8-9c2b-a2bee626b578.png">

