### PR TITLE
[Table] Newly focused cell after keyboard navigation is now transformed

### DIFF
--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -15,7 +15,11 @@ import { IRegion, Regions } from "../regions";
 import { DragEvents } from "./dragEvents";
 import { Draggable, ICoordinateData, IDraggableProps } from "./draggable";
 
-export type ISelectedRegionTransform = (region: IRegion, event: MouseEvent, coords?: ICoordinateData) => IRegion;
+export type ISelectedRegionTransform = (
+    region: IRegion,
+    event: MouseEvent | KeyboardEvent,
+    coords?: ICoordinateData,
+) => IRegion;
 
 export interface ISelectableProps {
     /**

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1826,6 +1826,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
 
         // change selection to match new focus cell location
         const newSelectionRegions = [Regions.cell(newFocusedCell.row, newFocusedCell.col)];
+        const { selectedRegionTransform } = this.props;
+        if (selectedRegionTransform != null) {
+            // tslint:disable-next-line no-unnecessary-callback-wrapper
+            newSelectionRegions.forEach(region => selectedRegionTransform(region, undefined));
+        }
         this.handleSelection(newSelectionRegions);
         this.handleFocus(newFocusedCell);
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1828,7 +1828,6 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const newSelectionRegions = [Regions.cell(newFocusedCell.row, newFocusedCell.col)];
         const { selectedRegionTransform } = this.props;
         if (selectedRegionTransform != null) {
-            // tslint:disable-next-line no-unnecessary-callback-wrapper
             newSelectionRegions.forEach(region => selectedRegionTransform(region, undefined));
         }
         this.handleSelection(newSelectionRegions);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1829,7 +1829,7 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         const { selectedRegionTransform } = this.props;
         const transformedSelectionRegions =
             selectedRegionTransform != null
-                ? newSelectionRegions.map(region => selectedRegionTransform(region, undefined))
+                ? newSelectionRegions.map(region => selectedRegionTransform(region, e))
                 : newSelectionRegions;
         this.handleSelection(transformedSelectionRegions);
         this.handleFocus(newFocusedCell);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1827,10 +1827,11 @@ export class Table extends AbstractComponent<ITableProps, ITableState> {
         // change selection to match new focus cell location
         const newSelectionRegions = [Regions.cell(newFocusedCell.row, newFocusedCell.col)];
         const { selectedRegionTransform } = this.props;
-        if (selectedRegionTransform != null) {
-            newSelectionRegions.forEach(region => selectedRegionTransform(region, undefined));
-        }
-        this.handleSelection(newSelectionRegions);
+        const transformedSelectionRegions =
+            selectedRegionTransform != null
+                ? newSelectionRegions.map(region => selectedRegionTransform(region, undefined))
+                : newSelectionRegions;
+        this.handleSelection(transformedSelectionRegions);
         this.handleFocus(newFocusedCell);
 
         // keep the focused cell in view


### PR DESCRIPTION
#### Fixes #2871 

#### Changes proposed in this pull request:

This pull request implements a change to the `Table` component that passes the newly focused cell through the `selectedRegionTransform` function of the table if it is present. This is to ensure that invariants enforced in the `selectedRegionTransform` function (e.g., "only whole rows should be selected") are not violated after the user navigates to another cell with the keyboard.

#### Reviewers should focus on:

Please check my changes made to the `handleFocusMove()` method of the `Table` component. I have updated the table dev app as well to make this change easier to test.
