### PR TITLE
[all] fix displayName for Blueprint3

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -9,6 +9,8 @@ import * as React from "react";
 import { IconName } from "@blueprintjs/icons";
 import { Intent } from "./intent";
 
+export const DISPLAYNAME_PREFIX = "Blueprint3";
+
 /**
  * Alias for all valid HTML props for `<div>` element.
  * Does not include React's `ref` or `key`.

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -108,7 +108,7 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
         isOpen: false,
     };
 
-    public static displayName = "Blueprint2.Alert";
+    public static displayName = "Blueprint3.Alert";
 
     public render() {
         const {

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes, Intent, IProps } from "../../common";
+import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Intent, IProps } from "../../common";
 import {
     ALERT_WARN_CANCEL_ESCAPE_KEY,
     ALERT_WARN_CANCEL_OUTSIDE_CLICK,
@@ -108,7 +108,7 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
         isOpen: false,
     };
 
-    public static displayName = "Blueprint3.Alert";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Alert`;
 
     public render() {
         const {

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 export interface IButtonGroupProps extends IProps, HTMLDivProps {
     /**
@@ -47,7 +47,7 @@ export interface IButtonGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class ButtonGroup extends React.PureComponent<IButtonGroupProps, {}> {
-    public static displayName = "Blueprint3.ButtonGroup";
+    public static displayName = `${DISPLAYNAME_PREFIX}.ButtonGroup`;
 
     public render() {
         const { alignText, className, fill, minimal, large, vertical, ...htmlProps } = this.props;

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -47,7 +47,7 @@ export interface IButtonGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class ButtonGroup extends React.PureComponent<IButtonGroupProps, {}> {
-    public static displayName = "Blueprint2.ButtonGroup";
+    public static displayName = "Blueprint3.ButtonGroup";
 
     public render() {
         const { alignText, className, fill, minimal, large, vertical, ...htmlProps } = this.props;

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -9,13 +9,13 @@
 
 import * as React from "react";
 
-import { removeNonHTMLProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { AbstractButton, IButtonProps } from "./abstractButton";
 
 export { IButtonProps };
 
 export class Button extends AbstractButton<React.ButtonHTMLAttributes<HTMLButtonElement>> {
-    public static displayName = "Blueprint3.Button";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Button`;
 
     public render() {
         return (
@@ -27,7 +27,7 @@ export class Button extends AbstractButton<React.ButtonHTMLAttributes<HTMLButton
 }
 
 export class AnchorButton extends AbstractButton<React.AnchorHTMLAttributes<HTMLAnchorElement>> {
-    public static displayName = "Blueprint3.AnchorButton";
+    public static displayName = `${DISPLAYNAME_PREFIX}.AnchorButton`;
 
     public render() {
         const { href, tabIndex = 0 } = this.props;

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -15,7 +15,7 @@ import { AbstractButton, IButtonProps } from "./abstractButton";
 export { IButtonProps };
 
 export class Button extends AbstractButton<React.ButtonHTMLAttributes<HTMLButtonElement>> {
-    public static displayName = "Blueprint2.Button";
+    public static displayName = "Blueprint3.Button";
 
     public render() {
         return (
@@ -27,7 +27,7 @@ export class Button extends AbstractButton<React.ButtonHTMLAttributes<HTMLButton
 }
 
 export class AnchorButton extends AbstractButton<React.AnchorHTMLAttributes<HTMLAnchorElement>> {
-    public static displayName = "Blueprint2.AnchorButton";
+    public static displayName = "Blueprint3.AnchorButton";
 
     public render() {
         const { href, tabIndex = 0 } = this.props;

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, HTMLDivProps, IIntentProps, Intent, IProps } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, HTMLDivProps, IIntentProps, Intent, IProps } from "../../common";
 import { Icon } from "../../index";
 import { H4 } from "../html/html";
 import { IconName } from "../icon/icon";
@@ -41,6 +41,8 @@ export interface ICalloutProps extends IIntentProps, IProps, HTMLDivProps {
 }
 
 export class Callout extends React.PureComponent<ICalloutProps, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Callout`;
+
     public render() {
         const { className, children, icon, intent, title, ...htmlProps } = this.props;
         const iconName = this.getIconName(icon, intent);

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -39,7 +39,7 @@ export interface ICardProps extends IProps, HTMLDivProps {
 }
 
 export class Card extends React.PureComponent<ICardProps, {}> {
-    public static displayName = "Blueprint2.Card";
+    public static displayName = "Blueprint3.Card";
     public static defaultProps: ICardProps = {
         elevation: Elevation.ZERO,
         interactive: false,

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
 import { Elevation } from "../../common/elevation";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 export interface ICardProps extends IProps, HTMLDivProps {
     /**
@@ -39,7 +39,7 @@ export interface ICardProps extends IProps, HTMLDivProps {
 }
 
 export class Card extends React.PureComponent<ICardProps, {}> {
-    public static displayName = "Blueprint3.Card";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Card`;
     public static defaultProps: ICardProps = {
         elevation: Elevation.ZERO,
         interactive: false,

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -84,7 +84,7 @@ export enum AnimationStates {
  * These are all animated.
  */
 export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseState> {
-    public static displayName = "Blueprint2.Collapse";
+    public static displayName = "Blueprint3.Collapse";
 
     public static defaultProps: ICollapseProps = {
         component: "div",

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
 export interface ICollapseProps extends IProps {
     /**
@@ -84,7 +84,7 @@ export enum AnimationStates {
  * These are all animated.
  */
 export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseState> {
-    public static displayName = "Blueprint3.Collapse";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Collapse`;
 
     public static defaultProps: ICollapseProps = {
         component: "div",

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -56,7 +56,7 @@ export interface ICollapsibleListProps extends IProps {
 
 /** @deprecated use `<OverflowList>` for automatic overflow based on available space. */
 export class CollapsibleList extends React.Component<ICollapsibleListProps, {}> {
-    public static displayName = "Blueprint2.CollapsibleList";
+    public static displayName = "Blueprint3.CollapsibleList";
 
     public static defaultProps: ICollapsibleListProps = {
         collapseFrom: Boundary.START,

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -11,7 +11,7 @@ import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { isElementOfType } from "../../common/utils";
 import { Menu } from "../menu/menu";
 import { IMenuItemProps, MenuItem } from "../menu/menuItem";
@@ -56,7 +56,7 @@ export interface ICollapsibleListProps extends IProps {
 
 /** @deprecated use `<OverflowList>` for automatic overflow based on available space. */
 export class CollapsibleList extends React.Component<ICollapsibleListProps, {}> {
-    public static displayName = "Blueprint3.CollapsibleList";
+    public static displayName = `${DISPLAYNAME_PREFIX}.CollapsibleList`;
 
     public static defaultProps: ICollapsibleListProps = {
         collapseFrom: Boundary.START,

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -68,7 +68,7 @@ export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
         isOpen: false,
     };
 
-    public static displayName = "Blueprint2.Dialog";
+    public static displayName = "Blueprint3.Dialog";
 
     public render() {
         return (

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
@@ -68,7 +68,7 @@ export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
         isOpen: false,
     };
 
-    public static displayName = "Blueprint3.Dialog";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Dialog`;
 
     public render() {
         return (

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
-import { IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp, safeInvoke } from "../../common/utils";
 import { Browser } from "../../compatibility";
 
@@ -105,6 +105,8 @@ const BUFFER_WIDTH_EDGE = 5;
 const BUFFER_WIDTH_IE = 30;
 
 export class EditableText extends AbstractPureComponent<IEditableTextProps, IEditableTextState> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.EditableText`;
+
     public static defaultProps: IEditableTextProps = {
         confirmOnEnterKey: false,
         defaultValue: "",

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 export interface IControlGroupProps extends IProps, HTMLDivProps {
     /**
@@ -26,7 +26,7 @@ export interface IControlGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class ControlGroup extends React.PureComponent<IControlGroupProps, {}> {
-    public static displayName = "Blueprint3.ControlGroup";
+    public static displayName = `${DISPLAYNAME_PREFIX}.ControlGroup`;
 
     public render() {
         const { children, className, fill, vertical, ...htmlProps } = this.props;

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -26,7 +26,7 @@ export interface IControlGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class ControlGroup extends React.PureComponent<IControlGroupProps, {}> {
-    public static displayName = "Blueprint2.ControlGroup";
+    public static displayName = "Blueprint3.ControlGroup";
 
     public render() {
         const { children, className, fill, vertical, ...htmlProps } = this.props;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -132,7 +132,7 @@ const Control: React.SFC<IControlInternalProps> = ({
 export interface ISwitchProps extends IControlProps {}
 
 export class Switch extends React.PureComponent<ISwitchProps> {
-    public static displayName = "Blueprint2.Switch";
+    public static displayName = "Blueprint3.Switch";
 
     public render() {
         return <Control {...this.props} type="checkbox" typeClassName={Classes.SWITCH} />;
@@ -146,7 +146,7 @@ export class Switch extends React.PureComponent<ISwitchProps> {
 export interface IRadioProps extends IControlProps {}
 
 export class Radio extends React.PureComponent<IRadioProps> {
-    public static displayName = "Blueprint2.Radio";
+    public static displayName = "Blueprint3.Radio";
 
     public render() {
         return <Control {...this.props} type="radio" typeClassName={Classes.RADIO} />;
@@ -178,7 +178,7 @@ export interface ICheckboxState {
 }
 
 export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState> {
-    public static displayName = "Blueprint2.Checkbox";
+    public static displayName = "Blueprint3.Checkbox";
 
     public state: ICheckboxState = {
         indeterminate: this.props.indeterminate || this.props.defaultIndeterminate || false,

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 
 import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
-import { HTMLInputProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 
 export interface IControlProps extends IProps, HTMLInputProps {
@@ -132,7 +132,7 @@ const Control: React.SFC<IControlInternalProps> = ({
 export interface ISwitchProps extends IControlProps {}
 
 export class Switch extends React.PureComponent<ISwitchProps> {
-    public static displayName = "Blueprint3.Switch";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Switch`;
 
     public render() {
         return <Control {...this.props} type="checkbox" typeClassName={Classes.SWITCH} />;
@@ -146,7 +146,7 @@ export class Switch extends React.PureComponent<ISwitchProps> {
 export interface IRadioProps extends IControlProps {}
 
 export class Radio extends React.PureComponent<IRadioProps> {
-    public static displayName = "Blueprint3.Radio";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Radio`;
 
     public render() {
         return <Control {...this.props} type="radio" typeClassName={Classes.RADIO} />;
@@ -178,7 +178,7 @@ export interface ICheckboxState {
 }
 
 export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState> {
-    public static displayName = "Blueprint3.Checkbox";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Checkbox`;
 
     public state: ICheckboxState = {
         indeterminate: this.props.indeterminate || this.props.defaultIndeterminate || false,

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -56,7 +56,7 @@ export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElem
 // TODO: write tests (ignoring for now to get a build passing quickly)
 /* istanbul ignore next */
 export class FileInput extends React.PureComponent<IFileInputProps, {}> {
-    public static displayName = "Blueprint2.FileInput";
+    public static displayName = "Blueprint3.FileInput";
 
     public static defaultProps: IFileInputProps = {
         inputProps: {},

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { Utils } from "../../common";
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
 export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, IProps {
     /**
@@ -56,7 +56,7 @@ export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElem
 // TODO: write tests (ignoring for now to get a build passing quickly)
 /* istanbul ignore next */
 export class FileInput extends React.PureComponent<IFileInputProps, {}> {
-    public static displayName = "Blueprint3.FileInput";
+    public static displayName = `${DISPLAYNAME_PREFIX}.FileInput`;
 
     public static defaultProps: IFileInputProps = {
         inputProps: {},

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 
 export interface IFormGroupProps extends IIntentProps, IProps {
     /**
@@ -42,6 +42,8 @@ export interface IFormGroupProps extends IIntentProps, IProps {
 }
 
 export class FormGroup extends React.PureComponent<IFormGroupProps, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.FormGroup`;
+
     public render() {
         const { children, helperText, label, labelFor, labelInfo } = this.props;
         return (

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -59,7 +59,7 @@ export interface IInputGroupState {
 }
 
 export class InputGroup extends React.PureComponent<IInputGroupProps & HTMLInputProps, IInputGroupState> {
-    public static displayName = "Blueprint2.InputGroup";
+    public static displayName = "Blueprint3.InputGroup";
 
     public state: IInputGroupState = {
         rightElementWidth: DEFAULT_RIGHT_ELEMENT_WIDTH,

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -8,7 +8,14 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { HTMLInputProps, IControlledProps, IIntentProps, IProps, removeNonHTMLProps } from "../../common/props";
+import {
+    DISPLAYNAME_PREFIX,
+    HTMLInputProps,
+    IControlledProps,
+    IIntentProps,
+    IProps,
+    removeNonHTMLProps,
+} from "../../common/props";
 import { Icon, IconName } from "../icon/icon";
 
 const DEFAULT_RIGHT_ELEMENT_WIDTH = 10;
@@ -59,7 +66,7 @@ export interface IInputGroupState {
 }
 
 export class InputGroup extends React.PureComponent<IInputGroupProps & HTMLInputProps, IInputGroupState> {
-    public static displayName = "Blueprint3.InputGroup";
+    public static displayName = `${DISPLAYNAME_PREFIX}.InputGroup`;
 
     public state: IInputGroupState = {
         rightElementWidth: DEFAULT_RIGHT_ELEMENT_WIDTH,

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -11,6 +11,7 @@ import { IconName } from "@blueprintjs/icons";
 import {
     AbstractPureComponent,
     Classes,
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IIntentProps,
     IProps,
@@ -139,7 +140,7 @@ enum IncrementDirection {
 }
 
 export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumericInputProps, INumericInputState> {
-    public static displayName = "Blueprint3.NumericInput";
+    public static displayName = `${DISPLAYNAME_PREFIX}.NumericInput`;
 
     public static VALUE_EMPTY = "";
     public static VALUE_ZERO = "0";

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -139,7 +139,7 @@ enum IncrementDirection {
 }
 
 export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumericInputProps, INumericInputState> {
-    public static displayName = "Blueprint2.NumericInput";
+    public static displayName = "Blueprint3.NumericInput";
 
     public static VALUE_EMPTY = "";
     public static VALUE_ZERO = "0";

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
-import { IOptionProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IOptionProps, IProps } from "../../common/props";
 import { isElementOfType } from "../../common/utils";
 import { IRadioProps, Radio } from "./controls";
 
@@ -58,7 +58,7 @@ function nextName() {
 }
 
 export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
-    public static displayName = "Blueprint3.RadioGroup";
+    public static displayName = `${DISPLAYNAME_PREFIX}.RadioGroup`;
 
     // a unique name for this group, which can be overridden by `name` prop.
     private autoGroupName = nextName();

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -58,7 +58,7 @@ function nextName() {
 }
 
 export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
-    public static displayName = "Blueprint2.RadioGroup";
+    public static displayName = "Blueprint3.RadioGroup";
 
     // a unique name for this group, which can be overridden by `name` prop.
     private autoGroupName = nextName();

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -29,7 +29,7 @@ export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTML
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
-    public static displayName = "Blueprint2.TextArea";
+    public static displayName = "Blueprint3.TextArea";
 
     public render() {
         const { className, fill, intent, large, inputRef, ...htmlProps } = this.props;

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 
 export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     /**
@@ -29,7 +29,7 @@ export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTML
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
-    public static displayName = "Blueprint3.TextArea";
+    public static displayName = `${DISPLAYNAME_PREFIX}.TextArea`;
 
     public render() {
         const { className, fill, intent, large, inputRef, ...htmlProps } = this.props;

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes, IProps } from "../../common";
+import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
 import { KeyCombo } from "./keyCombo";
 
 export interface IHotkeyProps extends IProps {

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 import classNames from "classnames";
-import { AbstractPureComponent, Classes, IProps } from "../../common";
+import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
 import { isElementOfType } from "../../common/utils";
 import { H4 } from "../html/html";
@@ -32,6 +32,8 @@ export interface IHotkeysProps extends IProps {
 }
 
 export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Hotkeys`;
+
     public static defaultProps = {
         tabIndex: 0,
     };

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -6,7 +6,7 @@
 
 import classNames from "classnames";
 import * as React from "react";
-import { Classes, IProps } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
 import { Icon, IconName } from "../icon/icon";
 import { normalizeKeyCombo } from "./hotkeyParser";
 
@@ -38,6 +38,8 @@ export interface IKeyComboProps extends IProps {
 }
 
 export class KeyCombo extends React.Component<IKeyComboProps, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.KeyCombo`;
+
     public render() {
         const { className, combo, minimal } = this.props;
         const keys = normalizeKeyCombo(combo)

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -56,7 +56,7 @@ export interface IIconProps extends IIntentProps, IProps {
 }
 
 export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<SVGElement>> {
-    public static displayName = "Blueprint2.Icon";
+    public static displayName = "Blueprint3.Icon";
 
     public static readonly SIZE_STANDARD = 16;
     public static readonly SIZE_LARGE = 20;

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { IconName, IconSvgPaths16, IconSvgPaths20 } from "@blueprintjs/icons";
-import { Classes, IIntentProps, IProps } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common";
 
 export { IconName };
 
@@ -56,7 +56,7 @@ export interface IIconProps extends IIntentProps, IProps {
 }
 
 export class Icon extends React.PureComponent<IIconProps & React.SVGAttributes<SVGElement>> {
-    public static displayName = "Blueprint3.Icon";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Icon`;
 
     public static readonly SIZE_STANDARD = 16;
     public static readonly SIZE_LARGE = 20;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { MenuDivider } from "./menuDivider";
 import { MenuItem } from "./menuItem";
 
@@ -21,7 +21,7 @@ export interface IMenuProps extends IProps {
 }
 
 export class Menu extends React.Component<IMenuProps, {}> {
-    public static displayName = "Blueprint3.Menu";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Menu`;
 
     public static Divider = MenuDivider;
     public static Item = MenuItem;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -21,7 +21,7 @@ export interface IMenuProps extends IProps {
 }
 
 export class Menu extends React.Component<IMenuProps, {}> {
-    public static displayName = "Blueprint2.Menu";
+    public static displayName = "Blueprint3.Menu";
 
     public static Divider = MenuDivider;
     public static Item = MenuItem;

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { H6 } from "../html/html";
 
 export interface IMenuDividerProps extends IProps {
@@ -20,7 +20,7 @@ export interface IMenuDividerProps extends IProps {
 }
 
 export class MenuDivider extends React.Component<IMenuDividerProps, {}> {
-    public static displayName = "Blueprint3.MenuDivider";
+    public static displayName = `${DISPLAYNAME_PREFIX}.MenuDivider`;
 
     public render() {
         const { className, title } = this.props;

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -20,7 +20,7 @@ export interface IMenuDividerProps extends IProps {
 }
 
 export class MenuDivider extends React.Component<IMenuDividerProps, {}> {
-    public static displayName = "Blueprint2.MenuDivider";
+    public static displayName = "Blueprint3.MenuDivider";
 
     public render() {
         const { className, title } = this.props;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { Modifiers } from "popper.js";
 import * as Classes from "../../common/classes";
 import { Position } from "../../common/position";
-import { IActionProps, ILinkProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IActionProps, ILinkProps } from "../../common/props";
 import { Icon } from "../icon/icon";
 import { IPopoverProps, Popover, PopoverInteractionKind } from "../popover/popover";
 import { Text } from "../text/text";
@@ -80,7 +80,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         shouldDismissPopover: true,
         text: "",
     };
-    public static displayName = "Blueprint3.MenuItem";
+    public static displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;
 
     public render() {
         const {

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -80,7 +80,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         shouldDismissPopover: true,
         text: "",
     };
-    public static displayName = "Blueprint2.MenuItem";
+    public static displayName = "Blueprint3.MenuItem";
 
     public render() {
         const {

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 import { NavbarDivider } from "./navbarDivider";
 import { NavbarGroup } from "./navbarGroup";
 import { NavbarHeading } from "./navbarHeading";
@@ -25,7 +25,7 @@ export interface INavbarProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class Navbar extends React.PureComponent<INavbarProps, {}> {
-    public static displayName = "Blueprint3.Navbar";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Navbar`;
 
     public static Divider = NavbarDivider;
     public static Group = NavbarGroup;

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -25,7 +25,7 @@ export interface INavbarProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class Navbar extends React.PureComponent<INavbarProps, {}> {
-    public static displayName = "Blueprint2.Navbar";
+    public static displayName = "Blueprint3.Navbar";
 
     public static Divider = NavbarDivider;
     public static Group = NavbarGroup;

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 // allow the empty interface so we can label it clearly in the docs
 export interface INavbarDividerProps extends IProps, HTMLDivProps {
@@ -17,7 +17,7 @@ export interface INavbarDividerProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarDivider extends React.PureComponent<INavbarDividerProps, {}> {
-    public static displayName = "Blueprint3.NavbarDivider";
+    public static displayName = `${DISPLAYNAME_PREFIX}.NavbarDivider`;
 
     public render() {
         const { className, ...htmlProps } = this.props;

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -17,7 +17,7 @@ export interface INavbarDividerProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarDivider extends React.PureComponent<INavbarDividerProps, {}> {
-    public static displayName = "Blueprint2.NavbarDivider";
+    public static displayName = "Blueprint3.NavbarDivider";
 
     public render() {
         const { className, ...htmlProps } = this.props;

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 export interface INavbarGroupProps extends IProps, HTMLDivProps {
     /**
@@ -22,7 +22,7 @@ export interface INavbarGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarGroup extends React.PureComponent<INavbarGroupProps, {}> {
-    public static displayName = "Blueprint3.NavbarGroup";
+    public static displayName = `${DISPLAYNAME_PREFIX}.NavbarGroup`;
 
     public static defaultProps: INavbarGroupProps = {
         align: Alignment.LEFT,

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -22,7 +22,7 @@ export interface INavbarGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarGroup extends React.PureComponent<INavbarGroupProps, {}> {
-    public static displayName = "Blueprint2.NavbarGroup";
+    public static displayName = "Blueprint3.NavbarGroup";
 
     public static defaultProps: INavbarGroupProps = {
         align: Alignment.LEFT,

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -17,7 +17,7 @@ export interface INavbarHeadingProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarHeading extends React.PureComponent<INavbarHeadingProps, {}> {
-    public static displayName = "Blueprint2.NavbarHeading";
+    public static displayName = "Blueprint3.NavbarHeading";
 
     public render() {
         const { children, className, ...htmlProps } = this.props;

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
-import { HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 // allow the empty interface so we can label it clearly in the docs
 export interface INavbarHeadingProps extends IProps, HTMLDivProps {
@@ -17,7 +17,7 @@ export interface INavbarHeadingProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 export class NavbarHeading extends React.PureComponent<INavbarHeadingProps, {}> {
-    public static displayName = "Blueprint3.NavbarHeading";
+    public static displayName = `${DISPLAYNAME_PREFIX}.NavbarHeading`;
 
     public render() {
         const { children, className, ...htmlProps } = this.props;

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { ensureElement } from "../../common/utils";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -11,7 +11,7 @@ import ResizeObserver from "resize-observer-polyfill";
 import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { throttle } from "../../common/utils";
 
 export interface IOverflowListProps<T> extends IProps {
@@ -74,7 +74,7 @@ export interface IOverflowListState<T> {
 }
 
 export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, IOverflowListState<T>> {
-    public static displayName = "Blueprint3.OverflowList";
+    public static displayName = `${DISPLAYNAME_PREFIX}.OverflowList`;
 
     public static defaultProps: Partial<IOverflowListProps<any>> = {
         collapseFrom: Boundary.START,

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -74,7 +74,7 @@ export interface IOverflowListState<T> {
 }
 
 export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, IOverflowListState<T>> {
-    public static displayName = "Blueprint2.OverflowList";
+    public static displayName = "Blueprint3.OverflowList";
 
     public static defaultProps: Partial<IOverflowListProps<any>> = {
         collapseFrom: Boundary.START,

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -149,7 +149,7 @@ export interface IOverlayState {
 }
 
 export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
-    public static displayName = "Blueprint2.Overlay";
+    public static displayName = "Blueprint3.Overlay";
 
     public static defaultProps: IOverlayProps = {
         autoFocus: true,

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -11,7 +11,7 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { findDOMNode } from "react-dom";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 import { Portal } from "../portal/portal";
 
@@ -149,7 +149,7 @@ export interface IOverlayState {
 }
 
 export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
-    public static displayName = "Blueprint3.Overlay";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Overlay`;
 
     public static defaultProps: IOverlayProps = {
         autoFocus: true,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -83,7 +83,7 @@ export interface IPopoverState {
 }
 
 export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState> {
-    public static displayName = "Blueprint2.Popover";
+    public static displayName = "Blueprint3.Popover";
 
     public static defaultProps: IPopoverProps = {
         defaultIsOpen: false,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -13,7 +13,7 @@ import ResizeObserver from "resize-observer-polyfill";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
-import { HTMLDivProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps } from "../../common/props";
 import * as Utils from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { Tooltip } from "../tooltip/tooltip";
@@ -83,7 +83,7 @@ export interface IPopoverState {
 }
 
 export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState> {
-    public static displayName = "Blueprint3.Popover";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
     public static defaultProps: IPopoverProps = {
         defaultIsOpen: false,

--- a/packages/core/src/components/popover/popoverArrow.tsx
+++ b/packages/core/src/components/popover/popoverArrow.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import { PopperArrowProps } from "react-popper";
 
 import * as Classes from "../../common/classes";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { getPosition } from "./popperUtils";
 
 // these paths come from the Core Kit Sketch file
@@ -51,4 +52,4 @@ export const PopoverArrow: React.SFC<IPopoverArrowProps> = ({ arrowProps: { ref,
         </svg>
     </div>
 );
-PopoverArrow.displayName = "Blueprint3.PopoverArrow";
+PopoverArrow.displayName = `${DISPLAYNAME_PREFIX}.PopoverArrow`;

--- a/packages/core/src/components/popover/popoverArrow.tsx
+++ b/packages/core/src/components/popover/popoverArrow.tsx
@@ -51,4 +51,4 @@ export const PopoverArrow: React.SFC<IPopoverArrowProps> = ({ arrowProps: { ref,
         </svg>
     </div>
 );
-PopoverArrow.displayName = "Blueprint2.PopoverArrow";
+PopoverArrow.displayName = "Blueprint3.PopoverArrow";

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -9,7 +9,7 @@ import * as ReactDOM from "react-dom";
 
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { isFunction } from "../../common/utils";
 
 /** Detect if `React.createPortal()` API method does not exist. */
@@ -46,7 +46,7 @@ const REACT_CONTEXT_TYPES: React.ValidationMap<IPortalContext> = {
  * Any class names passed to this element will be propagated to the new container element on document.body.
  */
 export class Portal extends React.Component<IPortalProps, IPortalState> {
-    public static displayName = "Blueprint3.Portal";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Portal`;
     public static contextTypes = REACT_CONTEXT_TYPES;
 
     public context: IPortalContext;

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -46,7 +46,7 @@ const REACT_CONTEXT_TYPES: React.ValidationMap<IPortalContext> = {
  * Any class names passed to this element will be propagated to the new container element on document.body.
  */
 export class Portal extends React.Component<IPortalProps, IPortalState> {
-    public static displayName = "Blueprint2.Portal";
+    public static displayName = "Blueprint3.Portal";
     public static contextTypes = REACT_CONTEXT_TYPES;
 
     public context: IPortalContext;

--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -33,7 +33,7 @@ export interface IProgressBarProps extends IProps, IIntentProps {
 }
 
 export class ProgressBar extends React.PureComponent<IProgressBarProps, {}> {
-    public static displayName = "Blueprint2.ProgressBar";
+    public static displayName = "Blueprint3.ProgressBar";
 
     public render() {
         const { animate = true, className, intent, stripes = true, value } = this.props;

--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 
 export interface IProgressBarProps extends IProps, IIntentProps {
@@ -33,7 +33,7 @@ export interface IProgressBarProps extends IProps, IIntentProps {
 }
 
 export class ProgressBar extends React.PureComponent<IProgressBarProps, {}> {
-    public static displayName = "Blueprint3.ProgressBar";
+    public static displayName = `${DISPLAYNAME_PREFIX}.ProgressBar`;
 
     public render() {
         const { animate = true, className, intent, stripes = true, value } = this.props;

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -39,7 +39,7 @@ const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"];
 
 /** Internal component for a Handle with click/drag/keyboard logic to determine a new value. */
 export class Handle extends AbstractPureComponent<IInternalHandleProps, IHandleState> {
-    public static displayName = "Blueprint2.SliderHandle";
+    public static displayName = "Blueprint3.SliderHandle";
 
     public state = {
         isMoving: false,

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { clamp, safeInvoke } from "../../common/utils";
 import { IHandleProps } from "./handleProps";
 import { formatPercentage } from "./sliderUtils";
@@ -39,7 +40,7 @@ const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"];
 
 /** Internal component for a Handle with click/drag/keyboard logic to determine a new value. */
 export class Handle extends AbstractPureComponent<IInternalHandleProps, IHandleState> {
-    public static displayName = "Blueprint3.SliderHandle";
+    public static displayName = `${DISPLAYNAME_PREFIX}.SliderHandle`;
 
     public state = {
         isMoving: false,

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Intent, IProps } from "../../common";
+import { DISPLAYNAME_PREFIX, Intent, IProps } from "../../common";
 
 export const HandleType = {
     /** A full handle appears as a small square. */

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -118,7 +118,7 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
         defaultTrackIntent: Intent.NONE,
     };
 
-    public static displayName = "Blueprint2.MultiSlider";
+    public static displayName = "Blueprint3.MultiSlider";
 
     public static Handle: React.SFC<IHandleProps> = () => null;
 

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { Classes, Intent } from "../../common";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Errors from "../../common/errors";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import * as Utils from "../../common/utils";
 import { Handle } from "./handle";
 import { HandleInteractionKind, HandleType, IHandleProps } from "./handleProps";
@@ -118,7 +118,7 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
         defaultTrackIntent: Intent.NONE,
     };
 
-    public static displayName = "Blueprint3.MultiSlider";
+    public static displayName = `${DISPLAYNAME_PREFIX}.MultiSlider`;
 
     public static Handle: React.SFC<IHandleProps> = () => null;
 

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -38,7 +38,7 @@ export class RangeSlider extends AbstractPureComponent<IRangeSliderProps> {
         value: [0, 10],
     };
 
-    public static displayName = "Blueprint2.RangeSlider";
+    public static displayName = "Blueprint3.RangeSlider";
 
     public render() {
         const { value, ...props } = this.props;

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Errors from "../../common/errors";
 import { Intent } from "../../common/intent";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { ISliderBaseProps, MultiSlider } from "./multiSlider";
 
 export type NumberRange = [number, number];
@@ -38,7 +39,7 @@ export class RangeSlider extends AbstractPureComponent<IRangeSliderProps> {
         value: [0, 10],
     };
 
-    public static displayName = "Blueprint3.RangeSlider";
+    public static displayName = `${DISPLAYNAME_PREFIX}.RangeSlider`;
 
     public render() {
         const { value, ...props } = this.props;

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -38,7 +38,7 @@ export class Slider extends AbstractPureComponent<ISliderProps> {
         value: 0,
     };
 
-    public static displayName = "Blueprint2.Slider";
+    public static displayName = "Blueprint3.Slider";
 
     public render() {
         const { initialValue, value, onChange, onRelease, ...props } = this.props;

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import { Intent } from "../../common/intent";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { ISliderBaseProps, MultiSlider } from "./multiSlider";
 
 export interface ISliderProps extends ISliderBaseProps {
@@ -38,7 +39,7 @@ export class Slider extends AbstractPureComponent<ISliderProps> {
         value: 0,
     };
 
-    public static displayName = "Blueprint3.Slider";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Slider`;
 
     public render() {
         const { initialValue, value, onChange, onRelease, ...props } = this.props;

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
-import { IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 
 // see http://stackoverflow.com/a/18473154/3124288 for calculating arc path
@@ -43,7 +43,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
 }
 
 export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
-    public static displayName = "Blueprint3.Spinner";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Spinner`;
 
     public static readonly SIZE_SMALL = 24;
     public static readonly SIZE_STANDARD = 50;

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -43,7 +43,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
 }
 
 export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
-    public static displayName = "Blueprint2.Spinner";
+    public static displayName = "Blueprint3.Spinner";
 
     public static readonly SIZE_SMALL = 24;
     public static readonly SIZE_STANDARD = 50;

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
 export type TabId = string | number;
 
@@ -50,7 +50,7 @@ export class Tab extends React.PureComponent<ITabProps, {}> {
         id: undefined,
     };
 
-    public static displayName = "Blueprint3.Tab";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Tab`;
 
     // this component is never rendered directly; see Tabs#renderTabPanel()
     /* istanbul ignore next */

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -50,7 +50,7 @@ export class Tab extends React.PureComponent<ITabProps, {}> {
         id: undefined,
     };
 
-    public static displayName = "Blueprint2.Tab";
+    public static displayName = "Blueprint3.Tab";
 
     // this component is never rendered directly; see Tabs#renderTabPanel()
     /* istanbul ignore next */

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { ITabProps, TabId } from "./tab";
 
 export interface ITabTitleProps extends ITabProps {
@@ -22,7 +23,7 @@ export interface ITabTitleProps extends ITabProps {
 }
 
 export class TabTitle extends React.PureComponent<ITabTitleProps, {}> {
-    public static displayName = "Blueprint3.TabTitle";
+    public static displayName = `${DISPLAYNAME_PREFIX}.TabTitle`;
 
     public render() {
         const { disabled, id, parentId, selected } = this.props;

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -22,7 +22,7 @@ export interface ITabTitleProps extends ITabProps {
 }
 
 export class TabTitle extends React.PureComponent<ITabTitleProps, {}> {
-    public static displayName = "Blueprint2.TabTitle";
+    public static displayName = "Blueprint3.TabTitle";
 
     public render() {
         const { disabled, id, parentId, selected } = this.props;

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -95,7 +95,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
         vertical: false,
     };
 
-    public static displayName = "Blueprint2.Tabs";
+    public static displayName = "Blueprint3.Tabs";
 
     private tablistElement: HTMLDivElement;
     private refHandlers = {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import * as Utils from "../../common/utils";
 
 import { ITabProps, Tab, TabId } from "./tab";
@@ -95,7 +95,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
         vertical: false,
     };
 
-    public static displayName = "Blueprint3.Tabs";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Tabs`;
 
     private tablistElement: HTMLDivElement;
     private refHandlers = {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -172,7 +172,7 @@ export interface ITagInputState {
 const NONE = -1;
 
 export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputState> {
-    public static displayName = "Blueprint2.TagInput";
+    public static displayName = "Blueprint3.TagInput";
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         addOnBlur: false,

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
-import { HTMLInputProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
 import * as Utils from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { ITagProps, Tag } from "../tag/tag";
@@ -172,7 +172,7 @@ export interface ITagInputState {
 const NONE = -1;
 
 export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputState> {
-    public static displayName = "Blueprint3.TagInput";
+    public static displayName = `${DISPLAYNAME_PREFIX}.TagInput`;
 
     public static defaultProps: Partial<ITagInputProps> & object = {
         addOnBlur: false,

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, IIntentProps, IProps, Utils } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, IIntentProps, IProps, Utils } from "../../common";
 import { Icon, IconName } from "../icon/icon";
 import { Text } from "../text/text";
 
@@ -75,7 +75,7 @@ export interface ITagProps extends IProps, IIntentProps, React.HTMLAttributes<HT
 }
 
 export class Tag extends React.PureComponent<ITagProps, {}> {
-    public static displayName = "Blueprint3.Tag";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Tag`;
 
     public render() {
         const {

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -75,7 +75,7 @@ export interface ITagProps extends IProps, IIntentProps, React.HTMLAttributes<HT
 }
 
 export class Tag extends React.PureComponent<ITagProps, {}> {
-    public static displayName = "Blueprint2.Tag";
+    public static displayName = "Blueprint3.Tag";
 
     public render() {
         const {

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
 export interface ITextProps extends IProps {
     /**
@@ -31,6 +31,8 @@ export interface ITextState {
 }
 
 export class Text extends React.PureComponent<ITextProps, ITextState> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Text`;
+
     public state: ITextState = {
         isContentOverflowing: false,
         textContent: "",

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
-import { IActionProps, IIntentProps, ILinkProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IActionProps, IIntentProps, ILinkProps, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 import { ButtonGroup } from "../button/buttonGroup";
 import { AnchorButton, Button } from "../button/buttons";
@@ -51,7 +51,7 @@ export class Toast extends AbstractPureComponent<IToastProps, {}> {
         timeout: 5000,
     };
 
-    public static displayName = "Blueprint3.Toast";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Toast`;
 
     public render(): JSX.Element {
         const { className, icon, intent, message } = this.props;

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -51,7 +51,7 @@ export class Toast extends AbstractPureComponent<IToastProps, {}> {
         timeout: 5000,
     };
 
-    public static displayName = "Blueprint2.Toast";
+    public static displayName = "Blueprint3.Toast";
 
     public render(): JSX.Element {
         const { className, icon, intent, message } = this.props;

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -13,7 +13,7 @@ import * as Classes from "../../common/classes";
 import { TOASTER_CREATE_NULL, TOASTER_WARN_INLINE } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { Position } from "../../common/position";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { isNodeEnv, safeInvoke } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { IToastProps, Toast } from "./toast";
@@ -90,6 +90,8 @@ export interface IToasterState {
 }
 
 export class Toaster extends AbstractPureComponent<IToasterProps, IToasterState> implements IToaster {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Toaster`;
+
     public static defaultProps: IToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -46,7 +46,7 @@ export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
 }
 
 export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
-    public static displayName = "Blueprint2.Tooltip";
+    public static displayName = "Blueprint3.Tooltip";
 
     public static defaultProps: Partial<ITooltipProps> = {
         hoverCloseDelay: 0,

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IIntentProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IIntentProps } from "../../common/props";
 import { Popover, PopoverInteractionKind } from "../popover/popover";
 import { IPopoverSharedProps } from "../popover/popoverSharedProps";
 
@@ -46,7 +46,7 @@ export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
 }
 
 export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
-    public static displayName = "Blueprint3.Tooltip";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Tooltip`;
 
     public static defaultProps: Partial<ITooltipProps> = {
         hoverCloseDelay: 0,

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { isFunction } from "../../common/utils";
 import { ITreeNode, TreeNode } from "./treeNode";
 
@@ -53,6 +53,8 @@ export interface ITreeProps<T = {}> extends IProps {
 }
 
 export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Tree`;
+
     public static ofType<T>() {
         return Tree as new (props: ITreeProps<T>) => Tree<T>;
     }

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 import { Collapse } from "../collapse/collapse";
 import { Icon, IconName } from "../icon/icon";
@@ -77,6 +77,8 @@ export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
 }
 
 export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.TreeNode`;
+
     public static ofType<T>() {
         return TreeNode as new (props: ITreeNodeProps<T>) => TreeNode<T>;
     }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -126,7 +126,7 @@ export interface IDateInputState {
 }
 
 export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInputState> {
-    public static displayName = "Blueprint2.DateInput";
+    public static displayName = "Blueprint3.DateInput";
 
     public static defaultProps: Partial<IDateInputProps> = {
         closeOnSelection: true,

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -10,6 +10,7 @@ import { DayPickerProps } from "react-day-picker/types/props";
 
 import {
     AbstractPureComponent,
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
@@ -126,7 +127,7 @@ export interface IDateInputState {
 }
 
 export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInputState> {
-    public static displayName = "Blueprint3.DateInput";
+    public static displayName = `${DISPLAYNAME_PREFIX}.DateInput`;
 
     public static defaultProps: Partial<IDateInputProps> = {
         closeOnSelection: true,

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -4,7 +4,14 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { AbstractPureComponent, Button, Classes as CoreClasses, IProps, Utils } from "@blueprintjs/core";
+import {
+    AbstractPureComponent,
+    Button,
+    Classes as CoreClasses,
+    DISPLAYNAME_PREFIX,
+    IProps,
+    Utils,
+} from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import ReactDayPicker from "react-day-picker";
@@ -79,7 +86,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         showActionsBar: false,
     };
 
-    public static displayName = "Blueprint3.DatePicker";
+    public static displayName = `${DISPLAYNAME_PREFIX}.DatePicker`;
 
     private ignoreNextMonthChange = false;
 

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -79,7 +79,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         showActionsBar: false,
     };
 
-    public static displayName = "Blueprint2.DatePicker";
+    public static displayName = "Blueprint3.DatePicker";
 
     private ignoreNextMonthChange = false;
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -204,7 +204,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         startInputProps: {},
     };
 
-    public static displayName = "Blueprint2.DateRangeInput";
+    public static displayName = "Blueprint3.DateRangeInput";
 
     private startInputRef: HTMLInputElement;
     private endInputRef: HTMLInputElement;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -13,6 +13,7 @@ import {
     AbstractPureComponent,
     Boundary,
     Classes,
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
@@ -204,7 +205,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         startInputProps: {},
     };
 
-    public static displayName = "Blueprint3.DateRangeInput";
+    public static displayName = `${DISPLAYNAME_PREFIX}.DateRangeInput`;
 
     private startInputRef: HTMLInputElement;
     private endInputRef: HTMLInputElement;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -4,7 +4,16 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { AbstractPureComponent, Boundary, Classes, IProps, Menu, MenuItem, Utils } from "@blueprintjs/core";
+import {
+    AbstractPureComponent,
+    Boundary,
+    Classes,
+    DISPLAYNAME_PREFIX,
+    IProps,
+    Menu,
+    MenuItem,
+    Utils,
+} from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import ReactDayPicker from "react-day-picker";
@@ -124,7 +133,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         shortcuts: true,
     };
 
-    public static displayName = "Blueprint3.DateRangePicker";
+    public static displayName = `${DISPLAYNAME_PREFIX}.DateRangePicker`;
 
     private get isControlled() {
         return this.props.value != null;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -124,7 +124,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         shortcuts: true,
     };
 
-    public static displayName = "Blueprint2.DateRangePicker";
+    public static displayName = "Blueprint3.DateRangePicker";
 
     private get isControlled() {
         return this.props.value != null;

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -7,7 +7,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent, DISPLAYNAME_PREFIX, IProps, Utils } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -63,7 +63,7 @@ export class DateTimePicker extends AbstractPureComponent<IDateTimePickerProps, 
         defaultValue: new Date(),
     };
 
-    public static displayName = "Blueprint3.DateTimePicker";
+    public static displayName = `${DISPLAYNAME_PREFIX}.DateTimePicker`;
 
     public constructor(props?: IDateTimePickerProps, context?: any) {
         super(props, context);

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -63,7 +63,7 @@ export class DateTimePicker extends AbstractPureComponent<IDateTimePickerProps, 
         defaultValue: new Date(),
     };
 
-    public static displayName = "Blueprint2.DateTimePicker";
+    public static displayName = "Blueprint3.DateTimePicker";
 
     public constructor(props?: IDateTimePickerProps, context?: any) {
         super(props, context);

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -4,7 +4,15 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes as CoreClasses, HTMLSelect, Icon, IProps, Keys, Utils as BlueprintUtils } from "@blueprintjs/core";
+import {
+    Classes as CoreClasses,
+    DISPLAYNAME_PREFIX,
+    HTMLSelect,
+    Icon,
+    IProps,
+    Keys,
+    Utils as BlueprintUtils,
+} from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -116,7 +124,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         useAmPm: false,
     };
 
-    public static displayName = "Blueprint3.TimePicker";
+    public static displayName = `${DISPLAYNAME_PREFIX}.TimePicker`;
 
     public constructor(props?: ITimePickerProps, context?: any) {
         super(props, context);

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -116,7 +116,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         useAmPm: false,
     };
 
-    public static displayName = "Blueprint2.TimePicker";
+    public static displayName = "Blueprint3.TimePicker";
 
     public constructor(props?: ITimePickerProps, context?: any) {
         super(props, context);

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -7,7 +7,15 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { HTMLInputProps, IInputGroupProps, InputGroup, IOverlayProps, Overlay, Utils } from "@blueprintjs/core";
+import {
+    DISPLAYNAME_PREFIX,
+    HTMLInputProps,
+    IInputGroupProps,
+    InputGroup,
+    IOverlayProps,
+    Overlay,
+    Utils,
+} from "@blueprintjs/core";
 
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -59,7 +67,7 @@ export interface IOmnibarState<T> {
 }
 
 export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarState<T>> {
-    public static displayName = "Blueprint3.Omnibar";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Omnibar`;
 
     public static ofType<T>() {
         return Omnibar as new (props: IOmnibarProps<T>) => Omnibar<T>;

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -59,7 +59,7 @@ export interface IOmnibarState<T> {
 }
 
 export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarState<T>> {
-    public static displayName = "Blueprint2.Omnibar";
+    public static displayName = "Blueprint3.Omnibar";
 
     public static ofType<T>() {
         return Omnibar as new (props: IOmnibarProps<T>) => Omnibar<T>;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { IProps, Keys, Menu, Utils } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, IProps, Keys, Menu, Utils } from "@blueprintjs/core";
 import { IItemListRendererProps, IItemModifiers, IListItemsProps, renderFilteredItems } from "../../common";
 
 export interface IQueryListProps<T> extends IListItemsProps<T> {
@@ -91,7 +91,7 @@ export interface IQueryListState<T> {
 }
 
 export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryListState<T>> {
-    public static displayName = "Blueprint3.QueryList";
+    public static displayName = `${DISPLAYNAME_PREFIX}.QueryList`;
 
     public static ofType<T>() {
         return QueryList as new (props: IQueryListProps<T>) => QueryList<T>;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -91,7 +91,7 @@ export interface IQueryListState<T> {
 }
 
 export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryListState<T>> {
-    public static displayName = "Blueprint2.QueryList";
+    public static displayName = "Blueprint3.QueryList";
 
     public static ofType<T>() {
         return QueryList as new (props: IQueryListProps<T>) => QueryList<T>;

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -7,6 +7,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import {
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IPopoverProps,
     ITagInputProps,
@@ -54,7 +55,7 @@ export interface IMultiSelectState<T> {
 }
 
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
-    public static displayName = "Blueprint3.MultiSelect";
+    public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect`;
 
     public static ofType<T>() {
         return MultiSelect as new (props: IMultiSelectProps<T>) => MultiSelect<T>;

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -54,7 +54,7 @@ export interface IMultiSelectState<T> {
 }
 
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
-    public static displayName = "Blueprint2.MultiSelect";
+    public static displayName = "Blueprint3.MultiSelect";
 
     public static ofType<T>() {
         return MultiSelect as new (props: IMultiSelectProps<T>) => MultiSelect<T>;

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -75,7 +75,7 @@ export interface ISelectState<T> {
 }
 
 export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState<T>> {
-    public static displayName = "Blueprint2.Select";
+    public static displayName = "Blueprint3.Select";
 
     public static ofType<T>() {
         return Select as new (props: ISelectProps<T>) => Select<T>;

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 
 import {
     Button,
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
@@ -75,7 +76,7 @@ export interface ISelectState<T> {
 }
 
 export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState<T>> {
-    public static displayName = "Blueprint3.Select";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Select`;
 
     public static ofType<T>() {
         return Select as new (props: ISelectProps<T>) => Select<T>;

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import {
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
@@ -56,7 +57,7 @@ export interface ISuggestState<T> {
 }
 
 export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestState<T>> {
-    public static displayName = "Blueprint3.Suggest";
+    public static displayName = `${DISPLAYNAME_PREFIX}.Suggest`;
 
     // Note: can't use <T> in static members, so this remains dynamically typed.
     public static defaultProps = {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -56,7 +56,7 @@ export interface ISuggestState<T> {
 }
 
 export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestState<T>> {
-    public static displayName = "Blueprint2.Suggest";
+    public static displayName = "Blueprint3.Suggest";
 
     // Note: can't use <T> in static members, so this remains dynamically typed.
     public static defaultProps = {

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -97,7 +97,7 @@ export interface ITimezonePickerState {
 const TypedSelect = Select.ofType<ITimezoneItem>();
 
 export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, ITimezonePickerState> {
-    public static displayName = "Blueprint2.TimezonePicker";
+    public static displayName = "Blueprint3.TimezonePicker";
 
     public static defaultProps: Partial<ITimezonePickerProps> = {
         date: new Date(),

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -11,6 +11,7 @@ import {
     AbstractPureComponent,
     Button,
     Classes as CoreClasses,
+    DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IButtonProps,
     IInputGroupProps,
@@ -97,7 +98,7 @@ export interface ITimezonePickerState {
 const TypedSelect = Select.ofType<ITimezoneItem>();
 
 export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, ITimezonePickerState> {
-    public static displayName = "Blueprint3.TimezonePicker";
+    public static displayName = `${DISPLAYNAME_PREFIX}.TimezonePicker`;
 
     public static defaultProps: Partial<ITimezonePickerProps> = {
         date: new Date(),


### PR DESCRIPTION
- new `DISPLAYNAME_PREFIX` constant in core props.ts
- interpolated in every `static displayName` to ensure consistent prefix
- one place to update them all in the future!
