### PR TITLE
[core] remove quotes on $ns variable value

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -5,7 +5,8 @@
 @import "mixins";
 
 // Namespace appended to the beginning of each CSS class: `.#{$ns}-button`.
-$ns: "bp3" !default;
+// Do not quote this value, for Less consumers.
+$ns: bp3 !default;
 
 // easily the most important variable, so it comes up top
 // (so other variables can use it to define themselves)


### PR DESCRIPTION
Less preserves the quotes when interpolating
`.@{ns}-button` &rArr; `."bp3"-button` 😢 