### PR TITLE
[webpack-build-scripts] put assets in assets/ dir, preserve filenames

### DIFF
--- a/packages/webpack-build-scripts/webpack.config.base.js
+++ b/packages/webpack-build-scripts/webpack.config.base.js
@@ -130,7 +130,7 @@ module.exports = {
                 test: /\.(eot|ttf|woff|woff2|svg|png|gif|jpe?g)$/,
                 loader: require.resolve("file-loader"),
                 options: {
-                    name: "[name].[ext]",
+                    name: "[name].[ext]?[hash]",
                     outputPath: "assets/",
                 },
             },

--- a/packages/webpack-build-scripts/webpack.config.base.js
+++ b/packages/webpack-build-scripts/webpack.config.base.js
@@ -129,6 +129,10 @@ module.exports = {
             {
                 test: /\.(eot|ttf|woff|woff2|svg|png|gif|jpe?g)$/,
                 loader: require.resolve("file-loader"),
+                options: {
+                    name: "[name].[ext]",
+                    outputPath: "assets/",
+                },
             },
         ],
     },


### PR DESCRIPTION
- put assets in `assets/` directory so they don't pollute the root directory
- preserve original filename (much shorter than hash) but include hash as query param for cache busting