### PR TITLE
[DateTime] Add `isUserChange` support for DateInput

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -73,9 +73,8 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
 
     /**
      * Called when the user selects a new valid date through the `DatePicker` or by typing
-     * in the input. `hasUserManuallySelectedDate` is true if the user selected a day, and false
-     * if the date was automatically changed by the user navigating to a new month or year rather
-     * than explicitly clicking on a date in the calendar.
+     * in the input. The second argument is true if and only if the user clicked on a date in the
+     * calendar; it will be false if the date was changed by choosing a new month or year.
      */
     onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -73,10 +73,11 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
 
     /**
      * Called when the user selects a new valid date through the `DatePicker` or by typing
-     * in the input. The second argument is true if and only if the user clicked on a date in the
-     * calendar; it will be false if the date was changed by choosing a new month or year.
+     * in the input. The second argument is true if the user clicked on a date in the
+     * calendar, changed the input value, or cleared the selection; it will be false if the date
+     * was changed by choosing a new month or year.
      */
-    onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
+    onChange?: (selectedDate: Date, isUserChange: boolean) => void;
 
     /**
      * Called when the user finishes typing in a new date and the date causes an error state.
@@ -269,7 +270,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
 
     private handleDateChange = (
         newDate: Date | null,
-        hasUserManuallySelectedDate: boolean,
+        isUserChange: boolean,
         didSubmitWithEnter = false,
     ) => {
         const prevDate = this.state.value;
@@ -278,7 +279,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         // enabled) time. for UX purposes, we want to close the popover only if
         // the user explicitly clicked a day within the current month.
         const isOpen =
-            !hasUserManuallySelectedDate ||
+            !isUserChange ||
             !this.props.closeOnSelection ||
             (prevDate != null && (this.hasMonthChanged(prevDate, newDate) || this.hasTimeChanged(prevDate, newDate)));
 
@@ -295,7 +296,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         } else {
             this.setState({ isInputFocused, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, newDate, hasUserManuallySelectedDate);
+        Utils.safeInvoke(this.props.onChange, newDate, isUserChange);
     };
 
     private hasMonthChanged(prevDate: Date | null, nextDate: Date | null) {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -268,11 +268,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         this.setState({ isOpen: false });
     };
 
-    private handleDateChange = (
-        newDate: Date | null,
-        isUserChange: boolean,
-        didSubmitWithEnter = false,
-    ) => {
+    private handleDateChange = (newDate: Date | null, isUserChange: boolean, didSubmitWithEnter = false) => {
         const prevDate = this.state.value;
 
         // this change handler was triggered by a change in month, day, or (if

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -73,9 +73,11 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
 
     /**
      * Called when the user selects a new valid date through the `DatePicker` or by typing
-     * in the input.
+     * in the input. `hasUserManuallySelectedDate` is true if the user selected a day, and false
+     * if the date was automatically changed by the user navigating to a new month or year rather
+     * than explicitly clicking on a date in the calendar.
      */
-    onChange?: (selectedDate: Date) => void;
+    onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
 
     /**
      * Called when the user finishes typing in a new date and the date causes an error state.
@@ -294,7 +296,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         } else {
             this.setState({ isInputFocused, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, newDate);
+        Utils.safeInvoke(this.props.onChange, newDate, hasUserManuallySelectedDate);
     };
 
     private hasMonthChanged(prevDate: Date | null, nextDate: Date | null) {
@@ -338,10 +340,10 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
             } else {
                 this.setState({ valueString });
             }
-            Utils.safeInvoke(this.props.onChange, value);
+            Utils.safeInvoke(this.props.onChange, value, true);
         } else {
             if (valueString.length === 0) {
-                Utils.safeInvoke(this.props.onChange, null);
+                Utils.safeInvoke(this.props.onChange, null, true);
             }
             this.setState({ valueString });
         }
@@ -367,7 +369,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
             } else if (!this.isDateInRange(date)) {
                 Utils.safeInvoke(this.props.onError, date);
             } else {
-                Utils.safeInvoke(this.props.onChange, date);
+                Utils.safeInvoke(this.props.onChange, date, true);
             }
         } else {
             if (valueString.length === 0) {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -45,10 +45,10 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
      * Called when the user selects a day.
      * If being used in an uncontrolled manner, `selectedDate` will be `null` if the user clicks the currently selected
      * day. If being used in a controlled manner, `selectedDate` will contain the day clicked no matter what.
-     * `hasUserManuallySelectedDate` is true if the user selected a day, and false if the date was automatically changed
+     * `isUserChange` is true if the user selected a day, and false if the date was automatically changed
      * by the user navigating to a new month or year rather than explicitly clicking on a date in the calendar.
      */
-    onChange?: (selectedDate: Date, hasUserManuallySelectedDate: boolean) => void;
+    onChange?: (selectedDate: Date, isUserChange: boolean) => void;
 
     /**
      * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -473,7 +473,7 @@ describe("<DateInput>", () => {
 
             assert.isTrue(onChange.calledOnce);
             assertDateEquals(onChange.args[0][0], new Date("4/27/2016"));
-            assert.isTrue(onChange.args[0][1], "expected hasUserManuallySelectedDate to be true");
+            assert.isTrue(onChange.args[0][1], "expected isUserChange to be true");
         });
 
         it("Clearing the date in the DatePicker invokes onChange with null but doesn't change UI", () => {
@@ -545,7 +545,7 @@ describe("<DateInput>", () => {
             assert.deepEqual(onChange.firstCall.args, [DATE, true]);
         });
 
-        it("hasUserManuallySelectedDate is false when month changes", () => {
+        it("isUserChange is false when month changes", () => {
             const onChange = sinon.spy();
             const wrapper = mount(<DateInput {...DATE_FORMAT} onChange={onChange} value={DATE} />);
             wrapper.setState({ isOpen: true });
@@ -555,7 +555,7 @@ describe("<DateInput>", () => {
                 .simulate("change", { value: Months.FEBRUARY.toString() });
 
             assert.isTrue(onChange.calledOnce);
-            assert.isFalse(onChange.args[0][1], "expected hasUserManuallySelectedDate to be false");
+            assert.isFalse(onChange.args[0][1], "expected isUserChange to be false");
         });
     });
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -473,6 +473,7 @@ describe("<DateInput>", () => {
 
             assert.isTrue(onChange.calledOnce);
             assertDateEquals(onChange.args[0][0], new Date("4/27/2016"));
+            assert.isTrue(onChange.args[0][1], "expected hasUserManuallySelectedDate to be true");
         });
 
         it("Clearing the date in the DatePicker invokes onChange with null but doesn't change UI", () => {
@@ -481,7 +482,7 @@ describe("<DateInput>", () => {
             root.setState({ isOpen: true });
             getDay(4).simulate("click");
             assert.equal(root.find(InputGroup).prop("value"), "4/4/2016");
-            assert.isTrue(onChange.calledWith(null));
+            assert.isTrue(onChange.calledWith(null, true));
         });
 
         it("Updating value updates the text box", () => {
@@ -515,7 +516,7 @@ describe("<DateInput>", () => {
                 <DateInput {...DATE_FORMAT} value={new Date(2016, Months.JULY, 22)} onChange={onChange} />,
             );
             root.find("input").simulate("change", { target: { value: "" } });
-            assert.isTrue(onChange.calledWith(null));
+            assert.isTrue(onChange.calledWith(null, true));
         });
 
         it.skip("Formats locale-specific format strings properly", () => {
@@ -542,6 +543,19 @@ describe("<DateInput>", () => {
 
             assert.isTrue(onChange.calledOnce);
             assert.deepEqual(onChange.firstCall.args, [DATE]);
+        });
+
+        it("hasUserManuallySelectedDate is false when month changes", () => {
+            const onChange = sinon.spy();
+            const wrapper = mount(<DateInput {...DATE_FORMAT} onChange={onChange} value={DATE} />);
+            wrapper.setState({ isOpen: true });
+
+            wrapper
+                .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
+                .simulate("change", { value: Months.FEBRUARY.toString() });
+
+            assert.isTrue(onChange.calledOnce);
+            assert.isTrue(onChange.args[0][1], "expected hasUserManuallySelectedDate to be false");
         });
     });
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -435,7 +435,7 @@ describe("<DateInput>", () => {
             getDay(DATE.getDate()).simulate("click");
 
             assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.firstCall.args, [DATE]);
+            assert.deepEqual(onChange.firstCall.args, [DATE, true]);
         });
     });
 
@@ -542,7 +542,7 @@ describe("<DateInput>", () => {
                 .simulate("click");
 
             assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.firstCall.args, [DATE]);
+            assert.deepEqual(onChange.firstCall.args, [DATE, true]);
         });
 
         it("hasUserManuallySelectedDate is false when month changes", () => {
@@ -555,7 +555,7 @@ describe("<DateInput>", () => {
                 .simulate("change", { value: Months.FEBRUARY.toString() });
 
             assert.isTrue(onChange.calledOnce);
-            assert.isTrue(onChange.args[0][1], "expected hasUserManuallySelectedDate to be false");
+            assert.isFalse(onChange.args[0][1], "expected hasUserManuallySelectedDate to be false");
         });
     });
 

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -381,11 +381,11 @@ describe("<DatePicker>", () => {
 
             root.find(".DayPicker-NavButton--prev").simulate("click");
             assert.isTrue(onChange.calledOnce, "expected onChange called");
-            assert.isFalse(onChange.firstCall.args[1], "expected hasUserManuallySelectedDate to be false");
+            assert.isFalse(onChange.firstCall.args[1], "expected isUserChange to be false");
 
             months.simulate("change", { target: { value: Months.JUNE } });
             assert.isTrue(onChange.calledTwice, "expected onChange called again");
-            assert.isFalse(onChange.secondCall.args[1], "expected hasUserManuallySelectedDate to be false again");
+            assert.isFalse(onChange.secondCall.args[1], "expected isUserChange to be false again");
         });
 
         it("can change displayed date with the dropdowns in the caption", () => {


### PR DESCRIPTION
#### Fixes #2418

#### Checklist
- [X] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [X] Include tests
- [X] Update documentation

#### Changes proposed in this pull request:
* Add `isUserChange` support for DateInput to be able to distinguish month/year changes from real date selections.
* Change the name of the second parameter of the onChange handler in `IDatePickerProps` to `isUserChange`, so all supported components use the same argument name.