### PR TITLE
[table] fix invisible table menu icon

### DIFF
--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -152,6 +152,7 @@ $dark-selectable-header-menu-selected-hover-background:
 }
 
 .#{$ns}-table-th-menu {
+  position: relative;
   cursor: $action-cursor;
   width: $column-header-min-height; // create a larger, more accessible click target
   height: $column-header-min-height;


### PR DESCRIPTION
#### Fixes #2865

#### Changes proposed in this pull request:

* [table] Fixes stacking context of `.bp3-table-th-menu`: menu icon was covered by `.bp3-table-th-menu-container-background` before

#### Reviewers should focus on:

* Menu Icon in `<ColumnHeaderCell>` with `menuRenderer`
