### PR TITLE
defined a default empty value for tagInput's inputValue

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -169,13 +169,14 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         inputProps: {},
+        inputValue: "",
         separator: ",",
         tagProps: {},
     };
 
     public state: ITagInputState = {
         activeIndex: NONE,
-        inputValue: this.props.inputValue || "",
+        inputValue: this.props.inputValue,
         isInputFocused: false,
     };
 

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -175,7 +175,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
 
     public state: ITagInputState = {
         activeIndex: NONE,
-        inputValue: this.props.inputValue,
+        inputValue: this.props.inputValue || "",
         isInputFocused: false,
     };
 

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -472,6 +472,11 @@ describe("<TagInput>", () => {
             wrapper.setProps({ inputValue: NEW_VALUE });
             expect(wrapper.find("input").prop("value")).to.equal(NEW_VALUE);
         });
+
+        it("has a default empty string value", () => {
+            const input = shallow(<TagInput values={VALUES} />).find("input");
+            expect(input.prop("value")).to.equal("");
+        });
     });
 
     function pressEnterInInput(wrapper: ShallowWrapper<any, any>, value: string) {


### PR DESCRIPTION

#### Fixes #2483

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests

#### Changes proposed in this pull request:

Added a default empty string value for the `inputValue` property, in order to correct the warning mentioned in the issue.