### PR TITLE
DateInput tab fix

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -379,10 +379,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
         if (e.which === Keys.ENTER) {
             const nextDate = this.parseDate(this.state.valueString);
             this.handleDateChange(nextDate, true, true);
-        } else if (e.which === Keys.TAB && e.shiftKey) {
-            // close the popover if focus will move to the previous element on
-            // the page. tabbing forward should *not* close the popover, because
-            // focus will be moving into the popover itself.
+        } else if (e.which === Keys.TAB) {
             this.setState({ isOpen: false });
         } else if (e.which === Keys.ESCAPE) {
             this.setState({ isOpen: false });


### PR DESCRIPTION
#### Fixes #2901

#### Changes proposed in this pull request:

This ensures that when pressing `tab` the focus of the datepicker is blurred and disabled.

The comment included is no longer valid, as the popover is by default handled in a portal, which means the tab index is incorrect anyway.

#### Reviewers should focus on:

Whether this breaks anything in terms of UI.

