### PR TITLE
[select] ensure valid initially selected item

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -161,8 +161,8 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                     query: "",
                 });
             }
-            Utils.safeInvoke(this.props.onItemSelect, item, evt);
         }
+        Utils.safeInvoke(this.props.onItemSelect, item, evt);
     };
 
     private handlePopoverInteraction = (nextOpenState: boolean) =>

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -37,7 +37,7 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S extends
             // only filtered items re-rendered
             testProps.itemRenderer.resetHistory();
             wrapper.setState({ query: "1999" });
-            assert.equal(testProps.itemRenderer.callCount, 4, "re-render");
+            assert.equal(testProps.itemRenderer.callCount, 2, "re-render");
         });
 
         it("renders noResults when given empty list", () => {


### PR DESCRIPTION
#### Fixes #2634 

#### Changes proposed in this pull request:

- ensure QueryList always selects a valid item, especially when resetting.
- much of this is setup for the next PR which will introduce un/controlled query & activeItem support to all components.