### PR TITLE
fix icons alignment

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -10,6 +10,8 @@
   display: inline-block;
   // respect dimensions exactly
   flex: 0 0 auto;
+  // sit nicely with inline text
+  vertical-align: text-bottom;
 
   &:not(:empty)::before {
     // clear font icon when there's an <svg> image


### PR DESCRIPTION
`vertical-align: text-bottom` makes icons sit much better with inline text.

![image](https://user-images.githubusercontent.com/464822/47750219-24edf580-dc4c-11e8-9652-4fda6e8a0c0e.png) | ➡️ | ![image](https://user-images.githubusercontent.com/464822/47750165-0982ea80-dc4c-11e8-9dd9-2d436fc40f96.png)
-|-|-
