### PR TITLE
use default type params for HotkeysTarget & CMTarget

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -16,13 +16,13 @@ import { getDisplayName, isFunction, safeInvoke } from "../../common/utils";
 import { isDarkTheme } from "../../common/utils/isDarkTheme";
 import * as ContextMenu from "./contextMenu";
 
-export interface IContextMenuTarget extends React.Component<any, any> {
+export interface IContextMenuTargetComponent extends React.Component {
     render(): React.ReactElement<any> | null | undefined;
     renderContextMenu(e: React.MouseEvent<HTMLElement>): JSX.Element | undefined;
     onContextMenuClose?(): void;
 }
 
-export function ContextMenuTarget<T extends IConstructor<IContextMenuTarget>>(WrappedComponent: T) {
+export function ContextMenuTarget<T extends IConstructor<IContextMenuTargetComponent>>(WrappedComponent: T) {
     if (!isFunction(WrappedComponent.prototype.renderContextMenu)) {
         console.warn(CONTEXTMENU_WARN_DECORATOR_NO_METHOD);
     }

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -15,7 +15,7 @@ import { Hotkey, IHotkeyProps } from "./hotkey";
 
 export { Hotkey, IHotkeyProps } from "./hotkey";
 export { KeyCombo, IKeyComboProps } from "./keyCombo";
-export { HotkeysTarget, IHotkeysTarget } from "./hotkeysTarget";
+export { HotkeysTarget, IHotkeysTargetComponent } from "./hotkeysTarget";
 export { IKeyCombo, comboMatches, getKeyCombo, getKeyComboString, parseKeyCombo } from "./hotkeyParser";
 export { IHotkeysDialogProps, hideHotkeysDialog, setHotkeysDialogProps } from "./hotkeysDialog";
 

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -12,7 +12,7 @@ import { getDisplayName, isFunction, safeInvoke } from "../../common/utils";
 import { IHotkeysProps } from "./hotkeys";
 import { HotkeyScope, HotkeysEvents } from "./hotkeysEvents";
 
-export interface IHotkeysTarget {
+export interface IHotkeysTargetComponent extends React.Component {
     /** Components decorated with the `@HotkeysTarget` decorator must implement React's component `render` function. */
     render(): React.ReactElement<any> | null | undefined;
 
@@ -23,9 +23,7 @@ export interface IHotkeysTarget {
     renderHotkeys(): React.ReactElement<IHotkeysProps>;
 }
 
-export type IHotkeysComponent = IHotkeysTarget & React.Component<any, any> & React.ComponentLifecycle<any, any>;
-
-export function HotkeysTarget<T extends IConstructor<IHotkeysComponent>>(WrappedComponent: T) {
+export function HotkeysTarget<T extends IConstructor<IHotkeysTargetComponent>>(WrappedComponent: T) {
     if (!isFunction(WrappedComponent.prototype.renderHotkeys)) {
         console.warn(HOTKEYS_WARN_DECORATOR_NO_METHOD);
     }


### PR DESCRIPTION
#### Fixes TS compiler errors like the following:

```
lerna ERR! ERROR in [at-loader] ../../node_modules/@blueprintjs/core/dist/esm/components/hotkeys/hotkeysTarget.d.ts:4:18
lerna ERR!     TS2320: Interface 'IHotkeysTarget' cannot simultaneously extend types 'Component<any, any, any>' and 'ComponentLifecycle<any, any, never>'.
```
