### PR TITLE
Add Popover support for "auto-start" and "auto-end"

### DIFF
--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -124,7 +124,15 @@ The following example shows all supported `Position` values and how each behaves
 
 #### Automatic positioning
 
-The `position` can also be set to the string literal `"auto"` (this is actually the default value). In this mode, the Popover will continually re-position itself to the side with the most space available, adjusting its alignment intuitively as well. This is useful for guaranteeing that the Popover remains visible while scrolling within a parent container.
+The Popover's `position` can also be chosen _automatically_ via `"auto"`, `"auto-start"`, or `"auto-end"`. All of these options choose and continually update the <span class="docs-popover-position-label-side">__side__</span> for you to avoid overflowing the boundary element (when scrolling within it, for instance). The options differ in how they handle <span class="docs-popover-position-label-alignment">__alignment__</span>:
+
+- In `"auto"` mode (the default for `position`), the Popover will align itself to the center of the target as it flips sides.
+- In `"auto-start"` mode, the Popover will align itself to the `start` of the target (i.e., the top edge when the popover is on the left or right, or the left edge when the popover is on the top or bottom).
+- In `"auto-end"` mode, the Popover will align itself to the `end` of the target (i.e., the bottom edge when the popover is on the left or right, or the right edge when the popover is on the top or bottom).
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    You can also specify a specific initial position (e.g. `LEFT`, `TOP_RIGHT`) and still update the Popover's position automatically by enabling the modifiers `flip` and `preventOverflow`. [See below](#core/components/popover.modifiers) for information about modifiers.
+</div>
 
 @### Modifiers
 

--- a/packages/core/src/components/popover/popoverMigrationUtils.ts
+++ b/packages/core/src/components/popover/popoverMigrationUtils.ts
@@ -11,7 +11,7 @@ import { Position } from "../../common/position";
  * Convert a position to a placement.
  * @param position the position to convert
  */
-export function positionToPlacement(position: Position | "auto"): Placement {
+export function positionToPlacement(position: Position | "auto" | "auto-start" | "auto-end"): Placement {
     /* istanbul ignore next */
     switch (position) {
         case Position.TOP_LEFT:
@@ -39,7 +39,10 @@ export function positionToPlacement(position: Position | "auto"): Placement {
         case Position.LEFT_TOP:
             return "left-start";
         case "auto":
-            return "auto";
+        case "auto-start":
+        case "auto-end":
+            // Return the string unchanged.
+            return position;
         default:
             return assertNever(position);
     }

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -109,7 +109,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * user scrolls around.
      * @default "auto"
      */
-    position?: Position | "auto";
+    position?: Position | "auto" | "auto-start" | "auto-end";
 
     /**
      * Space-delimited string of class names applied to the target element.

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -87,11 +87,11 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
         minimal: false,
         modifiers: {
             arrow: { enabled: true },
-            flip: { enabled: false },
-            keepTogether: { enabled: false },
-            preventOverflow: { enabled: false, boundariesElement: "scrollParent" },
+            flip: { enabled: true },
+            keepTogether: { enabled: true },
+            preventOverflow: { enabled: true, boundariesElement: "scrollParent" },
         },
-        position: "left",
+        position: "auto",
         sliderValue: 5,
         usePortal: true,
     };

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -42,8 +42,10 @@ const INTERACTION_KINDS = [
     { label: "Hover (target only)", value: PopoverInteractionKind.HOVER_TARGET_ONLY.toString() },
 ];
 
-const VALID_POSITIONS: Array<Position | "auto"> = [
+const VALID_POSITIONS: Array<Position | "auto" | "auto-start" | "auto-end"> = [
     "auto",
+    "auto-start",
+    "auto-end",
     Position.TOP_LEFT,
     Position.TOP,
     Position.TOP_RIGHT,
@@ -69,7 +71,7 @@ export interface IPopoverExampleState {
     isOpen?: boolean;
     minimal?: boolean;
     modifiers?: PopperJS.Modifiers;
-    position?: Position | "auto";
+    position?: Position | "auto" | "auto-start" | "auto-end";
     sliderValue?: number;
     usePortal?: boolean;
 }
@@ -85,11 +87,11 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
         minimal: false,
         modifiers: {
             arrow: { enabled: true },
-            flip: { enabled: true },
-            keepTogether: { enabled: true },
-            preventOverflow: { enabled: true, boundariesElement: "scrollParent" },
+            flip: { enabled: false },
+            keepTogether: { enabled: false },
+            preventOverflow: { enabled: false, boundariesElement: "scrollParent" },
         },
-        position: "auto",
+        position: "left",
         sliderValue: 5,
         usePortal: true,
     };
@@ -99,7 +101,9 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
         const hasBackdrop = this.state.hasBackdrop && interactionKind === PopoverInteractionKind.CLICK;
         this.setState({ interactionKind, hasBackdrop });
     });
-    private handlePositionChange = handleStringChange((position: Position | "auto") => this.setState({ position }));
+    private handlePositionChange = handleStringChange((position: Position | "auto" | "auto-start" | "auto-end") =>
+        this.setState({ position }),
+    );
     private handleBoundaryChange = handleStringChange((boundary: PopperJS.Boundary) =>
         this.setState({
             modifiers: {


### PR DESCRIPTION
#### Fixes #2770 

#### Checklist

- [x] ~[Enable CircleCI for your fork](https://circleci.com/add-projects)~ __N/A__
- [x] ~Include tests~ __N/A__ (typings change)
- [x] Update documentation

#### Changes proposed in this pull request:

- #2770 Popover now supports `"auto-start"` and `"auto-end"`.
  - Updated example
  - Updated docs

#### Reviewers should focus on:

- Docs language

#### Screenshot

![image](https://user-images.githubusercontent.com/443450/43795284-bfa47aee-9a35-11e8-882a-2ef61a86fa38.png)
