### PR TITLE
[MenuItem] submenu tabbing support!

### DIFF
--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -9,10 +9,14 @@
   > .#{$ns}-popover-wrapper {
     display: block;
 
-    &.#{$ns}-popover-open > .#{$ns}-menu-item {
-      // keep a trail of hovered items as submenus are opened
-      // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
-      @extend .#{$ns}-menu-item:hover;
+    > .#{$ns}-popover-target {
+      display: inherit;
+
+      &.#{$ns}-popover-open > .#{$ns}-menu-item {
+        // keep a trail of hovered items as submenus are opened
+        // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
+        @extend .#{$ns}-menu-item:hover;
+      }
     }
   }
 

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -29,7 +29,8 @@
       box-shadow: $pt-popover-box-shadow;
     }
 
-    .#{$ns}-dark & {
+    .#{$ns}-dark &,
+    &.#{$ns}-dark {
       box-shadow: none;
 
       > .#{$ns}-popover-content {

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -8,21 +8,21 @@
 .#{$ns}-submenu {
   > .#{$ns}-popover-wrapper {
     display: block;
+  }
 
-    > .#{$ns}-popover-target {
-      display: inherit;
+  .#{$ns}-popover-target {
+    display: block;
 
-      &.#{$ns}-popover-open > .#{$ns}-menu-item {
-        // keep a trail of hovered items as submenus are opened
-        // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
-        @extend .#{$ns}-menu-item:hover;
-      }
+    &.#{$ns}-popover-open > .#{$ns}-menu-item {
+      // keep a trail of hovered items as submenus are opened
+      // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
+      @extend .#{$ns}-menu-item:hover;
     }
   }
 
-  // horizontal padding leaves some space from parent menu item, and extends mouse zone
   &.#{$ns}-popover {
     box-shadow: none;
+    // horizontal padding leaves some space from parent menu item, and extends mouse zone
     padding: 0 $half-grid-size;
 
     > .#{$ns}-popover-content {

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -66,6 +66,12 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
      * @default true
      */
     shouldDismissPopover?: boolean;
+
+    /**
+     * HTML tab index. When `disabled`, `tabIndex` is always `-1`.
+     * @default 0
+     */
+    tabIndex?: number;
 }
 
 export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {
@@ -74,6 +80,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         multiline: false,
         popoverProps: {},
         shouldDismissPopover: true,
+        tabIndex: 0,
         text: "",
     };
     public static displayName = "Blueprint2.MenuItem";

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -151,12 +151,14 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         const { disabled, popoverProps } = this.props;
         return (
             <Popover
+                autoFocus={false}
                 disabled={disabled}
                 enforceFocus={false}
                 hoverCloseDelay={0}
                 interactionKind={PopoverInteractionKind.HOVER}
                 modifiers={SUBMENU_POPOVER_MODIFIERS}
                 position={Position.RIGHT_TOP}
+                usePortal={false}
                 {...popoverProps}
                 content={<Menu>{children}</Menu>}
                 minimal={true}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -165,7 +165,11 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
         return (
             <Manager>
-                <WrapperTagName className={classNames(Classes.POPOVER_WRAPPER, className)}>
+                <WrapperTagName
+                    className={classNames(Classes.POPOVER_WRAPPER, className)}
+                    // blur at this level captures focus leaving target _and content when usePortal=false_
+                    onBlur={this.handleTargetBlur}
+                >
                     <Reference innerRef={this.refHandlers.target}>{this.renderTarget}</Reference>
                     <Overlay
                         autoFocus={this.props.autoFocus}

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -39,9 +39,7 @@ export class MenuExample extends React.PureComponent<IExampleProps, {}> {
                         <MenuItem icon="italic" text="Italic" />
                         <MenuItem icon="underline" text="Underline" />
                     </MenuItem>
-                    <MenuItem icon="asterisk" text="Miscellaneous">
-                        <MenuItem icon="badge" text="Badge" />
-                        <MenuItem icon="book" text="Long items will truncate when they reach max-width" />
+                    <MenuItem icon="asterisk" text="Learn more">
                         <MenuItem icon="more" text="Look in here for even more items">
                             <MenuItem icon="briefcase" text="Briefcase" />
                             <MenuItem icon="calculator" text="Calculator" />
@@ -53,6 +51,9 @@ export class MenuExample extends React.PureComponent<IExampleProps, {}> {
                                 <MenuItem icon="square" text="Square" />
                             </MenuItem>
                         </MenuItem>
+                        <MenuItem icon="book" text="Set a max-width to truncate long items." />
+                        <MenuItem icon="badge" text="Submenus do not use portals." />
+                        <MenuItem icon="arrow-right" text="Try tabbing through items." />
                     </MenuItem>
                 </Menu>
             </Example>


### PR DESCRIPTION
#### Changes proposed in this pull request:

- add `MenuItem` `tabIndex` prop, so all menu items (not just those with `href`s) can be tabbed to!
- ⚠️ disable portals for popovers so all submenu items are nicely ordered in a container for tabbing
    - this is slightly dangerous as folks may rely on the portal behavior, but it's oh so much better.
- move Popover `onBlur` handler to the wrapper so it captures focus leaving the entire thing
    - this include content with `usePortal={false}` so a submenu will close when tabbing past its last item!
- fix submenu styles