### PR TITLE
[Tag] don't render text if no children

### DIFF
--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, IIntentProps, IProps, Utils } from "../../common";
+import { isReactNodeEmpty } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { Text } from "../text/text";
 
@@ -117,9 +118,11 @@ export class Tag extends React.PureComponent<ITagProps, {}> {
         return (
             <span {...htmlProps} className={tagClasses} tabIndex={interactive ? tabIndex : undefined}>
                 <Icon icon={icon} />
-                <Text className={Classes.FILL} ellipsize={!multiline} tagName="span">
-                    {children}
-                </Text>
+                {!isReactNodeEmpty(children) && (
+                    <Text className={Classes.FILL} ellipsize={!multiline} tagName="span">
+                        {children}
+                    </Text>
+                )}
                 <Icon icon={rightIcon} />
                 {removeButton}
             </span>

--- a/packages/core/test/tag/tagTests.tsx
+++ b/packages/core/test/tag/tagTests.tsx
@@ -21,6 +21,14 @@ describe("<Tag>", () => {
         );
     });
 
+    it("text is not rendered if omitted", () => {
+        assert.isFalse(
+            shallow(<Tag icon="tick" />)
+                .find(Text)
+                .exists(),
+        );
+    });
+
     it("renders icons", () => {
         const wrapper = shallow(<Tag icon="tick" rightIcon="airplane" />);
         assert.lengthOf(wrapper.find(Icon), 2);


### PR DESCRIPTION
#### Fixes #2991 

#### Changes proposed in this pull request:

- only render `Text` child if children is not empty.
- this is analogous to what we did in #2775 for `Button`