### PR TITLE
[DateInput] notify onError listener on key down Enter

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -343,13 +343,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
                 this.setState({ isInputFocused: false });
             }
 
-            if (isNaN(date.valueOf())) {
-                Utils.safeInvoke(this.props.onError, new Date(undefined));
-            } else if (!this.isDateInRange(date)) {
-                Utils.safeInvoke(this.props.onError, date);
-            } else {
-                Utils.safeInvoke(this.props.onChange, date, true);
-            }
+            this.invokeDateChangeListener(date);
         } else {
             if (valueString.length === 0) {
                 this.setState({ isInputFocused: false, value: null, valueString: null });
@@ -422,6 +416,16 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
             this.lastElementInPopover.removeEventListener("blur", this.handlePopoverBlur);
         }
     };
+
+    private invokeDateChangeListener(date: Date) {
+        if (isNaN(date.valueOf())) {
+            Utils.safeInvoke(this.props.onError, new Date(undefined));
+        } else if (!this.isDateInRange(date)) {
+            Utils.safeInvoke(this.props.onError, date);
+        } else {
+            Utils.safeInvoke(this.props.onChange, date, true);
+        }
+    }
 
     /** safe wrapper around invoking input props event handler (prop defaults to undefined) */
     private safeInvokeInputProp(name: keyof HTMLInputProps, e: React.SyntheticEvent<HTMLElement>) {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -418,8 +418,8 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
     };
 
     private invokeDateChangeListener(newDate: Date | null, isUserChange: boolean) {
-        if (newDate === null) {
-            Utils.safeInvoke(this.props.onError, newDate);
+        if (newDate == null) {
+            Utils.safeInvoke(this.props.onError, null);
         } else if (isNaN(newDate.valueOf())) {
             Utils.safeInvoke(this.props.onError, new Date(undefined));
         } else if (!this.isDateInRange(newDate)) {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -417,13 +417,15 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         }
     };
 
-    private invokeDateChangeListener(date: Date, isUserChange: boolean) {
-        if (isNaN(date.valueOf())) {
+    private invokeDateChangeListener(newDate: Date | null, isUserChange: boolean) {
+        if (newDate === null) {
+            Utils.safeInvoke(this.props.onError, newDate);
+        } else if (isNaN(newDate.valueOf())) {
             Utils.safeInvoke(this.props.onError, new Date(undefined));
-        } else if (!this.isDateInRange(date)) {
-            Utils.safeInvoke(this.props.onError, date);
+        } else if (!this.isDateInRange(newDate)) {
+            Utils.safeInvoke(this.props.onError, newDate);
         } else {
-            Utils.safeInvoke(this.props.onChange, date, isUserChange);
+            Utils.safeInvoke(this.props.onChange, newDate, isUserChange);
         }
     }
 

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -275,7 +275,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         } else {
             this.setState({ isInputFocused, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, newDate, isUserChange);
+        this.invokeDateChangeListener(newDate, isUserChange);
     };
 
     private hasMonthChanged(prevDate: Date | null, nextDate: Date | null) {
@@ -343,7 +343,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
                 this.setState({ isInputFocused: false });
             }
 
-            this.invokeDateChangeListener(date);
+            this.invokeDateChangeListener(date, true);
         } else {
             if (valueString.length === 0) {
                 this.setState({ isInputFocused: false, value: null, valueString: null });
@@ -417,13 +417,13 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         }
     };
 
-    private invokeDateChangeListener(date: Date) {
+    private invokeDateChangeListener(date: Date, isUserChange: boolean) {
         if (isNaN(date.valueOf())) {
             Utils.safeInvoke(this.props.onError, new Date(undefined));
         } else if (!this.isDateInRange(date)) {
             Utils.safeInvoke(this.props.onError, date);
         } else {
-            Utils.safeInvoke(this.props.onChange, date, true);
+            Utils.safeInvoke(this.props.onChange, date, isUserChange);
         }
     }
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -415,10 +415,10 @@ describe("<DateInput>", () => {
                     outOfRangeMessage={rangeMessage}
                 />,
             );
-            const value = "2/1/2030";
+            const outOfRangeDate = "2/1/2030";
             wrapper
                 .find("input")
-                .simulate("change", { target: { value } })
+                .simulate("change", { target: { outOfRangeDate } })
                 .simulate("keydown", { which: Keys.ENTER });
 
             assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
@@ -437,14 +437,14 @@ describe("<DateInput>", () => {
                     outOfRangeMessage={rangeMessage}
                 />,
             );
-            const value = "2/1/2030";
+            const outOfRangeDate = "2/1/2030";
             wrapper
                 .find("input")
-                .simulate("change", { target: { value } })
+                .simulate("change", { target: { outOfRangeDate } })
                 .simulate("keydown", { which: Keys.ENTER });
 
             assert.isTrue(onError.calledOnce);
-            assertDateEquals(onError.args[0][0], new Date(value));
+            assertDateEquals(onError.args[0][0], new Date(outOfRangeDate));
         });
 
         it("Typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -403,7 +403,7 @@ describe("<DateInput>", () => {
             assertDateEquals(onError.args[0][0], new Date(value));
         });
 
-        it("typing in a date out of range and pressing enter displays the error message", () => {
+        it("typing in a date out of range and pressing enter displays the error message and calls onError with invalid date", () => {
             const rangeMessage = "RANGE ERROR";
             const onError = sinon.spy();
             const wrapper = mount(
@@ -423,25 +423,6 @@ describe("<DateInput>", () => {
 
             assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
-        });
-
-        it("typing in a date out of range and pressing enter calls onError with invalid date", () => {
-            const rangeMessage = "RANGE ERROR";
-            const onError = sinon.spy();
-            const wrapper = mount(
-                <DateInput
-                    {...DATE_FORMAT}
-                    defaultValue={new Date(2015, Months.MAY, 1)}
-                    minDate={new Date(2015, Months.MARCH, 1)}
-                    onError={onError}
-                    outOfRangeMessage={rangeMessage}
-                />,
-            );
-            const outOfRangeDate = "2/1/2030";
-            wrapper
-                .find("input")
-                .simulate("change", { target: { outOfRangeDate } })
-                .simulate("keydown", { which: Keys.ENTER });
 
             assert.isTrue(onError.calledOnce);
             assertDateEquals(onError.args[0][0], new Date(outOfRangeDate));

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -403,7 +403,7 @@ describe("<DateInput>", () => {
             assertDateEquals(onError.args[0][0], new Date(value));
         });
 
-        it("typing in a date out of range and pressing enter displays the error message and calls onError with invalid date", () => {
+        it("typing in a date out of range and pressing enter displays the error message", () => {
             const rangeMessage = "RANGE ERROR";
             const onError = sinon.spy();
             const wrapper = mount(
@@ -423,6 +423,25 @@ describe("<DateInput>", () => {
 
             assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
+        });
+
+        it("typing in a date out of range and pressing enter calls onError with invalid date", () => {
+            const rangeMessage = "RANGE ERROR";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput
+                    {...DATE_FORMAT}
+                    defaultValue={new Date(2015, Months.MAY, 1)}
+                    minDate={new Date(2015, Months.MARCH, 1)}
+                    onError={onError}
+                    outOfRangeMessage={rangeMessage}
+                />,
+            );
+            const value = "2/1/2030";
+            wrapper
+                .find("input")
+                .simulate("change", { target: { value } })
+                .simulate("keydown", { which: Keys.ENTER });
 
             assert.isTrue(onError.calledOnce);
             assertDateEquals(onError.args[0][0], new Date(value));

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -403,6 +403,31 @@ describe("<DateInput>", () => {
             assertDateEquals(onError.args[0][0], new Date(value));
         });
 
+        it("typing in a date out of range and pressing enter displays the error message and calls onError with invalid date", () => {
+            const rangeMessage = "RANGE ERROR";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput
+                    {...DATE_FORMAT}
+                    defaultValue={new Date(2015, Months.MAY, 1)}
+                    minDate={new Date(2015, Months.MARCH, 1)}
+                    onError={onError}
+                    outOfRangeMessage={rangeMessage}
+                />,
+            );
+            const value = "2/1/2030";
+            wrapper
+                .find("input")
+                .simulate("change", { target: { value } })
+                .simulate("keydown", { which: Keys.ENTER });
+
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
+
+            assert.isTrue(onError.calledOnce);
+            assertDateEquals(onError.args[0][0], new Date(value));
+        });
+
         it("Typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {
             const invalidDateMessage = "INVALID DATE";
             const onError = sinon.spy();

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -421,6 +421,9 @@ describe("<DateInput>", () => {
                 .simulate("change", { target: { outOfRangeDate } })
                 .simulate("keydown", { which: Keys.ENTER });
 
+            // tslint:disable-next-line:no-console
+            console.log(wrapper.find(InputGroup));
+
             assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/2550

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation: **N/A**

#### Changes proposed in this pull request:

- Fix a bug in `<DateInput>` where pressing <kbd>Enter</kbd> with an out of range date wouldn't invoke `onError`.
- In order to fix, I referenced the logic in `handleInputBlur` which handles out of range and invalid dates correctly.

#### Reviewers should focus on:

- The tests in `dateInputTests.tsx` don't appear to conform to a naming pattern but I'd like to sentence case tests in a follow up PR if that sounds reasonable. Concrete example:
  - "Clicking a date in... " => "clicking a date in..."

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
