### PR TITLE
Remove null from signature of formatDate

### DIFF
--- a/packages/datetime/src/dateFormat.tsx
+++ b/packages/datetime/src/dateFormat.tsx
@@ -33,11 +33,10 @@ export interface IDateFormatProps {
 
     /**
      * Function to render a JavaScript `Date` to a string.
-     * The special value `null` indicates the absence of a date.
      * Optional `locale` argument comes directly from the prop on this component:
      * if the prop is defined, then the argument will be too.
      */
-    formatDate(date: Date | null, locale?: string): string;
+    formatDate(date: Date, locale?: string): string;
 
     /**
      * Function to deserialize user input text to a JavaScript `Date` object.


### PR DESCRIPTION
#### Fixes #2612 

#### Changes proposed in this pull request:

As per https://github.com/palantir/blueprint/issues/2612 - Remove null from the signature of the `formatDate` function.

#### Reviewers should focus on:

~~This is a non-backward compatible API change.~~

#### Screenshot

N/A
