### PR TITLE
[DateInput] Add support for datepicker clearButtonText and todayButtonText props.

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -37,6 +37,13 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
     canClearSelection?: boolean;
 
     /**
+     * Text for the reset button in the date picker action bar.
+     * Passed to `DatePicker` component.
+     * @default "Clear"
+     */
+    clearButtonText?: string;
+
+    /**
      * Whether the calendar popover should close when a date is selected.
      * @default true
      */
@@ -108,6 +115,13 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
      * in the input field, pass `new Date(undefined)` to the value prop.
      */
     value?: Date | null;
+
+    /**
+     * Text for the today button in the date picker action bar.
+     * Passed to `DatePicker` component.
+     * @default "Today"
+     */
+    todayButtonText?: string;
 }
 
 export interface IDateInputState {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -11,7 +11,7 @@ import * as sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup, Intent, Keys, Popover, Position } from "@blueprintjs/core";
 import { Months } from "../src/common/months";
-import { Classes, DateInput, IDateInputProps, TimePicker, TimePrecision } from "../src/index";
+import { Classes, DateInput, DatePicker, IDateInputProps, TimePicker, TimePrecision } from "../src/index";
 import { DATE_FORMAT } from "./common/dateFormat";
 import * as DateTestUtils from "./common/dateTestUtils";
 
@@ -199,6 +199,21 @@ describe("<DateInput>", () => {
 
         // ensure this additional prop was passed through undeterred.
         assert.equal(timePicker.prop("disabled"), true);
+    });
+
+    it("clearButtonText and todayButtonText props are passed to DatePicker", () => {
+        const datePickerProps = {
+            clearButtonText: "clear",
+            todayButtonText: "today",
+        };
+
+        const wrapper = mount(<DateInput {...DATE_FORMAT} {...datePickerProps} />).setState({
+            isOpen: true,
+        });
+        const datePicker = wrapper.find(DatePicker);
+
+        assert.equal(datePicker.prop("clearButtonText"), "clear");
+        assert.equal(datePicker.prop("todayButtonText"), "today");
     });
 
     it("inputProps are passed to InputGroup", () => {


### PR DESCRIPTION
#### Fixes #3015 

#### Changes proposed in this pull request:

Add `todayButtonText` and `clearButtonText` props to `DateInput` so these properties can be passed down to the underlaying `DatePicker` that is used by it when the props are spread into that component.

#### Reviewers should focus on:

The adding of both props to the `DateInput` component.
