### PR TITLE
[Select] Update query list scroll behavior

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -169,10 +169,10 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
             if (activeBottomEdge >= parentScrollTop + parentHeight) {
                 // offscreen bottom: align bottom of item with bottom of viewport
-                this.itemsParentRef.scrollTop = activeBottomEdge + activeHeight - parentHeight;
+                this.itemsParentRef.scrollTop = activeBottomEdge - parentHeight;
             } else if (activeTopEdge <= parentScrollTop) {
                 // offscreen top: align top of item with top of viewport
-                this.itemsParentRef.scrollTop = activeTopEdge - activeHeight;
+                this.itemsParentRef.scrollTop = activeTopEdge;
             }
         }
     }


### PR DESCRIPTION
#### Changes proposed in this pull request:

When scrolling the active item into view for query lists, only scroll that item exactly into view and no more, fixes the same issue that https://github.com/palantir/blueprint/pull/3096 attempts to fix but in a different and more consistent manner. I've tested this will menu items of multiple heights and it seems to work fine.

#### Reviewers should focus on:

Should this belong under a flag prop?
