### PR TITLE
[2.x] docs version selector links to latest

### DIFF
--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -73,30 +73,14 @@ export class NavHeader extends React.PureComponent<INavHeaderProps, {}> {
 
     private renderVersionsMenu() {
         const { versions } = this.props;
-        if (versions.length === 1) {
-            return (
-                <Popover position={Position.BOTTOM} key="_versions">
-                    <Tag interactive={true} minimal={true} round={true}>
-                        v{versions[0].version.split(".", 1)} <Icon icon="caret-down" />
-                    </Tag>
-                    <Menu className="docs-version-list">
-                        <MenuItem text="View latest version" href="/docs" />
-                    </Menu>
-                </Popover>
-            );
-        }
-
-        const match = /docs\/v([0-9]+)/.exec(location.href);
-        // default to latest release if we can't find a major version in the URL
-        const currentRelease = match == null ? versions[versions.length - 1].version : match[1];
-        const releaseItems = versions.map((rel, i) => <MenuItem key={i} href={rel.url} text={rel.version} />);
-        const menu = <Menu className="docs-version-list">{releaseItems}</Menu>;
-
         return (
-            <Popover content={menu} position={Position.BOTTOM} key="_versions">
+            <Popover position={Position.BOTTOM} key="_versions">
                 <Tag interactive={true} minimal={true} round={true}>
-                    v{currentRelease.split(".", 1)} <Icon icon="caret-down" />
+                    v{versions[0].version.split(".", 1)} <Icon icon="caret-down" />
                 </Tag>
+                <Menu className="docs-version-list">
+                    <MenuItem text="View latest version" href="/docs" />
+                </Menu>
             </Popover>
         );
     }

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -75,9 +75,14 @@ export class NavHeader extends React.PureComponent<INavHeaderProps, {}> {
         const { versions } = this.props;
         if (versions.length === 1) {
             return (
-                <div className={Classes.TEXT_MUTED} key="_versions">
-                    v{versions[0].version}
-                </div>
+                <Popover position={Position.BOTTOM} key="_versions">
+                    <Tag interactive={true} minimal={true} round={true}>
+                        v{versions[0].version.split(".", 1)} <Icon icon="caret-down" />
+                    </Tag>
+                    <Menu className="docs-version-list">
+                        <MenuItem text="View latest version" href="/docs" />
+                    </Menu>
+                </Popover>
             );
         }
 

--- a/packages/docs-data/compile-docs-data
+++ b/packages/docs-data/compile-docs-data
@@ -98,36 +98,12 @@ function generateReleasesData() {
  * Create a JSON file containing published versions of the documentation
  */
 function generateVersionsData() {
-    let stdout = "";
-    const child = spawn("git", ["tag"]);
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", data => {
-        stdout += data;
-    });
-    child.on("close", () => {
-        /** @type {Map<string, string>} */
-        const majorVersionMap = stdout
-            .split("\n")
-            // turn @blueprintjs/core@* tags into version numbers
-            .filter(val => /\@blueprintjs\/core\@[1-9]\d*\.\d+\.\d+.*/.test(val))
-            .map(val => val.slice("@blueprintjs/core@".length))
-            .reduce((map, version) => {
-                const major = semver.major(version);
-                if (!map.has(major) || semver.gt(version, map.get(major))) {
-                    map.set(major, version);
-                }
-                return map;
-            }, new Map());
-        // sort in reverse order (so latest is first)
-        const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
-
-        console.info("[docs-data] Major versions found:", majorVersions.join(", "));
-
-        fs.writeFileSync(
-            path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME),
-            JSON.stringify(strMapToObj(majorVersionMap), null, 2),
-        );
-    });
+    // Release/2.x: only include current package.json version
+    const coreVersion = require(`${PACKAGES_DIR}/core/package.json`).version;
+    fs.writeFileSync(
+        path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME),
+        JSON.stringify({ [semver.major(coreVersion)]: coreVersion }, null, 2),
+    );
 }
 
 function strMapToObj(strMap) {


### PR DESCRIPTION
follow up from #2545

versions selector on 2.x site now only links to latest, as the other versions do not matter here.

![image](https://user-images.githubusercontent.com/464822/40680791-201e59b6-633c-11e8-97b6-f3810fcc98b9.png)
