### PR TITLE
Allow users to browse omnibar options without query

### DIFF
--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -81,7 +81,7 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { inputProps = {}, isOpen, overlayProps = {} } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
-        const handlers = isOpen && listProps.query.length > 0 ? { onKeyDown: handleKeyDown, onKeyUp: handleKeyUp } : {};
+        const handlers = isOpen ? { onKeyDown: handleKeyDown, onKeyUp: handleKeyUp } : {};
 
         return (
             <Overlay


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/3129

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests (N/A)
- [ ] Update documentation (N/A)

#### Changes proposed in this pull request:

Allow users to browse omnibar options without query
