### PR TITLE
less brittle element type checks

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -71,11 +71,25 @@ export function getDisplayName(ComponentClass: React.ComponentType | INamed) {
     return (ComponentClass as React.ComponentType).displayName || (ComponentClass as INamed).name || "Unknown";
 }
 
+/**
+ * Returns true if the given JSX element matches the given component type.
+ *
+ * NOTE: This function only checks equality of `displayName` for performance and
+ * to tolerate multiple minor versions of a component being included in one
+ * application bundle.
+ * @param element JSX element in question
+ * @param ComponentType desired component type of element
+ */
 export function isElementOfType<P = {}>(
     element: any,
-    ComponentClass: React.ComponentType<P>,
+    ComponentType: React.ComponentType<P>,
 ): element is React.ReactElement<P> {
-    return element != null && element.type === React.createElement(ComponentClass).type;
+    return (
+        element != null &&
+        element.type != null &&
+        element.type.displayName != null &&
+        element.type.displayName === ComponentType.displayName
+    );
 }
 
 /**

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -16,6 +16,13 @@ import { Handle } from "./handle";
 import { HandleInteractionKind, HandleType, IHandleProps } from "./handleProps";
 import { argMin, fillValues, formatPercentage } from "./sliderUtils";
 
+/**
+ * SFC used to pass slider handle props to a `MultiSlider`.
+ * This element is not rendered directly.
+ */
+const MultiSliderHandle: React.SFC<IHandleProps> = () => null;
+MultiSliderHandle.displayName = `${DISPLAYNAME_PREFIX}.MultiSliderHandle`;
+
 // TODO: move this to props.ts in a follow up PR
 /** A convenience type for React's optional children prop. */
 export interface IChildrenProps {
@@ -120,7 +127,7 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
 
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSlider`;
 
-    public static Handle: React.SFC<IHandleProps> = () => null;
+    public static Handle = MultiSliderHandle;
 
     public state: ISliderState = {
         labelPrecision: getLabelPrecision(this.props),

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -202,7 +202,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
 
     /** Filters children to only `<Tab>`s */
     private getTabChildren(props: ITabsProps & { children?: React.ReactNode } = this.props) {
-        return React.Children.toArray(props.children).filter(isTabChild);
+        return React.Children.toArray(props.children).filter(isTabElement);
     }
 
     /** Queries root HTML element for all tabs with optional filter selector */
@@ -293,7 +293,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
     };
 
     private renderTabTitle = (child: React.ReactChild) => {
-        if (isTabChild(child)) {
+        if (isTabElement(child)) {
             const { id } = child.props;
             return (
                 <TabTitle
@@ -312,6 +312,6 @@ function isEventKeyCode(e: React.KeyboardEvent<HTMLElement>, ...codes: number[])
     return codes.indexOf(e.which) >= 0;
 }
 
-function isTabChild(child: any): child is TabElement {
-    return child != null && child.type.__blueprintTab === true;
+function isTabElement(child: any): child is TabElement {
+    return Utils.isElementOfType(child, Tab);
 }

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -111,10 +111,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
     public render() {
         const { indicatorWrapperStyle, selectedTabId } = this.state;
 
-        const tabTitles = React.Children.map(
-            this.props.children,
-            child => (Utils.isElementOfType(child, Tab) ? this.renderTabTitle(child as TabElement) : child),
-        );
+        const tabTitles = React.Children.map(this.props.children, this.renderTabTitle);
 
         const tabPanels = this.getTabChildren()
             .filter(this.props.renderActiveTabPanelOnly ? tab => tab.props.id === selectedTabId : () => true)
@@ -205,9 +202,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
 
     /** Filters children to only `<Tab>`s */
     private getTabChildren(props: ITabsProps & { children?: React.ReactNode } = this.props) {
-        return React.Children.toArray(props.children).filter(child => {
-            return Utils.isElementOfType(child, Tab);
-        }) as TabElement[];
+        return React.Children.toArray(props.children).filter(isTabChild);
     }
 
     /** Queries root HTML element for all tabs with optional filter selector */
@@ -297,19 +292,26 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
         );
     };
 
-    private renderTabTitle = (tab: TabElement) => {
-        const { id } = tab.props;
-        return (
-            <TabTitle
-                {...tab.props}
-                parentId={this.props.id}
-                onClick={this.handleTabClick}
-                selected={id === this.state.selectedTabId}
-            />
-        );
+    private renderTabTitle = (child: React.ReactChild) => {
+        if (isTabChild(child)) {
+            const { id } = child.props;
+            return (
+                <TabTitle
+                    {...child.props}
+                    parentId={this.props.id}
+                    onClick={this.handleTabClick}
+                    selected={id === this.state.selectedTabId}
+                />
+            );
+        }
+        return child;
     };
 }
 
 function isEventKeyCode(e: React.KeyboardEvent<HTMLElement>, ...codes: number[]) {
     return codes.indexOf(e.which) >= 0;
+}
+
+function isTabChild(child: any): child is TabElement {
+    return child != null && child.type.__blueprintTab === true;
 }

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -7,7 +7,13 @@ import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../common/classes";
 
-import { Classes as CoreClasses, IIntentProps, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    Classes as CoreClasses,
+    DISPLAYNAME_PREFIX,
+    IIntentProps,
+    IProps,
+    Utils as CoreUtils,
+} from "@blueprintjs/core";
 
 import { LoadableContent } from "../common/loadableContent";
 import { JSONFormat } from "./formats/jsonFormat";
@@ -93,7 +99,9 @@ export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.Rea
 
 export const emptyCellRenderer = () => <Cell />;
 
-export class Cell extends React.Component<ICellProps, {}> {
+export class Cell extends React.Component<ICellProps> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Cell`;
+
     public static defaultProps = {
         truncated: true,
         wrapText: false,

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -6,7 +6,14 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { EditableText, Hotkey, Hotkeys, HotkeysTarget, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    DISPLAYNAME_PREFIX,
+    EditableText,
+    Hotkey,
+    Hotkeys,
+    HotkeysTarget,
+    Utils as CoreUtils,
+} from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { Draggable } from "../interactions/draggable";
@@ -58,6 +65,8 @@ export interface IEditableCellState {
 
 @HotkeysTarget
 export class EditableCell extends React.Component<IEditableCellProps, IEditableCellState> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.EditableCell`;
+
     public static defaultProps = {
         truncated: true,
         wrapText: false,

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -4,6 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../../common/classes";
@@ -28,7 +29,9 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     stringify?: (obj: any) => string;
 }
 
-export class JSONFormat extends React.Component<IJSONFormatProps, {}> {
+export class JSONFormat extends React.Component<IJSONFormatProps> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.JSONFormat`;
+
     public static defaultProps: IJSONFormatProps = {
         omitQuotesOnStrings: true,
         stringify: (obj: any) => JSON.stringify(obj, null, 2),

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Icon, IProps, Popover, Position } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, Icon, IProps, Popover, Position } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -131,6 +131,8 @@ export interface ITruncatedFormatState {
 }
 
 export class TruncatedFormat extends React.PureComponent<ITruncatedFormatProps, ITruncatedFormatState> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.TruncatedFormat`;
+
     public static defaultProps: ITruncatedFormatProps = {
         detectTruncation: false,
         measureByApproxOptions: {

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { IProps } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, IProps } from "@blueprintjs/core";
 import * as React from "react";
 import { emptyCellRenderer, ICellRenderer } from "./cell/cell";
 import { IColumnHeaderRenderer } from "./headers/columnHeader";
@@ -44,7 +44,9 @@ export interface IColumnProps extends IColumnNameProps, IProps {
     columnHeaderCellRenderer?: IColumnHeaderRenderer;
 }
 
-export class Column extends React.PureComponent<IColumnProps, {}> {
+export class Column extends React.PureComponent<IColumnProps> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Column`;
+
     public static defaultProps: IColumnProps = {
         cellRenderer: emptyCellRenderer,
     };

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -4,7 +4,15 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { AbstractComponent, Hotkey, Hotkeys, HotkeysTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    AbstractComponent,
+    DISPLAYNAME_PREFIX,
+    Hotkey,
+    Hotkeys,
+    HotkeysTarget,
+    IProps,
+    Utils as CoreUtils,
+} from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -403,6 +411,8 @@ export interface ITableState {
 
 @HotkeysTarget
 export class Table extends AbstractComponent<ITableProps, ITableState> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Table`;
+
     public static defaultProps: ITableProps = {
         defaultColumnWidth: 150,
         defaultRowHeight: 20,
@@ -886,8 +896,10 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         if (numColumns != null && columnWidths != null && columnWidths.length !== numColumns) {
             throw new Error(Errors.TABLE_NUM_COLUMNS_COLUMN_WIDTHS_MISMATCH);
         }
-        React.Children.forEach(children, (child: React.ReactElement<any>) => {
+        React.Children.forEach(children, child => {
             if (!CoreUtils.isElementOfType(child, Column)) {
+                console.log((child as any).type.displayName);
+
                 throw new Error(Errors.TABLE_NON_COLUMN_CHILDREN_WARNING);
             }
         });

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -898,8 +898,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         }
         React.Children.forEach(children, child => {
             if (!CoreUtils.isElementOfType(child, Column)) {
-                console.log((child as any).type.displayName);
-
                 throw new Error(Errors.TABLE_NON_COLUMN_CHILDREN_WARNING);
             }
         });


### PR DESCRIPTION
#### Fixes #2958 

#### Changes proposed in this pull request:

- ⚠️ `Utils.isElementOfType` now checks `displayName` equality to support multiple minor versions.
    - Utils are not part of the public API (though they are exported) so this will not be considered an API break
- previously it created an element which is potentially expensive (for react-hot-loader support)
- refactor `Tabs` and `MultiSlider` a little bit to support this new usage.

#### Reviewers should focus on:

- does this still support react-hot-loader?