### PR TITLE
[timepicker] Fix allowing to type time that exceeds time bounds

### DIFF
--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -354,11 +354,10 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
             setTimeUnit(unit, time, newValue, this.state.isPm);
             if (DateUtils.isTimeInRange(newValue, this.props.minTime, this.props.maxTime)) {
                 this.updateState({ value: newValue });
-            } else if (!DateUtils.areSameTime(this.state.value, this.props.minTime)) {
-                this.updateState(this.getFullStateFromValue(newValue, this.props.useAmPm));
+            } else {
+                this.updateState(this.getFullStateFromValue(this.state.value, this.props.useAmPm));
             }
         } else {
-            // reset to last known good state
             this.updateState(this.getFullStateFromValue(this.state.value, this.props.useAmPm));
         }
     }

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -281,6 +281,42 @@ describe("<TimePicker>", () => {
             assertTimeIs(timePicker.state.value, 2, 0, 0, 0);
         });
 
+        it("can not type time greater than maxTime", () => {
+            const defaultValue = createTimeObject(10, 20);
+            const wrapper = mount(<TimePicker defaultValue={defaultValue} precision={TimePrecision.MILLISECOND} />);
+
+            wrapper.setProps({
+                maxTime: createTimeObject(21),
+                minTime: createTimeObject(18),
+            });
+
+            const hourInput = wrapper
+                .find(`.${Classes.TIMEPICKER_INPUT}.${Classes.TIMEPICKER_HOUR}`)
+                .getDOMNode() as HTMLInputElement;
+
+            changeInputThenBlur(hourInput, "22");
+
+            assert.strictEqual(hourInput.getAttribute("value"), "18");
+        });
+
+        it("can not type time smaller than minTime", () => {
+            const defaultValue = createTimeObject(10, 20);
+            const wrapper = mount(<TimePicker defaultValue={defaultValue} precision={TimePrecision.MILLISECOND} />);
+
+            wrapper.setProps({
+                maxTime: createTimeObject(21),
+                minTime: createTimeObject(18),
+            });
+
+            const hourInput = wrapper
+                .find(`.${Classes.TIMEPICKER_INPUT}.${Classes.TIMEPICKER_HOUR}`)
+                .getDOMNode() as HTMLInputElement;
+
+            changeInputThenBlur(hourInput, "16");
+
+            assert.strictEqual(hourInput.getAttribute("value"), "18");
+        });
+
         it("time can't be smaller minTime, while decrementing unit", () => {
             renderTimePicker({
                 minTime: createTimeObject(15, 32, 20, 600),


### PR DESCRIPTION
#### Fixes #2794 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:
Fixed #2794 
<!-- fill this out -->

#### Reviewers should focus on:
`NumericInput` has prop called `clampValueOnBlur`, which indicates whenever or not input automatically clamp to boundaries. Should We introduce similar functionality for `Timepicker`?
