### PR TITLE
Fix collapse button jumping in demo

### DIFF
--- a/packages/docs-app/src/examples/core-examples/collapseExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapseExample.tsx
@@ -38,7 +38,7 @@ export class CollapseExample extends React.PureComponent<IExampleProps, ICollaps
 
         return (
             <Example options={options} {...this.props}>
-                <div style={{ width: "100%" }}>
+                <div style={{ width: "100%", height: "100%", margin: 0 }}>
                     <Button onClick={this.handleClick}>{this.state.isOpen ? "Hide" : "Show"} build logs</Button>
                     <Collapse isOpen={this.state.isOpen} keepChildrenMounted={this.state.keepChildrenMounted}>
                         <Pre>


### PR DESCRIPTION
#### Changes proposed in this pull request:

Stops collapse button from moving left/right in collapse demo, shown here:

![collapse-move-gif](https://media.giphy.com/media/DCHfpfpmZHM5SechyN/giphy.gif)

<!-- fill this out -->

#### Reviewers should focus on:
Minor in-line css changes in:

https://github.com/palantir/blueprint/compare/develop...mattfwood:mw/fix-collapse-demo?expand=1#diff-e8d90268ddca67b0ed4f7f87ec7e791f

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
