### PR TITLE
[PanelStack] use IPanel in openPanel() public API

### DIFF
--- a/packages/core/src/components/panel-stack/panelProps.ts
+++ b/packages/core/src/components/panel-stack/panelProps.ts
@@ -54,7 +54,7 @@ export interface IPanelProps {
      * @param props The props to be passed to the new panel.
      * @param options Additional options for the new panel.
      */
-    openPanel<P>(component: React.ComponentType<P & IPanelProps>, props: P, options: IPanelOptions): void;
+    openPanel<P>(panel: IPanel<P>): void;
 }
 
 export interface IPanelOptions {

--- a/packages/core/src/components/panel-stack/panelProps.ts
+++ b/packages/core/src/components/panel-stack/panelProps.ts
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-export interface IPanel<P = {}> extends IPanelOptions {
+export interface IPanel<P = {}> {
     /**
      * The component type to render for this panel. This is a reference to the
      * component class or SFC, _not_ a JSX.Element, so it can be re-created
@@ -19,6 +19,12 @@ export interface IPanel<P = {}> extends IPanelOptions {
      * in `IPanelProps` will be injected by `PanelStack`.
      */
     props?: P;
+
+    /**
+     * The title to be displayed above this panel. It is also used as the text
+     * of the back button for any panel opened by this panel.
+     */
+    title?: React.ReactNode;
 }
 
 /**
@@ -50,17 +56,6 @@ export interface IPanelProps {
 
     /**
      * Call this method to open a new panel on the top of the stack.
-     * @param component The React component of the new panel.
-     * @param props The props to be passed to the new panel.
-     * @param options Additional options for the new panel.
      */
     openPanel<P>(panel: IPanel<P>): void;
-}
-
-export interface IPanelOptions {
-    /**
-     * The title to be displayed above this panel. It is also used as the text
-     * of the back button for any panel opened by this panel.
-     */
-    title?: React.ReactNode;
 }

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -82,7 +82,7 @@ export class PanelStack extends React.PureComponent<IPanelStackProps, IPanelStac
     private handlePanelClose = (panel: IPanel) => {
         const { stack } = this.state;
         // only remove this panel if it is at the top and not the only one.
-        if (stack[0] !== panel || stack.length === 0) {
+        if (stack[0] !== panel || stack.length <= 1) {
             return;
         }
         safeInvoke(this.props.onClose, panel);

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -9,14 +9,23 @@ import * as React from "react";
 import { Classes } from "../../common";
 import { Button } from "../button/buttons";
 import { Text } from "../text/text";
-import { IPanel, IPanelProps } from "./panelProps";
+import { IPanel } from "./panelProps";
 
 export interface IPanelViewProps {
+    /**
+     * Callback invoked when the user presses the back button or a panel invokes
+     * the `closePanel()` injected prop method.
+     */
+    onClose: (removedPanel: IPanel) => void;
+
+    /**
+     * Callback invoked when a panel invokes the `openPanel(panel)` injected
+     * prop method.
+     */
+    onOpen: (addedPanel: IPanel) => void;
+
     /** The panel to be displayed. */
     panel: IPanel;
-
-    /** Props to inject into the panel, in addition to its own props. */
-    panelProps: IPanelProps;
 
     /** The previous panel in the stack, for rendering the "back" button. */
     previousPanel?: IPanel;
@@ -24,7 +33,7 @@ export interface IPanelViewProps {
 
 export class PanelView extends React.PureComponent<IPanelViewProps> {
     public render() {
-        const { panel, panelProps } = this.props;
+        const { panel, onOpen } = this.props;
         // two <span> tags in header ensure title is centered as long as
         // possible, due to `flex: 1` magic.
         return (
@@ -36,7 +45,7 @@ export class PanelView extends React.PureComponent<IPanelViewProps> {
                     </Text>
                     <span />
                 </div>
-                <panel.component {...panelProps} {...panel.props} />
+                <panel.component openPanel={onOpen} closePanel={this.handleClose} {...panel.props} />
             </div>
         );
     }
@@ -50,10 +59,12 @@ export class PanelView extends React.PureComponent<IPanelViewProps> {
                 className={Classes.PANEL_STACK_HEADER_BACK}
                 icon="chevron-left"
                 minimal={true}
-                onClick={this.props.panelProps.closePanel}
+                onClick={this.handleClose}
                 small={true}
                 text={this.props.previousPanel.title}
             />
         );
     }
+
+    private handleClose = () => this.props.onClose(this.props.panel);
 }

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -21,7 +21,7 @@ export class TestPanel extends React.Component<IPanelProps> {
         );
     }
 
-    private openPanel = () => this.props.openPanel(TestPanel, {}, { title: "New Panel 1" });
+    private openPanel = () => this.props.openPanel({ component: TestPanel, title: "New Panel 1" });
 }
 
 describe("<PanelStack>", () => {

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -71,7 +71,11 @@ class PanelExample extends React.PureComponent<IPanelProps & IPanelExampleProps>
     }
 
     private openNewPanel = () => {
-        const newPanelNumber = this.props.panelNumber + 1;
-        this.props.openPanel(PanelExample, { panelNumber: newPanelNumber }, { title: "Panel " + newPanelNumber });
+        const panelNumber = this.props.panelNumber + 1;
+        this.props.openPanel({
+            component: PanelExample,
+            props: { panelNumber },
+            title: `Panel ${panelNumber}`,
+        });
     };
 }


### PR DESCRIPTION
- `openPanel` accepts IPanel instead of three args.
    -this is more future-proof as we can update the one interface in non-breaking ways and see benefits everywhere, whereas changing the signature of the function would be breaking.
- `PanelView` `onClose/Open` props cleans up the `PanelStack` logic

cc @kadhirvelm 