### PR TITLE
[Popover] target supports TargetRenderer function

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -37,22 +37,28 @@ export type PopoverInteractionKind = typeof PopoverInteractionKind[keyof typeof 
  *
  * **Always spread the given `props` and attach the `ref` handler to an element
  * that supports HTML props**. Failure to do this will break the positioning and
- * all built-in interactions.
+ * all built-in interactions!
  *
  * ```tsx
  * import { Button, Popover, TargetRenderer } from "@blueprintjs/core";
  *
  * const ButtonTarget: TargetRenderer = (props, ref, isOpen) => (
  *     // always spread props and attach ref handler!
- *     <Button {...props} elementRef={ref} intent="primary" text="Custom button target" />
+ *     <Button {...props} elementRef={ref} intent="primary" text="Custom target" />
  * );
  *
  * <Popover content={<em>Hello!</em>} target={ButtonTarget} />
  * ```
  */
 export type TargetRenderer = (
+    /**
+     * Props such as `className` and event handlers to attach to the target
+     * element, for `Popover` interactions.
+     */
     props: React.HTMLAttributes<HTMLElement>,
+    /** Ref handler required to position popover relative to target element. */
     ref: (ref: HTMLElement) => void,
+    /** Whether the popover is currently open. */
     isOpen: boolean,
 ) => JSX.Element;
 
@@ -97,12 +103,8 @@ export interface IPopoverProps extends IPopoverSharedProps {
 
     /**
      * The target to which the popover content is attached. Instead of this
-     * prop, a target element (not `TargetRenderer`) can be passed as the first
-     * element in `children`.
-     *
-     * Providing a `TargetRenderer` function will invoke that function with a
-     * bag of `props` and a `ref` handler that must both be attached to a DOM
-     * element.
+     * prop, a target element (not a `TargetRenderer`) can be passed as the
+     * first element in `children`.
      */
     target?: string | JSX.Element | TargetRenderer;
 }

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Button, Intent, IPopoverProps, Popover, Position } from "@blueprintjs/core";
+import { Button, IPopoverProps, Popover, Position, TargetRenderer } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { FileMenu } from "./common/fileMenu";
 
@@ -16,13 +16,17 @@ export class PopoverMinimalExample extends React.PureComponent<IExampleProps> {
 
         return (
             <Example options={false} {...this.props}>
-                <Popover {...baseProps} minimal={true}>
-                    <Button intent={Intent.PRIMARY}>Minimal</Button>
-                </Popover>
-                <Popover {...baseProps}>
-                    <Button>Default</Button>
-                </Popover>
+                <Popover {...baseProps} minimal={true} target={this.renderLeftButton} />
+                <Popover {...baseProps} target={this.renderRightButton} />
             </Example>
         );
     }
+
+    private renderLeftButton: TargetRenderer = (props, ref, isOpen) => {
+        return <Button active={isOpen} intent="primary" text="Minimal" elementRef={ref} {...props} />;
+    };
+
+    private renderRightButton: TargetRenderer = (props, ref, isOpen) => {
+        return <Button active={isOpen} text="Default" elementRef={ref} {...props} />;
+    };
 }


### PR DESCRIPTION
#### Does this fix any issues?

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

`Popover` `target` prop now supports new `TargetRenderer` function type. This usage allows your target element to _also_ be the `Classes.POPOVER_TARGET` (assuming you spread the given props as required) and thereby remove one of the DOM wrapper elements!

⚠️  The `content` prop did not get this treatment as it's buried deep in the popover DOM already and would not derive any benefit from callbackification.

```tsx
import { Button, Popover, TargetRenderer } from "@blueprintjs/core";

const ButtonTarget: TargetRenderer = (props, ref, isOpen) => (
    // always spread props and attach ref handler!
    <Button {...props} active={isOpen} elementRef={ref} text="Custom target" />
);
<Popover content={<em>Hello!</em>} target={ButtonTarget} />
```

The above code now renders the following psuedo-markup:

```html
<span class="@ns-popover-wrapper">
    <Button class="@ns-popover-target @ns-active" text="Custom target" />
</span>
```

#### Reviewers should focus on:

- massive edits to "Popover Concepts" docs to explain content/target usage. 
   thanks @themadcreator 📖 

