### PR TITLE
core/TextArea: Accept inputRef prop

### DIFF
--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -19,6 +19,11 @@ export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTML
      * Whether the text area should appear with large styling.
      */
     large?: boolean;
+
+    /**
+     * Ref handler that receives HTML `<textarea>` element backing this component.
+     */
+    inputRef?: (ref: HTMLTextAreaElement | null) => any;
 }
 
 // this component is simple enough that tests would be purely tautological.
@@ -27,7 +32,7 @@ export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
     public static displayName = "Blueprint2.TextArea";
 
     public render() {
-        const { className, fill, intent, large, ...htmlProps } = this.props;
+        const { className, fill, intent, large, inputRef, ...htmlProps } = this.props;
 
         const rootClasses = classNames(
             Classes.INPUT,
@@ -39,6 +44,6 @@ export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
             className,
         );
 
-        return <textarea {...htmlProps} className={rootClasses} />;
+        return <textarea {...htmlProps} className={rootClasses} ref={inputRef} />;
     }
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:

I often times find it necessary to interact with the raw DOM element of text areas in particular for imperative operations such as selection, cursor position and focus management. core/InputGroup accomplishes this with an "inputRef" prop that effectively exposes the "ref" prop of the underlying ReactElement. I decided to maintain consistency with core/InputGroup etc. by using the prop name "inputRef", although this is a slight misnomer.