### PR TITLE
TS sourcemaps & fix code coverage reports

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -23,7 +23,7 @@
         "noUnusedParameters": true,
         "pretty": true,
         "removeComments": false,
-        "sourceMap": false,
+        "sourceMap": true,
         "stripInternal": true,
         "target": "es5",
         "typeRoots": ["../node_modules/@types"]

--- a/packages/core/src/accessibility/focusStyleManager.ts
+++ b/packages/core/src/accessibility/focusStyleManager.ts
@@ -7,6 +7,7 @@
 import { FOCUS_DISABLED } from "../common/classes";
 import { InteractionModeEngine } from "../common/interactionMode";
 
+/* istanbul ignore next */
 const fakeFocusEngine = {
     isActive: () => true,
     start: () => true,

--- a/packages/docs-app/src/tsconfig.json
+++ b/packages/docs-app/src/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "declaration": false,
         "lib": ["dom", "es5", "es6"],
-        "outDir": "../dist"
+        "outDir": "../dist",
+        "sourceMap": false
     }
 }

--- a/packages/karma-build-scripts/createKarmaConfig.js
+++ b/packages/karma-build-scripts/createKarmaConfig.js
@@ -34,7 +34,6 @@ module.exports = function createKarmaConfig(
         coverageReporter: {
             check: {
                 each: {
-                    // ensure some coverage of each file, but rely mainly on overall watermarks
                     lines: COVERAGE_PERCENT,
                     statements: COVERAGE_PERCENT,
                     excludes: coverageExcludes,

--- a/packages/karma-build-scripts/createKarmaConfig.js
+++ b/packages/karma-build-scripts/createKarmaConfig.js
@@ -34,6 +34,7 @@ module.exports = function createKarmaConfig(
         coverageReporter: {
             check: {
                 each: {
+                    // ensure some coverage of each file, but rely mainly on overall watermarks
                     lines: COVERAGE_PERCENT,
                     statements: COVERAGE_PERCENT,
                     excludes: coverageExcludes,
@@ -41,11 +42,8 @@ module.exports = function createKarmaConfig(
                 },
             },
             includeAllSources: true,
-            reporters: [
-                { type: "html", dir: "coverage" },
-                { type: "lcov" },
-                { type: "text" },
-            ],
+            // save interim raw coverage report in memory. remapCoverage will output final report.
+            type: "in-memory",
             watermarks: {
                 lines: [COVERAGE_PERCENT, COVERAGE_PERCENT_HIGH],
                 statements: [COVERAGE_PERCENT, COVERAGE_PERCENT_HIGH],
@@ -73,7 +71,13 @@ module.exports = function createKarmaConfig(
         port: KARMA_SERVER_PORT,
         preprocessors: {
             [path.join(dirname, "test/**/*.ts")]: "sourcemap",
-            [path.join(dirname, "test/index.ts")]: "webpack",
+            [path.join(dirname, "test/index.ts")]: ["webpack", "sourcemap"],
+        },
+        // define where to save final remapped coverage reports
+        remapCoverageReporter: {
+            'text-summary': null,
+            html: './coverage/html',
+            cobertura: './coverage/cobertura.xml'
         },
         reporters: ["mocha"],
         singleRun: true,
@@ -112,7 +116,8 @@ module.exports = function createKarmaConfig(
     }
 
     if (coverage) {
-        config.reporters.push("coverage");
+        // enable coverage. these plugins are already configured above.
+        config.reporters.push("coverage", "remap-coverage");
     }
 
     return config;

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -15,6 +15,7 @@
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
+    "karma-remap-coverage": "^0.1.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.5",
     "mocha": "^4.1.0"

--- a/packages/landing-app/src/tsconfig.json
+++ b/packages/landing-app/src/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "declaration": false,
         "lib": ["dom", "es5", "es6"],
-        "outDir": "../dist"
+        "outDir": "../dist",
+        "sourceMap": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,9 +229,15 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
-amdefine@>=0.0.4:
+amdefine@>=0.0.4, amdefine@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-cyan@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
+  dependencies:
+    ansi-wrap "0.1.0"
 
 ansi-escapes@^3.0.0:
   version "3.0.0"
@@ -240,6 +246,12 @@ ansi-escapes@^3.0.0:
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
+
+ansi-red@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
+  dependencies:
+    ansi-wrap "0.1.0"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -264,6 +276,10 @@ ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-wrap@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
 ansicolors@~0.2.1:
   version "0.2.1"
@@ -300,6 +316,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
+  dependencies:
+    arr-flatten "^1.0.1"
+    array-slice "^0.2.3"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -313,6 +336,10 @@ arr-diff@^4.0.0:
 arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-2.1.0.tgz#20f9eab5ec70f5c7d215b1077b1c39161d292c7d"
 
 arr-union@^3.1.0:
   version "3.1.0"
@@ -2716,6 +2743,12 @@ express@^4.15.2, express@^4.16.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend-shallow@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
+  dependencies:
+    kind-of "^1.1.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -4184,7 +4217,7 @@ istanbul-lib-instrument@^1.7.3:
     istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
-istanbul@^0.4.0:
+istanbul@0.4.5, istanbul@^0.4.0:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
   dependencies:
@@ -4354,6 +4387,12 @@ karma-mocha@^1.3.0:
   dependencies:
     minimist "1.2.0"
 
+karma-remap-coverage@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/karma-remap-coverage/-/karma-remap-coverage-0.1.5.tgz#d2e3bb2dd00adcd256603a702b08c371370fbc12"
+  dependencies:
+    remap-istanbul "^0.10"
+
 karma-sourcemap-loader@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
@@ -4405,6 +4444,10 @@ karma@^1.7.1:
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
+
+kind-of@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
 
 kind-of@^2.0.1:
   version "2.0.1"
@@ -4993,7 +5036,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@3.0.x, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@3.0.x, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5849,6 +5892,16 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+plugin-error@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-0.1.2.tgz#3b9bb3335ccf00f425e07437e19276967da47ace"
+  dependencies:
+    ansi-cyan "^0.1.1"
+    ansi-red "^0.1.1"
+    arr-diff "^1.0.1"
+    arr-union "^2.0.1"
+    extend-shallow "^1.1.2"
+
 popper.js@^1.12.9, popper.js@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.1.tgz#b8815e5cda6f62fc2042e47618649f75866e6753"
@@ -6637,6 +6690,17 @@ readable-stream@~1.0.2:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -6736,6 +6800,17 @@ regjsparser@^0.1.4:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   dependencies:
     jsesc "~0.5.0"
+
+remap-istanbul@^0.10:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/remap-istanbul/-/remap-istanbul-0.10.1.tgz#3aa58dd5021d499f336d3ba5bf3bbb91c1b88e37"
+  dependencies:
+    amdefine "^1.0.0"
+    istanbul "0.4.5"
+    minimatch "^3.0.3"
+    plugin-error "^0.1.2"
+    source-map "^0.6.1"
+    through2 "2.0.1"
 
 remark-parse@^4.0.0:
   version "4.0.0"
@@ -7903,6 +7978,13 @@ text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
 
+through2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.1.tgz#384e75314d49f32de12eebb8136b8eb6b5d59da9"
+  dependencies:
+    readable-stream "~2.0.0"
+    xtend "~4.0.0"
+
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -8743,7 +8825,7 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
- enable typescript sourcemaps in tsconfig, so each package will now include `*.{d.ts,js,js.map}` for each original TS file.

# before:
![image](https://user-images.githubusercontent.com/464822/41564573-1f81f1bc-7308-11e8-91dd-50f8227d86f1.png)

# after:
![image](https://user-images.githubusercontent.com/464822/41564585-292192f4-7308-11e8-8a12-922bf85a4e29.png)

👍 👍 👍 