### PR TITLE
[docs] handful of small edits

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -24,9 +24,10 @@ export interface IButtonProps extends IActionProps {
     active?: boolean;
 
     /**
-     * Text alignment within button. By default, icons and text will be centered within the button.
-     * Passing this prop will cause the text container to fill the button and align the text within that
-     * to the appropriate side. `icon` and `rightIcon` will be pushed to either side.
+     * Text alignment within button. By default, icons and text will be centered
+     * within the button. Passing `"left"` or `"right"` will align the button
+     * text to that side and push `icon` and `rightIcon` to either edge. Passing
+     * `"center"` will center the text and icons together.
      * @default Alignment.CENTER
      */
     alignText?: Alignment;

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -12,11 +12,10 @@ import { HTMLDivProps, IProps } from "../../common/props";
 
 export interface IButtonGroupProps extends IProps, HTMLDivProps {
     /**
-     * Text alignment of button contents.
-     * This prop only has an effect if buttons are wider than their default widths.
-     *
-     * `Alignment.LEFT` will left-align button text and push `rightIcon` to right side.
-     * `Alignment.RIGHT` right-aligns text and pushes `icon` to left side.
+     * Text alignment within button. By default, icons and text will be centered
+     * within the button. Passing `"left"` or `"right"` will align the button
+     * text to that side and push `icon` and `rightIcon` to either edge. Passing
+     * `"center"` will center the text and icons together.
      */
     alignText?: Alignment;
 

--- a/packages/core/src/components/navbar/navbar.md
+++ b/packages/core/src/components/navbar/navbar.md
@@ -42,7 +42,7 @@ the full range of HTML `<div>` props.
 ```tsx
 <Navbar>
     <Navbar.Group align={Alignment.LEFT}>
-        <Navbar.Heading>Blueprint</NavbarHeading>
+        <Navbar.Heading>Blueprint</Navbar.Heading>
         <Navbar.Divider />
         <Button className="@ns-minimal" icon="home" text="Home" />
         <Button className="@ns-minimal" icon="document" text="Files" />

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -49,7 +49,7 @@ export class OmnibarExample extends React.PureComponent<IExampleProps, IOmnibarE
                 <Hotkey
                     allowInInput={true}
                     global={true}
-                    combo="meta + k"
+                    combo="shift + o"
                     label="Show Omnibar"
                     onKeyDown={this.handleToggle}
                 />
@@ -70,7 +70,7 @@ export class OmnibarExample extends React.PureComponent<IExampleProps, IOmnibarE
                 <span>
                     <Button text="Click to show Omnibar" onClick={this.handleClick} />
                     {" or press "}
-                    <KeyCombo combo="meta + k" />
+                    <KeyCombo combo="shift + o" />
                 </span>
 
                 <FilmOmnibar

--- a/packages/table/src/docs/table.md
+++ b/packages/table/src/docs/table.md
@@ -7,6 +7,13 @@ A highly interactive React `Table` component.
   [`HTMLTable` in **@blueprintjs/core**](#core/components/html-table).
 </div>
 
+Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
+Do not forget to include `blueprint-table.css` on your page.
+
+```sh
+npm install --save @blueprintjs/table
+```
+
 ### Features
 
 * High-scale, data-agnostic
@@ -17,10 +24,6 @@ A highly interactive React `Table` component.
 * Editable headers and cells
 * Integrated header and context menus
 
-```sh
-npm install --save @blueprintjs/core @blueprintjs/table
-```
-
 @## Basic usage
 
 To create a table, you must define the rows and columns. Add children to the `Table` to create columns,
@@ -29,6 +32,8 @@ and change the `numRows` prop on the `Table` to set the number of rows.
 For example, this code creates an empty table with three columns and five rows:
 
 ```tsx
+import { Column, Table } from "@blueprintjs/table";
+
 <Table numRows={5}>
     <Column />
     <Column />
@@ -44,6 +49,8 @@ This is useful when working with typed columnar data, like database results.
 For example, this creates a table that renders dollar values:
 
 ```tsx
+import { Cell, Column, Table } from "@blueprintjs/table";
+
 const cellRenderer = (rowIndex: number) => {
     return <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>
 };


### PR DESCRIPTION
- fixes #2419: change omnibar hotkey to `shift+o` to avoid FF conflict
- fixes #2695: `Navbar.Heading` typo
- fixes #2696: mention table.css in Table docs
- clarify `Button` `alignText`