### PR TITLE
fix small regressions

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -190,6 +190,10 @@ Styleguide button-group
       width: 100%;
     }
 
+    .#{$ns}-popover-target {
+      display: block;
+    }
+
     &:not(.#{$ns}-minimal) {
       > .#{$ns}-popover-wrapper:first-child .#{$ns}-button,
       > .#{$ns}-button:first-child {

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -48,6 +48,12 @@ class ContextMenu extends AbstractPureComponent<IOverlayLifecycleProps, IContext
         const content = <div onContextMenu={this.cancelContextMenu}>{this.state.menu}</div>;
         const popoverClassName = classNames({ [Classes.DARK]: this.state.isDarkTheme });
 
+        // HACKHACK: workaround until we have access to Popper#scheduleUpdate().
+        // https://github.com/palantir/blueprint/issues/692
+        // Generate key based on offset so a new Popover instance is created
+        // when offset changes, to force recomputing position.
+        const key = this.state.offset == null ? "" : `${this.state.offset.left}x${this.state.offset.top}`;
+
         // wrap the popover in a positioned div to make sure it is properly
         // offset on the screen.
         return (
@@ -57,6 +63,7 @@ class ContextMenu extends AbstractPureComponent<IOverlayLifecycleProps, IContext
                     backdropProps={{ onContextMenu: this.handleBackdropContextMenu }}
                     content={content}
                     enforceFocus={false}
+                    key={key}
                     hasBackdrop={true}
                     isOpen={this.state.isOpen}
                     minimal={true}

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -66,9 +66,13 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
             className,
         );
 
-        const optionChildren = options.map(value => {
-            const option: IHTMLOptionProps = typeof value === "object" ? value : { value, label: value.toString() };
-            return <option key={option.value} {...option} />;
+        const optionChildren = options.map(option => {
+            const { value, label }: IHTMLOptionProps = typeof option === "object" ? option : { value: option };
+            return (
+                <option key={value} value={value}>
+                    {label || value}
+                </option>
+            );
         });
 
         return (

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -68,11 +68,7 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
 
         const optionChildren = options.map(option => {
             const { value, label }: IHTMLOptionProps = typeof option === "object" ? option : { value: option };
-            return (
-                <option key={value} value={value}>
-                    {label || value}
-                </option>
-            );
+            return <option key={value} value={value} children={label || value} />;
         });
 
         return (

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -58,7 +58,11 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
      */
     multiline?: boolean;
 
-    /** Props to spread to `Popover`. Note that `content` and `minimal` cannot be changed. */
+    /**
+     * Props to spread to `Popover`. Note that `content` and `minimal` cannot be
+     * changed and `usePortal` defaults to `false` so all submenus will live in
+     * the same container.
+     */
     popoverProps?: Partial<IPopoverProps>;
 
     /**
@@ -144,12 +148,14 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         const { disabled, popoverProps } = this.props;
         return (
             <Popover
+                autoFocus={false}
                 disabled={disabled}
                 enforceFocus={false}
                 hoverCloseDelay={0}
                 interactionKind={PopoverInteractionKind.HOVER}
                 modifiers={SUBMENU_POPOVER_MODIFIERS}
                 position={Position.RIGHT_TOP}
+                usePortal={false}
                 {...popoverProps}
                 content={<Menu>{children}</Menu>}
                 minimal={true}

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -27,6 +27,15 @@ import { IBlueprintExampleData } from "../../tags/reactExamples";
 
 type IToastDemo = IToastProps & { button: string };
 
+const POSITIONS = [
+    Position.TOP_LEFT,
+    Position.TOP,
+    Position.TOP_RIGHT,
+    Position.BOTTOM_LEFT,
+    Position.BOTTOM,
+    Position.BOTTOM_RIGHT,
+];
+
 export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IToasterProps> {
     public state: IToasterProps = {
         autoFocus: false,
@@ -114,14 +123,7 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
                 <H5>Props</H5>
                 <Label>
                     Position
-                    <HTMLSelect value={position} onChange={this.handlePositionChange}>
-                        <option value={Position.TOP_LEFT}>Top left</option>
-                        <option value={Position.TOP}>Top center</option>
-                        <option value={Position.TOP_RIGHT}>Top right</option>
-                        <option value={Position.BOTTOM_LEFT}>Bottom left</option>
-                        <option value={Position.BOTTOM}>Bottom center</option>
-                        <option value={Position.BOTTOM_RIGHT}>Bottom right</option>
-                    </HTMLSelect>
+                    <HTMLSelect value={position} onChange={this.handlePositionChange} options={POSITIONS} />
                 </Label>
                 <Switch label="Auto focus" checked={autoFocus} onChange={this.toggleAutoFocus} />
                 <Switch label="Can escape key clear" checked={canEscapeKeyClear} onChange={this.toggleEscapeKey} />


### PR DESCRIPTION
- fix vertical button groups
- `ContextMenu` fix double-right-click behavior so it moves the menu
- `MenuItem` bring back `usePortal={false}` (removed unsafely in #2539)