### PR TITLE
[Select] Flag to optionally scroll to active item for select components

### DIFF
--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -113,7 +113,9 @@ export interface IListItemsProps<T> extends IProps {
     resetOnSelect?: boolean;
 
     /**
-     * Whether the active item should be scrolled into view when the active item is changed.
+     * When the active item is controlled, whether the active item should be scrolled into view when
+     * an external change to the active item is made. External changes do not include selecting an item
+     * in the list, searching for an item, or changing the selection via up and down arrow keys.
      * @default true
      */
     scrollToActiveItem?: boolean;

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -113,6 +113,12 @@ export interface IListItemsProps<T> extends IProps {
     resetOnSelect?: boolean;
 
     /**
+     * Whether the active item should be scrolled into view when the active item is changed.
+     * @default true
+     */
+    scrollToActiveItem?: boolean;
+
+    /**
      * Query string passed to `itemListPredicate` or `itemPredicate` to filter items.
      * This value is controlled: its state must be managed externally by attaching an `onChange`
      * handler to the relevant element in your `renderer` implementation.

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -113,9 +113,10 @@ export interface IListItemsProps<T> extends IProps {
     resetOnSelect?: boolean;
 
     /**
-     * When the active item is controlled, whether the active item should be scrolled into view when
-     * an external change to the active item is made. External changes do not include selecting an item
-     * in the list, searching for an item, or changing the selection via up and down arrow keys.
+     * When `activeItem` is controlled, whether the active item should _always_
+     * be scrolled into view when the prop changes. If `false`, only changes
+     * that result from built-in interactions (clicking, querying, or using
+     * arrow keys) will scroll the active item into view.
      * @default true
      */
     scrollToActiveItem?: boolean;

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -116,7 +116,8 @@ export interface IListItemsProps<T> extends IProps {
      * When `activeItem` is controlled, whether the active item should _always_
      * be scrolled into view when the prop changes. If `false`, only changes
      * that result from built-in interactions (clicking, querying, or using
-     * arrow keys) will scroll the active item into view.
+     * arrow keys) will scroll the active item into view. Ignored if the
+     * `activeItem` prop is omitted (uncontrolled behavior).
      * @default true
      */
     scrollToActiveItem?: boolean;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -98,6 +98,13 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
      */
     private shouldCheckActiveItemInViewport = false;
 
+    /**
+     * The item that we expect to be the next selected active item (based on click
+     * or key interactions). When scrollToActiveItem = false, used to detect if
+     * an unexpected external change to the active item has been made.
+     */
+    private expectedNextActiveItem: T | null = null;
+
     public constructor(props: IQueryListProps<T>, context?: any) {
         super(props, context);
         const { query = "" } = this.props;
@@ -152,7 +159,11 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     public scrollActiveItemIntoView() {
-        if (this.props.scrollToActiveItem === false) {
+        const scrollToActiveItem = this.props.scrollToActiveItem !== false;
+        const externalChangeToActiveItem = this.expectedNextActiveItem !== this.props.activeItem;
+        this.expectedNextActiveItem = null;
+
+        if (!scrollToActiveItem && externalChangeToActiveItem) {
             return;
         }
 
@@ -298,6 +309,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     private setActiveItem(activeItem: T | null) {
+        this.expectedNextActiveItem = activeItem;
         if (this.props.activeItem === undefined) {
             // indicate that the active item may need to be scrolled into view after update.
             this.shouldCheckActiveItemInViewport = true;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -152,6 +152,10 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     }
 
     public scrollActiveItemIntoView() {
+        if (this.props.scrollToActiveItem === false) {
+            return;
+        }
+
         const activeElement = this.getActiveElement();
         if (this.itemsParentRef != null && activeElement != null) {
             const { offsetTop: activeTop, offsetHeight: activeHeight } = activeElement;


### PR DESCRIPTION
#### Changes proposed in this pull request:

Adds a flag `scrollToActiveItem` which defaults to `true` for select list components.

#### Screenshot

Prevents this undesirable scrolling behavior when updating active item based on mouse hover:

![select-infinite-scroll](https://user-images.githubusercontent.com/993321/47673811-0c1e0b00-db8c-11e8-8ab5-d7c0b58a2789.gif)

Note this is just by hovering, no scroll wheel was used in the creation of this gif.
