### PR TITLE
vertical-align on buttons

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -102,6 +102,7 @@ $button-intents: (
   border-radius: $pt-border-radius;
   cursor: pointer;
   padding: $button-padding;
+  vertical-align: middle;
   text-align: left;
   font-size: $pt-font-size;
 }


### PR DESCRIPTION
#### Fixes #2487 

could argue this is a regression. we used to have this property in 1.x: https://github.com/palantir/blueprint/blob/release/1.x/packages/core/src/components/button/_common.scss#L102

makes sense to set it for buttons that are not in flex containers.