### PR TITLE
match event handler prop name with code and docs

### DIFF
--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -17,7 +17,7 @@ function handleResize(entries: IResizeEntry[]) {
     console.log(entries.map(e => `${e.contentRect.width} x ${e.contentRect.height}`));
 }
 
-<ResizeSensor onChange={handleResize}>
+<ResizeSensor onResize={handleResize}>
     <div style={{ width: this.props.width }} />
 </ResizeSensor>
 ```


### PR DESCRIPTION
#### Changes proposed in this pull request:

Corrected example of ResizeSensor API to use `onResize` vs. `onChange` so it matches the surrounding instructions and the imported class def.

#### Reviewers should focus on:

The example code's usage of `onResize` compared with expectations in `resizeSensor.tsx`.
