### PR TITLE
[Popover] captureDismiss=false by default 

### DIFF
--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -257,7 +257,7 @@ Cancel the dismiss behavior on subtrees by nesting
 originating inside disabled elements (either via the `disabled` attribute or
 `Classes.DISABLED`) will never dismiss a popover.
 
-Additionally, the prop `captureDismiss` (enabled by default) will prevent click
+Additionally, the prop `captureDismiss` (disabled by default) will prevent click
 events from dismissing _grandparent_ popovers (not the `Popover` immediately
 containing the dismiss element). `MenuItem` disables this feature such that
 clicking any submenu item will close all submenus, which is desirable behavior

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -86,7 +86,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
     public static defaultProps: IPopoverProps = {
-        captureDismiss: true,
+        captureDismiss: false,
         defaultIsOpen: false,
         disabled: false,
         hasBackdrop: false,

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -21,7 +21,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * element will close the parent popover.
      *
      * See http://blueprintjs.com/docs/#core/components/popover.closing-on-click
-     * @default true
+     * @default false
      */
     captureDismiss?: boolean;
 

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -644,9 +644,9 @@ describe("<Popover>", () => {
                 true,
             ));
 
-        it("inner dismiss does not close outer popover", () =>
+        it("captureDismiss={true} inner dismiss does not close outer popover", () =>
             assertClickToClose(
-                <Popover defaultIsOpen={true} usePortal={false}>
+                <Popover captureDismiss={true} defaultIsOpen={true} usePortal={false}>
                     <button>Target</button>
                     <button className={Classes.POPOVER_DISMISS} id="btn">
                         Dismiss


### PR DESCRIPTION
#### Fixes #2763 

#### Changes proposed in this pull request:

- disable `captureDismiss` by default as the `preventDefault()` call breaks `<a href>` behavior 😢 