### PR TITLE
Form group: hide label when falsy

### DIFF
--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -48,9 +48,11 @@ export class FormGroup extends React.PureComponent<IFormGroupProps, {}> {
         const { children, helperText, label, labelFor, labelInfo } = this.props;
         return (
             <div className={this.getClassName()}>
-                <label className={Classes.LABEL} htmlFor={labelFor}>
-                    {label} <span className={Classes.TEXT_MUTED}>{labelInfo}</span>
-                </label>
+                {label && (
+                    <label className={Classes.LABEL} htmlFor={labelFor}>
+                        {label} <span className={Classes.TEXT_MUTED}>{labelInfo}</span>
+                    </label>
+                )}
                 <div className={Classes.FORM_CONTENT}>
                     {children}
                     {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}

--- a/packages/core/test/forms/formGroupTests.tsx
+++ b/packages/core/test/forms/formGroupTests.tsx
@@ -36,6 +36,11 @@ describe("<FormGroup>", () => {
         assert.strictEqual(label.prop("htmlFor"), "foo");
     });
 
+    it("hides label when falsy", () => {
+        const label = shallow(<FormGroup />).find("label");
+        assert.strictEqual(label.length, 0);
+    });
+
     it("labelInfo=JSX renders JSX content in label", () => {
         const info = <em>fill me out</em>;
         const label = shallow(<FormGroup label="label" labelInfo={info} />).find("label");

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -15,6 +15,7 @@ export interface IFormGroupExampleState {
     helperText: boolean;
     inline: boolean;
     intent: Intent;
+    label: boolean;
     requiredLabel: boolean;
 }
 
@@ -24,17 +25,19 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
         helperText: false,
         inline: false,
         intent: Intent.NONE,
+        label: true,
         requiredLabel: true,
     };
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
     private handleHelperTextChange = handleBooleanChange(helperText => this.setState({ helperText }));
     private handleInlineChange = handleBooleanChange(inline => this.setState({ inline }));
+    private handleLabelChange = handleBooleanChange(label => this.setState({ label }));
     private handleRequiredLabelChange = handleBooleanChange(requiredLabel => this.setState({ requiredLabel }));
     private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
 
     public render() {
-        const { disabled, helperText, inline, intent, requiredLabel } = this.state;
+        const { disabled, helperText, inline, intent, label, requiredLabel } = this.state;
 
         const options = (
             <>
@@ -42,6 +45,7 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                 <Switch label="Disabled" checked={disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Inline" checked={inline} onChange={this.handleInlineChange} />
                 <Switch label="Show helper text" checked={helperText} onChange={this.handleHelperTextChange} />
+                <Switch label="Show label" checked={label} onChange={this.handleLabelChange} />
                 <Switch label="Show label info" checked={requiredLabel} onChange={this.handleRequiredLabelChange} />
                 <IntentSelect intent={intent} onChange={this.handleIntentChange} />
             </>
@@ -54,7 +58,7 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                     helperText={helperText && "Helper text with details..."}
                     inline={inline}
                     intent={intent}
-                    label="Label"
+                    label={label && "Label"}
                     labelFor="text-input"
                     labelInfo={requiredLabel && "(required)"}
                 >
@@ -65,7 +69,7 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                     helperText={helperText && "Helper text with details..."}
                     inline={inline}
                     intent={intent}
-                    label="Label"
+                    label={label && "Label"}
                     labelFor="text-input"
                     labelInfo={requiredLabel && "(required)"}
                 >


### PR DESCRIPTION
#### Checklist
- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

I'd like to hide the `<label>` tag when no label is passed so it doesn't take any space (margin) in the layout.
