### PR TITLE
[Button] Utils.isEmptyReactNode solves icon regression

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -29,7 +29,7 @@ export function isFunction(value: any): value is Function {
  * composed of those. If `node` is an array, only one level of the array is
  * checked, for performance reasons.
  */
-export function isEmptyReactNode(node?: React.ReactNode, skipArray = false): boolean {
+export function isReactNodeEmpty(node?: React.ReactNode, skipArray = false): boolean {
     return (
         node == null ||
         node === "" ||
@@ -37,7 +37,7 @@ export function isEmptyReactNode(node?: React.ReactNode, skipArray = false): boo
         (!skipArray &&
             Array.isArray(node) &&
             // only recurse one level through arrays, for performance
-            (node.length === 0 || node.every(n => isEmptyReactNode(n, true))))
+            (node.length === 0 || node.every(n => isReactNodeEmpty(n, true))))
     );
 }
 

--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -25,6 +25,23 @@ export function isFunction(value: any): value is Function {
 }
 
 /**
+ * Returns true if `node` is null/undefined, false, empty string, or an array
+ * composed of those. If `node` is an array, only one level of the array is
+ * checked, for performance reasons.
+ */
+export function isEmptyReactNode(node?: React.ReactNode, skipArray = false): boolean {
+    return (
+        node == null ||
+        node === "" ||
+        node === false ||
+        (!skipArray &&
+            Array.isArray(node) &&
+            // only recurse one level through arrays, for performance
+            (node.length === 0 || node.every(n => isEmptyReactNode(n, true))))
+    );
+}
+
+/**
  * Converts a React child to an element: non-empty string or number or
  * `React.Fragment` (React 16.3+) is wrapped in given tag name; empty strings
  * are discarded.

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -11,7 +11,7 @@ import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IActionProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
+import { isEmptyReactNode, safeInvoke } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
 
@@ -149,7 +149,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={Icon.SIZE_LARGE} />,
             <Icon key="leftIcon" icon={icon} />,
-            ((text != null && text !== "") || (children != null && children !== "")) && (
+            (!isEmptyReactNode(text) || !isEmptyReactNode(children)) && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}
                     {children}

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -11,7 +11,7 @@ import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
 import * as Keys from "../../common/keys";
 import { IActionProps } from "../../common/props";
-import { isEmptyReactNode, safeInvoke } from "../../common/utils";
+import { isReactNodeEmpty, safeInvoke } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
 
@@ -149,7 +149,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={Icon.SIZE_LARGE} />,
             <Icon key="leftIcon" icon={icon} />,
-            (!isEmptyReactNode(text) || !isEmptyReactNode(children)) && (
+            (!isReactNodeEmpty(text) || !isReactNodeEmpty(children)) && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}
                     {children}

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -37,16 +37,16 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             assert.equal(wrapper.text(), "some text");
         });
 
-        it("renders the button text prop when text={0}", () => {
-            const wrapper = button({ text: 0 }, true);
-            assert.equal(wrapper.text(), "0");
-        });
-
         it("wraps string children in spans", () => {
             // so text can be hidden when loading
             const wrapper = button({}, true, "raw string", <em>not a string</em>);
             assert.equal(wrapper.find("span").length, 1, "span not found");
             assert.equal(wrapper.find("em").length, 1, "em not found");
+        });
+
+        it("renders span if text={0}", () => {
+            const wrapper = button({ text: 0 }, true);
+            assert.equal(wrapper.text(), "0");
         });
 
         it('doesn\'t render a span if text=""', () => {

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -22,6 +22,7 @@ describe("Utils", () => {
         assert.isTrue(Utils.isEmptyReactNode(null), "null");
         assert.isTrue(Utils.isEmptyReactNode(""), '""');
         assert.isTrue(Utils.isEmptyReactNode([]), "[]");
+        assert.isTrue(Utils.isEmptyReactNode([undefined, null, false, ""]), "array");
         // not empty nodes
         assert.isFalse(Utils.isEmptyReactNode(0), "0");
         assert.isFalse(Utils.isEmptyReactNode("text"), "text");

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -16,6 +16,19 @@ describe("Utils", () => {
         assert.isFalse(Utils.isFunction(undefined));
     });
 
+    it("isEmptyReactNode", () => {
+        // empty nodes
+        assert.isTrue(Utils.isEmptyReactNode(undefined), "undefined");
+        assert.isTrue(Utils.isEmptyReactNode(null), "null");
+        assert.isTrue(Utils.isEmptyReactNode(""), '""');
+        assert.isTrue(Utils.isEmptyReactNode([]), "[]");
+        // not empty nodes
+        assert.isFalse(Utils.isEmptyReactNode(0), "0");
+        assert.isFalse(Utils.isEmptyReactNode("text"), "text");
+        assert.isFalse(Utils.isEmptyReactNode(<div />), "<div />");
+        assert.isFalse(Utils.isEmptyReactNode([null, <div key="div" />]), "array");
+    });
+
     it("safeInvoke", () => {
         assert.doesNotThrow(() => Utils.safeInvoke(undefined, 1, "2", true, 4));
 

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -16,18 +16,18 @@ describe("Utils", () => {
         assert.isFalse(Utils.isFunction(undefined));
     });
 
-    it("isEmptyReactNode", () => {
+    it("isReactNodeEmpty", () => {
         // empty nodes
-        assert.isTrue(Utils.isEmptyReactNode(undefined), "undefined");
-        assert.isTrue(Utils.isEmptyReactNode(null), "null");
-        assert.isTrue(Utils.isEmptyReactNode(""), '""');
-        assert.isTrue(Utils.isEmptyReactNode([]), "[]");
-        assert.isTrue(Utils.isEmptyReactNode([undefined, null, false, ""]), "array");
+        assert.isTrue(Utils.isReactNodeEmpty(undefined), "undefined");
+        assert.isTrue(Utils.isReactNodeEmpty(null), "null");
+        assert.isTrue(Utils.isReactNodeEmpty(""), '""');
+        assert.isTrue(Utils.isReactNodeEmpty([]), "[]");
+        assert.isTrue(Utils.isReactNodeEmpty([undefined, null, false, ""]), "array");
         // not empty nodes
-        assert.isFalse(Utils.isEmptyReactNode(0), "0");
-        assert.isFalse(Utils.isEmptyReactNode("text"), "text");
-        assert.isFalse(Utils.isEmptyReactNode(<div />), "<div />");
-        assert.isFalse(Utils.isEmptyReactNode([null, <div key="div" />]), "array");
+        assert.isFalse(Utils.isReactNodeEmpty(0), "0");
+        assert.isFalse(Utils.isReactNodeEmpty("text"), "text");
+        assert.isFalse(Utils.isReactNodeEmpty(<div />), "<div />");
+        assert.isFalse(Utils.isReactNodeEmpty([null, <div key="div" />]), "array");
     });
 
     it("safeInvoke", () => {


### PR DESCRIPTION
#### Fixes #2769 

#### Changes proposed in this pull request:

- `Utils.isEmptyReactNode` to ensure correct detection of empty nodes.
- this fixes a regression in #2727 where `children` is easily non-null