### PR TITLE
[Checkbox] refactor indicators style

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -235,16 +235,11 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      border-radius: 50%;
-      background: $white;
+      background-image: radial-gradient($white 0%, $white 28%, transparent 32%);
     }
 
     input:checked:disabled ~ .#{$ns}-control-indicator::before {
-      box-shadow: none;
+      background-image: radial-gradient(rgba($white, 0.5) 0%, rgba($white, 0.5) 28%, transparent 32%);
     }
 
     input:focus ~ .#{$ns}-control-indicator {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -128,6 +128,13 @@ $control-indicator-spacing: $pt-grid-size !default;
     height: $control-indicator-size;
     vertical-align: middle;
     user-select: none;
+
+    &::before {
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+      content: "";
+    }
   }
 
   &:hover .#{$ns}-control-indicator {
@@ -190,13 +197,6 @@ $control-indicator-spacing: $pt-grid-size !default;
 
     .#{$ns}-control-indicator {
       border-radius: $pt-border-radius;
-
-      &::before {
-        display: block;
-        width: 100%;
-        height: 100%;
-        content: "";
-      }
     }
 
     input:checked ~ .#{$ns}-control-indicator {
@@ -237,16 +237,12 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      display: inline-block;
       position: absolute;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
       border-radius: 50%;
       background: $white;
-      width: 1em;
-      height: 1em;
-      content: "";
     }
 
     input:checked:disabled ~ .#{$ns}-control-indicator::before {
@@ -320,7 +316,6 @@ $control-indicator-spacing: $pt-grid-size !default;
       transition: background-color $pt-transition-duration $pt-transition-ease;
 
       &::before {
-        display: block;
         position: relative;
         top: $switch-indicator-margin;
         left: $switch-indicator-margin;
@@ -330,7 +325,6 @@ $control-indicator-spacing: $pt-grid-size !default;
         background-clip: padding-box;
         width: $switch-height - ($switch-indicator-margin * 2);
         height: $switch-height - ($switch-indicator-margin * 2);
-        content: "";
         transition: left $pt-transition-duration $pt-transition-ease;
       }
     }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -266,8 +266,6 @@ $control-indicator-spacing: $pt-grid-size !default;
   */
 
   // stylelint-disable-next-line order/order
-  $switch-height: $control-indicator-size !default;
-  $switch-height-large: $pt-grid-size * 2 !default;
   $switch-width: 1.75em !default;
   $switch-indicator-margin: 2px !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
@@ -290,11 +288,9 @@ $control-indicator-spacing: $pt-grid-size !default;
   $dark-switch-checked-background-color-active: $blue5 !default;
   $dark-switch-checked-background-color-disabled: rgba($blue1, 0.5) !default;
 
-  $switch-indicator-border: border-shadow($pt-border-shadow-opacity) !default;
   $switch-indicator-background-color: $white !default;
   $switch-indicator-background-color-disabled: rgba($white, 0.8) !default;
-  $dark-switch-indicator-border: border-shadow($pt-dark-border-shadow-opacity) !default;
-  $dark-switch-indicator-background-color: $dark-gray4 !default;
+  $dark-switch-indicator-background-color: $dark-gray5 !default;
   $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.#{$ns}-switch {
@@ -340,17 +336,15 @@ $control-indicator-spacing: $pt-grid-size !default;
       // stylelint-disable-next-line declaration-no-important
       box-shadow: none !important;
       width: $switch-width;
-      height: $switch-height;
       transition: background-color $pt-transition-duration $pt-transition-ease;
 
       &::before {
         position: relative;
-        border-radius: $switch-height;
         left: 0;
         margin: $switch-indicator-margin;
+        border-radius: 50%;
         box-shadow: $button-box-shadow-overlay;
         background: $switch-indicator-background-color;
-        background-clip: padding-box;
         width: $switch-indicator-size;
         height: $switch-indicator-size;
         transition: left $pt-transition-duration $pt-transition-ease;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -250,11 +250,11 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      background-image: radial-gradient($white 0%, $white 28%, transparent 32%);
+      background-image: radial-gradient($white, $white 28%, transparent 32%);
     }
 
     input:checked:disabled ~ .#{$ns}-control-indicator::before {
-      background-image: radial-gradient(rgba($white, 0.5) 0%, rgba($white, 0.5) 28%, transparent 32%);
+      background-image: radial-gradient(rgba($white, 0.5), rgba($white, 0.5) 28%, transparent 32%);
     }
 
     input:focus ~ .#{$ns}-control-indicator {
@@ -309,9 +309,9 @@ $control-indicator-spacing: $pt-grid-size !default;
   $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.#{$ns}-switch {
-    @mixin indicator-colors($selector, $default-color, $hover-color, $active-color, $disabled-color) {
+    @mixin indicator-colors($selector, $color, $hover-color, $active-color, $disabled-color) {
       input#{$selector} ~ .#{$ns}-control-indicator {
-        background: $default-color;
+        background: $color;
       }
 
       &:hover input#{$selector} ~ .#{$ns}-control-indicator {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -124,9 +124,12 @@ $control-indicator-spacing: $pt-grid-size !default;
     background-color: $control-background-color;
     background-image: $button-gradient;
     cursor: pointer;
-    width: $control-indicator-size;
-    height: $control-indicator-size;
+    width: 1em;
+    height: 1em;
     vertical-align: middle;
+    // font-size is used to size indicator for all control types,
+    // to reduce property changes needed across types and sizes (large).
+    font-size: $control-indicator-size;
     user-select: none;
 
     &::before {
@@ -226,14 +229,9 @@ $control-indicator-spacing: $pt-grid-size !default;
   Styleguide radio
   */
 
-  // stylelint-disable-next-line order/order
-  $radio-indicator-font-size: $pt-grid-size * 0.6 !default;
-  $radio-indicator-font-size-large: $pt-grid-size * 0.8 !default;
-
   &.#{$ns}-radio {
     .#{$ns}-control-indicator {
       border-radius: 50%;
-      font-size: $radio-indicator-font-size;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
@@ -275,9 +273,9 @@ $control-indicator-spacing: $pt-grid-size !default;
   // stylelint-disable-next-line order/order
   $switch-height: $control-indicator-size !default;
   $switch-height-large: $pt-grid-size * 2 !default;
-  $switch-width: $pt-grid-size * 2.8 !default;
-  $switch-width-large: $pt-grid-size * 3.2 !default;
-  $switch-indicator-margin: $pt-grid-size * 0.2 !default;
+  $switch-width: 1.75em !default;
+  $switch-indicator-margin: 2px !default;
+  $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
 
   $switch-background-color: rgba($gray4, 0.5) !default;
   $switch-background-color-hover: rgba($gray2, 0.5) !default;
@@ -287,6 +285,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   $switch-checked-background-color-hover: $control-checked-background-color-hover !default;
   $switch-checked-background-color-active: $control-checked-background-color-active !default;
   $switch-checked-background-color-disabled: rgba($blue3, 0.5) !default;
+
   $dark-switch-background-color: rgba($black, 0.5) !default;
   $dark-switch-background-color-hover: rgba($black, 0.7) !default;
   $dark-switch-background-color-active: rgba($black, 0.9) !default;
@@ -304,7 +303,8 @@ $control-indicator-spacing: $pt-grid-size !default;
   $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.#{$ns}-switch {
-    @include indicator-position($switch-width);
+    // convert em variable to px value
+    @include indicator-position($switch-width / 1em * $control-indicator-size);
 
     .#{$ns}-control-indicator {
       border: none;
@@ -317,14 +317,14 @@ $control-indicator-spacing: $pt-grid-size !default;
 
       &::before {
         position: relative;
-        top: $switch-indicator-margin;
-        left: $switch-indicator-margin;
         border-radius: $switch-height;
+        left: 0;
+        margin: $switch-indicator-margin;
         box-shadow: $button-box-shadow-overlay;
         background: $switch-indicator-background-color;
         background-clip: padding-box;
-        width: $switch-height - ($switch-indicator-margin * 2);
-        height: $switch-height - ($switch-indicator-margin * 2);
+        width: $switch-indicator-size;
+        height: $switch-indicator-size;
         transition: left $pt-transition-duration $pt-transition-ease;
       }
     }
@@ -384,15 +384,12 @@ $control-indicator-spacing: $pt-grid-size !default;
 
   &.#{$ns}-large {
     @include indicator-position($control-indicator-size-large);
+    // larger text
     font-size: $pt-font-size-large;
 
     .#{$ns}-control-indicator {
-      width: $control-indicator-size-large;
-      height: $control-indicator-size-large;
-    }
-
-    &.#{$ns}-radio .#{$ns}-control-indicator {
-      font-size: $radio-indicator-font-size-large;
+      // em-based sizing
+      font-size: $control-indicator-size-large;
     }
 
     &.#{$ns}-align-right .#{$ns}-control-indicator {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -298,14 +298,47 @@ $control-indicator-spacing: $pt-grid-size !default;
   $dark-switch-indicator-background-color-disabled: rgba($black, 0.4) !default;
 
   &.#{$ns}-switch {
+    @mixin indicator-colors($selector, $default-color, $hover-color, $active-color, $disabled-color) {
+      input#{$selector} ~ .#{$ns}-control-indicator {
+        background: $default-color;
+      }
+
+      &:hover input#{$selector} ~ .#{$ns}-control-indicator {
+        background: $hover-color;
+      }
+
+      input#{$selector}:not(:disabled):active ~ .#{$ns}-control-indicator {
+        background: $active-color;
+      }
+
+      input#{$selector}:disabled ~ .#{$ns}-control-indicator {
+        background: $disabled-color;
+      }
+    }
+
+    @include indicator-colors(
+      "",
+      $switch-background-color,
+      $switch-background-color-hover,
+      $switch-background-color-active,
+      $switch-background-color-disabled
+    );
+    @include indicator-colors(
+      ":checked",
+      $switch-checked-background-color,
+      $switch-checked-background-color-hover,
+      $switch-checked-background-color-active,
+      $switch-checked-background-color-disabled
+    );
     // convert em variable to px value
     @include indicator-position($switch-width / 1em * $control-indicator-size);
 
     .#{$ns}-control-indicator {
       border: none;
       border-radius: $switch-width;
-      box-shadow: none;
-      background: $switch-background-color;
+      // override default button styles, never have a box-shadow here.
+      // stylelint-disable-next-line declaration-no-important
+      box-shadow: none !important;
       width: $switch-width;
       height: $switch-height;
       transition: background-color $pt-transition-duration $pt-transition-ease;
@@ -324,58 +357,44 @@ $control-indicator-spacing: $pt-grid-size !default;
       }
     }
 
-    input:checked ~ .#{$ns}-control-indicator {
-      box-shadow: none;
-      background-color: $switch-checked-background-color;
-      width: $switch-width;
-      height: $switch-height;
-
-      &::before {
-        left: $switch-width - $switch-height + $switch-indicator-margin;
-        box-shadow: $button-box-shadow-overlay;
-      }
+    input:checked ~ .#{$ns}-control-indicator::before {
+      // 1em is size of indicator
+      left: $switch-width - 1em;
     }
 
-    &:hover {
-      .#{$ns}-control-indicator {
-        background-color: $switch-background-color-hover;
-      }
-
-      input:checked ~ .#{$ns}-control-indicator {
-        background-color: $switch-checked-background-color-hover;
-      }
+    &.#{$ns}-large {
+      @include indicator-position($switch-width / 1em * $control-indicator-size-large);
     }
 
-    input:not(:disabled):active {
-      ~ .#{$ns}-control-indicator {
-        box-shadow: none;
-        background-color: $switch-background-color-active;
+    .#{$ns}-dark & {
+      @include indicator-colors(
+        "",
+        $switch-background-color,
+        $switch-background-color-hover,
+        $switch-background-color-active,
+        $switch-background-color-disabled
+      );
+      @include indicator-colors(
+        ":checked",
+        $switch-checked-background-color,
+        $switch-checked-background-color-hover,
+        $switch-checked-background-color-active,
+        $switch-checked-background-color-disabled
+      );
+
+      .#{$ns}-control-indicator::before {
+        box-shadow: $dark-button-box-shadow;
+        background: $dark-switch-indicator-background-color;
       }
 
-      &:checked ~ .#{$ns}-control-indicator {
-        background-color: $control-checked-background-color-active;
-
-        &::before {
-          box-shadow: $button-box-shadow-overlay;
-        }
-      }
-    }
-
-    input:disabled {
-      ~ .#{$ns}-control-indicator {
-        background-color: $switch-background-color-disabled;
-
-        &::before {
-          box-shadow: none;
-          background-color: $switch-indicator-background-color-disabled;
-        }
-      }
-
-      &:checked ~ .#{$ns}-control-indicator {
-        background-color: $switch-checked-background-color-disabled;
+      input:checked ~ .#{$ns}-control-indicator::before {
+        // inset shadow so it forms a dark line instead of blurring into the blue
+        box-shadow: inset $dark-button-box-shadow;
       }
     }
   }
+
+
 
   &.#{$ns}-large {
     @include indicator-position($control-indicator-size-large);
@@ -389,29 +408,6 @@ $control-indicator-spacing: $pt-grid-size !default;
 
     &.#{$ns}-align-right .#{$ns}-control-indicator {
       margin-top: 0;
-    }
-
-    &.#{$ns}-switch {
-      @include indicator-position($switch-width-large);
-
-      .#{$ns}-control-indicator {
-        width: $switch-width-large;
-        height: $switch-height-large;
-
-        &::before {
-          width: $switch-height-large - ($switch-indicator-margin * 2);
-          height: $switch-height-large - ($switch-indicator-margin * 2);
-        }
-      }
-
-      input:checked ~ .#{$ns}-control-indicator {
-        width: $switch-width-large;
-        height: $switch-height-large;
-
-        &::before {
-          left: $switch-width-large - $switch-height-large + $switch-indicator-margin;
-        }
-      }
     }
   }
 
@@ -448,74 +444,6 @@ $control-indicator-spacing: $pt-grid-size !default;
       &:indeterminate {
         ~ .#{$ns}-control-indicator {
           color: $dark-button-color-disabled;
-        }
-      }
-    }
-
-    &.#{$ns}-switch {
-      .#{$ns}-control-indicator {
-        box-shadow: none;
-        background: $dark-switch-background-color;
-
-        &::before {
-          box-shadow: $dark-button-box-shadow;
-          background: $dark-switch-indicator-background-color;
-        }
-      }
-
-      input:checked ~ .#{$ns}-control-indicator {
-        box-shadow: none;
-        background-color: $dark-switch-checked-background-color;
-
-        &::before {
-          box-shadow: inset $dark-button-box-shadow;
-        }
-      }
-
-      &:hover {
-        .#{$ns}-control-indicator {
-          background: $dark-switch-background-color-hover;
-        }
-
-        input:checked ~ .#{$ns}-control-indicator {
-          background: $dark-switch-checked-background-color-hover;
-        }
-      }
-
-      input:not(:disabled):active {
-        ~ .#{$ns}-control-indicator {
-          box-shadow: none;
-          background: $dark-switch-background-color-active;
-
-          // we're in too deep to quit
-          // stylelint-disable max-nesting-depth
-          &::before {
-            box-shadow: $dark-button-box-shadow;
-          }
-        }
-
-        &:checked ~ .#{$ns}-control-indicator {
-          background: $dark-switch-checked-background-color-active;
-
-          &::before {
-            box-shadow: inset $dark-button-box-shadow;
-          }
-        }
-      }
-
-      input:disabled {
-        ~ .#{$ns}-control-indicator {
-          background: $dark-switch-background-color-disabled;
-
-          &::before {
-            box-shadow: none;
-            background: $dark-switch-indicator-background-color-disabled;
-          }
-          // stylelint-enable max-nesting-depth
-        }
-
-        &:checked ~ .#{$ns}-control-indicator {
-          background: $dark-switch-checked-background-color-disabled;
         }
       }
     }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -254,7 +254,7 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked:disabled ~ .#{$ns}-control-indicator::before {
-      background-image: radial-gradient(rgba($white, 0.5), rgba($white, 0.5) 28%, transparent 32%);
+      opacity: 0.5;
     }
 
     input:focus ~ .#{$ns}-control-indicator {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -166,6 +166,21 @@ $control-indicator-spacing: $pt-grid-size !default;
     margin-left: $control-indicator-spacing;
   }
 
+  &.#{$ns}-large {
+    @include indicator-position($control-indicator-size-large);
+    // larger text
+    font-size: $pt-font-size-large;
+
+    .#{$ns}-control-indicator {
+      // em-based sizing
+      font-size: $control-indicator-size-large;
+    }
+
+    &.#{$ns}-align-right .#{$ns}-control-indicator {
+      margin-top: 0;
+    }
+  }
+
   /*
   Checkbox
 
@@ -385,23 +400,6 @@ $control-indicator-spacing: $pt-grid-size !default;
         // inset shadow so it forms a dark line instead of blurring into the blue
         box-shadow: inset $dark-button-box-shadow;
       }
-    }
-  }
-
-
-
-  &.#{$ns}-large {
-    @include indicator-position($control-indicator-size-large);
-    // larger text
-    font-size: $pt-font-size-large;
-
-    .#{$ns}-control-indicator {
-      // em-based sizing
-      font-size: $control-indicator-size-large;
-    }
-
-    &.#{$ns}-align-right .#{$ns}-control-indicator {
-      margin-top: 0;
     }
   }
 


### PR DESCRIPTION
- as much shared indicator style as possible
- indicator uses `1em` for size so all we have to do for large is bump the `font-size`
   - switch uses other values to achieve its oblong appearance
- Radio indicator uses radial-gradient for the white dot
- Switch `indicator-colors()` mixin for legibility & remove unused variables