### PR TITLE
[Menu] Add Menu child components as static properties of the Menu component

### DIFF
--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -4,8 +4,10 @@ Menus display lists of interactive items.
 
 @## JavaScript API
 
-The `Menu`, `MenuItem`, and `MenuDivider` components are available in the **@blueprintjs/core**
-package. Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
+The `Menu` component is available in the **@blueprintjs/core** package. The package also includes
+two small helper components: `MenuItem` and `MenuDivider`. These can be referenced by their aliases
+as well: `Menu.Item` and `Menu.Divider`, respectively. Make sure to review the
+[getting started docs for installation info](#blueprint/getting-started).
 
 The `Menu` API includes three stateless React components:
 

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -9,6 +9,8 @@ import * as React from "react";
 
 import * as Classes from "../../common/classes";
 import { IProps } from "../../common/props";
+import { MenuDivider } from "./menuDivider";
+import { MenuItem } from "./menuItem";
 
 export interface IMenuProps extends IProps {
     /** Whether the menu items in this menu should use a large appearance. */
@@ -20,6 +22,9 @@ export interface IMenuProps extends IProps {
 
 export class Menu extends React.Component<IMenuProps, {}> {
     public static displayName = "Blueprint2.Menu";
+
+    public static Divider = MenuDivider;
+    public static Item = MenuItem;
 
     public render() {
         const classes = classNames(Classes.MENU, { [Classes.LARGE]: this.props.large }, this.props.className);


### PR DESCRIPTION
Not related to an issue.

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [X] Update documentation

#### Changes proposed in this pull request:

Added static properties to the `Menu` component to allow easier importing of it's child components `MenuDivider` and `MenuItem`. Extending an **existing pattern** found on the `NavBar` component.

Allow imports such as: 
```
import { ..., Menu, MenuDivider, MenuItem, ... } from '@blueprintjs/core';
```
to be reduced to:
```
import { ..., Menu, ... } from '@blueprintjs/core';
``` 

Where usage of `MenuDivider` would be changed to `Menu.Divider` etc...

I've also aligned the reference to this pattern on the `Menu` component's documentation page to match the `NavBar` documentation.