### PR TITLE
[Input/InputGroup/TextArea] small modifier follow-ups

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -49,7 +49,7 @@ $pt-border-radius: floor($pt-grid-size / 3) !default;
 // Buttons
 $pt-button-height: $pt-grid-size * 3 !default;
 $pt-button-height-small: $pt-grid-size * 2.4 !default;
-$pt-button-height-smaller: $pt-grid-size * 1.8 !default;
+$pt-button-height-smaller: $pt-grid-size * 2 !default;
 $pt-button-height-large: $pt-grid-size * 4 !default;
 
 // Inputs

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -6,7 +6,7 @@
 @import "../button/common";
 
 $input-padding-horizontal: $pt-grid-size !default;
-$input-small-padding: $pt-grid-size * 0.7 !default;
+$input-small-padding: $pt-input-height-small - $pt-icon-size-standard !default;
 $input-font-weight: 400 !default;
 $input-transition: box-shadow $pt-transition-duration $pt-transition-ease;
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -159,7 +159,7 @@ $control-group-stack: (
 
   &[type="search"],
   &.#{$ns}-round {
-    padding: 0 ($input-padding-horizontal * 1.5);
+    padding: 0 ($input-small-padding * 1.5);
   }
 }
 

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -185,11 +185,11 @@ $input-button-height-small: $pt-button-height-smaller !default;
       @include pt-input-small();
 
       &:not(:first-child) {
-        padding-left: $pt-icon-size-standard + $input-small-padding * 2;
+        padding-left: $pt-icon-size-standard + $input-small-padding;
       }
 
       &:not(:last-child) {
-        padding-right: $pt-icon-size-standard + $input-small-padding * 2;
+        padding-right: $pt-icon-size-standard + $input-small-padding;
       }
     }
   }

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -85,10 +85,13 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   // direct descendant to exclude icons in buttons
   > .#{$ns}-icon {
-    @include pt-icon($pt-icon-size-standard);
     // bump icon up so it sits above input
     z-index: 1;
     color: $pt-icon-color;
+
+    &:empty {
+      @include pt-icon($pt-icon-size-standard);
+    }
   }
 
   // adjusting the margin of spinners in input groups

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -91,20 +91,25 @@ Markup:
 Styleguide textarea
 */
 
-// stylelint-disable selector-no-qualifying-type
+// stylelint-disable-next-line selector-no-qualifying-type
 textarea.#{$ns}-input {
   max-width: 100%;
-  height: auto;
   padding: $input-padding-horizontal;
-  line-height: $pt-line-height;
 
-  &.#{$ns}-large {
-    line-height: $pt-line-height;
-    font-size: $pt-font-size-large;
+  &,
+  &.#{$ns}-large,
+  &.#{$ns}-small {
+    // override input styles for these modifiers.
+    // line-height is needed to center text on <input> but not on multiline <textarea>
+    height: auto;
+    line-height: inherit;
+  }
+
+  &.#{$ns}-small {
+    padding: $input-small-padding;
   }
 
   .#{$ns}-dark & {
     @include pt-dark-input();
   }
 }
-// stylelint-enable selector-no-qualifying-type

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -21,6 +21,11 @@ export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTML
     large?: boolean;
 
     /**
+     * Whether the text area should appear with small styling.
+     */
+    small?: boolean;
+
+    /**
      * Ref handler that receives HTML `<textarea>` element backing this component.
      */
     inputRef?: (ref: HTMLTextAreaElement | null) => any;
@@ -32,7 +37,7 @@ export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TextArea`;
 
     public render() {
-        const { className, fill, intent, large, inputRef, ...htmlProps } = this.props;
+        const { className, fill, inputRef, intent, large, small, ...htmlProps } = this.props;
 
         const rootClasses = classNames(
             Classes.INPUT,
@@ -40,6 +45,7 @@ export class TextArea extends React.PureComponent<ITextAreaProps, {}> {
             {
                 [Classes.FILL]: fill,
                 [Classes.LARGE]: large,
+                [Classes.SMALL]: small,
             },
             className,
         );


### PR DESCRIPTION
#### Follow-ups from #2953 

#### Changes proposed in this pull request:

- adjust newly added variables a bit so small inputs sit better.
    - smaller buttons are a little bigger so there's more space around icon
    - adjust input small padding so icon remains centered
- fix font icon size in input-group CSS example
- fix padding on small+round inputs
- refactor `<textarea>` styles to better support small/large sizes
- add `TextArea` `small` prop

#### Screenshots

before (#2953) | after (this PR)
---|--
![image](https://user-images.githubusercontent.com/464822/46504039-8eabe880-c7e1-11e8-8799-9e349d42dc1f.png) | ![image](https://user-images.githubusercontent.com/464822/46504028-8784da80-c7e1-11e8-916b-d92eea8dc8f9.png)
![image](https://user-images.githubusercontent.com/464822/46504055-9c616e00-c7e1-11e8-82b8-e22c00406874.png)| ![image](https://user-images.githubusercontent.com/464822/46504064-a2574f00-c7e1-11e8-87ad-6b97f0c51cef.png)

cc @tnrich. thank you for getting this started!