### PR TITLE
[select] un/controlled activeItem & query!

### DIFF
--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -18,6 +18,7 @@ export interface ISuggestExampleState {
     film: IFilm;
     minimal: boolean;
     openOnKeyDown: boolean;
+    resetOnSelect: boolean;
 }
 
 export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestExampleState> {
@@ -26,11 +27,13 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
         film: TOP_100_FILMS[0],
         minimal: true,
         openOnKeyDown: false,
+        resetOnSelect: false,
     };
 
     private handleCloseOnSelectChange = this.handleSwitchChange("closeOnSelect");
     private handleOpenOnKeyDownChange = this.handleSwitchChange("openOnKeyDown");
     private handleMinimalChange = this.handleSwitchChange("minimal");
+    private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
 
     public render() {
         const { film, minimal, ...flags } = this.state;
@@ -61,6 +64,11 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
                     label="Open popover on key down"
                     checked={this.state.openOnKeyDown}
                     onChange={this.handleOpenOnKeyDownChange}
+                />
+                <Switch
+                    label="Reset on select"
+                    checked={this.state.resetOnSelect}
+                    onChange={this.handleResetOnSelectChange}
                 />
                 <H5>Popover props</H5>
                 <Switch

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -9,6 +9,9 @@
  * An `itemListRenderer` receives this object as its sole argument.
  */
 export interface IItemListRendererProps<T> {
+    /** The currently focused item (for keyboard interactions). */
+    activeItem: T | undefined;
+
     /**
      * Array of items filtered by `itemListPredicate` or `itemPredicate`.
      * See `items` for the full list of items.

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -10,7 +10,7 @@
  */
 export interface IItemListRendererProps<T> {
     /** The currently focused item (for keyboard interactions). */
-    activeItem: T | undefined;
+    activeItem: T | null;
 
     /**
      * Array of items filtered by `itemListPredicate` or `itemPredicate`.

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -11,6 +11,13 @@ import { ItemListPredicate, ItemPredicate } from "./predicate";
 
 /** Reusable generic props for a component that operates on a filterable, selectable list of `items`. */
 export interface IListItemsProps<T> extends IProps {
+    /**
+     * The currently focused item, for keyboard interactions. If omitted, this
+     * prop will be controlled by the component. Use `onActiveItemChange` to
+     * listen for updates.
+     */
+    activeItem?: T | undefined;
+
     /** Array of items in the list. */
     items: T[];
 
@@ -73,10 +80,22 @@ export interface IListItemsProps<T> extends IProps {
     noResults?: React.ReactNode;
 
     /**
+     * Invoked when user interaction should change the active item: arrow keys move it up/down
+     * in the list, selecting an item makes it active, and changing the query may reset it to
+     * the first item in the list if it no longer matches the filter.
+     */
+    onActiveItemChange?: (activeItem: T | undefined) => void;
+
+    /**
      * Callback invoked when an item from the list is selected,
      * typically by clicking or pressing `enter` key.
      */
     onItemSelect: (item: T, event?: React.SyntheticEvent<HTMLElement>) => void;
+
+    /**
+     * Callback invoked when the query string changes.
+     */
+    onQueryChange?: (query: string, event?: React.ChangeEvent<HTMLInputElement>) => void;
 
     /**
      * Whether the querying state should be reset to initial when an item is
@@ -85,4 +104,11 @@ export interface IListItemsProps<T> extends IProps {
      * @default false
      */
     resetOnSelect?: boolean;
+
+    /**
+     * Query string passed to `itemListPredicate` or `itemPredicate` to filter items.
+     * This value is controlled: its state must be managed externally by attaching an `onChange`
+     * handler to the relevant element in your `renderer` implementation.
+     */
+    query?: string;
 }

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -77,4 +77,12 @@ export interface IListItemsProps<T> extends IProps {
      * typically by clicking or pressing `enter` key.
      */
     onItemSelect: (item: T, event?: React.SyntheticEvent<HTMLElement>) => void;
+
+    /**
+     * Whether the querying state should be reset to initial when an item is
+     * selected (immediately before `onItemSelect` is invoked). The query will
+     * become the empty string and the first item will be made active.
+     * @default false
+     */
+    resetOnSelect?: boolean;
 }

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -12,11 +12,12 @@ import { ItemListPredicate, ItemPredicate } from "./predicate";
 /** Reusable generic props for a component that operates on a filterable, selectable list of `items`. */
 export interface IListItemsProps<T> extends IProps {
     /**
-     * The currently focused item, for keyboard interactions. If omitted, this
-     * prop will be controlled by the component. Use `onActiveItemChange` to
-     * listen for updates.
+     * The currently focused item for keyboard interactions, or `null` to
+     * indicate that no item is active. If omitted, this prop will be
+     * uncontrolled (managed by the component's state). Use `onActiveItemChange`
+     * to listen for updates.
      */
-    activeItem?: T | undefined;
+    activeItem?: T | null;
 
     /** Array of items in the list. */
     items: T[];
@@ -84,7 +85,7 @@ export interface IListItemsProps<T> extends IProps {
      * in the list, selecting an item makes it active, and changing the query may reset it to
      * the first item in the list if it no longer matches the filter.
      */
-    onActiveItemChange?: (activeItem: T | undefined) => void;
+    onActiveItemChange?: (activeItem: T | null) => void;
 
     /**
      * Callback invoked when an item from the list is selected,

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -14,9 +14,9 @@ import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export interface IOmnibarProps<T> extends IListItemsProps<T> {
     /**
-     * Props to spread to `InputGroup`. All props are supported except `ref` (use `inputRef` instead).
-     * If you want to control the filter input, you can pass `value` and `onChange` here
-     * to override `Select`'s own behavior.
+     * Props to spread to the query `InputGroup`. Use `query` and
+     * `onQueryChange` instead of `inputProps.value` and `inputProps.onChange`
+     * to control this input. Use `inputRef` instead of `ref`.
      */
     inputProps?: IInputGroupProps & HTMLInputProps;
 

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -48,9 +48,6 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
 
     /** Props to spread to `Overlay`. */
     overlayProps?: Partial<IOverlayProps>;
-
-    /** The query string. */
-    query?: string;
 }
 
 export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -45,21 +45,12 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
     query?: string;
 }
 
-export interface IOmnibarState<T> {
-    activeItem?: T;
-    query: string;
-}
-
-export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarState<T>> {
+export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
     public static displayName = "Blueprint2.Omnibar";
 
     public static ofType<T>() {
         return Omnibar as new (props: IOmnibarProps<T>) => Omnibar<T>;
     }
-
-    public state: IOmnibarState<T> = {
-        query: this.props.query || "",
-    };
 
     private TypedQueryList = QueryList.ofType<T>();
     private queryList?: QueryList<T> | null;
@@ -74,31 +65,18 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
         return (
             <this.TypedQueryList
                 {...restProps}
-                activeItem={this.state.activeItem}
                 initialContent={initialContent}
-                onActiveItemChange={this.handleActiveItemChange}
                 onItemSelect={this.props.onItemSelect}
-                query={this.state.query}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
             />
         );
     }
 
-    public componentWillReceiveProps(nextProps: IOmnibarProps<T>) {
-        const { isOpen } = nextProps;
-        const canClearQuery = !this.props.isOpen && isOpen && this.props.resetOnSelect;
-
-        this.setState({
-            activeItem: canClearQuery ? this.props.items[0] : this.state.activeItem,
-            query: canClearQuery ? "" : this.state.query,
-        });
-    }
-
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { inputProps = {}, isOpen, overlayProps = {} } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
-        const handlers = isOpen && !this.isQueryEmpty() ? { onKeyDown: handleKeyDown, onKeyUp: handleKeyUp } : {};
+        const handlers = isOpen && listProps.query.length > 0 ? { onKeyDown: handleKeyDown, onKeyUp: handleKeyUp } : {};
 
         return (
             <Overlay
@@ -114,24 +92,14 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>, IOmnibarSt
                         large={true}
                         leftIcon="search"
                         placeholder="Search..."
-                        value={listProps.query}
                         {...inputProps}
-                        onChange={this.handleQueryChange}
+                        onChange={listProps.handleQueryChange}
+                        value={listProps.query}
                     />
                     {listProps.itemList}
                 </div>
             </Overlay>
         );
-    };
-
-    private isQueryEmpty = () => this.state.query.length === 0;
-
-    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
-
-    private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
-        const { inputProps = {} } = this.props;
-        this.setState({ query: event.currentTarget.value });
-        Utils.safeInvoke(inputProps.onChange, event);
     };
 
     private handleOverlayClose = (event?: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -43,14 +43,6 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
 
     /** The query string. */
     query?: string;
-
-    /**
-     * Whether the filtering state should be reset to initial when an item is selected
-     * (immediately before `onItemSelect` is invoked). The query will become the empty string
-     * and the first item will be made active.
-     * @default false
-     */
-    resetOnSelect?: boolean;
 }
 
 export interface IOmnibarState<T> {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -93,23 +93,28 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
      */
     private shouldCheckActiveItemInViewport: boolean = false;
 
+    public constructor(props: IQueryListProps<T>, context?: any) {
+        super(props, context);
+        const { query = "" } = this.props;
+        const filteredItems = getFilteredItems(query, this.props);
+        this.state = { activeItem: getFirstEnabledItem(filteredItems, this.props.itemDisabled), filteredItems, query };
+    }
+
     public render() {
-        const { className, items, renderer, query, itemListRenderer = this.renderItemList } = this.props;
-        const { filteredItems } = this.state;
+        const { className, items, renderer, itemListRenderer = this.renderItemList } = this.props;
         return renderer({
+            ...this.state,
             className,
-            filteredItems,
             handleItemSelect: this.handleItemSelect,
             handleKeyDown: this.handleKeyDown,
             handleKeyUp: this.handleKeyUp,
+            handleQueryChange: this.handleQueryChange,
             itemList: itemListRenderer({
-                filteredItems,
+                ...this.state,
                 items,
                 itemsParentRef: this.refHandlers.itemsParent,
-                query,
                 renderItem: this.renderItem,
             }),
-            query,
         });
     }
 

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -11,19 +11,6 @@ import { IItemListRendererProps, IItemModifiers, IListItemsProps, renderFiltered
 
 export interface IQueryListProps<T> extends IListItemsProps<T> {
     /**
-     * The active item is the current keyboard-focused element.
-     * Listen to `onActiveItemChange` for updates from interactions.
-     */
-    activeItem: T | undefined;
-
-    /**
-     * Invoked when user interaction should change the active item: arrow keys move it up/down
-     * in the list, selecting an item makes it active, and changing the query may reset it to
-     * the first item in the list if it no longer matches the filter.
-     */
-    onActiveItemChange: (activeItem: T | undefined) => void;
-
-    /**
      * Callback invoked when user presses a key, after processing `QueryList`'s own key events
      * (up/down to navigate active item). This callback is passed to `renderer` and (along with
      * `onKeyUp`) can be attached to arbitrary content elements to support keyboard selection.
@@ -42,25 +29,13 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
      * Receives an object with props that should be applied to elements as necessary.
      */
     renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
-
-    /**
-     * Query string passed to `itemListPredicate` or `itemPredicate` to filter items.
-     * This value is controlled: its state must be managed externally by attaching an `onChange`
-     * handler to the relevant element in your `renderer` implementation.
-     */
-    query: string;
 }
 
 /**
  * An object describing how to render a `QueryList`.
  * A `QueryList` `renderer` receives this object as its sole argument.
  */
-export interface IQueryListRendererProps<T> extends IProps {
-    /**
-     * Array of items filtered by `itemListPredicate` or `itemPredicate`.
-     */
-    filteredItems: T[];
-
+export interface IQueryListRendererProps<T> extends IQueryListState<T>, IProps {
     /**
      * Selection handler that should be invoked when a new item has been chosen,
      * perhaps because the user clicked it.
@@ -79,15 +54,25 @@ export interface IQueryListRendererProps<T> extends IProps {
      */
     handleKeyUp: React.KeyboardEventHandler<HTMLElement>;
 
+    /**
+     * Change handler for query string. Attach this to an input element to allow
+     * `QueryList` to control the query.
+     */
+    handleQueryChange: React.ChangeEventHandler<HTMLInputElement>;
+
     /** Rendered elements returned from `itemListRenderer` prop. */
     itemList: React.ReactNode;
-
-    /** The current query string. */
-    query: string;
 }
 
 export interface IQueryListState<T> {
+    /** The currently focused item (for keyboard interactions). */
+    activeItem: T | undefined;
+
+    /** The original `items` array filtered by `itemListPredicate` or `itemPredicate`. */
     filteredItems: T[];
+
+    /** The current query string. */
+    query: string;
 }
 
 export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryListState<T>> {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -275,7 +275,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     };
 
     private handleQueryChange = (event?: React.ChangeEvent<HTMLInputElement>) => {
-        const query = event == null ? "" : event.currentTarget.value;
+        const query = event == null ? "" : event.target.value;
         this.setQuery(query);
         Utils.safeInvoke(this.props.onQueryChange, query, event);
     };

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -184,13 +184,15 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     // TODO resetActiveItem = this.props.resetOnQuery
     public setQuery(query: string, resetActiveItem = false) {
+        if (query !== this.state.query) {
+            Utils.safeInvoke(this.props.onQueryChange, query);
+        }
         this.setState({ filteredItems: getFilteredItems(query, this.props), query }, () => {
             // wait will state has updated so we select the first from newly filtered items
             if (resetActiveItem) {
-                this.setActiveItem("first");
+                this.setFirstActiveItem();
             }
         });
-        Utils.safeInvoke(this.props.onQueryChange, query);
     }
 
     /** default `itemListRenderer` implementation */
@@ -289,7 +291,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         return getFirstEnabledItem(this.state.filteredItems, this.props.itemDisabled, direction, startIndex);
     }
 
-    private setActiveItem(activeItem: T | "first" | undefined) {
+    private setActiveItem(activeItem: T | undefined) {
         if (this.props.activeItem == null) {
             this.setState({ activeItem });
         }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -66,7 +66,7 @@ export interface IQueryListRendererProps<T> extends IQueryListState<T>, IProps {
 
 export interface IQueryListState<T> {
     /** The currently focused item (for keyboard interactions). */
-    activeItem: T | undefined;
+    activeItem: T | null;
 
     /** The original `items` array filtered by `itemListPredicate` or `itemPredicate`. */
     filteredItems: T[];
@@ -119,7 +119,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     public componentWillReceiveProps(nextProps: IQueryListProps<T>) {
-        if (nextProps.activeItem != null) {
+        if (nextProps.activeItem !== undefined) {
             this.setState({ activeItem: nextProps.activeItem });
         }
         if (nextProps.query != null) {
@@ -287,12 +287,12 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
      * index. An `undefined` return value means no suitable item was found.
      * @param direction amount to move in each iteration, typically +/-1
      */
-    private getNextActiveItem(direction: number, startIndex = this.getActiveIndex()): T | undefined {
+    private getNextActiveItem(direction: number, startIndex = this.getActiveIndex()): T | null {
         return getFirstEnabledItem(this.state.filteredItems, this.props.itemDisabled, direction, startIndex);
     }
 
-    private setActiveItem(activeItem: T | undefined) {
-        if (this.props.activeItem == null) {
+    private setActiveItem(activeItem: T | null) {
+        if (this.props.activeItem === undefined) {
             this.setState({ activeItem });
         }
         Utils.safeInvoke(this.props.onActiveItemChange, activeItem);
@@ -327,8 +327,8 @@ function wrapNumber(value: number, min: number, max: number) {
     return value;
 }
 
-function isItemDisabled<T>(item: T, index: number, itemDisabled?: IListItemsProps<T>["itemDisabled"]) {
-    if (itemDisabled == null) {
+function isItemDisabled<T>(item: T | null, index: number, itemDisabled?: IListItemsProps<T>["itemDisabled"]) {
+    if (itemDisabled == null || item == null) {
         return false;
     } else if (Utils.isFunction(itemDisabled)) {
         return itemDisabled(item, index);
@@ -349,9 +349,9 @@ export function getFirstEnabledItem<T>(
     itemDisabled?: keyof T | ((item: T, index: number) => boolean),
     direction = 1,
     startIndex = items.length - 1,
-): T | undefined {
+): T | null {
     if (items.length === 0) {
-        return undefined;
+        return null;
     }
     // remember where we started to prevent an infinite loop
     let index = startIndex;
@@ -363,5 +363,5 @@ export function getFirstEnabledItem<T>(
             return items[index];
         }
     } while (index !== startIndex);
-    return undefined;
+    return null;
 }

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -32,14 +32,6 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     popoverProps?: Partial<IPopoverProps> & object;
 
-    /**
-     * Whether the filtering state should be reset to initial when an item is selected
-     * (immediately before `onItemSelect` is invoked), or when the popover closes.
-     * The query will become the empty string and the first item will be made active.
-     * @default false
-     */
-    resetOnSelect?: boolean;
-
     /** Props to spread to `TagInput`. */
     tagInputProps?: Partial<ITagInputProps> & object;
 

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -23,7 +23,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     popoverProps?: Partial<IPopoverProps> & object;
 
-    /** Props to spread to `TagInput`. */
+    /** Props to spread to `TagInput`. Use `query` and `onQueryChange` to control the input. */
     tagInputProps?: Partial<ITagInputProps> & object;
 
     /** Custom renderer to transform an item into tag content. */

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -6,16 +6,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import {
-    HTMLInputProps,
-    IPopoverProps,
-    ITagInputProps,
-    Keys,
-    Popover,
-    Position,
-    TagInput,
-    Utils,
-} from "@blueprintjs/core";
+import { IPopoverProps, ITagInputProps, Keys, Popover, Position, TagInput, Utils } from "@blueprintjs/core";
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
@@ -39,22 +30,19 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     tagRenderer: (item: T) => React.ReactNode;
 }
 
-export interface IMultiSelectState<T> {
-    activeItem?: T;
+export interface IMultiSelectState {
     isOpen: boolean;
-    query: string;
 }
 
-export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState<T>> {
+export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState> {
     public static displayName = "Blueprint2.MultiSelect";
 
     public static ofType<T>() {
         return MultiSelect as new (props: IMultiSelectProps<T>) => MultiSelect<T>;
     }
 
-    public state: IMultiSelectState<T> = {
+    public state: IMultiSelectState = {
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
-        query: "",
     };
 
     private TypedQueryList = QueryList.ofType<T>();
@@ -71,15 +59,13 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { openOnKeyDown, popoverProps, resetOnSelect, tagInputProps, ...restProps } = this.props;
+        const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                activeItem={this.state.activeItem}
-                onActiveItemChange={this.handleActiveItemChange}
                 onItemSelect={this.handleItemSelect}
-                query={this.state.query}
+                onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
             />
@@ -88,13 +74,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { tagInputProps = {}, popoverProps = {}, selectedItems = [] } = this.props;
-        const { handleKeyDown, handleKeyUp, query } = listProps;
-        const defaultInputProps: HTMLInputProps = {
-            placeholder: "Search...",
-            ...tagInputProps.inputProps,
-            onChange: this.handleQueryChange,
-            value: query,
-        };
+        const { handleKeyDown, handleKeyUp } = listProps;
 
         return (
             <Popover
@@ -108,17 +88,18 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpened={this.handlePopoverOpened}
-                onOpening={this.handlePopoverOpening}
             >
                 <div
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                 >
                     <TagInput
+                        placeholder="Search..."
                         {...tagInputProps}
-                        inputProps={defaultInputProps}
-                        inputRef={this.refHandlers.input}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
+                        inputRef={this.refHandlers.input}
+                        inputValue={listProps.query}
+                        onInputChange={listProps.handleQueryChange}
                         values={selectedItems.map(this.props.tagRenderer)}
                     />
                 </div>
@@ -129,59 +110,31 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         );
     };
 
-    private isQueryEmpty = () => this.state.query.length === 0;
-
-    private handleQueryChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
-        const { tagInputProps = {}, openOnKeyDown } = this.props;
-        const query = evt.currentTarget.value;
-        this.setState({ query, isOpen: !this.isQueryEmpty() || !openOnKeyDown });
-
-        if (tagInputProps.inputProps != null) {
-            Utils.safeInvoke(tagInputProps.inputProps.onChange, evt);
-        }
-    };
-
     private handleItemSelect = (item: T, evt?: React.SyntheticEvent<HTMLElement>) => {
         if (this.input != null) {
             this.input.focus();
         }
-        // make sure the query is valid by checking if activeItem is defined
-        if (this.state.activeItem != null) {
-            if (this.props.resetOnSelect && !this.isQueryEmpty()) {
-                this.setState({
-                    activeItem: this.props.items[0],
-                    query: "",
-                });
-            }
-        }
         Utils.safeInvoke(this.props.onItemSelect, item, evt);
+    };
+
+    private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ isOpen: query.length > 0 || !this.props.openOnKeyDown });
+        Utils.safeInvoke(this.props.onQueryChange, query, evt);
     };
 
     private handlePopoverInteraction = (nextOpenState: boolean) =>
         requestAnimationFrame(() => {
             // deferring to rAF to get properly updated activeElement
-            const { popoverProps = {}, resetOnSelect } = this.props;
+            const { popoverProps = {} } = this.props;
             if (this.input != null && this.input !== document.activeElement) {
                 // the input is no longer focused so we can close the popover
-                this.setState({
-                    activeItem: resetOnSelect ? this.props.items[0] : this.state.activeItem,
-                    isOpen: false,
-                    query: resetOnSelect ? "" : this.state.query,
-                });
+                this.setState({ isOpen: false });
             } else if (!this.props.openOnKeyDown) {
                 // open the popover when focusing the tag input
                 this.setState({ isOpen: true });
             }
             Utils.safeInvoke(popoverProps.onInteraction, nextOpenState);
         });
-
-    private handlePopoverOpening = (node: HTMLElement) => {
-        const { popoverProps = {}, resetOnSelect } = this.props;
-        if (resetOnSelect) {
-            this.setState({ activeItem: this.props.items[0] });
-        }
-        Utils.safeInvoke(popoverProps.onOpening, node);
-    };
 
     private handlePopoverOpened = (node: HTMLElement) => {
         const { popoverProps = {} } = this.props;
@@ -192,26 +145,18 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         Utils.safeInvoke(popoverProps.onOpened, node);
     };
 
-    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
-
     private getTargetKeyDownHandler = (
         handleQueryListKeyDown: React.EventHandler<React.KeyboardEvent<HTMLElement>>,
     ) => {
         return (e: React.KeyboardEvent<HTMLElement>) => {
             const { which } = e;
-            const { resetOnSelect } = this.props;
-
             if (which === Keys.ESCAPE || which === Keys.TAB) {
                 // By default the escape key will not trigger a blur on the
                 // input element. It must be done explicitly.
                 if (this.input != null) {
                     this.input.blur();
                 }
-                this.setState({
-                    activeItem: resetOnSelect ? this.props.items[0] : this.state.activeItem,
-                    isOpen: false,
-                    query: resetOnSelect ? "" : this.state.query,
-                });
+                this.setState({ isOpen: false });
             } else if (!(which === Keys.BACKSPACE || which === Keys.ARROW_LEFT || which === Keys.ARROW_RIGHT)) {
                 this.setState({ isOpen: true });
             }

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -86,7 +86,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, inputProps, popoverProps, onQueryChange, ...restProps } = this.props;
+        const { filterable, inputProps, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -37,9 +37,9 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
     disabled?: boolean;
 
     /**
-     * Props to spread to `InputGroup`. All props are supported except `ref` (use `inputRef` instead).
-     * If you want to control the filter input, you can pass `value` and `onChange` here
-     * to override `Select`'s own behavior.
+     * Props to spread to the query `InputGroup`. Use `query` and
+     * `onQueryChange` instead of `inputProps.value` and `inputProps.onChange`
+     * to control this input. Use `inputRef` instead of `ref`.
      */
     inputProps?: IInputGroupProps & HTMLInputProps;
 

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -47,14 +47,6 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
     popoverProps?: Partial<IPopoverProps> & object;
 
     /**
-     * Whether the filtering state should be reset to initial when an item is selected
-     * (immediately before `onItemSelect` is invoked). The query will become the empty string
-     * and the first item will be made active.
-     * @default false
-     */
-    resetOnSelect?: boolean;
-
-    /**
      * Whether the filtering state should be reset to initial when the popover closes.
      * The query will become the empty string and the first item will be made active.
      * @default false

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -109,14 +109,11 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
         const { filterable = true, disabled = false, inputProps = {}, popoverProps = {} } = this.props;
 
-        const clearButton =
-            listProps.query.length > 0 ? <Button icon="cross" minimal={true} onClick={this.resetQuery} /> : undefined;
-
         const input = (
             <InputGroup
                 leftIcon="search"
                 placeholder="Filter..."
-                rightElement={clearButton}
+                rightElement={this.maybeRenderClearButton(listProps.query)}
                 {...inputProps}
                 inputRef={this.refHandlers.input}
                 onChange={listProps.handleQueryChange}
@@ -153,6 +150,10 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
             </Popover>
         );
     };
+
+    private maybeRenderClearButton(query: string) {
+        return query.length > 0 ? <Button icon="cross" minimal={true} onClick={this.resetQuery} /> : undefined;
+    }
 
     private handleTargetKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
         // open popover when arrow key pressed on target while closed

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -28,9 +28,9 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     closeOnSelect?: boolean;
 
     /**
-     * Props to spread to `InputGroup`. All props are supported except `ref` (use `inputRef` instead).
-     * If you want to control the filter input, you can pass `value` and `onChange` here
-     * to override `Suggest`'s own behavior.
+     * Props to spread to `InputGroup`. Use `query` and `onQueryChange` instead
+     * of `inputProps.value` and `inputProps.onChange` to control this input.
+     * Use `inputRef` instead of `ref`.
      */
     inputProps?: IInputGroupProps & HTMLInputProps;
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -49,10 +49,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 }
 
 export interface ISuggestState<T> {
-    activeItem?: T;
     isOpen: boolean;
-    isTyping: boolean;
-    query: string;
     selectedItem?: T;
 }
 
@@ -71,8 +68,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     public state: ISuggestState<T> = {
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
-        isTyping: false,
-        query: "",
     };
 
     private TypedQueryList = QueryList.ofType<T>();
@@ -94,10 +89,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         return (
             <this.TypedQueryList
                 {...restProps}
-                activeItem={this.state.activeItem}
-                onActiveItemChange={this.handleActiveItemChange}
                 onItemSelect={this.handleItemSelect}
-                query={this.state.query}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
             />
@@ -111,33 +103,33 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { inputValueRenderer, inputProps = {}, popoverProps = {} } = this.props;
-        const { isTyping, selectedItem, query } = this.state;
+        const { inputProps = {}, popoverProps = {} } = this.props;
+        const { isOpen, selectedItem } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
-        const inputValue: string = isTyping ? query : selectedItem ? inputValueRenderer(selectedItem) : "";
+        const { placeholder = "Search..." } = inputProps;
 
+        const selectedItemText = selectedItem ? this.props.inputValueRenderer(selectedItem) : "";
         return (
             <Popover
                 autoFocus={false}
                 enforceFocus={false}
-                isOpen={this.state.isOpen}
+                isOpen={isOpen}
                 position={Position.BOTTOM_LEFT}
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpened={this.handlePopoverOpened}
-                onClosing={this.handlePopoverClosing}
             >
                 <InputGroup
-                    placeholder="Search..."
-                    value={inputValue}
                     {...inputProps}
+                    placeholder={isOpen && selectedItemText ? selectedItemText : placeholder}
                     inputRef={this.refHandlers.input}
-                    onChange={this.handleQueryChange}
+                    onChange={listProps.handleQueryChange}
                     onFocus={this.handleInputFocus}
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTargetKeyUpHandler(handleKeyUp)}
+                    value={isOpen ? listProps.query : selectedItemText}
                 />
                 <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                     {listProps.itemList}
@@ -168,8 +160,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(inputProps.onFocus, event);
     };
 
-    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
-
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         let nextOpenState: boolean;
         if (!this.props.closeOnSelect) {
@@ -187,8 +177,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
         this.setState({
             isOpen: nextOpenState,
-            isTyping: false,
-            query: "",
             selectedItem: item,
         });
 
@@ -218,37 +206,11 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(popoverProps.onOpened, node);
     };
 
-    private handlePopoverClosing = (node: HTMLElement) => {
-        const { popoverProps = {} } = this.props;
-        const { selectedItem } = this.state;
-
-        // reset the query when the popover close, make sure that the list
-        // isn't filtered on when the popover opens next
-        this.setState({
-            activeItem: selectedItem ? selectedItem : this.props.items[0],
-            query: "",
-        });
-
-        Utils.safeInvoke(popoverProps.onClosing, node);
-    };
-
-    private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
-        const { inputProps = {} } = this.props;
-
-        this.setState({
-            isTyping: true,
-            query: event.currentTarget.value,
-        });
-
-        Utils.safeInvoke(inputProps.onChange, event);
-    };
-
     private getTargetKeyDownHandler = (
         handleQueryListKeyDown: React.EventHandler<React.KeyboardEvent<HTMLElement>>,
     ) => {
         return (evt: React.KeyboardEvent<HTMLInputElement>) => {
             const { which } = evt;
-            const { isTyping, selectedItem } = this.state;
             const { inputProps = {}, openOnKeyDown } = this.props;
 
             if (which === Keys.ESCAPE || which === Keys.TAB) {
@@ -257,7 +219,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 }
                 this.setState({
                     isOpen: false,
-                    selectedItem: isTyping ? undefined : selectedItem,
                 });
             } else if (
                 openOnKeyDown &&

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -48,10 +48,8 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 }
 
 export interface ISuggestState<T> {
-    activeItem?: T;
     isOpen: boolean;
     isTyping: boolean;
-    query: string;
     selectedItem?: T;
 }
 
@@ -71,7 +69,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     public state: ISuggestState<T> = {
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
         isTyping: false,
-        query: "",
     };
 
     private TypedQueryList = QueryList.ofType<T>();
@@ -93,10 +90,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         return (
             <this.TypedQueryList
                 {...restProps}
-                activeItem={this.state.activeItem}
-                onActiveItemChange={this.handleActiveItemChange}
                 onItemSelect={this.handleItemSelect}
-                query={this.state.query}
+                onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
             />
@@ -111,8 +106,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { inputValueRenderer, inputProps = {}, popoverProps = {} } = this.props;
-        const { isTyping, selectedItem, query } = this.state;
-        const { handleKeyDown, handleKeyUp } = listProps;
+        const { isTyping, selectedItem } = this.state;
+        const { handleKeyDown, handleKeyUp, query } = listProps;
         const inputValue: string = isTyping ? query : selectedItem ? inputValueRenderer(selectedItem) : "";
 
         return (
@@ -126,17 +121,16 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpened={this.handlePopoverOpened}
-                onClosing={this.handlePopoverClosing}
             >
                 <InputGroup
                     placeholder="Search..."
-                    value={inputValue}
                     {...inputProps}
                     inputRef={this.refHandlers.input}
-                    onChange={this.handleQueryChange}
+                    onChange={listProps.handleQueryChange}
                     onFocus={this.handleInputFocus}
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTargetKeyUpHandler(handleKeyUp)}
+                    value={inputValue}
                 />
                 <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                     {listProps.itemList}
@@ -167,8 +161,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(inputProps.onFocus, event);
     };
 
-    private handleActiveItemChange = (activeItem?: T) => this.setState({ activeItem });
-
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         let nextOpenState: boolean;
         if (!this.props.closeOnSelect) {
@@ -187,7 +179,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         this.setState({
             isOpen: nextOpenState,
             isTyping: false,
-            query: "",
             selectedItem: item,
         });
 
@@ -217,29 +208,9 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(popoverProps.onOpened, node);
     };
 
-    private handlePopoverClosing = (node: HTMLElement) => {
-        const { popoverProps = {} } = this.props;
-        const { selectedItem } = this.state;
-
-        // reset the query when the popover close, make sure that the list
-        // isn't filtered on when the popover opens next
-        this.setState({
-            activeItem: selectedItem ? selectedItem : this.props.items[0],
-            query: "",
-        });
-
-        Utils.safeInvoke(popoverProps.onClosing, node);
-    };
-
-    private handleQueryChange = (event: React.FormEvent<HTMLInputElement>) => {
-        const { inputProps = {} } = this.props;
-
-        this.setState({
-            isTyping: true,
-            query: event.currentTarget.value,
-        });
-
-        Utils.safeInvoke(inputProps.onChange, event);
+    private handleQueryChange = (query: string, event?: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ isTyping: true });
+        Utils.safeInvoke(this.props.onQueryChange, query, event);
     };
 
     private getTargetKeyDownHandler = (

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -38,7 +38,7 @@ describe("<MultiSelect>", () => {
         };
     });
 
-    selectComponentSuite<IMultiSelectProps<IFilm>, IMultiSelectState<IFilm>>(props =>
+    selectComponentSuite<IMultiSelectProps<IFilm>, IMultiSelectState>(props =>
         mount(<MultiSelect {...props} popoverProps={{ isOpen: true, usePortal: false }} tagRenderer={renderTag} />),
     );
 

--- a/packages/select/test/omnibarTests.tsx
+++ b/packages/select/test/omnibarTests.tsx
@@ -11,7 +11,5 @@ import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<Omnibar>", () => {
     // must have query to show any items
-    selectComponentSuite(props =>
-        mount(<Omnibar {...props} query=" " isOpen={true} overlayProps={{ usePortal: false }} />),
-    );
+    selectComponentSuite(props => mount(<Omnibar {...props} isOpen={true} overlayProps={{ usePortal: false }} />));
 });

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -16,7 +16,6 @@ import { IQueryListRendererProps, ItemListPredicate, ItemListRenderer, QueryList
 describe("<QueryList>", () => {
     const FilmQueryList = QueryList.ofType<IFilm>();
     const testProps = {
-        activeItem: TOP_100_FILMS[0],
         itemRenderer: sinon.spy(renderFilm),
         items: TOP_100_FILMS.slice(0, 20),
         onActiveItemChange: sinon.spy(),
@@ -37,7 +36,7 @@ describe("<QueryList>", () => {
         );
 
         it("renderItem calls itemRenderer", () => {
-            const wrapper = shallow(<FilmQueryList {...testProps} query="19" itemListRenderer={itemListRenderer} />);
+            const wrapper = shallow(<FilmQueryList {...testProps} itemListRenderer={itemListRenderer} />);
             assert.lengthOf(wrapper.find("ul.foo"), 1, "should find element");
             assert.equal(testProps.itemRenderer.callCount, 20);
         });
@@ -89,7 +88,7 @@ describe("<QueryList>", () => {
             const filmQueryList = mount(<FilmQueryList {...testProps} items={[myItem]} activeItem={myItem} query="" />);
             filmQueryList.setState({ query: "query" });
             filmQueryList.setState({ activeItem: undefined });
-            assert.equal(testProps.onActiveItemChange.callCount, 0);
+            assert.equal(testProps.onActiveItemChange.callCount, 1);
         });
     });
 

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -11,6 +11,7 @@ import { IItemListRendererProps, renderFilteredItems } from "../src";
 
 describe("renderFilteredItems()", () => {
     const PROPS: IItemListRendererProps<string> = {
+        activeItem: "one",
         filteredItems: ["one"],
         items: ["one", "two", "three"],
         itemsParentRef: sinon.stub(),

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -35,7 +35,7 @@ describe("<Select>", () => {
         };
     });
 
-    selectComponentSuite<ISelectProps<IFilm>, ISelectState<IFilm>>(props =>
+    selectComponentSuite<ISelectProps<IFilm>, ISelectState>(props =>
         mount(<Select {...props} popoverProps={{ isOpen: true, usePortal: false }} />),
     );
 
@@ -56,12 +56,11 @@ describe("<Select>", () => {
         assert.strictEqual(wrapper.find(Popover).prop("disabled"), true);
     });
 
-    it("input can be controlled with inputProps", () => {
+    it("inputProps value and onChange are ignored", () => {
         const inputProps = { value: "nailed it", onChange: sinon.spy() };
         const input = select({ inputProps }).find("input");
-        assert.equal(input.prop("value"), inputProps.value);
-        input.simulate("change");
-        assert.isTrue(inputProps.onChange.calledOnce);
+        assert.notEqual(input.prop("onChange"), inputProps.onChange);
+        assert.notEqual(input.prop("value"), inputProps.value);
     });
 
     it("popover can be controlled with popoverProps", () => {

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -11,8 +11,7 @@ import * as React from "react";
 import * as sinon from "sinon";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
-import { ISuggestProps, ISuggestState, Suggest } from "../src/components/select/suggest";
-import { selectComponentSuite } from "./selectComponentSuite";
+import { ISuggestProps, Suggest } from "../src/components/select/suggest";
 
 describe("Suggest", () => {
     const FilmSuggest = Suggest.ofType<IFilm>();
@@ -37,15 +36,16 @@ describe("Suggest", () => {
         };
     });
 
-    selectComponentSuite<ISuggestProps<IFilm>, ISuggestState<IFilm>>(props =>
-        mount(
-            <Suggest
-                {...props}
-                inputValueRenderer={inputValueRenderer}
-                popoverProps={{ isOpen: true, usePortal: false }}
-            />,
-        ),
-    );
+    // TODO: Suggest does not use the new APIs yet as it requires more extensive refactors
+    // selectComponentSuite<ISuggestProps<IFilm>, ISuggestState<IFilm>>(props =>
+    //     mount(
+    //         <Suggest
+    //             {...props}
+    //             inputValueRenderer={inputValueRenderer}
+    //             popoverProps={{ isOpen: true, usePortal: false }}
+    //         />,
+    //     ),
+    // );
 
     describe("Basic behavior", () => {
         it("renders an input that triggers a popover containing items", () => {
@@ -140,13 +140,12 @@ describe("Suggest", () => {
     });
 
     describe("inputProps", () => {
-        it("value and onChange are ignored", () => {
-            const value = "nailed it";
-            const onChange = sinon.spy();
-
-            const input = suggest({ inputProps: { value, onChange } }).find("input");
-            assert.notStrictEqual(input.prop("onChange"), onChange);
-            assert.notStrictEqual(input.prop("value"), value);
+        it("input can be controlled with inputProps", () => {
+            const inputProps = { value: "nailed it", onChange: sinon.spy() };
+            const input = suggest({ inputProps }).find("input");
+            assert.equal(input.prop("value"), inputProps.value);
+            input.simulate("change");
+            assert.isTrue(inputProps.onChange.calledOnce);
         });
 
         it("invokes inputProps key handlers", () => {

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -140,12 +140,13 @@ describe("Suggest", () => {
     });
 
     describe("inputProps", () => {
-        it("input can be controlled with inputProps", () => {
-            const inputProps = { value: "nailed it", onChange: sinon.spy() };
-            const input = suggest({ inputProps }).find("input");
-            assert.equal(input.prop("value"), inputProps.value);
-            input.simulate("change");
-            assert.isTrue(inputProps.onChange.calledOnce);
+        it("value and onChange are ignored", () => {
+            const value = "nailed it";
+            const onChange = sinon.spy();
+
+            const input = suggest({ inputProps: { value, onChange } }).find("input");
+            assert.notStrictEqual(input.prop("onChange"), onChange);
+            assert.notStrictEqual(input.prop("value"), value);
         });
 
         it("invokes inputProps key handlers", () => {

--- a/packages/timezone/test/timezonePickerTests.tsx
+++ b/packages/timezone/test/timezonePickerTests.tsx
@@ -87,12 +87,12 @@ describe("<TimezonePicker>", () => {
         const timezonePicker = shallow(<TimezonePicker {...DEFAULT_PROPS} />);
 
         const query1 = "test query 1";
-        findInputGroup(timezonePicker).simulate("change", { currentTarget: { value: query1 } });
+        findInputGroup(timezonePicker).simulate("change", { target: { value: query1 } });
         assert.strictEqual(timezonePicker.state("query"), query1);
         const items1 = findSelect(timezonePicker).prop("items");
 
         const query2 = "test query 2";
-        findInputGroup(timezonePicker).simulate("change", { currentTarget: { value: query2 } });
+        findInputGroup(timezonePicker).simulate("change", { target: { value: query2 } });
         assert.strictEqual(timezonePicker.state("query"), query2);
         const items2 = findSelect(timezonePicker).prop("items");
 
@@ -161,15 +161,6 @@ describe("<TimezonePicker>", () => {
         clickFirstMenuItem(timezonePicker);
         assert.isTrue(onChange.calledOnce);
         assert.strictEqual(timezonePicker.find(Button).prop("text"), value);
-    });
-
-    it("invokes the onChange input prop", () => {
-        const query = "test query";
-        const onInputChange = sinon.spy();
-        const timezonePicker = shallow(<TimezonePicker {...DEFAULT_PROPS} inputProps={{ onChange: onInputChange }} />);
-        const inputGroup = findInputGroup(timezonePicker);
-        inputGroup.simulate("change", { currentTarget: { value: query } });
-        assert.isTrue(onInputChange.calledOnce);
     });
 
     it("popover can be controlled with popover props", () => {


### PR DESCRIPTION
#### Significant refactor to `select` components in which most state is moved into `QueryList` enabling _controlled and uncontrolled_ usage of `query` and `activeItem` (keyboard selection state).

- ⭐️ optional `query`/`onQueryChange`, `activeItem`/`onActiveItemChange` props supported in all 4 components, implemented in `QueryList`
- `resetOnSelect` has also been made a "common" prop, supported natively in `QueryList`
- each component's state now reflects the features it adds on top of `QueryList` (like a few track `isOpen` for their popover)

#### Reviewers should focus on:

- I recognize that this PR is very large and I'd be happy to break it up into smaller chunks if you suggest lines along which to cut. I already pulled several features out of my original attempt (see #2646 and #2723).
    - Ok, I reverted `Suggest` in here because it requires more work than the others. See #2748
- The commits do a fairly good job of telling the story, so that may be a good way to review.