### PR TITLE
[HTMLSelect] fix option labels display & use `value` as label if not specified

### DIFF
--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -66,19 +66,31 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
             className,
         );
 
-        const optionChildren = options.map(value => {
-            const option: IHTMLOptionProps = typeof value === "object" ? value : { value, label: value.toString() };
-            return <option key={option.value} {...option} />;
-        });
-
         return (
             <div className={classes}>
                 <select disabled={disabled} ref={elementRef} {...htmlProps} multiple={false}>
-                    {optionChildren}
+                    {this.renderOptions(options)}
                     {htmlProps.children}
                 </select>
                 <Icon icon="double-caret-vertical" />
             </div>
         );
+    }
+
+    private renderOptions(options: Array<string | number | IHTMLOptionProps>) {
+        return options.map(value => {
+            const option: IHTMLOptionProps = typeof value === "object" ? this.coercePlainObj(value) : ({
+                value,
+                label: value.toString()
+            });
+            return <option key={option.value} children={option.label} {...option} />;
+        });
+    }
+
+    private coercePlainObj(option: IHTMLOptionProps) {
+        return {
+            value: option.value,
+            label: option.label || option.value.toString()
+        }
     }
 }

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -79,18 +79,21 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
 
     private renderOptions(options: Array<string | number | IHTMLOptionProps>) {
         return options.map(value => {
-            const option: IHTMLOptionProps = typeof value === "object" ? this.coercePlainObj(value) : ({
-                value,
-                label: value.toString()
-            });
+            const option: IHTMLOptionProps =
+                typeof value === "object"
+                    ? this.coercePlainObj(value)
+                    : {
+                          label: value.toString(),
+                          value,
+                      };
             return <option key={option.value} children={option.label} {...option} />;
         });
     }
 
     private coercePlainObj(option: IHTMLOptionProps) {
         return {
+            label: option.label || option.value.toString(),
             value: option.value,
-            label: option.label || option.value.toString()
-        }
+        };
     }
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:

This PR addresses 2 related but different issues with the core/HTMLSelect component:

**1) Options' labels are not being rendered**

I first noticed this on the Popover example page:
<img width="360" alt="screen shot 2018-07-11 at 12 22 48 pm" src="https://user-images.githubusercontent.com/21088170/42595651-c9e8f540-8507-11e8-872e-49a81c17cf6c.png">

Apparently, React (16.2 at least) does not respect use of the `label` HTML attribute in lieu of child text nodes for `<option>` elements (upstream bug?).

This PR reverts to specifying labels for `<option>` items as inner HTML, rather than specifying them via the element's `label` attribute, which appears to display correctly:
<img width="335" alt="screen shot 2018-07-11 at 12 23 11 pm" src="https://user-images.githubusercontent.com/21088170/42596044-2098293c-8509-11e8-927d-3b66d519c8a5.png">


**2) If consumer supplies an array of `{value, label}` plain objects as `options={...} `, the component does not fallback to using the value of `value` as the `label` in cases where `label` is either not supplied or is falsy.**

I understand that it might seem logical to put the burden of ensuring proper argument syntax on the consumer, but I can foresee cases where this fallback logic would avoid unpleasant surprises, even for consumers who are aware of the proper syntax.

For instance, if consumer supplies:

`options={ [{value:1, label:"one"}, {value:2}, {value:3, label:"three"}, {value:4, label:undefined}] }`

the the current behavior would be to render options 2 & 4 as empty. The logic in this PR would at least render "2" & "4" respectively.
