### PR TITLE
[select] QueryList reset followups

### DIFF
--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -47,11 +47,12 @@ export class OmnibarExample extends React.PureComponent<IExampleProps, IOmnibarE
         return (
             <Hotkeys>
                 <Hotkey
-                    allowInInput={true}
                     global={true}
                     combo="shift + o"
                     label="Show Omnibar"
                     onKeyDown={this.handleToggle}
+                    // prevent typing "O" in omnibar input
+                    preventDefault={true}
                 />
             </Hotkeys>
         );

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -92,10 +92,11 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     };
 
     /**
-     * flag indicating that we should check whether selected item is in viewport after rendering,
-     * typically because of keyboard change.
+     * Flag indicating that we should check whether selected item is in viewport
+     * after rendering, typically because of keyboard change. Set to `true` when
+     * manipulating state in a way that may cause active item to scroll away.
      */
-    private shouldCheckActiveItemInViewport: boolean = false;
+    private shouldCheckActiveItemInViewport = false;
 
     public constructor(props: IQueryListProps<T>, context?: any) {
         super(props, context);
@@ -124,6 +125,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     public componentWillReceiveProps(nextProps: IQueryListProps<T>) {
         if (nextProps.activeItem !== undefined) {
+            this.shouldCheckActiveItemInViewport = true;
             this.setState({ activeItem: nextProps.activeItem });
         }
         if (nextProps.query != null) {
@@ -137,7 +139,6 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
                 include: ["items", "itemListPredicate", "itemPredicate"],
             })
         ) {
-            this.shouldCheckActiveItemInViewport = true;
             this.setQuery(this.state.query);
         }
 
@@ -177,6 +178,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     public setQuery(query: string, resetActiveItem = this.props.resetOnQuery) {
+        this.shouldCheckActiveItemInViewport = true;
         if (query !== this.state.query) {
             Utils.safeInvoke(this.props.onQueryChange, query);
         }
@@ -254,8 +256,6 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             event.preventDefault();
             const nextActiveItem = this.getNextActiveItem(keyCode === Keys.ARROW_UP ? -1 : 1);
             if (nextActiveItem != null) {
-                // indicate that the active item may need to be scrolled into view after update.
-                this.shouldCheckActiveItemInViewport = true;
                 this.setActiveItem(nextActiveItem);
             }
         }
@@ -292,13 +292,11 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     private setActiveItem(activeItem: T | null) {
         if (this.props.activeItem === undefined) {
+            // indicate that the active item may need to be scrolled into view after update.
+            this.shouldCheckActiveItemInViewport = true;
             this.setState({ activeItem });
         }
         Utils.safeInvoke(this.props.onActiveItemChange, activeItem);
-    }
-
-    private setFirstActiveItem() {
-        this.setActiveItem(this.getNextActiveItem(1, this.state.filteredItems.length - 1));
     }
 }
 

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -88,7 +88,7 @@ describe("<QueryList>", () => {
             const filmQueryList = mount(<FilmQueryList {...testProps} items={[myItem]} activeItem={myItem} query="" />);
             filmQueryList.setState({ query: "query" });
             filmQueryList.setState({ activeItem: undefined });
-            assert.equal(testProps.onActiveItemChange.callCount, 1);
+            assert.equal(testProps.onActiveItemChange.callCount, 0);
         });
     });
 

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -77,19 +77,21 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
 
         it("querying does not reset active item when resetOnQuery=false", () => {
             const wrapper = render({ ...testProps, query: "19", resetOnQuery: false });
+            // more specific query does not change active item.
             wrapper.setProps({ query: "199" });
-
             assert.strictEqual(testProps.onActiveItemChange.lastCall, null);
         });
 
         it("querying resets active item when resetOnQuery=true", () => {
             const wrapper = render({ ...testProps, query: "19", resetOnQuery: true });
+            // more specific query picks the first item.
             wrapper.setProps({ query: "199" });
             assert.strictEqual(testProps.onActiveItemChange.lastCall.args[0].rank, 1);
         });
 
         it("querying resets active item if it does not match", () => {
             const wrapper = render({ ...testProps, query: "19", resetOnQuery: false });
+            // a different query altogether invalidates the previous active item, so QL chooses the first.
             wrapper.setProps({ query: "Forrest" });
             assert.strictEqual(testProps.onActiveItemChange.lastCall.args[0].title, "Forrest Gump");
         });

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -36,7 +36,7 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
 
     describe("common behavior", () => {
         it("itemRenderer is called for each child", () => {
-            const wrapper = render({ ...testProps, resetOnQuery: false });
+            const wrapper = render(testProps);
             // each item is rendered once
             assert.equal(testProps.itemRenderer.callCount, 15);
             // only filtered items re-rendered
@@ -77,23 +77,20 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
 
         it("querying does not reset active item when resetOnQuery=false", () => {
             const wrapper = render({ ...testProps, query: "19", resetOnQuery: false });
-
-            assert.strictEqual(testProps.onActiveItemChange.lastCall, null);
-
-            // querying should not select any new active item
-            findInput(wrapper).simulate("change", { target: { value: "Forrest" } });
+            wrapper.setProps({ query: "199" });
 
             assert.strictEqual(testProps.onActiveItemChange.lastCall, null);
         });
 
         it("querying resets active item when resetOnQuery=true", () => {
-            const wrapper = render({ ...testProps, query: "19" });
+            const wrapper = render({ ...testProps, query: "19", resetOnQuery: true });
+            wrapper.setProps({ query: "199" });
+            assert.strictEqual(testProps.onActiveItemChange.lastCall.args[0].rank, 1);
+        });
 
-            assert.strictEqual(testProps.onActiveItemChange.lastCall, null);
-
-            // querying should select Forrest Gump
-            findInput(wrapper).simulate("change", { target: { value: "Forrest" } });
-
+        it("querying resets active item if it does not match", () => {
+            const wrapper = render({ ...testProps, query: "19", resetOnQuery: false });
+            wrapper.setProps({ query: "Forrest" });
             assert.strictEqual(testProps.onActiveItemChange.lastCall.args[0].title, "Forrest Gump");
         });
     });


### PR DESCRIPTION
#### Follow up from #2894 

#### Changes proposed in this pull request:

- always reset active item if it's now filtered or disabled (even if `resetOnQuery=false`).
    - this behavior existed before but didn't work very well. i refactored the state manipulation logic and now it works very well.
- better handling of `shouldCheckActiveItemInViewport` so the active item is always visible in the viewport.
    - this behavior regressed at some point. no longer!
- adjust omnibar example hotkey props for better experience.

CC @switz - followups from your recent PR.
