### PR TITLE
[table] fix wrapText on EditableCell component

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -136,6 +136,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
         return (
             <Cell
                 {...spreadableProps}
+                wrapText={wrapText}
                 truncated={false}
                 interactive={interactive}
                 cellRef={this.refHandlers.cell}

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -130,12 +130,12 @@ describe("<EditableCell>", () => {
     it("defaults to no wrapText", () => {
         const elem = mount(<EditableCell />);
 
-        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT} div`).length).to.equal(2);
+        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT}`).length).to.equal(2);
     });
 
-    it("wraps text when wrapsText is true", () => {
+    it("wraps text when wrapText is true", () => {
         const elem = mount(<EditableCell wrapText={true} />);
 
-        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT} div`).length).to.equal(0);
+        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT}`).length).to.equal(0);
     });
 });

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -128,17 +128,13 @@ describe("<EditableCell>", () => {
     });
 
     it("defaults to no wrapText", () => {
-        const elem = mount(
-            <EditableCell />,
-        );
+        const elem = mount(<EditableCell />);
 
         expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT} div`).length).to.equal(2);
     });
 
     it("wraps text when wrapsText is true", () => {
-        const elem = mount(
-            <EditableCell wrapText={true} />,
-        );
+        const elem = mount(<EditableCell wrapText={true} />);
 
         expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT} div`).length).to.equal(0);
     });

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -130,12 +130,12 @@ describe("<EditableCell>", () => {
     it("defaults to no wrapText", () => {
         const elem = mount(<EditableCell />);
 
-        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT}`).length).to.equal(2);
+        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT}`).children().length).to.equal(1);
     });
 
     it("wraps text when wrapText is true", () => {
         const elem = mount(<EditableCell wrapText={true} />);
 
-        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT}`).length).to.equal(0);
+        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT}`).children().length).to.equal(0);
     });
 });

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -126,4 +126,20 @@ describe("<EditableCell>", () => {
         elem.find("input").simulate("blur");
         expect(onChangeSpy.firstCall.args).to.deep.equal([CHANGED_VALUE, ROW_INDEX, COLUMN_INDEX]);
     });
+
+    it("defaults to no wrapText", () => {
+        const elem = mount(
+            <EditableCell />,
+        );
+
+        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT} div`).length).to.equal(2);
+    });
+
+    it("wraps text when wrapsText is true", () => {
+        const elem = mount(
+            <EditableCell wrapText={true} />,
+        );
+
+        expect(elem.find(`.${Classes.TABLE_NO_WRAP_TEXT} div`).length).to.equal(0);
+    });
 });


### PR DESCRIPTION
#### Fixes #2700

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)  (I tried to do this, but circecli is not showing my fork, and there is an error that github service is partial degregated)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Fixes bug where wrapText={true} has doesn't work for 

#### Reviewers should focus on:

fix and tests

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
