### PR TITLE
[hotkeys] Fix sorting for global hotkey groups with labels

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -44,15 +44,12 @@ export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}> {
             (child: React.ReactElement<IHotkeyProps>) => child.props,
         );
 
-        // sort by group label alphabetically, globals first
+        // sort by group label alphabetically, prioritize globals
         hotkeys.sort((a, b) => {
-            if (a.global) {
-                return b.global ? 0 : -1;
+            if (a.global === b.global) {
+                return a.group.localeCompare(b.group);
             }
-            if (b.global) {
-                return 1;
-            }
-            return a.group.localeCompare(b.group);
+            return a.global ? -1 : 1;
         });
 
         let lastGroup = null as string;

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -89,9 +89,27 @@ describe("Hotkeys", () => {
                         />
                         <Hotkey
                             {...this.props}
+                            combo="4"
+                            global={true}
+                            group="A"
+                            label="sorted 1"
+                            onKeyDown={globalKeyDownSpy}
+                            onKeyUp={globalKeyUpSpy}
+                        />
+                        <Hotkey
+                            {...this.props}
                             combo="2"
                             global={true}
                             label="global hotkey"
+                            onKeyDown={globalKeyDownSpy}
+                            onKeyUp={globalKeyUpSpy}
+                        />
+                        <Hotkey
+                            {...this.props}
+                            combo="5"
+                            global={true}
+                            group="A"
+                            label="sorted 2"
                             onKeyDown={globalKeyDownSpy}
                             onKeyUp={globalKeyUpSpy}
                         />
@@ -151,6 +169,31 @@ describe("Hotkeys", () => {
                 expect(document.querySelector("." + Classes.HOTKEY_COLUMN)).to.exist;
                 expect(document.querySelector("." + Classes.OVERLAY_OPEN).classList.contains(Classes.OVERLAY_INLINE)).to
                     .be.false;
+                hideHotkeysDialog();
+                comp.detach();
+                attachTo.remove();
+                done();
+            }, TEST_TIMEOUT_DURATION);
+        });
+
+        it("sorts hotkeys in hotkey dialog", done => {
+            const TEST_TIMEOUT_DURATION = 30;
+
+            comp = mount(<TestComponent />, { attachTo });
+            const node = ReactDOM.findDOMNode(comp.instance());
+
+            dispatchTestKeyboardEvent(node, "keydown", "/", true);
+
+            // wait for the dialog to animate in
+            setTimeout(() => {
+                const hotkeyLabels = Array.from(document.querySelectorAll("." + Classes.HOTKEY_LABEL)).map(
+                    el => el.textContent,
+                );
+
+                expect(document.querySelector("." + Classes.HOTKEY_COLUMN)).to.exist;
+                expect(document.querySelector("." + Classes.OVERLAY_OPEN).classList.contains(Classes.OVERLAY_INLINE)).to
+                    .be.false;
+                expect(hotkeyLabels).to.deep.equal(["sorted 1", "sorted 2", "global hotkey", "local hotkey"]);
                 hideHotkeysDialog();
                 comp.detach();
                 attachTo.remove();


### PR DESCRIPTION
Hotkey groups with labels that are have the global={true} prop should
now also be alphabetically sorted.

Fixes #2439 

#### Changes proposed in this pull request:
The change will prioritize global hotkeys, but still sort them with other global hotkey groups. If a hotkey group is both global but also has a group name, it will still sort it alphabetically.

#### Reviewers should focus on:
Sorting and order of global hotkey groups with a group name set.
