### PR TITLE
[tslint] reject bp3- prefix too

### DIFF
--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -116,7 +116,7 @@ describe("<PanelStack>", () => {
 
         const transitionGroupClassName = panelStackWrapper.findClass(TEST_CLASS_NAME).props().className;
         assert.exists(transitionGroupClassName);
-        assert.equal(transitionGroupClassName.indexOf("bp3-panel-stack"), 0);
+        assert.equal(transitionGroupClassName.indexOf(Classes.PANEL_STACK), 0);
     });
 
     it("can render a panel without a title", () => {

--- a/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
+++ b/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
@@ -9,8 +9,9 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 import { addImportToFile } from "./utils/addImportToFile";
 
-// find all pt- prefixed classes, except those that begin with pt-icon (handled by other rules)
-const BLUEPRINT_CLASSNAME_PATTERN = /[^\w-<.](pt-(?!icon-?)[\w-]+)/g;
+// find all pt- prefixed classes, except those that begin with pt-icon (handled by other rules).
+// currently support pt- and bp3- prefixes.
+const BLUEPRINT_CLASSNAME_PATTERN = /[^\w-<.]((pt|bp3)-(?!icon-?)[\w-]+)/g;
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
@@ -121,7 +122,7 @@ function wrapForParent(statement: string, node: ts.Node) {
 /** Converts a `pt-class-name` literal to `Classes.CLASS_NAME` constant. */
 function convertPtClassName(text: string) {
     const className = text
-        .replace("pt-", "")
+        .replace(/(pt|bp3)-/, "")
         .replace(/-/g, "_")
         .toUpperCase();
     return `Classes.${className}`;

--- a/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
+++ b/packages/tslint-config/src/rules/blueprintClassesConstantsRule.ts
@@ -79,10 +79,11 @@ function getAllMatches(className: string) {
 
 /** Produce replacement text for a string literal that contains invalid classes. */
 function getLiteralReplacement(className: string, ptClassStrings: string[]) {
-    // remove all illegal classnames, then slice off the quotes, and trim any remaining white space
+    // remove all illegal classnames, then slice off the quotes, then merge & trim any remaining white space
     const stringWithoutPtClasses = ptClassStrings
         .reduce((value, cssClass) => value.replace(cssClass, ""), className)
         .slice(1, -1)
+        .replace(/(\s)+/, "$1")
         .trim();
     // special case: only one invalid class name
     if (stringWithoutPtClasses.length === 0 && ptClassStrings.length === 1) {

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.fix
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.fix
@@ -1,2 +1,3 @@
 // Make sure that this rule doesn't modify icon classes, that's handled elsewhere.
 <span className"pt-icon pt-icon-folder-open" />
+<span className"bp3-icon bp3-icon-folder-open" />

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test-icons.tsx.lint
@@ -1,2 +1,3 @@
 // Make sure that this rule doesn't modify icon classes, that's handled elsewhere.
 <span className"pt-icon pt-icon-folder-open" />
+<span className"bp3-icon bp3-icon-folder-open" />

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.fix
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.fix
@@ -1,13 +1,17 @@
 import { Classes } from "@blueprintjs/core";
 apt-get
 at 4pt-size
+
 `${Classes.LARGE} script-source apt-get`
 `script-source ${Classes.LARGE} apt-get`
 `${template} ${Classes.LARGE}`
+`${template} ${Classes.VERTICAL} ${Classes.FILL}`
 
 <Button className=`${Classes.LARGE} my-class` />
+<Button className={Classes.MINIMAL} />
 
 classNames(Classes.BUTTON, Classes.INTENT_PRIMARY)
+classNames(Classes.BUTTON, Classes.MINIMAL)
 
 <pt-popover> // angular directive
 

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.fix
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.fix
@@ -1,7 +1,7 @@
 import { Classes } from "@blueprintjs/core";
 apt-get
 at 4pt-size
-`${Classes.LARGE} script-source  apt-get`
+`${Classes.LARGE} script-source apt-get`
 `script-source ${Classes.LARGE} apt-get`
 `${template} ${Classes.LARGE}`
 

--- a/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
+++ b/packages/tslint-config/test/rules/blueprint-classes-constants/true/test.tsx.lint
@@ -1,17 +1,25 @@
 apt-get
 at 4pt-size
+
 "script-source pt-large apt-get"
                ~~~~~~~~  [msg]
 `script-source pt-large apt-get`
                ~~~~~~~~  [msg]
 `${template} pt-large`
              ~~~~~~~~  [msg]
+`${template} pt-vertical bp3-fill`
+             ~~~~~~~~~~~  [msg]
 
 <Button className="my-class pt-large" />
                             ~~~~~~~~ [msg]
+<Button className="bp3-minimal" />
+                   ~~~~~~~~~~~ [msg]
 
 classNames(Classes.BUTTON, "pt-intent-primary")
                             ~~~~~~~~~~~~~~~~~ [msg]
+classNames("bp3-button", "bp3-minimal")
+            ~~~~~~~~~~ [msg]
+                          ~~~~~~~~~~~ [msg]
 
 <pt-popover> // angular directive
 


### PR DESCRIPTION
#### Fixes #2995 

#### Changes proposed in this pull request:

- reject `bp3-` prefix (and tests)
- merge multiple spaces in remaining template string