### PR TITLE
[Core] Added missing text css classnames to Classes module

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -47,7 +47,9 @@ export const UI_TEXT = `${NS}-ui-text`;
 export const RUNNING_TEXT = `${NS}-running-text`;
 export const MONOSPACE_TEXT = `${NS}-monospace-text`;
 export const TEXT_LARGE = `${NS}-text-large`;
+export const TEXT_SMALL = `${NS}-text-small`;
 export const TEXT_MUTED = `${NS}-text-muted`;
+export const TEXT_DISABLED = `${NS}-text-disabled`;
 export const TEXT_OVERFLOW_ELLIPSIS = `${NS}-text-overflow-ellipsis`;
 
 // textual elements
@@ -57,6 +59,7 @@ export const CODE_BLOCK = `${NS}-code-block`;
 export const HEADING = `${NS}-heading`;
 export const LIST = `${NS}-list`;
 export const LIST_UNSTYLED = `${NS}-list-unstyled`;
+export const RTL = `${NS}-rtl`;
 
 // components
 export const ALERT = `${NS}-alert`;


### PR DESCRIPTION
Not related to an open issue (that I could find). Noticed in use that the `bp3-text-small` class wasn't available as an export of the `Classes` module. Checked the [typography documentation page](http://blueprintjs.com/docs/#core/typography) and noticed that a couple more weren't available so I've added those too.

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)

#### Changes proposed in this pull request:

Added exports to the `Classes` module for the following text CSS classes:

 - `bp3-text-small`
 - `bp3-text-disabled`
 - `bp3-rtl`
