### PR TITLE
three little fixes

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -270,6 +270,16 @@ Styleguide preformatted
     background: $pt-dark-code-background-color;
     color: $pt-dark-code-text-color;
   }
+
+  a > & {
+    // <code> in links. markdown: [`code`](http://url)
+    // $pt-link-color does not have good contrast with non-link <code>'s in light theme, so we use a brighter hue
+    color: $pt-intent-primary;
+
+    .#{$ns}-dark & {
+      color: inherit;
+    }
+  }
 }
 
 %code-block {

--- a/packages/core/src/components/popover/popoverArrow.tsx
+++ b/packages/core/src/components/popover/popoverArrow.tsx
@@ -43,8 +43,8 @@ export interface IPopoverArrowProps {
     placement: Placement;
 }
 
-export const PopoverArrow: React.SFC<IPopoverArrowProps> = ({ arrowProps, placement }) => (
-    <div className={Classes.POPOVER_ARROW} {...arrowProps}>
+export const PopoverArrow: React.SFC<IPopoverArrowProps> = ({ arrowProps: { ref, style }, placement }) => (
+    <div className={Classes.POPOVER_ARROW} ref={ref} style={isNaN(style.left) ? {} : style}>
         <svg viewBox="0 0 30 30" style={{ transform: `rotate(${getArrowAngle(placement)}deg)` }}>
             <path className={Classes.POPOVER_ARROW + "-border"} d={SVG_SHADOW_PATH} />
             <path className={Classes.POPOVER_ARROW + "-fill"} d={SVG_ARROW_PATH} />

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -263,7 +263,8 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
 
     private updateHash() {
         // update state based on current hash location
-        this.handleNavigation(location.hash.slice(1));
+        const sectionId = location.hash.slice(1);
+        this.handleNavigation(sectionId === "" ? this.props.defaultPageId : sectionId);
     }
 
     private handleHashChange = () => {


### PR DESCRIPTION
- `a > code` looks like a link
  ![image](https://user-images.githubusercontent.com/464822/42480875-7ef9ea7c-8394-11e8-9805-053d8f3db30a.png)
- fix `PopoverArrow` NaN warnings (mostly in tests)
- `Documentation` navigates to default page when hash is empty

