### PR TITLE
[docs] improve button-group docs

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -9,35 +9,33 @@
 Button groups
 
 Markup:
-<div>
-  <div class="#{$ns}-button-group {{.modifier}}">
-    <a class="#{$ns}-button #{$ns}-icon-database" tabindex="0" role="button">Queries</a>
-    <a class="#{$ns}-button #{$ns}-icon-function" tabindex="0" role="button">Functions</a>
-    <a class="#{$ns}-button" tabindex="0" role="button">
-      Options <span class="#{$ns}-icon-standard #{$ns}-icon-caret-down #{$ns}-align-right"></span>
-    </a>
-  </div>
-  <br /><br /><br />
-  <div class="#{$ns}-button-group {{.modifier}}">
-    <a class="#{$ns}-button #{$ns}-icon-chart" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-control" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-graph" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-camera" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-map" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-code" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-th" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-time" tabindex="0" role="button"></a>
-    <a class="#{$ns}-button #{$ns}-icon-compressed" tabindex="0" role="button"></a>
-  </div>
-  <br /><br /><br />
-  <div class="#{$ns}-button-group {{.modifier}}">
-    <button type="button" class="#{$ns}-button #{$ns}-intent-success">Save</button>
-    <button type="button" class="#{$ns}-button #{$ns}-intent-success #{$ns}-icon-caret-down"></button>
-  </div>
+<div class="#{$ns}-button-group {{.modifier}}">
+  <button type="button" class="#{$ns}-button #{$ns}-intent-success">Save</button>
+  <button type="button" class="#{$ns}-button #{$ns}-intent-success #{$ns}-icon-caret-down"></button>
+</div>
+<div class="#{$ns}-button-group {{.modifier}}">
+  <a class="#{$ns}-button #{$ns}-icon-database" tabindex="0" role="button">Queries</a>
+  <a class="#{$ns}-button #{$ns}-icon-function" tabindex="0" role="button">Functions</a>
+  <a class="#{$ns}-button" tabindex="0" role="button">
+    Options <span class="#{$ns}-icon-standard #{$ns}-icon-caret-down #{$ns}-align-right"></span>
+  </a>
+</div>
+<div class="#{$ns}-button-group {{.modifier}}">
+  <a class="#{$ns}-button #{$ns}-icon-chart" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-control" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-graph" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-camera" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-map" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-code" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-th" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-time" tabindex="0" role="button"></a>
+  <a class="#{$ns}-button #{$ns}-icon-compressed" tabindex="0" role="button"></a>
 </div>
 
+.#{$ns}-fill - Buttons expand equally to fill container
 .#{$ns}-large - Use large buttons
 .#{$ns}-minimal - Use minimal buttons
+.#{$ns}-vertical - Vertical layout
 
 Styleguide button-group
 */
@@ -142,6 +140,7 @@ Styleguide button-group
 
   &.#{$ns}-fill {
     display: flex;
+    width: 100%;
   }
 
   .#{$ns}-button.#{$ns}-fill,
@@ -178,6 +177,11 @@ Styleguide button-group
     flex-direction: column;
     align-items: stretch;
     vertical-align: top;
+
+    &.#{$ns}-fill {
+      width: unset;
+      height: 100%;
+    }
 
     .#{$ns}-button {
       // we never want that margin-right when vertical

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -181,10 +181,15 @@ a.#{$ns}-button {
 .#{$ns}-button-text {
   // default: don't grow to fill but allow shrinking as necessary
   flex: 0 1 auto;
+}
 
-  // when alignment is set, grow to fill and inherit `text-align` set on `.#{$ns}-button`
-  .#{$ns}-align-left > &,
-  .#{$ns}-align-right > & {
-    flex: 1 1 auto;
+// when alignment is set, grow to fill and inherit `text-align` set on `.#{$ns}-button`
+.#{$ns}-button,
+.#{$ns}-button-group {
+  &.#{$ns}-align-left,
+  &.#{$ns}-align-right {
+    .#{$ns}-button-text {
+      flex: 1 1 auto;
+    }
   }
 }

--- a/packages/core/src/components/button/button-group.md
+++ b/packages/core/src/components/button/button-group.md
@@ -17,8 +17,9 @@ Button groups arrange multiple buttons in a horizontal or vertical group.
 some modifer props for common flexbox patterns:
 
 - Enable the `fill` prop on a button group to make all buttons expand equally to
-  fill the available space. Then add the class `Classes.FIXED` to individual
-  buttons to revert them to their original default sizes.
+  fill the available space.
+    - Buttons will expand horizontally by default, or vertically if the `vertical` prop is enabled.
+    - Add the class `Classes.FIXED` to individual buttons to revert them to their initial sizes.
 
 - Alternatively, enable the `fill` prop on specific buttons (instead of on the
   group) to expand them equally to fill the available space while other
@@ -36,12 +37,14 @@ Use the `alignText` prop to control icon and text alignment in the buttons. Set
 this prop on `ButtonGroup` to affect all buttons in the group, or set the prop
 on individual buttons directly.
 
-Vertical groups can be combined with other modifier props.
-
 @## Props
 
-This component is a simple wrapper around the CSS API.
-It exposes shorthand props for CSS modifier classes and supports the full range of HTML props.
+Most of the `ButtonGroup` props are also supported by `Button` directly; setting
+these props on `ButtonGroup` will apply the same value to all buttons in the
+group. Note that most modifiers, once enabled on the group, cannot be overridden
+on child buttons (due to the cascading nature of CSS).
+
+The component also supports all HTML `<div>` props.
 
 ```tsx
 <ButtonGroup minimal={true} onMouseEnter={...}>

--- a/packages/core/src/components/button/button-group.md
+++ b/packages/core/src/components/button/button-group.md
@@ -6,9 +6,37 @@ Button groups arrange multiple buttons in a horizontal or vertical group.
 
 @## Usage with popovers
 
-`Button`s inside a `ButtonGroup` can optionally be wrapped with a [`Popover`](#core/components/popover).
+`Button`s inside a `ButtonGroup` can trivially be wrapped with a
+[`Popover`](#core/components/popover) to create complex toolbars.
 
 @reactExample ButtonGroupPopoverExample
+
+@## Flex layout
+
+`ButtonGroup` is a CSS inline flex row (or column if vertical) and provides
+some modifer props for common flexbox patterns:
+
+- Enable the `fill` prop on a button group to make all buttons expand equally to
+  fill the available space. Then add the class `Classes.FIXED` to individual
+  buttons to revert them to their original default sizes.
+
+- Alternatively, enable the `fill` prop on specific buttons (instead of on the
+  group) to expand them equally to fill the available space while other
+  buttons retain their original sizes.
+
+You can adjust the specific size of a button with the `flex-basis` or `width`
+CSS properties.
+
+@## Vertical layout
+
+Buttons in a vertical group all have the same width as the widest button in the
+group.
+
+Use the `alignText` prop to control icon and text alignment in the buttons. Set
+this prop on `ButtonGroup` to affect all buttons in the group, or set the prop
+on individual buttons directly.
+
+Vertical groups can be combined with other modifier props.
 
 @## Props
 
@@ -33,32 +61,3 @@ You can apply sizing directly on the button group container element.
 You should implement interactive segmented controls as button groups.
 
 @css button-group
-
-@### Responsive button groups
-
-Add the class `@ns-fill` to a button group to make all buttons expand equally to fill the
-available space. Then add the class `@ns-fixed` to individual buttons to revert them to their
-original default sizes.
-
-Alternatively, add the class `@ns-fill` to an individual button (instead of to the container)
-to expand it to fill the available space while other buttons retain their original sizes.
-
-You can adjust the specific size of a button with the `flex-basis` CSS property.
-
-@css button-group-fill
-
-@### Vertical button groups
-
-Add the class `Classes.VERTICAL` to create a vertical button group. The buttons in a vertical
-group all have the same size as the widest button in the group.
-
-Add the modifier class `Classes.ALIGN_LEFT` (or `align={Alignment.LEFT}` in the React component) to
-left-align button text and icon and right-align `rightIcon`.
-
-You can also combine vertical groups with the `Classes.FILL` and `Classes.MINIMAL` class modifiers.
-
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    In vertical button groups, button content will be centered by default. You can align button content to the left or right using `.@ns-align-left` and `.@ns-align-right`, respectively.
-</div>
-
-@css button-group-vertical

--- a/packages/core/src/components/button/button.md
+++ b/packages/core/src/components/button/button.md
@@ -41,18 +41,18 @@ using the `Icon` component.
 
 @## Props
 
-You can provide your own props to these components as if they were regular JSX
-HTML elements. If you specify other attributes that the component provides, such
-as a `role` for an `<AnchorButton>`, you'll overide the default value.
+The two button components each support arbitrary HTML props for their underlying
+DOM element (`<button>` and `<a>` respectively). Specifying an HTML prop will
+override the component's default for it, such as `role` on `<AnchorButton>`.
 
 @interface IButtonProps
 
 @## CSS
 
 Use the `@ns-button` class to access button styles. You should implement buttons using the
-`<button>` or `<a>` tags rather than `<div>` for the purposes of HTML accessibility and semantics.
+`<button>` or `<a>` tags rather than `<div>` for accessibility.
 
-* Make sure to include `type="button"` on `<button>` tags (use `type="submit"` when used in a
+* Make sure to include `type="button"` on `<button>` tags (use `type="submit"` to submit a
   `<form>`) and `role="button"` on `<a>` tags for accessibility.
 * Add the attribute `tabindex="0"` to make `<a>` tags focusable. `<button>` elements are
   focusable by default.

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -49,13 +49,11 @@ export class ButtonGroupExample extends React.PureComponent<IExampleProps, IButt
                 <Switch checked={this.state.iconOnly} label="Icons only" onChange={this.handleIconOnlyChange} />
             </>
         );
-        // have the container take up the full-width if `fill` is true;
-        // otherwise, disable full-width styles to keep a vertical button group
-        // from taking up the full width.
-        const style: React.CSSProperties = { minWidth: 200, flexGrow: this.state.fill ? 1 : undefined };
+
         return (
             <Example options={options} {...this.props}>
-                <ButtonGroup style={style} {...bgProps}>
+                {/* set `minWidth` so `alignText` will have an effect when vertical */}
+                <ButtonGroup style={{ minWidth: 200 }} {...bgProps}>
                     <Button icon="database">{!iconOnly && "Queries"}</Button>
                     <Button icon="function">{!iconOnly && "Functions"}</Button>
                     <AnchorButton icon="cog" rightIcon="caret-down">

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -4,17 +4,15 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Alignment, Button, ButtonGroup, H5, IconName, Intent, Popover, Position, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Alignment, Button, ButtonGroup, H5, IconName, Popover, Position, Switch } from "@blueprintjs/core";
+import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 
 import { AlignmentSelect } from "./common/alignmentSelect";
 import { FileMenu } from "./common/fileMenu";
-import { IntentSelect } from "./common/intentSelect";
 
 export interface IButtonGroupPopoverExampleState {
     alignText: Alignment;
-    intent: Intent;
     large: boolean;
     minimal: boolean;
     vertical: boolean;
@@ -23,19 +21,16 @@ export interface IButtonGroupPopoverExampleState {
 export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps, IButtonGroupPopoverExampleState> {
     public state: IButtonGroupPopoverExampleState = {
         alignText: Alignment.CENTER,
-        intent: Intent.NONE,
         large: false,
         minimal: false,
         vertical: false,
     };
 
-    private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
     public render() {
-        const { intent, ...bgProps } = this.state;
         const options = (
             <>
                 <H5>Props</H5>
@@ -43,13 +38,11 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
                 <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />
-                <H5>Button props</H5>
-                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
             </>
         );
         return (
             <Example options={options} {...this.props}>
-                <ButtonGroup {...bgProps} style={{ minWidth: 120 }}>
+                <ButtonGroup {...this.state} style={{ minWidth: 120 }}>
                     {this.renderButton("File", "document")}
                     {this.renderButton("Edit", "edit")}
                     {this.renderButton("View", "eye-open")}
@@ -59,12 +52,12 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
     }
 
     private renderButton(text: string, iconName: IconName) {
-        const { intent, vertical } = this.state;
+        const { vertical } = this.state;
         const rightIconName: IconName = vertical ? "caret-right" : "caret-down";
         const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
         return (
             <Popover content={<FileMenu />} position={position}>
-                <Button intent={intent} rightIcon={rightIconName} icon={iconName} text={text} />
+                <Button rightIcon={rightIconName} icon={iconName} text={text} />
             </Popover>
         );
     }


### PR DESCRIPTION
(separate PR targeting `docs-rewrite` branch because this one's kinda big)

- fix button group alignment support (#2358 introduced regression)
- fix vertical fill: expands vertically!
- merge CSS examples into one
- move CSS sub-sections up and make them about React usage