### PR TITLE
[Spinner] prevent track overflow

### DIFF
--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -21,9 +21,6 @@
 
   svg {
     display: block;
-    // reduce effective image size a little bit to keep overflowing circle edges
-    // visible and inside the bounds of the Spinner element (no outer overflow).
-    padding: 1px;
   }
 
   path {

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -21,6 +21,9 @@
 
   svg {
     display: block;
+    // reduce effective image size a little bit to keep overflowing circle edges
+    // visible and inside the bounds of the Spinner element (no outer overflow).
+    padding: 1px;
   }
 
   path {

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -14,7 +14,7 @@ import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 
 // see http://stackoverflow.com/a/18473154/3124288 for calculating arc path
-const SPINNER_TRACK = "M 50,50 m 0,-44.5 a 44.5,44.5 0 1 1 0,89 a 44.5,44.5 0 1 1 0,-89";
+const SPINNER_TRACK = `M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90`;
 
 // unitless total length of SVG path, to which stroke-dash* properties are relative.
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -35,8 +35,8 @@ export interface ISpinnerProps extends IProps, IIntentProps {
     size?: number;
 
     /**
-     * HTML tag for the wrapper element. If rendering a `<Spinner>` inside an
-     * `<svg>`, change this to an SVG element like `"g"`.
+     * HTML tag for the two wrapper elements. If rendering a `<Spinner>` inside
+     * an `<svg>`, change this to an SVG element like `"g"`.
      * @default "div"
      */
     tagName?: keyof JSX.IntrinsicElements;
@@ -84,7 +84,7 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
         // - SPINNER_ANIMATION isolates svg from parent display and is always centered inside root element.
         return (
             <TagName className={classes}>
-                <span className={Classes.SPINNER_ANIMATION}>
+                <TagName className={Classes.SPINNER_ANIMATION}>
                     <svg height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
                         <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
                         <path
@@ -95,7 +95,7 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
                             strokeDashoffset={strokeOffset}
                         />
                     </svg>
-                </span>
+                </TagName>
             </TagName>
         );
     }

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -14,7 +14,8 @@ import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 
 // see http://stackoverflow.com/a/18473154/3124288 for calculating arc path
-const SPINNER_TRACK = `M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90`;
+const R = 45;
+const SPINNER_TRACK = `M 50,50 m 0,-${R} a ${R},${R} 0 1 1 0,${R * 2} a ${R},${R} 0 1 1 0,-${R * 2}`;
 
 // unitless total length of SVG path, to which stroke-dash* properties are relative.
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength
@@ -74,7 +75,7 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
             className,
         );
 
-        // attempt to keep spinner stroke width constant at all sizes
+        // keep spinner track width consistent at all sizes (down to about 10px).
         const strokeWidth = Math.min(MIN_STROKE_WIDTH, STROKE_WIDTH * Spinner.SIZE_LARGE / size);
 
         const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
@@ -85,7 +86,12 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
         return (
             <TagName className={classes}>
                 <TagName className={Classes.SPINNER_ANIMATION}>
-                    <svg height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
+                    <svg
+                        width={size}
+                        height={size}
+                        strokeWidth={strokeWidth.toFixed(2)}
+                        viewBox={this.getViewBox(strokeWidth)}
+                    >
                         <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
                         <path
                             className={Classes.SPINNER_HEAD}
@@ -106,6 +112,10 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
         }
     }
 
+    /**
+     * Resolve size to a pixel value.
+     * Size can be set by className, props, default, or minimum constant.
+     */
     private getSize() {
         const { className = "", size } = this.props;
         if (size == null) {
@@ -118,5 +128,13 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
             return Spinner.SIZE_STANDARD;
         }
         return Math.max(MIN_SIZE, size);
+    }
+
+    /** Compute viewbox such that stroked track sits exactly at edge of image frame. */
+    private getViewBox(strokeWidth: number) {
+        const radius = R + strokeWidth / 2;
+        const viewBoxX = (50 - radius).toFixed(2);
+        const viewBoxWidth = (radius * 2).toFixed(2);
+        return `${viewBoxX} ${viewBoxX} ${viewBoxWidth} ${viewBoxWidth}`;
     }
 }

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -58,6 +58,15 @@ describe("Spinner", () => {
         assertStrokePercent(root, 0.35);
     });
 
+    it("viewBox adjusts based on size", () => {
+        function viewBox(size: number) {
+            return mount(<Spinner size={size} />)
+                .find("svg")
+                .prop("viewBox");
+        }
+        assert.notEqual(viewBox(Spinner.SIZE_SMALL), viewBox(Spinner.SIZE_LARGE), "expected different viewBoxes");
+    });
+
     function assertStrokePercent(wrapper: ReactWrapper<any, {}>, percent: number) {
         const head = wrapper.find(`.${Classes.SPINNER_HEAD}`);
         // NOTE: strokeDasharray is string "X X", but parseInt terminates at non-numeric character

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -19,10 +19,11 @@ describe("Spinner", () => {
         assert.lengthOf(root.find("path"), 2);
     });
 
-    it("tagName determines root tag", () => {
+    it("tagName determines both container elements", () => {
         const tagName = "article";
         const root = mount(<Spinner tagName={tagName} />);
         assert.isTrue(root.is({ tagName }));
+        assert.lengthOf(root.find(tagName), 2);
     });
 
     it("Classes.LARGE/SMALL determine default size", () => {


### PR DESCRIPTION
#### Fixes #2966 

#### Changes proposed in this pull request:

- 🌟 compute spinner SVG `viewBox` based on computed `strokeWidth` so the track always exactly fills the frame to the edge and never exceeds it.
- 👍 also, `tagName` now affects both DOM wrappers so it can actually be used in an SVG.

#### Screenshots

20px:
![image](https://user-images.githubusercontent.com/464822/46044359-6af4ee00-c0cf-11e8-85dd-83807ab0286e.png)

50px:
![image](https://user-images.githubusercontent.com/464822/46044414-89f38000-c0cf-11e8-9ef4-5b604b5cba3e.png)

100px:
![image](https://user-images.githubusercontent.com/464822/46044382-75af8300-c0cf-11e8-8a96-d36e46365e3d.png)

175px:
![image](https://user-images.githubusercontent.com/464822/46044402-82cc7200-c0cf-11e8-808f-72d6dd4fe592.png)
