### PR TITLE
Publish 3.0.0-rc.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0-rc.1",
   "description": "Core styles & components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
merging `next` into `develop`

```
- @blueprintjs/core@3.0.0-rc.1
```