### PR TITLE
path set to normalize and blueprint css files

### DIFF
--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -36,10 +36,10 @@ Don't forget to include the **main CSS file** from each Blueprint package!
 
 ```html
 <!-- in index.html, or however you manage your CSS files -->
-<link href="path/to/node_modules/normalize.css/normalize.css" rel="stylesheet" />
+<link href="../node_modules/normalize.css/normalize.css" rel="stylesheet" />
 <!-- blueprint-icons.css file must be included alongside blueprint.css! -->
-<link href="path/to/node_modules/@blueprintjs/icons/lib/css/blueprint-icons.css" rel="stylesheet" />
-<link href="path/to/node_modules/@blueprintjs/core/lib/css/blueprint.css" rel="stylesheet" />
+<link href="../node_modules/@blueprintjs/icons/lib/css/blueprint-icons.css" rel="stylesheet" />
+<link href="../node_modules/@blueprintjs/core/lib/css/blueprint.css" rel="stylesheet" />
 <!-- add other blueprint-*.css files here -->
 ```
 


### PR DESCRIPTION
path of css files are set as per create-react-app folder structure

#### Fixes #0000

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

<!-- fill this out -->

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
