### PR TITLE
[ControlGroup] fix HTMLSelect support

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -57,6 +57,7 @@ Styleguide control-group
   // changes to change the z-index of a disabled element).
 
   .#{$ns}-button,
+  .#{$ns}-html-select,
   .#{$ns}-input,
   .#{$ns}-select {
     // create a new stacking context
@@ -97,6 +98,7 @@ Styleguide control-group
   }
 
   .#{$ns}-button,
+  .#{$ns}-html-select select,
   .#{$ns}-select select {
     z-index: index($control-group-stack, "button-default");
     // inherit radius since it's most likely to be zero

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -7,6 +7,8 @@
   @include pt-button-base();
   @include pt-button();
   border-radius: $pt-border-radius;
+  // fill parent container
+  width: 100%;
   height: $pt-button-height;
   padding: 0 ($input-padding-horizontal * 2.5) 0 $input-padding-horizontal;
 

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -6,8 +6,10 @@
 
 import * as React from "react";
 
-import { Button, ControlGroup, InputGroup, Switch } from "@blueprintjs/core";
+import { Button, ControlGroup, HTMLSelect, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+
+const FILTER_OPTIONS = ["Filter", "Name - ascending", "Name - descending", "Price - ascending", "Price - descending"];
 
 export interface IControlGroupExampleState {
     fill: boolean;
@@ -39,8 +41,9 @@ export class ControlGroupExample extends React.PureComponent<IExampleProps, ICon
         return (
             <Example options={options} {...this.props}>
                 <ControlGroup style={style} {...this.state}>
-                    <Button icon="filter">Filter</Button>
+                    <HTMLSelect options={FILTER_OPTIONS} />
                     <InputGroup placeholder="Find filters..." />
+                    <Button icon="arrow-right" />
                 </ControlGroup>
             </Example>
         );


### PR DESCRIPTION
#### Fixes #2743

#### Changes proposed in this pull request:

- add new selector added in 3.0 to control-group scss
- add more control types to ControlGroupExample
- HTMLSelect `<select>` tag grows to fill parent (fixes `fill` bug I found in example)

