### PR TITLE
[Checkbox] indicator is inline element

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -20,7 +20,54 @@ $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
 $control-indicator-spacing: $pt-grid-size !default;
 
+@mixin checked-control($selector: ":checked") {
+  input#{$selector} ~ .#{$ns}-control-indicator {
+    box-shadow: $button-intent-box-shadow;
+    background-color: $control-checked-background-color;
+    background-image: $button-intent-gradient;
+    color: $white;
+  }
+
+  &:hover input#{$selector} ~ .#{$ns}-control-indicator {
+    box-shadow: $button-intent-box-shadow;
+    background-color: $control-checked-background-color-hover;
+  }
+
+  input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
+    box-shadow: $button-intent-box-shadow-active;
+    background: $control-checked-background-color-active;
+  }
+
+  input:disabled#{$selector} ~ .#{$ns}-control-indicator {
+    box-shadow: none;
+    background: rgba($control-checked-background-color, 0.5);
+  }
+
+  .#{$ns}-dark & {
+    input#{$selector} ~ .#{$ns}-control-indicator {
+      box-shadow: $dark-button-intent-box-shadow;
+    }
+
+    &:hover input#{$selector} ~ .#{$ns}-control-indicator {
+      box-shadow: $dark-button-intent-box-shadow;
+      background-color: $control-checked-background-color-hover;
+    }
+
+    input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
+      box-shadow: $dark-button-intent-box-shadow-active;
+      background-color: $control-checked-background-color-active;
+    }
+
+    input:disabled#{$selector} ~ .#{$ns}-control-indicator {
+      box-shadow: none;
+      background: rgba($control-checked-background-color-active, 0.5);
+    }
+  }
+}
+
 .#{$ns}-control {
+  @include checked-control();
+
   display: block;
   position: relative;
   margin-bottom: $pt-grid-size;
@@ -35,14 +82,6 @@ $control-indicator-spacing: $pt-grid-size !default;
   &.#{$ns}-inline {
     display: inline-block;
     margin-right: $pt-grid-size * 2;
-  }
-
-  input {
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 0;
-    z-index: -1; // don't let it intercept clicks
   }
 
   .#{$ns}-control-indicator {
@@ -62,51 +101,31 @@ $control-indicator-spacing: $pt-grid-size !default;
     user-select: none;
   }
 
-  input:checked ~ .#{$ns}-control-indicator {
-    box-shadow: $button-intent-box-shadow;
-    background-color: $control-checked-background-color;
-    background-image: $button-intent-gradient;
-    color: $white;
+  &:hover .#{$ns}-control-indicator {
+    background-color: $control-background-color-hover;
   }
 
-  &:hover {
-    .#{$ns}-control-indicator {
-      background-color: $control-background-color-hover;
-    }
-
-    input:checked ~ .#{$ns}-control-indicator {
-      box-shadow: $button-intent-box-shadow;
-      background-color: $control-checked-background-color-hover;
-    }
+  input {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: -1; // don't let it intercept clicks
   }
 
-  input:not(:disabled):active {
-    ~ .#{$ns}-control-indicator {
-      box-shadow: $button-box-shadow-active;
-      background: $control-background-color-active;
-    }
+  input:not(:disabled):active ~ .#{$ns}-control-indicator {
+    box-shadow: $button-box-shadow-active;
+    background: $control-background-color-active;
+  }
 
-    &:checked ~ .#{$ns}-control-indicator {
-      box-shadow: $button-intent-box-shadow-active;
-      background: $control-checked-background-color-active;
-    }
+  input:disabled ~ .#{$ns}-control-indicator {
+    box-shadow: none;
+    background: $button-background-color-disabled;
+    cursor: not-allowed;
   }
 
   input:focus ~ .#{$ns}-control-indicator {
     @include focus-outline();
-  }
-
-  input:disabled {
-    ~ .#{$ns}-control-indicator {
-      box-shadow: none;
-      background: $button-background-color-disabled;
-      cursor: not-allowed;
-    }
-
-    &:checked ~ .#{$ns}-control-indicator {
-      box-shadow: none;
-      background: rgba($control-checked-background-color, 0.5);
-    }
   }
 
   /*
@@ -130,16 +149,12 @@ $control-indicator-spacing: $pt-grid-size !default;
   */
 
   &.#{$ns}-checkbox {
+    // make :indeterminate look like :checked _for Checkbox only_
+    @include checked-control(":indeterminate");
+
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
       font-size: $control-indicator-size;
-    }
-
-    input:indeterminate,
-    &:hover input:indeterminate {
-      // :indeterminate should behave like :checked with different icon
-      // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
-      @extend input:checked;
     }
 
     // CSS API support
@@ -389,52 +404,27 @@ $control-indicator-spacing: $pt-grid-size !default;
       background-image: $dark-button-gradient;
     }
 
-    input:checked ~ .#{$ns}-control-indicator {
-      box-shadow: $dark-button-intent-box-shadow;
+    &:hover .#{$ns}-control-indicator {
+      background-color: $dark-control-background-color-hover;
     }
 
-    &:hover {
-      .#{$ns}-control-indicator {
-        background-color: $dark-control-background-color-hover;
-      }
+    input:not(:disabled):active ~ .#{$ns}-control-indicator {
+      box-shadow: $dark-button-box-shadow-active;
+      background: $dark-control-background-color-active;
     }
 
-    input:not(:disabled):active {
-      ~ .#{$ns}-control-indicator {
-        box-shadow: $dark-button-box-shadow-active;
-        background: $dark-control-background-color-active;
-      }
-
-      &:checked ~ .#{$ns}-control-indicator {
-        box-shadow: $dark-button-intent-box-shadow-active;
-        background-color: $control-checked-background-color-active;
-      }
+    input:disabled ~ .#{$ns}-control-indicator {
+      box-shadow: none;
+      background: $dark-button-background-color-disabled;
+      cursor: not-allowed;
     }
 
-    input:disabled {
-      ~ .#{$ns}-control-indicator {
-        box-shadow: none;
-        background: $dark-button-background-color-disabled;
-        cursor: not-allowed;
-      }
-
-      &:checked ~ .#{$ns}-control-indicator {
-        box-shadow: none;
-        background: rgba($control-checked-background-color-active, 0.5);
-      }
-    }
-
-    &.#{$ns}-checkbox {
-      input:checked {
-        &:disabled ~ .#{$ns}-control-indicator::before {
+    &.#{$ns}-checkbox input:disabled {
+      &:checked,
+      &:indeterminate {
+        ~ .#{$ns}-control-indicator {
           color: $dark-button-color-disabled;
         }
-      }
-    }
-
-    &.#{$ns}-radio {
-      input:checked:disabled ~ .#{$ns}-control-indicator::before {
-        background: $dark-button-color-disabled;
       }
     }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -16,16 +16,16 @@ $control-checked-background-color: nth(map-get($button-intents, "primary"), 1) !
 $control-checked-background-color-hover: nth(map-get($button-intents, "primary"), 2) !default;
 $control-checked-background-color-active: nth(map-get($button-intents, "primary"), 3) !default;
 
+$control-indicator-size: $pt-icon-size-standard !default;
+$control-indicator-size-large: $pt-icon-size-large !default;
+$control-indicator-spacing: $pt-grid-size !default;
+
 .#{$ns}-control {
   display: block;
   position: relative;
   margin-bottom: $pt-grid-size;
   cursor: pointer;
-  // controls sometimes don't have text in their <label>, so we set a minimum height
-  min-height: $control-indicator-size;
-  padding-left: $control-indicator-size + $pt-grid-size;
   text-transform: none;
-  line-height: $control-indicator-size;
 
   &.#{$ns}-disabled {
     cursor: not-allowed;
@@ -46,11 +46,10 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   .#{$ns}-control-indicator {
-    @include pt-icon($pt-icon-size-standard);
-    position: absolute;
-    top: 0;
-    left: 0;
-    margin: 0;
+    display: inline-block;
+    position: relative;
+    margin-top: -3px;
+    margin-right: $control-indicator-spacing;
     border: none;
     box-shadow: $button-box-shadow;
     background-clip: padding-box;
@@ -59,7 +58,7 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     cursor: pointer;
     width: $control-indicator-size;
     height: $control-indicator-size;
-    line-height: $control-indicator-size;
+    vertical-align: middle;
     user-select: none;
   }
 
@@ -253,8 +252,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.#{$ns}-switch {
-    padding-left: $switch-width + $pt-grid-size;
-
     .#{$ns}-control-indicator {
       border: none;
       border-radius: $switch-width;
@@ -278,11 +275,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         content: "";
         transition: left $pt-transition-duration $pt-transition-ease;
       }
-    }
-
-    &.#{$ns}-align-right {
-      padding-right: $switch-width + $pt-grid-size;
-      padding-left: 0;
     }
 
     input:checked ~ .#{$ns}-control-indicator {
@@ -339,37 +331,19 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
   }
 
   // right-aligned indicator is glued to the right side of the container
-  &.#{$ns}-align-right {
-    padding-right: $control-indicator-size + $pt-grid-size;
-    padding-left: 0;
-
-    .#{$ns}-control-indicator {
-      right: 0;
-      left: auto;
-    }
+  &.#{$ns}-align-right .#{$ns}-control-indicator {
+    float: right;
+    margin-top: 1px;
+    margin-right: 0;
+    margin-left: $control-indicator-spacing;
   }
 
   &.#{$ns}-large {
-    min-height: $control-indicator-size-large;
-    padding-left: $control-indicator-size-large + $pt-grid-size;
-    line-height: $control-indicator-size-large;
     font-size: $pt-font-size-large;
 
     .#{$ns}-control-indicator {
       width: $control-indicator-size-large;
       height: $control-indicator-size-large;
-      line-height: $control-indicator-size-large;
-      font-family: $icons20-family;
-      font-size: $control-indicator-size-large;
-    }
-
-    &.#{$ns}-align-right {
-      padding-right: $control-indicator-size-large + $pt-grid-size;
-      padding-left: 0;
-    }
-
-    &.#{$ns}-checkbox input:checked ~ .#{$ns}-control-indicator::before {
-      top: 1px;
     }
 
     &.#{$ns}-radio .#{$ns}-control-indicator {
@@ -377,8 +351,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
     }
 
     &.#{$ns}-switch {
-      padding-left: $switch-width-large + $pt-grid-size;
-
       .#{$ns}-control-indicator {
         width: $switch-width-large;
         height: $switch-height-large;
@@ -389,6 +361,10 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         }
       }
 
+      &.#{$ns}-align-right .#{$ns}-control-indicator {
+        margin-top: 0;
+      }
+
       input:checked ~ .#{$ns}-control-indicator {
         width: $switch-width-large;
         height: $switch-height-large;
@@ -396,11 +372,6 @@ $control-checked-background-color-active: nth(map-get($button-intents, "primary"
         &::before {
           left: $switch-width-large - $switch-height-large + $switch-indicator-margin;
         }
-      }
-
-      &.#{$ns}-align-right {
-        padding-right: $switch-width-large + $pt-grid-size;
-        padding-left: 0;
       }
     }
   }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -20,7 +20,7 @@ $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
 $control-indicator-spacing: $pt-grid-size !default;
 
-@mixin checked-control($selector: ":checked") {
+@mixin control-checked-colors($selector: ":checked") {
   input#{$selector} ~ .#{$ns}-control-indicator {
     box-shadow: $button-intent-box-shadow;
     background-color: $control-checked-background-color;
@@ -66,7 +66,7 @@ $control-indicator-spacing: $pt-grid-size !default;
 }
 
 .#{$ns}-control {
-  @include checked-control();
+  @include control-checked-colors();
 
   display: block;
   position: relative;
@@ -149,7 +149,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   */
 
   &.#{$ns}-checkbox {
-    @mixin indicator-icon($icon) {
+    @mixin indicator-inline-icon($icon) {
       &::before {
         // embed SVG icon image as backgroud-image above gradient.
         // the SVG image content is inlined into the CSS, so use this sparingly.
@@ -158,7 +158,7 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     // make :indeterminate look like :checked _for Checkbox only_
-    @include checked-control(":indeterminate");
+    @include control-checked-colors(":indeterminate");
 
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
@@ -172,11 +172,11 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator {
-      @include indicator-icon("small-tick");
+      @include indicator-inline-icon("small-tick");
     }
 
     input:indeterminate ~ .#{$ns}-control-indicator {
-      @include indicator-icon("small-minus");
+      @include indicator-inline-icon("small-minus");
     }
   }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -84,6 +84,14 @@ $control-indicator-spacing: $pt-grid-size !default;
     margin-right: $pt-grid-size * 2;
   }
 
+  input {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: -1; // don't let it intercept clicks
+  }
+
   .#{$ns}-control-indicator {
     display: inline-block;
     position: relative;
@@ -105,14 +113,6 @@ $control-indicator-spacing: $pt-grid-size !default;
     background-color: $control-background-color-hover;
   }
 
-  input {
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 0;
-    z-index: -1; // don't let it intercept clicks
-  }
-
   input:not(:disabled):active ~ .#{$ns}-control-indicator {
     box-shadow: $button-box-shadow-active;
     background: $control-background-color-active;
@@ -126,6 +126,14 @@ $control-indicator-spacing: $pt-grid-size !default;
 
   input:focus ~ .#{$ns}-control-indicator {
     @include focus-outline();
+  }
+
+  // right-aligned indicator is glued to the right side of the container
+  &.#{$ns}-align-right .#{$ns}-control-indicator {
+    float: right;
+    margin-top: 1px;
+    margin-right: 0;
+    margin-left: $control-indicator-spacing;
   }
 
   /*
@@ -356,14 +364,6 @@ $control-indicator-spacing: $pt-grid-size !default;
         background-color: $switch-checked-background-color-disabled;
       }
     }
-  }
-
-  // right-aligned indicator is glued to the right side of the container
-  &.#{$ns}-align-right .#{$ns}-control-indicator {
-    float: right;
-    margin-top: 1px;
-    margin-right: 0;
-    margin-left: $control-indicator-spacing;
   }
 
   &.#{$ns}-large {

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -12,6 +12,7 @@ import { AlignmentSelect } from "./common/alignmentSelect";
 
 export interface ICheckboxExampleState {
     alignIndicator: Alignment;
+    disabled: boolean;
     inline: boolean;
     large: boolean;
     value?: string;
@@ -20,6 +21,7 @@ export interface ICheckboxExampleState {
 export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckboxExampleState> {
     public state: ICheckboxExampleState = {
         alignIndicator: Alignment.LEFT,
+        disabled: false,
         inline: false,
         large: false,
     };
@@ -28,6 +30,7 @@ export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckbo
         const options = (
             <>
                 <H5>Props</H5>
+                <Switch checked={this.state.disabled} label="Disabled" onChange={this.handleDisabledChange} />
                 <Switch checked={this.state.inline} label="Inline" onChange={this.handleInlineChange} />
                 <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
                 <AlignmentSelect
@@ -59,6 +62,7 @@ export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckbo
 
     // tslint:disable:member-ordering
     private handleAlignChange = (alignIndicator: Alignment) => this.setState({ alignIndicator });
+    private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
     private handleInlineChange = handleBooleanChange(inline => this.setState({ inline }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 }


### PR DESCRIPTION
- Checkbox alignment has always been a few pixels off from normal text, because the indicator relied heavily on line-height for centering (classic 2014).
- In this PR, control indicator is now an inline element and does not rely on line-height for positioning.
- Also refactor away from a bad `@extend` that generated very bloated CSS.

### before
height: 16px. padding/position.
![image](https://user-images.githubusercontent.com/464822/43106318-0741f782-8e8d-11e8-982d-381b08ec467f.png)

### after
height: 18px (standard line-height). centered: perfect.
![image](https://user-images.githubusercontent.com/464822/43106296-e9f12900-8e8c-11e8-94b4-468fa39280be.png)
