### PR TITLE
initial animation state depends on isOpen prop

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -94,7 +94,7 @@ export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseSta
     };
 
     public state = {
-        animationState: AnimationStates.OPEN,
+        animationState: this.props.isOpen ? AnimationStates.OPEN : AnimationStates.CLOSED,
         height: "0px",
     };
 


### PR DESCRIPTION
This has caused perf issues for us - all the children of Collapse get mounted even though the Collapse are initially closed, which ends up in a bunch of unnecessary network requests.

Toggling the Collapse open and closed fixes the issue and everything behaves as expected - because the children are unmounted as expected. It is just the initial render where the states are out of sync, which this PR should fix.