### PR TITLE
fix HTML_TABLE_CONDENSED name (reverts 3.x break)

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -14,7 +14,6 @@ const NS = process.env.BLUEPRINT_NAMESPACE || "bp3";
 export const ACTIVE = `${NS}-active`;
 export const ALIGN_LEFT = `${NS}-align-left`;
 export const ALIGN_RIGHT = `${NS}-align-right`;
-export const CONDENSED = `${NS}-condensed`;
 export const DARK = `${NS}-dark`;
 export const DISABLED = `${NS}-disabled`;
 export const FILL = `${NS}-fill`;
@@ -116,8 +115,9 @@ export const HTML_SELECT = `${NS}-html-select`;
 export const SELECT = `${NS}-select`;
 
 export const HTML_TABLE = `${NS}-html-table`;
-export const HTML_TABLE_STRIPED = `${HTML_TABLE}-striped`;
 export const HTML_TABLE_BORDERED = `${HTML_TABLE}-bordered`;
+export const HTML_TABLE_CONDENSED = `${HTML_TABLE}-condensed`;
+export const HTML_TABLE_STRIPED = `${HTML_TABLE}-striped`;
 
 export const INPUT = `${NS}-input`;
 export const INPUT_GHOST = `${INPUT}-ghost`;

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -34,11 +34,11 @@ Markup:
   </tbody>
 </table>
 
-.#{$ns}-condensed - Small, condensed appearance
-.#{$ns}-html-table-striped - Striped appearance
 .#{$ns}-html-table-bordered - Bordered appearance
+.#{$ns}-html-table-condensed - Condensed smaller appearance
+.#{$ns}-html-table-striped - Striped appearance
 .#{$ns}-interactive - Enables hover styles on rows
-.#{$ns}-small - Small, condensed appearance for this element and all child elements
+.#{$ns}-small - Small, condensed appearance for this element _and all child elements_
 
 Styleguide html-table
 */
@@ -101,7 +101,7 @@ $dark-table-border-color: $pt-dark-divider-white !default;
 table.#{$ns}-html-table {
   @extend %html-table;
 
-  &.#{$ns}-condensed,
+  &.#{$ns}-html-table-condensed,
   &.#{$ns}-small {
     $small-vertical-padding: centered-text($table-row-height-small);
 

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -7,9 +7,9 @@
 import classNames from "classnames";
 import * as React from "react";
 import {
-    CONDENSED,
     HTML_TABLE,
     HTML_TABLE_BORDERED,
+    HTML_TABLE_CONDENSED,
     HTML_TABLE_STRIPED,
     INTERACTIVE,
     SMALL,
@@ -44,8 +44,8 @@ export class HTMLTable extends React.PureComponent<IHTMLTableProps> {
         const classes = classNames(
             HTML_TABLE,
             {
-                [CONDENSED]: condensed,
                 [HTML_TABLE_BORDERED]: bordered,
+                [HTML_TABLE_CONDENSED]: condensed,
                 [HTML_TABLE_STRIPED]: striped,
                 [INTERACTIVE]: interactive,
                 [SMALL]: small,


### PR DESCRIPTION
- replace `Classes.CONDENSED` (added in #2904 with the wrong name) with `Classes.HTML_TABLE_CONDENSED`. 
- this is actually a revert to pre-3.x usage.