### PR TITLE
enable port configuration in webpack dev server. Closes #2921

### DIFF
--- a/packages/docs-app/README.md
+++ b/packages/docs-app/README.md
@@ -10,3 +10,5 @@ From the root of the repo:
 1. Run `yarn`
 1. Run `yarn dev`
 1. Open your browser to http://localhost:9000/
+
+*Note: if you want to run the development server on a different port, set the `PORT` environment variable.*

--- a/packages/webpack-build-scripts/webpack.config.base.js
+++ b/packages/webpack-build-scripts/webpack.config.base.js
@@ -18,6 +18,7 @@ const { getPackageName } = require("./utils");
 
 // globals
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
+const DEV_PORT = process.env.PORT || 9000;
 const PACKAGE_NAME = getPackageName();
 
 /**
@@ -105,7 +106,7 @@ module.exports = {
             warnings: true,
             errors: true,
         },
-        port: 9000,
+        port: DEV_PORT,
     },
 
     module: {


### PR DESCRIPTION
#### Fixes #2921

#### Changes proposed in this pull request:

Allows configuring the webpack dev server port

#### Reviewers should focus on:

Running the dev server with and without the `PORT` env set
