### PR TITLE
[Core] Rerender popovers when content resizes

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import { ModifierFn } from "popper.js";
 import * as React from "react";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from "react-popper";
+import ResizeObserver from "resize-observer-polyfill";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
@@ -126,6 +127,9 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     // a flag that indicates whether the target previously lost focus to another
     // element on the same page.
     private lostFocusOnSamePage = true;
+
+    // A reference to the Resize observer to prevent it getting recreated on every render
+    private popperObserver: ResizeObserver;
 
     private refHandlers = {
         popover: (ref: HTMLElement) => {
@@ -287,6 +291,12 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
             },
             this.props.popoverClassName,
         );
+
+        // If the popover resizes, force popper to rerender.
+        if (this.popoverElement && !this.popperObserver) {
+            this.popperObserver = new ResizeObserver(popperProps.scheduleUpdate);
+            this.popperObserver.observe(this.popoverElement);
+        }
 
         return (
             <div className={Classes.TRANSITION_CONTAINER} ref={popperProps.ref} style={popperProps.style}>


### PR DESCRIPTION
#### Fixes #2684 / #692

#### Changes proposed in this pull request:

Proposed solution is to implement ResizeObserver as mentioned [here](https://github.com/palantir/blueprint/issues/692#issuecomment-393992276) to monitor for resizes on `this.popoverElement`. 

* I found the performance severely impacted if blindly creating an observer on every call to `Popover.renderPopover`, so instead initialise the observer on mount and then update reference to the `Popper.scheduleUpdate` on every call to `Popover.renderPopover` instead. 

* Realised that the DOM node the observer is watching may get removed when the popover is unmounted, so it would stop working, decided to update this on every `componentDidUpdate` which seems to work much better.

* I am unsure how to implement tests for this change, but if they are required I can spend more time looking into this.

#### Screenshot

##### Before 
![Alt Text](https://thumbs.gfycat.com/EnergeticConfusedAmericanbittern-size_restricted.gif)

##### After
![Alt Text](https://thumbs.gfycat.com/SnivelingFlashyDikkops-size_restricted.gif)

