### PR TITLE
[Switch] Fix indicator when line-height != 1

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -354,7 +354,7 @@ $control-indicator-spacing: $pt-grid-size !default;
       transition: background-color $pt-transition-duration $pt-transition-ease;
 
       &::before {
-        position: relative;
+        position: absolute;
         left: 0;
         margin: $switch-indicator-margin;
         border-radius: 50%;


### PR DESCRIPTION
#### Fixes #2922 

#### Changes proposed in this pull request:

- a little `position` change makes all the difference -- ensure the indicator stays inside the switch body at all times.