### PR TITLE
[Select Documentation] Fix incorrect argument name

### DIFF
--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -95,7 +95,7 @@ const filterFilm: ItemPredicate<IFilm> = (query, film) => {
     return film.title.toLowerCase().indexOf(query.toLowerCase()) >= 0;
 };
 
-const renderFilm: ItemRenderer<Film> = (item, { handleClick, modifiers }) => {
+const renderFilm: ItemRenderer<Film> = (film, { handleClick, modifiers }) => {
     if (!modifiers.filtered) {
         return null;
     }


### PR DESCRIPTION
Copied this over and realized that the argument should not be item but rather film.

#### Changes proposed in this pull request:

Change the typo


