### PR TITLE
[Spinner] Classes.LARGE/SMALL determine default size

### DIFF
--- a/packages/core/scripts/upgrade-blueprint-3.0.0-rename.sh
+++ b/packages/core/scripts/upgrade-blueprint-3.0.0-rename.sh
@@ -199,7 +199,6 @@ renameString "Classes\.SVG_SPINNER,?" ''
 warn SVGSpinner 'DELETED. Spinner now supports usage in an SVG.'
 warn SVGPopover 'DELETED. Set *TagName props to SVG elements.'
 warn SVGTooltip 'DELETED. Set *TagName props to SVG elements.'
-warn Spinner '`small/large` replaced with single `size` prop'
 warn "\\bTable\\b" '@blueprintjs/core Table component renamed to HTMLTable (@blueprintjs/table package unchanged).'
 
 # String enums

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -70,6 +70,8 @@ export const SLIDER_ZERO_LABEL_STEP = ns + ` <Slider> labelStepSize must be grea
 export const RANGESLIDER_NULL_VALUE = ns + ` <RangeSlider> value prop must be an array of two non-null numbers.`;
 export const MULTISLIDER_INVALID_CHILD = ns + ` <MultiSlider> children must be <SliderHandle>s or <SliderTrackStop>s`;
 
+export const SPINNER_WARN_CLASSES_SIZE = ns + ` <Spinner> Classes.SMALL/LARGE are ignored if size prop is set.`;
+
 export const TOASTER_CREATE_NULL =
     ns +
     ` Toaster.create() is not supported inside React lifecycle methods in React 16.` +

--- a/packages/core/src/components/spinner/spinner.md
+++ b/packages/core/src/components/spinner/spinner.md
@@ -15,6 +15,12 @@ this prop is defined, the spinner head will smoothly animate as `value`
 changes. Omitting `value` will result in an "indeterminate" spinner where the
 head spins indefinitely (this is the default appearance).
 
+The `size` prop determines the pixel width/height of the spinner. Size constants
+are provided as static properties: `Spinner.SIZE_SMALL`,
+`Spinner.SIZE_STANDARD`, `Spinner.SIZE_LARGE`. Small and large sizes can be set
+by including `Classes.LARGE` or `Classes.SMALL` in `className` instead of the
+`size` prop.
+
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h4 class="@ns-heading">IE11 compatibility note</h4>
     IE11 [does not support CSS transitions on SVG elements][msdn-css-svg] so spinners with known

--- a/packages/core/src/components/spinner/spinner.md
+++ b/packages/core/src/components/spinner/spinner.md
@@ -18,8 +18,8 @@ head spins indefinitely (this is the default appearance).
 The `size` prop determines the pixel width/height of the spinner. Size constants
 are provided as static properties: `Spinner.SIZE_SMALL`,
 `Spinner.SIZE_STANDARD`, `Spinner.SIZE_LARGE`. Small and large sizes can be set
-by including `Classes.LARGE` or `Classes.SMALL` in `className` instead of the
-`size` prop.
+by including `Classes.SMALL` or `Classes.LARGE` in `className` instead of the
+`size` prop (this prevents an API break when upgrading to 3.x).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h4 class="@ns-heading">IE11 compatibility note</h4>

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -7,6 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
 import { IIntentProps, IProps } from "../../common/props";
@@ -41,7 +42,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
     value?: number;
 }
 
-export class Spinner extends React.PureComponent<ISpinnerProps, {}> {
+export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
     public static displayName = "Blueprint2.Spinner";
 
     public static readonly SIZE_SMALL = 24;

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
+import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
 import { IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 
@@ -77,8 +78,23 @@ export class Spinner extends React.PureComponent<ISpinnerProps, {}> {
         );
     }
 
+    protected validateProps({ className = "", size }: ISpinnerProps) {
+        if (size != null && (className.indexOf(Classes.SMALL) >= 0 || className.indexOf(Classes.LARGE) >= 0)) {
+            console.warn(SPINNER_WARN_CLASSES_SIZE);
+        }
+    }
+
     private getSize() {
-        const { size = Spinner.SIZE_STANDARD } = this.props;
+        const { className = "", size } = this.props;
+        if (size == null) {
+            // allow Classes constants to determine default size.
+            if (className.indexOf(Classes.SMALL) >= 0) {
+                return Spinner.SIZE_SMALL;
+            } else if (className.indexOf(Classes.LARGE) >= 0) {
+                return Spinner.SIZE_LARGE;
+            }
+            return Spinner.SIZE_STANDARD;
+        }
         return Math.max(MIN_SIZE, size);
     }
 }

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -7,7 +7,9 @@
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
+import { stub } from "sinon";
 
+import { SPINNER_WARN_CLASSES_SIZE } from "../../src/common/errors";
 import { Classes, Spinner } from "../../src/index";
 
 describe("Spinner", () => {
@@ -15,6 +17,22 @@ describe("Spinner", () => {
         const root = mount(<Spinner />);
         assert.lengthOf(root.find(`.${Classes.SPINNER}`), 1);
         assert.lengthOf(root.find("path"), 2);
+    });
+
+    it("Classes.LARGE/SMALL determine default size", () => {
+        const root = mount(<Spinner className={Classes.SMALL} />);
+        assert.equal(root.find("svg").prop("height"), Spinner.SIZE_SMALL, "small");
+
+        root.setProps({ className: Classes.LARGE });
+        assert.equal(root.find("svg").prop("height"), Spinner.SIZE_LARGE, "large");
+    });
+
+    it("size overrides Classes.LARGE/SMALL", () => {
+        const warnSpy = stub(console, "warn");
+        const root = mount(<Spinner className={Classes.SMALL} size={32} />);
+        assert.equal(root.find("svg").prop("height"), 32, "size prop");
+        assert.equal(warnSpy.args[0][0], SPINNER_WARN_CLASSES_SIZE);
+        warnSpy.restore();
     });
 
     it("defaults to spinning quarter circle", () => {


### PR DESCRIPTION
- 👍  this actually un-breaks a 3.0 API break: `<Spinner className={Classes.SMALL} />` now works as it used to!
- remove the replacer from the upgrade script as it's no longer breaking