### PR TITLE
[Popover] new captureDismiss=true prop for better uncontrolled click-to-close

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -149,6 +149,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         return (
             <Popover
                 autoFocus={false}
+                captureDismiss={false}
                 disabled={disabled}
                 enforceFocus={false}
                 hoverCloseDelay={0}

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -240,16 +240,46 @@ The following example demonstrates the various interaction kinds (note: these Po
 
 @### Closing on click
 
-To enable click-to-close behavior on an element inside a popover, simply add the
-class `Classes.POPOVER_DISMISS` to that element. For example, the **Dismiss**
-button in the top-level [Popover example](#core/components/popover) has this
-class. To enable this behavior on the entire popover, pass the
-`popoverClassName={Classes.POPOVER_DISMISS}` prop.
+Sometimes it is desirable for an element inside a `Popover` to close the popover
+on click. `Popover` supports a pair of CSS classes, `Classes.POPOVER_DISMISS`
+and `Classes.POPOVER_DISMISS_OVERRIDE`, that can be attached to elements to
+describe whether click events should dismiss the enclosing popover.
+
+To mark an element (and its children) as "dismiss elements", simply add the
+class `Classes.POPOVER_DISMISS`. For example, the **Dismiss** button in the
+top-level [Popover example](#core/components/popover) has this class, and all
+`MenuItem`s receive this class by default (see `shouldDismissPopover` prop). To
+enable this behavior on the entire popover body, pass
+`popoverClassName={Classes.POPOVER_DISMISS}`.
+
+Cancel the dismiss behavior on subtrees by nesting
+`Classes.POPOVER_DISMISS_OVERRIDE` inside `Classes.POPOVER_DISMISS`. Clicks
+originating inside disabled elements (either via the `disabled` attribute or
+`Classes.DISABLED`) will never dismiss a popover.
+
+Additionally, the prop `captureDismiss` (enabled by default) will prevent click
+events from dismissing _grandparent_ popovers (not the `Popover` immediately
+containing the dismiss element). `MenuItem` disables this feature such that
+clicking any submenu item will close all submenus, which is desirable behavior
+for a menu tree.
+
+```tsx
+<div className={Classes.POPOVER_DISMISS}>
+    <button>Click me to dismiss</button>
+    <button disabled={true}>I will not dismiss</button>
+    <div className={Classes.POPOVER_DISMISS_OVERRIDE}>
+        <button>I too shall not dismiss</button>
+    </div>
+</div>
+```
+
+@reactExample PopoverDismissExample
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     Dismiss elements won't have any effect in a popover with
-    `PopoverInteractionKind.HOVER_TARGET_ONLY`, because there is no way to interact with the popover
-    content itself (the popover is dismissed the moment the user mouses away from the target).
+    `PopoverInteractionKind.HOVER_TARGET_ONLY`, because there is no way to
+    interact with the popover content itself: the popover is dismissed the
+    moment the user mouses away from the target.
 </div>
 
 @### Backdrop

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -86,6 +86,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
     public static defaultProps: IPopoverProps = {
+        captureDismiss: true,
         defaultIsOpen: false,
         disabled: false,
         hasBackdrop: false,
@@ -422,10 +423,14 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
 
     private handlePopoverClick = (e: React.MouseEvent<HTMLElement>) => {
         const eventTarget = e.target as HTMLElement;
-        const shouldDismiss = eventTarget.closest(`.${Classes.POPOVER_DISMISS}`) != null;
-        const overrideDismiss = eventTarget.closest(`.${Classes.POPOVER_DISMISS_OVERRIDE}`) != null;
-        if (shouldDismiss && !overrideDismiss) {
+        // an OVERRIDE inside a DISMISS does not dismiss, and a DISMISS inside an OVERRIDE will dismiss.
+        const dismissElement = eventTarget.closest(`.${Classes.POPOVER_DISMISS}, .${Classes.POPOVER_DISMISS_OVERRIDE}`);
+        const shouldDismiss = dismissElement != null && dismissElement.classList.contains(Classes.POPOVER_DISMISS);
+        if (shouldDismiss && !e.isDefaultPrevented()) {
             this.setOpenState(false, e);
+            if (this.props.captureDismiss) {
+                e.preventDefault();
+            }
         }
     };
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -426,7 +426,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         // an OVERRIDE inside a DISMISS does not dismiss, and a DISMISS inside an OVERRIDE will dismiss.
         const dismissElement = eventTarget.closest(`.${Classes.POPOVER_DISMISS}, .${Classes.POPOVER_DISMISS_OVERRIDE}`);
         const shouldDismiss = dismissElement != null && dismissElement.classList.contains(Classes.POPOVER_DISMISS);
-        if (shouldDismiss && !e.isDefaultPrevented()) {
+        const isDisabled = eventTarget.closest(`:disabled, .${Classes.DISABLED}`) != null;
+        if (shouldDismiss && !isDisabled && !e.isDefaultPrevented()) {
             this.setOpenState(false, e);
             if (this.props.captureDismiss) {
                 e.preventDefault();

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -15,6 +15,17 @@ export { PopperModifiers };
 /** Props shared between `Popover` and `Tooltip`. */
 export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     /**
+     * When enabled, `preventDefault()` is invoked on `click` events that close
+     * this popover, which will prevent those clicks from closing outer
+     * popovers. When disabled, clicking inside a `Classes.POPOVER_DISMISS`
+     * element will close the parent popover.
+     *
+     * See http://blueprintjs.com/docs/#core/components/popover.closing-on-click
+     * @default true
+     */
+    captureDismiss?: boolean;
+
+    /**
      * Initial opened state when uncontrolled.
      * @default false
      */

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -607,57 +607,70 @@ describe("<Popover>", () => {
     });
 
     describe("closing on click", () => {
-        it("Classes.POPOVER_DISMISS closes on click", () => {
-            wrapper = renderPopover(
-                { defaultIsOpen: true },
+        it("Classes.POPOVER_DISMISS closes on click", () =>
+            assertClickToClose(
                 <button className={Classes.POPOVER_DISMISS} id="btn">
                     Dismiss
                 </button>,
-            );
-            wrapper.find("#btn").simulate("click");
-            wrapper.assertIsOpen(false);
-        });
+                false,
+            ));
 
-        it("Classes.POPOVER_DISMISS_OVERRIDE does not close", () => {
-            wrapper = renderPopover(
-                { defaultIsOpen: true },
+        it("Classes.POPOVER_DISMISS_OVERRIDE does not close", () =>
+            assertClickToClose(
                 <span className={Classes.POPOVER_DISMISS}>
                     <button className={Classes.POPOVER_DISMISS_OVERRIDE} id="btn">
                         Dismiss
                     </button>
                 </span>,
-            );
-            wrapper.find("#btn").simulate("click");
-            wrapper.assertIsOpen(true);
-        });
+                true,
+            ));
 
-        it("inner dismiss does not close outer popover", () => {
-            wrapper = renderPopover(
-                { defaultIsOpen: true },
+        it(":disabled does not close", () =>
+            assertClickToClose(
+                <button className={Classes.POPOVER_DISMISS} disabled={true} id="btn">
+                    Dismiss
+                </button>,
+                true,
+            ));
+
+        it("Classes.DISABLED does not close", () =>
+            assertClickToClose(
+                // testing nested behavior too
+                <div className={Classes.DISABLED}>
+                    <button className={Classes.POPOVER_DISMISS} id="btn">
+                        Dismiss
+                    </button>
+                </div>,
+                true,
+            ));
+
+        it("inner dismiss does not close outer popover", () =>
+            assertClickToClose(
                 <Popover defaultIsOpen={true} usePortal={false}>
                     <button>Target</button>
                     <button className={Classes.POPOVER_DISMISS} id="btn">
                         Dismiss
                     </button>
                 </Popover>,
-            );
-            wrapper.find("#btn").simulate("click");
-            wrapper.assertIsOpen(true);
-        });
+                true,
+            ));
 
-        it("captureDismiss={false} inner dismiss closes outer popover", () => {
-            wrapper = renderPopover(
-                { defaultIsOpen: true },
+        it("captureDismiss={false} inner dismiss closes outer popover", () =>
+            assertClickToClose(
                 <Popover captureDismiss={false} defaultIsOpen={true} usePortal={false}>
                     <button>Target</button>
                     <button className={Classes.POPOVER_DISMISS} id="btn">
                         Dismiss
                     </button>
                 </Popover>,
-            );
+                false,
+            ));
+
+        function assertClickToClose(children: React.ReactNode, expectedIsOpen: boolean) {
+            wrapper = renderPopover({ defaultIsOpen: true }, children);
             wrapper.find("#btn").simulate("click");
-            wrapper.assertIsOpen(false);
-        });
+            wrapper.assertIsOpen(expectedIsOpen);
+        }
     });
 
     interface IPopoverWrapper extends ReactWrapper<IPopoverProps, IPopoverState> {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -496,30 +496,18 @@ describe("<Popover>", () => {
 
         it("clicking POPOVER_DISMISS closes popover when usePortal=true", () => {
             wrapper = renderPopover(
-                {
-                    interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
-                    usePortal: true,
-                },
+                { defaultIsOpen: true, usePortal: true },
                 <button className={Classes.POPOVER_DISMISS}>Dismiss</button>,
             );
-
-            wrapper.simulateTarget("click").assertIsOpen();
-
-            dispatchMouseEvent(document.getElementsByClassName(Classes.POPOVER_DISMISS)[0], "click");
+            findInPortal(wrapper, `.${Classes.POPOVER_DISMISS}`).simulate("click");
             wrapper.update().assertIsOpen(false);
         });
 
         it("clicking POPOVER_DISMISS closes popover when usePortal=false", () => {
             wrapper = renderPopover(
-                {
-                    interactionKind: PopoverInteractionKind.CLICK_TARGET_ONLY,
-                    usePortal: false,
-                },
+                { defaultIsOpen: true, usePortal: false },
                 <button className={Classes.POPOVER_DISMISS}>Dismiss</button>,
             );
-
-            wrapper.simulateTarget("click").assertIsOpen();
-
             wrapper.findClass(Classes.POPOVER_DISMISS).simulate("click");
             wrapper.assertIsOpen(false);
         });
@@ -618,6 +606,60 @@ describe("<Popover>", () => {
         });
     });
 
+    describe("closing on click", () => {
+        it("Classes.POPOVER_DISMISS closes on click", () => {
+            wrapper = renderPopover(
+                { defaultIsOpen: true },
+                <button className={Classes.POPOVER_DISMISS} id="btn">
+                    Dismiss
+                </button>,
+            );
+            wrapper.find("#btn").simulate("click");
+            wrapper.assertIsOpen(false);
+        });
+
+        it("Classes.POPOVER_DISMISS_OVERRIDE does not close", () => {
+            wrapper = renderPopover(
+                { defaultIsOpen: true },
+                <span className={Classes.POPOVER_DISMISS}>
+                    <button className={Classes.POPOVER_DISMISS_OVERRIDE} id="btn">
+                        Dismiss
+                    </button>
+                </span>,
+            );
+            wrapper.find("#btn").simulate("click");
+            wrapper.assertIsOpen(true);
+        });
+
+        it("inner dismiss does not close outer popover", () => {
+            wrapper = renderPopover(
+                { defaultIsOpen: true },
+                <Popover defaultIsOpen={true} usePortal={false}>
+                    <button>Target</button>
+                    <button className={Classes.POPOVER_DISMISS} id="btn">
+                        Dismiss
+                    </button>
+                </Popover>,
+            );
+            wrapper.find("#btn").simulate("click");
+            wrapper.assertIsOpen(true);
+        });
+
+        it("captureDismiss={false} inner dismiss closes outer popover", () => {
+            wrapper = renderPopover(
+                { defaultIsOpen: true },
+                <Popover captureDismiss={false} defaultIsOpen={true} usePortal={false}>
+                    <button>Target</button>
+                    <button className={Classes.POPOVER_DISMISS} id="btn">
+                        Dismiss
+                    </button>
+                </Popover>,
+            );
+            wrapper.find("#btn").simulate("click");
+            wrapper.assertIsOpen(false);
+        });
+    });
+
     interface IPopoverWrapper extends ReactWrapper<IPopoverProps, IPopoverState> {
         popoverElement: HTMLElement;
         assertFindClass(className: string, expected?: boolean, msg?: string): this;
@@ -633,7 +675,7 @@ describe("<Popover>", () => {
         wrapper = mount(
             <Popover usePortal={false} {...props} hoverCloseDelay={0} hoverOpenDelay={0}>
                 <button>Target</button>
-                <p>Text {content}</p>
+                <div>Text {content}</div>
             </Popover>,
             { attachTo: testsContainerElement },
         ) as IPopoverWrapper;
@@ -642,8 +684,9 @@ describe("<Popover>", () => {
             (expected ? assert.isTrue : assert.isFalse)(wrapper.findClass(className).exists(), msg);
             return wrapper;
         };
-        wrapper.assertIsOpen = (isOpen = true) => {
-            assert.equal(wrapper.find(Overlay).prop("isOpen"), isOpen, "assertIsOpen");
+        wrapper.assertIsOpen = (isOpen = true, index = 0) => {
+            const overlay = wrapper.find(Overlay).at(index);
+            assert.equal(overlay.prop("isOpen"), isOpen, "assertIsOpen");
             return wrapper;
         };
         wrapper.assertOnInteractionCalled = (called = true) => {

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -33,6 +33,7 @@ export * from "./nonIdealStateExample";
 export * from "./overflowListExample";
 export * from "./overlayExample";
 export * from "./panelStackExample";
+export * from "./popoverDismissExample";
 export * from "./popoverExample";
 export * from "./popoverInteractionKindExample";
 export * from "./popoverMinimalExample";

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import * as React from "react";
+
+import { Button, Callout, Classes, Popover } from "@blueprintjs/core";
+import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+
+export class PopoverDismissExample extends React.PureComponent<IExampleProps, { isOpen: boolean }> {
+    public state = { isOpen: true };
+    private timeoutId: number;
+
+    public componentWillUnmount() {
+        window.clearTimeout(this.timeoutId);
+    }
+
+    public render() {
+        return (
+            <Example options={false} {...this.props}>
+                <Popover
+                    isOpen={this.state.isOpen}
+                    onInteraction={this.handleInteraction}
+                    onClosed={this.reopen}
+                    position="right"
+                    usePortal={false}
+                >
+                    <Button intent="primary" text="Try it out" />
+                    <>
+                        <div>
+                            <Button text="Default" />
+                            <Button className={Classes.POPOVER_DISMISS} intent="danger" text="Dismiss" />
+                            <Button
+                                className={Classes.POPOVER_DISMISS}
+                                intent="danger"
+                                text="No dismiss"
+                                disabled={true}
+                            />
+                        </div>
+                        <Callout intent="warning" className={Classes.POPOVER_DISMISS}>
+                            <p>Click callout to dismiss.</p>
+                            <div>
+                                <Button
+                                    className={Classes.POPOVER_DISMISS_OVERRIDE}
+                                    intent="success"
+                                    text="Dismiss override"
+                                />
+                                <Button disabled={true} text="Nope" />
+                            </div>
+                        </Callout>
+                    </>
+                </Popover>
+                <p className="docs-reopen-message">
+                    <em className={Classes.TEXT_MUTED}>Popover will reopen...</em>
+                </p>
+            </Example>
+        );
+    }
+
+    private handleInteraction = (isOpen: boolean) => this.setState({ isOpen });
+
+    private reopen = () => {
+        window.clearTimeout(this.timeoutId);
+        this.timeoutId = window.setTimeout(() => this.setState({ isOpen: true }), 150);
+    };
+}

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -6,11 +6,14 @@
 
 import * as React from "react";
 
-import { Button, Callout, Classes, Popover } from "@blueprintjs/core";
+import { Button, Callout, Classes, Popover, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 
-export class PopoverDismissExample extends React.PureComponent<IExampleProps, { isOpen: boolean }> {
-    public state = { isOpen: true };
+export class PopoverDismissExample extends React.PureComponent<
+    IExampleProps,
+    { captureDismiss: boolean; isOpen: boolean }
+> {
+    public state = { captureDismiss: true, isOpen: true };
     private timeoutId: number;
 
     public componentWillUnmount() {
@@ -29,27 +32,23 @@ export class PopoverDismissExample extends React.PureComponent<IExampleProps, { 
                 >
                     <Button intent="primary" text="Try it out" />
                     <>
+                        {POPOVER_CONTENTS}
                         <div>
-                            <Button text="Default" />
-                            <Button className={Classes.POPOVER_DISMISS} intent="danger" text="Dismiss" />
-                            <Button
-                                className={Classes.POPOVER_DISMISS}
-                                intent="danger"
-                                text="No dismiss"
-                                disabled={true}
+                            <Switch
+                                checked={this.state.captureDismiss}
+                                inline={true}
+                                label="Capture dismiss"
+                                onChange={this.handleDismissChange}
                             />
+                            <Popover
+                                captureDismiss={this.state.captureDismiss}
+                                content={POPOVER_CONTENTS}
+                                position="right"
+                                usePortal={false}
+                            >
+                                <Button text="Nested" rightIcon="caret-right" />
+                            </Popover>
                         </div>
-                        <Callout intent="warning" className={Classes.POPOVER_DISMISS}>
-                            <p>Click callout to dismiss.</p>
-                            <div>
-                                <Button
-                                    className={Classes.POPOVER_DISMISS_OVERRIDE}
-                                    intent="success"
-                                    text="Dismiss override"
-                                />
-                                <Button disabled={true} text="Nope" />
-                            </div>
-                        </Callout>
                     </>
                 </Popover>
                 <p className="docs-reopen-message">
@@ -60,9 +59,28 @@ export class PopoverDismissExample extends React.PureComponent<IExampleProps, { 
     }
 
     private handleInteraction = (isOpen: boolean) => this.setState({ isOpen });
+    private handleDismissChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+        this.setState({ captureDismiss: event.target.checked });
 
     private reopen = () => {
         window.clearTimeout(this.timeoutId);
         this.timeoutId = window.setTimeout(() => this.setState({ isOpen: true }), 150);
     };
 }
+
+const POPOVER_CONTENTS = (
+    <>
+        <div>
+            <Button text="Default" />
+            <Button className={Classes.POPOVER_DISMISS} intent="danger" text="Dismiss" />
+            <Button className={Classes.POPOVER_DISMISS} intent="danger" text="No dismiss" disabled={true} />
+        </div>
+        <Callout intent="warning" className={Classes.POPOVER_DISMISS}>
+            <p>Click callout to dismiss.</p>
+            <div>
+                <Button className={Classes.POPOVER_DISMISS_OVERRIDE} intent="success" text="Dismiss override" />
+                <Button disabled={true} text="Nope" />
+            </div>
+        </Callout>
+    </>
+);

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -288,7 +288,6 @@
       margin: $pt-grid-size 0;
     }
   }
-
 }
 
 #{example("PanelStackExample")} {

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -269,6 +269,28 @@
   }
 }
 
+#{example("PopoverDismissExample")} {
+  height: 220px;
+
+  .docs-reopen-message {
+    width: 240px;
+    text-align: center;
+  }
+
+  .#{$ns}-popover-content {
+    padding: $pt-grid-size * 2;
+
+    .#{$ns}-button:not(:first-child) {
+      margin-left: $pt-grid-size;
+    }
+
+    .#{$ns}-callout {
+      margin-top: $pt-grid-size;
+    }
+  }
+
+}
+
 #{example("PanelStackExample")} {
   .docs-panel-stack-example {
     box-shadow: $pt-elevation-shadow-0;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -285,7 +285,7 @@
     }
 
     .#{$ns}-callout {
-      margin-top: $pt-grid-size;
+      margin: $pt-grid-size 0;
     }
   }
 


### PR DESCRIPTION
#### Fixes #2735, Fixes #2092, Fixes #2091 

#### Changes proposed in this pull request:

- improve `Classes.POPOVER_DISMISS` behavior:
    - walk up DOM tree, looking for first DISMISS or DISMISS_OVERRIDE. only dismiss if DISMISS found. this makes for very easy dismiss overriding (and I think fixes some deep issues with the old impl).
    - ignore DISMISS clicks if they come from inside a disabled element.
- new `Popover` `captureDismiss` prop (default `true`) invokes `preventDefault()` on `Classes.POPOVER_DISMISS` clicks. `Popover` now ignores dismiss clicks if default is prevented, so Popovers around a `Popover captureDismiss` will not close when an inner popover is dismissed.
- `MenuItem` disables `captureDismiss` to preserve existing (desired) behavior where clicking a nested submenu closes the entire hierarchy.
- add nice tests for all this new behavior
