### PR TITLE
3.0.0-rc.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-rc.0",
   "description": "Core styles & components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -38,7 +38,7 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/icons": "^3.0.0-beta.0",
+    "@blueprintjs/icons": "^3.0.0-rc.0",
     "@types/dom4": "^2.0.0",
     "classnames": "^2.2",
     "dom4": "^2.0.1",
@@ -54,9 +54,9 @@
     "react-dom": "^15.3.0 || 16"
   },
   "devDependencies": {
-    "@blueprintjs/karma-build-scripts": "^0.6.1",
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/test-commons": "^0.6.0",
+    "@blueprintjs/karma-build-scripts": "^0.7.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/test-commons": "^0.7.0",
     "enzyme": "^3.3.0",
     "karma": "^1.7.1",
     "mocha": "^4.1.0",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/datetime",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Components for interacting with dates and times",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -33,15 +33,15 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
     "classnames": "^2.2",
     "react-day-picker": "^7.0.7",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/karma-build-scripts": "^0.6.1",
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/test-commons": "^0.6.0",
+    "@blueprintjs/karma-build-scripts": "^0.7.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/test-commons": "^0.7.0",
     "enzyme": "^3.3.0",
     "karma": "^1.7.1",
     "mocha": "^4.1.0",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/docs-app",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Blueprint Documentation Site",
   "private": true,
   "scripts": {
@@ -16,16 +16,16 @@
     "verify": "run-p dist lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
-    "@blueprintjs/datetime": "^3.0.0-beta.0",
-    "@blueprintjs/docs-data": "^3.0.0-beta.0",
-    "@blueprintjs/docs-theme": "^3.0.0-beta.0",
-    "@blueprintjs/icons": "^3.0.0-beta.0",
-    "@blueprintjs/labs": "^0.16.0",
-    "@blueprintjs/select": "^3.0.0-beta.0",
-    "@blueprintjs/table": "^3.0.0-beta.0",
-    "@blueprintjs/test-commons": "^0.6.0",
-    "@blueprintjs/timezone": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
+    "@blueprintjs/datetime": "^3.0.0-rc.0",
+    "@blueprintjs/docs-data": "^3.0.0-rc.0",
+    "@blueprintjs/docs-theme": "^3.0.0-rc.0",
+    "@blueprintjs/icons": "^3.0.0-rc.0",
+    "@blueprintjs/labs": "^0.16.1",
+    "@blueprintjs/select": "^3.0.0-rc.0",
+    "@blueprintjs/table": "^3.0.0-rc.0",
+    "@blueprintjs/test-commons": "^0.7.0",
+    "@blueprintjs/timezone": "^3.0.0-rc.0",
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",
     "dom4": "^2.0.1",
@@ -38,8 +38,8 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/webpack-build-scripts": "^0.5.2",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/webpack-build-scripts": "^0.5.3",
     "@types/chroma-js": "^1.3.3",
     "npm-run-all": "^4.1.2",
     "webpack": "^3.10.0",

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/docs-data",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "private": true,
@@ -10,8 +10,8 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
-    "@blueprintjs/docs-theme": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
+    "@blueprintjs/docs-theme": "^3.0.0-rc.0",
     "documentalist": "^1.4.0",
     "glob": "^7.1.2",
     "highlights": "^3.1.1",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/docs-theme",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-rc.0",
   "description": "Blueprint theme for documentalist",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -28,15 +28,15 @@
     "verify": "npm-run-all compile -p dist lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.1",
-    "@blueprintjs/select": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
+    "@blueprintjs/select": "^3.0.0-rc.0",
     "classnames": "^2.2",
     "documentalist": "^1.4.0",
     "fuzzaldrin-plus": "^0.5.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/node-build-scripts": "^0.6.1",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
     "@types/fuzzaldrin-plus": "^0.0.1",
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/icons",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Components, fonts, icons, and css files for creating and displaying icons.",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -37,8 +37,8 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/test-commons": "^0.6.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/test-commons": "^0.7.0",
     "enzyme": "^3.3.0",
     "mocha": "^4.1.0",
     "npm-run-all": "^4.1.2",

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@blueprintjs/karma-build-scripts",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Karma build scripts for @blueprintjs packages",
   "scripts": {
     "test": "exit 0"
   },
   "dependencies": {
-    "@blueprintjs/webpack-build-scripts": "^0.5.2",
+    "@blueprintjs/webpack-build-scripts": "^0.5.3",
     "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/labs",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Incubator for unstable and in-development Blueprint components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -32,15 +32,15 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
-    "@blueprintjs/select": "^3.0.0-beta.0",
-    "@blueprintjs/timezone": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
+    "@blueprintjs/select": "^3.0.0-rc.0",
+    "@blueprintjs/timezone": "^3.0.0-rc.0",
     "classnames": "^2.2",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/test-commons": "^0.6.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/test-commons": "^0.7.0",
     "enzyme": "^3.3.0",
     "karma": "^1.7.1",
     "npm-run-all": "^4.1.2",

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/landing-app",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Blueprint landing page",
   "private": true,
   "scripts": {
@@ -16,13 +16,13 @@
     "verify": "run-p dist lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
     "classnames": "^2.2.5",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },
   "devDependencies": {
-    "@blueprintjs/webpack-build-scripts": "^0.5.2",
+    "@blueprintjs/webpack-build-scripts": "^0.5.3",
     "copy-webpack-plugin": "^4.2.0",
     "npm-run-all": "^4.1.2",
     "raw-loader": "^0.5.1",

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/node-build-scripts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Node.js build scripts for @blueprintjs packages",
   "scripts": {
     "test": "exit 0"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/select",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Components related to selecting items from a list",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -33,13 +33,13 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
     "classnames": "^2.2",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/karma-build-scripts": "^0.6.1",
-    "@blueprintjs/node-build-scripts": "^0.6.1",
+    "@blueprintjs/karma-build-scripts": "^0.7.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
     "enzyme": "^3.3.0",
     "karma": "^1.7.1",
     "mocha": "^4.1.0",

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table-dev-app",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Dev application for @blueprintjs/table",
   "private": true,
   "scripts": {
@@ -16,8 +16,8 @@
     "verify": "npm-run-all -p dist lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
-    "@blueprintjs/table": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
+    "@blueprintjs/table": "^3.0.0-rc.0",
     "classnames": "^2.2.5",
     "dom4": "^2.0.1",
     "normalize.css": "^8.0.0",
@@ -25,7 +25,7 @@
     "react-dom": "^16.2.0"
   },
   "devDependencies": {
-    "@blueprintjs/webpack-build-scripts": "^0.5.2",
+    "@blueprintjs/webpack-build-scripts": "^0.5.3",
     "npm-run-all": "^4.1.2",
     "stylelint": "~8.4.0",
     "webpack": "^3.10.0",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/table",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Scalable interactive table component",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -33,14 +33,14 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
     "classnames": "^2.2",
     "prop-types": "^15.6.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/test-commons": "^0.6.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/test-commons": "^0.7.0",
     "enzyme": "^3.3.0",
     "karma": "^1.7.1",
     "lodash": "^4.17.4",

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/test-commons",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Common utilities for tests in @blueprintjs packages",
   "main": "lib/cjs/index.js",
   "typings": "lib/cjs/index.d.ts",

--- a/packages/test-react15/package.json
+++ b/packages/test-react15/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-react15",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "React 15 dependencies for testing",
   "private": true,
   "dependencies": {

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/timezone",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-rc.0",
   "description": "Components related to timezone selection and UI",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -33,16 +33,16 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.0.0-beta.0",
-    "@blueprintjs/select": "^3.0.0-beta.0",
+    "@blueprintjs/core": "^3.0.0-rc.0",
+    "@blueprintjs/select": "^3.0.0-rc.0",
     "classnames": "^2.2",
     "moment": "^2.14.1",
     "moment-timezone": "^0.5.13",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@blueprintjs/node-build-scripts": "^0.6.1",
-    "@blueprintjs/test-commons": "^0.6.0",
+    "@blueprintjs/node-build-scripts": "^0.6.2",
+    "@blueprintjs/test-commons": "^0.7.0",
     "@types/moment-timezone": "^0.5.0",
     "enzyme": "^3.3.0",
     "karma": "^1.7.1",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/tslint-config",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "TSLint configuration for @blueprintjs packages",
   "scripts": {
     "compile": "tsc -p ./src",

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/webpack-build-scripts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Webpack build scripts for @blueprintjs packages",
   "scripts": {
     "test": "exit 0"


### PR DESCRIPTION
merge `next` back into `develop`

 - @blueprintjs/core@3.0.0-rc.0
 - @blueprintjs/datetime@3.0.0-rc.0
 - @blueprintjs/docs-app@3.0.0-rc.0
 - @blueprintjs/docs-data@3.0.0-rc.0
 - @blueprintjs/docs-theme@3.0.0-rc.0
 - @blueprintjs/icons@3.0.0-rc.0
 - @blueprintjs/karma-build-scripts@0.7.0
 - @blueprintjs/labs@0.16.1
 - @blueprintjs/landing-app@3.0.0-rc.0
 - @blueprintjs/node-build-scripts@0.6.2
 - @blueprintjs/select@3.0.0-rc.0
 - @blueprintjs/table-dev-app@3.0.0-rc.0
 - @blueprintjs/table@3.0.0-rc.0
 - @blueprintjs/test-commons@0.7.0
 - test-react15@1.0.2
 - @blueprintjs/timezone@3.0.0-rc.0
 - @blueprintjs/tslint-config@1.4.1
 - @blueprintjs/webpack-build-scripts@0.5.3