### PR TITLE
[docs] Navigator results limit

### DIFF
--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Icon, MenuItem, Utils } from "@blueprintjs/core";
+import { Classes, Icon, IInputGroupProps, MenuItem, Utils } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Omnibar } from "@blueprintjs/select";
 
 import { IHeadingNode, IPageNode } from "documentalist/dist/client";
@@ -38,6 +38,7 @@ export interface INavigationSection {
 }
 
 const NavOmnibar = Omnibar.ofType<INavigationSection>();
+const INPUT_PROPS: IInputGroupProps = { placeholder: "Fuzzy search headings..." };
 
 export class Navigator extends React.PureComponent<INavigatorProps> {
     private sections: INavigationSection[];
@@ -63,6 +64,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
         return (
             <NavOmnibar
                 className="docs-navigator-menu"
+                inputProps={INPUT_PROPS}
                 itemListPredicate={this.filterMatches}
                 isOpen={this.props.isOpen}
                 items={this.sections}
@@ -75,7 +77,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
     }
 
     private filterMatches: ItemListPredicate<INavigationSection> = (query, items) =>
-        filter(items, query, { key: "filterKey", isPath: true });
+        filter(items, query, { key: "filterKey", isPath: true, maxResults: 10, useExtensionBonus: true });
 
     private renderItem: ItemRenderer<INavigationSection> = (section, props) => {
         if (!props.modifiers.matchesPredicate) {

--- a/packages/docs-theme/src/styles/_navigator.scss
+++ b/packages/docs-theme/src/styles/_navigator.scss
@@ -10,6 +10,7 @@ $navigator-width: $pt-grid-size * 40;
   .#{$ns}-menu-item small {
     // center-align text and SVG icons
     display: flex;
+    align-items: center;
   }
 
   .#{$ns}-menu-item.#{$ns}-active small {


### PR DESCRIPTION
- fix navigator path alignment
- limit search results to 10
- better placeholder `"Fuzzy search headings..."`