### PR TITLE
[docs] Navigator supports excluding items

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -8,7 +8,7 @@ import { Classes, setHotkeysDialogProps } from "@blueprintjs/core";
 import { IPackageInfo } from "@blueprintjs/docs-data";
 import { Banner, Documentation, IDocumentationProps, INavMenuItemProps, NavMenuItem } from "@blueprintjs/docs-theme";
 import classNames from "classnames";
-import { isPageNode, ITsDocBase } from "documentalist/dist/client";
+import { IHeadingNode, isPageNode, ITsDocBase } from "documentalist/dist/client";
 import * as React from "react";
 import { NavHeader } from "./navHeader";
 import { NavIcon } from "./navIcons";
@@ -19,6 +19,7 @@ const THEME_LOCAL_STORAGE_KEY = "blueprint-docs-theme";
 
 // detect Components page and subheadings
 const COMPONENTS_PATTERN = /\/components(\.\w+)?$/;
+const isNavSection = ({ route }: IHeadingNode) => COMPONENTS_PATTERN.test(route);
 
 /** Return the current theme className. */
 export function getTheme(): string {
@@ -70,6 +71,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
                 className={this.state.themeName}
                 footer={footer}
                 header={header}
+                navigatorExclude={isNavSection}
                 onComponentUpdate={this.handleComponentUpdate}
                 renderNavMenuItem={this.renderNavMenuItem}
                 renderViewSourceLinkText={this.renderViewSourceLinkText}
@@ -95,7 +97,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
                 </div>
             );
         }
-        if (COMPONENTS_PATTERN.test(route)) {
+        if (isNavSection(props.section)) {
             // non-interactive header that expands its menu
             return <div className="docs-nav-section docs-nav-expanded">{title}</div>;
         }

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from "classnames";
-import { isPageNode, ITsDocBase, linkify } from "documentalist/dist/client";
+import { IHeadingNode, IPageNode, isPageNode, ITsDocBase, linkify } from "documentalist/dist/client";
 import * as React from "react";
 
 import { Classes, FocusStyleManager, Hotkey, Hotkeys, HotkeysTarget, IProps, Overlay, Utils } from "@blueprintjs/core";
@@ -52,6 +52,13 @@ export interface IDocumentationProps extends IProps {
      * Use `.docs-nav-title` on an element for proper padding relative to other sidebar elements.
      */
     header: React.ReactNode;
+
+    /**
+     * Callback invoked to determine if given nav node should *not* be
+     * searchable in the navigator. Returning `true` will exclude the item from
+     * the navigator search results.
+     */
+    navigatorExclude?: (node: IPageNode | IHeadingNode) => boolean;
 
     /**
      * Callback invoked whenever the component props or state change (specifically,
@@ -185,7 +192,12 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
                 <Overlay className={apiClasses} isOpen={isApiBrowserOpen} onClose={this.handleApiBrowserClose}>
                     <TypescriptExample tag="typescript" value={activeApiMember} />
                 </Overlay>
-                <Navigator isOpen={this.state.isNavigatorOpen} items={nav} onClose={this.handleCloseNavigator} />
+                <Navigator
+                    isOpen={this.state.isNavigatorOpen}
+                    items={nav}
+                    itemExclude={this.props.navigatorExclude}
+                    onClose={this.handleCloseNavigator}
+                />
             </div>
         );
     }

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -45,7 +45,8 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
     public componentDidMount() {
         this.sections = [];
         eachLayoutNode(this.props.items, (node, parents) => {
-            if (Utils.safeInvoke(this.props.itemExclude, node)) {
+            if (Utils.safeInvoke(this.props.itemExclude, node) === true) {
+                // ignore excluded item
                 return;
             }
             const { route, title } = node;

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Icon, MenuItem } from "@blueprintjs/core";
+import { Classes, Icon, MenuItem, Utils } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Omnibar } from "@blueprintjs/select";
 
 import { IHeadingNode, IPageNode } from "documentalist/dist/client";
@@ -14,8 +14,19 @@ import * as React from "react";
 import { eachLayoutNode } from "../common/utils";
 
 export interface INavigatorProps {
+    /** Whether navigator is open. */
     isOpen: boolean;
+
+    /** All potentially navigable items. */
     items: Array<IPageNode | IHeadingNode>;
+
+    /** Callback to determine if a given item should be excluded. */
+    itemExclude?: (node: IPageNode | IHeadingNode) => boolean;
+
+    /**
+     * Callback invoked when the navigator is closed. Navigation is performed by
+     * updating browser `location` directly.
+     */
     onClose: () => void;
 }
 
@@ -34,6 +45,9 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
     public componentDidMount() {
         this.sections = [];
         eachLayoutNode(this.props.items, (node, parents) => {
+            if (Utils.safeInvoke(this.props.itemExclude, node)) {
+                return;
+            }
             const { route, title } = node;
             const path = parents.map(p => p.title).reverse();
             const filterKey = [...path, "`" + title].join("/");


### PR DESCRIPTION
- new `Documentation` `navigatorExclude` and `Navigator` `itemExclude` props to support excluding items from the navigator results.

can no longer navigate to "Components" page or "Overlays" section.