### PR TITLE
Using tagName JSX variable for MenuItem

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -73,8 +73,6 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
 
     /**
      * Name of the HTML tag that wraps the MenuItem.
-     *
-     * By default a `<a>` is used
      * @default "a"
      */
     tagName?: keyof JSX.IntrinsicElements;
@@ -86,7 +84,6 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         multiline: false,
         popoverProps: {},
         shouldDismissPopover: true,
-        tagName: "a",
         text: "",
     };
     public static displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -70,6 +70,14 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
      * @default true
      */
     shouldDismissPopover?: boolean;
+
+    /**
+     * Name of the HTML tag that wraps the MenuItem.
+     *
+     * By default a `<a>` is used
+     * @default "a"
+     */
+    tagName?: keyof JSX.IntrinsicElements;
 }
 
 export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {
@@ -78,6 +86,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         multiline: false,
         popoverProps: {},
         shouldDismissPopover: true,
+        tagName: "a",
         text: "",
     };
     public static displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;
@@ -95,6 +104,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
             popoverProps,
             shouldDismissPopover,
             text,
+            tagName: TagName = "a",
             ...htmlProps
         } = this.props;
         const hasSubmenu = children != null;
@@ -114,14 +124,14 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         );
 
         const target = (
-            <a {...htmlProps} {...(disabled ? DISABLED_PROPS : {})} className={anchorClasses}>
+            <TagName {...htmlProps} {...(disabled ? DISABLED_PROPS : {})} className={anchorClasses}>
                 <Icon icon={icon} />
                 <Text className={Classes.FILL} ellipsize={!multiline}>
                     {text}
                 </Text>
                 {this.maybeRenderLabel(labelElement)}
                 {hasSubmenu && <Icon icon="caret-right" />}
-            </a>
+            </TagName>
         );
 
         const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });


### PR DESCRIPTION
#### Fixes #185

#### Changes proposed in this pull request:

the MenuItem now supports the property tagName which defaults to "a"

#### Reviewers should focus on:

./src/components/menu/menuItem.tsx

#### notes,

I'm on windows so I'm unable to build any of the testing stuff because your `yarn verify` setup is requiring access to `bash`... so someone is going to have to test this as I'm unable to.

```cmd
PS C:\*obsured*\blueprint> yarn verify
yarn run v1.10.1
$ npm-run-all -s compile dist:libs dist:apps -p test lint
$ lerna run compile
lerna info version 2.7.1
lerna info versioning independent
$ tsc -p ./src
$ tsc -p ./src
lerna ERR! compile Errored while running script in '@blueprintjs/icons'
lerna ERR! execute callback with error
lerna ERR! Error: Command failed: yarn run compile
lerna ERR! 'bash' is not recognized as an internal or external command,
lerna ERR! operable program or batch file.
lerna ERR! error Command failed with exit code 1.
lerna ERR! ERROR: "compile:css" exited with 1.
```
