### PR TITLE
[Checkbox] inline SVG background-image for icon

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "compile": "run-p \"compile:*\"",
     "compile:esm": "tsc -p ./src",
     "compile:cjs": "tsc -p ./src/tsconfig.cjs.json",
-    "compile:css": "sass-compile ./src",
+    "compile:css": "sass-compile ./src --functions ./scripts/sass-inline-svg.js",
     "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
     "dist": "run-s \"dist:*\"",
     "dist:bundle": "cross-env NODE_ENV=production webpack",
@@ -64,6 +64,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
+    "sass-inline-svg": "^1.1.0",
     "typescript": "~2.8.3",
     "webpack": "^3.10.0"
   },

--- a/packages/core/scripts/sass-inline-svg.js
+++ b/packages/core/scripts/sass-inline-svg.js
@@ -1,0 +1,12 @@
+const inliner = require('sass-inline-svg');
+
+module.exports = {
+    // Sass function to inline a UI Icon svg and change its path color:
+    // svg("16px/icon-name.svg", (path: (fill: $color)) )
+    'svg': inliner('../../resources/icons', {
+        // run through SVGO first
+        optimize: true,
+        // minimal "uri" encoding is smaller than base64
+        encodingFormat: "uri"
+    })
+};

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -129,9 +129,14 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   */
 
   &.#{$ns}-checkbox {
+    @mixin indicator-icon($icon) {
+      // embed SVG icon image as backgroud-image above gradient.
+      // the SVG image content is inlined into the CSS, so use this sparingly.
+      background-image: $button-intent-gradient, svg("16px/#{$icon}.svg", (path: (fill: $white)));
+    }
+
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
-      font-size: $control-indicator-size;
     }
 
     input:indeterminate,
@@ -141,13 +146,12 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       @extend input:checked;
     }
 
-    // embed SVG images as backgroud-image above gradient
     input:checked ~ .#{$ns}-control-indicator {
-      background-image: $button-intent-gradient, svg("16px/small-tick.svg", (path: (fill: $white)));
+      @include indicator-icon("small-tick");
     }
 
     input:indeterminate ~ .#{$ns}-control-indicator {
-      background-image: $button-intent-gradient, svg("16px/small-minus.svg", (path: (fill: $white)));
+      @include indicator-icon("small-minus");
     }
   }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -131,8 +131,8 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   &.#{$ns}-checkbox {
     @mixin indicator-icon($icon) {
       &::before {
-      // embed SVG icon image as backgroud-image above gradient.
-      // the SVG image content is inlined into the CSS, so use this sparingly.
+        // embed SVG icon image as backgroud-image above gradient.
+        // the SVG image content is inlined into the CSS, so use this sparingly.
         background-image: svg("16px/#{$icon}.svg", (path: (fill: $white)));
       }
     }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -46,7 +46,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   .#{$ns}-control-indicator {
-    @include pt-icon($pt-icon-size-standard);
     position: absolute;
     top: 0;
     left: 0;
@@ -59,7 +58,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     cursor: pointer;
     width: $control-indicator-size;
     height: $control-indicator-size;
-    line-height: $control-indicator-size;
     user-select: none;
   }
 
@@ -134,15 +132,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
       font-size: $control-indicator-size;
-
-      // pseudo-element will contain SVG image for pseudo-state.
-      // size it to scale with container so only one image is needed.
-      &::before {
-        display: block;
-        width: 100%;
-        height: 100%;
-        content: "";
-      }
     }
 
     input:indeterminate,
@@ -152,13 +141,13 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       @extend input:checked;
     }
 
-    // embed SVG images for pseudo-states
-    input:checked ~ .#{$ns}-control-indicator::before {
-      background: svg("16px/small-tick.svg", (path: (fill: $white)));
+    // embed SVG images as backgroud-image above gradient
+    input:checked ~ .#{$ns}-control-indicator {
+      background-image: $button-intent-gradient, svg("16px/small-tick.svg", (path: (fill: $white)));
     }
 
-    input:indeterminate ~ .#{$ns}-control-indicator::before {
-      background: svg("16px/small-minus.svg", (path: (fill: $white)));
+    input:indeterminate ~ .#{$ns}-control-indicator {
+      background-image: $button-intent-gradient, svg("16px/small-minus.svg", (path: (fill: $white)));
     }
   }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -134,6 +134,15 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
       font-size: $control-indicator-size;
+
+      // pseudo-element will contain SVG image for pseudo-state.
+      // size it to scale with container so only one image is needed.
+      &::before {
+        display: block;
+        width: 100%;
+        height: 100%;
+        content: "";
+      }
     }
 
     input:indeterminate,
@@ -143,13 +152,13 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
       @extend input:checked;
     }
 
-    // CSS API support
-    input:checked ~ .#{$ns}-control-indicator:empty::before {
-      content: $pt-icon-small-tick;
+    // embed SVG images for pseudo-states
+    input:checked ~ .#{$ns}-control-indicator::before {
+      background: svg("16px/small-tick.svg", (path: (fill: $white)));
     }
 
-    input:indeterminate ~ .#{$ns}-control-indicator:empty::before {
-      content: $pt-icon-small-minus;
+    input:indeterminate ~ .#{$ns}-control-indicator::before {
+      background: svg("16px/small-minus.svg", (path: (fill: $white)));
     }
   }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -130,13 +130,22 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
 
   &.#{$ns}-checkbox {
     @mixin indicator-icon($icon) {
+      &::before {
       // embed SVG icon image as backgroud-image above gradient.
       // the SVG image content is inlined into the CSS, so use this sparingly.
-      background-image: $button-intent-gradient, svg("16px/#{$icon}.svg", (path: (fill: $white)));
+        background-image: svg("16px/#{$icon}.svg", (path: (fill: $white)));
+      }
     }
 
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
+
+      &::before {
+        display: block;
+        width: 100%;
+        height: 100%;
+        content: "";
+      }
     }
 
     input:indeterminate,

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -15,7 +15,6 @@ import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
 import { HTMLInputProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
-import { Icon } from "../icon/icon";
 
 export interface IControlProps extends IProps, HTMLInputProps {
     // NOTE: HTML props are duplicated here to provide control-specific documentation
@@ -69,7 +68,6 @@ export interface IControlProps extends IProps, HTMLInputProps {
 
 /** Internal props for Checkbox/Radio/Switch to render correctly. */
 interface IControlInternalProps extends IControlProps {
-    indicator?: JSX.Element;
     type: "checkbox" | "radio";
     typeClassName: string;
 }
@@ -82,7 +80,6 @@ const Control: React.SFC<IControlInternalProps> = ({
     alignIndicator,
     children,
     className,
-    indicator,
     inline,
     inputRef,
     label,
@@ -107,7 +104,7 @@ const Control: React.SFC<IControlInternalProps> = ({
     return (
         <label className={classes} style={style}>
             <input {...htmlProps} ref={inputRef} type={type} />
-            <span className={Classes.CONTROL_INDICATOR}>{indicator}</span>
+            <span className={Classes.CONTROL_INDICATOR} />
             {label}
             {labelElement}
             {children}
@@ -184,7 +181,6 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
         return (
             <Control
                 {...controlProps}
-                indicator={this.renderIndicator()}
                 inputRef={this.handleInputRef}
                 onChange={this.handleChange}
                 type="checkbox"
@@ -203,15 +199,6 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
 
     public componentDidUpdate() {
         this.updateIndeterminate();
-    }
-
-    private renderIndicator() {
-        if (this.state.indeterminate) {
-            return <Icon icon="small-minus" />;
-        } else if (this.state.checked) {
-            return <Icon icon="small-tick" />;
-        }
-        return null;
     }
 
     private updateIndeterminate() {

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -159,9 +159,8 @@ export interface ICheckboxProps extends IControlProps {
     indeterminate?: boolean;
 }
 
-// checkbox stores state so it can render an icon in the indicator
 export interface ICheckboxState {
-    checked: boolean;
+    // Checkbox adds support for uncontrolled indeterminate state
     indeterminate: boolean;
 }
 
@@ -169,7 +168,6 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
     public static displayName = "Blueprint2.Checkbox";
 
     public state: ICheckboxState = {
-        checked: this.props.checked || this.props.defaultChecked || false,
         indeterminate: this.props.indeterminate || this.props.defaultIndeterminate || false,
     };
 
@@ -189,8 +187,11 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
         );
     }
 
-    public componentWillReceiveProps({ checked, indeterminate }: ICheckboxProps) {
-        this.setState({ checked, indeterminate });
+    public componentWillReceiveProps({ indeterminate }: ICheckboxProps) {
+        // put props into state if controlled by props
+        if (indeterminate != null) {
+            this.setState({ indeterminate });
+        }
     }
 
     public componentDidMount() {
@@ -208,8 +209,12 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
     }
 
     private handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
-        const { checked, indeterminate } = evt.target;
-        this.setState({ checked, indeterminate });
+        const { indeterminate } = evt.target;
+        // update state immediately only if uncontrolled
+        if (this.props.indeterminate == null) {
+            this.setState({ indeterminate });
+        }
+        // otherwise wait for props change. always invoke handler.
         safeInvoke(this.props.onChange, evt);
     };
 

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -8,7 +8,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { Classes, Icon } from "../../src";
+import { Classes } from "../../src";
 import { Checkbox, IControlProps, Radio, Switch } from "../../src/components/forms/controls";
 
 type ControlType = typeof Checkbox | typeof Radio | typeof Switch;
@@ -27,28 +27,6 @@ describe("Controls:", () => {
             it("default prop sets element state", () => {
                 mount(<Checkbox defaultIndeterminate={true} inputRef={handleInputRef} />);
                 assert.isTrue(input.indeterminate);
-            });
-        });
-
-        describe("indicator icon", () => {
-            it("default renders nothing", () => {
-                const icon = mount(<Checkbox />).find(Icon);
-                assert.isFalse(icon.exists());
-            });
-
-            it("checked renders tick", () => {
-                const icon = mount(<Checkbox checked={true} />).find(Icon);
-                assert.equal(icon.prop("icon"), "small-tick");
-            });
-
-            it("indeterminate renders minus", () => {
-                const icon = mount(<Checkbox indeterminate={true} />).find(Icon);
-                assert.equal(icon.prop("icon"), "small-minus");
-            });
-
-            it("checked overrides indeterminate", () => {
-                const icon = mount(<Checkbox checked={true} indeterminate={true} />).find(Icon);
-                assert.equal(icon.prop("icon"), "small-minus");
             });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,6 +680,10 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
+bindings@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
+
 blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
@@ -1788,7 +1792,7 @@ css-select-base-adapter@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz#0102b3d14630df86c3eb9fa9f5456270106cf990"
 
-css-select@~1.2.0:
+css-select@^1.2.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -1883,6 +1887,13 @@ csso@^3.3.1:
   dependencies:
     css-tree "1.0.0-alpha.27"
 
+csso@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-2.0.0.tgz#178b43a44621221c27756086f531e02f42900ee8"
+  dependencies:
+    clap "^1.0.9"
+    source-map "^0.5.3"
+
 csso@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
@@ -1938,6 +1949,13 @@ dateformat@^1.0.11, dateformat@^1.0.12, dateformat@^1.0.6:
   dependencies:
     get-stdin "^4.0.1"
     meow "^3.3.0"
+
+deasync@^0.1.7:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.13.tgz#815c2b69bbd1117cae570152cd895661c09f20ea"
+  dependencies:
+    bindings "~1.2.1"
+    nan "^2.0.7"
 
 debug@2.2.0:
   version "2.2.0"
@@ -2174,7 +2192,7 @@ dom-serialize@^2.2.0:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
-dom-serializer@0, dom-serializer@~0.1.0:
+dom-serializer@0, dom-serializer@^0.1.0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -3646,7 +3664,7 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
-htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+htmlparser2@^3.9.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -4273,6 +4291,13 @@ js-yaml@3.x, js-yaml@^3.10.0, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0, js
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@~3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
 
 js-yaml@~3.7.0:
   version "3.7.0"
@@ -5047,6 +5072,10 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
+mini-svg-data-uri@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.0.1.tgz#d81ffc14b85558860581cc58d9790daaecbe91bf"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -5193,6 +5222,10 @@ multicast-dns@^6.0.1:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nan@^2.0.7:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nan@^2.0.9, nan@^2.3.0, nan@^2.3.2:
   version "2.8.0"
@@ -7115,6 +7148,18 @@ sass-graph@^2.1.1, sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
+sass-inline-svg@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sass-inline-svg/-/sass-inline-svg-1.1.0.tgz#c7233820f7bf8fd3dfc64fb3ee21c07abe514c25"
+  dependencies:
+    css-select "^1.2.0"
+    deasync "^0.1.7"
+    dom-serializer "^0.1.0"
+    htmlparser2 "^3.9.0"
+    mini-svg-data-uri "^1.0.0"
+    object-assign "^4.0.1"
+    svgo "^0.6.6"
+
 sass-loader@^6.0.6:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.6.tgz#e9d5e6c1f155faa32a4b26d7a9b7107c225e40f9"
@@ -7903,6 +7948,18 @@ supports-color@^5.2.0, supports-color@^5.3.0:
 svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+
+svgo@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.6.6.tgz#b340889036f20f9b447543077d0f5573ed044c08"
+  dependencies:
+    coa "~1.0.1"
+    colors "~1.1.2"
+    csso "~2.0.0"
+    js-yaml "~3.6.0"
+    mkdirp "~0.5.1"
+    sax "~1.2.1"
+    whet.extend "~0.9.9"
 
 svgo@^0.7.0:
   version "0.7.2"


### PR DESCRIPTION
- Checkbox suffered greatly in the switch to SVG icons because its implementation no longer relied purely on CSS: React state was necessary to ensure the correct icon was rendered at the correct time.
    - This introduced a bunch of subtle bugs where the DOM and the state could get out of sync (due to an incorrect implementation of un/controlled state).
- This PR brings us back to the CSS-only world by _embedding the SVG images_ for `small-tick` and `small-minus` in the checkbox CSS directly.
   - This is functionally identical to the oild font usage `content: $pt-icon-small-tick` (in fact, that's the line that was replaced) so we no longer even need to support the font fallback!
   - As a result, I was able to remove from the React component the `indicator` logic _and_ the `checked` state (which was only needed to render the icon) and all associated tests.
   - This amounts to reverting almost all of #2323.

#### What about the bytes?

Each icon adds ~300B to the total file size. Yes, bytes. This is not significant.

`blueprint.css`  290K &rArr; 291K