### PR TITLE
[Select] Add placeholder prop to multiselect component

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -20,6 +20,9 @@ import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export interface IMultiSelectProps<T> extends IListItemsProps<T> {
+    /* Input placeholder text that will appear when any item is selected */
+    placeholder?: string;
+
     /** Controlled selected values. */
     selectedItems?: T[];
 
@@ -45,6 +48,10 @@ export interface IMultiSelectState {
 
 export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IMultiSelectState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect`;
+
+    public static defaultProps = {
+        placeholder: "Search...",
+    };
 
     public static ofType<T>() {
         return MultiSelect as new (props: IMultiSelectProps<T>) => MultiSelect<T>;
@@ -82,7 +89,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { tagInputProps = {}, popoverProps = {}, selectedItems = [] } = this.props;
+        const { tagInputProps = {}, popoverProps = {}, selectedItems = [], placeholder } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
 
         return (
@@ -103,7 +110,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                 >
                     <TagInput
-                        placeholder="Search..."
+                        placeholder={placeholder}
                         {...tagInputProps}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         inputRef={this.refHandlers.input}

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -28,7 +28,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
      * @default false
      */
     openOnKeyDown?: boolean;
-    
+
     /**
      * Input placeholder text. Shorthand for `tagInputProps.placeholder`.
      * @default "Search..."

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -20,9 +20,6 @@ import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export interface IMultiSelectProps<T> extends IListItemsProps<T> {
-    /* Input placeholder text that will appear when any item is selected */
-    placeholder?: string;
-
     /** Controlled selected values. */
     selectedItems?: T[];
 
@@ -31,6 +28,12 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
      * @default false
      */
     openOnKeyDown?: boolean;
+    
+    /**
+     * Input placeholder text. Shorthand for `tagInputProps.placeholder`.
+     * @default "Search..."
+     */
+    placeholder?: string;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     popoverProps?: Partial<IPopoverProps> & object;

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -42,6 +42,13 @@ describe("<MultiSelect>", () => {
         mount(<MultiSelect {...props} popoverProps={{ isOpen: true, usePortal: false }} tagRenderer={renderTag} />),
     );
 
+    it("placeholder can be controlled with placeholder prop", () => {
+        const placeholder = "look here";
+
+        const input = multiselect({ placeholder }).find("input");
+        assert.equal((input.getDOMNode() as HTMLInputElement).placeholder, placeholder);
+    });
+
     it("placeholder can be controlled with TagInput's inputProps", () => {
         const placeholder = "look here";
 


### PR DESCRIPTION
#### Fixes #2799

#### Changes proposed in this pull request:
- Add `placeholder` prop at the top of Multiselect component.

#### Reviewers should focus on:
- Multiselect `placeholder` prop.

Note that you can still change the placeholder as before by doing:
```
<MultiSelect tagInputProps={{ placeholder: 'Search anything...' }} />
```
as well as:
```
<MultiSelect placeholder="Search anything..." />
```