### PR TITLE
[Icon] fix font icons on IE11

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -13,8 +13,10 @@
 
   &:not(:empty)::before {
     // clear font icon when there's an <svg> image
-    // stylelint-disable-next-line declaration-no-important
+    // stylelint-disable
+    content: "" !important; // fallback for IE11
     content: unset !important;
+    // stylelint-enable
   }
 
   > svg {


### PR DESCRIPTION
#### Fixes #2918 

#### Changes proposed in this pull request:

- seems as though IE does not properly support CSS `unset` keyword.