### PR TITLE
[Switch] fix switch styles variables for dark theme

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -378,17 +378,17 @@ $control-indicator-spacing: $pt-grid-size !default;
     .#{$ns}-dark & {
       @include indicator-colors(
         "",
-        $switch-background-color,
-        $switch-background-color-hover,
-        $switch-background-color-active,
-        $switch-background-color-disabled
+        $dark-switch-background-color,
+        $dark-switch-background-color-hover,
+        $dark-switch-background-color-active,
+        $dark-switch-background-color-disabled
       );
       @include indicator-colors(
         ":checked",
-        $switch-checked-background-color,
-        $switch-checked-background-color-hover,
-        $switch-checked-background-color-active,
-        $switch-checked-background-color-disabled
+        $dark-switch-checked-background-color,
+        $dark-switch-checked-background-color-hover,
+        $dark-switch-checked-background-color-active,
+        $dark-switch-checked-background-color-disabled
       );
 
       .#{$ns}-control-indicator::before {


### PR DESCRIPTION
#### Fixes #0000

#### Changes proposed in this pull request:
- Use switch component styles' variables properly for light and dark themes.

#### Reviewers should focus on:
- The way to update the switch component styles in Dark theme.

