### PR TITLE
Horizontal scrolling is no longer disabled when columns filling width with no rows of data

### DIFF
--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -280,6 +280,10 @@ export class Grid {
         return rowIndex >= this.numRows || columnIndex >= this.numCols;
     }
 
+    public isGhostColumn(columnIndex: number) {
+        return columnIndex >= this.numCols;
+    }
+
     public getExtremaClasses(rowIndex: number, columnIndex: number, rowEnd: number, columnEnd: number) {
         if (rowIndex === rowEnd && columnIndex === columnEnd) {
             return [Classes.TABLE_LAST_IN_COLUMN, Classes.TABLE_LAST_IN_ROW];

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1193,7 +1193,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const columnIndices = this.grid.getColumnIndicesInRect(viewportRect, enableGhostCells);
 
         const isViewportUnscrolledHorizontally = viewportRect != null && viewportRect.left === 0;
-        const areGhostColumnsVisible = enableGhostCells && this.grid.isGhostIndex(0, columnIndices.columnIndexEnd);
+        const areGhostColumnsVisible = enableGhostCells && this.grid.isGhostColumn(columnIndices.columnIndexEnd);
         const areColumnHeadersLoading = this.hasLoadingOption(
             this.props.loadingOptions,
             TableLoadingOption.COLUMN_HEADERS,

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -148,6 +148,56 @@ describe("<Table>", () => {
         expect(onVisibleCellsChange.lastCall.calledWith(rowIndices, columnIndices)).to.be.true;
     });
 
+    describe("Horizontally scrolling", () => {
+        const CONTAINER_WIDTH = 500;
+        const CONTAINER_HEIGHT = 500;
+
+        describe("with no rows of data and ghost cells enabled", () => {
+            it("isn't disabled when there are actual columns filling width", () => {
+                // large values that will force scrolling
+                const LARGE_COLUMN_WIDTH = 300;
+                const columnWidths = Array(3).fill(LARGE_COLUMN_WIDTH);
+
+                const { containerElement, table } = mountTable({ columnWidths });
+                const tableContainer = table.find(`.${Classes.TABLE_CONTAINER}`);
+                expect(tableContainer.hasClass(Classes.TABLE_NO_HORIZONTAL_SCROLL)).to.be.false;
+
+                // clean up created div
+                document.body.removeChild(containerElement);
+            });
+
+            it("is disabled when there are ghost cells filling width", () => {
+                // small value so no scrolling needed
+                const SMALL_COLUMN_WIDTH = 50;
+                const columnWidths = Array(3).fill(SMALL_COLUMN_WIDTH);
+
+                const { containerElement, table } = mountTable({ columnWidths });
+                const tableContainer = table.find(`.${Classes.TABLE_CONTAINER}`);
+                expect(tableContainer.hasClass(Classes.TABLE_NO_HORIZONTAL_SCROLL)).to.be.true;
+
+                // clean up created div
+                document.body.removeChild(containerElement);
+            });
+        });
+
+        function mountTable(tableProps: Partial<ITableProps> & object = {}) {
+            const containerElement = document.createElement("div");
+            containerElement.style.width = `${CONTAINER_WIDTH}px`;
+            containerElement.style.height = `${CONTAINER_HEIGHT}px`;
+            document.body.appendChild(containerElement);
+
+            const table = mount(
+                <Table numRows={0} enableGhostCells={true} {...tableProps}>
+                    <Column cellRenderer={renderDummyCell} />
+                    <Column cellRenderer={renderDummyCell} />
+                    <Column cellRenderer={renderDummyCell} />
+                </Table>,
+                { attachTo: containerElement },
+            );
+            return { containerElement, table };
+        }
+    });
+
     describe("Instance methods", () => {
         describe("resizeRowsByApproximateHeight", () => {
             const STR_LENGTH_SHORT = 10;


### PR DESCRIPTION
#### Fixes #2553 

#### Checklist
- [x] Include tests

#### Changes proposed in this pull request:

Tables are now horizontally scrollable when there are no rows of data but real columns extend beyond the container width.
