### PR TITLE
Tabs overflow

### DIFF
--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -187,6 +187,7 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
     };
 
     private repartition(growing: boolean) {
+        console.log('repart', growing, this.spacer.getBoundingClientRect().width )
         if (this.spacer == null) {
             return;
         }
@@ -195,7 +196,7 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
                 overflow: [],
                 visible: this.props.items,
             });
-        } else if (this.spacer.getBoundingClientRect().width < 1) {
+        } else if (this.spacer.getBoundingClientRect().width < .5) {
             // spacer has flex-shrink and width 1px so if it's any smaller then we know to shrink
             this.setState(state => {
                 if (state.visible.length <= this.props.minVisibleItems) {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -82,6 +82,11 @@ $tab-indicator-width: 3px !default;
 
   // this is fine.
   // stylelint-disable-next-line selector-no-universal
+  .#{$ns}-overflow-list > *:not(:last-child) {
+    margin-right: $pt-grid-size * 2;
+  }
+
+  //is there is way to do this conditiaonlly?
   > *:not(:last-child) {
     margin-right: $pt-grid-size * 2;
   }

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -153,7 +153,6 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
             [Classes.LARGE]: this.props.large,
         });
 
-        console.log('-- RENDER', tabTitles, tabPanels)
         return (
             <div className={classes}>
                 <div
@@ -164,15 +163,17 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
                     role="tablist"
                 >
                     {tabIndicator}
-                    <OverflowList
-                        items={tabTitles}
-                        collapseFrom="end"
-                        observeParents={true}
-                        overflowRenderer={this.overflowRenderer}
-                        visibleItemRenderer={this.visibleItemsRenderer}
-                        ref={this.refHandlers.overflowList}
-                        {...this.props.overflowListProps}
-                    />
+                    {this.props.overflow ?
+                         <OverflowList
+                            items={tabTitles}
+                            collapseFrom="end"
+                            observeParents={true}
+                            overflowRenderer={this.overflowRenderer}
+                            visibleItemRenderer={this.visibleItemsRenderer}
+                            ref={this.refHandlers.overflowList}
+                            {...this.props.overflowListProps}
+                        /> : tabTitles
+                    }
                 </div>
                 {tabPanels}
             </div>
@@ -187,7 +188,6 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
         const overflowMenu = (
             <Menu>
                 {items.map((item) => {
-                    console.log('-- OVERFLOW', item)
                     //Return tabs as menu items and other items as themselves
                     if (item.props.panel) {
                         return (<MenuItem
@@ -203,6 +203,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
             </Menu>
         )
 
+        //
         return (
             <Popover content={overflowMenu}>
                 <span style={{lineHeight: '30px', cursor: 'pointer'}}>Overflow</span>
@@ -340,7 +341,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
         const tabIdSelector = `${TAB_SELECTOR}[data-tab-id="${this.state.selectedTabId}"]`;
         const selectedTabElement = this.tablistElement.querySelector(tabIdSelector) as HTMLElement;
         //Check if there are any overflow elementsR
-        const isOverflowing = this.overflowElement.state.overflow.length
+        const isOverflowing = this.overflowElement && this.overflowElement.state.overflow.length
         console.log('-- MOVE', selectedTabElement, isOverflowing, this.overflowElement, this.tablistElement)
 
         let indicatorWrapperStyle: React.CSSProperties = { display: 'none' };
@@ -357,14 +358,13 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
             const { clientHeight, clientWidth, offsetLeft, offsetTop } = selectedTabElement;
             indicatorWrapperStyle = indicatorWrapperCreator(clientHeight, clientWidth, offsetLeft, offsetTop)
         } else if (isOverflowing && selectedTabElement === null) {
-            //Find out whether or not it's beginning or end, though this should be a controllable prop so
-            //no actual discovery will need to be made here
+            //Find the overflow dropdown span
             const numTabChildren = this.overflowElement.element.children.length
-            const beginningChild = this.overflowElement.element.children[0]
-            const endingChild = this.overflowElement.element.children[numTabChildren - 2]
+            const collapseFrom = this.props.overflowListProps.collapseFrom || "end"
+            const overflowElementChildren = this.overflowElement.element.children
             //Find span element containing dropdown list
-            const overflowListElement = beginningChild.tagName === 'SPAN' ? beginningChild : endingChild
-
+            const overflowListElement =
+                collapseFrom === "end" ? overflowElementChildren[numTabChildren - 2] : overflowElementChildren[0]
 
             const { clientHeight, clientWidth, offsetLeft, offsetTop } = overflowListElement;
             indicatorWrapperStyle = indicatorWrapperCreator(clientHeight, clientWidth, offsetLeft, offsetTop)

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -42,7 +42,20 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
             </>
         );
 
+        const testPanel1 = () => {
+            return <div style={{height: '100px', width: '100px', backgroundColor: 'red'}}>Test</div>
+        }
+
+        const testPanel2 = () => {
+            return <div style={{height: '100px', width: '100px', backgroundColor: 'blue'}}>Test</div>
+        }
+
+        const testPanel3 = () => {
+            return <div style={{height: '100px', width: '100px', backgroundColor: 'green'}}>Test</div>
+        }
+
         return (
+            <div style={{width: '90%'}}>
             <Example className="docs-tabs-example" options={options} {...this.props}>
                 <Navbar>
                     <Navbar.Group>
@@ -52,35 +65,46 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
                     </Navbar.Group>
                     <Navbar.Group align={Alignment.RIGHT}>
                         {/* controlled mode & no panels (see h1 below): */}
-                        <Tabs
-                            animate={this.state.animate}
-                            id="navbar"
-                            large={true}
-                            onChange={this.handleNavbarTabChange}
-                            selectedTabId={this.state.navbarTabId}
-                        >
-                            <Tab id="Home" title="Home" />
-                            <Tab id="Files" title="Files" />
-                            <Tab id="Builds" title="Builds" />
-                        </Tabs>
+
+                        {
+                            <Tabs
+                                animate={this.state.animate}
+                                id="navbar"
+                                large={true}
+                                overflow={true}
+                                onChange={this.handleNavbarTabChange}
+                                selectedTabId={this.state.navbarTabId}
+                            >
+                                <Tab id="Home" title="Home"/>
+                                <Tab id="Files" title="Files"/>
+                                <Tab id="Builds" title="Builds"/>
+                            </Tabs>
+                        }
                     </Navbar.Group>
                 </Navbar>
                 {/* uncontrolled mode & each Tab has a panel: */}
-                <Tabs
-                    animate={this.state.animate}
-                    id="TabsExample"
-                    key={this.state.vertical ? "vertical" : "horizontal"}
-                    renderActiveTabPanelOnly={this.state.activePanelOnly}
-                    vertical={this.state.vertical}
-                >
-                    <Tab id="rx" title="React" panel={<ReactPanel />} />
-                    <Tab id="ng" title="Angular" panel={<AngularPanel />} />
-                    <Tab id="mb" title="Ember" panel={<EmberPanel />} />
-                    <Tab id="bb" disabled={true} title="Backbone" panel={<BackbonePanel />} />
-                    <Tabs.Expander />
-                    <InputGroup className={Classes.FILL} type="text" placeholder="Search..." />
-                </Tabs>
+
+                {
+                    <Tabs
+                        animate={this.state.animate}
+                        id="TabsExample"
+                        key={this.state.vertical ? "vertical" : "horizontal"}
+                        renderActiveTabPanelOnly={this.state.activePanelOnly}
+                        vertical={this.state.vertical}
+                        overflow={true}
+                        overflowListProps={{collapseFrom: 'start'}}
+                    >
+                        <Tab id="rx" title="React" panel={<ReactPanel/>}/>
+                        <Tab id="ng" title="Angular" panel={<AngularPanel/>}/>
+                        <Tab id="mb" title="Ember" panel={<EmberPanel/>}/>
+                        <Tab id="bb" title="Backbone" panel={<BackbonePanel/>}/>
+                        <Tabs.Expander/>
+                        <InputGroup type="text" placeholder="Search..."/>
+                    </Tabs>
+
+                }
             </Example>
+            </div>
         );
     }
 

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Alignment, Classes, H3, H5, InputGroup, Navbar, Switch, Tab, TabId, Tabs } from "@blueprintjs/core";
+import { Alignment, Classes, H3, H5, InputGroup, Navbar, Switch, Tab, TabId, Tabs, Slider, Label } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ITabsExampleState {
@@ -14,6 +14,8 @@ export interface ITabsExampleState {
     animate: boolean;
     navbarTabId: TabId;
     vertical: boolean;
+    overflow: boolean;
+    overflowWidth: number;
 }
 
 export class TabsExample extends React.PureComponent<IExampleProps, ITabsExampleState> {
@@ -21,12 +23,15 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
         activePanelOnly: false,
         animate: true,
         navbarTabId: "Home",
+        overflow: false,
+        overflowWidth: 100,
         vertical: false,
     };
 
     private toggleActiveOnly = handleBooleanChange(activePanelOnly => this.setState({ activePanelOnly }));
     private toggleAnimate = handleBooleanChange(animate => this.setState({ animate }));
     private toggleVertical = handleBooleanChange(vertical => this.setState({ vertical }));
+    private toggleOverflow = handleBooleanChange(overflow => this.setState({ overflow }));
 
     public render() {
         const options = (
@@ -39,23 +44,24 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
                     label="Render active tab panel only"
                     onChange={this.toggleActiveOnly}
                 />
+                <Switch
+                    checked={this.state.overflow}
+                    label="Overflow"
+                    onChange={this.toggleOverflow}
+                />
+                <Label>Overflow Width</Label>
+                <Slider
+                    labelRenderer={this.renderLabel}
+                    labelStepSize={25}
+                    max={100}
+                    onChange={this.handleChangeWidth}
+                    showTrackFill={false}
+                    value={this.state.overflowWidth}
+                />
             </>
         );
 
-        const testPanel1 = () => {
-            return <div style={{height: '100px', width: '100px', backgroundColor: 'red'}}>Test</div>
-        }
-
-        const testPanel2 = () => {
-            return <div style={{height: '100px', width: '100px', backgroundColor: 'blue'}}>Test</div>
-        }
-
-        const testPanel3 = () => {
-            return <div style={{height: '100px', width: '100px', backgroundColor: 'green'}}>Test</div>
-        }
-
         return (
-            <div style={{width: '90%'}}>
             <Example className="docs-tabs-example" options={options} {...this.props}>
                 <Navbar>
                     <Navbar.Group>
@@ -65,13 +71,12 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
                     </Navbar.Group>
                     <Navbar.Group align={Alignment.RIGHT}>
                         {/* controlled mode & no panels (see h1 below): */}
-
                         {
                             <Tabs
                                 animate={this.state.animate}
                                 id="navbar"
                                 large={true}
-                                overflow={true}
+                                overflow={this.state.overflow}
                                 onChange={this.handleNavbarTabChange}
                                 selectedTabId={this.state.navbarTabId}
                             >
@@ -83,31 +88,35 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
                     </Navbar.Group>
                 </Navbar>
                 {/* uncontrolled mode & each Tab has a panel: */}
-
                 {
-                    <Tabs
-                        animate={this.state.animate}
-                        id="TabsExample"
-                        key={this.state.vertical ? "vertical" : "horizontal"}
-                        renderActiveTabPanelOnly={this.state.activePanelOnly}
-                        vertical={this.state.vertical}
-                        overflow={true}
-                        overflowListProps={{collapseFrom: 'start'}}
-                    >
-                        <Tab id="rx" title="React" panel={<ReactPanel/>}/>
-                        <Tab id="ng" title="Angular" panel={<AngularPanel/>}/>
-                        <Tab id="mb" title="Ember" panel={<EmberPanel/>}/>
-                        <Tab id="bb" title="Backbone" panel={<BackbonePanel/>}/>
-                        <Tabs.Expander/>
-                        <InputGroup type="text" placeholder="Search..."/>
-                    </Tabs>
-
+                    <div style={{ width: `${this.state.overflowWidth}%`, marginRight: "auto" }}>
+                        <Tabs
+                            animate={this.state.animate}
+                            id="TabsExample"
+                            key={this.state.vertical ? "vertical" : "horizontal"}
+                            renderActiveTabPanelOnly={this.state.activePanelOnly}
+                            vertical={this.state.vertical}
+                            overflow={this.state.overflow}
+                            overflowListProps={{collapseFrom: "start"}}
+                        >
+                            <Tab id="rx" title="React" panel={<ReactPanel/>}/>
+                            <Tab id="ng" title="Angular" panel={<AngularPanel/>}/>
+                            <Tab id="mb" title="Ember" panel={<EmberPanel/>}/>
+                            <Tab id="bb" title="Backbone" panel={<BackbonePanel/>}/>
+                            <Tabs.Expander/>
+                            <InputGroup type="text" placeholder="Search..."/>
+                        </Tabs>
+                    </div>
                 }
             </Example>
-            </div>
         );
     }
 
+    private renderLabel(value: number) {
+        return `${value}%`;
+    }
+
+    private handleChangeWidth = (overflowWidth: number) => this.setState({ overflowWidth });
     private handleNavbarTabChange = (navbarTabId: TabId) => this.setState({ navbarTabId });
 }
 


### PR DESCRIPTION
#### Fixes
https://github.com/palantir/blueprint/issues/2689

#### Checklist
- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Added the new oveflowList component to tabs. Very experimental currently. Lots of cleanup to do but want to make sure the basics are there. 

#### Reviewers should focus on:

- I utilize a timeout so the overflowList can repartition and accurately let the parent component know what's overflowing. This might not be the most appropriate way to do this. 
- The moveSelectionIndicator needs to account for the overflowing element, however if this is done by resizing the indicator may not completely underline the overflowTab
- Allow use of your own overflowRenderer but have a default in place, what should this default look like (Button with dropdown icon that pops into a standard menu?)
- Support for vertical tabs?
- The overflowList repartition function is too sensitive at 1 so I set it to .5 which matches the functionality I'd like to achieve. However I don't think we should modify the overflowList just for this, will need to look into exactly how the 1px flex shrink calculates overflow. 