### PR TITLE
Remove `HACKHACK`

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -141,10 +141,8 @@ export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseSta
             transition: isAutoHeight ? "none" : undefined,
         };
 
-        // HACKHACK: type cast because there's no single overload that supports all
-        // three ReactTypes (string | ComponentClass | StatelessComponent)
         return React.createElement(
-            this.props.component as any,
+            this.props.component,
             {
                 className: classNames(Classes.COLLAPSE, this.props.className),
                 style: containerStyle,


### PR DESCRIPTION
BP requires `"@types/react": "^16.0.34"` and it is pinned by `yarn.lock`.

For this version of typings, it is provided an overload, then the `HACKHACK` does not persist.

```ts
    function createElement<P>(
        type: SFC<P> | ComponentClass<P> | string,
        props?: Attributes & P,
        ...children: ReactNode[]): ReactElement<P>;
```

#### Fixes #2785 

