### PR TITLE
[Core] support dark intent colors on icons

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -9,10 +9,10 @@
   @each $intent, $color in $pt-intent-text-colors {
     &.#{$ns}-intent-#{$intent} {
       color: $color;
-    }
 
-    .#{$ns}-dark &.#{$ns}-intent-#{$intent} {
-      color: map-get($pt-dark-intent-text-colors, $intent);
+      .#{$ns}-dark & {
+        color: map-get($pt-dark-intent-text-colors, $intent);
+      }
     }
   }
 }

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -6,9 +6,13 @@
 #{$icon-classes} {
   display: inline-block;
 
-  @each $intent, $color in $pt-intent-colors {
+  @each $intent, $color in $pt-intent-text-colors {
     &.#{$ns}-intent-#{$intent} {
       color: $color;
+    }
+
+    .#{$ns}-dark &.#{$ns}-intent-#{$intent} {
+      color: map-get($pt-dark-intent-text-colors, $intent);
     }
   }
 }

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -6,13 +6,15 @@
 
 import * as React from "react";
 
-import { H5, Icon, Label, Slider } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Classes, H5, Icon, Intent, Label, Slider } from "@blueprintjs/core";
+import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 import { IconSelect } from "./common/iconSelect";
+import { IntentSelect } from "./common/intentSelect";
 
 export interface IIconExampleState {
     icon: IconName;
+    intent: Intent;
     iconSize: number;
 }
 
@@ -20,10 +22,11 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
     public state: IIconExampleState = {
         icon: "calendar",
         iconSize: Icon.SIZE_STANDARD,
+        intent: Intent.NONE,
     };
 
     public render() {
-        const { icon, iconSize } = this.state;
+        const { icon, iconSize, intent } = this.state;
 
         const options = (
             <>
@@ -38,16 +41,20 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
                     value={iconSize}
                     onChange={this.handleIconSizeChange}
                 />
+                <H5>Example</H5>
+                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
             </>
         );
 
         return (
             <Example options={options} {...this.props}>
-                <Icon icon={icon} iconSize={iconSize} />
+                <Icon icon={icon} iconSize={iconSize} className={Classes.intentClass(intent)} />
             </Example>
         );
     }
 
+    // tslint:disable-next-line:member-ordering
+    private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
     private handleIconSizeChange = (iconSize: number) => this.setState({ iconSize });
     private handleIconNameChange = (icon: IconName) => this.setState({ icon });
 }

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Classes, H5, Icon, Intent, Label, Slider } from "@blueprintjs/core";
+import { H5, Icon, Intent, Label, Slider } from "@blueprintjs/core";
 import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 import { IconSelect } from "./common/iconSelect";
@@ -14,8 +14,8 @@ import { IntentSelect } from "./common/intentSelect";
 
 export interface IIconExampleState {
     icon: IconName;
-    intent: Intent;
     iconSize: number;
+    intent: Intent;
 }
 
 export class IconExample extends React.PureComponent<IExampleProps, IIconExampleState> {
@@ -32,6 +32,7 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
             <>
                 <H5>Props</H5>
                 <IconSelect iconName={icon} onChange={this.handleIconNameChange} />
+                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <Label text="Icon size" />
                 <Slider
                     labelStepSize={MAX_ICON_SIZE / 5}
@@ -41,14 +42,12 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
                     value={iconSize}
                     onChange={this.handleIconSizeChange}
                 />
-                <H5>Example</H5>
-                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
             </>
         );
 
         return (
             <Example options={options} {...this.props}>
-                <Icon icon={icon} iconSize={iconSize} className={Classes.intentClass(intent)} />
+                <Icon icon={icon} iconSize={iconSize} intent={intent} />
             </Example>
         );
     }


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/1745

also added a intent select in the icon example, so it's easy to test out