### PR TITLE
[DatePicker] time support: timePrecision & timePickerProps

### DIFF
--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -111,6 +111,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 }
 
 .#{$ns}-datepicker .#{$ns}-timepicker {
+  margin-top: $datepicker-padding;
   margin-bottom: $datepicker-padding * 2;
   text-align: center;
 

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -109,3 +109,10 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     color: $pt-dark-text-color;
   }
 }
+
+.#{$ns}-datepicker .#{$ns}-timepicker {
+  margin-top: $pt-grid-size;
+  border-top: 1px solid $pt-divider-black;
+  padding-top: $pt-grid-size;
+  text-align: center;
+}

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -111,8 +111,11 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 }
 
 .#{$ns}-datepicker .#{$ns}-timepicker {
-  margin-top: $pt-grid-size;
-  border-top: 1px solid $pt-divider-black;
-  padding-top: $pt-grid-size;
+  margin-bottom: $datepicker-padding * 2;
   text-align: center;
+
+  // adjust margin when actions bar is hidden
+  &:last-child {
+    margin-bottom: $datepicker-padding;
+  }
 }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -27,8 +27,6 @@ import { isDateValid, isDayInRange } from "./common/dateUtils";
 import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
 import { DatePicker } from "./datePicker";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
-import { DateTimePicker } from "./dateTimePicker";
-import { ITimePickerProps, TimePrecision } from "./timePicker";
 
 export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps, IProps {
     /**
@@ -110,19 +108,6 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
      * in the input field, pass `new Date(undefined)` to the value prop.
      */
     value?: Date | null;
-
-    /**
-     * Any props to be passed on to the `TimePicker`. `value`, `onChange`, and
-     * `timePrecision` will be ignored in favor of the corresponding top-level
-     * props on this component.
-     */
-    timePickerProps?: ITimePickerProps;
-
-    /**
-     * Adds a time chooser to the bottom of the popover.
-     * Passed to the `DateTimePicker` component.
-     */
-    timePrecision?: TimePrecision;
 }
 
 export interface IDateInputState {
@@ -144,7 +129,6 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         minDate: getDefaultMinDate(),
         outOfRangeMessage: "Out of range",
         reverseMonthAndYearMenus: false,
-        timePickerProps: {},
     };
 
     public state: IDateInputState = {
@@ -186,24 +170,17 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
             },
         };
 
-        const popoverContent =
-            this.props.timePrecision === undefined ? (
+        const wrappedPopoverContent = (
+            <div ref={this.refHandlers.popoverContent}>
                 <DatePicker
                     {...this.props}
                     dayPickerProps={dayPickerProps}
                     onChange={this.handleDateChange}
                     value={dateValue}
                 />
-            ) : (
-                <DateTimePicker
-                    canClearSelection={this.props.canClearSelection}
-                    onChange={this.handleDateChange}
-                    value={value}
-                    datePickerProps={this.props}
-                    timePickerProps={{ ...this.props.timePickerProps, precision: this.props.timePrecision }}
-                />
-            );
-        const wrappedPopoverContent = <div ref={this.refHandlers.popoverContent}>{popoverContent}</div>;
+            </div>
+        );
+
         // assign default empty object here to prevent mutation
         const { popoverProps = {} } = this.props;
         const inputProps = this.getInputPropsWithDefaults();

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -236,7 +236,8 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         }
 
         // allow toggling selected date by clicking it again (if prop enabled)
-        const newValue = this.props.canClearSelection && modifiers.selected ? null : day;
+        const newValue =
+            this.props.canClearSelection && modifiers.selected ? null : DateUtils.getDateTime(day, this.state.value);
         this.updateValue(newValue, true);
     };
 
@@ -248,7 +249,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         const displayDate = selectedDay == null ? 1 : Math.min(selectedDay, maxDaysInMonth);
 
         // 12:00 matches the underlying react-day-picker timestamp behavior
-        const value = new Date(displayYear, displayMonth, displayDate, 12);
+        const value = DateUtils.getDateTime(new Date(displayYear, displayMonth, displayDate, 12), this.state.value);
         // clamp between min and max dates
         if (value < minDate) {
             return minDate;
@@ -284,7 +285,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
 
     private handleTimeChange = (time: Date) => {
         Utils.safeInvoke(this.props.timePickerProps.onChange, time);
-        const newValue = getDateTime(this.state.value || new Date(), time);
+        const newValue = DateUtils.getDateTime(this.state.value || new Date(), time);
         this.updateValue(newValue, true);
     };
 

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -15,6 +15,7 @@ import * as Errors from "./common/errors";
 import { DatePickerCaption } from "./datePickerCaption";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
 import { DatePickerNavbar } from "./datePickerNavbar";
+import { TimePicker } from "./timePicker";
 
 export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     /**
@@ -75,6 +76,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         minDate: getDefaultMinDate(),
         reverseMonthAndYearMenus: false,
         showActionsBar: false,
+        timePickerProps: {},
     };
 
     public static displayName = `${DISPLAYNAME_PREFIX}.DatePicker`;
@@ -125,6 +127,7 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
                     selectedDays={this.state.value}
                     toMonth={maxDate}
                 />
+                {this.maybeRenderTimePicker()}
                 {showActionsBar && this.renderOptionsBar()}
             </div>
         );
@@ -200,6 +203,21 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         ];
     }
 
+    private maybeRenderTimePicker() {
+        const { timePrecision, timePickerProps } = this.props;
+        if (timePrecision == null && timePickerProps === DatePicker.defaultProps.timePickerProps) {
+            return null;
+        }
+        return (
+            <TimePicker
+                precision={timePrecision}
+                {...timePickerProps}
+                onChange={this.handleTimeChange}
+                value={this.state.value}
+            />
+        );
+    }
+
     private handleDayClick = (day: Date, modifiers: DayModifiers, e: React.MouseEvent<HTMLDivElement>) => {
         Utils.safeInvoke(this.props.dayPickerProps.onDayClick, day, modifiers, e);
         if (modifiers.disabled) {
@@ -262,6 +280,12 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
         const selectedDay = value.getDate();
         this.setState({ displayMonth, displayYear, selectedDay });
         this.updateValue(value, true);
+    };
+
+    private handleTimeChange = (time: Date) => {
+        Utils.safeInvoke(this.props.timePickerProps.onChange, time);
+        const newValue = getDateTime(this.state.value || new Date(), time);
+        this.updateValue(newValue, true);
     };
 
     /**

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -285,7 +285,8 @@ export class DatePicker extends AbstractPureComponent<IDatePickerProps, IDatePic
 
     private handleTimeChange = (time: Date) => {
         Utils.safeInvoke(this.props.timePickerProps.onChange, time);
-        const newValue = DateUtils.getDateTime(this.state.value || new Date(), time);
+        const { value } = this.state;
+        const newValue = DateUtils.getDateTime(value != null ? value : new Date(), time);
         this.updateValue(newValue, true);
     };
 

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -112,7 +112,8 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
             Classes.DATEPICKER_CAPTION_MEASURE,
             this.containerElement,
         );
-        const monthSelectWidth = this.containerElement.firstElementChild.clientWidth;
+        const monthSelectWidth =
+            this.containerElement == null ? 0 : this.containerElement.firstElementChild.clientWidth;
         const rightOffset = Math.max(2, monthSelectWidth - monthTextWidth - Icon.SIZE_STANDARD - 2);
         this.setState({ monthRightOffset: rightOffset });
     }

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -73,6 +73,11 @@ export interface IDatePickerBaseProps {
 
     /**
      * Further configure the `TimePicker` that appears beneath the calendar.
+     * `onChange` and `value` are ignored in favor of the corresponding
+     * top-level props on this component.
+     *
+     * Passing any defined value to this prop (even `{}`) will cause the
+     * `TimePicker` to appear.
      */
     timePickerProps?: ITimePickerProps;
 }

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -6,6 +6,7 @@
 
 import { LocaleUtils } from "react-day-picker/types/utils";
 import { Months } from "./common/months";
+import { ITimePickerProps, TimePrecision } from "./timePicker";
 
 // DatePicker supports a simpler set of modifiers (for now).
 // also we need an interface for the dictionary without `today` and `outside` injected by r-d-p.

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -59,6 +59,22 @@ export interface IDatePickerBaseProps {
      * @default false
      */
     reverseMonthAndYearMenus?: boolean;
+
+    /**
+     * The precision of time selection that accompanies the calendar. Passing a
+     * value other than `"none"` (or providing `timePickerProps`) shows a
+     * `TimePicker` below the calendar. Time is preserved across date changes.
+     *
+     * This is shorthand for `timePickerProps.precision` and is a quick way to
+     * enable time selection.
+     * @default "none"
+     */
+    timePrecision?: TimePrecision | "none";
+
+    /**
+     * Further configure the `TimePicker` that appears beneath the calendar.
+     */
+    timePickerProps?: ITimePickerProps;
 }
 
 export const DISABLED_MODIFIER = "disabled";

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -62,14 +62,13 @@ export interface IDatePickerBaseProps {
 
     /**
      * The precision of time selection that accompanies the calendar. Passing a
-     * value other than `"none"` (or providing `timePickerProps`) shows a
+     * `TimePrecision` value (or providing `timePickerProps`) shows a
      * `TimePicker` below the calendar. Time is preserved across date changes.
      *
      * This is shorthand for `timePickerProps.precision` and is a quick way to
      * enable time selection.
-     * @default "none"
      */
-    timePrecision?: TimePrecision | "none";
+    timePrecision?: TimePrecision;
 
     /**
      * Further configure the `TimePicker` that appears beneath the calendar.

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -57,6 +57,7 @@ export interface IDateTimePickerState {
     timeValue?: Date;
 }
 
+/** @deprecated since 3.4.0. Prefer `<DatePicker>` with `timePrecision` and `timePickerProps`. */
 export class DateTimePicker extends AbstractPureComponent<IDateTimePickerProps, IDateTimePickerState> {
     public static defaultProps: IDateTimePickerProps = {
         canClearSelection: true,

--- a/packages/datetime/src/datetimepicker.md
+++ b/packages/datetime/src/datetimepicker.md
@@ -3,6 +3,12 @@
 `DateTimePicker` composes a [`DatePicker`](#datetime/datepicker)
 and a [`TimePicker`](#datetime/timepicker) into one container.
 
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">Deprecated: use [Date picker](#datetime/datepicker)</h4>
+    This component is **deprecated since 3.4.0** with the addition of `<DatePicker>` `timePrecision` and `timePickerProps` props to trivially add time selection
+    to the existing date selection.
+</div>
+
 @reactExample DateTimePickerExample
 
 @## Props

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -409,7 +409,7 @@ function formatTime(time: number, unit: TimeUnit) {
 }
 
 function getStringValueFromInputEvent(e: React.SyntheticEvent<HTMLInputElement>) {
-    return (e.currentTarget as HTMLInputElement).value;
+    return (e.target as HTMLInputElement).value;
 }
 
 interface IKeyEventMap {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -192,8 +192,8 @@ describe("<DateInput>", () => {
 
         const timePicker = wrapper.find(TimePicker);
 
-        // ensure the top-level props override props by the same name in timePickerProps
-        assert.equal(timePicker.prop("precision"), TimePrecision.SECOND);
+        // value > timePickerProps > timePrecision
+        assert.equal(timePicker.prop("precision"), TimePrecision.MILLISECOND);
         assert.notEqual(timePicker.prop("onChange"), onChange);
         DateTestUtils.assertDatesEqual(timePicker.prop("value"), value);
 

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -20,7 +20,7 @@ import { IDatePickerState } from "../src/datePicker";
 import { Classes, DatePicker, IDatePickerModifiers, IDatePickerProps, TimePicker, TimePrecision } from "../src/index";
 import { assertDatesEqual, assertDayDisabled, assertDayHidden } from "./common/dateTestUtils";
 
-describe.only("<DatePicker>", () => {
+describe("<DatePicker>", () => {
     it(`renders .${Classes.DATEPICKER}`, () => {
         assert.lengthOf(wrap(<DatePicker />).root.find(`.${Classes.DATEPICKER}`), 1);
     });

--- a/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
@@ -11,8 +11,13 @@ import moment from "moment";
 import * as React from "react";
 
 const FORMAT = "dddd, LL";
+const FORMAT_TIME = "dddd, LL LT";
 
-export const MomentDate: React.SFC<{ date: Date; format?: string }> = ({ date, format = FORMAT }) => {
+export const MomentDate: React.SFC<{ date: Date; format?: string; withTime?: boolean }> = ({
+    date,
+    withTime = false,
+    format = withTime ? FORMAT_TIME : FORMAT,
+}) => {
     const m = moment(date);
     if (m.isValid()) {
         return <Tag intent={Intent.PRIMARY}>{m.format(format)}</Tag>;

--- a/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
@@ -13,7 +13,7 @@ export interface IPrecisionSelectProps {
     /**
      * The precision-string option to display as selected.
      */
-    value: TimePrecision;
+    value: TimePrecision | "none" | undefined;
 
     /**
      * The callback to fire when the selected value changes.
@@ -21,9 +21,9 @@ export interface IPrecisionSelectProps {
     onChange: (event: React.FormEvent<HTMLElement>) => void;
 
     /**
-     * Whether or not to allow an empty option.
+     * Whether or not to allow a `"none"` option.
      */
-    allowEmpty?: boolean;
+    allowNone?: boolean;
 
     /**
      * Label to show over the dropdown of precisions.
@@ -36,7 +36,7 @@ export const PrecisionSelect: React.SFC<IPrecisionSelectProps> = props => (
     <label className={Classes.LABEL}>
         {props.label || "Precision"}
         <HTMLSelect value={props.value} onChange={props.onChange}>
-            {props.allowEmpty ? <option value="-1">None</option> : undefined}
+            {props.allowNone && <option value="none">None</option>}
             <option value={TimePrecision.MINUTE}>Minute</option>
             <option value={TimePrecision.SECOND}>Second</option>
             <option value={TimePrecision.MILLISECOND}>Millisecond</option>

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -65,10 +65,10 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
                 <Switch label="Reverse month and year menus" checked={reverse} onChange={this.toggleReverseMenus} />
                 <FormatSelect format={format} onChange={this.handleFormatChange} />
                 <PrecisionSelect
+                    allowNone={true}
                     label="Time precision"
-                    allowEmpty={true}
-                    value={timePrecision}
                     onChange={this.toggleTimePrecision}
+                    value={timePrecision}
                 />
             </>
         );

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -35,8 +35,8 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
     private toggleSelection = handleBooleanChange(closeOnSelection => this.setState({ closeOnSelection }));
     private toggleDisabled = handleBooleanChange(disabled => this.setState({ disabled }));
     private toggleReverseMenus = handleBooleanChange(reverse => this.setState({ reverseMonthAndYearMenus: reverse }));
-    private toggleTimePrecision = handleStringChange((timePrecision: TimePrecision) =>
-        this.setState({ timePrecision }),
+    private toggleTimePrecision = handleStringChange((timePrecision: TimePrecision | "none") =>
+        this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
     );
 
     public render() {

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -56,14 +56,8 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
 
         return (
             <Example options={options} {...this.props}>
-                <DatePicker
-                    className={Classes.ELEVATION_1}
-                    maxDate={new Date("10/1/2018")}
-                    minDate={new Date("4/20/2016")}
-                    onChange={this.handleDateChange}
-                    {...props}
-                />
-                <MomentDate date={date} withTime={this.state.timePrecision !== undefined} />
+                <DatePicker className={Classes.ELEVATION_1} onChange={this.handleDateChange} {...props} />
+                <MomentDate date={date} withTime={props.timePrecision !== undefined} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -5,16 +5,18 @@
  */
 
 import { Classes, H5, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 
-import { DatePicker } from "@blueprintjs/datetime";
+import { DatePicker, TimePrecision } from "@blueprintjs/datetime";
 import { MomentDate } from "./common/momentDate";
+import { PrecisionSelect } from "./common/precisionSelect";
 
 export interface IDatePickerExampleState {
     date: Date | null;
     reverseMonthAndYearMenus: boolean;
     showActionsBar: boolean;
+    timePrecision: TimePrecision | undefined;
 }
 
 export class DatePickerExample extends React.PureComponent<IExampleProps, IDatePickerExampleState> {
@@ -22,22 +24,32 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
         date: null,
         reverseMonthAndYearMenus: false,
         showActionsBar: false,
+        timePrecision: undefined,
     };
 
     private toggleActionsBar = handleBooleanChange(showActionsBar => this.setState({ showActionsBar }));
     private toggleReverseMenus = handleBooleanChange(reverse => this.setState({ reverseMonthAndYearMenus: reverse }));
+    private handlePrecisionChange = handleStringChange((p: TimePrecision | "none") =>
+        this.setState({ timePrecision: p === "none" ? undefined : p }),
+    );
 
     public render() {
-        const { date, showActionsBar, reverseMonthAndYearMenus: reverseMenus } = this.state;
+        const { date, ...props } = this.state;
 
         const options = (
             <>
                 <H5>Props</H5>
-                <Switch checked={showActionsBar} label="Show actions bar" onChange={this.toggleActionsBar} />
+                <Switch checked={props.showActionsBar} label="Show actions bar" onChange={this.toggleActionsBar} />
                 <Switch
-                    checked={reverseMenus}
+                    checked={props.reverseMonthAndYearMenus}
                     label="Reverse month and year menus"
                     onChange={this.toggleReverseMenus}
+                />
+                <PrecisionSelect
+                    allowNone={true}
+                    label="Time precision"
+                    value={props.timePrecision}
+                    onChange={this.handlePrecisionChange}
                 />
             </>
         );
@@ -46,11 +58,12 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
             <Example options={options} {...this.props}>
                 <DatePicker
                     className={Classes.ELEVATION_1}
+                    maxDate={new Date("10/1/2018")}
+                    minDate={new Date("4/20/2016")}
                     onChange={this.handleDateChange}
-                    reverseMonthAndYearMenus={reverseMenus}
-                    showActionsBar={showActionsBar}
+                    {...props}
                 />
-                <MomentDate date={date} />
+                <MomentDate date={date} withTime={this.state.timePrecision !== undefined} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -5,19 +5,12 @@
  */
 
 import { Classes, H5, HTMLSelect, Label, Switch } from "@blueprintjs/core";
-import {
-    Example,
-    handleBooleanChange,
-    handleNumberChange,
-    handleStringChange,
-    IExampleProps,
-} from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
 import moment from "moment";
 import * as React from "react";
 
-import { DateRange, DateRangePicker, TimePrecision } from "@blueprintjs/datetime";
+import { DateRange, DateRangePicker } from "@blueprintjs/datetime";
 import { MomentDateRange } from "./common/momentDate";
-import { PrecisionSelect } from "./common/precisionSelect";
 
 export interface IDateRangePickerExampleState {
     allowSingleDayRange?: boolean;
@@ -27,7 +20,6 @@ export interface IDateRangePickerExampleState {
     minDateIndex?: number;
     reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
-    timePrecision?: TimePrecision;
 }
 
 interface IDateOption {
@@ -74,9 +66,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
 
     private handleMaxDateIndexChange = handleNumberChange(maxDateIndex => this.setState({ maxDateIndex }));
     private handleMinDateIndexChange = handleNumberChange(minDateIndex => this.setState({ minDateIndex }));
-    private handlePrecisionChange = handleStringChange((timePrecision: TimePrecision | undefined) =>
-        this.setState({ timePrecision }),
-    );
 
     private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
         this.setState({ reverseMonthAndYearMenus }),
@@ -88,18 +77,20 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
     });
 
     public render() {
-        const { minDateIndex, maxDateIndex, ...props } = this.state;
-        const minDate = MIN_DATE_OPTIONS[minDateIndex].value;
-        const maxDate = MAX_DATE_OPTIONS[maxDateIndex].value;
+        const minDate = MIN_DATE_OPTIONS[this.state.minDateIndex].value;
+        const maxDate = MAX_DATE_OPTIONS[this.state.maxDateIndex].value;
 
         return (
             <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
                 <DateRangePicker
-                    {...props}
+                    allowSingleDayRange={this.state.allowSingleDayRange}
+                    contiguousCalendarMonths={this.state.contiguousCalendarMonths}
                     className={Classes.ELEVATION_1}
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateChange}
+                    reverseMonthAndYearMenus={this.state.reverseMonthAndYearMenus}
+                    shortcuts={this.state.shortcuts}
                 />
                 <MomentDateRange range={this.state.dateRange} />
             </Example>
@@ -141,14 +132,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                         MAX_DATE_OPTIONS,
                         this.handleMaxDateIndexChange,
                     )}
-                </div>
-                <div>
-                    <PrecisionSelect
-                        allowNone={true}
-                        label="Time precision"
-                        value={this.state.timePrecision}
-                        onChange={this.handlePrecisionChange}
-                    />
                 </div>
             </>
         );

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -5,12 +5,19 @@
  */
 
 import { Classes, H5, HTMLSelect, Label, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
+import {
+    Example,
+    handleBooleanChange,
+    handleNumberChange,
+    handleStringChange,
+    IExampleProps,
+} from "@blueprintjs/docs-theme";
 import moment from "moment";
 import * as React from "react";
 
-import { DateRange, DateRangePicker } from "@blueprintjs/datetime";
+import { DateRange, DateRangePicker, TimePrecision } from "@blueprintjs/datetime";
 import { MomentDateRange } from "./common/momentDate";
+import { PrecisionSelect } from "./common/precisionSelect";
 
 export interface IDateRangePickerExampleState {
     allowSingleDayRange?: boolean;
@@ -20,6 +27,7 @@ export interface IDateRangePickerExampleState {
     minDateIndex?: number;
     reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
+    timePrecision?: TimePrecision;
 }
 
 interface IDateOption {
@@ -66,6 +74,9 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
 
     private handleMaxDateIndexChange = handleNumberChange(maxDateIndex => this.setState({ maxDateIndex }));
     private handleMinDateIndexChange = handleNumberChange(minDateIndex => this.setState({ minDateIndex }));
+    private handlePrecisionChange = handleStringChange((timePrecision: TimePrecision | undefined) =>
+        this.setState({ timePrecision }),
+    );
 
     private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
         this.setState({ reverseMonthAndYearMenus }),
@@ -77,20 +88,18 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
     });
 
     public render() {
-        const minDate = MIN_DATE_OPTIONS[this.state.minDateIndex].value;
-        const maxDate = MAX_DATE_OPTIONS[this.state.maxDateIndex].value;
+        const { minDateIndex, maxDateIndex, ...props } = this.state;
+        const minDate = MIN_DATE_OPTIONS[minDateIndex].value;
+        const maxDate = MAX_DATE_OPTIONS[maxDateIndex].value;
 
         return (
             <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
                 <DateRangePicker
-                    allowSingleDayRange={this.state.allowSingleDayRange}
-                    contiguousCalendarMonths={this.state.contiguousCalendarMonths}
+                    {...props}
                     className={Classes.ELEVATION_1}
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateChange}
-                    reverseMonthAndYearMenus={this.state.reverseMonthAndYearMenus}
-                    shortcuts={this.state.shortcuts}
                 />
                 <MomentDateRange range={this.state.dateRange} />
             </Example>
@@ -132,6 +141,14 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                         MAX_DATE_OPTIONS,
                         this.handleMaxDateIndexChange,
                     )}
+                </div>
+                <div>
+                    <PrecisionSelect
+                        allowNone={true}
+                        label="Time precision"
+                        value={this.state.timePrecision}
+                        onChange={this.handlePrecisionChange}
+                    />
                 </div>
             </>
         );


### PR DESCRIPTION
#### Changes proposed in this pull request:

- add `timePrecision` and `timePickerProps` to shared date picker props
   - and remove them from `DateInputProps`
- `DatePicker` now includes time selection if one of the above props is defined
- ❌ **Deprecate** `DateTimePicker` since `DatePicker` can do it all now