### PR TITLE
Added support for defaultSelectedItem.

### DIFF
--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -39,8 +39,8 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     inputValueRenderer: (item: T) => string;
 
     /**
-     * The default selected item, or undefined. If provided, the item will be
-     * used as uncontrolled default state.
+     * The uncontrolled default selected item.
+     * This prop is ignored if selectedItem is used to control the state.
      */
     defaultSelectedItem?: T;
 
@@ -96,8 +96,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
         // Initialize the state.
         this.state = {
-            isOpen: false,
-            selectedItem: this.retrieveInitialSelectedItem(),
+            isOpen: (props.popoverProps && props.popoverProps.isOpen) || false,
+            selectedItem: this.getInitialSelectedItem(),
         };
     }
 
@@ -214,7 +214,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(this.props.onItemSelect, item, event);
     };
 
-    private retrieveInitialSelectedItem = (): T | null => {
+    private getInitialSelectedItem(): T | null {
         // First check if controlled mode is enabled ( selectedItem defined ).
         // Otherwise check for the defaultSelectedItem ( uncontrolled mode with default value )
         // Otherwise nothing is set, just leave null for uncontrolled mode.

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -40,7 +40,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 
     /**
      * The uncontrolled default selected item.
-     * This prop is ignored if selectedItem is used to control the state.
+     * This prop is ignored if `selectedItem` is used to control the state.
      */
     defaultSelectedItem?: T;
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -39,6 +39,12 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     inputValueRenderer: (item: T) => string;
 
     /**
+     * The default selected item, or undefined. If provided, the item will be
+     * used as uncontrolled default state.
+     */
+    defaultSelectedItem?: T;
+
+    /**
      * The currently selected item, or `null` to indicate that no item is selected.
      * If omitted, this prop will be uncontrolled (managed by the component's state).
      * Use `onItemSelect` to listen for updates.
@@ -73,11 +79,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         return Suggest as new (props: ISuggestProps<T>) => Suggest<T>;
     }
 
-    public state: ISuggestState<T> = {
-        isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
-        selectedItem: this.props.selectedItem !== undefined ? this.props.selectedItem : null,
-    };
-
     private TypedQueryList = QueryList.ofType<T>();
     private input?: HTMLInputElement | null;
     private queryList?: QueryList<T> | null;
@@ -89,6 +90,16 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         },
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };
+
+    constructor(props: ISuggestProps<T>, context?: any) {
+        super(props, context);
+
+        // Initialize the state.
+        this.state = {
+            isOpen: false,
+            selectedItem: this.retrieveInitialSelectedItem(),
+        };
+    }
 
     public render() {
         // omit props specific to this component, spread the rest.
@@ -201,6 +212,19 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         }
 
         Utils.safeInvoke(this.props.onItemSelect, item, event);
+    };
+
+    private retrieveInitialSelectedItem = (): T | null => {
+        // First check if controlled mode is enabled ( selectedItem defined ).
+        // Otherwise check for the defaultSelectedItem ( uncontrolled mode with default value )
+        // Otherwise nothing is set, just leave null for uncontrolled mode.
+        if (this.props.selectedItem !== undefined) {
+            return this.props.selectedItem;
+        } else if (this.props.defaultSelectedItem !== undefined) {
+            return this.props.defaultSelectedItem;
+        } else {
+            return null;
+        }
     };
 
     private handlePopoverInteraction = (nextOpenState: boolean) =>

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -225,7 +225,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         } else {
             return null;
         }
-    };
+    }
 
     private handlePopoverInteraction = (nextOpenState: boolean) =>
         requestAnimationFrame(() => {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -93,8 +93,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     constructor(props: ISuggestProps<T>, context?: any) {
         super(props, context);
-
-        // Initialize the state.
         this.state = {
             isOpen: (props.popoverProps && props.popoverProps.isOpen) || false,
             selectedItem: this.getInitialSelectedItem(),
@@ -215,9 +213,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     };
 
     private getInitialSelectedItem(): T | null {
-        // First check if controlled mode is enabled ( selectedItem defined ).
-        // Otherwise check for the defaultSelectedItem ( uncontrolled mode with default value )
-        // Otherwise nothing is set, just leave null for uncontrolled mode.
+        // controlled > uncontrolled > default
         if (this.props.selectedItem !== undefined) {
             return this.props.selectedItem;
         } else if (this.props.defaultSelectedItem !== undefined) {

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -213,7 +213,6 @@ describe("Suggest", () => {
     describe("Uncontrolled Mode with default value", () => {
         it("initialize the selectedItem with the defaultSelectedItem", () => {
             const defaultSelectedItem = TOP_100_FILMS[0];
-            assert.isNotNull(defaultSelectedItem, "The selected item we test must not be null");
             const wrapper = suggest({ defaultSelectedItem });
             assert.strictEqual(
                 wrapper.state().selectedItem,
@@ -226,7 +225,6 @@ describe("Suggest", () => {
             const ITEM_INDEX = 4;
             const defaultSelectedItem = TOP_100_FILMS[0];
             const nextSelectedItem = TOP_100_FILMS[ITEM_INDEX];
-            assert.isNotNull(defaultSelectedItem, "The selected item we test must not be null");
             const wrapper = suggest({ defaultSelectedItem });
             assert.strictEqual(
                 wrapper.state().selectedItem,

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -210,6 +210,36 @@ describe("Suggest", () => {
         }
     });
 
+    describe("Uncontrolled Mode with default value", () => {
+        it("initialize the selectedItem with the defaultSelectedItem", () => {
+            const defaultSelectedItem = TOP_100_FILMS[0];
+            assert.isNotNull(defaultSelectedItem, "The selected item we test must not be null");
+            const wrapper = suggest({ defaultSelectedItem });
+            assert.strictEqual(
+                wrapper.state().selectedItem,
+                defaultSelectedItem,
+                "The selected item should be initialized",
+            );
+        });
+
+        it("when a new item is selected, it changes the selectedItem", () => {
+            const ITEM_INDEX = 4;
+            const defaultSelectedItem = TOP_100_FILMS[0];
+            const nextSelectedItem = TOP_100_FILMS[ITEM_INDEX];
+            assert.isNotNull(defaultSelectedItem, "The selected item we test must not be null");
+            const wrapper = suggest({ defaultSelectedItem });
+            assert.strictEqual(
+                wrapper.state().selectedItem,
+                defaultSelectedItem,
+                "The selected item should be initialized",
+            );
+            simulateFocus(wrapper);
+            selectItem(wrapper, ITEM_INDEX);
+            assert.isTrue(handlers.onItemSelect.called, "onItemSelect should be called after selection");
+            assert.strictEqual(wrapper.state().selectedItem, nextSelectedItem, "the selectedItem should be updated");
+        });
+    });
+
     describe("Controlled Mode", () => {
         it("initialize the selectedItem with the given value", () => {
             const selectedItem = TOP_100_FILMS[0];


### PR DESCRIPTION
#### Fixes #2784 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Fixes #2784.

#### Reviewers should focus on:

The `Suggest` now accepts a defaultSelectedItem prop to set the initial value of the component in uncontrolled mode ( default uncontrolled state ).

 