### PR TITLE
[Spinner] add additional child element to isolate spinner from parent

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -208,6 +208,7 @@ export const START = `${NS}-start`;
 export const END = `${NS}-end`;
 
 export const SPINNER = `${NS}-spinner`;
+export const SPINNER_ANIMATION = `${SPINNER}-animation`;
 export const SPINNER_HEAD = `${SPINNER}-head`;
 export const SPINNER_NO_SPIN = `${NS}-no-spin`;
 export const SPINNER_TRACK = `${SPINNER}-track`;

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -10,10 +10,14 @@
 }
 
 .#{$ns}-spinner {
+  // center animation container inside parent element to isolate layout
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   // allow paths to overflow container -- critical for edges of circles!
   overflow: visible;
   vertical-align: middle;
-  animation: pt-spinner-animation ($pt-transition-duration * 5) linear infinite;
 
   svg {
     display: block;
@@ -33,8 +37,13 @@
   .#{$ns}-spinner-track {
     stroke: $progress-track-color;
   }
+}
 
-  &.#{$ns}-no-spin {
+// put the animation on a child HTML element to isolate it from display of parent
+.#{$ns}-spinner-animation {
+  animation: pt-spinner-animation ($pt-transition-duration * 5) linear infinite;
+
+  .#{$ns}-no-spin > & {
     animation: none;
   }
 }

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -81,16 +81,18 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
 
         return (
             <TagName className={classes}>
-                <svg height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
-                    <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
-                    <path
-                        className={Classes.SPINNER_HEAD}
-                        d={SPINNER_TRACK}
-                        pathLength={PATH_LENGTH}
-                        strokeDasharray={`${PATH_LENGTH} ${PATH_LENGTH}`}
-                        strokeDashoffset={strokeOffset}
-                    />
-                </svg>
+                <span className={Classes.SPINNER_ANIMATION}>
+                    <svg height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
+                        <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
+                        <path
+                            className={Classes.SPINNER_HEAD}
+                            d={SPINNER_TRACK}
+                            pathLength={PATH_LENGTH}
+                            strokeDasharray={`${PATH_LENGTH} ${PATH_LENGTH}`}
+                            strokeDashoffset={strokeOffset}
+                        />
+                    </svg>
+                </span>
             </TagName>
         );
     }

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -79,6 +79,9 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
 
         const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
 
+        // multiple DOM elements around SVG are necessary to properly isolate animation:
+        // - SVG elements in IE do not support anim/trans so they must be set on a parent HTML element.
+        // - SPINNER_ANIMATION isolates svg from parent display and is always centered inside root element.
         return (
             <TagName className={classes}>
                 <span className={Classes.SPINNER_ANIMATION}>


### PR DESCRIPTION
#### Fixes #2880 

#### Changes proposed in this pull request:

- add `spinner-animation` element to isolate spinner from parent display styles
- this is basically what we had [back in 1.x](https://blueprintjs.com/docs/versions/1/#core/components/progress/spinner.css-api) with `.pt-spinner > .pt-spinner-svg-container > svg`
