### PR TITLE
[Breadcrumbs] inline SVG icons

### DIFF
--- a/packages/core/scripts/sass-inline-svg.js
+++ b/packages/core/scripts/sass-inline-svg.js
@@ -2,8 +2,8 @@ const inliner = require('sass-inline-svg');
 
 module.exports = {
     // Sass function to inline a UI Icon svg and change its path color:
-    // svg("16px/icon-name.svg", (path: (fill: $color)) )
-    'svg': inliner('../../resources/icons', {
+    // svg-icon("16px/icon-name.svg", (path: (fill: $color)) )
+    'svg-icon': inliner('../../resources/icons', {
         // run through SVGO first
         optimize: true,
         // minimal "uri" encoding is smaller than base64

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -19,9 +19,6 @@ Markup:
 Styleguide breadcrumbs
 */
 
-// shaving off 1px for perfect centering (... icon is 5px high)
-$breadcrumb-line-height: $pt-icon-size-large - 1px !default;
-
 .#{$ns}-breadcrumbs {
   display: flex;
   flex-wrap: wrap;
@@ -39,10 +36,12 @@ $breadcrumb-line-height: $pt-icon-size-large - 1px !default;
     align-items: center;
 
     &::after {
-      @include pt-icon();
-      padding: 0 ($pt-grid-size / 2);
-      color: $pt-icon-color;
-      content: $pt-icon-chevron-right;
+      display: block;
+      margin: 0 ($pt-grid-size / 2);
+      background: svg-icon("16px/chevron-right.svg", (path: (fill: $pt-icon-color)));
+      width: $pt-icon-size-standard;
+      height: $pt-icon-size-standard;
+      content: "";
     }
 
     &:last-of-type::after {
@@ -55,7 +54,6 @@ $breadcrumb-line-height: $pt-icon-size-large - 1px !default;
 .#{$ns}-breadcrumb-current,
 .#{$ns}-breadcrumbs-collapsed {
   display: inline-block;
-  line-height: $breadcrumb-line-height;
   font-size: $pt-font-size-large;
 }
 
@@ -92,12 +90,14 @@ $breadcrumb-line-height: $pt-icon-size-large - 1px !default;
   border-radius: $pt-border-radius;
   background: $light-gray1;
   cursor: pointer;
-  padding: 0 ($pt-grid-size / 2);
+  padding: 1px ($pt-grid-size / 2);
 
   &::before {
-    @include pt-icon($pt-icon-size-large);
-    line-height: $breadcrumb-line-height;
-    content: $pt-icon-more;
+    display: block;
+    background: svg-icon("16px/more.svg", (circle: (fill: $pt-icon-color))) center no-repeat;
+    width: $pt-icon-size-standard;
+    height: $pt-icon-size-standard;
+    content: "";
   }
 
   &:hover {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -206,7 +206,7 @@ $control-indicator-spacing: $pt-grid-size !default;
       &::before {
         // embed SVG icon image as backgroud-image above gradient.
         // the SVG image content is inlined into the CSS, so use this sparingly.
-        background-image: svg("16px/#{$icon}.svg", (path: (fill: $white)));
+        background-image: svg-icon("16px/#{$icon}.svg", (path: (fill: $white)));
       }
     }
 


### PR DESCRIPTION
#### Fixes #2732 

#### Changes proposed in this pull request:

- inline SVG icons in breadcrumbs css, like we did for checkboxes in #2709 

