### PR TITLE
Fixed containerElement query to not throw errors, align with 2.x/3.x

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -252,8 +252,8 @@ export class Overlay extends React.Component<IOverlayProps, IOverlayState> {
             const isFocusOutsideModal = !this.containerElement.contains(document.activeElement);
             if (isFocusOutsideModal) {
                 // element marked autofocus has higher priority than the other clowns
-                const autofocusElement = this.containerElement.query("[autofocus]") as HTMLElement;
-                const wrapperElement = this.containerElement.query("[tabindex]") as HTMLElement;
+                const autofocusElement = this.containerElement.querySelector("[autofocus]") as HTMLElement;
+                const wrapperElement = this.containerElement.querySelector("[tabindex]") as HTMLElement;
                 if (autofocusElement != null) {
                     autofocusElement.focus();
                 } else if (wrapperElement != null) {


### PR DESCRIPTION
#### Fixes overlay errors being thrown when trying to focus in an overlay.

<img width="434" alt="screen shot 2018-09-05 at 10 23 31" src="https://user-images.githubusercontent.com/885066/45099677-d877b500-b0f5-11e8-8747-dff173278f06.png">

I checked the 2.x/3.x branches and aligned this code to those, which fixed my issues. This appears to just have been a typo in 1.x.

