### PR TITLE
[core] use IOptionProps instead of IHTMLOptionProps

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -81,8 +81,8 @@ export interface IOptionProps extends IProps {
     /** Whether this option is non-interactive. */
     disabled?: boolean;
 
-    /** Label text for this option. */
-    label: string;
+    /** Label text for this option. If omitted, `value` is used as the label. */
+    label?: string;
 
     /** Value of this option. */
     value: string | number;

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -42,9 +42,9 @@ export interface IRadioGroupProps extends IProps {
     onChange: (event: React.FormEvent<HTMLInputElement>) => void;
 
     /**
-     * Array of options to render in the group.
-     * This prop is mutually exclusive with `children`: either provide an array of `IOptionProps`
-     * objects or provide `<Radio>` children elements.
+     * Array of options to render in the group. This prop is mutually exclusive
+     * with `children`: either provide an array of `IOptionProps` objects or
+     * provide `<Radio>` children elements.
      */
     options?: IOptionProps[];
 
@@ -91,19 +91,20 @@ export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
 
     private renderOptions() {
         return this.props.options.map(option => (
-            <Radio {...option} {...this.getRadioProps(option)} key={option.value} />
+            <Radio {...this.getRadioProps(option)} key={option.value} labelElement={option.label || option.value} />
         ));
     }
 
     private getRadioProps(optionProps: IOptionProps): IRadioProps {
         const { name } = this.props;
-        const { value, disabled } = optionProps;
+        const { disabled, value } = optionProps;
         return {
             checked: value === this.props.selectedValue,
             disabled: disabled || this.props.disabled,
             inline: this.props.inline,
             name: name == null ? this.autoGroupName : name,
             onChange: this.props.onChange,
+            value,
         };
     }
 }

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -7,16 +7,9 @@
 import classNames from "classnames";
 import * as React from "react";
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
+import { IOptionProps } from "../../common/props";
 import { IElementRefProps } from "../html/html";
 import { Icon } from "../icon/icon";
-
-export interface IHTMLOptionProps {
-    /** Optional label for this option. Defaults to `value`. */
-    label?: string;
-
-    /** Value of this option. Should be locally unique. */
-    value: string | number;
-}
 
 export interface IHTMLSelectProps
     extends IElementRefProps<HTMLSelectElement>,
@@ -44,7 +37,7 @@ export interface IHTMLSelectProps
      * `{ label?, value }` objects. If no `label` is supplied, `value`
      * will be used as the label.
      */
-    options?: Array<string | number | IHTMLOptionProps>;
+    options?: Array<string | number | IOptionProps>;
 
     /** Controlled value of this component. */
     value?: string | number;
@@ -67,7 +60,7 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
         );
 
         const optionChildren = options.map(option => {
-            const { value, label }: IHTMLOptionProps = typeof option === "object" ? option : { value: option };
+            const { value, label }: IOptionProps = typeof option === "object" ? option : { value: option };
             return <option key={value} value={value} children={label || value} />;
         });
 

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -62,6 +62,20 @@ describe("<RadioGroup>", () => {
         assert.isTrue(findInput(group, { value: "c" }).prop("disabled"), "radio c not disabled");
     });
 
+    it("options label defaults to value", () => {
+        const OPTIONS = [{ value: "text" }, { value: 23 }];
+        const group = mount(<RadioGroup onChange={emptyHandler} options={OPTIONS} selectedValue="b" />);
+        OPTIONS.forEach(props => {
+            assert.strictEqual(
+                findInput(group, props)
+                    .parents()
+                    .first()
+                    .text(),
+                props.value.toString(),
+            );
+        });
+    });
+
     it("uses options if given both options and children (with conosle warning)", () => {
         const warnSpy = stub(console, "warn");
         const group = mount(

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -7,9 +7,9 @@ import * as React from "react";
 
 import {
     HTMLSelect,
-    IHTMLOptionProps,
     Intent,
     INumericInputProps,
+    IOptionProps,
     Label,
     NumericInput,
     Position,
@@ -138,7 +138,7 @@ export class NumericInputBasicExample extends React.PureComponent<IExampleProps,
     private renderSelectMenu(
         label: string,
         selectedValue: number | string,
-        options: IHTMLOptionProps[],
+        options: IOptionProps[],
         onChange: React.FormEventHandler<HTMLElement>,
     ) {
         return (


### PR DESCRIPTION
- I added `IHTMLOptionProps` in #2605 without realizing we already had `IOptionProps` used in RadioGroup. oops!
- this PR removes `IHTMLOptionProps` in favor of `IOptionProps` which is maybe a tiny API break but i doubt anyone actually uses the type
- `RadioGroup` `options` prop supports optional `label`
