### PR TITLE
[Icon] use desc element for title (no browser tootltip, still a11y)

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -96,7 +96,7 @@ export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<S
                 height={iconSize}
                 viewBox={viewBox}
             >
-                {title ? <title>{title}</title> : null}
+                {title && <desc>{title}</desc>}
                 {paths}
             </svg>
         );

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -47,10 +47,10 @@ export interface IIconProps extends IIntentProps, IProps {
     style?: React.CSSProperties;
 
     /**
-     * Description string.
-     * Browsers usually render this as a tooltip on hover, whereas screen
-     * readers will use it for aural feedback.
-     * By default, this is set to the icon's name for accessibility.
+     * Description string. This string does not appear in normal browsers, but
+     * it increases accessibility. For instance, screen readers will use it for
+     * aural feedback. By default, this is set to the icon's name for
+     * accessibility.
      */
     title?: string | false | null;
 }

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -46,14 +46,14 @@ describe("<Icon>", () => {
         assert.isTrue(icon.isEmptyRender());
     });
 
-    it("title sets content of <title> element", () => {
+    it("title sets content of <desc> element", () => {
         const icon = shallow(<Icon icon="airplane" title="bird" />);
-        assert.equal(icon.find("title").text(), "bird");
+        assert.equal(icon.find("desc").text(), "bird");
     });
 
-    it("title defaults to icon name", () => {
+    it("desc defaults to icon name", () => {
         const icon = shallow(<Icon icon="airplane" />);
-        assert.equal(icon.find("title").text(), "airplane");
+        assert.equal(icon.find("desc").text(), "airplane");
     });
 
     /** Asserts that rendered icon has given className. */


### PR DESCRIPTION
#### Fixes #2321 

try hovering an icon, especially one in a button. no browser tooltip!