### PR TITLE
[Checkbox] revert to padding/margin

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -65,8 +65,29 @@ $control-indicator-spacing: $pt-grid-size !default;
   }
 }
 
+@mixin indicator-position($size) {
+  $padding: $size + $control-indicator-spacing;
+
+  &:not(.#{$ns}-align-right) {
+    padding-left: $padding;
+
+    .#{$ns}-control-indicator {
+      margin-left: -$padding;
+    }
+  }
+
+  &.#{$ns}-align-right {
+    padding-right: $padding;
+
+    .#{$ns}-control-indicator {
+      margin-right: -$padding;
+    }
+  }
+}
+
 .#{$ns}-control {
   @include control-checked-colors();
+  @include indicator-position($control-indicator-size);
 
   display: block;
   position: relative;
@@ -132,7 +153,6 @@ $control-indicator-spacing: $pt-grid-size !default;
   &.#{$ns}-align-right .#{$ns}-control-indicator {
     float: right;
     margin-top: 1px;
-    margin-right: 0;
     margin-left: $control-indicator-spacing;
   }
 
@@ -288,6 +308,8 @@ $control-indicator-spacing: $pt-grid-size !default;
   $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.#{$ns}-switch {
+    @include indicator-position($switch-width);
+
     .#{$ns}-control-indicator {
       border: none;
       border-radius: $switch-width;
@@ -367,6 +389,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   }
 
   &.#{$ns}-large {
+    @include indicator-position($control-indicator-size-large);
     font-size: $pt-font-size-large;
 
     .#{$ns}-control-indicator {
@@ -379,6 +402,8 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     &.#{$ns}-switch {
+      @include indicator-position($switch-width-large);
+
       .#{$ns}-control-indicator {
         width: $switch-width-large;
         height: $switch-height-large;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -401,6 +401,10 @@ $control-indicator-spacing: $pt-grid-size !default;
       font-size: $radio-indicator-font-size-large;
     }
 
+    &.#{$ns}-align-right .#{$ns}-control-indicator {
+      margin-top: 0;
+    }
+
     &.#{$ns}-switch {
       @include indicator-position($switch-width-large);
 
@@ -412,10 +416,6 @@ $control-indicator-spacing: $pt-grid-size !default;
           width: $switch-height-large - ($switch-indicator-margin * 2);
           height: $switch-height-large - ($switch-indicator-margin * 2);
         }
-      }
-
-      &.#{$ns}-align-right .#{$ns}-control-indicator {
-        margin-top: 0;
       }
 
       input:checked ~ .#{$ns}-control-indicator {


### PR DESCRIPTION
- **before** #2716 removed the padding-left on checkbox which caused checkboxes with lots of content to use default flow layout: 
![image](https://user-images.githubusercontent.com/464822/43164528-40fc8a96-8f46-11e8-88e8-27059aa45774.png)
- **after** this PR brings back the padding/margin combo _as a mixin_ so it's much less repetitive:
![image](https://user-images.githubusercontent.com/464822/43164588-60baf688-8f46-11e8-807b-f3585fe762e9.png)
