### PR TITLE
Single Month Only Prop in DateRangePicker

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -129,9 +129,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatP
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
-     * Whether to show only a single month calendar
-     * If `true`, will only show a single month calendar
-     * If `false`, will show two sequential calendars side-by-side
+     * Whether to show only a single month calendar.
      * @default false
      */
     singleMonthOnly?: boolean;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -129,6 +129,14 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatP
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
+     * Whether to show only a single month calendar
+     * If `true`, will only show a single month calendar
+     * If `false`, will show two sequential calendars side-by-side
+     * @default false
+     */
+    singleMonthOnly?: boolean;
+
+    /**
      * Props to pass to the start-date [input group](#core/components/text-inputs.input-group).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `ref` is not supported; use `inputRef` instead.
@@ -202,6 +210,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         popoverProps: {},
         selectAllOnFocus: false,
         shortcuts: true,
+        singleMonthOnly: false,
         startInputProps: {},
     };
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -101,6 +101,14 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
+     * Whether the start and end dates of the range can be the same day.
+     * If `true`, clicking a selected date will create a one-day range.
+     * If `false`, clicking a selected date will clear the selection.
+     * @default false
+     */
+    singleMonthOnly?: boolean;
+
+    /**
      * The currently selected `DateRange`.
      * If this prop is provided, the component acts in a controlled manner.
      */
@@ -125,6 +133,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         minDate: getDefaultMinDate(),
         reverseMonthAndYearMenus: false,
         shortcuts: true,
+        singleMonthOnly: false,
         timePickerProps: {},
     };
 
@@ -194,8 +203,8 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
     }
 
     public render() {
-        const { className, contiguousCalendarMonths } = this.props;
-        const isShowingOneMonth = DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
+        const { className, contiguousCalendarMonths, singleMonthOnly } = this.props;
+        const isShowingOneMonth = singleMonthOnly || DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
 
         const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
             [DateClasses.DATERANGEPICKER_CONTIGUOUS]: contiguousCalendarMonths,

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -101,9 +101,9 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
-     * Whether the start and end dates of the range can be the same day.
-     * If `true`, clicking a selected date will create a one-day range.
-     * If `false`, clicking a selected date will clear the selection.
+     * Whether to show only a single month calendar
+     * If `true`, will only show a single month calendar
+     * If `false`, will show two sequential calendars side-by-side
      * @default false
      */
     singleMonthOnly?: boolean;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -101,9 +101,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
-     * Whether to show only a single month calendar
-     * If `true`, will only show a single month calendar
-     * If `false`, will show two sequential calendars side-by-side
+     * Whether to show only a single month calendar.
      * @default false
      */
     singleMonthOnly?: boolean;

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -270,6 +270,12 @@ describe("<DateRangeInput>", () => {
         expect(root.find(DateRangePicker).prop("contiguousCalendarMonths")).to.be.false;
     });
 
+    it("accepts singleMonthOnly prop and passes it to the date range picker", () => {
+        const { root } = wrap(<DateRangeInput {...DATE_FORMAT} singleMonthOnly={false} />);
+        root.setState({ isOpen: true });
+        expect(root.find(DateRangePicker).prop("singleMonthOnly")).to.be.false;
+    });
+
     it("accepts shortcuts prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} shortcuts={false} />);
         root.setState({ isOpen: true });

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -355,6 +355,11 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(wrapper.find(Button).every({ disabled: true }));
         });
 
+        it("only shows one calendar when singleMonthOnly is set", () => {
+            const { right } = render({ singleMonthOnly: true });
+            assert.isFalse(right.wrapper.exists());
+        });
+
         it("left calendar is bound between minDate and (maxDate - 1 month)", () => {
             const minDate = new Date(2015, Months.JANUARY, 1);
             const maxDate = new Date(2015, Months.DECEMBER, 15);

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -73,7 +73,7 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
                 />
                 <Switch
                     checked={this.state.singleMonthOnly}
-                    label="Show single month only"
+                    label="Single month only"
                     onChange={this.toggleSingleMonth}
                 />
                 <Switch checked={this.state.shortcuts} label="Show shortcuts" onChange={this.toggleShortcuts} />

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -21,6 +21,8 @@ export interface IDateRangeInputExampleState {
     range: DateRange;
     reverseMonthAndYearMenus: boolean;
     selectAllOnFocus: boolean;
+    shortcuts: boolean;
+    singleMonthOnly: boolean;
 }
 
 export class DateRangeInputExample extends React.PureComponent<IExampleProps, IDateRangeInputExampleState> {
@@ -33,6 +35,8 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
         range: [null, null],
         reverseMonthAndYearMenus: false,
         selectAllOnFocus: false,
+        shortcuts: true,
+        singleMonthOnly: false,
     };
 
     private toggleContiguous = handleBooleanChange(contiguous => {
@@ -45,6 +49,8 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
     private toggleSelection = handleBooleanChange(closeOnSelection => this.setState({ closeOnSelection }));
     private toggleSelectAllOnFocus = handleBooleanChange(selectAllOnFocus => this.setState({ selectAllOnFocus }));
     private toggleSingleDay = handleBooleanChange(allowSingleDayRange => this.setState({ allowSingleDayRange }));
+    private toggleSingleMonth = handleBooleanChange(singleMonthOnly => this.setState({ singleMonthOnly }));
+    private toggleShortcuts = handleBooleanChange(shortcuts => this.setState({ shortcuts }));
 
     public render() {
         const { format, range, ...spreadProps } = this.state;
@@ -65,6 +71,12 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
                     label="Allow single day range"
                     onChange={this.toggleSingleDay}
                 />
+                <Switch
+                    checked={this.state.singleMonthOnly}
+                    label="Show single month only"
+                    onChange={this.toggleSingleMonth}
+                />
+                <Switch checked={this.state.shortcuts} label="Show shortcuts" onChange={this.toggleShortcuts} />
                 <Switch
                     checked={this.state.closeOnSelection}
                     label="Close on selection"

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -65,13 +65,13 @@ const MAX_DATE_OPTIONS: IDateOption[] = [
 export class DateRangePickerExample extends React.PureComponent<IExampleProps, IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
-        singleMonthOnly: false,
         contiguousCalendarMonths: true,
         dateRange: [null, null],
         maxDateIndex: 0,
         minDateIndex: 0,
         reverseMonthAndYearMenus: false,
         shortcuts: true,
+        singleMonthOnly: false,
     };
 
     private handleMaxDateIndexChange = handleNumberChange(maxDateIndex => this.setState({ maxDateIndex }));

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -21,6 +21,7 @@ import { PrecisionSelect } from "./common/precisionSelect";
 
 export interface IDateRangePickerExampleState {
     allowSingleDayRange?: boolean;
+    singleMonthOnly?: boolean;
     contiguousCalendarMonths?: boolean;
     dateRange?: DateRange;
     maxDateIndex?: number;
@@ -64,6 +65,7 @@ const MAX_DATE_OPTIONS: IDateOption[] = [
 export class DateRangePickerExample extends React.PureComponent<IExampleProps, IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
+        singleMonthOnly: false,
         contiguousCalendarMonths: true,
         dateRange: [null, null],
         maxDateIndex: 0,
@@ -82,6 +84,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
         this.setState({ reverseMonthAndYearMenus }),
     );
     private toggleSingleDay = handleBooleanChange(allowSingleDayRange => this.setState({ allowSingleDayRange }));
+    private toggleSingleMonth = handleBooleanChange(singleMonthOnly => this.setState({ singleMonthOnly }));
     private toggleShortcuts = handleBooleanChange(shortcuts => this.setState({ shortcuts }));
     private toggleContiguousCalendarMonths = handleBooleanChange(contiguousCalendarMonths => {
         this.setState({ contiguousCalendarMonths });
@@ -114,6 +117,11 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                         checked={this.state.allowSingleDayRange}
                         label="Allow single day range"
                         onChange={this.toggleSingleDay}
+                    />
+                    <Switch
+                        checked={this.state.singleMonthOnly}
+                        label="Show single month only"
+                        onChange={this.toggleSingleMonth}
                     />
                     <Switch
                         checked={this.state.contiguousCalendarMonths}

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -120,7 +120,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                     />
                     <Switch
                         checked={this.state.singleMonthOnly}
-                        label="Show single month only"
+                        label="Single month only"
                         onChange={this.toggleSingleMonth}
                     />
                     <Switch


### PR DESCRIPTION
#### Fixes #3133
#### Changes proposed in this pull request:

Added a `singleMonthOnly` prop to show only a single month in the DateRangePicker and DateRangeInput. Have set the prop to default to false, to avoid visual breaking changes to anyone using this already and not passing the prop.

#### Screenshot
By default,
<img width="640" alt="screenshot 2018-11-11 at 6 57 26 pm" src="https://user-images.githubusercontent.com/1647344/48313630-633cca80-e5e5-11e8-9715-6d1a5d120bbc.png">

When `singleMonthOnly` prop is set to true
<img width="437" alt="screenshot 2018-11-11 at 6 57 03 pm" src="https://user-images.githubusercontent.com/1647344/48313596-f6293500-e5e4-11e8-90c2-da88b669c118.png">

