### PR TITLE
[Icon] revert to inline-block

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -3,7 +3,7 @@
 
 @import "~@blueprintjs/icons/src/icons";
 
-// the SVG icon class
+// the icon class which will contain an SVG icon
 .#{$ns}-icon {
   // remove any extra inline space and ensure centering with text
   display: inline-flex;
@@ -34,7 +34,10 @@
   }
 }
 
-// legacy font styles
+//
+// LEGACY icon font styles
+//
+
 span.#{$ns}-icon-standard {
   @include pt-icon($pt-icon-size-standard);
   display: inline-block;
@@ -60,7 +63,6 @@ span.#{$ns}-icon:empty {
 }
 
 @each $name, $content in $icons {
-  // only insert font glyph if <svg> image is not present
   .#{$ns}-icon-#{$name}::before {
     content: $content;
   }

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -12,7 +12,8 @@
 
   &:not(:empty)::before {
     // clear font icon when there's an <svg> image
-    content: unset;
+    // stylelint-disable-next-line declaration-no-important
+    content: unset !important;
   }
 
   // inherit text color unless `color` prop is set

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -5,8 +5,9 @@
 
 // the icon class which will contain an SVG icon
 .#{$ns}-icon {
-  // remove any extra inline space and ensure centering with text
-  display: inline-flex;
+  // ensure icons sit inline with text & isolate svg from surrounding elements
+  // (vertical alignment in flow is usually off due to svg - not an issue with flex.)
+  display: inline-block;
   // respect dimensions exactly
   flex: 0 0 auto;
 
@@ -16,9 +17,14 @@
     content: unset !important;
   }
 
-  // inherit text color unless `color` prop is set
-  > svg:not([fill]) {
-    fill: currentColor;
+  > svg {
+    // prevent extra vertical whitespace
+    display: block;
+
+    // inherit text color unless explicit fill is set
+    &:not([fill]) {
+      fill: currentColor;
+    }
   }
 }
 
@@ -51,7 +57,6 @@ span.#{$ns}-icon-large {
 
 // only apply icon font styles when <svg> image is not present
 span.#{$ns}-icon:empty {
-  display: inline-block;
   line-height: 1;
   font-family: $icons20-family;
   font-size: inherit;


### PR DESCRIPTION
#### Fixes #2892 (regressions from #2884)

#### Changes proposed in this pull request:

- go back to using `inline-block` because hey it's not an API break and it worked reliably
- take no chances with double-icons: `!important` on content clearing
- fixes tag removable and timepicker arrows