### PR TITLE
[1.x] docs version selector links to latest

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -67,25 +67,14 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
 
     private renderVersionsMenu() {
         const { versions } = this.props;
-        if (versions.length === 1) {
-            return (
-                <div className="pt-text-muted" key="_versions">
-                    v{versions[0].version}
-                </div>
-            );
-        }
-
-        const match = /docs\/v([0-9]+)/.exec(location.href);
-        // default to latest release if we can't find a major version in the URL
-        const currentRelease = match == null ? versions[0].version : match[1];
-        const releaseItems = versions.map((rel, i) => <MenuItem key={i} href={rel.url} text={rel.version} />);
-        const menu = <Menu className="docs-version-list">{releaseItems}</Menu>;
-
         return (
-            <Popover content={menu} position={Position.BOTTOM} key="_versions">
+            <Popover position={Position.BOTTOM} key="_versions">
                 <button className="docs-version-selector pt-text-muted">
-                    v{currentRelease} <span className="pt-icon-standard pt-icon-caret-down" />
+                    v{versions[0].version} <span className="pt-icon-standard pt-icon-caret-down" />
                 </button>
+                <Menu className="docs-version-list">
+                    <MenuItem text="View latest version" href="/docs" />
+                </Menu>
             </Popover>
         );
     }

--- a/packages/docs-data/compile-docs-data
+++ b/packages/docs-data/compile-docs-data
@@ -96,38 +96,17 @@ function generateReleasesData() {
  * Create a JSON file containing published versions of the documentation
  */
 function generateVersionsData() {
-    let stdout = "";
-    const child = spawn("git", ["tag"]);
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", data => {
-        stdout += data;
-    });
-    child.on("close", () => {
-        /** @type {Map<string, string>} */
-        const majorVersionMap = stdout
-            .split("\n")
-            // turn @blueprintjs/core@* tags into version numbers
-            .filter(val => /\@blueprintjs\/core\@[1-9]\d*\.\d+\.\d+.*/.test(val))
-            .map(val => val.slice("@blueprintjs/core@".length))
-            .reduce((map, version) => {
-                const major = semver.major(version);
-                if (!map.has(major) || semver.gt(version, map.get(major))) {
-                    map.set(major, version);
-                }
-                return map;
-            }, new Map());
-        // sort in reverse order (so latest is first)
-        const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
-
-        console.info("[docs-data] Major versions found:", majorVersions.join(", "));
-
-        fs.writeFileSync(path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME), JSON.stringify(strMapToObj(majorVersionMap), null, 2));
-    });
+    // Release/1.x: only include current package.json version
+    const coreVersion = require(`${PACKAGES_DIR}/core/package.json`).version;
+    fs.writeFileSync(
+        path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME),
+        JSON.stringify({ [semver.major(coreVersion)]: coreVersion }, null, 2),
+    );
 }
 
 function strMapToObj(strMap) {
-    let obj = Object.create(null);
-    for (let [k,v] of strMap) {
+    const obj = Object.create(null);
+    for (const [k, v] of strMap) {
         // We don’t escape the key '__proto__'
         // which can cause problems on older engines
         obj[k] = v;


### PR DESCRIPTION
follow up from #2545

versions selector on 1.x site now only links to latest, as the other versions do not matter here.

![image](https://user-images.githubusercontent.com/464822/40680727-eef28650-633b-11e8-9b2d-c0dd3c3c6a3c.png)

