### PR TITLE
[Core] Add margin back to NonIdealState component

### DIFF
--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -14,6 +14,7 @@ Markup:
   </div>
   <h4 class="#{$ns}-heading">This folder is empty</h4>
   <div>Create a new file to populate the folder.</div>
+  <button class="#{$ns}-button #{$ns}-intent-primary">Create</button>
 </div>
 
 Styleguide non-ideal-state
@@ -23,11 +24,13 @@ Styleguide non-ideal-state
   @include pt-flex-container(column, $pt-grid-size * 2);
   align-items: center;
   justify-content: center;
-  margin: 0 auto;
   width: 100%;
-  max-width: $pt-grid-size * 40;
   height: 100%;
   text-align: center;
+
+  > * {
+    max-width: $pt-grid-size * 40;
+  }
 }
 
 .#{$ns}-non-ideal-state-visual {

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -23,6 +23,7 @@ Styleguide non-ideal-state
   @include pt-flex-container(column, $pt-grid-size * 2);
   align-items: center;
   justify-content: center;
+  margin: 0 auto;
   width: 100%;
   max-width: $pt-grid-size * 40;
   height: 100%;


### PR DESCRIPTION
#### Changes proposed in this pull request:

`auto` horizontal margins on `NonIdealState`s [were removed](https://github.com/palantir/blueprint/pull/2489/files#diff-27d14069409a15d17d8c55b7c834997dL26) between the `3.0.0-beta.0` and `3.0.0-beta.1` releases, causing visual breaks for users which were relying on that to do centering. This PR brings that margin back.