### PR TITLE
Create a fixer for classes-constants lint rule

### DIFF
--- a/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
+++ b/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
@@ -93,25 +93,11 @@ function getReplacement(
                 new Lint.Replacement(node.getStart(), node.getWidth(), wrapForParent(replacement, node, node.parent)),
             );
         } else {
-            if (ptClassStrings.length === 1) {
-                const replacement = convertPtClassName(ptClassStrings[0]);
-                replacements.push(
-                    new Lint.Replacement(
-                        node.getStart(),
-                        node.getWidth(),
-                        wrapForParent(replacement, node, node.parent),
-                    ),
-                );
-            } else {
-                const replacement = `\`${templateStrings}\``;
-                replacements.push(
-                    new Lint.Replacement(
-                        node.getStart(),
-                        node.getWidth(),
-                        wrapForParent(replacement, node, node.parent),
-                    ),
-                );
-            }
+            const replacement =
+                ptClassStrings.length === 1 ? convertPtClassName(ptClassStrings[0]) : `\`${templateStrings}\``;
+            replacements.push(
+                new Lint.Replacement(node.getStart(), node.getWidth(), wrapForParent(replacement, node, node.parent)),
+            );
         }
     } else if (utils.isTemplateExpression(node) || utils.isNoSubstitutionTemplateLiteral(node)) {
         let replacementText = node.getText();

--- a/packages/tslint-config/src/rules/utils/addImportToFile.ts
+++ b/packages/tslint-config/src/rules/utils/addImportToFile.ts
@@ -1,0 +1,50 @@
+import { Replacement } from "tslint";
+import * as utils from "tsutils";
+import * as ts from "typescript";
+
+export function addImportToFile(file: ts.SourceFile, imports: string[], packageName: string) {
+    const packageToModify = file.statements.find(
+        statement => utils.isImportDeclaration(statement) && statement.moduleSpecifier.getText() === `"${packageName}"`
+    ) as ts.ImportDeclaration;
+    if (
+        packageToModify &&
+        packageToModify.importClause &&
+        packageToModify.importClause.namedBindings &&
+        utils.isNamedImports(packageToModify.importClause.namedBindings)
+    ) {
+        const existingImports = packageToModify.importClause.namedBindings.elements.map(el => el.name.getText());
+        // Poor man's lodash.uniq without the dep.
+        const newImports = Array.from(new Set(existingImports.concat(imports))).sort((a, b) =>
+            a.toLowerCase().localeCompare(b.toLowerCase())
+        );
+        const importString = `{ ${newImports.join(", ")} }`;
+        return Replacement.replaceNode(packageToModify.importClause.namedBindings, importString);
+    } else {
+        // we always place the import in alphabetical order. If imports are already alpha-ordered, this will act nicely
+        // with existing lint rules. If imports are not alpha-ordered, this may appear weird.
+        const allImports = file.statements.filter(utils.isImportDeclaration);
+        const newImportIndex = allImports.findIndex(imp => {
+            // slice the quotes off each module specifier
+            return compare(imp.moduleSpecifier.getText().slice(1, -1), packageName) === 1;
+        });
+        const startIndex = newImportIndex === -1 ? 0 : allImports[newImportIndex].getStart();
+        return Replacement.appendText(startIndex, `import { ${imports.join(", ")} } from "${packageName}";\n`);
+    }
+}
+
+// taken from tslint orderedImportRules
+function compare(a: string, b: string): 0 | 1 | -1 {
+    function isLow(value: string) {
+        return value[0] === "." || value[0] === "/";
+    }
+    if (isLow(a) && !isLow(b)) {
+        return 1;
+    } else if (!isLow(a) && isLow(b)) {
+        return -1;
+    } else if (a > b) {
+        return 1;
+    } else if (a < b) {
+        return -1;
+    }
+    return 0;
+}

--- a/packages/tslint-config/src/rules/utils/addImportToFile.ts
+++ b/packages/tslint-config/src/rules/utils/addImportToFile.ts
@@ -1,10 +1,16 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
 import { Replacement } from "tslint";
 import * as utils from "tsutils";
 import * as ts from "typescript";
 
 export function addImportToFile(file: ts.SourceFile, imports: string[], packageName: string) {
     const packageToModify = file.statements.find(
-        statement => utils.isImportDeclaration(statement) && statement.moduleSpecifier.getText() === `"${packageName}"`
+        statement => utils.isImportDeclaration(statement) && statement.moduleSpecifier.getText() === `"${packageName}"`,
     ) as ts.ImportDeclaration;
     if (
         packageToModify &&
@@ -15,7 +21,7 @@ export function addImportToFile(file: ts.SourceFile, imports: string[], packageN
         const existingImports = packageToModify.importClause.namedBindings.elements.map(el => el.name.getText());
         // Poor man's lodash.uniq without the dep.
         const newImports = Array.from(new Set(existingImports.concat(imports))).sort((a, b) =>
-            a.toLowerCase().localeCompare(b.toLowerCase())
+            a.toLowerCase().localeCompare(b.toLowerCase()),
         );
         const importString = `{ ${newImports.join(", ")} }`;
         return Replacement.replaceNode(packageToModify.importClause.namedBindings, importString);
@@ -32,11 +38,12 @@ export function addImportToFile(file: ts.SourceFile, imports: string[], packageN
     }
 }
 
+function isLow(value: string) {
+    return value[0] === "." || value[0] === "/";
+}
+
 // taken from tslint orderedImportRules
 function compare(a: string, b: string): 0 | 1 | -1 {
-    function isLow(value: string) {
-        return value[0] === "." || value[0] === "/";
-    }
     if (isLow(a) && !isLow(b)) {
         return 1;
     } else if (!isLow(a) && isLow(b)) {

--- a/packages/tslint-config/src/tsconfig.json
+++ b/packages/tslint-config/src/tsconfig.json
@@ -1,9 +1,8 @@
 {
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
-        "lib": ["es6"],
+        "lib": ["es6", "dom"],
         "module": "commonjs",
-        "outDir": "../lib/rules",
-        "skipLibCheck": true
+        "outDir": "../lib/rules"
     }
 }

--- a/packages/tslint-config/src/tsconfig.json
+++ b/packages/tslint-config/src/tsconfig.json
@@ -1,7 +1,9 @@
 {
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
+        "lib": ["es6"],
         "module": "commonjs",
-        "outDir": "../lib/rules"
+        "outDir": "../lib/rules",
+        "skipLibCheck": true
     }
 }

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.fix
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.fix
@@ -1,0 +1,2 @@
+// Make sure that this rule doesn't modify icon classes, that's handled elsewhere.
+<span className"pt-icon pt-icon-folder-open" />

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.lint
@@ -1,0 +1,2 @@
+// Make sure that this rule doesn't modify icon classes, that's handled elsewhere.
+<span className"pt-icon pt-icon-folder-open" />

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.fix
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.fix
@@ -1,0 +1,13 @@
+import { Classes } from "@blueprintjs/core";
+apt-get
+at 4pt-size
+`${Classes.LARGE} script-source  apt-get`
+`script-source ${Classes.LARGE} apt-get`
+`${template} ${Classes.LARGE}`
+
+<Button className=`${Classes.LARGE} my-class` />
+
+classNames(Classes.BUTTON, Classes.INTENT_PRIMARY)
+
+<pt-popover> // angular directive
+

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
@@ -1,17 +1,17 @@
 apt-get
 at 4pt-size
 "script-source pt-large apt-get"
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [msg]
+               ~~~~~~~~  [msg]
 `script-source pt-large apt-get`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [msg]
+               ~~~~~~~~  [msg]
 `${template} pt-large`
-~~~~~~~~~~~~~~~~~~~~~~  [msg]
+             ~~~~~~~~  [msg]
 
 <Button className="my-class pt-large" />
-                  ~~~~~~~~~~~~~~~~~~~ [msg]
+                            ~~~~~~~~ [msg]
 
 classNames(Classes.BUTTON, "pt-intent-primary")
-                           ~~~~~~~~~~~~~~~~~~~ [msg]
+                            ~~~~~~~~~~~~~~~~~ [msg]
 
 <pt-popover> // angular directive
 

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
@@ -1,17 +1,17 @@
 apt-get
 at 4pt-size
 "script-source pt-large apt-get"
-               ~~~~~~~~  [msg]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [msg]
 `script-source pt-large apt-get`
-               ~~~~~~~~  [msg]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [msg]
 `${template} pt-large`
-             ~~~~~~~~  [msg]
+~~~~~~~~~~~~~~~~~~~~~~  [msg]
 
 <Button className="my-class pt-large" />
-                            ~~~~~~~~  [msg]
+                  ~~~~~~~~~~~~~~~~~~~ [msg]
 
 classNames(Classes.BUTTON, "pt-intent-primary")
-                            ~~~~~~~~~~~~~~~~~  [msg]
+                           ~~~~~~~~~~~~~~~~~~~ [msg]
 
 <pt-popover> // angular directive
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests

#### Changes proposed in this pull request:

Create a fixer for classes-constants lint rule
1. The lint rule will now fail the entire node, instead of just the pt-* string
2. The lint rule now has a fixer that will replace the pt-* string with the blueprint import

This does not create a fixer for icons, since that rule is slightly more complex, and should handle the options for creating an `<Icon {...} />` element, or using `IconNames`

#### Reviewers should focus on:

Lint rule semantics/test cases. 

