### PR TITLE
upgrade to TypeScript 2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sinon": "^4.1.4",
     "stylelint-config-palantir": "^3.0.2",
     "stylelint-scss": "^2.5.0",
-    "typescript": "~2.7.2"
+    "typescript": "~2.8.3"
   },
   "engines": {
     "node": ">=6.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -67,7 +67,7 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
         );
 
         const optionChildren = options.map(value => {
-            const option = typeof value === "object" ? value : { value };
+            const option: IHTMLOptionProps = typeof value === "object" ? value : { value, label: value.toString() };
             return <option key={option.value} {...option} />;
         });
 

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -49,7 +49,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -45,7 +45,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -47,7 +47,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -26,7 +26,7 @@
     "stylelint-junit-formatter": "^0.2.0",
     "svgo": "^1.0.3",
     "tslint": "^5.9.1",
-    "typescript": "~2.7.2"
+    "typescript": "~2.8.3"
   },
   "repository": {
     "type": "git",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -47,7 +47,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -49,7 +49,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.1"
   },

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "react": "^16.2.0",
-    "typescript": "~2.7.2"
+    "typescript": "~2.8.3"
   },
   "repository": {
     "type": "git",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -50,7 +50,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8251,9 +8251,9 @@ typescript@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
-typescript@~2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@~2.8.3:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
- restores editing support in VSCode (I was having problems with TS2.7.2 not re-compiling on changes).
- no changes to .d.ts files so this is not breaking (verified locally by diffing .d.ts files agains those in 3.0.0 packages)