### PR TITLE
Fix reset of active item when query hasn't changed

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -189,12 +189,12 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
         // always reset active item if it's now filtered or disabled
         const activeIndex = this.getActiveIndex(filteredItems);
-        if (
-            hasQueryChanged &&
-            (resetActiveItem ||
-                activeIndex < 0 ||
-                isItemDisabled(this.state.activeItem, activeIndex, this.props.itemDisabled))
-        ) {
+        const shouldUpdateActiveItem =
+            resetActiveItem ||
+            activeIndex < 0 ||
+            isItemDisabled(this.state.activeItem, activeIndex, this.props.itemDisabled);
+
+        if (hasQueryChanged && shouldUpdateActiveItem) {
             this.setActiveItem(getFirstEnabledItem(filteredItems, this.props.itemDisabled));
         }
     }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -179,18 +179,21 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     public setQuery(query: string, resetActiveItem = this.props.resetOnQuery) {
         this.shouldCheckActiveItemInViewport = true;
-        if (query !== this.state.query) {
+        const hasQueryChanged = query !== this.state.query;
+        if (hasQueryChanged) {
             Utils.safeInvoke(this.props.onQueryChange, query);
         }
+
         const filteredItems = getFilteredItems(query, this.props);
         this.setState({ filteredItems, query });
 
         // always reset active item if it's now filtered or disabled
         const activeIndex = this.getActiveIndex(filteredItems);
         if (
-            resetActiveItem ||
-            activeIndex < 0 ||
-            isItemDisabled(this.state.activeItem, activeIndex, this.props.itemDisabled)
+            hasQueryChanged &&
+            (resetActiveItem ||
+                activeIndex < 0 ||
+                isItemDisabled(this.state.activeItem, activeIndex, this.props.itemDisabled))
         ) {
             this.setActiveItem(getFirstEnabledItem(filteredItems, this.props.itemDisabled));
         }

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -5,11 +5,12 @@
  */
 
 import { assert } from "chai";
-import { mount, shallow } from "enzyme";
+import { mount, ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
+import { IQueryListProps } from "@blueprintjs/select";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import { IQueryListRendererProps, ItemListPredicate, ItemListRenderer, QueryList } from "../src/index";
 
@@ -88,6 +89,19 @@ describe("<QueryList>", () => {
             const filmQueryList = mount(<FilmQueryList {...testProps} items={[myItem]} activeItem={myItem} query="" />);
             filmQueryList.setState({ query: "query" });
             filmQueryList.setState({ activeItem: undefined });
+            assert.equal(testProps.onActiveItemChange.callCount, 0);
+        });
+
+        it("ensure onActiveItemChange is not called updating props and query doesn't change", () => {
+            const myItem = { title: "Toy Story 3", year: 2010, rank: 1 };
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                activeItem: myItem,
+                items: [myItem],
+                query: "",
+            };
+            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>> = mount(<FilmQueryList {...props} />);
+            filmQueryList.setProps(props);
             assert.equal(testProps.onActiveItemChange.callCount, 0);
         });
     });


### PR DESCRIPTION
#### Changes proposed in this pull request:

Fixed an issue where query lists with controlled queries and `resetOnQuery={false}` would reset the active item when receiving new props despite the query itself not changing.