### PR TITLE
IPopoverSharedProps used by Popover and Tooltip, some prop renames

### DIFF
--- a/packages/core/scripts/upgrade-blueprint-3.0.0-rename.sh
+++ b/packages/core/scripts/upgrade-blueprint-3.0.0-rename.sh
@@ -173,6 +173,8 @@ renameProp popoverWillClose onClosing
 renameProp popoverWillOpen onOpening
 renameString 'requiredLabel={true}' 'labelInfo="(required)"'
 renameProp requiredLabel labelInfo
+renameProp rootElementTag wrapperTagName
+renameProp targetElementTag targetTagName
 
 # Classes constants
 renameString "Classes\.CALLOUT_TITLE" "Classes.HEADING"

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -13,7 +13,8 @@ import * as Classes from "../../common/classes";
 import { Position } from "../../common/position";
 import { safeInvoke } from "../../common/utils";
 import { IOverlayLifecycleProps } from "../overlay/overlay";
-import { Popover, PopperModifiers } from "../popover/popover";
+import { Popover } from "../popover/popover";
+import { PopperModifiers } from "../popover/popoverSharedProps";
 
 export interface IOffset {
     left: number;

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -51,6 +51,7 @@ export * from "./overflow-list/overflowList";
 export * from "./overlay/overlay";
 export * from "./text/text";
 export * from "./popover/popover";
+export * from "./popover/popoverSharedProps";
 export * from "./portal/portal";
 export * from "./progress-bar/progressBar";
 export * from "./slider/handleProps";

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -5,24 +5,21 @@
  */
 
 import classNames from "classnames";
-import { ModifierFn, Modifiers as PopperModifiers } from "popper.js";
+import { ModifierFn } from "popper.js";
 import * as React from "react";
 import { Manager, Popper, Target } from "react-popper";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
-import { Position } from "../../common/position";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { HTMLDivProps } from "../../common/props";
 import * as Utils from "../../common/utils";
-import { IOverlayableProps, Overlay } from "../overlay/overlay";
+import { Overlay } from "../overlay/overlay";
 import { Tooltip } from "../tooltip/tooltip";
 import { getArrowAngle, PopoverArrow } from "./arrow";
 import { positionToPlacement } from "./popoverMigrationUtils";
+import { IPopoverSharedProps, PopperModifiers } from "./popoverProps";
 import { arrowOffsetModifier, getTransformOrigin } from "./popperUtils";
-
-// re-export this symbol for library consumers
-export { PopperModifiers };
 
 export const PopoverInteractionKind = {
     CLICK: "click" as "click",
@@ -32,46 +29,15 @@ export const PopoverInteractionKind = {
 };
 export type PopoverInteractionKind = typeof PopoverInteractionKind[keyof typeof PopoverInteractionKind];
 
-export interface IPopoverProps extends IOverlayableProps, IProps {
+export interface IPopoverProps extends IPopoverSharedProps {
     /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
     /**
-     * The content displayed inside the popover.
-     * This can instead be provided as the second `children` element (first is `target`).
+     * The content displayed inside the popover. This can instead be provided as
+     * the _second_ element in `children` (first is `target`).
      */
     content?: string | JSX.Element;
-
-    /**
-     * Initial opened state when uncontrolled.
-     * @default false
-     */
-    defaultIsOpen?: boolean;
-
-    /**
-     * The amount of time in milliseconds the popover should remain open after the
-     * user hovers off the trigger. The timer is canceled if the user mouses over the
-     * target before it expires. This option only applies when `interactionKind` is `HOVER` or
-     * `HOVER_TARGET_ONLY`.
-     * @default 300
-     */
-    hoverCloseDelay?: number;
-
-    /**
-     * The amount of time in milliseconds the popover should wait before opening after the the
-     * user hovers over the trigger. The timer is canceled if the user mouses away from the
-     * target before it expires. This option only applies when `interactionKind` is `HOVER` or
-     * `HOVER_TARGET_ONLY`.
-     * @default 150
-     */
-    hoverOpenDelay?: number;
-
-    /**
-     * Whether a popover should automatically inherit the dark theme from its parent.
-     * Note that this prop is ignored if `usePortal={false}`, as the Popover will inherit dark theme via CSS.
-     * @default true
-     */
-    inheritDarkTheme?: boolean;
 
     /**
      * The kind of interaction that triggers the display of the popover.
@@ -80,59 +46,22 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     interactionKind?: PopoverInteractionKind;
 
     /**
-     * Prevents the popover from appearing when `true`, even if `isOpen={true}`.
-     * @default false
-     */
-    disabled?: boolean;
-
-    /**
-     * Enables an invisible overlay beneath the popover that captures clicks and prevents
-     * interaction with the rest of the document until the popover is closed.
-     * This prop is only available when `interactionKind` is `PopoverInteractionKind.CLICK`.
-     * When popovers with backdrop are opened, they become focused.
+     * Enables an invisible overlay beneath the popover that captures clicks and
+     * prevents interaction with the rest of the document until the popover is
+     * closed. This prop is only available when `interactionKind` is
+     * `PopoverInteractionKind.CLICK`. When popovers with backdrop are opened,
+     * they become focused.
      * @default false
      */
     hasBackdrop?: boolean;
 
     /**
-     * Whether the popover is visible. Passing this prop puts the popover in
-     * controlled mode, where the only way to change visibility is by updating this property.
-     * If `disabled={true}`, this prop will be ignored, and the popover will remain closed.
-     * @default undefined
-     */
-    isOpen?: boolean;
-
-    /**
-     * Whether to apply minimal styles to this popover, which includes removing the arrow
-     * and adding `Classes.MINIMAL` to minimize and accelerate the transitions.
+     * Whether to apply minimal styles to this popover, which includes removing
+     * the arrow and adding `Classes.MINIMAL` to minimize and accelerate the
+     * transitions.
      * @default false
      */
     minimal?: boolean;
-
-    /**
-     * Popper modifier options, passed directly to internal Popper instance.
-     * See https://popper.js.org/popper-documentation.html#modifiers for complete details.
-     */
-    modifiers?: PopperModifiers;
-
-    /**
-     * Callback invoked in controlled mode when the popover open state *would* change due to
-     * user interaction based on the value of `interactionKind`.
-     */
-    onInteraction?: (nextOpenState: boolean, e?: React.SyntheticEvent<HTMLElement>) => void;
-
-    /**
-     * Whether the popover should open when its target is focused.
-     * If `true`, target will render with `tabindex="0"` to make it focusable via keyboard navigation.
-     * This prop is only available when `interactionKind` is `HOVER` or `HOVER_TARGET_ONLY`.
-     * @default true
-     */
-    openOnTargetFocus?: boolean;
-
-    /**
-     * A space-delimited string of class names applied to the popover.
-     */
-    popoverClassName?: string;
 
     /**
      * Ref supplied to the `Classes.POPOVER` element.
@@ -140,55 +69,10 @@ export interface IPopoverProps extends IOverlayableProps, IProps {
     popoverRef?: (ref: HTMLDivElement | null) => void;
 
     /**
-     * Space-delimited string of class names applied to the
-     * portal that holds the popover if `usePortal={true}`.
-     */
-    portalClassName?: string;
-
-    /**
-     * The position (relative to the target) at which the popover should appear.
-     *
-     * The default value of `"auto"` will choose the best position when opened
-     * and will allow the popover to reposition itself to remain onscreen as the
-     * user scrolls around.
-     */
-    position?: Position | "auto";
-
-    /**
-     * The name of the HTML tag to use when rendering the popover target wrapper
-     * element (`Classes.POPOVER_WRAPPER`).
-     * @default "span"
-     */
-    rootElementTag?: string;
-
-    /**
-     * The target element to which the popover content is attached.
-     * This can instead be provided as the first `children` element.
+     * The target to which the popover content is attached. This can instead be
+     * provided as the _first_ element in `children`.
      */
     target?: string | JSX.Element;
-
-    /**
-     * Space-delimited string of class names applied to the target.
-     */
-    targetClassName?: string;
-
-    /**
-     * The name of the HTML tag to use when rendering the popover target element.
-     * @default "div"
-     */
-    targetElementTag?: string;
-
-    /**
-     * Whether the popover should be rendered inside a `Portal` attached to `document.body`.
-     * Rendering content inside a `Portal` allows the popover content to escape the physical bounds of its
-     * parent while still being positioned correctly relative to its target.
-     *
-     * Using a `Portal` is necessary if any ancestor of the target hides overflow or uses very complex positioning.
-     * Not using a `Portal` can result in smoother performance when scrolling and allows the popover content to inherit
-     * CSS styles from surrounding elements.
-     * @default true
-     */
-    usePortal?: boolean;
 }
 
 export interface IPopoverState {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -18,7 +18,7 @@ import { Overlay } from "../overlay/overlay";
 import { Tooltip } from "../tooltip/tooltip";
 import { getArrowAngle, PopoverArrow } from "./arrow";
 import { positionToPlacement } from "./popoverMigrationUtils";
-import { IPopoverSharedProps, PopperModifiers } from "./popoverProps";
+import { IPopoverSharedProps, PopperModifiers } from "./popoverSharedProps";
 import { arrowOffsetModifier, getTransformOrigin } from "./popperUtils";
 
 export const PopoverInteractionKind = {
@@ -97,10 +97,10 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         modifiers: {},
         openOnTargetFocus: true,
         position: "auto",
-        rootElementTag: "span",
-        targetElementTag: "div",
+        targetTagName: "div",
         transitionDuration: 300,
         usePortal: true,
+        wrapperTagName: "span",
     };
 
     /**
@@ -139,7 +139,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     }
 
     public render() {
-        const { className, disabled, targetClassName, targetElementTag } = this.props;
+        const { className, disabled, targetClassName, targetTagName, wrapperTagName } = this.props;
         const { isOpen } = this.state;
         const isHoverInteractionKind = this.isHoverInteractionKind();
 
@@ -184,8 +184,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         }
 
         return (
-            <Manager tag={this.props.rootElementTag} className={classNames(Classes.POPOVER_WRAPPER, className)}>
-                <Target {...targetProps} component={targetElementTag} innerRef={this.refHandlers.target}>
+            <Manager tag={wrapperTagName} className={classNames(Classes.POPOVER_WRAPPER, className)}>
+                <Target {...targetProps} component={targetTagName} innerRef={this.refHandlers.target}>
                     {target}
                 </Target>
                 <Overlay

--- a/packages/core/src/components/popover/popoverProps.tsx
+++ b/packages/core/src/components/popover/popoverProps.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { Modifiers as PopperModifiers } from "popper.js";
+import { Position } from "../../common/position";
+import { IProps } from "../../common/props";
+import { IOverlayableProps } from "../overlay/overlay";
+
+// re-export this symbol for library consumers
+export { PopperModifiers };
+
+export interface IPopoverSharedProps extends IOverlayableProps, IProps {
+    /**
+     * Initial opened state when uncontrolled.
+     * @default false
+     */
+    defaultIsOpen?: boolean;
+
+    /**
+     * Prevents the popover from appearing when `true`.
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * The amount of time in milliseconds the popover should remain open after
+     * the user hovers off the trigger. The timer is canceled if the user mouses
+     * over the target before it expires.
+     * @default 300
+     */
+    hoverCloseDelay?: number;
+
+    /**
+     * The amount of time in milliseconds the popover should wait before opening
+     * after the user hovers over the trigger. The timer is canceled if the user
+     * mouses away from the target before it expires.
+     * @default 150
+     */
+    hoverOpenDelay?: number;
+
+    /**
+     * Whether a popover that uses a `Portal` should automatically inherit the
+     * dark theme from its parent.
+     * @default true
+     */
+    inheritDarkTheme?: boolean;
+
+    /**
+     * Whether the popover is visible. Passing this prop puts the popover in
+     * controlled mode, where the only way to change visibility is by updating
+     * this property. If `disabled={true}`, this prop will be ignored, and the
+     * popover will remain closed.
+     * @default undefined
+     */
+    isOpen?: boolean;
+
+    /**
+     * Popper modifier options, passed directly to internal Popper instance. See
+     * https://popper.js.org/popper-documentation.html#modifiers for complete
+     * details.
+     */
+    modifiers?: PopperModifiers;
+
+    /**
+     * Callback invoked in controlled mode when the popover open state *would*
+     * change due to user interaction.
+     */
+    onInteraction?: (nextOpenState: boolean) => void;
+
+    /**
+     * Whether the popover should open when its target is focused. If `true`,
+     * target will render with `tabindex="0"` to make it focusable via keyboard
+     * navigation.
+     * @default true
+     */
+    openOnTargetFocus?: boolean;
+
+    /**
+     * A space-delimited string of class names applied to the popover element.
+     */
+    popoverClassName?: string;
+
+    /**
+     * Space-delimited string of class names applied to the `Portal` element if
+     * `usePortal={true}`.
+     */
+    portalClassName?: string;
+
+    /**
+     * The position (relative to the target) at which the popover should appear.
+     *
+     * The default value of `"auto"` will choose the best position when opened
+     * and will allow the popover to reposition itself to remain onscreen as the
+     * user scrolls around.
+     * @default "auto"
+     */
+    position?: Position | "auto";
+
+    /**
+     * Space-delimited string of class names applied to the target element.
+     */
+    targetClassName?: string;
+
+    /**
+     * HTML tag name for the target element. This must be an HTML element to
+     * ensure that it supports the necessary DOM event handlers.
+     *
+     * By default, a `<span>` tag is used so popovers appear as inline-block
+     * elements and can be nested in text. Use `<div>` tag for a block element.
+     * @default "span"
+     */
+    targetElementTag?: keyof JSX.IntrinsicElements;
+
+    /**
+     * Whether the popover should be rendered inside a `Portal` attached to
+     * `document.body`.
+     *
+     * Rendering content inside a `Portal` allows the popover content to escape
+     * the physical bounds of its parent while still being positioned correctly
+     * relative to its target. Using a `Portal` is necessary if any ancestor of
+     * the target hides overflow or uses very complex positioning.
+     *
+     * Not using a `Portal` can result in smoother performance when scrolling
+     * and allows the popover content to inherit CSS styles from surrounding
+     * elements, but it remains subject to the overflow bounds of its ancestors.
+     * @default true
+     */
+    usePortal?: boolean;
+
+    /**
+     * HTML tag name for the wrapper element, which also receives the
+     * `className` prop.
+     * @default "span"
+     */
+    rootElementTag?: keyof JSX.IntrinsicElements;
+}

--- a/packages/core/src/components/popover/popoverSharedProps.tsx
+++ b/packages/core/src/components/popover/popoverSharedProps.tsx
@@ -12,6 +12,7 @@ import { IOverlayableProps } from "../overlay/overlay";
 // re-export this symbol for library consumers
 export { PopperModifiers };
 
+/** Props shared between `Popover` and `Tooltip`. */
 export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     /**
      * Initial opened state when uncontrolled.

--- a/packages/core/src/components/popover/popoverSharedProps.tsx
+++ b/packages/core/src/components/popover/popoverSharedProps.tsx
@@ -112,7 +112,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * elements and can be nested in text. Use `<div>` tag for a block element.
      * @default "span"
      */
-    targetElementTag?: keyof JSX.IntrinsicElements;
+    targetTagName?: keyof JSX.IntrinsicElements;
 
     /**
      * Whether the popover should be rendered inside a `Portal` attached to
@@ -135,5 +135,5 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * `className` prop.
      * @default "span"
      */
-    rootElementTag?: keyof JSX.IntrinsicElements;
+    wrapperTagName?: keyof JSX.IntrinsicElements;
 }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -8,142 +8,55 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { Position } from "../../common/position";
-import { IIntentProps, IProps } from "../../common/props";
-import { IOverlayLifecycleProps } from "../overlay/overlay";
-import { Popover, PopoverInteractionKind, PopperModifiers } from "../popover/popover";
+import { IIntentProps } from "../../common/props";
+import { Popover, PopoverInteractionKind } from "../popover/popover";
+import { IPopoverSharedProps } from "../popover/popoverProps";
 
-export interface ITooltipProps extends IProps, IIntentProps, IOverlayLifecycleProps {
+export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
     /**
      * The content that will be displayed inside of the tooltip.
      */
     content: JSX.Element | string;
 
     /**
-     * Initial opened state when uncontrolled.
-     * @default false
-     */
-    defaultIsOpen?: boolean;
-
-    /**
-     * Prevents the popover from appearing when `true`.
-     * @default false
-     */
-    disabled?: boolean;
-
-    /**
-     * The amount of time in milliseconds the tooltip should remain open after the
-     * user hovers off the trigger. The timer is canceled if the user mouses over the
-     * target before it expires.
+     * The amount of time in milliseconds the tooltip should remain open after
+     * the user hovers off the trigger. The timer is canceled if the user mouses
+     * over the target before it expires.
      * @default 0
      */
     hoverCloseDelay?: number;
 
     /**
-     * The amount of time in milliseconds the tooltip should wait before opening after the
-     * user hovers over the trigger. The timer is canceled if the user mouses away from the
-     * target before it expires.
+     * The amount of time in milliseconds the tooltip should wait before opening
+     * after the user hovers over the trigger. The timer is canceled if the user
+     * mouses away from the target before it expires.
      * @default 100
      */
     hoverOpenDelay?: number;
 
     /**
-     * Whether a tooltip that uses a `Portal` should automatically inherit the dark theme from its parent.
-     * @default true
-     */
-    inheritDarkTheme?: boolean;
-
-    /**
-     * Whether the popover is visible. Passing this prop puts the popover in
-     * controlled mode, where the only way to change visibility is by updating this property.
-     * @default undefined
-     */
-    isOpen?: boolean;
-
-    /**
-     * Popper modifier options, passed directly to internal Popper instance.
-     * See https://popper.js.org/popper-documentation.html#modifiers for complete details.
-     */
-    modifiers?: PopperModifiers;
-
-    /**
-     * Callback invoked in controlled mode when the tooltip open state *would* change due to
-     * user interaction.
-     */
-    onInteraction?: (nextOpenState: boolean) => void;
-
-    /**
-     * Whether the tooltip should open when its target is focused.
-     * If `true`, target will render with `tabindex="0"` to make it focusable via keyboard navigation.
-     * @default true
-     */
-    openOnTargetFocus?: boolean;
-
-    /**
-     * Space-delimited string of class names applied to the
-     * portal which holds the tooltip if `usePortal={true}`.
-     */
-    portalClassName?: string;
-
-    /**
-     * The position (relative to the target) at which the popover should appear.
-     *
-     * The default value of `"auto"` will choose the best position when opened
-     * and will allow the popover to reposition itself to remain onscreen as the
-     * user scrolls around.
-     * @default "auto"
-     */
-    position?: Position | "auto";
-
-    /**
-     * The name of the HTML tag to use when rendering the popover target wrapper element (`Classes.POPOVER_WRAPPER`).
-     * @default "span"
-     */
-    rootElementTag?: string;
-
-    /**
-     * The name of the HTML tag to use when rendering the popover target element.
-     * @default "div"
-     */
-    targetElementTag?: string;
-
-    /**
-     * A space-delimited string of class names that are applied to the tooltip.
-     */
-    tooltipClassName?: string;
-
-    /**
-     * Indicates how long (in milliseconds) the tooltip's appear/disappear transition takes.
-     * This is used by React `CSSTransition` to know when a transition completes
-     * and must match the duration of the animation in CSS.
-     * Only set this prop if you override Blueprint's default transitions with new transitions of a different length.
+     * Indicates how long (in milliseconds) the tooltip's appear/disappear
+     * transition takes. This is used by React `CSSTransition` to know when a
+     * transition completes and must match the duration of the animation in CSS.
+     * Only set this prop if you override Blueprint's default transitions with
+     * new transitions of a different length.
      * @default 100
      */
     transitionDuration?: number;
-
-    /**
-     * Whether the tooltip is rendered inside a `Portal` so it can escape the usual DOM flow.
-     * If `false`, it is rendered as a sibling of the target element.
-     * @default true
-     */
-    usePortal?: boolean;
 }
 
 export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
     public static displayName = "Blueprint2.Tooltip";
 
     public static defaultProps: Partial<ITooltipProps> = {
-        defaultIsOpen: false,
-        disabled: false,
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
-        openOnTargetFocus: true,
         transitionDuration: 100,
     };
 
     public render() {
-        const { children, intent, tooltipClassName, ...restProps } = this.props;
-        const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), tooltipClassName);
+        const { children, intent, popoverClassName, ...restProps } = this.props;
+        const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), popoverClassName);
 
         return (
             <Popover

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import * as Classes from "../../common/classes";
 import { IIntentProps } from "../../common/props";
 import { Popover, PopoverInteractionKind } from "../popover/popover";
-import { IPopoverSharedProps } from "../popover/popoverProps";
+import { IPopoverSharedProps } from "../popover/popoverSharedProps";
 
 export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
     /**

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -207,9 +207,10 @@ describe("<Popover>", () => {
         assert.isTrue(expectedBackdrop.matches(`.${Classes.POPOVER_BACKDROP}`));
     });
 
-    it("rootElementTag prop renders the right elements", () => {
-        wrapper = renderPopover({ isOpen: true, rootElementTag: "article" });
-        assert.isNotNull(wrapper.find("article"));
+    it("*TagName props render the right elements", () => {
+        wrapper = renderPopover({ isOpen: true, targetTagName: "address", wrapperTagName: "article" });
+        assert.isTrue(wrapper.find("address").hasClass(Classes.POPOVER_TARGET));
+        assert.isTrue(wrapper.find("article").hasClass(Classes.POPOVER_WRAPPER));
     });
 
     it("supports overlay lifecycle props", () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -48,7 +48,7 @@ describe("<Tooltip>", () => {
             const tooltip = renderTooltip({
                 className: "bar",
                 isOpen: true,
-                tooltipClassName: "foo",
+                popoverClassName: "foo",
             });
             assert.lengthOf(tooltip.find(`.${Classes.TOOLTIP}.foo`).hostNodes(), 1, "tooltip");
             assert.lengthOf(tooltip.find(`.${Classes.POPOVER_WRAPPER}.bar`).hostNodes(), 1, "popover wrapper");
@@ -109,9 +109,10 @@ describe("<Tooltip>", () => {
         });
     });
 
-    it("rootElementTag prop renders the right elements", () => {
-        const tooltip = renderTooltip({ isOpen: true, rootElementTag: "section" });
-        assert.lengthOf(tooltip.find(`section.${Classes.POPOVER_WRAPPER}`), 1);
+    it("*TagName props render the right elements", () => {
+        const tooltip = renderTooltip({ isOpen: true, targetTagName: "address", wrapperTagName: "article" });
+        assert.isTrue(tooltip.find("address").hasClass(Classes.POPOVER_TARGET));
+        assert.isTrue(tooltip.find("article").hasClass(Classes.POPOVER_WRAPPER));
     });
 
     it("supports overlay lifecycle props", () => {


### PR DESCRIPTION
pulling out the renames from #2609 and unifying the props interfaces between Popover and Tooltip.

#### Changes proposed in this pull request:

- `IPopoverSharedProps` for the common Popover/Tooltip bits
- 🔥 `rootElementTag` => `wrapperTagName`
- 🔥 `targetElementTag` => `targetTagName`
