### PR TITLE
[Overlay] better lifecycle props for all overlay components

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -17,8 +17,9 @@ import { safeInvoke } from "../../common/utils";
 import { Button } from "../button/buttons";
 import { Dialog } from "../dialog/dialog";
 import { Icon, IconName } from "../icon/icon";
+import { IOverlayLifecycleProps } from "../overlay/overlay";
 
-export interface IAlertProps extends IProps {
+export interface IAlertProps extends IOverlayLifecycleProps, IProps {
     /**
      * Whether pressing <kbd>escape</kbd> when focused on the Alert should cancel the alert.
      * If this prop is enabled, then either `onCancel` or `onClose` must also be defined.
@@ -110,16 +111,25 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
     public static displayName = "Blueprint2.Alert";
 
     public render() {
-        const { children, className, icon, intent, cancelButtonText, confirmButtonText } = this.props;
+        const {
+            canEscapeKeyCancel,
+            canOutsideClickCancel,
+            children,
+            className,
+            icon,
+            intent,
+            cancelButtonText,
+            confirmButtonText,
+            onClose,
+            ...overlayProps
+        } = this.props;
         return (
             <Dialog
+                {...overlayProps}
                 className={classNames(Classes.ALERT, className)}
-                canEscapeKeyClose={this.props.canEscapeKeyCancel}
-                canOutsideClickClose={this.props.canOutsideClickCancel}
-                isOpen={this.props.isOpen}
+                canEscapeKeyClose={canEscapeKeyCancel}
+                canOutsideClickClose={canOutsideClickCancel}
                 onClose={this.handleCancel}
-                style={this.props.style}
-                transitionDuration={this.props.transitionDuration}
             >
                 <div className={Classes.ALERT_BODY}>
                     <Icon icon={icon} iconSize={40} intent={intent} />

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -12,16 +12,12 @@ import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { Position } from "../../common/position";
 import { safeInvoke } from "../../common/utils";
+import { IOverlayLifecycleProps } from "../overlay/overlay";
 import { Popover, PopperModifiers } from "../popover/popover";
 
 export interface IOffset {
     left: number;
     top: number;
-}
-
-interface IContextMenuProps {
-    /** Callback invoked after the menu has finished transitioning to a closed state. */
-    didClose: () => void;
 }
 
 interface IContextMenuState {
@@ -38,7 +34,7 @@ const POPPER_MODIFIERS: PopperModifiers = {
 const TRANSITION_DURATION = 100;
 
 /* istanbul ignore next */
-class ContextMenu extends AbstractPureComponent<IContextMenuProps, IContextMenuState> {
+class ContextMenu extends AbstractPureComponent<IOverlayLifecycleProps, IContextMenuState> {
     public state: IContextMenuState = {
         isDarkTheme: false,
         isOpen: false,
@@ -56,6 +52,7 @@ class ContextMenu extends AbstractPureComponent<IContextMenuProps, IContextMenuS
         return (
             <div className={Classes.CONTEXT_MENU_POPOVER_TARGET} style={this.state.offset}>
                 <Popover
+                    {...this.props}
                     backdropProps={{ onContextMenu: this.handleBackdropContextMenu }}
                     content={content}
                     enforceFocus={false}
@@ -66,7 +63,6 @@ class ContextMenu extends AbstractPureComponent<IContextMenuProps, IContextMenuS
                     onInteraction={this.handlePopoverInteraction}
                     position={Position.RIGHT_TOP}
                     popoverClassName={popoverClassName}
-                    popoverDidClose={this.props.didClose}
                     target={<div />}
                     transitionDuration={TRANSITION_DURATION}
                 />
@@ -122,7 +118,7 @@ export function show(menu: JSX.Element, offset: IOffset, onClose?: () => void, i
         contextMenuElement = document.createElement("div");
         contextMenuElement.classList.add(Classes.CONTEXT_MENU);
         document.body.appendChild(contextMenuElement);
-        contextMenu = ReactDOM.render(<ContextMenu didClose={remove} />, contextMenuElement) as ContextMenu;
+        contextMenu = ReactDOM.render(<ContextMenu onClosed={remove} />, contextMenuElement) as ContextMenu;
     }
 
     contextMenu.show(menu, offset, onClose, isDarkTheme);

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -15,7 +15,7 @@ import { IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 import { Portal } from "../portal/portal";
 
-export interface IOverlayableProps {
+export interface IOverlayableProps extends IOverlayLifecycleProps {
     /**
      * Whether the overlay should acquire application focus when it first opens.
      * @default true
@@ -72,11 +72,26 @@ export interface IOverlayableProps {
     /**
      * A callback that is invoked when user interaction causes the overlay to close, such as
      * clicking on the overlay or pressing the `esc` key (if enabled).
+     *
      * Receives the event from the user's interaction, if there was an event (generally either a
      * mouse or key event). Note that, since this component is controlled by the `isOpen` prop, it
      * will not actually close itself until that prop becomes `false`.
      */
-    onClose?(event?: React.SyntheticEvent<HTMLElement>): void;
+    onClose?: (event?: React.SyntheticEvent<HTMLElement>) => void;
+}
+
+export interface IOverlayLifecycleProps {
+    /** Lifecycle method invoked when an Overlay begins to close. (Specifically, when the close transition begins.) */
+    onClosing?: () => void;
+
+    /** Lifecycle method invoked when an Overlay has finished transitioning to the closed state. */
+    onClosed?: () => void;
+
+    /** Lifecycle method invoked when an Overlay begins to open. */
+    onOpening?: () => void;
+
+    /** Lifecycle method invoked when an Overlay has finished transitioning to the open state. */
+    onOpened?: () => void;
 }
 
 export interface IBackdropProps {
@@ -101,16 +116,6 @@ export interface IBackdropProps {
 }
 
 export interface IOverlayProps extends IOverlayableProps, IBackdropProps, IProps {
-    /** Lifecycle callback invoked after the overlay opens and is mounted in the DOM. */
-    didOpen?: () => any;
-
-    /**
-     * Lifecycle callback invoked after a child element finishes exiting the DOM.
-     * This will be invoked for each child of the `Overlay` except for the backdrop element.
-     * The argument is the underlying HTML element that left the DOM.
-     */
-    didClose?: (node: HTMLElement) => any;
-
     /**
      * Toggles the visibility of the overlay and its children.
      * This prop is required because the component is controlled.
@@ -195,7 +200,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             </TransitionGroup>
         );
         if (usePortal) {
-            return <Portal onChildrenMount={this.handleContentMount}>{transitionGroup}</Portal>;
+            return <Portal>{transitionGroup}</Portal>;
         } else {
             return transitionGroup;
         }
@@ -266,9 +271,16 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             ) : (
                 <span className={Classes.OVERLAY_CONTENT}>{child}</span>
             );
-        const { transitionDuration, transitionName } = this.props;
+        const { onOpening, onOpened, onClosing, onClosed, transitionDuration, transitionName } = this.props;
         return (
-            <CSSTransition classNames={transitionName} onExited={this.props.didClose} timeout={transitionDuration}>
+            <CSSTransition
+                classNames={transitionName}
+                onEntering={onOpening}
+                onEntered={onOpened}
+                onExiting={onClosing}
+                onExited={onClosed}
+                timeout={transitionDuration}
+            >
                 {decoratedChild}
             </CSSTransition>
         );
@@ -339,9 +351,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             document.addEventListener("mousedown", this.handleDocumentClick);
         }
 
-        if (!this.props.usePortal) {
-            safeInvoke(this.props.didOpen);
-        } else if (this.props.hasBackdrop) {
+        if (this.props.hasBackdrop && this.props.usePortal) {
             // add a class to the body to prevent scrolling of content below the overlay
             document.body.classList.add(Classes.OVERLAY_OPEN);
         }
@@ -375,12 +385,6 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
         if (isOpen && canOutsideClickClose && !isClickInThisOverlayOrDescendant) {
             // casting to any because this is a native event
             safeInvoke(onClose, e as any);
-        }
-    };
-
-    private handleContentMount = () => {
-        if (this.props.isOpen) {
-            safeInvoke(this.props.didOpen);
         }
     };
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -81,16 +81,26 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
 }
 
 export interface IOverlayLifecycleProps {
-    /** Lifecycle method invoked when an Overlay begins to close. (Specifically, when the close transition begins.) */
+    /**
+     * Lifecycle method invoked just before the CSS _close_ transition begins.
+     */
     onClosing?: () => void;
 
-    /** Lifecycle method invoked when an Overlay has finished transitioning to the closed state. */
+    /**
+     * Lifecycle method invoked just after the CSS _close_ transition ends but
+     * before it has been removed from the DOM.
+     */
     onClosed?: () => void;
 
-    /** Lifecycle method invoked when an Overlay begins to open. */
+    /**
+     * Lifecycle method invoked just after mounting in the DOM but just before
+     * the CSS _open_ transition begins.
+     */
     onOpening?: () => void;
 
-    /** Lifecycle method invoked when an Overlay has finished transitioning to the open state. */
+    /**
+     * Lifecycle method invoked just after the CSS _open_ transition ends.
+     */
     onOpened?: () => void;
 }
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -82,26 +82,30 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
 
 export interface IOverlayLifecycleProps {
     /**
-     * Lifecycle method invoked just before the CSS _close_ transition begins.
+     * Lifecycle method invoked just before the CSS _close_ transition begins on
+     * a child. Receives the DOM element of the child being closed.
      */
-    onClosing?: () => void;
+    onClosing?: (node: HTMLElement) => void;
 
     /**
      * Lifecycle method invoked just after the CSS _close_ transition ends but
-     * before it has been removed from the DOM.
+     * before the child has been removed from the DOM. Receives the DOM element
+     * of the child being closed.
      */
-    onClosed?: () => void;
+    onClosed?: (node: HTMLElement) => void;
 
     /**
-     * Lifecycle method invoked just after mounting in the DOM but just before
-     * the CSS _open_ transition begins.
+     * Lifecycle method invoked just after mounting the child in the DOM but
+     * just before the CSS _open_ transition begins. Receives the DOM element of
+     * the child being opened.
      */
-    onOpening?: () => void;
+    onOpening?: (node: HTMLElement) => void;
 
     /**
      * Lifecycle method invoked just after the CSS _open_ transition ends.
+     * Receives the DOM element of the child being opened.
      */
-    onOpened?: () => void;
+    onOpened?: (node: HTMLElement) => void;
 }
 
 export interface IBackdropProps {

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -10,9 +10,10 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { Position } from "../../common/position";
 import { IIntentProps, IProps } from "../../common/props";
+import { IOverlayLifecycleProps } from "../overlay/overlay";
 import { Popover, PopoverInteractionKind, PopperModifiers } from "../popover/popover";
 
-export interface ITooltipProps extends IProps, IIntentProps {
+export interface ITooltipProps extends IProps, IIntentProps, IOverlayLifecycleProps {
     /**
      * The content that will be displayed inside of the tooltip.
      */

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -46,6 +46,19 @@ describe("<Alert>", () => {
         assert.lengthOf(wrapper.find(Icon), 1);
     });
 
+    it("supports overlay lifecycle props", () => {
+        const onOpening = spy();
+        const wrapper = mount(
+            <Alert isOpen={true} onOpening={onOpening}>
+                Alert
+                <p>Are you sure you want to delete this file?</p>
+                <p>There is no going back.</p>
+            </Alert>,
+        );
+        assert.isTrue(onOpening.calledOnce);
+        wrapper.unmount();
+    });
+
     describe("confirm button", () => {
         const onConfirm = spy();
         const onClose = spy();

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -75,6 +75,16 @@ describe("<Dialog>", () => {
         assert.isTrue(onClose.notCalled);
     });
 
+    it("supports overlay lifecycle props", () => {
+        const onOpening = spy();
+        mount(
+            <Dialog isOpen={true} onOpening={onOpening}>
+                body
+            </Dialog>,
+        );
+        assert.isTrue(onOpening.calledOnce);
+    });
+
     describe("header", () => {
         it(`renders .${Classes.DIALOG_HEADER} if title prop is given`, () => {
             const dialog = mount(

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -86,68 +86,6 @@ describe("<Overlay>", () => {
         overlay.unmount();
     });
 
-    it("invokes didOpen when Overlay is opened", () => {
-        const didOpen = spy();
-        mountWrapper(
-            <Overlay didOpen={didOpen} isOpen={false}>
-                {createOverlayContents()}
-            </Overlay>,
-        );
-        assert.isTrue(didOpen.notCalled, "didOpen invoked when overlay closed");
-
-        wrapper.setProps({ isOpen: true });
-        assert.isTrue(didOpen.calledOnce, "didOpen not invoked when overlay open");
-    });
-
-    it("invokes didOpen when inline Overlay is opened", () => {
-        const didOpen = spy();
-        mountWrapper(
-            <Overlay didOpen={didOpen} isOpen={false} usePortal={false}>
-                {createOverlayContents()}
-            </Overlay>,
-        );
-        assert.isTrue(didOpen.notCalled, "didOpen invoked when overlay closed");
-
-        wrapper.setProps({ isOpen: true });
-        assert.isTrue(didOpen.calledOnce, "didOpen not invoked when overlay open");
-    });
-
-    it("invokes didClose when Overlay is closed", done => {
-        const didClose = spy();
-        mountWrapper(
-            <Overlay didClose={didClose} isOpen={true} transitionDuration={1}>
-                {createOverlayContents()}
-            </Overlay>,
-        );
-        assert.isTrue(didClose.notCalled, "didClose invoked when overlay open");
-
-        wrapper.setProps({ isOpen: false });
-        // didClose relies on transition onExited so we go async for a sec
-        setTimeout(() => {
-            wrapper.update();
-            assert.isTrue(didClose.calledOnce, "didClose not invoked when overlay closed");
-            assert.isFalse(wrapper.find("strong").exists(), "no content");
-            done();
-        });
-    });
-
-    it("invokes didClose when inline Overlay is closed", done => {
-        const didClose = spy();
-        mountWrapper(
-            <Overlay didClose={didClose} isOpen={true} usePortal={false} transitionDuration={1}>
-                {createOverlayContents()}
-            </Overlay>,
-        );
-        assert.isTrue(didClose.notCalled, "didClose invoked when overlay open");
-
-        wrapper.setProps({ isOpen: false });
-        // didClose relies on transition onExited so we go async for a sec
-        setTimeout(() => {
-            assert.isTrue(didClose.calledOnce, "didClose not invoked when overlay closed");
-            done();
-        });
-    });
-
     it("renders portal attached to body when not inline after first opened", () => {
         mountWrapper(<Overlay isOpen={false}>{createOverlayContents()}</Overlay>);
         assert.lengthOf(wrapper.find(Portal), 0, "unexpected Portal");
@@ -475,6 +413,43 @@ describe("<Overlay>", () => {
                 done();
             });
         }
+    });
+
+    it("lifecycle methods called as expected", done => {
+        // these lifecycles are passed directly to CSSTransition from react-transition-group
+        // so we do not need to test these extensively. one integration test should do.
+        const onClosed = spy();
+        const onClosing = spy();
+        const onOpened = spy();
+        const onOpening = spy();
+        wrapper = mountWrapper(
+            <Overlay
+                {...{ onClosed, onClosing, onOpened, onOpening }}
+                isOpen={true}
+                usePortal={false}
+                // transition duration shorter than timeout below to ensure it's done
+                transitionDuration={8}
+            >
+                {createOverlayContents()}
+            </Overlay>,
+        );
+        assert.isTrue(onOpening.calledOnce, "onOpening");
+        assert.isFalse(onOpened.calledOnce, "onOpened not called yet");
+
+        setTimeout(() => {
+            // on*ed called after transition completes
+            assert.isTrue(onOpened.calledOnce, "onOpened");
+
+            wrapper.setProps({ isOpen: false });
+            // on*ing called immediately when prop changes
+            assert.isTrue(onClosing.calledOnce, "onClosing");
+            assert.isFalse(onClosed.calledOnce, "onClosed not called yet");
+
+            setTimeout(() => {
+                assert.isTrue(onClosed.calledOnce, "onOpened");
+                done();
+            }, 10);
+        }, 10);
     });
 
     let index = 0;

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -173,53 +173,6 @@ describe("<Popover>", () => {
         warnSpy.restore();
     });
 
-    it("lifecycle methods are called appropriately", done => {
-        const popoverWillOpen = sinon.spy(() =>
-            assert.lengthOf(testsContainerElement.getElementsByClassName(Classes.POPOVER), 0),
-        );
-        const popoverDidOpen = sinon.spy(() =>
-            assert.lengthOf(testsContainerElement.getElementsByClassName(Classes.POPOVER), 1),
-        );
-        const popoverWillClose = sinon.spy(() =>
-            assert.lengthOf(testsContainerElement.getElementsByClassName(Classes.POPOVER), 1),
-        );
-        // DOM is still present in didClose; element is removed shortly after
-        const popoverDidClose = sinon.spy();
-
-        wrapper = renderPopover({
-            interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
-            popoverDidClose,
-            popoverDidOpen,
-            popoverWillClose,
-            popoverWillOpen,
-            transitionDuration: 1,
-        }).simulateTarget("click");
-        assert.isTrue(popoverWillOpen.calledOnce);
-        assert.isTrue(popoverDidOpen.calledOnce);
-        assert.isTrue(popoverWillClose.notCalled);
-        assert.isTrue(popoverDidClose.notCalled);
-
-        wrapper.simulateTarget("click");
-        setTimeout(() => {
-            assert.isTrue(popoverDidOpen.calledOnce);
-            assert.isTrue(popoverWillOpen.calledOnce);
-            assert.isTrue(popoverWillClose.calledOnce);
-            assert.isTrue(popoverDidClose.calledOnce);
-            assert.lengthOf(testsContainerElement.getElementsByClassName(Classes.POPOVER), 0);
-            done();
-        });
-    });
-
-    it("popoverDidOpen is called even if popoverWillOpen is not specified", () => {
-        const popoverDidOpen = sinon.spy();
-        renderPopover({
-            interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
-            popoverDidOpen,
-        }).simulateTarget("click");
-
-        assert.isTrue(popoverDidOpen.calledOnce);
-    });
-
     it("inherits dark theme from trigger ancestor", () => {
         testsContainerElement.classList.add(Classes.DARK);
         const { popover } = renderPopover({ isOpen: true, inheritDarkTheme: true, usePortal: true });

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -212,6 +212,12 @@ describe("<Popover>", () => {
         assert.isNotNull(wrapper.find("article"));
     });
 
+    it("supports overlay lifecycle props", () => {
+        const onOpening = sinon.spy();
+        wrapper = renderPopover({ isOpen: true, onOpening });
+        assert.isTrue(onOpening.calledOnce);
+    });
+
     describe("openOnTargetFocus", () => {
         describe("if true (default)", () => {
             it('adds tabindex="0" to target\'s child node when interactionKind is HOVER', () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -114,6 +114,12 @@ describe("<Tooltip>", () => {
         assert.lengthOf(tooltip.find(`section.${Classes.POPOVER_WRAPPER}`), 1);
     });
 
+    it("supports overlay lifecycle props", () => {
+        const onOpening = spy();
+        renderTooltip({ isOpen: true, onOpening });
+        assert.isTrue(onOpening.calledOnce);
+    });
+
     function renderTooltip(props?: Partial<ITooltipProps>) {
         return mount(
             <Tooltip content={<p>Text</p>} hoverOpenDelay={0} {...props} usePortal={false}>

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -218,14 +218,14 @@ describe("<DateInput>", () => {
     });
 
     it("popoverProps are passed to Popover", () => {
-        const popoverWillOpen = sinon.spy();
+        const onOpening = sinon.spy();
         const wrapper = mount(
             <DateInput
                 {...DATE_FORMAT}
                 popoverProps={{
                     autoFocus: true,
                     content: "fail",
-                    popoverWillOpen,
+                    onOpening,
                     position: Position.TOP,
                     usePortal: false,
                 }}
@@ -238,7 +238,7 @@ describe("<DateInput>", () => {
         assert.notStrictEqual(popover.prop("content"), "fail", "content cannot be changed");
         assert.strictEqual(popover.prop("position"), Position.TOP);
         assert.strictEqual(popover.prop("usePortal"), false);
-        assert.isTrue(popoverWillOpen.calledOnce);
+        assert.isTrue(onOpening.calledOnce);
     });
 
     describe("when uncontrolled", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -16,6 +16,7 @@ import {
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
+    IPopoverProps,
     Keys,
     Popover,
     Position,
@@ -355,23 +356,13 @@ describe("<DateRangeInput>", () => {
 
     describe("popoverProps", () => {
         it("accepts custom popoverProps", () => {
-            const popoverProps = {
-                onClosing: sinon.spy(),
-                onOpened: sinon.spy(),
-                onOpening: sinon.spy(),
+            const popoverProps: Partial<IPopoverProps> = {
+                backdropProps: {},
                 position: Position.TOP_LEFT,
             };
-            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />);
-
-            expect(root.find(Popover).prop("position")).to.equal(Position.TOP_LEFT);
-
-            root.setState({ isOpen: true });
-            expect(popoverProps.onOpening.calledOnce).to.be.true;
-            expect(popoverProps.onOpened.calledOnce).to.be.true;
-
-            // not testing popoverProps.onClose, because it has some setTimeout stuff to work around
-            root.setState({ isOpen: false });
-            expect(popoverProps.onClosing.calledOnce).to.be.true;
+            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            expect(popover.prop("backdropProps")).to.equal(popoverProps.backdropProps);
+            expect(popover.prop("position")).to.equal(popoverProps.position);
         });
 
         it("ignores autoFocus, enforceFocus, and content in custom popoverProps", () => {
@@ -381,10 +372,8 @@ describe("<DateRangeInput>", () => {
                 content: CUSTOM_CONTENT,
                 enforceFocus: true,
             };
-            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />);
-
+            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
             // this test assumes the following values will be the defaults internally
-            const popover = root.find(Popover);
             expect(popover.prop("autoFocus")).to.be.false;
             expect(popover.prop("enforceFocus")).to.be.false;
             expect(popover.prop("content")).to.not.equal(CUSTOM_CONTENT);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -356,9 +356,9 @@ describe("<DateRangeInput>", () => {
     describe("popoverProps", () => {
         it("accepts custom popoverProps", () => {
             const popoverProps = {
-                popoverDidOpen: sinon.spy(),
-                popoverWillClose: sinon.spy(),
-                popoverWillOpen: sinon.spy(),
+                onClosing: sinon.spy(),
+                onOpened: sinon.spy(),
+                onOpening: sinon.spy(),
                 position: Position.TOP_LEFT,
             };
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />);
@@ -366,12 +366,12 @@ describe("<DateRangeInput>", () => {
             expect(root.find(Popover).prop("position")).to.equal(Position.TOP_LEFT);
 
             root.setState({ isOpen: true });
-            expect(popoverProps.popoverWillOpen.calledOnce).to.be.true;
-            expect(popoverProps.popoverDidOpen.calledOnce).to.be.true;
+            expect(popoverProps.onOpening.calledOnce).to.be.true;
+            expect(popoverProps.onOpened.calledOnce).to.be.true;
 
             // not testing popoverProps.onClose, because it has some setTimeout stuff to work around
             root.setState({ isOpen: false });
-            expect(popoverProps.popoverWillClose.calledOnce).to.be.true;
+            expect(popoverProps.onClosing.calledOnce).to.be.true;
         });
 
         it("ignores autoFocus, enforceFocus, and content in custom popoverProps", () => {

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -15,7 +15,6 @@ import {
     FormGroup,
     H5,
     Intent,
-    IOverlayLifecycleProps,
     Label,
     Menu,
     MenuDivider,
@@ -133,7 +132,6 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
                         popoverClassName={exampleIndex <= 2 ? Classes.POPOVER_CONTENT_SIZING : ""}
                         portalClassName="foo"
                         {...popoverProps}
-                        {...LIFECYCLE}
                         enforceFocus={false}
                         isOpen={this.state.isOpen === true ? /* Controlled */ true : /* Uncontrolled */ undefined}
                     >
@@ -300,10 +298,3 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
         }
     };
 }
-
-const LIFECYCLE: IOverlayLifecycleProps = {
-    onClosed: () => console.log("closed"),
-    onClosing: () => console.log("closing"),
-    onOpened: () => console.log("opened"),
-    onOpening: () => console.log("opening"),
-};

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -15,6 +15,7 @@ import {
     FormGroup,
     H5,
     Intent,
+    IOverlayLifecycleProps,
     Label,
     Menu,
     MenuDivider,
@@ -132,6 +133,7 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
                         popoverClassName={exampleIndex <= 2 ? Classes.POPOVER_CONTENT_SIZING : ""}
                         portalClassName="foo"
                         {...popoverProps}
+                        {...LIFECYCLE}
                         enforceFocus={false}
                         isOpen={this.state.isOpen === true ? /* Controlled */ true : /* Uncontrolled */ undefined}
                     >
@@ -298,3 +300,10 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
         }
     };
 }
+
+const LIFECYCLE: IOverlayLifecycleProps = {
+    onClosed: () => console.log("closed"),
+    onClosing: () => console.log("closing"),
+    onOpened: () => console.log("opened"),
+    onOpening: () => console.log("opening"),
+};

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, H5, IPopoverProps, Switch } from "@blueprintjs/core";
+import { H5, Switch } from "@blueprintjs/core";
 import { DateRange, DateRangeInput, IDateFormatProps } from "@blueprintjs/datetime";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
@@ -18,7 +18,6 @@ export interface IDateRangeInputExampleState {
     contiguousCalendarMonths: boolean;
     disabled: boolean;
     format: IDateFormatProps;
-    isPopoverOpen: boolean;
     range: DateRange;
     reverseMonthAndYearMenus: boolean;
     selectAllOnFocus: boolean;
@@ -31,15 +30,9 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
         contiguousCalendarMonths: true,
         disabled: false,
         format: FORMATS[0],
-        isPopoverOpen: false,
         range: [null, null],
         reverseMonthAndYearMenus: false,
         selectAllOnFocus: false,
-    };
-
-    private popoverProps: Partial<IPopoverProps> = {
-        popoverWillClose: () => this.setState({ isPopoverOpen: false }),
-        popoverWillOpen: () => this.setState({ isPopoverOpen: true }),
     };
 
     private toggleContiguous = handleBooleanChange(contiguous => {
@@ -57,13 +50,8 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
         const { format, range, ...spreadProps } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
-                <DateRangeInput
-                    {...spreadProps}
-                    {...format}
-                    onChange={this.handleRangeChange}
-                    popoverProps={this.popoverProps}
-                />
-                <MomentDateRange className={this.state.isPopoverOpen ? Classes.INLINE : ""} range={range} />
+                <DateRangeInput {...spreadProps} {...format} onChange={this.handleRangeChange} />
+                <MomentDateRange range={range} />
             </Example>
         );
     }

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -7,16 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import {
-    HTMLInputProps,
-    IBackdropProps,
-    IInputGroupProps,
-    InputGroup,
-    IOverlayableProps,
-    IOverlayProps,
-    Overlay,
-    Utils,
-} from "@blueprintjs/core";
+import { HTMLInputProps, IInputGroupProps, InputGroup, IOverlayProps, Overlay, Utils } from "@blueprintjs/core";
 
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -36,16 +27,19 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
     isOpen: boolean;
 
     /**
-     * A callback that is invoked when user interaction causes the overlay to close, such as
-     * clicking on the overlay or pressing the `esc` key (if enabled).
-     * Receives the event from the user's interaction, if there was an event (generally either a
-     * mouse or key event). Note that, since this component is controlled by the `isOpen` prop, it
-     * will not actually close itself until that prop becomes `false`.
+     * A callback that is invoked when user interaction causes the omnibar to
+     * close, such as clicking on the overlay or pressing the `esc` key (if
+     * enabled). Receives the event from the user's interaction, if there was an
+     * event (generally either a mouse or key event).
+     *
+     * Note that due to controlled usage, this component will not actually close
+     * itself until the `isOpen` prop becomes `false`.
+     * .
      */
     onClose?: (event?: React.SyntheticEvent<HTMLElement>) => void;
 
-    /** Props to spread to `Overlay`. Note that `content` cannot be changed. */
-    overlayProps?: Partial<IOverlayProps> & object;
+    /** Props to spread to `Overlay`. */
+    overlayProps?: Partial<IOverlayProps>;
 
     /**
      * Whether the filtering state should be reset to initial when an item is selected
@@ -56,7 +50,7 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
     resetOnSelect?: boolean;
 }
 
-export interface IOmnibarState<T> extends IOverlayableProps, IBackdropProps {
+export interface IOmnibarState<T> {
     activeItem?: T;
     query: string;
 }
@@ -151,7 +145,9 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
         Utils.safeInvoke(inputProps.onChange, event);
     };
 
-    private handleOverlayClose = (event: React.SyntheticEvent<HTMLElement>) => {
+    private handleOverlayClose = (event?: React.SyntheticEvent<HTMLElement>) => {
+        const { overlayProps = {} } = this.props;
+        Utils.safeInvoke(overlayProps.onClose, event);
         Utils.safeInvoke(this.props.onClose, event);
     };
 }

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -183,21 +183,21 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             Utils.safeInvoke(popoverProps.onInteraction, nextOpenState);
         });
 
-    private handlePopoverOpening = () => {
+    private handlePopoverOpening = (node: HTMLElement) => {
         const { popoverProps = {}, resetOnSelect } = this.props;
         if (resetOnSelect) {
             this.setState({ activeItem: this.props.items[0] });
         }
-        Utils.safeInvoke(popoverProps.onOpening);
+        Utils.safeInvoke(popoverProps.onOpening, node);
     };
 
-    private handlePopoverOpened = () => {
+    private handlePopoverOpened = (node: HTMLElement) => {
         const { popoverProps = {} } = this.props;
         if (this.queryList != null) {
             // scroll active item into view after popover transition completes and all dimensions are stable.
             this.queryList.scrollActiveItemIntoView();
         }
-        Utils.safeInvoke(popoverProps.onOpened);
+        Utils.safeInvoke(popoverProps.onOpened, node);
     };
 
     private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -115,8 +115,8 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
-                popoverDidOpen={this.handlePopoverDidOpen}
-                popoverWillOpen={this.handlePopoverWillOpen}
+                onOpened={this.handlePopoverOpened}
+                onOpening={this.handlePopoverOpening}
             >
                 <div
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
@@ -183,21 +183,21 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             Utils.safeInvoke(popoverProps.onInteraction, nextOpenState);
         });
 
-    private handlePopoverWillOpen = () => {
+    private handlePopoverOpening = () => {
         const { popoverProps = {}, resetOnSelect } = this.props;
         if (resetOnSelect) {
             this.setState({ activeItem: this.props.items[0] });
         }
-        Utils.safeInvoke(popoverProps.popoverWillOpen);
+        Utils.safeInvoke(popoverProps.onOpening);
     };
 
-    private handlePopoverDidOpen = () => {
+    private handlePopoverOpened = () => {
         const { popoverProps = {} } = this.props;
         if (this.queryList != null) {
             // scroll active item into view after popover transition completes and all dimensions are stable.
             this.queryList.scrollActiveItemIntoView();
         }
-        Utils.safeInvoke(popoverProps.popoverDidOpen);
+        Utils.safeInvoke(popoverProps.onOpened);
     };
 
     private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -138,7 +138,6 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
 
         const input = (
             <InputGroup
-                autoFocus={true}
                 leftIcon="search"
                 placeholder="Filter..."
                 rightElement={this.maybeRenderInputClearButton()}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -210,7 +210,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         Utils.safeInvoke(popoverProps.onInteraction, isOpen);
     };
 
-    private handlePopoverOpening = () => {
+    private handlePopoverOpening = (node: HTMLElement) => {
         const { popoverProps = {}, resetOnClose } = this.props;
         // save currently focused element before popover steals focus, so we can restore it when closing.
         this.previousFocusedElement = document.activeElement as HTMLElement;
@@ -219,10 +219,10 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
             this.resetQuery();
         }
 
-        Utils.safeInvoke(popoverProps.onOpening);
+        Utils.safeInvoke(popoverProps.onOpening, node);
     };
 
-    private handlePopoverOpened = () => {
+    private handlePopoverOpened = (node: HTMLElement) => {
         // scroll active item into view after popover transition completes and all dimensions are stable.
         if (this.list != null) {
             this.list.scrollActiveItemIntoView();
@@ -237,10 +237,10 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         });
 
         const { popoverProps = {} } = this.props;
-        Utils.safeInvoke(popoverProps.onOpened);
+        Utils.safeInvoke(popoverProps.onOpened, node);
     };
 
-    private handlePopoverClosing = () => {
+    private handlePopoverClosing = (node: HTMLElement) => {
         // restore focus to saved element.
         // timeout allows popover to begin closing and remove focus handlers beforehand.
         requestAnimationFrame(() => {
@@ -251,7 +251,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         });
 
         const { popoverProps = {} } = this.props;
-        Utils.safeInvoke(popoverProps.onClosing);
+        Utils.safeInvoke(popoverProps.onClosing, node);
     };
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -161,9 +161,9 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
-                popoverWillOpen={this.handlePopoverWillOpen}
-                popoverDidOpen={this.handlePopoverDidOpen}
-                popoverWillClose={this.handlePopoverWillClose}
+                onOpening={this.handlePopoverOpening}
+                onOpened={this.handlePopoverOpened}
+                onClosing={this.handlePopoverClosing}
             >
                 <div
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}
@@ -211,7 +211,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         Utils.safeInvoke(popoverProps.onInteraction, isOpen);
     };
 
-    private handlePopoverWillOpen = () => {
+    private handlePopoverOpening = () => {
         const { popoverProps = {}, resetOnClose } = this.props;
         // save currently focused element before popover steals focus, so we can restore it when closing.
         this.previousFocusedElement = document.activeElement as HTMLElement;
@@ -220,10 +220,10 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
             this.resetQuery();
         }
 
-        Utils.safeInvoke(popoverProps.popoverWillOpen);
+        Utils.safeInvoke(popoverProps.onOpening);
     };
 
-    private handlePopoverDidOpen = () => {
+    private handlePopoverOpened = () => {
         // scroll active item into view after popover transition completes and all dimensions are stable.
         if (this.list != null) {
             this.list.scrollActiveItemIntoView();
@@ -238,10 +238,10 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         });
 
         const { popoverProps = {} } = this.props;
-        Utils.safeInvoke(popoverProps.popoverDidOpen);
+        Utils.safeInvoke(popoverProps.onOpened);
     };
 
-    private handlePopoverWillClose = () => {
+    private handlePopoverClosing = () => {
         // restore focus to saved element.
         // timeout allows popover to begin closing and remove focus handlers beforehand.
         requestAnimationFrame(() => {
@@ -252,7 +252,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         });
 
         const { popoverProps = {} } = this.props;
-        Utils.safeInvoke(popoverProps.popoverWillClose);
+        Utils.safeInvoke(popoverProps.onClosing);
     };
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -125,8 +125,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
-                popoverDidOpen={this.handlePopoverDidOpen}
-                popoverWillClose={this.handlePopoverWillClose}
+                onOpened={this.handlePopoverOpened}
+                onClosing={this.handlePopoverClosing}
             >
                 <InputGroup
                     placeholder="Search..."
@@ -205,7 +205,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             Utils.safeInvoke(popoverProps.onInteraction, nextOpenState);
         });
 
-    private handlePopoverDidOpen = () => {
+    private handlePopoverOpened = () => {
         const { popoverProps = {} } = this.props;
 
         // scroll active item into view after popover transition completes and all dimensions are stable.
@@ -213,10 +213,10 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             this.queryList.scrollActiveItemIntoView();
         }
 
-        Utils.safeInvoke(popoverProps.popoverDidOpen);
+        Utils.safeInvoke(popoverProps.onOpened);
     };
 
-    private handlePopoverWillClose = () => {
+    private handlePopoverClosing = () => {
         const { popoverProps = {} } = this.props;
         const { selectedItem } = this.state;
 
@@ -227,7 +227,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             query: "",
         });
 
-        Utils.safeInvoke(popoverProps.popoverDidOpen);
+        Utils.safeInvoke(popoverProps.onClosing);
     };
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -205,7 +205,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             Utils.safeInvoke(popoverProps.onInteraction, nextOpenState);
         });
 
-    private handlePopoverOpened = () => {
+    private handlePopoverOpened = (node: HTMLElement) => {
         const { popoverProps = {} } = this.props;
 
         // scroll active item into view after popover transition completes and all dimensions are stable.
@@ -213,10 +213,10 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             this.queryList.scrollActiveItemIntoView();
         }
 
-        Utils.safeInvoke(popoverProps.onOpened);
+        Utils.safeInvoke(popoverProps.onOpened, node);
     };
 
-    private handlePopoverClosing = () => {
+    private handlePopoverClosing = (node: HTMLElement) => {
         const { popoverProps = {} } = this.props;
         const { selectedItem } = this.state;
 
@@ -227,7 +227,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             query: "",
         });
 
-        Utils.safeInvoke(popoverProps.onClosing);
+        Utils.safeInvoke(popoverProps.onClosing, node);
     };
 
     private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -108,13 +108,13 @@ describe("<Select>", () => {
     });
 
     it("popover can be controlled with popoverProps", () => {
-        // Select defines its own popoverWillOpen so this ensures that the passthrough happens
-        const popoverWillOpen = sinon.spy();
+        // Select defines its own onOpening so this ensures that the passthrough happens
+        const onOpening = sinon.spy();
         const modifiers = {}; // our own instance
-        const wrapper = select({ popoverProps: { popoverWillOpen, modifiers } });
+        const wrapper = select({ popoverProps: { onOpening, modifiers } });
         wrapper.find("article").simulate("click");
         assert.strictEqual(wrapper.find(Popover).prop("modifiers"), modifiers);
-        assert.isTrue(popoverWillOpen.calledOnce);
+        assert.isTrue(onOpening.calledOnce);
     });
 
     it("returns focus to focusable target after popover closed");

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, InputGroup, Keys, MenuItem, Popover } from "@blueprintjs/core";
+import { Classes, InputGroup, IPopoverProps, Keys, MenuItem, Popover } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -242,10 +242,10 @@ describe("Suggest", () => {
     });
 
     describe("popoverProps", () => {
-        const popoverWillOpen = sinon.spy();
+        const onOpening = sinon.spy();
 
         afterEach(() => {
-            popoverWillOpen.resetHistory();
+            onOpening.resetHistory();
         });
 
         it("popover can be controlled with popoverProps", () => {
@@ -253,15 +253,15 @@ describe("Suggest", () => {
             const wrapper = suggest({ popoverProps: getPopoverProps(false, tetherOptions) });
             wrapper.setProps({ popoverProps: getPopoverProps(true, tetherOptions) });
             assert.strictEqual(wrapper.find(Popover).prop("tetherOptions"), tetherOptions);
-            assert.isTrue(popoverWillOpen.calledOnce);
+            assert.isTrue(onOpening.calledOnce);
         });
 
-        function getPopoverProps(isOpen: boolean, tetherOptions: any) {
+        function getPopoverProps(isOpen: boolean, modifiers: any): Partial<IPopoverProps> {
             return {
                 ...defaultProps.popoverProps,
                 isOpen,
-                popoverWillOpen,
-                tetherOptions,
+                modifiers,
+                onOpening,
             };
         }
     });

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -249,10 +249,10 @@ describe("Suggest", () => {
         });
 
         it("popover can be controlled with popoverProps", () => {
-            const tetherOptions = {}; // our own instance
-            const wrapper = suggest({ popoverProps: getPopoverProps(false, tetherOptions) });
-            wrapper.setProps({ popoverProps: getPopoverProps(true, tetherOptions) });
-            assert.strictEqual(wrapper.find(Popover).prop("tetherOptions"), tetherOptions);
+            const modifiers = {}; // our own instance
+            const wrapper = suggest({ popoverProps: getPopoverProps(false, modifiers) });
+            wrapper.setProps({ popoverProps: getPopoverProps(true, modifiers) }).update();
+            assert.strictEqual(wrapper.find(Popover).prop("modifiers"), modifiers);
             assert.isTrue(onOpening.calledOnce);
         });
 

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -198,8 +198,8 @@ export class ColumnHeaderCell extends AbstractPureComponent<IColumnHeaderCellPro
                     position={Position.BOTTOM}
                     className={Classes.TABLE_TH_MENU}
                     modifiers={{ preventOverflow: { boundariesElement: "window" } }}
-                    popoverDidOpen={this.handlePopoverDidOpen}
-                    popoverWillClose={this.handlePopoverWillClose}
+                    onOpened={this.handlePopoverOpened}
+                    onClosing={this.handlePopoverClosing}
                 >
                     <Icon icon={menuIcon} />
                 </Popover>
@@ -207,11 +207,6 @@ export class ColumnHeaderCell extends AbstractPureComponent<IColumnHeaderCellPro
         );
     }
 
-    private handlePopoverDidOpen = () => {
-        this.setState({ isActive: true });
-    };
-
-    private handlePopoverWillClose = () => {
-        this.setState({ isActive: false });
-    };
+    private handlePopoverOpened = () => this.setState({ isActive: true });
+    private handlePopoverClosing = () => this.setState({ isActive: false });
 }


### PR DESCRIPTION
#### Fixes #2402 

#### Changes proposed in this pull request:

- `IOverlayLifecycleProps` defines `onOpening`, `onOpened`, `onClosing`, `onClosed`
     - 4 methods passed directly to CSSTransition to leverage their reliable code
     - 🔥this results in slightly different semantics, mainly that the popover content is always mounted in the DOM during any of these lifecycles.
         - previously, in `onOpening` and `onClosed` the content was not in the DOM (before entering or after exiting, respectively)
- 🔥 replace `Overlay` `didOpen`, `didClose` props with those above
- 🔥 replace `Popover` `popoverDid/Will*` props with those above

#### Reviewers should focus on:

> slightly different semantics, mainly that the popover content is always mounted in the DOM during any of these lifecycles.

could this be an issue? @invliD thoughts?