### PR TITLE
[TagInput] Use $input-padding-horizontal when empty for consistency with <InputGroup>

### DIFF
--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -20,13 +20,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 
   padding-left: $tag-input-padding;
   line-height: inherit;
 
-  // use the conventional Blueprint input padding when empty
-  // (else when there are tags present, use a smaller, identical padding on all sides)
-  // see: https://github.com/palantir/blueprint/issues/2872
-  &.#{$ns}-tag-input-empty {
-    padding-left: $input-padding-horizontal;
-  }
-
   .#{$ns}-tag-input-icon {
     // margins to center icon in one-line input
     margin-top: $tag-input-icon-padding;
@@ -43,6 +36,13 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 
     align-self: stretch;
     margin-top: $tag-input-padding;
     margin-right: $tag-input-icon-padding;
+
+    // use the larger, conventional input padding when there are no tags and no left icon present.
+    // see: https://github.com/palantir/blueprint/issues/2872
+    &:first-child .#{$ns}-input-ghost:first-child {
+      // recall that some padding-left is already applied on the root component.
+      padding-left: $input-padding-horizontal - $tag-input-padding;
+    }
 
     > * {
       margin-bottom: $tag-input-padding;

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -20,6 +20,13 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 
   padding-left: $tag-input-padding;
   line-height: inherit;
 
+  // use the conventional Blueprint input padding when empty
+  // (else when there are tags present, use a smaller, identical padding on all sides)
+  // see: https://github.com/palantir/blueprint/issues/2872
+  &.#{$ns}-tag-input-empty {
+    padding-left: $input-padding-horizontal;
+  }
+
   .#{$ns}-tag-input-icon {
     // margins to center icon in one-line input
     margin-top: $tag-input-icon-padding;

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -214,6 +214,10 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     public render() {
         const { className, disabled, fill, inputProps, large, leftIcon, placeholder, values } = this.props;
 
+        // use placeholder prop only if it's defined and values list is empty or contains only falsy values
+        const isSomeValueDefined = values.some(val => !!val);
+        const resolvedPlaceholder = placeholder == null || isSomeValueDefined ? inputProps.placeholder : placeholder;
+
         const classes = classNames(
             Classes.INPUT,
             Classes.TAG_INPUT,
@@ -222,14 +226,14 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
                 [Classes.DISABLED]: disabled,
                 [Classes.FILL]: fill,
                 [Classes.LARGE]: large,
+                // add CSS class when empty so the placeholder padding can match that of an empty <InputGroup>
+                // (also, no need for this to be part of the public Classes API)
+                // see: https://github.com/palantir/blueprint/issues/2872
+                [`${Classes.TAG_INPUT}-empty`]: !isSomeValueDefined,
             },
             className,
         );
         const isLarge = classes.indexOf(Classes.LARGE) > NONE;
-
-        // use placeholder prop only if it's defined and values list is empty or contains only falsy values
-        const isSomeValueDefined = values.some(val => !!val);
-        const resolvedPlaceholder = placeholder == null || isSomeValueDefined ? inputProps.placeholder : placeholder;
 
         return (
             <div className={classes} onBlur={this.handleContainerBlur} onClick={this.handleContainerClick}>

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -214,10 +214,6 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     public render() {
         const { className, disabled, fill, inputProps, large, leftIcon, placeholder, values } = this.props;
 
-        // use placeholder prop only if it's defined and values list is empty or contains only falsy values
-        const isSomeValueDefined = values.some(val => !!val);
-        const resolvedPlaceholder = placeholder == null || isSomeValueDefined ? inputProps.placeholder : placeholder;
-
         const classes = classNames(
             Classes.INPUT,
             Classes.TAG_INPUT,
@@ -226,14 +222,14 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
                 [Classes.DISABLED]: disabled,
                 [Classes.FILL]: fill,
                 [Classes.LARGE]: large,
-                // add CSS class when empty so the placeholder padding can match that of an empty <InputGroup>
-                // (also, no need for this to be part of the public Classes API)
-                // see: https://github.com/palantir/blueprint/issues/2872
-                [`${Classes.TAG_INPUT}-empty`]: !isSomeValueDefined,
             },
             className,
         );
         const isLarge = classes.indexOf(Classes.LARGE) > NONE;
+
+        // use placeholder prop only if it's defined and values list is empty or contains only falsy values
+        const isSomeValueDefined = values.some(val => !!val);
+        const resolvedPlaceholder = placeholder == null || isSomeValueDefined ? inputProps.placeholder : placeholder;
 
         return (
             <div className={classes} onBlur={this.handleContainerBlur} onClick={this.handleContainerClick}>

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -29,6 +29,7 @@ export interface ITagInputExampleState {
     fill: boolean;
     intent: boolean;
     large: boolean;
+    leftIcon: boolean;
     minimal: boolean;
     values: React.ReactNode[];
 }
@@ -41,6 +42,7 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
         fill: false,
         intent: false,
         large: false,
+        leftIcon: true,
         minimal: false,
         values: VALUES,
     };
@@ -51,6 +53,7 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
     private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
     private handleIntentChange = handleBooleanChange(intent => this.setState({ intent }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
+    private handleLeftIconChange = handleBooleanChange(leftIcon => this.setState({ leftIcon }));
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
 
     public render() {
@@ -78,7 +81,7 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
             <Example options={this.renderOptions()} {...this.props}>
                 <TagInput
                     {...props}
-                    leftIcon="user"
+                    leftIcon={this.state.leftIcon ? "user" : undefined}
                     onChange={this.handleChange}
                     placeholder="Separate values with commas..."
                     rightElement={clearButton}
@@ -95,6 +98,7 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
                 <H5>Props</H5>
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
+                <Switch label="Left icon" checked={this.state.leftIcon} onChange={this.handleLeftIconChange} />
                 <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />
                 <Switch label="Add on paste" checked={this.state.addOnPaste} onChange={this.handleAddOnPasteChange} />
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />


### PR DESCRIPTION
#### Fixes #2872 

#### Checklist

- [x] ~[Enable CircleCI for your fork](https://circleci.com/add-projects)~ __N/A__
- [x] ~Include tests~ __N/A__
- [x] ~Update documentation~ __N/A__

#### Changes proposed in this pull request:

- `<TagInput>` now uses `$input-padding-horizontal` when empty.
    - Same as `<InputGroup>`.

#### Reviewers should focus on:

Minor as this fix may be, there were a few ways to do it, none of which felt great:
- Inline style on the component
    - Felt dirty given our current scheme driven by CSS classes.
- Add an `-empty` CSS class to `.bp3-tag-input`, change its padding-left to 10px.
    - __(This is what I did.)__
    - Modifies the element that sets the existing padding.
    - Minor con: it introduces a new (non-exported) CSS class into the vocabulary.
- Add an `-empty` CSS class to `.bp3-tag-input-values` to scope this clunky special class strictly _within_ the outer `<TagInput>` element.
    - Feels a little cleaner philosophically.
    - But then we have padding split between `bp3-tag-input` and `bp3-tag-input-values`.
- Use some CSS `:empty` wizardry on `.bp3-tag-input-values`.
    - `bp3-input-ghost` is always present as a child, so that selector won't be satisfied unless I add another child for the tags, which could break line-wrapping behavior for tags/ghost input.
    - Would rather not have conditional logic in CSS.

#### Screenshot

My icon styles are a little screwy for some reason after I pull from latest `develop`, but note that the padding is all that changed in this PR:

_BEFORE_

`<TagInput>` 5px padding !== vs `<InputGroup>` 10px padding:

![image](https://user-images.githubusercontent.com/443450/44972781-431acc00-af0f-11e8-97f8-d7e272593f08.png)

![image](https://user-images.githubusercontent.com/443450/44972816-5f1e6d80-af0f-11e8-9c5b-77e035102027.png)


_AFTER_

`<TagInput>` 10px padding == `<InputGroup>` 10px padding (and the padding reverts to 5px when there are tags present, as before):

![2018-09-03 00 07 04](https://user-images.githubusercontent.com/443450/44972734-1961a500-af0f-11e8-9a8e-30c44b3325f1.gif)

![image](https://user-images.githubusercontent.com/443450/44972816-5f1e6d80-af0f-11e8-9c5b-77e035102027.png)
