### PR TITLE
[docs] redirect old docs/v{1,2}/ URLs to new URLs

### DIFF
--- a/site/docs/v1/index.html
+++ b/site/docs/v1/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=../versions/1/" />
+  </head>
+  <title>Blueprint v1 redirect</title>
+</html>

--- a/site/docs/v2/index.html
+++ b/site/docs/v2/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=../versions/2/" />
+  </head>
+  <title>Blueprint v2 redirect</title>
+</html>

--- a/site/docs/versions/index.html
+++ b/site/docs/versions/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=../" />
+  </head>
+</html>


### PR DESCRIPTION
#### Fixes #2766, Fixes #2765 

#### Changes proposed in this pull request:

Add redirects between the following URLs:
- `docs/versions/` => `docs/` - invalid route, nothing to show there
- `docs/v1/` => `docs/versions/1/` - legacy route pre #2545 
- `docs/v2/` => `docs/versions/2/` - legacy route pre #2545 