### PR TITLE
upgrade documentalist, add "edit this page" links

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -4,11 +4,11 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, setHotkeysDialogProps } from "@blueprintjs/core";
+import { AnchorButton, Classes, setHotkeysDialogProps } from "@blueprintjs/core";
 import { IDocsCompleteData } from "@blueprintjs/docs-data";
 import { Banner, Documentation, IDocumentationProps, INavMenuItemProps, NavMenuItem } from "@blueprintjs/docs-theme";
 import classNames from "classnames";
-import { IHeadingNode, isPageNode, ITsDocBase } from "documentalist/dist/client";
+import { IHeadingNode, IPageData, isPageNode, ITsDocBase } from "documentalist/dist/client";
 import * as React from "react";
 import { NavHeader } from "./navHeader";
 import { NavIcon } from "./navIcons";
@@ -78,6 +78,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
                 navigatorExclude={isNavSection}
                 onComponentUpdate={this.handleComponentUpdate}
                 renderNavMenuItem={this.renderNavMenuItem}
+                renderPageActions={this.renderPageActions}
                 renderViewSourceLinkText={this.renderViewSourceLinkText}
             />
         );
@@ -102,6 +103,18 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
         }
         return <NavMenuItem {...props} />;
     };
+
+    private renderPageActions(page: IPageData) {
+        return (
+            <AnchorButton
+                href={`https://github.com/palantir/blueprint/blob/develop/${page.sourcePath}`}
+                icon="edit"
+                minimal={true}
+                target="_blank"
+                text="Edit this page"
+            />
+        );
+    }
 
     private renderViewSourceLinkText(entry: ITsDocBase) {
         return `@blueprintjs/${entry.fileName.split("/", 2)[1]}`;

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -17,6 +17,10 @@ const DARK_THEME = Classes.DARK;
 const LIGHT_THEME = "";
 const THEME_LOCAL_STORAGE_KEY = "blueprint-docs-theme";
 
+const GITHUB_SOURCE_URL = "https://github.com/palantir/blueprint/blob/develop";
+const NPM_URL = "https://www.npmjs.com/package";
+const DOCS_BANNER_URL = "http://blueprintjs.com/docs/versions/2";
+
 // detect Components page and subheadings
 const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
 const isNavSection = ({ route }: IHeadingNode) => COMPONENTS_PATTERN.test(route);
@@ -44,7 +48,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
 
     public render() {
         const banner = (
-            <Banner href="http://blueprintjs.com/docs/v2/">
+            <Banner href={DOCS_BANNER_URL}>
                 This documentation is for&nbsp;<strong>Blueprint v3.0.0</strong>, which is currently under development.
                 Click here to go to the v2.x docs.
             </Banner>
@@ -107,7 +111,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
     private renderPageActions(page: IPageData) {
         return (
             <AnchorButton
-                href={`https://github.com/palantir/blueprint/blob/develop/${page.sourcePath}`}
+                href={`${GITHUB_SOURCE_URL}/${page.sourcePath}`}
                 icon="edit"
                 minimal={true}
                 target="_blank"
@@ -127,7 +131,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
         }
         const version = this.props.useNextVersion && pkg.nextVersion ? pkg.nextVersion : pkg.version;
         return (
-            <a className={Classes.TEXT_MUTED} href={`https://www.npmjs.com/package/${pkg.name}`} target="_blank">
+            <a className={Classes.TEXT_MUTED} href={`${NPM_URL}/${pkg.name}`} target="_blank">
                 <small>{version}</small>
             </a>
         );

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -17,15 +17,16 @@ import {
     Position,
     Tag,
 } from "@blueprintjs/core";
-import { IPackageInfo } from "@blueprintjs/docs-data";
 import { NavButton } from "@blueprintjs/docs-theme";
+import { INpmPackage } from "documentalist/dist/client";
 import * as React from "react";
 import { Logo } from "./logo";
 
 export interface INavHeaderProps {
     onToggleDark: (useDark: boolean) => void;
     useDarkTheme: boolean;
-    versions: IPackageInfo[];
+    useNextVersion: boolean;
+    packageData: INpmPackage;
 }
 
 @HotkeysTarget
@@ -72,26 +73,24 @@ export class NavHeader extends React.PureComponent<INavHeaderProps, {}> {
     }
 
     private renderVersionsMenu() {
-        const { versions } = this.props;
+        const { version, nextVersion, versions } = this.props.packageData;
         if (versions.length === 1) {
-            return (
-                <div className={Classes.TEXT_MUTED} key="_versions">
-                    v{versions[0].version}
-                </div>
-            );
+            return <div className={Classes.TEXT_MUTED}>v{versions[0]}</div>;
         }
 
-        const match = /docs\/v([0-9]+)/.exec(location.href);
         // default to latest release if we can't find a major version in the URL
-        const currentRelease = match == null ? versions[0].version : match[1];
-        const releaseItems = versions.map((rel, i) => <MenuItem key={i} href={rel.url} text={rel.version} />);
-        const menu = <Menu className="docs-version-list">{releaseItems}</Menu>;
-
+        const [currentRelease] = /\/versions\/([0-9]+)/.exec(location.href) || [
+            this.props.useNextVersion ? nextVersion : version,
+        ];
+        const releaseItems = versions.map(v => (
+            <MenuItem href={v === currentRelease ? "/docs" : `/docs/versions/${major(v)}`} key={v} text={v} />
+        ));
         return (
-            <Popover content={menu} position={Position.BOTTOM} key="_versions">
+            <Popover position={Position.BOTTOM}>
                 <Tag interactive={true} minimal={true} round={true}>
-                    v{currentRelease.split(".", 1)} <Icon icon="caret-down" />
+                    v{major(currentRelease)} <Icon icon="caret-down" />
                 </Tag>
+                <Menu className="docs-version-list">{releaseItems}</Menu>
             </Popover>
         );
     }
@@ -99,4 +98,9 @@ export class NavHeader extends React.PureComponent<INavHeaderProps, {}> {
     private handleDarkSwitchChange = () => {
         this.props.onToggleDark(!this.props.useDarkTheme);
     };
+}
+
+/** Get major component of semver string. */
+function major(version: string) {
+    return version.split(".", 1)[0];
 }

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -10,27 +10,12 @@ import "dom4";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { docsData as docs, IPackageInfo, releasesData, versionsData } from "@blueprintjs/docs-data";
+import { docsData } from "@blueprintjs/docs-data";
 import { createDefaultRenderers, ReactDocsTagRenderer, ReactExampleTagRenderer } from "@blueprintjs/docs-theme";
 
 import { BlueprintDocs } from "./components/blueprintDocs";
 import * as ReactDocs from "./tags/reactDocs";
 import { reactExamples } from "./tags/reactExamples";
-
-const releases: IPackageInfo[] = releasesData.map(pkg => ({
-    ...pkg,
-    url: `https://www.npmjs.com/package/${pkg.name}`,
-}));
-
-// sort versions so latest is first
-const majorVersions = Object.keys(versionsData)
-    .sort()
-    .reverse();
-const latestMajor = majorVersions[0];
-const versions: IPackageInfo[] = majorVersions.map(majorVersion => ({
-    url: majorVersion === latestMajor ? `/docs` : `/docs/versions/${majorVersion}`,
-    version: versionsData[majorVersion],
-}));
 
 const reactDocs = new ReactDocsTagRenderer(ReactDocs as any);
 const reactExample = new ReactExampleTagRenderer(reactExamples);
@@ -42,6 +27,6 @@ const tagRenderers = {
 };
 
 ReactDOM.render(
-    <BlueprintDocs {...{ docs, tagRenderers, releases, versions }} defaultPageId="blueprint" />,
+    <BlueprintDocs defaultPageId="blueprint" docs={docsData} tagRenderers={tagRenderers} useNextVersion={true} />,
     document.querySelector("#blueprint-documentation"),
 );

--- a/packages/docs-data/compile-docs-data.js
+++ b/packages/docs-data/compile-docs-data.js
@@ -31,7 +31,8 @@ const DOCS_DATA_PATH = path.join(GENERATED_SRC_DIR, "docs.json");
         }
         await generateDocumentalistData();
     } catch (err) {
-        console.log(`[docs-data] Failed to generate JSON data:`);
+        // console.error messages get swallowed by lerna but console.log is emitted to terminal.
+        console.log(`[docs-data] ERROR when generating JSON docs data:`);
         console.log(err);
         throw err;
     }

--- a/packages/docs-data/compile-docs-data.js
+++ b/packages/docs-data/compile-docs-data.js
@@ -22,22 +22,17 @@ const GENERATED_SRC_DIR = path.resolve(process.cwd(), "./src/generated");
 const BUILD_DIR = path.resolve(process.cwd(), "build");
 const NAV_PAGE_NAME = "_nav";
 
-const DOCS_DATA_FILENAME = "docs.json";
-const DOCS_RELEASES_FILENAME = "releases.json";
-const DOCS_VERSIONS_FIELENAME = "versions.json";
+const DOCS_DATA_PATH = path.join(GENERATED_SRC_DIR, "docs.json");
 
 (async () => {
     try {
         if (!fs.existsSync(GENERATED_SRC_DIR)) {
             fs.mkdirSync(GENERATED_SRC_DIR);
         }
-
         await generateDocumentalistData();
-        generateReleasesData();
-        generateVersionsData();
     } catch (err) {
-        console.error(`[docs-data] Failed to generate JSON data:`);
-        console.error(err);
+        console.log(`[docs-data] Failed to generate JSON data:`);
+        console.log(err);
         throw err;
     }
 })();
@@ -48,6 +43,7 @@ const DOCS_VERSIONS_FIELENAME = "versions.json";
 function generateDocumentalistData() {
     return new dm.Documentalist({
         markdown: { renderer: docsUtils.markedRenderer },
+        sourceBaseDir: ROOT_DIR,
         // must mark our @Decorator APIs as reserved so we can use them in code samples
         reservedTags: ["import", "ContextMenuTarget", "HotkeysTarget"],
     })
@@ -61,12 +57,25 @@ function generateDocumentalistData() {
             }),
         )
         .use(".scss", new dm.KssPlugin())
-        .documentGlobs("../*/src/**/*.{scss,md}", "../*/src/index.{ts,tsx}")
+        .use("package.json", new dm.NpmPlugin())
+        .documentGlobs("../*/src/**/*.{scss,md}", "../*/src/index.{ts,tsx}", "../*/package.json")
         .then(docs => JSON.stringify(docs, transformDocumentalistData, 2))
-        .then(content => fs.writeFileSync(path.join(GENERATED_SRC_DIR, DOCS_DATA_FILENAME), content));
+        .then(content => fs.writeFileSync(DOCS_DATA_PATH, content));
 }
 
 function transformDocumentalistData(key, value) {
+    if (key === "versions" && Array.isArray(value)) {
+        // one major version per release
+        const majors = new Map();
+        for (version of value) {
+            const major = semver.major(version)
+            if (!majors.has(major) || semver.gt(version, majors.get(major))) {
+                majors.set(major, version);
+            }
+        }
+        // reverse the list so highest version is first (easier indexing)
+        return Array.from(majors.values()).reverse();
+    }
     // remove all class declarations as they're currently unused and only increase bundle size
     if (value != null && value.kind !== "class") {
         return replaceNS(value);
@@ -74,73 +83,9 @@ function transformDocumentalistData(key, value) {
     return undefined;
 }
 
-/**
- * Create a JSON file containing latest released version of each project
- */
-function generateReleasesData() {
-    const packageDirectories = fs
-        .readdirSync(PACKAGES_DIR)
-        .map(name => path.join(PACKAGES_DIR, name))
-        .filter(source => fs.lstatSync(source).isDirectory());
-
-    const releases = packageDirectories
-        .filter(packagePath => fs.existsSync(path.resolve(packagePath, "package.json")))
-        .map(packagePath => require(path.resolve(packagePath, "package.json")))
-        // only include non-private projects
-        .filter(project => !project.private)
-        // just these two fields from package.json:
-        .map(({ name, version }) => ({ name, version }));
-
-    fs.writeFileSync(path.join(GENERATED_SRC_DIR, DOCS_RELEASES_FILENAME), JSON.stringify(releases, null, 2));
-}
-
-/**
- * Create a JSON file containing published versions of the documentation
- */
-function generateVersionsData() {
-    let stdout = "";
-    const child = spawn("git", ["tag"]);
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", data => {
-        stdout += data;
-    });
-    child.on("close", () => {
-        /** @type {Map<string, string>} */
-        const majorVersionMap = stdout
-            .split("\n")
-            // turn @blueprintjs/core@* tags into version numbers
-            .filter(val => /\@blueprintjs\/core\@[1-9]\d*\.\d+\.\d+.*/.test(val))
-            .map(val => val.slice("@blueprintjs/core@".length))
-            .reduce((map, version) => {
-                const major = semver.major(version);
-                if (!map.has(major) || semver.gt(version, map.get(major))) {
-                    map.set(major, version);
-                }
-                return map;
-            }, new Map());
-        // sort in reverse order (so latest is first)
-        const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
-
-        console.info("[docs-data] Major versions found:", majorVersions.join(", "));
-
-        fs.writeFileSync(
-            path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME),
-            JSON.stringify(strMapToObj(majorVersionMap), null, 2),
-        );
-    });
-}
-
-function strMapToObj(strMap) {
-    const obj = Object.create(null);
-    for (const [k, v] of strMap) {
-        // We don’t escape the key '__proto__'
-        // which can cause problems on older engines
-        obj[k] = v;
-    }
-    return obj;
-}
-
 /** @param {any} text replace `#{$ns}` with Blueprint class namespace. if not a string, simply returns `text`. */
 function replaceNS(text) {
-    return typeof text === "string" ? text.replace(/#{\$ns}|@ns/g, Classes.getClassNamespace()) : text;
+    return typeof text === "string"
+        ? text.replace(/#{\$ns}|@ns/g, Classes.getClassNamespace())
+        : text;
 }

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.0.0-beta.0",
     "@blueprintjs/docs-theme": "^3.0.0-beta.0",
-    "documentalist": "^1.3.2",
+    "documentalist": "^1.4.0",
     "glob": "^7.1.2",
     "highlights": "^3.1.1",
     "marked": "^0.3.6",

--- a/packages/docs-data/src/index.d.ts
+++ b/packages/docs-data/src/index.d.ts
@@ -2,19 +2,8 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-import { IDocsData } from "@blueprintjs/docs-theme";
+import { INpmPluginData, IMarkdownPluginData, IKssExample, IKssPluginData, ITypescriptPluginData } from "documentalist/dist/client";
 
-export interface IPackageInfo {
-    /** Name of package. Ignored for documentation site versions. */
-    name?: string;
-    url: string;
-    version: string;
-}
+export type IDocsCompleteData = IMarkdownPluginData & INpmPluginData & IKssPluginData & ITypescriptPluginData;
 
-export interface IVersionsInfo {
-    [majorVersion: string]: string;
-}
-
-export const docsData: IDocsData;
-export const releasesData: IPackageInfo[];
-export const versionsData: IVersionsInfo;
+export const docsData: IDocsCompleteData;

--- a/packages/docs-data/src/index.js
+++ b/packages/docs-data/src/index.js
@@ -5,6 +5,4 @@
 
 module.exports = {
     docsData: require("./generated/docs.json"),
-    releasesData: require("./generated/releases.json"),
-    versionsData: require("./generated/versions.json"),
 };

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -31,7 +31,7 @@
     "@blueprintjs/core": "^3.0.0-beta.1",
     "@blueprintjs/select": "^3.0.0-beta.0",
     "classnames": "^2.2",
-    "documentalist": "^1.3.2",
+    "documentalist": "^1.4.0",
     "fuzzaldrin-plus": "^0.5.0",
     "tslib": "^1.9.0"
   },

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -9,15 +9,23 @@ import {
     IBlock,
     IKssPluginData,
     IMarkdownPluginData,
+    INpmPluginData,
     ITsDocBase,
     ITypescriptPluginData,
 } from "documentalist/dist/client";
 
 /** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
-export type IDocsData = IMarkdownPluginData & (ITypescriptPluginData | {}) & (IKssPluginData | {});
+export type IDocsData = IMarkdownPluginData &
+    (ITypescriptPluginData | {}) &
+    (IKssPluginData | {}) &
+    (INpmPluginData | {});
 
 export function hasTypescriptData(docs: IDocsData): docs is IMarkdownPluginData & ITypescriptPluginData {
     return docs != null && (docs as ITypescriptPluginData).typescript != null;
+}
+
+export function hasNpmData(docs: IDocsData): docs is IMarkdownPluginData & INpmPluginData {
+    return docs != null && (docs as INpmPluginData).npm != null;
 }
 
 export function hasKssData(docs: IDocsData): docs is IMarkdownPluginData & IKssPluginData {

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from "classnames";
-import { IHeadingNode, IPageNode, isPageNode, ITsDocBase, linkify } from "documentalist/dist/client";
+import { IHeadingNode, IPageData, IPageNode, isPageNode, ITsDocBase, linkify } from "documentalist/dist/client";
 import * as React from "react";
 
 import { Classes, FocusStyleManager, Hotkey, Hotkeys, HotkeysTarget, IProps, Overlay, Utils } from "@blueprintjs/core";
@@ -79,6 +79,12 @@ export interface IDocumentationProps extends IProps {
      * The default implementation renders a `NavMenuItem` element, which is exported from this package.
      */
     renderNavMenuItem?: (props: INavMenuItemProps) => JSX.Element;
+
+    /**
+     * Callback invoked to render actions for a documentation page.
+     * Actions appear in an element in the upper-right corner of the page.
+     */
+    renderPageActions?: (page: IPageData) => React.ReactNode;
 
     /**
      * HTML element to use as the scroll parent. By default `document.documentElement` is assumed to be the scroll container.
@@ -186,7 +192,11 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
                         ref={this.refHandlers.content}
                         role="main"
                     >
-                        <Page page={pages[activePageId]} tagRenderers={this.props.tagRenderers} />
+                        <Page
+                            page={pages[activePageId]}
+                            renderActions={this.props.renderPageActions}
+                            tagRenderers={this.props.tagRenderers}
+                        />
                     </main>
                 </div>
                 <Overlay className={apiClasses} isOpen={isApiBrowserOpen} onClose={this.handleApiBrowserClose}>

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -13,14 +13,16 @@ import { renderBlock } from "./block";
 
 export interface IPageProps {
     page: IPageData;
+    renderActions: (page: IPageData) => React.ReactNode;
     tagRenderers: ITagRendererMap;
 }
 
-export const Page: React.SFC<IPageProps> = ({ tagRenderers, page }) => {
+export const Page: React.SFC<IPageProps> = ({ page, renderActions, tagRenderers }) => {
     // apply running text styles to blocks in pages (but not on blocks in examples)
     const pageContents = renderBlock(page, tagRenderers, Classes.TEXT_LARGE);
     return (
         <div className="docs-page" data-page-id={page.route}>
+            {renderActions && <div className="docs-page-actions">{renderActions(page)}</div>}
             {pageContents}
         </div>
     );

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -92,11 +92,20 @@ Page layout elements
 }
 
 .docs-page {
+  position: relative;
   max-width: $content-width;
   padding-top: 0;
   padding-right: $container-padding;
   padding-bottom: $content-padding * 2;
   padding-left: $content-padding * 2;
+}
+
+.docs-page-actions {
+  position: absolute;
+  top: $container-padding;
+  right: 0;
+  // above h1 heading
+  z-index: 1;
 }
 
 /*

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -7,9 +7,7 @@
 import * as React from "react";
 import * as tags from "./";
 
-import { IKssPluginData, IMarkdownPluginData, ITag, ITypescriptPluginData } from "documentalist/dist/client";
-
-export interface IDocsData extends IKssPluginData, IMarkdownPluginData, ITypescriptPluginData {}
+import { ITag } from "documentalist/dist/client";
 
 export function createDefaultRenderers(): Record<string, React.ComponentType<ITag>> {
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,9 +2138,9 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-documentalist@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/documentalist/-/documentalist-1.3.2.tgz#26f9a053c00e918d02c3f6865c8b314487427c71"
+documentalist@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/documentalist/-/documentalist-1.4.0.tgz#ed610cf9b8ab268acd33f13358c5f2bd5e391ff0"
   dependencies:
     "@types/kss" "^3.0.0"
     glob "^7.1.1"


### PR DESCRIPTION
#### Fixes #101 

#### Changes proposed in this pull request:

- upgrade to documentalist 1.4.0 and use new `NpmPlugin` so there's only one docs data file (versions and releases now live inside docs.json)
- add `Documentation` `renderPageActions` prop to customize upper-right actions
  - because docs-theme doesn't know about our github URL
- add "Edit this page" link in these actions

![image](https://user-images.githubusercontent.com/464822/41680501-88a6348a-7486-11e8-9149-0afa3d35b785.png)
