### PR TITLE
[TagInput] On paste, don't tag-ify text if no separator included

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -24,8 +24,14 @@ export interface ITagInputProps extends IProps {
     addOnBlur?: boolean;
 
     /**
-     * If true, `onAdd` will be invoked when the user pastes text into the
-     * input. Otherwise, pasted text will remain in the input.
+     * If true, `onAdd` will be invoked when the user pastes text containing the `separator`
+     * into the input. Otherwise, pasted text will remain in the input.
+     *
+     * __Note:__ For example, if `addOnPaste=true` and `separator="\n"` (new line), then:
+     * - Pasting `"hello"` will _not_ invoke `onAdd`
+     * - Pasting `"hello\n"` will invoke `onAdd` with `["hello"]`
+     * - Pasting `"hello\nworld"` will invoke `onAdd` with `["hello", "world"]`
+     *
      * @default true
      */
     addOnPaste?: boolean;

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -385,11 +385,21 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     };
 
     private handleInputPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+        const { separator } = this.props;
         const value = event.clipboardData.getData("text");
-        if (this.props.addOnPaste && value.length > 0) {
-            event.preventDefault();
-            this.addTags(value);
+
+        if (!this.props.addOnPaste || value.length === 0) {
+            return;
         }
+
+        // special case as a UX nicety: if the user pasted only one value with no delimiters in it, leave that value in
+        // the input field so that the user can refine it before converting it to a tag manually.
+        if (separator === false || value.split(separator).length === 1) {
+            return;
+        }
+
+        event.preventDefault();
+        this.addTags(value);
     };
 
     private handleRemoveTag = (event: React.MouseEvent<HTMLSpanElement>) => {

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -150,13 +150,32 @@ describe("<TagInput>", () => {
             });
         });
 
-        it("is invoked on paste when addOnPaste=true", () => {
-            const text = "pasted\ntext";
-            const onAdd = sinon.stub();
-            const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
-            wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
-            assert.isTrue(onAdd.calledOnce);
-            assert.deepEqual(onAdd.args[0][0], text.split("\n"));
+        describe("when addOnPaste=true", () => {
+            it("is invoked on paste if the text contains a delimiter between values", () => {
+                const text = "pasted\ntext";
+                const onAdd = sinon.stub();
+                const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
+                wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
+                assert.isTrue(onAdd.calledOnce);
+                assert.deepEqual(onAdd.args[0][0], ["pasted", "text"]);
+            });
+
+            it("is invoked on paste if the text contains a trailing delimiter", () => {
+                const text = "pasted\n";
+                const onAdd = sinon.stub();
+                const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
+                wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
+                assert.isTrue(onAdd.calledOnce);
+                assert.deepEqual(onAdd.args[0][0], ["pasted"]);
+            });
+
+            it("is not invoked on paste if the text does not include a delimiter", () => {
+                const text = "pasted";
+                const onAdd = sinon.stub();
+                const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
+                wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
+                assert.isTrue(onAdd.notCalled);
+            });
         });
 
         it("is not invoked on paste when addOnPaste=false", () => {


### PR DESCRIPTION
#### (No issue)

## Checklist

- [x] ~[Enable CircleCI for your fork](https://circleci.com/add-projects)~ __N/A__
- [x] Include tests
- [x] Update documentation

## Changes proposed in this pull request:

### 🌈 Enhancement
- __[TagInput]__ Slightly modified behavior for `addOnPaste`:

    If true, `onAdd` will be invoked when the user pastes text ___containing the separator___ into the input. Otherwise, pasted text will remain in the input.

    __Note:__ For example, if addOnPaste=true and separator="\n" (new line), then:

    - Pasting `"hello"` will _not_ invoke `onAdd`
    - Pasting `"hello\n"` will invoke `onAdd` with `["hello"]`
    - Pasting `"hello\nworld"` will invoke `onAdd` with `["hello", "world"]`

## Reviewers should focus on:

In the pre-`addOnPaste` world of Blueprint 1.X, we implemented this behavior via a custom `onPaste` callback, but that callback appears to no longer be supported. This was a specific request for our use case that we need to support somehow: reasoning is that users may want to refine a single line of pasted text before converting it to a tag manually. Seems like supporting it natively in `TagInput` would be reasonable?

## Screenshot

### 📘 Documentation

![image](https://user-images.githubusercontent.com/443450/44166168-8d7efa80-a07f-11e8-8c45-03ede5bd84fd.png)

### 📹 Demo

#### Case 1: Paste `"hello"`
This is the only case that changed: now, the "hello" text remains in the input on paste, since it doesn't include a separator.

![2018-08-15 11 39 20](https://user-images.githubusercontent.com/443450/44166375-1f870300-a080-11e8-9775-2de7d2f5d368.gif)

#### Case 2: Paste `"hello\n"`
This is unchanged: it's exactly how `TagInput` already works.

![2018-08-15 11 39 40](https://user-images.githubusercontent.com/443450/44166380-2281f380-a080-11e8-835b-2b1e4f16f388.gif)

#### Case 3: Paste `"hello\nworld"`
This is unchanged: it's exactly how `TagInput` already works.

![2018-08-15 11 40 09](https://user-images.githubusercontent.com/443450/44166384-244bb700-a080-11e8-81ce-405f184f5420.gif)

#### Case 4: Paste `"hello\nworld\n"`
This is unchanged: it's exactly how `TagInput` already works.

![2018-08-15 11 39 55](https://user-images.githubusercontent.com/443450/44166390-257ce400-a080-11e8-9270-9b1fdd56cb62.gif)
