### PR TITLE
[OverflowList] Recalculate visible items when modifying collapseFrom

### DIFF
--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -109,11 +109,12 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
     }
 
     public componentWillReceiveProps(nextProps: IOverflowListProps<T>) {
-        const { items, observeParents, overflowRenderer, visibleItemRenderer } = this.props;
+        const { collapseFrom, items, observeParents, overflowRenderer, visibleItemRenderer } = this.props;
         if (observeParents !== nextProps.observeParents) {
             console.warn(OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED);
         }
         if (
+            collapseFrom !== nextProps.collapseFrom ||
             items !== nextProps.items ||
             overflowRenderer !== nextProps.overflowRenderer ||
             visibleItemRenderer !== nextProps.visibleItemRenderer


### PR DESCRIPTION
#### Changes proposed in this pull request:

Previously, changing the `collapseFrom` prop of the `OverflowList` would not recalculate what's visible, leading to weird behavior where the overflow just moves from one side to the other, which reorders the items instead of keeping the order and overflowing the now correct items.