### PR TITLE
[new] ResizeSensor component

### DIFF
--- a/packages/core/src/components/components.md
+++ b/packages/core/src/components/components.md
@@ -20,6 +20,7 @@
 @page overflow-list
 @page panel-stack
 @page progress-bar
+@page resize-sensor
 @page skeleton
 @page spinner
 @page tabs

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -56,6 +56,7 @@ export * from "./popover/popover";
 export * from "./popover/popoverSharedProps";
 export * from "./portal/portal";
 export * from "./progress-bar/progressBar";
+export * from "./resize-sensor/resizeSensor";
 export * from "./slider/handleProps";
 export * from "./slider/multiSlider";
 export * from "./slider/rangeSlider";

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -11,7 +11,7 @@ import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { ResizeSensor } from "../resize-sensor/resizeSensor";
+import { IResizeEntry, ResizeSensor } from "../resize-sensor/resizeSensor";
 
 export interface IOverflowListProps<T> extends IProps {
     /**
@@ -151,7 +151,7 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
         return this.props.overflowRenderer(overflow);
     }
 
-    private resize = (entries: ResizeObserverEntry[]) => {
+    private resize = (entries: IResizeEntry[]) => {
         // if any parent is growing, assume we have more room than before
         const growing = entries.some(entry => {
             const previousWidth = this.previousWidths.get(entry.target) || 0;

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -6,13 +6,12 @@
 
 import classNames from "classnames";
 import * as React from "react";
-import ResizeObserver from "resize-observer-polyfill";
 
 import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { throttle } from "../../common/utils";
+import { ResizeSensor } from "../resize-sensor/resizeSensor";
 
 export interface IOverflowListProps<T> extends IProps {
     /**
@@ -85,35 +84,17 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
         return OverflowList as new (props: IOverflowListProps<T>) => OverflowList<T>;
     }
 
-    private element: Element | null = null;
-    private spacer: Element | null = null;
-    private observer: ResizeObserver;
+    public state: IOverflowListState<T> = {
+        overflow: [],
+        visible: this.props.items,
+    };
 
     /** A cache containing the widths of all elements being observed to detect growing/shrinking */
     private previousWidths = new Map<Element, number>();
-
-    public constructor(props: IOverflowListProps<T>, context?: any) {
-        super(props, context);
-
-        // constructor is necessary to ensure observer is defined
-        this.observer = new ResizeObserver(throttle(this.resize));
-        this.state = {
-            overflow: [],
-            visible: props.items,
-        };
-    }
+    private spacer: Element | null = null;
 
     public componentDidMount() {
-        if (this.element != null) {
-            // observer callback is invoked immediately when observing new elements
-            this.observer.observe(this.element);
-            if (this.props.observeParents) {
-                for (let element: Element | null = this.element; element != null; element = element.parentElement) {
-                    this.observer.observe(element);
-                }
-            }
-            this.repartition(false);
-        }
+        this.repartition(false);
     }
 
     public componentWillReceiveProps(nextProps: IOverflowListProps<T>) {
@@ -147,24 +128,18 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
         this.repartition(false);
     }
 
-    public componentWillUnmount() {
-        this.observer.disconnect();
-    }
-
     public render() {
-        const { className, collapseFrom, style, visibleItemRenderer } = this.props;
+        const { className, collapseFrom, observeParents, style, visibleItemRenderer } = this.props;
         const overflow = this.maybeRenderOverflow();
         return (
-            <div
-                className={classNames(Classes.OVERFLOW_LIST, className)}
-                ref={ref => (this.element = ref)}
-                style={style}
-            >
-                {collapseFrom === Boundary.START ? overflow : null}
-                {this.state.visible.map(visibleItemRenderer)}
-                {collapseFrom === Boundary.END ? overflow : null}
-                <div className={Classes.OVERFLOW_LIST_SPACER} ref={ref => (this.spacer = ref)} />
-            </div>
+            <ResizeSensor onResize={this.resize} observeParents={observeParents}>
+                <div className={classNames(Classes.OVERFLOW_LIST, className)} style={style}>
+                    {collapseFrom === Boundary.START ? overflow : null}
+                    {this.state.visible.map(visibleItemRenderer)}
+                    {collapseFrom === Boundary.END ? overflow : null}
+                    <div className={Classes.OVERFLOW_LIST_SPACER} ref={ref => (this.spacer = ref)} />
+                </div>
+            </ResizeSensor>
         );
     }
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -8,7 +8,6 @@ import classNames from "classnames";
 import { ModifierFn } from "popper.js";
 import * as React from "react";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from "react-popper";
-import ResizeObserver from "resize-observer-polyfill";
 
 import { AbstractPureComponent } from "../../common/abstractPureComponent";
 import * as Classes from "../../common/classes";
@@ -16,6 +15,7 @@ import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, HTMLDivProps } from "../../common/props";
 import * as Utils from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
+import { ResizeSensor } from "../resize-sensor/resizeSensor";
 import { Tooltip } from "../tooltip/tooltip";
 import { PopoverArrow } from "./popoverArrow";
 import { positionToPlacement } from "./popoverMigrationUtils";
@@ -128,9 +128,6 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     // element on the same page.
     private lostFocusOnSamePage = true;
 
-    // ResizeObserver instance to monitor for content size changes on the popover
-    private popperObserver: ResizeObserver;
-
     // Reference to the Poppper.scheduleUpdate() function, this changes every time the popper is mounted
     private popperScheduleUpdate: () => void;
 
@@ -208,7 +205,6 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
     public componentDidMount() {
         this.updateDarkParent();
-        this.popperObserver = new ResizeObserver(() => Utils.safeInvoke(this.popperScheduleUpdate));
     }
 
     public componentWillReceiveProps(nextProps: IPopoverProps) {
@@ -229,19 +225,6 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
     public componentDidUpdate() {
         this.updateDarkParent();
-
-        if (this.popoverElement != null) {
-            // Clear active observations to avoid the list growing.
-            this.popperObserver.disconnect();
-
-            // Ensure our observer has an up-to-date reference to popoverElement
-            this.popperObserver.observe(this.popoverElement);
-        }
-    }
-
-    public componentWillUnmount() {
-        super.componentWillUnmount();
-        this.popperObserver.disconnect();
     }
 
     protected validateProps(props: IPopoverProps & { children?: React.ReactNode }) {
@@ -310,18 +293,20 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
         return (
             <div className={Classes.TRANSITION_CONTAINER} ref={popperProps.ref} style={popperProps.style}>
-                <div className={popoverClasses} style={{ transformOrigin }} {...popoverHandlers}>
-                    {this.isArrowEnabled() && (
-                        <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
-                    )}
-                    <div className={Classes.POPOVER_CONTENT}>{this.understandChildren().content}</div>
-                </div>
+                <ResizeSensor onResize={this.handlePopoverResize}>
+                    <div className={popoverClasses} style={{ transformOrigin }} {...popoverHandlers}>
+                        {this.isArrowEnabled() && (
+                            <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
+                        )}
+                        <div className={Classes.POPOVER_CONTENT}>{this.understandChildren().content}</div>
+                    </div>
+                </ResizeSensor>
             </div>
         );
     };
 
     private renderTarget = (referenceProps: ReferenceChildrenProps) => {
-        const { targetClassName, targetTagName } = this.props;
+        const { targetClassName, targetTagName: TagName } = this.props;
         const { isOpen } = this.state;
         const isHoverInteractionKind = this.isHoverInteractionKind();
 
@@ -350,7 +335,11 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
             disabled: isOpen && Utils.isElementOfType(rawTarget, Tooltip) ? true : rawTarget.props.disabled,
             tabIndex: this.props.openOnTargetFocus && isHoverInteractionKind ? tabIndex : undefined,
         });
-        return React.createElement(targetTagName, targetProps, clonedTarget);
+        return (
+            <ResizeSensor onResize={this.handlePopoverResize}>
+                <TagName {...targetProps}>{clonedTarget}</TagName>
+            </ResizeSensor>
+        );
     };
 
     // content and target can be specified as props or as children. this method
@@ -439,6 +428,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
             this.setOpenState(false, e);
         }
     };
+
+    private handlePopoverResize = () => Utils.safeInvoke(this.popperScheduleUpdate);
 
     private handleOverlayClose = (e: React.SyntheticEvent<HTMLElement>) => {
         const eventTarget = e.target as HTMLElement;

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -4,8 +4,8 @@ tag: new
 
 @# Resize sensor
 
-`ResizeSensor` is a higher-order component that effectively provides a
-`"resize"` event for a single DOM element. It is a thin wrapper around
+`ResizeSensor` is a component that provides a `"resize"` event for its single
+DOM element child. It is a thin wrapper around
 [`ResizeObserver`][resizeobserver] to provide React bindings.
 
 [resizeobserver]: https://developers.google.com/web/updates/2016/10/resizeobserver
@@ -23,5 +23,13 @@ function handleResize(entries: IResizeEntry[]) {
 ```
 
 @## Props
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h4 class="@ns-heading">Asynchronous behavior</h4>
+    The `onResize` callback is invoked asynchronously after a resize is detected
+    and typically happens at the end of a frame (after layout, before paint).
+    Therefore, testing behavior that relies on this component involves setting a
+    timeout for the next frame.
+</div>
 
 @interface IResizeSensorProps

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -1,0 +1,27 @@
+---
+tag: new
+---
+
+@# Resize sensor
+
+`ResizeSensor` is a higher-order component that effectively provides a
+`"resize"` event for a single DOM element. It is a thin wrapper around
+[`ResizeObserver`][resizeobserver] to provide React bindings.
+
+[resizeobserver]: https://developers.google.com/web/updates/2016/10/resizeobserver
+
+```tsx
+import { IResizeEntry, ResizeSensor } from "@blueprintjs/core";
+
+function handleResize(entries: IResizeEntry[]) {
+    console.log(entries.map(e => `${e.contentRect.width} x ${e.contentRect.height}`));
+}
+
+<ResizeSensor onChange={handleResize}>
+    <div style={{ width: this.props.width }} />
+</ResizeSensor>
+```
+
+@## Props
+
+@interface IResizeSensorProps

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -20,6 +20,7 @@ export interface IResizeEntry {
     target: Element;
 }
 
+/** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 export interface IResizeSensorProps {
     /**
      * Callback invoked when the wrapped element resizes.

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -28,6 +28,9 @@ export interface IResizeSensorProps {
      * The `entries` array contains an entry for each observed element. In the
      * default case (no `observeParents`), the array will contain only one
      * element: the single child of the `ResizeSensor`.
+     *
+     * Note that this method is called _asynchronously_ after a resize is
+     * detected and typically it will be called no more than once per frame.
      */
     onResize: (entries: IResizeEntry[]) => void;
 

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -10,12 +10,20 @@ import ResizeObserver from "resize-observer-polyfill";
 import { findDOMNode } from "react-dom";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 
+/** A parallel type to `ResizeObserverEntry` (from resize-observer-polyfill). */
+export interface IResizeEntry {
+    /** Measured dimensions of the target. */
+    contentRect: DOMRectReadOnly;
+
+    /** The resized element. */
+    target: Element;
+}
+
 export interface IResizeSensorProps {
     /**
      * Callback invoked when the wrapped element resizes.
-     * Resize events are throttled for performance reasons.
      */
-    onResize: ResizeObserverCallback;
+    onResize: (entries: IResizeEntry[]) => void;
 
     /**
      * If `true`, all parent DOM elements of the container will also be

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+import ResizeObserver from "resize-observer-polyfill";
+
+import { findDOMNode } from "react-dom";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
+
+export interface IResizeSensorProps {
+    /**
+     * Callback invoked when the wrapped element resizes.
+     * Resize events are throttled for performance reasons.
+     */
+    onResize: ResizeObserverCallback;
+
+    /**
+     * If `true`, all parent DOM elements of the container will also be
+     * observed. If changes to a parent's size is detected, the overflow will be
+     * recalculated.
+     *
+     * Only enable this prop if the overflow should be recalculated when a
+     * parent element resizes in a way that does not also cause the
+     * `OverflowList` to resize.
+     * @default false
+     */
+    observeParents?: boolean;
+}
+
+export class ResizeSensor extends React.PureComponent<IResizeSensorProps> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Resize`;
+
+    private observer: ResizeObserver;
+
+    constructor(props: IResizeSensorProps, context?: any) {
+        super(props, context);
+        this.observer = new ResizeObserver(this.props.onResize);
+    }
+
+    public render() {
+        return React.Children.only(this.props.children);
+    }
+
+    public componentDidMount() {
+        // using findDOMNode for two reasons:
+        // 1. cloning to insert a ref is unwieldy and not performant.
+        // 2. ensure that we get an actual DOM node for observing.
+        const domNode = findDOMNode(this);
+        if (domNode != null) {
+            this.observeElement(domNode);
+        }
+    }
+
+    public componentDidUpdate(prevProps: IResizeSensorProps) {
+        const { observeParents, onResize } = this.props;
+        if (observeParents !== prevProps.observeParents || onResize !== prevProps.onResize) {
+            console.warn("<Resize> does not support changing props.");
+        }
+    }
+
+    public componentWillUnmount() {
+        this.observer.disconnect();
+    }
+
+    private observeElement(element: Element | null) {
+        if (element == null) {
+            this.observer.disconnect();
+            return;
+        }
+
+        // observer callback is invoked immediately when observing new elements
+        this.observer.observe(element);
+
+        if (this.props.observeParents) {
+            let parent = element.parentElement;
+            while (parent != null) {
+                this.observer.observe(parent);
+                parent = parent.parentElement;
+            }
+        }
+    }
+}

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -24,24 +24,28 @@ export interface IResizeEntry {
 export interface IResizeSensorProps {
     /**
      * Callback invoked when the wrapped element resizes.
+     *
+     * The `entries` array contains an entry for each observed element. In the
+     * default case (no `observeParents`), the array will contain only one
+     * element: the single child of the `ResizeSensor`.
      */
     onResize: (entries: IResizeEntry[]) => void;
 
     /**
      * If `true`, all parent DOM elements of the container will also be
-     * observed. If changes to a parent's size is detected, the overflow will be
-     * recalculated.
+     * observed for size changes. The array of entries passed to `onResize`
+     * will now contain an entry for each parent element up to the root of the
+     * document.
      *
-     * Only enable this prop if the overflow should be recalculated when a
-     * parent element resizes in a way that does not also cause the
-     * `OverflowList` to resize.
+     * Only enable this prop if a parent element resizes in a way that does
+     * not also cause the child element to resize.
      * @default false
      */
     observeParents?: boolean;
 }
 
 export class ResizeSensor extends React.PureComponent<IResizeSensorProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.Resize`;
+    public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
     private element: Element | null = null;
     private observer = new ResizeObserver(entries => safeInvoke(this.props.onResize, entries));

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -36,6 +36,7 @@ import "./popover/popoverTests";
 import "./popover/popperUtilTests";
 import "./portal/portalTests";
 import "./progress/progressBarTests";
+import "./resize-sensor/resizeSensorTests";
 import "./slider/handleTests";
 import "./slider/multiSliderTests";
 import "./slider/rangeSliderTests";

--- a/packages/core/test/isotest.js
+++ b/packages/core/test/isotest.js
@@ -21,12 +21,13 @@ const customProps = {
     Toaster: { usePortal: false },
 };
 
-const popoverTarget = React.createElement("button");
+const requiredChild = React.createElement("button");
 const customChildren = {
     Hotkeys: React.createElement(Core.Hotkey, customProps.Hotkey),
-    Popover: popoverTarget,
+    Popover: requiredChild,
+    ResizeSensor: requiredChild,
     Tabs: React.createElement(Core.Tab, { key: 1, id: 1, title: "Tab one" }),
-    Tooltip: popoverTarget,
+    Tooltip: requiredChild,
     Toaster: React.createElement(Core.Toast, { message: "Toast" }),
 };
 

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -18,7 +18,7 @@ describe("<ResizeSensor>", () => {
     document.documentElement.appendChild(testsContainerElement);
 
     afterEach(() => {
-        // clean up list after each test, if it was used
+        // clean up wrapper after each test, if it was used
         if (wrapper !== undefined) {
             wrapper.unmount();
             wrapper.detach();

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { assert } from "chai";
+import { mount, ReactWrapper } from "enzyme";
+import * as React from "react";
+import { spy } from "sinon";
+
+import { IResizeSensorProps, ResizeSensor } from "../../src/components/resize-sensor/resizeSensor";
+
+describe("<ResizeSensor>", () => {
+    // this scope variable is assigned in mountResizeSensor() and used in resize()
+    let wrapper: ReactWrapper<IResizeTesterProps, any> | undefined;
+    const testsContainerElement = document.createElement("div");
+    document.documentElement.appendChild(testsContainerElement);
+
+    afterEach(() => {
+        // clean up list after each test, if it was used
+        if (wrapper !== undefined) {
+            wrapper.unmount();
+            wrapper.detach();
+            wrapper = undefined;
+        }
+    });
+    after(() => testsContainerElement.remove());
+
+    it("onResize is called when size changes", async () => {
+        const onResize = spy();
+        mountResizeSensor(onResize);
+        await resize({ width: 200 });
+        await resize({ height: 100 });
+        await resize({ width: 55 });
+        assert.equal(onResize.callCount, 3);
+        assertResizeArgs(onResize, ["200x0", "200x100", "55x100"]);
+    });
+
+    it("onResize is called when size changes", async () => {
+        const onResize = spy();
+        mountResizeSensor(onResize);
+        await resize({ width: 200, id: 1 });
+        await resize({ height: 100, id: 2 });
+        await resize({ width: 55, id: 3 });
+        assertResizeArgs(onResize, ["200x0", "200x100", "55x100"]);
+    });
+
+    function mountResizeSensor(onResize: IResizeSensorProps["onResize"]) {
+        return (wrapper = mount<IResizeTesterProps>(
+            <ResizeTester onResize={onResize} />,
+            // must be in the DOM for measurement
+            { attachTo: testsContainerElement },
+        ));
+    }
+
+    function resize(size: ISizeProps) {
+        wrapper.setProps(size);
+        return new Promise(resolve => setTimeout(resolve, 30));
+    }
+
+    function assertResizeArgs(onResize: sinon.SinonSpy, sizes: string[]) {
+        assert.sameMembers(
+            onResize.args
+                .map(args => (args[0] as ResizeObserverEntry[])[0].contentRect)
+                .map(r => `${r.width}x${r.height}`),
+            sizes,
+        );
+    }
+});
+
+interface ISizeProps {
+    id?: number;
+    width?: number;
+    height?: number;
+}
+
+type IResizeTesterProps = IResizeSensorProps & ISizeProps;
+const ResizeTester: React.SFC<IResizeTesterProps> = ({ id, width, height, ...resizeProps }) => (
+    <ResizeSensor {...resizeProps}>
+        <div key={id} style={{ width, height }} />
+    </ResizeSensor>
+);

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -2,6 +2,14 @@
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
         "declaration": false,
-        "noEmit": true
+        "noEmit": true,
+        "lib": [
+          "dom",
+          "dom.iterable",
+          "es5",
+          "es2015.collection",
+          "es2015.iterable",
+          "es2015.promise"
+        ],
     }
 }


### PR DESCRIPTION
- `<ResizeSensor>` provides a React interface to `ResizeObserver` with a required `onResize` callback.
- refactor `OverflowList` and `Popover` to use this new guy.