### PR TITLE
Don't clear TagInput inputValue state if controlled

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -184,13 +184,14 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         addOnBlur: false,
         addOnPaste: true,
         inputProps: {},
+        inputValue: "",
         separator: /[,\n\r]/,
         tagProps: {},
     };
 
     public state: ITagInputState = {
         activeIndex: NONE,
-        inputValue: this.props.inputValue || "",
+        inputValue: this.props.inputValue,
         isInputFocused: false,
     };
 
@@ -206,7 +207,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         super.componentWillReceiveProps(nextProps);
 
         if (nextProps.inputValue !== this.props.inputValue) {
-            this.setState({ inputValue: nextProps.inputValue || "" });
+            this.setState({ inputValue: nextProps.inputValue });
         }
     }
 
@@ -262,8 +263,8 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     private addTags = (value: string) => {
         const { inputValue, onAdd, onChange, values } = this.props;
         const newValues = this.getValues(value);
-        let shouldClearInput = inputValue === undefined;
-        shouldClearInput = Utils.safeInvoke(onAdd, newValues) !== false && shouldClearInput;
+        let shouldClearInput =
+            Utils.safeInvoke(onAdd, newValues) !== false && inputValue === TagInput.defaultProps.inputValue;
         // avoid a potentially expensive computation if this prop is omitted
         if (Utils.isFunction(onChange)) {
             shouldClearInput = onChange([...values, ...newValues]) !== false && shouldClearInput;

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -184,14 +184,13 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         addOnBlur: false,
         addOnPaste: true,
         inputProps: {},
-        inputValue: "",
         separator: /[,\n\r]/,
         tagProps: {},
     };
 
     public state: ITagInputState = {
         activeIndex: NONE,
-        inputValue: this.props.inputValue,
+        inputValue: this.props.inputValue || "",
         isInputFocused: false,
     };
 
@@ -207,7 +206,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         super.componentWillReceiveProps(nextProps);
 
         if (nextProps.inputValue !== this.props.inputValue) {
-            this.setState({ inputValue: nextProps.inputValue });
+            this.setState({ inputValue: nextProps.inputValue || "" });
         }
     }
 
@@ -261,15 +260,16 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     }
 
     private addTags = (value: string) => {
-        const { onAdd, onChange, values } = this.props;
+        const { inputValue, onAdd, onChange, values } = this.props;
         const newValues = this.getValues(value);
-        let shouldClearInput = Utils.safeInvoke(onAdd, newValues);
+        let shouldClearInput = inputValue === undefined;
+        shouldClearInput = Utils.safeInvoke(onAdd, newValues) !== false && shouldClearInput;
         // avoid a potentially expensive computation if this prop is omitted
         if (Utils.isFunction(onChange)) {
-            shouldClearInput = shouldClearInput || onChange([...values, ...newValues]);
+            shouldClearInput = onChange([...values, ...newValues]) !== false && shouldClearInput;
         }
         // only explicit return false cancels text clearing
-        if (shouldClearInput !== false) {
+        if (shouldClearInput) {
             this.setState({ inputValue: "" });
         }
     };

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -169,9 +169,9 @@ export interface ITagInputProps extends IProps {
 }
 
 export interface ITagInputState {
-    activeIndex?: number;
-    inputValue?: string;
-    isInputFocused?: boolean;
+    activeIndex: number;
+    inputValue: string;
+    isInputFocused: boolean;
 }
 
 /** special value for absence of active tag */
@@ -184,14 +184,13 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         addOnBlur: false,
         addOnPaste: true,
         inputProps: {},
-        inputValue: "",
         separator: /[,\n\r]/,
         tagProps: {},
     };
 
     public state: ITagInputState = {
         activeIndex: NONE,
-        inputValue: this.props.inputValue,
+        inputValue: this.props.inputValue || "",
         isInputFocused: false,
     };
 
@@ -207,7 +206,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         super.componentWillReceiveProps(nextProps);
 
         if (nextProps.inputValue !== this.props.inputValue) {
-            this.setState({ inputValue: nextProps.inputValue });
+            this.setState({ inputValue: nextProps.inputValue || "" });
         }
     }
 
@@ -263,8 +262,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     private addTags = (value: string) => {
         const { inputValue, onAdd, onChange, values } = this.props;
         const newValues = this.getValues(value);
-        let shouldClearInput =
-            Utils.safeInvoke(onAdd, newValues) !== false && inputValue === TagInput.defaultProps.inputValue;
+        let shouldClearInput = Utils.safeInvoke(onAdd, newValues) !== false && inputValue === undefined;
         // avoid a potentially expensive computation if this prop is omitted
         if (Utils.isFunction(onChange)) {
             shouldClearInput = onChange([...values, ...newValues]) !== false && shouldClearInput;

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -210,6 +210,12 @@ describe("<TagInput>", () => {
             assert.strictEqual(wrapper.state().inputValue, "");
         });
 
+        it("does not clear the input if the input is controlled", () => {
+            const wrapper = mountTagInput(undefined, { inputValue: NEW_VALUE });
+            pressEnterInInput(wrapper, NEW_VALUE);
+            assert.strictEqual(wrapper.state().inputValue, NEW_VALUE);
+        });
+
         it("splits input value on separator RegExp", () => {
             const onAdd = sinon.stub();
             // this is actually the defaultProps value, but reproducing here for explicitness
@@ -355,6 +361,13 @@ describe("<TagInput>", () => {
             wrapper.setState({ inputValue: NEW_VALUE });
             pressEnterInInput(wrapper, NEW_VALUE);
             assert.strictEqual(wrapper.state().inputValue, "");
+        });
+
+        it("does not clear the input if the input is controlled", () => {
+            const onChange = sinon.stub();
+            const wrapper = shallow(<TagInput onChange={onChange} values={VALUES} inputValue={NEW_VALUE} />);
+            pressEnterInInput(wrapper, NEW_VALUE);
+            assert.strictEqual(wrapper.state().inputValue, NEW_VALUE);
         });
     });
 


### PR DESCRIPTION
#### Fixes #3134

#### Changes proposed in this pull request:

This change modifies `TagInput` to not clear the value displayed in the `input` field when adding tags if the consumer passes in their own `inputValue` prop. Previously, adding tags would clear this field, which resulted in confusing behavior in `MultiSelect`, as described in the issue. This seems philosophically correct: If the consumer specifies an explicit value for `inputValue`, it should never be overridden in `TagInput`'s state.