### PR TITLE
🔧 external source maps in css-dist

### DIFF
--- a/packages/node-build-scripts/css-dist.sh
+++ b/packages/node-build-scripts/css-dist.sh
@@ -5,4 +5,4 @@
 
 OUTPUT="${OUTPUT:-lib/css/}"
 
-postcss $OUTPUT/*.css --use autoprefixer --use postcss-discard-comments --replace
+postcss $OUTPUT/*.css --use autoprefixer --use postcss-discard-comments --replace --map


### PR DESCRIPTION
enable `--map` flag to postcss to externalize sourcemap. 

Sass compilation already generates  a `.css.map` file but without this flag, postcss would encode and inline the sourcemap, ballooning blueprint.css from 293K to 396K during a supposed production step!