### PR TITLE
Add condensed property to HTML tables

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -14,6 +14,7 @@ const NS = process.env.BLUEPRINT_NAMESPACE || "bp3";
 export const ACTIVE = `${NS}-active`;
 export const ALIGN_LEFT = `${NS}-align-left`;
 export const ALIGN_RIGHT = `${NS}-align-right`;
+export const CONDENSED = `${NS}-condensed`;
 export const DARK = `${NS}-dark`;
 export const DISABLED = `${NS}-disabled`;
 export const FILL = `${NS}-fill`;

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -34,11 +34,11 @@ Markup:
   </tbody>
 </table>
 
-.#{$ns}-small - Small, condensed appearance
-.#{$ns}-condensed - Small, condensed appearance for just this table and tabular elements
+.#{$ns}-condensed - Small, condensed appearance
 .#{$ns}-html-table-striped - Striped appearance
 .#{$ns}-html-table-bordered - Bordered appearance
 .#{$ns}-interactive - Enables hover styles on rows
+.#{$ns}-small - Small, condensed appearance for this element and all child elements
 
 Styleguide html-table
 */

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -35,6 +35,7 @@ Markup:
 </table>
 
 .#{$ns}-small - Small, condensed appearance
+.#{$ns}-condensed - Small, condensed appearance for just this table and tabular elements
 .#{$ns}-html-table-striped - Striped appearance
 .#{$ns}-html-table-bordered - Bordered appearance
 .#{$ns}-interactive - Enables hover styles on rows
@@ -100,6 +101,7 @@ $dark-table-border-color: $pt-dark-divider-white !default;
 table.#{$ns}-html-table {
   @extend %html-table;
 
+  &.#{$ns}-condensed,
   &.#{$ns}-small {
     $small-vertical-padding: centered-text($table-row-height-small);
 

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -26,7 +26,10 @@ export interface IHTMLTableProps extends React.HTMLAttributes<HTMLTableElement>,
     /** Enables hover styles on row. */
     interactive?: boolean;
 
-    /** @deprecated Use small, condensed appearance for this element and all child elements. */
+    /**
+     * Use small, condensed appearance for this element and all child elements.
+     * @deprecated
+     */
     small?: boolean;
 
     /** Use an alternate background color on odd rows. */
@@ -41,11 +44,11 @@ export class HTMLTable extends React.PureComponent<IHTMLTableProps> {
         const classes = classNames(
             HTML_TABLE,
             {
+                [CONDENSED]: condensed,
                 [HTML_TABLE_BORDERED]: bordered,
                 [HTML_TABLE_STRIPED]: striped,
                 [INTERACTIVE]: interactive,
                 [SMALL]: small,
-                [CONDENSED]: condensed,
             },
             className,
         );

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -20,13 +20,13 @@ export interface IHTMLTableProps extends React.HTMLAttributes<HTMLTableElement>,
     /** Enables borders between rows and cells. */
     bordered?: boolean;
 
-    /** Use condensed appearance for just this table and tabular elements. */
+    /** Use small, condensed appearance. */
     condensed?: boolean;
 
     /** Enables hover styles on row. */
     interactive?: boolean;
 
-    /** Use small, condensed appearance. */
+    /** Use small, condensed appearance for this element and all child elements. */
     small?: boolean;
 
     /** Use an alternate background color on odd rows. */

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -26,7 +26,7 @@ export interface IHTMLTableProps extends React.HTMLAttributes<HTMLTableElement>,
     /** Enables hover styles on row. */
     interactive?: boolean;
 
-    /** Use small, condensed appearance for this element and all child elements. */
+    /** @deprecated Use small, condensed appearance for this element and all child elements. */
     small?: boolean;
 
     /** Use an alternate background color on odd rows. */

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -6,12 +6,22 @@
 
 import classNames from "classnames";
 import * as React from "react";
-import { HTML_TABLE, HTML_TABLE_BORDERED, HTML_TABLE_STRIPED, INTERACTIVE, SMALL } from "../../common/classes";
+import {
+    CONDENSED,
+    HTML_TABLE,
+    HTML_TABLE_BORDERED,
+    HTML_TABLE_STRIPED,
+    INTERACTIVE,
+    SMALL,
+} from "../../common/classes";
 import { IElementRefProps } from "../html/html";
 
 export interface IHTMLTableProps extends React.HTMLAttributes<HTMLTableElement>, IElementRefProps<HTMLTableElement> {
     /** Enables borders between rows and cells. */
     bordered?: boolean;
+
+    /** Use condensed appearance for just this table and tabular elements. */
+    condensed?: boolean;
 
     /** Enables hover styles on row. */
     interactive?: boolean;
@@ -27,7 +37,7 @@ export interface IHTMLTableProps extends React.HTMLAttributes<HTMLTableElement>,
 /* istanbul ignore next */
 export class HTMLTable extends React.PureComponent<IHTMLTableProps> {
     public render() {
-        const { bordered, className, elementRef, interactive, small, striped, ...htmlProps } = this.props;
+        const { bordered, className, condensed, elementRef, interactive, small, striped, ...htmlProps } = this.props;
         const classes = classNames(
             HTML_TABLE,
             {
@@ -35,6 +45,7 @@ export class HTMLTable extends React.PureComponent<IHTMLTableProps> {
                 [HTML_TABLE_STRIPED]: striped,
                 [INTERACTIVE]: interactive,
                 [SMALL]: small,
+                [CONDENSED]: condensed,
             },
             className,
         );


### PR DESCRIPTION
#### Fixes #2806

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [X] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [X] Update documentation

#### Changes proposed in this pull request:

Add a condensed property to HTML tables that just modifies sizing for tables and tabular elements without affecting the sizing of, e.g., nested buttons.

#### Reviewers should focus on:

Whether the distinction between condensed and small for tables is clear.

#### Screenshot

![2018-09-05 13 55 38](https://user-images.githubusercontent.com/2065456/45111615-657d3700-b113-11e8-9f33-38bab5195d2e.gif)

