### PR TITLE
[Icon] Allow setting size on container span

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -22,6 +22,10 @@
   > svg {
     // prevent extra vertical whitespace
     display: block;
+    // Allow width and height to be set on the span in css. This is ignored if the
+    // span does not have an explicit size set.
+    width: inherit;
+    height: inherit;
 
     // inherit text color unless explicit fill is set
     &:not([fill]) {

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -47,7 +47,7 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
 
         return (
             <Example options={options} {...this.props}>
-                <Icon icon={icon} iconSize={iconSize} intent={intent} />
+                <Icon icon={icon} iconSize={iconSize} intent={intent} key={iconSize} />
             </Example>
         );
     }

--- a/packages/icons/src/index.md
+++ b/packages/icons/src/index.md
@@ -7,12 +7,12 @@ reference: icons
 Blueprint provides over 300 vector UI icons in two sizes (16px and 20px) and two formats (SVG and fonts).
 It's easy to change their color or apply effects like text shadows via standard SVG or CSS properties.
 
-There are two ways of using Blueprint UI icons, described in more detail in the
-[**Icon component documentation**](#core/components/icon):
+Many Blueprint components support an `icon` prop which accepts an icon name (such as `"history"`) or a JSX element to use as the icon.
 
-1. React component renders SVG paths: `<Icon icon="more" />`
-2. CSS classes use icon fonts: `<span className="@ns-icon-standard @ns-icon-more" />`
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    See the [**`Icon` component documentation**](#core/components/icon) for full API details.
+</div>
 
-Many Blueprint components support an `icon` prop to control a React `<Icon>` component, which accepts both the full name `@ns-icon-projects` and the short name `projects`.
+@reactExample IconExample
 
 @reactDocs Icons


### PR DESCRIPTION
While #2884 fixed many issues with the icons by wrapping them in an html tag, it removed the option to override an icon's size from CSS easily. It was still possible using:
```css
.my-cool-icon {
  svg {
    width: 48px;
    height: 48px;
  }
}
```
This, however, requires using the icon component's implementation details.

Before that change—and after this one—this is easily done as expected:
```css
.my-cool-icon {
  width: 48px;
  height: 48px;
}
```

I'm not sure what kind of tests or examples are useful here. You can test this easily by going to the icon component examples and setting a width on the `span` around the icon svg in the inspector—the icon will change size. Before this PR, nothing would happen.