### PR TITLE
[DatePicker] reuse existing components in caption

### DIFF
--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -49,6 +49,7 @@ Styleguide select
 
   .#{$ns}-icon {
     @extend %pt-select-arrow;
+    @include pt-icon-colors();
   }
 
   &.#{$ns}-minimal select {

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
 import { IOptionProps } from "../../common/props";
 import { IElementRefProps } from "../html/html";
-import { Icon } from "../icon/icon";
+import { Icon, IIconProps } from "../icon/icon";
 
 export interface IHTMLSelectProps
     extends IElementRefProps<HTMLSelectElement>,
@@ -19,6 +19,9 @@ export interface IHTMLSelectProps
 
     /** Whether this element should fill its container. */
     fill?: boolean;
+
+    /** Props to spread to the `<Icon>` element. */
+    iconProps?: Partial<IIconProps>;
 
     /** Whether to use large styles. */
     large?: boolean;
@@ -47,7 +50,17 @@ export interface IHTMLSelectProps
 /* istanbul ignore next */
 export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
     public render() {
-        const { className, disabled, elementRef, fill, large, minimal, options = [], ...htmlProps } = this.props;
+        const {
+            className,
+            disabled,
+            elementRef,
+            fill,
+            iconProps,
+            large,
+            minimal,
+            options = [],
+            ...htmlProps
+        } = this.props;
         const classes = classNames(
             HTML_SELECT,
             {
@@ -70,7 +83,7 @@ export class HTMLSelect extends React.PureComponent<IHTMLSelectProps> {
                     {optionChildren}
                     {htmlProps.children}
                 </select>
-                <Icon icon="double-caret-vertical" />
+                <Icon icon="double-caret-vertical" {...iconProps} />
             </div>
         );
     }

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -4,6 +4,8 @@
 @import "~@blueprintjs/core/src/common/variables";
 @import "~@blueprintjs/icons/src/icons";
 
+$datepicker-padding: $pt-grid-size / 2 !default;
+
 $datepicker-min-width: $pt-grid-size * 21 !default;
 $datepicker-day-size: $pt-grid-size * 3 !default;
 $datepicker-header-height: $pt-grid-size * 4 !default;

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -143,8 +143,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 .#{$ns}-datepicker-caption {
   @include pt-flex-container(row, $fill: ":first-child");
   justify-content: space-between;
-  margin-bottom: $datepicker-padding;
-  padding: 0 ($pt-button-height - $datepicker-padding);
+  margin: 0 ($pt-button-height - $datepicker-padding) $datepicker-padding;
 
   // HTMLSelect overrides for a narrower appearance
   select {

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -23,7 +23,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   position: relative;
   border-radius: $pt-border-radius;
   background: $datepicker-background-color;
-  padding: $pt-grid-size;
+  padding: $datepicker-padding;
   user-select: none;
 
   .DayPicker {
@@ -65,7 +65,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 
   .DayPicker-Weekday {
     @include calendar-day();
-    padding-top: $pt-grid-size / 2;
+    padding-top: $datepicker-padding;
     font-weight: 600;
 
     // normalize.css adds an underline to abbr[title] elements, remove it here
@@ -130,9 +130,9 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     display: flex;
     justify-content: space-between;
     margin-top: $pt-grid-size;
-    margin-bottom: -$pt-grid-size / 2;
+    margin-bottom: -$datepicker-padding;
     border-top: 1px solid $pt-divider-black;
-    padding-top: $pt-grid-size / 2;
+    padding-top: $datepicker-padding;
   }
 }
 
@@ -153,7 +153,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 .#{$ns}-datepicker-caption {
   @include pt-flex-container(row);
   justify-content: space-between;
-  margin-bottom: $pt-grid-size / 2;
+  margin-bottom: $datepicker-padding;
   border-bottom: 1px solid $pt-divider-black;
   padding: 0 $pt-button-height-small ($pt-grid-size / 2);
 
@@ -161,7 +161,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   select {
     flex-shrink: 1;
     padding-right: $pt-icon-size-standard;
-    padding-left: $pt-grid-size / 2;
+    padding-left: $datepicker-padding;
     font-weight: 600;
 
     + .#{$ns}-icon {
@@ -171,7 +171,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 }
 
 .#{$ns}-datepicker-caption-measure {
-  padding-left: $pt-grid-size / 2;
+  padding-left: $datepicker-padding;
   font-weight: 600;
 }
 

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -39,8 +39,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 
   .DayPicker-Month {
     display: inline-table;
-    margin: 0 auto;
-    padding: 0 $pt-grid-size / 2;
+    margin: 0 $datepicker-padding $datepicker-padding;
     border-collapse: collapse;
     border-spacing: 0;
     user-select: none;
@@ -155,7 +154,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   justify-content: space-between;
   margin-bottom: $datepicker-padding;
   border-bottom: 1px solid $pt-divider-black;
-  padding: 0 $pt-button-height-small ($pt-grid-size / 2);
+  padding: 0 ($pt-button-height - $datepicker-padding) ($datepicker-padding);
 
   // HTMLSelect overrides for a narrower appearance
   select {

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -150,7 +150,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 }
 
 .#{$ns}-datepicker-caption {
-  @include pt-flex-container(row);
+  @include pt-flex-container(row, $fill: ":first-child");
   justify-content: space-between;
   margin-bottom: $datepicker-padding;
   border-bottom: 1px solid $pt-divider-black;

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -141,7 +141,8 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   align-items: center;
   position: absolute;
   top: 0;
-  width: 100%;
+  right: 0;
+  left: 0;
   height: $pt-button-height;
 
   > :first-child {

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -152,62 +152,6 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     }
   }
 
-  .#{$ns}-datepicker-caption {
-    display: table-caption;
-    border-bottom: 1px solid $pt-divider-black;
-    padding: 0 $pt-grid-size;
-    text-align: center;
-
-    select {
-      margin: -$datepicker-header-margin 0 $datepicker-header-margin;
-      border: 0;
-      background: none;
-      cursor: pointer;
-      height: $pt-input-height;
-      // increase the size of the click target, clearing the caret on the right.
-      padding-right: $pt-icon-size-standard;
-      padding-left: $pt-grid-size / 2;
-      line-height: $pt-input-height;
-      color: $pt-text-color;
-      font-weight: 600;
-
-      // stylelint-disable property-no-vendor-prefix
-      -moz-appearance: none;
-      -webkit-appearance: none;
-      // stylelint-enable property-no-vendor-prefix
-
-      &:focus + .#{$ns}-datepicker-caption-caret {
-        display: inline;
-      }
-
-      &::-ms-expand {
-        // IE11 styling to hide the arrow
-        display: none;
-      }
-    }
-  }
-
-  .#{$ns}-datepicker-caption-select {
-    display: inline-block;
-    position: relative;
-
-    &:first-child {
-      margin-right: $pt-grid-size;
-    }
-
-    &:hover .#{$ns}-datepicker-caption-caret {
-      fill: $pt-icon-color-hover;
-    }
-  }
-
-  .#{$ns}-datepicker-caption-caret {
-    position: absolute;
-    top: 2px;
-    right: 0;
-    fill: $pt-icon-color;
-    pointer-events: none;
-  }
-
   .#{$ns}-datepicker-footer {
     display: flex;
     justify-content: space-between;
@@ -215,6 +159,26 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     margin-bottom: -$pt-grid-size / 2;
     border-top: 1px solid $pt-divider-black;
     padding-top: $pt-grid-size / 2;
+  }
+}
+
+.#{$ns}-datepicker-caption {
+  @include pt-flex-container(row);
+  justify-content: space-between;
+  margin-bottom: $pt-grid-size / 2;
+  border-bottom: 1px solid $pt-divider-black;
+  padding: 0 $pt-button-height-small ($pt-grid-size / 2);
+
+  // HTMLSelect overrides for a narrower appearance
+  select {
+    flex-shrink: 1;
+    padding-right: $pt-icon-size-standard;
+    padding-left: $pt-grid-size / 2;
+    font-weight: 600;
+
+    + .#{$ns}-icon {
+      right: 2px;
+    }
   }
 }
 
@@ -256,29 +220,6 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     &.DayPicker-Day--disabled {
       background: none;
       color: $pt-dark-text-color-disabled;
-    }
-  }
-
-  .#{$ns}-datepicker-caption {
-    border-bottom-color: $pt-dark-divider-black;
-
-    select {
-      color: $pt-dark-text-color;
-    }
-
-    option {
-      background-color: $dark-popover-background-color;
-    }
-
-    // we really need more than 4 compound selector
-    // to target the particular structure of this markup
-    // stylelint-disable-next-line
-    .#{$ns}-datepicker-caption-select:hover .#{$ns}-datepicker-caption-caret {
-      fill: $pt-dark-icon-color-hover;
-    }
-
-    .#{$ns}-datepicker-caption-caret {
-      fill: $pt-dark-icon-color;
     }
   }
 

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -148,7 +148,6 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
 
   // HTMLSelect overrides for a narrower appearance
   select {
-    flex-shrink: 1;
     padding-right: $pt-icon-size-standard;
     padding-left: $datepicker-padding;
     font-weight: 600;
@@ -161,6 +160,15 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   + .#{$ns}-divider {
     margin: 0;
   }
+}
+
+.#{$ns}-datepicker-month-select {
+  flex-shrink: 1;
+}
+
+.#{$ns}-datepicker-year-select {
+  flex-shrink: 1;
+  min-width: 60px;
 }
 
 .#{$ns}-datepicker-caption-measure {

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -51,34 +51,8 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     }
   }
 
-  .DayPicker-NavBar {
-    position: relative;
-  }
-
-  .DayPicker-NavButton {
-    @include pt-icon-colors();
-    position: absolute;
-    top: -$datepicker-header-margin;
-    cursor: pointer;
-    padding: $datepicker-header-margin + 1;
-
-    &--prev {
-      left: -$datepicker-header-margin;
-
-      &::before {
-        @include pt-icon();
-        content: $pt-icon-chevron-left;
-      }
-    }
-
-    &--next {
-      right: -$datepicker-header-margin;
-
-      &::before {
-        @include pt-icon();
-        content: $pt-icon-chevron-right;
-      }
-    }
+  .DayPicker-Caption {
+    display: table-caption;
   }
 
   .DayPicker-Weekdays {
@@ -159,6 +133,19 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     margin-bottom: -$pt-grid-size / 2;
     border-top: 1px solid $pt-divider-black;
     padding-top: $pt-grid-size / 2;
+  }
+}
+
+.#{$ns}-datepicker-navbar {
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: $pt-button-height;
+
+  > :first-child {
+    margin-right: auto;
   }
 }
 

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -17,6 +17,17 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   line-height: 1;
 }
 
+.#{$ns}-divider {
+  margin: $datepicker-padding;
+  background: $pt-divider-black;
+  width: 1px;
+
+  &.#{$ns}-vertical {
+    width: auto;
+    height: 1px;
+  }
+}
+
 // react-day-picker does not conform to our naming scheme
 // stylelint-disable selector-class-pattern
 .#{$ns}-datepicker {
@@ -124,15 +135,6 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
       color: $pt-text-color-disabled;
     }
   }
-
-  .#{$ns}-datepicker-footer {
-    display: flex;
-    justify-content: space-between;
-    margin-top: $pt-grid-size;
-    margin-bottom: -$datepicker-padding;
-    border-top: 1px solid $pt-divider-black;
-    padding-top: $datepicker-padding;
-  }
 }
 
 .#{$ns}-datepicker-navbar {
@@ -153,8 +155,7 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   @include pt-flex-container(row, $fill: ":first-child");
   justify-content: space-between;
   margin-bottom: $datepicker-padding;
-  border-bottom: 1px solid $pt-divider-black;
-  padding: 0 ($pt-button-height - $datepicker-padding) ($datepicker-padding);
+  padding: 0 ($pt-button-height - $datepicker-padding);
 
   // HTMLSelect overrides for a narrower appearance
   select {
@@ -167,11 +168,20 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
       right: 2px;
     }
   }
+
+  + .#{$ns}-divider {
+    margin: 0;
+  }
 }
 
 .#{$ns}-datepicker-caption-measure {
   padding-left: $datepicker-padding;
   font-weight: 600;
+}
+
+.#{$ns}-datepicker-footer {
+  display: flex;
+  justify-content: space-between;
 }
 
 .#{$ns}-dark .#{$ns}-datepicker {

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -17,17 +17,6 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   line-height: 1;
 }
 
-.#{$ns}-divider {
-  margin: $datepicker-padding;
-  background: $pt-divider-black;
-  width: 1px;
-
-  &.#{$ns}-vertical {
-    width: auto;
-    height: 1px;
-  }
-}
-
 // react-day-picker does not conform to our naming scheme
 // stylelint-disable selector-class-pattern
 .#{$ns}-datepicker {

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -119,11 +119,6 @@
 }
 
 .#{$ns}-menu.#{$ns}-daterangepicker-shortcuts {
-  display: inline-block;
-  margin-top: -$datepicker-padding;
-  margin-left: -$datepicker-padding;
   min-width: $pt-grid-size * 12;
-  padding-top: 0;
-  padding-right: $datepicker-padding;
-  padding-left: 0;
+  padding: 0;
 }

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -9,14 +9,9 @@
   display: flex;
   white-space: nowrap;
 
-  .DayPicker:not(:last-child) {
-    margin-right: $pt-grid-size;
-  }
-
-  .DayPicker:first-of-type {
-    .#{$ns}-datepicker-navbar {
-      left: $pt-grid-size;
-    }
+  // indent first navbar a bit
+  .DayPicker:first-of-type .#{$ns}-datepicker-navbar {
+    left: $datepicker-padding;
   }
 
   .DayPicker-NavButton--interactionDisabled {
@@ -26,7 +21,7 @@
   .#{$ns}-daterangepicker-shortcuts + .DayPicker {
     border-left: 1px solid $pt-divider-black;
     min-width: $datepicker-min-width + $pt-grid-size;
-    padding-left: $pt-grid-size;
+    padding-left: $datepicker-padding;
   }
 
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
@@ -37,10 +32,6 @@
 
     .#{$ns}-daterangepicker-shortcuts + .DayPicker {
       min-width: ($datepicker-min-width + $pt-grid-size) * 2;
-    }
-
-    .DayPicker-Month:not(:last-child) {
-      margin-right: $pt-grid-size;
     }
   }
 

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -129,10 +129,10 @@
 
 .#{$ns}-menu.#{$ns}-daterangepicker-shortcuts {
   display: inline-block;
-  margin-top: -$pt-grid-size / 2;
-  margin-left: -$pt-grid-size / 2;
-  min-width: $pt-grid-size * 15;
+  margin-top: -$datepicker-padding;
+  margin-left: -$datepicker-padding;
+  min-width: $pt-grid-size * 12;
   padding-top: 0;
-  padding-right: $pt-grid-size / 2;
+  padding-right: $datepicker-padding;
   padding-left: 0;
 }

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -13,6 +13,12 @@
     margin-right: $pt-grid-size;
   }
 
+  .DayPicker:first-of-type {
+    .#{$ns}-datepicker-navbar {
+      left: $pt-grid-size;
+    }
+  }
+
   .DayPicker-NavButton--interactionDisabled {
     display: none;
   }

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -23,6 +23,7 @@ export const DATEPICKER_DAY_SELECTED = `${DATEPICKER_DAY}--selected`;
 export const DATEPICKER_FOOTER = `${DATEPICKER}-footer`;
 export const DATEPICKER_MONTH_SELECT = `${DATEPICKER}-month-select`;
 export const DATEPICKER_YEAR_SELECT = `${DATEPICKER}-year-select`;
+export const DATEPICKER_NAVBAR = `${DATEPICKER}-navbar`;
 
 export const DATERANGEPICKER = `${NS}-daterangepicker`;
 export const DATERANGEPICKER_CONTIGUOUS = `${DATERANGEPICKER}-contiguous`;

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -181,8 +181,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
             {...props}
             maxDate={this.props.maxDate}
             minDate={this.props.minDate}
-            onMonthChange={this.handleMonthSelectChange}
-            onYearChange={this.handleYearSelectChange}
+            onDateChange={this.handleMonthChange}
             reverseMonthAndYearMenus={this.props.reverseMonthAndYearMenus}
         />
     );
@@ -243,53 +242,16 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
     private handleClearClick = () => this.updateValue(null, true);
 
     private handleMonthChange = (newDate: Date) => {
-        const displayMonth = newDate.getMonth();
-        const displayYear = newDate.getFullYear();
-        this.setState({ displayMonth, displayYear });
-
+        const date = this.computeValidDateInSpecifiedMonthYear(newDate.getFullYear(), newDate.getMonth());
+        this.setState({ displayMonth: date.getMonth(), displayYear: date.getFullYear() });
         if (this.state.value !== null) {
-            const value = this.computeValidDateInSpecifiedMonthYear(displayYear, displayMonth);
-            Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, value);
             // if handleDayClick just got run (so this flag is set), then the
             // user selected a date in a new month, so don't invoke onChange a
             // second time
-            this.updateValue(value, false, this.ignoreNextMonthChange);
+            this.updateValue(date, false, this.ignoreNextMonthChange);
             this.ignoreNextMonthChange = false;
         }
-        // don't change value if it's empty
-    };
-
-    private handleMonthSelectChange = (displayMonth: number) => {
-        this.setState({ displayMonth });
-        if (this.state.value !== null) {
-            const value = this.computeValidDateInSpecifiedMonthYear(this.state.value.getFullYear(), displayMonth);
-            Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, value);
-            this.updateValue(value, false);
-        }
-    };
-
-    private handleYearSelectChange = (displayYear: number) => {
-        let { displayMonth } = this.state;
-
-        if (this.state.value !== null) {
-            const value = this.computeValidDateInSpecifiedMonthYear(displayYear, displayMonth);
-            Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, value);
-            this.updateValue(value, false);
-            displayMonth = value.getMonth();
-        } else {
-            // if value is empty, then we need to clamp displayMonth to valid
-            // months between min and max dates.
-            const { minDate, maxDate } = this.props;
-            const minMonth = minDate.getMonth();
-            const maxMonth = maxDate.getMonth();
-            if (displayYear === minDate.getFullYear() && displayMonth < minMonth) {
-                displayMonth = minMonth;
-            } else if (displayYear === maxDate.getFullYear() && displayMonth > maxMonth) {
-                displayMonth = maxMonth;
-            }
-        }
-
-        this.setState({ displayMonth, displayYear });
+        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, date);
     };
 
     private handleTodayClick = () => {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { AbstractPureComponent, Button, DISPLAYNAME_PREFIX, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent, Button, DISPLAYNAME_PREFIX, Divider, IProps, Utils } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
@@ -125,8 +125,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
                     selectedDays={this.state.value}
                     toMonth={maxDate}
                 />
-                {showActionsBar ? <div className="bp3-divider bp3-vertical" /> : null}
-                {showActionsBar ? this.renderOptionsBar() : null}
+                {showActionsBar && this.renderOptionsBar()}
             </div>
         );
     }
@@ -192,12 +191,13 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
     );
 
     private renderOptionsBar() {
-        return (
-            <div className={Classes.DATEPICKER_FOOTER}>
+        return [
+            <Divider key="div" />,
+            <div className={Classes.DATEPICKER_FOOTER} key="footer">
                 <Button minimal={true} onClick={this.handleTodayClick} text="Today" />
                 <Button minimal={true} onClick={this.handleClearClick} text="Clear" />
-            </div>
-        );
+            </div>,
+        ];
     }
 
     private handleDayClick = (day: Date, modifiers: DayModifiers, e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -125,6 +125,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
                     selectedDays={this.state.value}
                     toMonth={maxDate}
                 />
+                {showActionsBar ? <div className="bp3-divider bp3-vertical" /> : null}
                 {showActionsBar ? this.renderOptionsBar() : null}
             </div>
         );

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -7,13 +7,14 @@
 import { AbstractPureComponent, Button, DISPLAYNAME_PREFIX, IProps, Utils } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
-import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps } from "react-day-picker";
+import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
 import * as Errors from "./common/errors";
 import { DatePickerCaption } from "./datePickerCaption";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
+import { DatePickerNavbar } from "./datePickerNavbar";
 
 export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     /**
@@ -115,6 +116,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
                     {...dayPickerProps}
                     canChangeMonth={true}
                     captionElement={this.renderCaption}
+                    navbarElement={this.renderNavbar}
                     disabledDays={this.getDisabledDaysModifier()}
                     fromMonth={minDate}
                     month={new Date(displayYear, displayMonth)}
@@ -183,6 +185,10 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
             onYearChange={this.handleYearSelectChange}
             reverseMonthAndYearMenus={this.props.reverseMonthAndYearMenus}
         />
+    );
+
+    private renderNavbar = (props: NavbarElementProps) => (
+        <DatePickerNavbar {...props} maxDate={this.props.maxDate} minDate={this.props.minDate} />
     );
 
     private renderOptionsBar() {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -31,6 +31,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
 
     private containerElement: HTMLElement;
     private displayedMonthText: string;
+    private monthWidthsCache: Record<string, number> = {};
 
     private handleMonthSelectChange = this.dateChangeHandler((d, month) => d.setMonth(month), this.props.onMonthChange);
     private handleYearSelectChange = this.dateChangeHandler((d, year) => d.setFullYear(year), this.props.onYearChange);
@@ -105,12 +106,13 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
     }
 
     private positionArrows() {
-        // measure width of text as rendered inside our container element.
-        const monthWidth = measureTextWidth(
-            this.displayedMonthText,
-            Classes.DATEPICKER_CAPTION_MEASURE,
-            this.containerElement,
-        );
+        const cachedWidth = this.monthWidthsCache[this.displayedMonthText];
+        // measure width of text as rendered inside our container element and cache the result.
+        const monthWidth =
+            cachedWidth != null
+                ? cachedWidth
+                : measureTextWidth(this.displayedMonthText, Classes.DATEPICKER_CAPTION_MEASURE, this.containerElement);
+        this.monthWidthsCache[this.displayedMonthText] = monthWidth;
         this.setState({ monthWidth });
     }
 

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -92,6 +92,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
                 <div className={Classes.DATEPICKER_CAPTION} ref={ref => (this.containerElement = ref)}>
                     {orderedSelects}
                 </div>
+                <div className="bp3-divider bp3-vertical" />
             </div>
         );
     }

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { HTMLSelect, IOptionProps, Utils } from "@blueprintjs/core";
+import { HTMLSelect, Icon, IOptionProps, Utils } from "@blueprintjs/core";
 import * as React from "react";
 import { CaptionElementProps } from "react-day-picker/types/props";
 
@@ -31,7 +31,6 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
 
     private containerElement: HTMLElement;
     private displayedMonthText: string;
-    private monthWidthsCache: Record<string, number> = {};
 
     private handleMonthSelectChange = this.dateChangeHandler((d, month) => d.setMonth(month), this.props.onMonthChange);
     private handleYearSelectChange = this.dateChangeHandler((d, year) => d.setFullYear(year), this.props.onYearChange);
@@ -106,14 +105,19 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
     }
 
     private positionArrows() {
-        const cachedWidth = this.monthWidthsCache[this.displayedMonthText];
-        // measure width of text as rendered inside our container element and cache the result.
-        const monthWidth =
-            cachedWidth != null
-                ? cachedWidth
-                : measureTextWidth(this.displayedMonthText, Classes.DATEPICKER_CAPTION_MEASURE, this.containerElement);
-        this.monthWidthsCache[this.displayedMonthText] = monthWidth;
-        this.setState({ monthWidth });
+        // measure width of text as rendered inside our container element.
+        const monthWidth = measureTextWidth(
+            this.displayedMonthText,
+            Classes.DATEPICKER_CAPTION_MEASURE,
+            this.containerElement,
+        );
+        if (monthWidth > this.containerElement.firstElementChild.clientWidth - Icon.SIZE_STANDARD) {
+            // if it's larger than the first child (month select) then use the default styles
+            this.setState({ monthWidth: undefined });
+        } else {
+            // otherwise put icon just after the end of the month name
+            this.setState({ monthWidth });
+        }
     }
 
     private dateChangeHandler(updater: (date: Date, value: number) => void, handler?: (value: number) => void) {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -23,11 +23,11 @@ export interface IDatePickerCaptionProps extends CaptionElementProps {
 }
 
 export interface IDatePickerCaptionState {
-    monthTextWidth: number;
+    monthRightOffset: number;
 }
 
 export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionProps, IDatePickerCaptionState> {
-    public state: IDatePickerCaptionState = { monthTextWidth: 0 };
+    public state: IDatePickerCaptionState = { monthRightOffset: 0 };
 
     private containerElement: HTMLElement;
     private displayedMonthText: string;
@@ -63,7 +63,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
 
         const monthSelect = (
             <HTMLSelect
-                iconProps={{ style: { left: this.state.monthTextWidth } }}
+                iconProps={{ style: { right: this.state.monthRightOffset } }}
                 className={Classes.DATEPICKER_MONTH_SELECT}
                 key="month"
                 minimal={true}
@@ -113,13 +113,8 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
             this.containerElement,
         );
         const monthSelectWidth = this.containerElement.firstElementChild.clientWidth;
-        if (monthTextWidth > monthSelectWidth - Icon.SIZE_STANDARD - 2) {
-            // if it's larger than the month select minus default icon position then fall back to CSS.
-            this.setState({ monthTextWidth: undefined });
-        } else {
-            // otherwise position icon just after the end of the month name.
-            this.setState({ monthTextWidth });
-        }
+        const rightOffset = Math.max(2, monthSelectWidth - monthTextWidth - Icon.SIZE_STANDARD - 2);
+        this.setState({ monthRightOffset: rightOffset });
     }
 
     private dateChangeHandler(updater: (date: Date, value: number) => void, handler?: (value: number) => void) {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -23,11 +23,11 @@ export interface IDatePickerCaptionProps extends CaptionElementProps {
 }
 
 export interface IDatePickerCaptionState {
-    monthWidth: number;
+    monthTextWidth: number;
 }
 
 export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionProps, IDatePickerCaptionState> {
-    public state: IDatePickerCaptionState = { monthWidth: 0 };
+    public state: IDatePickerCaptionState = { monthTextWidth: 0 };
 
     private containerElement: HTMLElement;
     private displayedMonthText: string;
@@ -63,7 +63,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
 
         const monthSelect = (
             <HTMLSelect
-                iconProps={{ style: { left: this.state.monthWidth } }}
+                iconProps={{ style: { left: this.state.monthTextWidth } }}
                 className={Classes.DATEPICKER_MONTH_SELECT}
                 key="month"
                 minimal={true}
@@ -106,17 +106,18 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
 
     private positionArrows() {
         // measure width of text as rendered inside our container element.
-        const monthWidth = measureTextWidth(
+        const monthTextWidth = measureTextWidth(
             this.displayedMonthText,
             Classes.DATEPICKER_CAPTION_MEASURE,
             this.containerElement,
         );
-        if (monthWidth > this.containerElement.firstElementChild.clientWidth - Icon.SIZE_STANDARD) {
-            // if it's larger than the first child (month select) then use the default styles
-            this.setState({ monthWidth: undefined });
+        const monthSelectWidth = this.containerElement.firstElementChild.clientWidth;
+        if (monthTextWidth > monthSelectWidth - Icon.SIZE_STANDARD - 2) {
+            // if it's larger than the month select minus default icon position then fall back to CSS.
+            this.setState({ monthTextWidth: undefined });
         } else {
-            // otherwise put icon just after the end of the month name
-            this.setState({ monthWidth });
+            // otherwise position icon just after the end of the month name.
+            this.setState({ monthTextWidth });
         }
     }
 

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { HTMLSelect, Icon, IOptionProps, Utils } from "@blueprintjs/core";
+import { Divider, HTMLSelect, Icon, IOptionProps, Utils } from "@blueprintjs/core";
 import * as React from "react";
 import { CaptionElementProps } from "react-day-picker/types/props";
 
@@ -92,7 +92,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
                 <div className={Classes.DATEPICKER_CAPTION} ref={ref => (this.containerElement = ref)}>
                     {orderedSelects}
                 </div>
-                <div className="bp3-divider bp3-vertical" />
+                <Divider />
             </div>
         );
     }

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -4,18 +4,21 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Icon, Utils as BlueprintUtils } from "@blueprintjs/core";
+import { HTMLSelect, IOptionProps, Utils } from "@blueprintjs/core";
 import * as React from "react";
 import { CaptionElementProps } from "react-day-picker/types/props";
 
 import * as Classes from "./common/classes";
-import * as Utils from "./common/utils";
+import { clone } from "./common/dateUtils";
+import { measureTextWidth } from "./common/utils";
 
 export interface IDatePickerCaptionProps extends CaptionElementProps {
     maxDate: Date;
     minDate: Date;
     onMonthChange?: (month: number) => void;
     onYearChange?: (year: number) => void;
+    /** Callback invoked when the month or year `<select>` is changed. */
+    onDateChange: (date: Date) => void;
     reverseMonthAndYearMenus?: boolean;
 }
 
@@ -24,13 +27,13 @@ export interface IDatePickerCaptionState {
 }
 
 export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionProps, IDatePickerCaptionState> {
-    public state: IDatePickerCaptionState = {
-        monthWidth: 0,
-    };
-
-    private displayedMonthText: string;
+    public state: IDatePickerCaptionState = { monthWidth: 0 };
 
     private containerElement: HTMLElement;
+    private displayedMonthText: string;
+
+    private handleMonthSelectChange = this.dateChangeHandler((d, month) => d.setMonth(month), this.props.onMonthChange);
+    private handleYearSelectChange = this.dateChangeHandler((d, year) => d.setFullYear(year), this.props.onYearChange);
 
     public render() {
         const { date, locale, localeUtils, minDate, maxDate } = this.props;
@@ -44,64 +47,40 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
         const startMonth = displayYear === minYear ? minDate.getMonth() : 0;
         const endMonth = displayYear === maxYear ? maxDate.getMonth() + 1 : undefined;
         const monthOptionElements = months
-            .map((name, i) => {
-                return (
-                    <option key={i} value={i.toString()}>
-                        {name}
-                    </option>
-                );
-            })
+            .map<IOptionProps>((month, i) => ({ label: month, value: i }))
             .slice(startMonth, endMonth);
 
-        const years = [minYear];
+        const years: Array<number | IOptionProps> = [minYear];
         for (let year = minYear + 1; year <= maxYear; ++year) {
             years.push(year);
         }
-        const yearOptionElements = years.map((year, i) => {
-            return (
-                <option key={i} value={year.toString()}>
-                    {year}
-                </option>
-            );
-        });
         // allow out-of-bounds years but disable the option. this handles the Dec 2016 case in #391.
         if (displayYear > maxYear) {
-            yearOptionElements.push(
-                <option key="next" disabled={true} value={displayYear.toString()}>
-                    {displayYear}
-                </option>,
-            );
+            years.push({ value: displayYear, disabled: true });
         }
 
         this.displayedMonthText = months[displayMonth];
 
         const monthSelect = (
-            <div className={Classes.DATEPICKER_CAPTION_SELECT} key="month">
-                <select
-                    className={Classes.DATEPICKER_MONTH_SELECT}
-                    onChange={this.handleMonthSelectChange}
-                    value={displayMonth.toString()}
-                >
-                    {monthOptionElements}
-                </select>
-                <Icon
-                    className={Classes.DATEPICKER_CAPTION_CARET}
-                    icon="caret-down"
-                    style={{ left: this.state.monthWidth + 5 }}
-                />
-            </div>
+            <HTMLSelect
+                iconProps={{ style: { left: this.state.monthWidth } }}
+                className={Classes.DATEPICKER_MONTH_SELECT}
+                key="month"
+                minimal={true}
+                onChange={this.handleMonthSelectChange}
+                value={displayMonth}
+                options={monthOptionElements}
+            />
         );
         const yearSelect = (
-            <div className={Classes.DATEPICKER_CAPTION_SELECT} key="year">
-                <select
-                    className={Classes.DATEPICKER_YEAR_SELECT}
-                    onChange={this.handleYearSelectChange}
-                    value={displayYear.toString()}
-                >
-                    {yearOptionElements}
-                </select>
-                <Icon className={Classes.DATEPICKER_CAPTION_CARET} icon="caret-down" />
-            </div>
+            <HTMLSelect
+                className={Classes.DATEPICKER_YEAR_SELECT}
+                key="year"
+                minimal={true}
+                onChange={this.handleYearSelectChange}
+                value={displayYear}
+                options={years}
+            />
         );
 
         const orderedSelects = this.props.reverseMonthAndYearMenus
@@ -123,8 +102,6 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
         this.positionArrows();
     }
 
-    private containerRefHandler = (r: HTMLElement) => (this.containerElement = r);
-
     private positionArrows() {
         // measure width of text as rendered inside our container element.
         const monthWidth = Utils.measureTextWidth(
@@ -135,13 +112,13 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
         this.setState({ monthWidth });
     }
 
-    private handleMonthSelectChange = (e: React.FormEvent<HTMLSelectElement>) => {
-        const month = parseInt((e.target as HTMLSelectElement).value, 10);
-        BlueprintUtils.safeInvoke(this.props.onMonthChange, month);
-    };
-
-    private handleYearSelectChange = (e: React.FormEvent<HTMLSelectElement>) => {
-        const year = parseInt((e.target as HTMLSelectElement).value, 10);
-        BlueprintUtils.safeInvoke(this.props.onYearChange, year);
-    };
+    private dateChangeHandler(updater: (date: Date, value: number) => void, handler?: (value: number) => void) {
+        return (e: React.FormEvent<HTMLSelectElement>) => {
+            const value = parseInt((e.target as HTMLSelectElement).value, 10);
+            const newDate = clone(this.props.date);
+            updater(newDate, value);
+            Utils.safeInvoke(this.props.onDateChange, newDate);
+            Utils.safeInvoke(handler, value);
+        };
+    }
 }

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -18,7 +18,7 @@ export interface IDatePickerCaptionProps extends CaptionElementProps {
     onMonthChange?: (month: number) => void;
     onYearChange?: (year: number) => void;
     /** Callback invoked when the month or year `<select>` is changed. */
-    onDateChange: (date: Date) => void;
+    onDateChange?: (date: Date) => void;
     reverseMonthAndYearMenus?: boolean;
 }
 
@@ -88,8 +88,10 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
             : [monthSelect, yearSelect];
 
         return (
-            <div className={Classes.DATEPICKER_CAPTION} ref={this.containerRefHandler}>
-                {orderedSelects}
+            <div className={this.props.classNames.caption}>
+                <div className={Classes.DATEPICKER_CAPTION} ref={ref => (this.containerElement = ref)}>
+                    {orderedSelects}
+                </div>
             </div>
         );
     }
@@ -104,7 +106,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
 
     private positionArrows() {
         // measure width of text as rendered inside our container element.
-        const monthWidth = Utils.measureTextWidth(
+        const monthWidth = measureTextWidth(
             this.displayedMonthText,
             Classes.DATEPICKER_CAPTION_MEASURE,
             this.containerElement,

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { Button } from "@blueprintjs/core";
+import * as React from "react";
+import { NavbarElementProps } from "react-day-picker/types/props";
+
+import classNames from "classnames";
+import * as Classes from "./common/classes";
+import { areSameMonth } from "./common/dateUtils";
+
+export interface IDatePickerNavbarProps extends NavbarElementProps {
+    maxDate: Date;
+    minDate: Date;
+}
+
+export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps> {
+    public render() {
+        const { classNames: classes, month, maxDate, minDate } = this.props;
+
+        return (
+            <div className={classNames(Classes.DATEPICKER_NAVBAR, classes.navBar)}>
+                <Button
+                    className={classes.navButtonPrev}
+                    disabled={areSameMonth(month, minDate)}
+                    icon="chevron-left"
+                    minimal={true}
+                    small={true}
+                    onClick={this.handlePreviousClick}
+                />
+                <Button
+                    className={classes.navButtonNext}
+                    disabled={areSameMonth(month, maxDate)}
+                    icon="chevron-right"
+                    minimal={true}
+                    small={true}
+                    onClick={this.handleNextClick}
+                />
+            </div>
+        );
+    }
+
+    private handleNextClick = () => this.props.onNextClick();
+    private handlePreviousClick = () => this.props.onPreviousClick();
+}

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -28,7 +28,6 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
                     disabled={areSameMonth(month, minDate)}
                     icon="chevron-left"
                     minimal={true}
-                    small={true}
                     onClick={this.handlePreviousClick}
                 />
                 <Button
@@ -36,7 +35,6 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
                     disabled={areSameMonth(month, maxDate)}
                     icon="chevron-right"
                     minimal={true}
-                    small={true}
                     onClick={this.handleNextClick}
                 />
             </div>

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the terms of the LICENSE file distributed with this project.
  */

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -255,6 +255,8 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             selectedDays: this.state.value,
         };
 
+        const shortcuts = this.maybeRenderShortcuts();
+
         if (contiguousCalendarMonths || isShowingOneMonth) {
             const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
                 [DateClasses.DATERANGEPICKER_CONTIGUOUS]: contiguousCalendarMonths,
@@ -264,7 +266,8 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             // use the left DayPicker when we only need one
             return (
                 <div className={classes}>
-                    {this.maybeRenderShortcuts()}
+                    {shortcuts}
+                    {shortcuts && <div className="bp3-divider" />}
                     <ReactDayPicker
                         {...dayPickerBaseProps}
                         captionElement={this.renderSingleCaption}
@@ -281,7 +284,8 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             // const rightMonth = contiguousCalendarMonths ? rightView.getFullDate()
             return (
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
-                    {this.maybeRenderShortcuts()}
+                    {shortcuts}
+                    {shortcuts && <div className="bp3-divider" />}
                     <ReactDayPicker
                         {...dayPickerBaseProps}
                         canChangeMonth={true}

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -9,6 +9,7 @@ import {
     Boundary,
     Classes,
     DISPLAYNAME_PREFIX,
+    Divider,
     IProps,
     Menu,
     MenuItem,
@@ -267,7 +268,6 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             return (
                 <div className={classes}>
                     {shortcuts}
-                    {shortcuts && <div className="bp3-divider" />}
                     <ReactDayPicker
                         {...dayPickerBaseProps}
                         captionElement={this.renderSingleCaption}
@@ -281,11 +281,9 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
                 </div>
             );
         } else {
-            // const rightMonth = contiguousCalendarMonths ? rightView.getFullDate()
             return (
                 <div className={classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className)}>
                     {shortcuts}
-                    {shortcuts && <div className="bp3-divider" />}
                     <ReactDayPicker
                         {...dayPickerBaseProps}
                         canChangeMonth={true}
@@ -381,7 +379,12 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             );
         });
 
-        return <Menu className={DateClasses.DATERANGEPICKER_SHORTCUTS}>{shortcutElements}</Menu>;
+        return [
+            <Menu key="shortcuts" className={DateClasses.DATERANGEPICKER_SHORTCUTS}>
+                {shortcutElements}
+            </Menu>,
+            <Divider key="div" />,
+        ];
     }
 
     private renderNavbar = (navbarProps: NavbarElementProps) => (

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import ReactDayPicker from "react-day-picker";
 import { DayModifiers } from "react-day-picker/types/common";
-import { CaptionElementProps, DayPickerProps } from "react-day-picker/types/props";
+import { CaptionElementProps, DayPickerProps, NavbarElementProps } from "react-day-picker/types/props";
 
 import * as DateClasses from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -37,6 +37,7 @@ import {
     IDatePickerModifiers,
     SELECTED_RANGE_MODIFIER,
 } from "./datePickerCore";
+import { DatePickerNavbar } from "./datePickerNavbar";
 import { DateRangeSelectionStrategy } from "./dateRangeSelectionStrategy";
 
 export interface IDateRangeShortcut {
@@ -267,6 +268,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
                     <ReactDayPicker
                         {...dayPickerBaseProps}
                         captionElement={this.renderSingleCaption}
+                        navbarElement={this.renderNavbar}
                         fromMonth={minDate}
                         month={leftView.getFullDate()}
                         numberOfMonths={isShowingOneMonth ? 1 : 2}
@@ -284,6 +286,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
                         {...dayPickerBaseProps}
                         canChangeMonth={true}
                         captionElement={this.renderLeftCaption}
+                        navbarElement={this.renderNavbar}
                         fromMonth={minDate}
                         month={leftView.getFullDate()}
                         onMonthChange={this.handleLeftMonthChange}
@@ -293,6 +296,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
                         {...dayPickerBaseProps}
                         canChangeMonth={true}
                         captionElement={this.renderRightCaption}
+                        navbarElement={this.renderNavbar}
                         fromMonth={DateUtils.getDateNextMonth(minDate)}
                         month={rightView.getFullDate()}
                         onMonthChange={this.handleRightMonthChange}
@@ -375,6 +379,10 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
 
         return <Menu className={DateClasses.DATERANGEPICKER_SHORTCUTS}>{shortcutElements}</Menu>;
     }
+
+    private renderNavbar = (navbarProps: NavbarElementProps) => (
+        <DatePickerNavbar {...navbarProps} maxDate={this.props.maxDate} minDate={this.props.minDate} />
+    );
 
     private renderSingleCaption = (captionProps: CaptionElementProps) => (
         <DatePickerCaption

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -122,7 +122,10 @@ describe("<DateInput>", () => {
             .find("input")
             .simulate("focus")
             .simulate("blur");
-        wrapper.find(`.${Classes.DATEPICKER_MONTH_SELECT}`).simulate("change", { value: Months.FEBRUARY.toString() });
+        wrapper
+            .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
+            .find("select")
+            .simulate("change", { value: Months.FEBRUARY.toString() });
         assert.isTrue(wrapper.find(Popover).prop("isOpen"));
     });
 
@@ -134,7 +137,10 @@ describe("<DateInput>", () => {
             .find("input")
             .simulate("focus")
             .simulate("blur");
-        wrapper.find(`.${Classes.DATEPICKER_YEAR_SELECT}`).simulate("change", { value: "2016" });
+        wrapper
+            .find(`.${Classes.DATEPICKER_YEAR_SELECT}`)
+            .find("select")
+            .simulate("change", { value: "2016" });
         assert.isTrue(wrapper.find(Popover).prop("isOpen"));
     });
 
@@ -325,6 +331,7 @@ describe("<DateInput>", () => {
             wrapper.setState({ isOpen: true });
             wrapper
                 .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
+                .find("select")
                 .simulate("change", { value: Months.FEBRUARY.toString() });
             assert.isTrue(wrapper.find(Popover).prop("isOpen"));
         });
@@ -557,6 +564,7 @@ describe("<DateInput>", () => {
 
             wrapper
                 .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
+                .find("select")
                 .simulate("change", { value: Months.FEBRUARY.toString() });
 
             assert.isTrue(onChange.calledOnce);

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -322,7 +322,11 @@ describe("<DateInput>", () => {
         it("Popover doesn't close when month changes", () => {
             const defaultValue = new Date(2017, Months.JANUARY, 1);
             const { root, changeSelect } = wrap(
-                <DateInput {...DATE_FORMAT} defaultValue={defaultValue} popoverProps={{ isOpen: true }} />,
+                <DateInput
+                    {...DATE_FORMAT}
+                    defaultValue={defaultValue}
+                    popoverProps={{ isOpen: true, usePortal: false }}
+                />,
             );
             changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
             assert.isTrue(root.find(Popover).prop("isOpen"));
@@ -552,7 +556,12 @@ describe("<DateInput>", () => {
         it("isUserChange is false when month changes", () => {
             const onChange = sinon.spy();
             wrap(
-                <DateInput {...DATE_FORMAT} onChange={onChange} popoverProps={{ isOpen: true }} value={DATE} />,
+                <DateInput
+                    {...DATE_FORMAT}
+                    onChange={onChange}
+                    popoverProps={{ isOpen: true, usePortal: false }}
+                    value={DATE}
+                />,
             ).changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
             assert.isTrue(onChange.calledOnce);
             assert.isFalse(onChange.args[0][1], "expected isUserChange to be false");

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -116,32 +116,26 @@ describe("<DateInput>", () => {
 
     it("Popover should not close if focus moves to month select", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
-        const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
-        wrapper.setState({ isOpen: true });
-        wrapper
+        const { root, changeSelect } = wrap(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
+        root.setState({ isOpen: true });
+        root
             .find("input")
             .simulate("focus")
             .simulate("blur");
-        wrapper
-            .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
-            .find("select")
-            .simulate("change", { value: Months.FEBRUARY.toString() });
-        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+        changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
+        assert.isTrue(root.find(Popover).prop("isOpen"));
     });
 
     it("Popover should not close if focus moves to year select", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
-        const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
-        wrapper.setState({ isOpen: true });
-        wrapper
+        const { root, changeSelect } = wrap(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
+        root.setState({ isOpen: true });
+        root
             .find("input")
             .simulate("focus")
             .simulate("blur");
-        wrapper
-            .find(`.${Classes.DATEPICKER_YEAR_SELECT}`)
-            .find("select")
-            .simulate("change", { value: "2016" });
-        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+        changeSelect(Classes.DATEPICKER_YEAR_SELECT, 2016);
+        assert.isTrue(root.find(Popover).prop("isOpen"));
     });
 
     it("setting timePrecision renders a TimePicker", () => {
@@ -327,13 +321,11 @@ describe("<DateInput>", () => {
 
         it("Popover doesn't close when month changes", () => {
             const defaultValue = new Date(2017, Months.JANUARY, 1);
-            const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
-            wrapper.setState({ isOpen: true });
-            wrapper
-                .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
-                .find("select")
-                .simulate("change", { value: Months.FEBRUARY.toString() });
-            assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+            const { root, changeSelect } = wrap(
+                <DateInput {...DATE_FORMAT} defaultValue={defaultValue} popoverProps={{ isOpen: true }} />,
+            );
+            changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
+            assert.isTrue(root.find(Popover).prop("isOpen"));
         });
 
         it("Popover doesn't close when time changes", () => {
@@ -559,14 +551,9 @@ describe("<DateInput>", () => {
 
         it("isUserChange is false when month changes", () => {
             const onChange = sinon.spy();
-            const wrapper = mount(<DateInput {...DATE_FORMAT} onChange={onChange} value={DATE} />);
-            wrapper.setState({ isOpen: true });
-
-            wrapper
-                .find(`.${Classes.DATEPICKER_MONTH_SELECT}`)
-                .find("select")
-                .simulate("change", { value: Months.FEBRUARY.toString() });
-
+            wrap(
+                <DateInput {...DATE_FORMAT} onChange={onChange} popoverProps={{ isOpen: true }} value={DATE} />,
+            ).changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
             assert.isTrue(onChange.calledOnce);
             assert.isFalse(onChange.args[0][1], "expected isUserChange to be false");
         });
@@ -624,6 +611,12 @@ describe("<DateInput>", () => {
     function wrap(dateInput: JSX.Element) {
         const wrapper = mount<IDateInputProps>(dateInput);
         return {
+            changeSelect: (className: string, value: React.ReactText) => {
+                return wrapper
+                    .find(`.${className}`)
+                    .find("select")
+                    .simulate("change", { target: { value: value.toString() } });
+            },
             getDay: (dayNumber = 1) => {
                 return wrapper
                     .find(`.${Classes.DATEPICKER_DAY}`)

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -9,6 +9,7 @@ import { mount } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
+import { HTMLSelect } from "@blueprintjs/core";
 import { ClassNames } from "react-day-picker/types/common";
 import { DatePickerCaption, IDatePickerCaptionProps } from "../src/datePickerCaption";
 import { Classes, IDatePickerLocaleUtils } from "../src/index";
@@ -42,14 +43,14 @@ describe("<DatePickerCaption>", () => {
         const onYearChange = sinon.spy();
         const { month, year } = renderDatePickerCaption({ onMonthChange, onYearChange });
 
-        assert.isTrue(onMonthChange.notCalled);
+        assert.isTrue(onMonthChange.notCalled, "onMonthChange before");
         month.simulate("change", { target: { value: 11 } });
-        assert.isTrue(onMonthChange.calledOnce);
+        assert.isTrue(onMonthChange.calledOnce, "onMonthChange after");
         assert.strictEqual(onMonthChange.args[0][0], 11);
 
-        assert.isTrue(onYearChange.notCalled);
+        assert.isTrue(onYearChange.notCalled, "onYearChange before");
         year.simulate("change", { target: { value: 2014 } });
-        assert.isTrue(onYearChange.calledOnce);
+        assert.isTrue(onYearChange.calledOnce, "onYearChange after");
         assert.strictEqual(onYearChange.args[0][0], 2014);
     });
 
@@ -87,9 +88,15 @@ describe("<DatePickerCaption>", () => {
         );
 
         return {
-            month: wrapper.find(`.${Classes.DATEPICKER_MONTH_SELECT}`),
+            month: wrapper
+                .find(HTMLSelect)
+                .filter({ className: Classes.DATEPICKER_MONTH_SELECT })
+                .find("select"),
             root: wrapper,
-            year: wrapper.find(`.${Classes.DATEPICKER_YEAR_SELECT}`),
+            year: wrapper
+                .find(HTMLSelect)
+                .filter({ className: Classes.DATEPICKER_YEAR_SELECT })
+                .find("select"),
         };
     }
 });

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -16,6 +16,7 @@ import { expectPropValidationError } from "@blueprintjs/test-commons";
 import * as DateUtils from "../src/common/dateUtils";
 import * as Errors from "../src/common/errors";
 import { Months } from "../src/common/months";
+import { DatePickerNavbar } from "../src/datePickerNavbar";
 import { IDateRangePickerState } from "../src/dateRangePicker";
 import {
     Classes as DateClasses,
@@ -1042,8 +1043,10 @@ describe("<DateRangePicker>", () => {
             },
             clickNavButton: (which: "next" | "prev", navIndex = 0) => {
                 wrapper
-                    .find(`.DayPicker-NavButton--${which}`)
+                    .find(DatePickerNavbar)
                     .at(navIndex)
+                    .find(`.DayPicker-NavButton--${which}`)
+                    .hostNodes()
                     .simulate("click");
                 return harness;
             },
@@ -1074,10 +1077,10 @@ describe("<DateRangePicker>", () => {
                     .at(which === "left" ? 0 : 1);
             },
             get monthSelect() {
-                return harness.wrapper.find({ className: DateClasses.DATEPICKER_MONTH_SELECT });
+                return harness.wrapper.find({ className: DateClasses.DATEPICKER_MONTH_SELECT }).find("select");
             },
             get yearSelect() {
-                return harness.wrapper.find({ className: DateClasses.DATEPICKER_YEAR_SELECT });
+                return harness.wrapper.find({ className: DateClasses.DATEPICKER_YEAR_SELECT }).find("select");
             },
 
             assertMonthYear: (month: number, year?: number) => {


### PR DESCRIPTION
#### Fixes #2801 

#### Changes proposed in this pull request:

- use minimal `HTMLSelect` for month/year dropdowns.
- use minimal `Button` for next/previous buttons.
- use `navbarElement` prop to render custom next/prev buttons instead of restyling the existing classes.
    - caption is responsible for month/year selects
    - navbar is responsible for prev/next buttons.
- `DatePicker` uses single `handleMonthChange` for all DayPicker events
    - caption (month/year select) and navbar (prev/next buttons) now all use the same logic for changes!
- use `Divider` for all the internal separators
- add `HTMLSelect` `iconProps` prop so we can position the icon


#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->

`DatePicker`
![datepicker-caption](https://user-images.githubusercontent.com/464822/43983521-cc67ae46-9caf-11e8-955a-527dccc8a430.gif)

`DateRangePicker`
![daterangepicker-caption](https://user-images.githubusercontent.com/464822/43983524-cdba22a6-9caf-11e8-990f-080076024aad.gif)

`DateRangePicker contiguousCalendarMonths`
![daterangepicker-caption-no-cont](https://user-images.githubusercontent.com/464822/43983527-cedff872-9caf-11e8-8c88-2d3dc9d0013f.gif)
