### PR TITLE
[Spinner] restore IE support

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -87,10 +87,9 @@ Styleguide button
     }
 
     .#{$ns}-button-spinner {
+      // spinner appears centered within button
       position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
+      margin: 0;
     }
 
     > :not(.#{$ns}-button-spinner) {

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -13,6 +13,11 @@
   // allow paths to overflow container -- critical for edges of circles!
   overflow: visible;
   vertical-align: middle;
+  animation: pt-spinner-animation ($pt-transition-duration * 5) linear infinite;
+
+  svg {
+    display: block;
+  }
 
   path {
     fill-opacity: 0;
@@ -21,7 +26,6 @@
   .#{$ns}-spinner-head {
     transform-origin: center;
     transition: stroke-dashoffset ($pt-transition-duration * 2) $pt-transition-ease;
-    animation: pt-spinner-animation ($pt-transition-duration * 5) linear infinite;
     stroke: $progress-head-color;
     stroke-linecap: round;
   }
@@ -30,7 +34,7 @@
     stroke: $progress-track-color;
   }
 
-  &.#{$ns}-no-spin .#{$ns}-spinner-head {
+  &.#{$ns}-no-spin {
     animation: none;
   }
 }

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -56,6 +56,13 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
     public static readonly SIZE_STANDARD = 50;
     public static readonly SIZE_LARGE = 100;
 
+    public componentDidUpdate(prevProps: ISpinnerProps) {
+        if (prevProps.value !== this.props.value) {
+            // IE/Edge: re-render after changing value to force SVG update
+            this.forceUpdate();
+        }
+    }
+
     public render() {
         const { className, intent, value, tagName: TagName = "div" } = this.props;
         const size = this.getSize();

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -35,6 +35,13 @@ export interface ISpinnerProps extends IProps, IIntentProps {
     size?: number;
 
     /**
+     * HTML tag for the wrapper element. If rendering a `<Spinner>` inside an
+     * `<svg>`, change this to an SVG element like `"g"`.
+     * @default "div"
+     */
+    tagName?: keyof JSX.IntrinsicElements;
+
+    /**
      * A value between 0 and 1 (inclusive) representing how far along the operation is.
      * Values below 0 or above 1 will be interpreted as 0 or 1 respectively.
      * Omitting this prop will result in an "indeterminate" spinner where the head spins indefinitely.
@@ -50,7 +57,7 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
     public static readonly SIZE_LARGE = 100;
 
     public render() {
-        const { className, intent, value } = this.props;
+        const { className, intent, value, tagName: TagName = "div" } = this.props;
         const size = this.getSize();
 
         const classes = classNames(
@@ -66,16 +73,18 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
         const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
 
         return (
-            <svg className={classes} height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
-                <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
-                <path
-                    className={Classes.SPINNER_HEAD}
-                    d={SPINNER_TRACK}
-                    pathLength={PATH_LENGTH}
-                    strokeDasharray={`${PATH_LENGTH} ${PATH_LENGTH}`}
-                    strokeDashoffset={strokeOffset}
-                />
-            </svg>
+            <TagName className={classes}>
+                <svg height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
+                    <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
+                    <path
+                        className={Classes.SPINNER_HEAD}
+                        d={SPINNER_TRACK}
+                        pathLength={PATH_LENGTH}
+                        strokeDasharray={`${PATH_LENGTH} ${PATH_LENGTH}`}
+                        strokeDashoffset={strokeOffset}
+                    />
+                </svg>
+            </TagName>
         );
     }
 

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -19,6 +19,12 @@ describe("Spinner", () => {
         assert.lengthOf(root.find("path"), 2);
     });
 
+    it("tagName determines root tag", () => {
+        const tagName = "article";
+        const root = mount(<Spinner tagName={tagName} />);
+        assert.isTrue(root.is({ tagName }));
+    });
+
     it("Classes.LARGE/SMALL determine default size", () => {
         const root = mount(<Spinner className={Classes.SMALL} />);
         assert.equal(root.find("svg").prop("height"), Spinner.SIZE_SMALL, "small");


### PR DESCRIPTION
#### Fixes #2816 

#### Changes proposed in this pull request:

- add HTML wrapper tag around `<svg>` and move animation to this element, because SVG tags do not support animations or transforms in IE 11 ([source](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/supportcsstransformsonsvg/?q=svg))

