### PR TITLE
[ControlGroup] Give border radius to :only-child

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -189,6 +189,7 @@ Styleguide control-group
     border-radius: 0 $pt-border-radius $pt-border-radius 0;
   }
 
+  // round all the corners of the only child element
   > :only-child {
     margin-right: 0;
     border-radius: $pt-border-radius;

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -189,6 +189,11 @@ Styleguide control-group
     border-radius: 0 $pt-border-radius $pt-border-radius 0;
   }
 
+  > :only-child {
+    margin-right: 0;
+    border-radius: $pt-border-radius;
+  }
+
   // bring back border radius on these buttons
   .#{$ns}-input-group .#{$ns}-button {
     border-radius: $pt-border-radius;


### PR DESCRIPTION
Currently when a ControlGroup only has a single child component the :last-child border rules are applied.

```
<ControlGroup>
    <Button icon="filter">Filter</Button>
</ControlGroup>
```

#### Screenshot

__Before:__
![screen shot 2018-07-30 at 9 31 29 am](https://user-images.githubusercontent.com/340715/43370937-17314e32-93dc-11e8-8419-f21daa3f9cee.png)


__After:__
![screen shot 2018-07-30 at 9 31 07 am](https://user-images.githubusercontent.com/340715/43370921-cebddaee-93db-11e8-8fc1-82c6fab5cc1d.png)


