### PR TITLE
[docs-theme] add Example forceUpdate prop to disable that behavior

### DIFF
--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -88,14 +88,19 @@ export interface IDocsExampleProps extends IExampleProps {
  * ```
  */
 export class Example extends React.PureComponent<IDocsExampleProps> {
-    private hasDelayedBeforeInitialRender = false;
+    public static defaultProps: Partial<IDocsExampleProps> = {
+        forceUpdate: true,
+        showOptionsBelowExample: false,
+    };
+
+    private hasDelayedInitialRender = false;
 
     public render() {
         const {
             children,
             className,
             data,
-            forceUpdate = true,
+            forceUpdate,
             html,
             id,
             options,
@@ -106,9 +111,8 @@ export class Example extends React.PureComponent<IDocsExampleProps> {
         } = this.props;
 
         // `forceUpdate` -  Don't let any React nodes into the DOM until the
-        // `requestAnimationFrame` delay has elapsed. This prevents
-        // `shouldComponentUpdate` snafus at lower levels.
-        if (forceUpdate && !this.hasDelayedBeforeInitialRender) {
+        // `requestAnimationFrame` delay has elapsed.
+        if (forceUpdate && !this.hasDelayedInitialRender) {
             return null;
         }
 
@@ -136,10 +140,9 @@ export class Example extends React.PureComponent<IDocsExampleProps> {
         // `forceUpdate` - The docs app suffers from a Flash of Unstyled Content
         // that causes components to mis-measure themselves on first render.
         // Delay initial render till the DOM loads with a requestAnimationFrame.
-        const { forceUpdate = true } = this.props;
-        if (forceUpdate) {
+        if (this.props.forceUpdate) {
             requestAnimationFrame(() => {
-                this.hasDelayedBeforeInitialRender = true;
+                this.hasDelayedInitialRender = true;
                 this.forceUpdate();
             });
         }

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -56,6 +56,13 @@ export interface IDocsExampleProps extends IExampleProps {
      * This prop is mutually exclusive with and takes priority over `children`.
      */
     html?: string;
+
+    /**
+     * Whether `forceUpdate()` should be invoked after the first render, to
+     * ensure correct DOM sizing.
+     * @default true
+     */
+    forceUpdate?: boolean;
 }
 
 /**
@@ -114,6 +121,9 @@ export class Example extends React.PureComponent<IDocsExampleProps> {
     }
 
     public componentDidMount() {
+        if (this.props.forceUpdate === false) {
+            return;
+        }
         // HACKHACK: The docs app suffers from a Flash of Unstyled Content that
         // causes some 'width: 100%' examples to mis-measure the horizontal
         // space available to them. Until that bug is squashed, we must delay


### PR DESCRIPTION
allow disabling `forceUpdate` behavior in `Example` frame as it interferes with non-React libraries.