### PR TITLE
[tslint] classes-constants rule fixes

### DIFF
--- a/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
+++ b/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
@@ -8,7 +8,7 @@ import * as Lint from "tslint";
 import * as ts from "typescript";
 
 // detect "pt-" *prefix*: not preceded by letter or dash
-const PATTERN = /[^\w-]pt-[\w-]+/;
+const PATTERN = /[^\w-<]pt-[\w-]+/;
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
@@ -31,7 +31,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (ts.isStringLiteral(node)) {
+        if (ts.isStringLiteralLike(node) || ts.isTemplateExpression(node)) {
             const match = PATTERN.exec(node.getFullText());
             if (match != null) {
                 // ignore first character of match: negated character class

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
@@ -2,11 +2,17 @@ apt-get
 at 4pt-size
 "script-source pt-large apt-get"
                ~~~~~~~~  [msg]
+`script-source pt-large apt-get`
+               ~~~~~~~~  [msg]
+`${template} pt-large`
+             ~~~~~~~~  [msg]
 
 <Button className="my-class pt-large" />
                             ~~~~~~~~  [msg]
 
 classNames(Classes.BUTTON, "pt-intent-primary")
                             ~~~~~~~~~~~~~~~~~  [msg]
+
+<pt-popover> // angular directive
 
 [msg]: use Blueprint `Classes` constant instead of string literal


### PR DESCRIPTION
- ignore angular directives `<pt-popover>`
- support template strings