### PR TITLE
Fix tabs querySelector on jsdom

### DIFF
--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -259,7 +259,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
      * Store the CSS values so the transition animation can start.
      */
     private moveSelectionIndicator() {
-        if (this.tablistElement === undefined || !this.props.animate) {
+        if (this.tablistElement == null || !this.props.animate) {
             return;
         }
 


### PR DESCRIPTION
blueprint's `tabs` rendering fail on jsdom. It may  happen on browser.

#### Changes proposed in this pull request:

`document.querySelector` returns `null` if document.body has no matched selector.

We have to consider this.

```
> document.querySelector('missing-selector')
null
```

#### Screenshot

My test case screenshot

![](https://i.gyazo.com/be9fa955ddbace9151477e1e3f3efca8.png)