### PR TITLE
[Portal] add container prop

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -76,6 +76,13 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
     transitionDuration?: number;
 
     /**
+     * The container that the Alert renders to.
+     * This prop only available when `usePortal` is set to `true`
+     * @default document.body
+     */
+    container?: HTMLElement;
+
+    /**
      * Handler invoked when the alert is canceled. Alerts can be **canceled** in the following ways:
      * - clicking the cancel button (if `cancelButtonText` is defined)
      * - pressing the escape key (if `canEscapeKeyCancel` is enabled)
@@ -130,6 +137,7 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
                 canEscapeKeyClose={canEscapeKeyCancel}
                 canOutsideClickClose={canOutsideClickCancel}
                 onClose={this.handleCancel}
+                container={this.props.container}
             >
                 <div className={Classes.ALERT_BODY}>
                     <Icon icon={icon} iconSize={40} intent={intent} />

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -76,11 +76,11 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
     transitionDuration?: number;
 
     /**
-     * The container that the Alert renders to.
-     * This prop only available when `usePortal` is set to `true`
+     * The container element into which the overlay renders its contents, when `usePortal` is `true`.
+     * This prop is ignored if `usePortal` is `false`.
      * @default document.body
      */
-    container?: HTMLElement;
+    portalContainer?: HTMLElement;
 
     /**
      * Handler invoked when the alert is canceled. Alerts can be **canceled** in the following ways:
@@ -137,7 +137,7 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
                 canEscapeKeyClose={canEscapeKeyCancel}
                 canOutsideClickClose={canOutsideClickCancel}
                 onClose={this.handleCancel}
-                container={this.props.container}
+                portalContainer={this.props.portalContainer}
             >
                 <div className={Classes.ALERT_BODY}>
                     <Icon icon={icon} iconSize={40} intent={intent} />

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -76,7 +76,7 @@ export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
                 {...this.props}
                 className={Classes.OVERLAY_SCROLL_CONTAINER}
                 hasBackdrop={true}
-                container={this.props.container}
+                portalContainer={this.props.portalContainer}
             >
                 <div className={Classes.DIALOG_CONTAINER}>
                     <div className={classNames(Classes.DIALOG, this.props.className)} style={this.props.style}>

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -72,7 +72,12 @@ export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
 
     public render() {
         return (
-            <Overlay {...this.props} className={Classes.OVERLAY_SCROLL_CONTAINER} hasBackdrop={true}>
+            <Overlay
+                {...this.props}
+                className={Classes.OVERLAY_SCROLL_CONTAINER}
+                hasBackdrop={true}
+                container={this.props.container}
+            >
                 <div className={Classes.DIALOG_CONTAINER}>
                     <div className={classNames(Classes.DIALOG, this.props.className)} style={this.props.style}>
                         {this.maybeRenderHeader()}

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -72,12 +72,7 @@ export class Dialog extends AbstractPureComponent<IDialogProps, {}> {
 
     public render() {
         return (
-            <Overlay
-                {...this.props}
-                className={Classes.OVERLAY_SCROLL_CONTAINER}
-                hasBackdrop={true}
-                portalContainer={this.props.portalContainer}
-            >
+            <Overlay {...this.props} className={Classes.OVERLAY_SCROLL_CONTAINER} hasBackdrop={true}>
                 <div className={Classes.DIALOG_CONTAINER}>
                     <div className={classNames(Classes.DIALOG, this.props.className)} style={this.props.style}>
                         {this.maybeRenderHeader()}

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -57,7 +57,7 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
 
     /**
      * Whether the overlay should be wrapped in a `Portal`, which renders its contents in a new
-     * element attached to `container` prop.
+     * element attached to `portalContainer` prop.
      *
      * This prop essentially determines which element is covered by the backdrop: if `false`,
      * then only its parent is covered; otherwise, the entire page is covered (because the parent
@@ -70,11 +70,11 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
     usePortal?: boolean;
 
     /**
-     * The container that the overlay renders its contents to.
-     * This prop only available when `usePortal` is set to `true`
+     * The container element into which the overlay renders its contents, when `usePortal` is `true`.
+     * This prop is ignored if `usePortal` is `false`.
      * @default document.body
      */
-    container?: HTMLElement;
+    portalContainer?: HTMLElement;
 
     /**
      * A callback that is invoked when user interaction causes the overlay to close, such as
@@ -192,7 +192,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             return null;
         }
 
-        const { children, className, usePortal, container, isOpen } = this.props;
+        const { children, className, usePortal, portalContainer, isOpen } = this.props;
 
         // TransitionGroup types require single array of children; does not support nested arrays.
         // So we must collapse backdrop and children into one array, and every item must be wrapped in a
@@ -220,10 +220,8 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
                 {childrenWithTransitions}
             </TransitionGroup>
         );
-        if (usePortal && container) {
-            return <Portal container={container}>{transitionGroup}</Portal>;
-        } else if (usePortal) {
-            return <Portal>{transitionGroup}</Portal>;
+        if (usePortal) {
+            return <Portal container={portalContainer}>{transitionGroup}</Portal>;
         } else {
             return transitionGroup;
         }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -57,7 +57,7 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
 
     /**
      * Whether the overlay should be wrapped in a `Portal`, which renders its contents in a new
-     * element attached to `document.body`.
+     * element attached to `container` prop.
      *
      * This prop essentially determines which element is covered by the backdrop: if `false`,
      * then only its parent is covered; otherwise, the entire page is covered (because the parent
@@ -68,6 +68,13 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
      * @default true
      */
     usePortal?: boolean;
+
+    /**
+     * The container that the overlay renders its contents to.
+     * This prop only available when `usePortal` is set to `true`
+     * @default document.body
+     */
+    container?: HTMLElement;
 
     /**
      * A callback that is invoked when user interaction causes the overlay to close, such as
@@ -185,7 +192,7 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
             return null;
         }
 
-        const { children, className, usePortal, isOpen } = this.props;
+        const { children, className, usePortal, container, isOpen } = this.props;
 
         // TransitionGroup types require single array of children; does not support nested arrays.
         // So we must collapse backdrop and children into one array, and every item must be wrapped in a
@@ -213,7 +220,9 @@ export class Overlay extends React.PureComponent<IOverlayProps, IOverlayState> {
                 {childrenWithTransitions}
             </TransitionGroup>
         );
-        if (usePortal) {
+        if (usePortal && container) {
+            return <Portal container={container}>{transitionGroup}</Portal>;
+        } else if (usePortal) {
             return <Portal>{transitionGroup}</Portal>;
         } else {
             return transitionGroup;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -190,6 +190,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
                         transitionDuration={this.props.transitionDuration}
                         transitionName={Classes.POPOVER}
                         usePortal={this.props.usePortal}
+                        container={this.props.container}
                     >
                         <Popper
                             innerRef={this.refHandlers.popover}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -190,7 +190,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
                         transitionDuration={this.props.transitionDuration}
                         transitionName={Classes.POPOVER}
                         usePortal={this.props.usePortal}
-                        container={this.props.container}
+                        portalContainer={this.props.portalContainer}
                     >
                         <Popper
                             innerRef={this.refHandlers.popover}

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -128,7 +128,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
 
     /**
      * Whether the popover should be rendered inside a `Portal` attached to
-     * `document.body`.
+     * `container` prop.
      *
      * Rendering content inside a `Portal` allows the popover content to escape
      * the physical bounds of its parent while still being positioned correctly
@@ -141,6 +141,13 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * @default true
      */
     usePortal?: boolean;
+
+    /**
+     * The container that the popover renders its contents to.
+     * This prop only available when `usePortal` is set to `true`
+     * @default document.body
+     */
+    container?: HTMLElement;
 
     /**
      * HTML tag name for the wrapper element, which also receives the

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -128,7 +128,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
 
     /**
      * Whether the popover should be rendered inside a `Portal` attached to
-     * `container` prop.
+     * `portalContainer` prop.
      *
      * Rendering content inside a `Portal` allows the popover content to escape
      * the physical bounds of its parent while still being positioned correctly
@@ -141,13 +141,6 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * @default true
      */
     usePortal?: boolean;
-
-    /**
-     * The container that the popover renders its contents to.
-     * This prop only available when `usePortal` is set to `true`
-     * @default document.body
-     */
-    container?: HTMLElement;
 
     /**
      * HTML tag name for the wrapper element, which also receives the

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -23,7 +23,8 @@ export interface IPortalProps extends IProps {
     onChildrenMount?: () => void;
 
     /**
-     * The HTML element that children will be mounted to. Default value is `document.body`.
+     * The HTML element that children will be mounted to.
+     * @default document.body
      */
     container?: HTMLElement;
 }

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -75,6 +75,9 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
     }
 
     public componentDidMount() {
+        if (!this.props.container) {
+            return;
+        }
         this.portalElement = this.createContainerElement();
         this.props.container.appendChild(this.portalElement);
         this.setState({ hasMounted: true }, this.props.onChildrenMount);

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -21,6 +21,11 @@ export interface IPortalProps extends IProps {
      * Callback invoked when the children of this `Portal` have been added to the DOM.
      */
     onChildrenMount?: () => void;
+
+    /**
+     * The HTML element that children will be mounted to. Default value is `document.body`.
+     */
+    container?: HTMLElement;
 }
 
 export interface IPortalState {
@@ -49,6 +54,9 @@ const REACT_CONTEXT_TYPES: ValidationMap<IPortalContext> = {
 export class Portal extends React.Component<IPortalProps, IPortalState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Portal`;
     public static contextTypes = REACT_CONTEXT_TYPES;
+    public static defaultProps: IPortalProps = {
+        container: typeof document !== "undefined" ? document.body : null,
+    };
 
     public context: IPortalContext;
     public state: IPortalState = { hasMounted: false };
@@ -68,7 +76,7 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
 
     public componentDidMount() {
         this.portalElement = this.createContainerElement();
-        document.body.appendChild(this.portalElement);
+        this.props.container.appendChild(this.portalElement);
         this.setState({ hasMounted: true }, this.props.onChildrenMount);
         if (cannotCreatePortal) {
             this.unstableRenderNoPortal();

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -67,7 +67,7 @@ export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}
                 popoverClassName={classes}
-                container={this.props.container}
+                portalContainer={this.props.portalContainer}
             >
                 {children}
             </Popover>

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -67,6 +67,7 @@ export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}
                 popoverClassName={classes}
+                container={this.props.container}
             >
                 {children}
             </Popover>

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -48,6 +48,7 @@ describe("<Alert>", () => {
         assert.lengthOf(container.getElementsByClassName(Classes.ALERT_BODY), 1);
         assert.lengthOf(container.getElementsByClassName(Classes.ALERT_CONTENTS), 1);
         assert.lengthOf(container.getElementsByClassName(Classes.ALERT_FOOTER), 1);
+        document.body.removeChild(container);
     });
 
     it("renders the icon correctly", () => {

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -35,6 +35,21 @@ describe("<Alert>", () => {
         assert.lengthOf(wrapper.find(`.${Classes.ALERT_FOOTER}`), 1);
     });
 
+    it("renders contents to specified container correctly", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        mount(
+            <Alert isOpen={true} container={container}>
+                <p>Are you sure you want to delete this file?</p>
+                <p>There is no going back.</p>
+            </Alert>,
+        );
+        assert.lengthOf(container.getElementsByClassName(Classes.ALERT), 1);
+        assert.lengthOf(container.getElementsByClassName(Classes.ALERT_BODY), 1);
+        assert.lengthOf(container.getElementsByClassName(Classes.ALERT_CONTENTS), 1);
+        assert.lengthOf(container.getElementsByClassName(Classes.ALERT_FOOTER), 1);
+    });
+
     it("renders the icon correctly", () => {
         const wrapper = shallow(
             <Alert icon="warning-sign" isOpen={true} confirmButtonText="Delete">

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -39,15 +39,12 @@ describe("<Alert>", () => {
         const container = document.createElement("div");
         document.body.appendChild(container);
         mount(
-            <Alert isOpen={true} container={container}>
+            <Alert isOpen={true} portalContainer={container}>
                 <p>Are you sure you want to delete this file?</p>
                 <p>There is no going back.</p>
             </Alert>,
         );
         assert.lengthOf(container.getElementsByClassName(Classes.ALERT), 1);
-        assert.lengthOf(container.getElementsByClassName(Classes.ALERT_BODY), 1);
-        assert.lengthOf(container.getElementsByClassName(Classes.ALERT_CONTENTS), 1);
-        assert.lengthOf(container.getElementsByClassName(Classes.ALERT_FOOTER), 1);
         document.body.removeChild(container);
     });
 

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -49,6 +49,7 @@ describe("<Dialog>", () => {
         ].forEach(className => {
             assert.lengthOf(container.getElementsByClassName(className), 1, `missing ${className}`);
         });
+        document.body.removeChild(container);
     });
 
     it("attempts to close when overlay backdrop element is moused down", () => {

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -35,20 +35,11 @@ describe("<Dialog>", () => {
         const container = document.createElement("div");
         document.body.appendChild(container);
         mount(
-            <Dialog isOpen={true} container={container}>
+            <Dialog isOpen={true} portalContainer={container}>
                 {createDialogContents()}
             </Dialog>,
         );
-        [
-            Classes.DIALOG,
-            Classes.DIALOG_BODY,
-            Classes.DIALOG_FOOTER,
-            Classes.DIALOG_FOOTER_ACTIONS,
-            Classes.DIALOG_HEADER,
-            Classes.OVERLAY_BACKDROP,
-        ].forEach(className => {
-            assert.lengthOf(container.getElementsByClassName(className), 1, `missing ${className}`);
-        });
+        assert.lengthOf(container.getElementsByClassName(Classes.DIALOG), 1, `missing ${Classes.DIALOG}`);
         document.body.removeChild(container);
     });
 

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -31,6 +31,26 @@ describe("<Dialog>", () => {
         });
     });
 
+    it("renders contents to specified container correctly", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        mount(
+            <Dialog isOpen={true} container={container}>
+                {createDialogContents()}
+            </Dialog>,
+        );
+        [
+            Classes.DIALOG,
+            Classes.DIALOG_BODY,
+            Classes.DIALOG_FOOTER,
+            Classes.DIALOG_FOOTER_ACTIONS,
+            Classes.DIALOG_HEADER,
+            Classes.OVERLAY_BACKDROP,
+        ].forEach(className => {
+            assert.lengthOf(container.getElementsByClassName(className), 1, `missing ${className}`);
+        });
+    });
+
     it("attempts to close when overlay backdrop element is moused down", () => {
         const onClose = spy();
         const dialog = mount(

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -63,7 +63,7 @@ describe("<Overlay>", () => {
         const container = document.createElement("div");
         document.body.appendChild(container);
         mountWrapper(
-            <Overlay isOpen={true} container={container}>
+            <Overlay isOpen={true} portalContainer={container}>
                 <p className={CLASS_TO_TEST}>test</p>
             </Overlay>,
         );

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -68,6 +68,7 @@ describe("<Overlay>", () => {
             </Overlay>,
         );
         assert.lengthOf(container.getElementsByClassName(CLASS_TO_TEST), 1);
+        document.body.removeChild(container);
     });
 
     it("renders Portal after first opened", () => {

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -58,6 +58,18 @@ describe("<Overlay>", () => {
         overlay.unmount();
     });
 
+    it("renders contents to specified container correctly", () => {
+        const CLASS_TO_TEST = "bp-test-content";
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        mountWrapper(
+            <Overlay isOpen={true} container={container}>
+                <p className={CLASS_TO_TEST}>test</p>
+            </Overlay>,
+        );
+        assert.lengthOf(container.getElementsByClassName(CLASS_TO_TEST), 1);
+    });
+
     it("renders Portal after first opened", () => {
         mountWrapper(<Overlay isOpen={false}>{createOverlayContents()}</Overlay>);
         assert.lengthOf(wrapper.find(Portal), 0, "unexpected Portal");

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -162,7 +162,7 @@ describe("<Popover>", () => {
     it("renders to specified container correctly", () => {
         const container = document.createElement("div");
         document.body.appendChild(container);
-        wrapper = renderPopover({ isOpen: true, usePortal: true, container });
+        wrapper = renderPopover({ isOpen: true, usePortal: true, portalContainer: container });
         assert.lengthOf(container.getElementsByClassName(Classes.POPOVER_CONTENT), 1);
         document.body.removeChild(container);
     });

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -159,6 +159,13 @@ describe("<Popover>", () => {
         assert.lengthOf(wrapper.find(Portal), 1);
     });
 
+    it("renders to specified container correctly", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        wrapper = renderPopover({ isOpen: true, usePortal: true, container });
+        assert.lengthOf(container.getElementsByClassName(Classes.POPOVER_CONTENT), 1);
+    });
+
     it("does not render Portal when usePortal=false", () => {
         wrapper = renderPopover({ isOpen: true, usePortal: false });
         assert.lengthOf(wrapper.find(Portal), 0);

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -164,6 +164,7 @@ describe("<Popover>", () => {
         document.body.appendChild(container);
         wrapper = renderPopover({ isOpen: true, usePortal: true, container });
         assert.lengthOf(container.getElementsByClassName(Classes.POPOVER_CONTENT), 1);
+        document.body.removeChild(container);
     });
 
     it("does not render Portal when usePortal=false", () => {

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -30,6 +30,18 @@ describe("<Portal>", () => {
         assert.lengthOf(document.getElementsByClassName(CLASS_TO_TEST), 1);
     });
 
+    it("attaches contents to specified container", () => {
+        const CLASS_TO_TEST = "bp-test-content";
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        portal = mount(
+            <Portal container={container}>
+                <p className={CLASS_TO_TEST}>test</p>
+            </Portal>,
+        );
+        assert.lengthOf(container.getElementsByClassName(CLASS_TO_TEST), 1);
+    });
+
     it("propagates className to portal element", () => {
         const CLASS_TO_TEST = "bp-test-klass";
         portal = mount(

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -40,6 +40,7 @@ describe("<Portal>", () => {
             </Portal>,
         );
         assert.lengthOf(container.getElementsByClassName(CLASS_TO_TEST), 1);
+        document.body.removeChild(container);
     });
 
     it("propagates className to portal element", () => {


### PR DESCRIPTION
#### Fixes #3033

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [x] Update documentation

#### Changes proposed in this pull request:

Add `container` prop to `<Portal>` `<Overlay>` `<Popover>` `<Tooltip>` `<Dialog>` `<Alert>` component to mount children into specified node.

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
