### PR TITLE
check for inputProps value when setting query in Omnibar

### DIFF
--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -94,9 +94,14 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
         const { isOpen } = nextProps;
         const canClearQuery = !this.props.isOpen && isOpen && this.props.resetOnSelect;
 
+        const query =
+            nextProps.inputProps && nextProps.inputProps.value
+                ? (nextProps.inputProps.value as string)
+                : this.state.query;
+
         this.setState({
             activeItem: canClearQuery ? this.props.items[0] : this.state.activeItem,
-            query: canClearQuery ? "" : this.state.query,
+            query: canClearQuery ? "" : query,
         });
     }
 


### PR DESCRIPTION
#### Fixes #1380 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)

#### Changes proposed in this pull request:

- In Omnibar, check if there is a value from inputProps when setting the query in componentWillReceiveProps. If there is one then use it and if not use this.state.query

#### Reviewers should focus on:

- Whether the Omnibar component works as expected
