### PR TITLE
blueprint-classes-constants rule only detects leading pt- *prefix*

### DIFF
--- a/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
+++ b/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
@@ -7,7 +7,8 @@
 import * as Lint from "tslint";
 import * as ts from "typescript";
 
-const PATTERN = /\bpt-[\w-]+\b/;
+// detect "pt-" *prefix*: not preceded by letter or dash
+const PATTERN = /[^\w-]pt-[\w-]+/;
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
@@ -33,7 +34,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
         if (ts.isStringLiteral(node)) {
             const match = PATTERN.exec(node.getFullText());
             if (match != null) {
-                ctx.addFailureAt(node.getFullStart() + match.index, match[0].length, Rule.FAILURE_STRING);
+                // ignore first character of match: negated character class
+                ctx.addFailureAt(node.getFullStart() + match.index + 1, match[0].length - 1, Rule.FAILURE_STRING);
             }
         }
         return ts.forEachChild(node, cb);

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
@@ -1,7 +1,12 @@
+apt-get
+at 4pt-size
+"script-source pt-large apt-get"
+               ~~~~~~~~  [msg]
+
 <Button className="my-class pt-large" />
-                            ~~~~~~~~    [msg]
+                            ~~~~~~~~  [msg]
 
 classNames(Classes.BUTTON, "pt-intent-primary")
-                            ~~~~~~~~~~~~~~~~~     [msg]
+                            ~~~~~~~~~~~~~~~~~  [msg]
 
 [msg]: use Blueprint `Classes` constant instead of string literal


### PR DESCRIPTION
#### Fixes #2568 

- update the regex to only detect `pt-` as a prefix: not preceded by letter or dash

cc @styu 