### PR TITLE
[RadioGroup] [HtmlSelect] options support className and disabled

### DIFF
--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -97,9 +97,10 @@ export class RadioGroup extends AbstractPureComponent<IRadioGroupProps, {}> {
 
     private getRadioProps(optionProps: IOptionProps): IRadioProps {
         const { name } = this.props;
-        const { disabled, value } = optionProps;
+        const { className, disabled, value } = optionProps;
         return {
             checked: value === this.props.selectedValue,
+            className,
             disabled: disabled || this.props.disabled,
             inline: this.props.inline,
             name: name == null ? this.autoGroupName : name,

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -60,9 +60,8 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
         );
 
         const optionChildren = options.map(option => {
-            const { className: optionClassName, value, label }: IOptionProps =
-                typeof option === "object" ? option : { value: option };
-            return <option className={optionClassName} key={value} value={value} children={label || value} />;
+            const props: IOptionProps = typeof option === "object" ? option : { value: option };
+            return <option {...props} key={props.value} children={props.label || props.value} />;
         });
 
         return (

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -60,8 +60,9 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
         );
 
         const optionChildren = options.map(option => {
-            const { value, label }: IOptionProps = typeof option === "object" ? option : { value: option };
-            return <option key={value} value={value} children={label || value} />;
+            const { className: optionClassName, value, label }: IOptionProps =
+                typeof option === "object" ? option : { value: option };
+            return <option className={optionClassName} key={value} value={value} children={label || value} />;
         });
 
         return (

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -52,14 +52,15 @@ describe("<RadioGroup>", () => {
 
     it("renders options as radio buttons", () => {
         const OPTIONS: IOptionProps[] = [
-            { label: "A", value: "a" },
+            { className: "foo", label: "A", value: "a" },
             { label: "B", value: "b" },
             { disabled: true, label: "C", value: "c" },
         ];
         const group = mount(<RadioGroup onChange={emptyHandler} options={OPTIONS} selectedValue="b" />);
-        assert.lengthOf(group.find(Radio), 3);
-        assert.isTrue(findInput(group, { checked: true }).is({ value: "b" }), "radio b not checked");
-        assert.isTrue(findInput(group, { value: "c" }).prop("disabled"), "radio c not disabled");
+        const radios = group.find(Radio);
+        assert.isTrue(radios.at(0).hasClass("foo"), "className");
+        assert.isTrue(radios.at(1).is({ checked: true }), "selectedValue");
+        assert.isTrue(radios.at(2).prop("disabled"), "disabled");
     });
 
     it("options label defaults to value", () => {

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -100,6 +100,17 @@ describe("<RadioGroup>", () => {
         assert.lengthOf(group.find(Radio), 2);
     });
 
+    it("passes custom classNames to options", () => {
+        const OPTIONS = [{ className: "apple", value: "a" }, { className: "banana", value: "b" }];
+        const group = mount(<RadioGroup onChange={emptyHandler} options={OPTIONS} selectedValue="a" />);
+        assert.strictEqual(findRadio(group, { value: "a" }).prop("className"), "apple");
+        assert.strictEqual(findRadio(group, { value: "b" }).prop("className"), "banana");
+    });
+
+    function findRadio(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
+        return wrapper.find(Radio).filter(props);
+    }
+
     function findInput(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
         return wrapper.find("input").filter(props);
     }

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -101,17 +101,6 @@ describe("<RadioGroup>", () => {
         assert.lengthOf(group.find(Radio), 2);
     });
 
-    it("passes custom classNames to options", () => {
-        const OPTIONS = [{ className: "apple", value: "a" }, { className: "banana", value: "b" }];
-        const group = mount(<RadioGroup onChange={emptyHandler} options={OPTIONS} selectedValue="a" />);
-        assert.strictEqual(findRadio(group, { value: "a" }).prop("className"), "apple");
-        assert.strictEqual(findRadio(group, { value: "b" }).prop("className"), "banana");
-    });
-
-    function findRadio(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
-        return wrapper.find(Radio).filter(props);
-    }
-
     function findInput(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
         return wrapper.find("input").filter(props);
     }

--- a/packages/core/test/html-select/htmlSelectTests.tsx
+++ b/packages/core/test/html-select/htmlSelectTests.tsx
@@ -5,31 +5,32 @@
  */
 
 import { assert } from "chai";
-import { EnzymePropSelector, mount, ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
 import * as React from "react";
 
-import { HTMLSelect, IOptionProps } from "../../src/index";
+import { IOptionProps } from "../../src/common/props";
+import { HTMLSelect } from "../../src/components/html-select/htmlSelect";
 
 describe("<HtmlSelect>", () => {
-    const emptyHandler = () => {
-        return;
-    };
+    const emptyHandler = () => true;
 
-    it("renders options without CSS classes by default", () => {
-        const OPTIONS: string[] = ["a", "b"];
-        const group = mount(<HTMLSelect onChange={emptyHandler} options={OPTIONS} />);
-        assert.isUndefined(findOption(group, { value: "a" }).prop("className"));
-        assert.isUndefined(findOption(group, { value: "b" }).prop("className"));
+    it("renders options strings", () => {
+        const options = mount(<HTMLSelect onChange={emptyHandler} options={["a", "b"]} />).find("option");
+        assert.equal(options.at(0).text(), "a");
+        assert.equal(options.at(1).text(), "b");
     });
 
-    it("passes custom classNames to options", () => {
-        const OPTIONS: IOptionProps[] = [{ className: "apple", value: "a" }, { className: "banana", value: "b" }];
-        const group = mount(<HTMLSelect onChange={emptyHandler} options={OPTIONS} />);
-        assert.strictEqual(findOption(group, { value: "a" }).prop("className"), "apple");
-        assert.strictEqual(findOption(group, { value: "b" }).prop("className"), "banana");
+    it("renders options props", () => {
+        const OPTIONS: IOptionProps[] = [
+            { value: "a" },
+            { value: "b", className: "foo" },
+            { value: "c", disabled: true },
+            { value: "d", label: "Dog" },
+        ];
+        const options = mount(<HTMLSelect onChange={emptyHandler} options={OPTIONS} />).find("option");
+        assert.equal(options.at(0).text(), "a", "value");
+        assert.isTrue(options.at(1).hasClass("foo"), "className");
+        assert.isTrue(options.at(2).prop("disabled"), "disabled");
+        assert.equal(options.at(3).text(), "Dog", "label");
     });
-
-    function findOption(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
-        return wrapper.find("option").filter(props);
-    }
 });

--- a/packages/core/test/html-select/htmlSelectTests.tsx
+++ b/packages/core/test/html-select/htmlSelectTests.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { assert } from "chai";
+import { EnzymePropSelector, mount, ReactWrapper } from "enzyme";
+import * as React from "react";
+
+import { HTMLSelect, IOptionProps } from "../../src/index";
+
+describe("<HtmlSelect>", () => {
+    const emptyHandler = () => {
+        return;
+    };
+
+    it("renders options without CSS classes by default", () => {
+        const OPTIONS: string[] = ["a", "b"];
+        const group = mount(<HTMLSelect onChange={emptyHandler} options={OPTIONS} />);
+        assert.isUndefined(findOption(group, { value: "a" }).prop("className"));
+        assert.isUndefined(findOption(group, { value: "b" }).prop("className"));
+    });
+
+    it("passes custom classNames to options", () => {
+        const OPTIONS: IOptionProps[] = [{ className: "apple", value: "a" }, { className: "banana", value: "b" }];
+        const group = mount(<HTMLSelect onChange={emptyHandler} options={OPTIONS} />);
+        assert.strictEqual(findOption(group, { value: "a" }).prop("className"), "apple");
+        assert.strictEqual(findOption(group, { value: "b" }).prop("className"), "banana");
+    });
+
+    function findOption(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
+        return wrapper.find("option").filter(props);
+    }
+});

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -25,6 +25,7 @@ import "./editable-text/editableTextTests";
 import "./forms/fileInputTests";
 import "./forms/formGroupTests";
 import "./hotkeys/hotkeysTests";
+import "./html-select/htmlSelectTests";
 import "./icon/iconTests";
 import "./menu/menuItemTests";
 import "./menu/menuTests";


### PR DESCRIPTION
#### Fixes #2782 

#### Checklist

- [x] Include tests

#### Changes proposed in this pull request:

- 🐛 Fix regression: `<RadioGroup>` passes custom `className` to its options
- 🐛 Fix regression: `<HtmlSelect>` passes custom `className` to its options

#### Reviewers should focus on:

Nothing in particular. Should be simple.

#### Screenshot

N/A