### PR TITLE
[Icon] unknown string icon name renders blank icon

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -25,23 +25,26 @@ export interface IIconProps extends IIntentProps, IProps {
     color?: string;
 
     /**
-     * Name of a Blueprint UI icon, or an icon element, to render.
-     * This prop is required because it determines the content of the component, but it can
+     * Name of a Blueprint UI icon, or an icon element, to render. This prop is
+     * required because it determines the content of the component, but it can
      * be explicitly set to falsy values to render nothing.
      *
-     * - If `null` or `undefined` or `false`, this component will render nothing.
-     * - If given an `IconName` (a string literal union of all icon names),
-     *   that icon will be rendered as an `<svg>` with `<path>` tags.
-     * - If given a `JSX.Element`, that element will be rendered and _all other props on this component are ignored._
-     *   This type is supported to simplify usage of this component in other Blueprint components.
-     *   As a consumer, you should never use `<Icon icon={<element />}` directly; simply render `<element />` instead.
+     * - If `null` or `undefined` or `false`, this component will render
+     *   nothing.
+     * - If given an `IconName` (a string literal union of all icon names), that
+     *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
+     *   will render a blank icon.
+     * - If given a `JSX.Element`, that element will be rendered and _all other
+     *   props on this component are ignored._ This type is supported to
+     *   simplify icon support in other Blueprint components. As a consumer, you
+     *   should avoid using `<Icon icon={<Element />}` directly; simply render
+     *   `<Element />` instead.
      */
     icon: IconName | JSX.Element | false | null | undefined;
 
     /**
-     * Size of the icon, in pixels.
-     * Blueprint contains 16px and 20px SVG icon images,
-     * and chooses the appropriate resolution based on this prop.
+     * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
+     * images, and chooses the appropriate resolution based on this prop.
      * @default Icon.SIZE_STANDARD = 16
      */
     iconSize?: number;
@@ -71,10 +74,16 @@ export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<H
     public static readonly SIZE_LARGE = 20;
 
     public render() {
+        const { icon } = this.props;
+        if (icon == null) {
+            return null;
+        } else if (typeof icon !== "string") {
+            return icon;
+        }
+
         const {
             className,
             color,
-            icon,
             iconSize = Icon.SIZE_STANDARD,
             intent,
             title = icon,
@@ -82,18 +91,10 @@ export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<H
             ...htmlprops
         } = this.props;
 
-        if (icon == null) {
-            return null;
-        } else if (typeof icon !== "string") {
-            return icon;
-        }
-
         // choose which pixel grid is most appropriate for given icon size
         const pixelGridSize = iconSize >= Icon.SIZE_LARGE ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD;
+        // render path elements, or nothing if icon name is unknown.
         const paths = this.renderSvgPaths(pixelGridSize, icon);
-        if (paths == null) {
-            return null;
-        }
 
         const classes = classNames(Classes.ICON, Classes.iconClass(icon), Classes.intentClass(intent), className);
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
@@ -108,7 +109,8 @@ export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<H
         );
     }
 
-    private renderSvgPaths(pathsSize: number, iconName: IconName) {
+    /** Render `<path>` elements for the given icon name. Returns `null` if name is unknown. */
+    private renderSvgPaths(pathsSize: number, iconName: IconName): JSX.Element[] | null {
         const svgPathsRecord = pathsSize === Icon.SIZE_STANDARD ? IconSvgPaths16 : IconSvgPaths20;
         const pathStrings = svgPathsRecord[iconName];
         if (pathStrings == null) {

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -33,7 +33,7 @@ export interface IIconProps extends IIntentProps, IProps {
      *   nothing.
      * - If given an `IconName` (a string literal union of all icon names), that
      *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
-     *   will render a blank icon.
+     *   will render a blank icon to occupy space.
      * - If given a `JSX.Element`, that element will be rendered and _all other
      *   props on this component are ignored._ This type is supported to
      *   simplify icon support in other Blueprint components. As a consumer, you

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -33,15 +33,17 @@ describe("<Icon>", () => {
     it("renders icon without color", () => assertIconColor(<Icon icon="add" />));
     it("renders icon color", () => assertIconColor(<Icon icon="add" color="red" />, "red"));
 
-    it("prefixed icon renders nothing", () => {
-        // @ts-ignore invalid icon
-        const icon = shallow(<Icon icon={Classes.iconClass("airplane")} />);
-        assert.isTrue(icon.isEmptyRender());
+    it("unknown icon name renders blank icon", () => {
+        assert.lengthOf(shallow(<Icon icon={"unknown" as any} />).find("path"), 0);
     });
 
-    it("passes through icon element unchanged", () => {
-        // this is supported to simplify usage of this component in other Blueprint components
-        // which accept `icon?: IconName | JSX.Element`.
+    it("prefixed icon renders blank icon", () => {
+        assert.lengthOf(shallow(<Icon icon={Classes.iconClass("airplane") as any} />).find("path"), 0);
+    });
+
+    it("icon element passes through unchanged", () => {
+        // NOTE: This is supported to simplify usage of this component in other
+        // Blueprint components which accept `icon?: IconName | JSX.Element`.
         const onClick = () => true;
         const icon = shallow(<Icon icon={<article onClick={onClick} />} />);
         assert.isTrue(icon.is("article"));
@@ -65,7 +67,9 @@ describe("<Icon>", () => {
 
     /** Asserts that rendered icon has given className. */
     function assertIcon(icon: React.ReactElement<IIconProps>, iconName: IconName) {
-        assert.strictEqual(shallow(icon).text(), iconName);
+        const wrapper = shallow(icon);
+        assert.strictEqual(wrapper.text(), iconName);
+        assert.isNotEmpty(wrapper.find("path"), "should find path elements");
     }
 
     /** Asserts that rendered icon has width/height equal to size. */


### PR DESCRIPTION
#### Fixes #2925 

#### Changes proposed in this pull request:

- unknown icon name renders markup but no path elements, resulting in blank icon.