### PR TITLE
use smaller (relative) font-size for `code`

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -263,7 +263,7 @@ Styleguide preformatted
   background: $pt-code-background-color;
   padding: 2px 5px;
   color: $pt-code-text-color;
-  font-size: $pt-font-size-small;
+  font-size: smaller;
 
   .#{$ns}-dark & {
     box-shadow: inset border-shadow(0.4);


### PR DESCRIPTION
so it'll adapt to container instead of always being 12px

## before
![image](https://user-images.githubusercontent.com/464822/41322310-310df174-6e5d-11e8-826a-0f41d8db697c.png)

## after (so subtle)
![image](https://user-images.githubusercontent.com/464822/41322315-38a6285c-6e5d-11e8-8af0-35934f242e24.png)
