### PR TITLE
Add one-click download for icons

### DIFF
--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -26,6 +26,7 @@
     "@blueprintjs/table": "^3.0.0-rc.0",
     "@blueprintjs/test-commons": "^0.7.0",
     "@blueprintjs/timezone": "^3.0.0-rc.0",
+    "@types/downloadjs": "^1.4.0",
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",
     "dom4": "^2.0.1",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -29,6 +29,7 @@
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",
     "dom4": "^2.0.1",
+    "downloadjs": "^1.4.7",
     "moment": "^2.18.1",
     "normalize.css": "^8.0.0",
     "popper.js": "^1.14.1",

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -6,6 +6,7 @@
 
 import { Classes, ContextMenuTarget, Icon, IconName, Menu, MenuItem } from "@blueprintjs/core";
 import classNames from "classnames";
+import download from "downloadjs";
 import * as React from "react";
 import { ClickToCopy } from "./clickToCopy";
 
@@ -16,9 +17,9 @@ export interface IDocsIconProps {
     tags: string;
 }
 
-const GITHUB_PATH = "https://github.com/palantir/blueprint/blob/develop/resources/icons";
-function openIconFile(iconName: IconName, iconSize: 16 | 20) {
-    window.open(`${GITHUB_PATH}/${iconSize}px/${iconName}.svg`);
+const GITHUB_RAW_PATH = "https://raw.githubusercontent.com/palantir/blueprint/develop/resources/icons";
+function downloadIconFile(iconName: IconName, iconSize: 16 | 20) {
+    download(`${GITHUB_RAW_PATH}/${iconSize}px/${iconName}.svg`);
 }
 
 @ContextMenuTarget
@@ -59,6 +60,6 @@ export class DocsIcon extends React.PureComponent<IDocsIconProps, {}> {
         );
     }
 
-    private handleClick16 = () => openIconFile(this.props.iconName, 16);
-    private handleClick20 = () => openIconFile(this.props.iconName, 20);
+    private handleClick16 = () => downloadIconFile(this.props.iconName, 16);
+    private handleClick20 = () => downloadIconFile(this.props.iconName, 20);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.0.tgz#00dc42fed6b36a7a6dabb8f7a9c9e678ee644e05"
 
+"@types/downloadjs@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/downloadjs/-/downloadjs-1.4.0.tgz#d356ccdbea1c3622f233aebff7e58cc6598309ed"
+
 "@types/enzyme-adapter-react-16@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.1.tgz#cb93338ccf6cd1b8fdda91027c4ffe56583537b5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,6 +2225,10 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://artifactory.palantir.build:443/artifactory/api/npm/all-npm/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,7 +2231,7 @@ dot-prop@^4.1.1:
 
 downloadjs@^1.4.7:
   version "1.4.7"
-  resolved "https://artifactory.palantir.build:443/artifactory/api/npm/all-npm/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
#### Fixes #2611 

#### Changes proposed in this pull request:

- Add dependency `downloadjs@^1.4.7` for easy plug-and-play downloads.
- Add ability to one-click download Blueprint icons from the right-click context menu in the docs.

#### Reviewers should focus on:

- Functionality: I've tested across multiple browsers and versions, but if you want to be extra safe you can test yourself.