### PR TITLE
[Suggest] Added selectedItem prop

### DIFF
--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -42,7 +42,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
      * Optionally, if provided the selected item will be in controlled mode.
      * Use the onItemSelect function to monitor changes.
      */
-    selectedItem?: T;
+    selectedItem?: T | null;
 
     /**
      * Whether the popover opens on key down or when the input is focused.
@@ -56,7 +56,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 
 export interface ISuggestState<T> {
     isOpen: boolean;
-    selectedItem?: T;
+    selectedItem: T | null;
 }
 
 export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestState<T>> {
@@ -74,7 +74,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     public state: ISuggestState<T> = {
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
-        selectedItem: this.props.selectedItem,
+        selectedItem: this.props.selectedItem !== undefined ? this.props.selectedItem : null,
     };
 
     private TypedQueryList = QueryList.ofType<T>();
@@ -105,7 +105,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     public componentWillReceiveProps(nextProps: ISuggestProps<T>) {
         // If the selected item prop changes, update the underlying state.
-        if (nextProps.selectedItem !== this.state.selectedItem) {
+        if (nextProps.selectedItem !== undefined && nextProps.selectedItem !== this.state.selectedItem) {
             this.setState({ selectedItem: nextProps.selectedItem });
         }
     }
@@ -188,8 +188,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             }
             nextOpenState = false;
         }
-        // just like EditableText, the internal state should only change when uncontrolled.
-        if (this.props.selectedItem == null) {
+        // the internal state should only change when uncontrolled.
+        if (this.props.selectedItem === undefined) {
             this.setState({
                 isOpen: nextOpenState,
                 selectedItem: item,

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -74,6 +74,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     public state: ISuggestState<T> = {
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
+        selectedItem: this.props.selectedItem
     };
 
     private TypedQueryList = QueryList.ofType<T>();

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -37,6 +37,12 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 
     /** Custom renderer to transform an item into a string for the input value. */
     inputValueRenderer: (item: T) => string;
+    
+    /**
+    * Optionally, if provided the selected item will be in controlled mode. 
+    * Use the onItemSelect function to monitor changes.
+    */
+    selectedItem?: T;
 
     /**
      * Whether the popover opens on key down or when the input is focused.

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -39,8 +39,9 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     inputValueRenderer: (item: T) => string;
 
     /**
-     * Optionally, if provided the selected item will be in controlled mode.
-     * Use the onItemSelect function to monitor changes.
+     * The currently selected item, or `null` to indicate that no item is selected. 
+     * If omitted, this prop will be uncontrolled (managed by the component's state). 
+     * Use `onItemSelect` to listen for updates.
      */
     selectedItem?: T | null;
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -73,8 +73,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     }
 
     public state: ISuggestState<T> = {
-        isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
-        selectedItem: this.props.selectedItem
+        isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false
     };
 
     private TypedQueryList = QueryList.ofType<T>();
@@ -111,10 +110,12 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { inputProps = {}, popoverProps = {} } = this.props;
-        const { isOpen, selectedItem } = this.state;
+        const { isOpen } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
         const { placeholder = "Search..." } = inputProps;
 
+        // Let's support both controlled and uncontrolled.
+        const selectedItem = this.props.selectedItem || this.state.selectedItem
         const selectedItemText = selectedItem ? this.props.inputValueRenderer(selectedItem) : "";
         return (
             <Popover

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -39,8 +39,8 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     inputValueRenderer: (item: T) => string;
 
     /**
-     * The currently selected item, or `null` to indicate that no item is selected. 
-     * If omitted, this prop will be uncontrolled (managed by the component's state). 
+     * The currently selected item, or `null` to indicate that no item is selected.
+     * If omitted, this prop will be uncontrolled (managed by the component's state).
      * Use `onItemSelect` to listen for updates.
      */
     selectedItem?: T | null;

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -115,7 +115,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         const { placeholder = "Search..." } = inputProps;
 
         // Let's support both controlled and uncontrolled.
-        const selectedItem = this.props.selectedItem || this.state.selectedItem
+        const selectedItem = this.props.selectedItem || this.state.selectedItem;
         const selectedItemText = selectedItem ? this.props.inputValueRenderer(selectedItem) : "";
         return (
             <Popover

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -37,11 +37,11 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 
     /** Custom renderer to transform an item into a string for the input value. */
     inputValueRenderer: (item: T) => string;
-    
+
     /**
-    * Optionally, if provided the selected item will be in controlled mode. 
-    * Use the onItemSelect function to monitor changes.
-    */
+     * Optionally, if provided the selected item will be in controlled mode.
+     * Use the onItemSelect function to monitor changes.
+     */
     selectedItem?: T;
 
     /**
@@ -73,7 +73,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     }
 
     public state: ISuggestState<T> = {
-        isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false
+        isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
+        selectedItem: this.props.selectedItem,
     };
 
     private TypedQueryList = QueryList.ofType<T>();
@@ -102,6 +103,13 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         );
     }
 
+    public componentWillReceiveProps(nextProps: ISuggestProps<T>) {
+        // If the selected item prop changes, update the underlying state.
+        if (nextProps.selectedItem !== this.state.selectedItem) {
+            this.setState({ selectedItem: nextProps.selectedItem });
+        }
+    }
+
     public componentDidUpdate(_prevProps: ISuggestProps<T>, prevState: ISuggestState<T>) {
         if (this.state.isOpen && !prevState.isOpen && this.queryList != null) {
             this.queryList.scrollActiveItemIntoView();
@@ -110,12 +118,10 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { inputProps = {}, popoverProps = {} } = this.props;
-        const { isOpen } = this.state;
+        const { isOpen, selectedItem } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
         const { placeholder = "Search..." } = inputProps;
 
-        // Let's support both controlled and uncontrolled.
-        const selectedItem = this.props.selectedItem || this.state.selectedItem;
         const selectedItemText = selectedItem ? this.props.inputValueRenderer(selectedItem) : "";
         return (
             <Popover

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -188,11 +188,16 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             }
             nextOpenState = false;
         }
-
-        this.setState({
-            isOpen: nextOpenState,
-            selectedItem: item,
-        });
+        // just like EditableText, the internal state should only change when uncontrolled.
+        if (this.props.selectedItem == null) {
+            this.setState({
+                isOpen: nextOpenState,
+                selectedItem: item,
+            });
+        } else {
+            // otherwise just set the next open state.
+            this.setState({ isOpen: nextOpenState });
+        }
 
         Utils.safeInvoke(this.props.onItemSelect, item, event);
     };

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -10,7 +10,6 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
-import { first } from "lodash";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import { ISuggestProps, ISuggestState, Suggest } from "../src/components/select/suggest";
 import { selectComponentSuite } from "./selectComponentSuite";
@@ -213,18 +212,31 @@ describe("Suggest", () => {
 
     describe("Controlled Mode", () => {
         it("initialize the selectedItem with the given value", () => {
-            const selectedItem = first(TOP_100_FILMS);
+            const selectedItem = TOP_100_FILMS[0];
             assert.isNotNull(selectedItem, "The selected item we test must not be null");
             const wrapper = suggest({ selectedItem });
             assert.strictEqual(wrapper.state().selectedItem, selectedItem);
         });
         it("propagates the selectedItem with new values", () => {
-            const selectedItem = first(TOP_100_FILMS);
+            const selectedItem = TOP_100_FILMS[0];
             assert.isNotNull(selectedItem, "The selected item we test must not be null");
             const wrapper = suggest();
             assert.isUndefined(wrapper.state().selectedItem);
             wrapper.setProps({ selectedItem });
             assert.strictEqual(wrapper.state().selectedItem, selectedItem);
+        });
+        it("when new item selected, it should respect the selectedItem prop", () => {
+            const selectedItem = TOP_100_FILMS[0];
+            const ITEM_INDEX = 4;
+            assert.isNotNull(selectedItem, "The selected item we test must not be null");
+            const wrapper = suggest({ selectedItem });
+            simulateFocus(wrapper);
+            selectItem(wrapper, ITEM_INDEX);
+            assert.isTrue(handlers.onItemSelect.called, "should be called after selection");
+            assert.strictEqual(wrapper.state().selectedItem, selectedItem, "the underlying state should not change");
+            const newSelectedItem = TOP_100_FILMS[ITEM_INDEX];
+            wrapper.setProps({ selectedItem: newSelectedItem });
+            assert.strictEqual(wrapper.state().selectedItem, newSelectedItem, "the selectedItem should be updated");
         });
     });
 

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -221,7 +221,7 @@ describe("Suggest", () => {
             const selectedItem = TOP_100_FILMS[0];
             assert.isNotNull(selectedItem, "The selected item we test must not be null");
             const wrapper = suggest();
-            assert.isUndefined(wrapper.state().selectedItem);
+            assert.isNull(wrapper.state().selectedItem);
             wrapper.setProps({ selectedItem });
             assert.strictEqual(wrapper.state().selectedItem, selectedItem);
         });
@@ -232,11 +232,23 @@ describe("Suggest", () => {
             const wrapper = suggest({ selectedItem });
             simulateFocus(wrapper);
             selectItem(wrapper, ITEM_INDEX);
-            assert.isTrue(handlers.onItemSelect.called, "should be called after selection");
+            assert.isTrue(handlers.onItemSelect.called, "onItemSelect should be called after selection");
             assert.strictEqual(wrapper.state().selectedItem, selectedItem, "the underlying state should not change");
             const newSelectedItem = TOP_100_FILMS[ITEM_INDEX];
             wrapper.setProps({ selectedItem: newSelectedItem });
             assert.strictEqual(wrapper.state().selectedItem, newSelectedItem, "the selectedItem should be updated");
+        });
+        it("preserves the empty selection", () => {
+            const ITEM_INDEX = 4;
+            const selectedItem = TOP_100_FILMS[0];
+            const wrapper = suggest({ selectedItem: null });
+            assert.isNull(wrapper.state().selectedItem);
+            simulateFocus(wrapper);
+            selectItem(wrapper, ITEM_INDEX);
+            assert.isTrue(handlers.onItemSelect.called, "onItemSelect should be called after selection");
+            assert.isNull(wrapper.state().selectedItem, "the underlying state should not change");
+            wrapper.setProps({ selectedItem });
+            assert.strictEqual(wrapper.state().selectedItem, selectedItem, "the selectedItem should be updated");
         });
     });
 

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -10,6 +10,7 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
+import { first } from "lodash";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import { ISuggestProps, ISuggestState, Suggest } from "../src/components/select/suggest";
 import { selectComponentSuite } from "./selectComponentSuite";
@@ -208,6 +209,23 @@ describe("Suggest", () => {
                 onOpening,
             };
         }
+    });
+
+    describe("Controlled Mode", () => {
+        it("initialize the selectedItem with the given value", () => {
+            const selectedItem = first(TOP_100_FILMS);
+            assert.isNotNull(selectedItem, "The selected item we test must not be null");
+            const wrapper = suggest({ selectedItem });
+            assert.strictEqual(wrapper.state().selectedItem, selectedItem);
+        });
+        it("propagates the selectedItem with new values", () => {
+            const selectedItem = first(TOP_100_FILMS);
+            assert.isNotNull(selectedItem, "The selected item we test must not be null");
+            const wrapper = suggest();
+            assert.isUndefined(wrapper.state().selectedItem);
+            wrapper.setProps({ selectedItem });
+            assert.strictEqual(wrapper.state().selectedItem, selectedItem);
+        });
     });
 
     function suggest(props: Partial<ISuggestProps<IFilm>> = {}, query?: string) {


### PR DESCRIPTION
#### Fixes #2784

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Fixes #2784.

#### Reviewers should focus on:

The `Suggest` component now takes an optional selectedItem prop. If defined the selectedItem state will be initialised with the given selectedItem.

