### PR TITLE
[Checkbox] fix icon appearance

### DIFF
--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -194,7 +194,12 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
     }
 
     public componentWillReceiveProps({ checked, indeterminate }: ICheckboxProps) {
-        this.setState({ checked, indeterminate });
+        if (checked != null) {
+            this.setState({ checked });
+        }
+        if (indeterminate != null) {
+            this.setState({ indeterminate });
+        }
     }
 
     public componentDidMount() {
@@ -206,10 +211,11 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
     }
 
     private renderIndicator() {
+        const size = this.props.large ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD;
         if (this.state.indeterminate) {
-            return <Icon icon="small-minus" />;
+            return <Icon icon="small-minus" iconSize={size} />;
         } else if (this.state.checked) {
-            return <Icon icon="small-tick" />;
+            return <Icon icon="small-tick" iconSize={size} />;
         }
         return null;
     }

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -211,7 +211,8 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
     }
 
     private renderIndicator() {
-        const size = this.props.large ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD;
+        const { className = "", large } = this.props;
+        const size = large || className.indexOf(Classes.LARGE) >= 0 ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD;
         if (this.state.indeterminate) {
             return <Icon icon="small-minus" iconSize={size} />;
         } else if (this.state.checked) {

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -50,6 +50,16 @@ describe("Controls:", () => {
                 const icon = mount(<Checkbox checked={true} indeterminate={true} />).find(Icon);
                 assert.equal(icon.prop("icon"), "small-minus");
             });
+
+            it("changes with props", () => {
+                const wrapper = mount(<Checkbox checked={false} />);
+                wrapper.setProps({ checked: true });
+                assert.equal(wrapper.find(Icon).prop("icon"), "small-tick");
+                wrapper.setProps({ checked: false, indeterminate: true });
+                assert.equal(wrapper.find(Icon).prop("icon"), "small-minus");
+                wrapper.setProps({ checked: false, indeterminate: false });
+                assert.isFalse(wrapper.find(Icon).exists());
+            });
         });
     });
 

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -37,7 +37,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
-                <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />
+                <AlignmentSelect align={this.state.alignText} label="Align text" onChange={this.handleAlignChange} />
             </>
         );
         return (

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -6,20 +6,55 @@
 
 import * as React from "react";
 
-import { Checkbox, Label } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Alignment, Checkbox, H5, Label, Switch } from "@blueprintjs/core";
+import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { AlignmentSelect } from "./common/alignmentSelect";
 
-export class CheckboxExample extends React.PureComponent<IExampleProps> {
+export interface ICheckboxExampleState {
+    alignIndicator: Alignment;
+    large: boolean;
+    value?: string;
+}
+
+export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckboxExampleState> {
+    public state: ICheckboxExampleState = {
+        alignIndicator: Alignment.LEFT,
+        large: false,
+    };
+
     public render() {
+        const options = (
+            <>
+                <H5>Props</H5>
+                <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
+                <AlignmentSelect
+                    align={this.state.alignIndicator}
+                    allowCenter={false}
+                    label="Align indicator"
+                    onChange={this.handleAlignChange}
+                />
+            </>
+        );
+
         return (
-            <Example options={false} {...this.props}>
-                <div>
-                    <Label>Assign responsibility</Label>
-                    <Checkbox label="Gilad Gray" defaultIndeterminate={true} />
-                    <Checkbox label="Jason Killian" />
-                    <Checkbox label="Antoine Llorca" />
-                </div>
+            <Example options={options} {...this.props}>
+                {this.renderExample()}
             </Example>
         );
     }
+
+    protected renderExample() {
+        return (
+            <div>
+                <Label>Assign responsibility</Label>
+                <Checkbox {...this.state} label="Gilad Gray" defaultIndeterminate={true} />
+                <Checkbox {...this.state} label="Jason Killian" />
+                <Checkbox {...this.state} label="Antoine Llorca" />
+            </div>
+        );
+    }
+
+    private handleAlignChange = (alignIndicator: Alignment) => this.setState({ alignIndicator });
+    // tslint:disable-next-line:member-ordering
+    private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 }

--- a/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
@@ -9,22 +9,26 @@ import * as React from "react";
 
 export interface IAlignSelectProps {
     align: Alignment | undefined;
+    allowCenter?: boolean;
+    label?: string;
     onChange: (align: Alignment) => void;
 }
 
 export class AlignmentSelect extends React.PureComponent<IAlignSelectProps> {
     public render() {
-        const { align } = this.props;
+        const { align, allowCenter = true, label = "Align text" } = this.props;
         return (
             <div>
-                Button alignment
+                {label}
                 <ButtonGroup fill={true} style={{ marginTop: 5 }}>
                     <Button active={align === Alignment.LEFT} text="Left" onClick={this.handleAlignLeft} />
-                    <Button
-                        active={align == null || align === Alignment.CENTER}
-                        text="Center"
-                        onClick={this.handleAlignCenter}
-                    />
+                    {allowCenter && (
+                        <Button
+                            active={align == null || align === Alignment.CENTER}
+                            text="Center"
+                            onClick={this.handleAlignCenter}
+                        />
+                    )}
                     <Button active={align === Alignment.RIGHT} text="Right" onClick={this.handleAlignRight} />
                 </ButtonGroup>
             </div>

--- a/packages/docs-app/src/examples/core-examples/radioExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/radioExample.tsx
@@ -7,29 +7,25 @@
 import * as React from "react";
 
 import { Radio, RadioGroup } from "@blueprintjs/core";
-import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleStringChange } from "@blueprintjs/docs-theme";
+import { CheckboxExample } from "./checkboxExample";
 
-export interface IRadioExampleState {
-    radioValue?: string;
-}
+export class RadioExample extends CheckboxExample {
+    private handleRadioChange = handleStringChange(value => this.setState({ value }));
 
-export class RadioExample extends React.PureComponent<IExampleProps, IRadioExampleState> {
-    public state: IRadioExampleState = {};
-
-    private handleRadioChange = handleStringChange(radioValue => this.setState({ radioValue }));
-
-    public render() {
+    // See CheckboxExample for options
+    protected renderExample() {
         return (
             <Example options={false} {...this.props}>
                 <RadioGroup
                     label="Determine lunch"
                     name="group"
                     onChange={this.handleRadioChange}
-                    selectedValue={this.state.radioValue}
+                    selectedValue={this.state.value}
                 >
-                    <Radio label="Soup" value="one" />
-                    <Radio label="Salad" value="two" />
-                    <Radio label="Sandwich" value="three" />
+                    <Radio {...this.state} label="Soup" value="one" />
+                    <Radio {...this.state} label="Salad" value="two" />
+                    <Radio {...this.state} label="Sandwich" value="three" />
                 </RadioGroup>
             </Example>
         );

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -7,23 +7,22 @@
 import * as React from "react";
 
 import { Code, Label, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { CheckboxExample } from "./checkboxExample";
 
-export class SwitchExample extends React.PureComponent<IExampleProps> {
-    public render() {
+export class SwitchExample extends CheckboxExample {
+    // See CheckboxExample for options
+    protected renderExample() {
         return (
-            <Example options={false} {...this.props}>
-                <div>
-                    <Label>Privacy setting</Label>
-                    <Switch labelElement={<strong>Enabled</strong>} />
-                    <Switch labelElement={<em>Public</em>} />
-                    <Switch labelElement={<u>Cooperative</u>} defaultChecked={true} />
-                    <small>
-                        This example uses <Code>labelElement</Code>
-                        <br /> to demonstrate JSX labels.
-                    </small>
-                </div>
-            </Example>
+            <div>
+                <Label>Privacy setting</Label>
+                <Switch {...this.state} labelElement={<strong>Enabled</strong>} />
+                <Switch {...this.state} labelElement={<em>Public</em>} />
+                <Switch {...this.state} labelElement={<u>Cooperative</u>} defaultChecked={true} />
+                <small>
+                    This example uses <Code>labelElement</Code>
+                    <br /> to demonstrate JSX labels.
+                </small>
+            </div>
         );
     }
 }


### PR DESCRIPTION
#### Fixes #2685

#### Changes proposed in this pull request:

- fix Checkbox state manipulation so it always renders the appropriate SVG icon for `checked` or `indeterminate`.
- use large icons when `large` prop is enabled.
- add `alignIndicator` + `large` options to controls examples