### PR TITLE
[Popover] add boundary prop for easier modifiers

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -86,7 +86,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
     public static defaultProps: IPopoverProps = {
-        boundariesElement: "scrollParent",
+        boundary: "scrollParent",
         captureDismiss: false,
         defaultIsOpen: false,
         disabled: false,
@@ -356,7 +356,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     }
 
     private getPopperModifiers(): PopperModifiers {
-        const { boundariesElement, modifiers } = this.props;
+        const { boundary, modifiers } = this.props;
         const { flip = {}, preventOverflow = {} } = modifiers;
         return {
             ...modifiers,
@@ -365,8 +365,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
                 fn: arrowOffsetModifier,
                 order: 510,
             },
-            flip: { boundariesElement, ...flip },
-            preventOverflow: { boundariesElement, ...preventOverflow },
+            flip: { boundariesElement: boundary, ...flip },
+            preventOverflow: { boundariesElement: boundary, ...preventOverflow },
             updatePopoverState: {
                 enabled: true,
                 fn: this.updatePopoverState,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -86,6 +86,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
     public static defaultProps: IPopoverProps = {
+        boundariesElement: "scrollParent",
         captureDismiss: false,
         defaultIsOpen: false,
         disabled: false,
@@ -145,7 +146,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         // as JSX component instead of intrinsic element. but because of its
         // type, tsc actually recognizes that it is _any_ intrinsic element, so
         // it can typecheck the HTML props!!
-        const { className, disabled, modifiers, wrapperTagName: WrapperTagName } = this.props;
+        const { className, disabled, wrapperTagName: WrapperTagName } = this.props;
         const { isOpen } = this.state;
 
         const isContentEmpty = Utils.ensureElement(this.understandChildren().content) == null;
@@ -154,19 +155,6 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         if (isContentEmpty && !disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
             console.warn(Errors.POPOVER_WARN_EMPTY_CONTENT);
         }
-        const allModifiers: PopperModifiers = {
-            ...modifiers,
-            arrowOffset: {
-                enabled: this.isArrowEnabled(),
-                fn: arrowOffsetModifier,
-                order: 510, // arrow is 500
-            },
-            updatePopoverState: {
-                enabled: true,
-                fn: this.updatePopoverState,
-                order: 900,
-            },
-        };
 
         return (
             <Manager>
@@ -195,7 +183,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
                         <Popper
                             innerRef={this.refHandlers.popover}
                             placement={positionToPlacement(this.props.position)}
-                            modifiers={allModifiers}
+                            modifiers={this.getPopperModifiers()}
                         >
                             {this.renderPopover}
                         </Popper>
@@ -365,6 +353,26 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         } else {
             return props.defaultIsOpen;
         }
+    }
+
+    private getPopperModifiers(): PopperModifiers {
+        const { boundariesElement, modifiers } = this.props;
+        const { flip = {}, preventOverflow = {} } = modifiers;
+        return {
+            ...modifiers,
+            arrowOffset: {
+                enabled: this.isArrowEnabled(),
+                fn: arrowOffsetModifier,
+                order: 510,
+            },
+            flip: { boundariesElement, ...flip },
+            preventOverflow: { boundariesElement, ...preventOverflow },
+            updatePopoverState: {
+                enabled: true,
+                fn: this.updatePopoverState,
+                order: 900,
+            },
+        };
     }
 
     private handleTargetFocus = (e: React.FocusEvent<HTMLElement>) => {

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Modifiers as PopperModifiers } from "popper.js";
+import { Boundary, Modifiers as PopperModifiers } from "popper.js";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
 import { IOverlayableProps } from "../overlay/overlay";
@@ -14,6 +14,13 @@ export { PopperModifiers };
 
 /** Props shared between `Popover` and `Tooltip`. */
 export interface IPopoverSharedProps extends IOverlayableProps, IProps {
+    /**
+     * Determines the boundary element used by Popper for its `flip` and
+     * `preventOverflow` modifiers.
+     * @default "viewport"
+     */
+    boundariesElement?: Boundary;
+
     /**
      * When enabled, `preventDefault()` is invoked on `click` events that close
      * this popover, which will prevent those clicks from closing outer

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -4,13 +4,13 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Boundary, Modifiers as PopperModifiers } from "popper.js";
+import { Boundary as PopperBoundary, Modifiers as PopperModifiers } from "popper.js";
 import { Position } from "../../common/position";
 import { IProps } from "../../common/props";
 import { IOverlayableProps } from "../overlay/overlay";
 
-// re-export this symbol for library consumers
-export { PopperModifiers };
+// re-export symbols for library consumers
+export { PopperBoundary, PopperModifiers };
 
 /** `Position` with `"auto"` values, used by `Popover` and `Tooltip`. */
 export const PopoverPosition = {
@@ -25,10 +25,11 @@ export type PopoverPosition = typeof PopoverPosition[keyof typeof PopoverPositio
 export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     /**
      * Determines the boundary element used by Popper for its `flip` and
-     * `preventOverflow` modifiers.
+     * `preventOverflow` modifiers. Three shorthand keywords are supported;
+     * Popper will find the correct DOM element itself.
      * @default "scrollParent"
      */
-    boundary?: Boundary;
+    boundary?: PopperBoundary;
 
     /**
      * When enabled, `preventDefault()` is invoked on `click` events that close

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -26,9 +26,9 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     /**
      * Determines the boundary element used by Popper for its `flip` and
      * `preventOverflow` modifiers.
-     * @default "viewport"
+     * @default "scrollParent"
      */
-    boundariesElement?: Boundary;
+    boundary?: Boundary;
 
     /**
      * When enabled, `preventDefault()` is invoked on `click` events that close

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -4,7 +4,6 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import PopperJS from "popper.js";
 import * as React from "react";
 
 import {
@@ -23,6 +22,8 @@ import {
     Popover,
     PopoverInteractionKind,
     PopoverPosition,
+    PopperBoundary,
+    PopperModifiers,
     RadioGroup,
     Slider,
     Switch,
@@ -63,7 +64,7 @@ const VALID_POSITIONS: PopoverPosition[] = [
 const POPPER_DOCS = "https://popper.js.org/popper-documentation.html#modifiers";
 
 export interface IPopoverExampleState {
-    boundariesElement?: PopperJS.Boundary;
+    boundary?: PopperBoundary;
     canEscapeKeyClose?: boolean;
     exampleIndex?: number;
     hasBackdrop?: boolean;
@@ -71,7 +72,7 @@ export interface IPopoverExampleState {
     interactionKind?: PopoverInteractionKind;
     isOpen?: boolean;
     minimal?: boolean;
-    modifiers?: PopperJS.Modifiers;
+    modifiers?: PopperModifiers;
     position?: PopoverPosition;
     sliderValue?: number;
     usePortal?: boolean;
@@ -79,7 +80,7 @@ export interface IPopoverExampleState {
 
 export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverExampleState> {
     public state: IPopoverExampleState = {
-        boundariesElement: "viewport",
+        boundary: "viewport",
         canEscapeKeyClose: true,
         exampleIndex: 0,
         hasBackdrop: false,
@@ -91,7 +92,7 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
             arrow: { enabled: true },
             flip: { enabled: true },
             keepTogether: { enabled: true },
-            preventOverflow: { enabled: true, boundariesElement: "scrollParent" },
+            preventOverflow: { enabled: true },
         },
         position: "auto",
         sliderValue: 5,
@@ -104,9 +105,7 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
         this.setState({ interactionKind, hasBackdrop });
     });
     private handlePositionChange = handleStringChange((position: PopoverPosition) => this.setState({ position }));
-    private handleBoundaryChange = handleStringChange((boundariesElement: PopperJS.Boundary) =>
-        this.setState({ boundariesElement }),
-    );
+    private handleBoundaryChange = handleStringChange((boundary: PopperBoundary) => this.setState({ boundary }));
 
     private toggleEscapeKey = handleBooleanChange(canEscapeKeyClose => this.setState({ canEscapeKeyClose }));
     private toggleIsOpen = handleBooleanChange(isOpen => this.setState({ isOpen }));
@@ -199,7 +198,7 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
                     <div style={{ marginTop: 5 }} />
                     <HTMLSelect
                         disabled={!preventOverflow.enabled}
-                        value={this.state.boundariesElement}
+                        value={this.state.boundary}
                         onChange={this.handleBoundaryChange}
                     >
                         <option value="scrollParent">scrollParent</option>
@@ -268,7 +267,7 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
 
     private handleSliderChange = (value: number) => this.setState({ sliderValue: value });
 
-    private getModifierChangeHandler(name: keyof PopperJS.Modifiers) {
+    private getModifierChangeHandler(name: keyof PopperModifiers) {
         return handleBooleanChange(enabled => {
             this.setState({
                 modifiers: {

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -63,6 +63,7 @@ const VALID_POSITIONS: Array<Position | "auto" | "auto-start" | "auto-end"> = [
 const POPPER_DOCS = "https://popper.js.org/popper-documentation.html#modifiers";
 
 export interface IPopoverExampleState {
+    boundariesElement?: PopperJS.Boundary;
     canEscapeKeyClose?: boolean;
     exampleIndex?: number;
     hasBackdrop?: boolean;
@@ -78,6 +79,7 @@ export interface IPopoverExampleState {
 
 export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverExampleState> {
     public state: IPopoverExampleState = {
+        boundariesElement: "viewport",
         canEscapeKeyClose: true,
         exampleIndex: 0,
         hasBackdrop: false,
@@ -104,16 +106,8 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
     private handlePositionChange = handleStringChange((position: Position | "auto" | "auto-start" | "auto-end") =>
         this.setState({ position }),
     );
-    private handleBoundaryChange = handleStringChange((boundary: PopperJS.Boundary) =>
-        this.setState({
-            modifiers: {
-                ...this.state.modifiers,
-                preventOverflow: {
-                    boundariesElement: boundary,
-                    enabled: boundary.length > 0,
-                },
-            },
-        }),
+    private handleBoundaryChange = handleStringChange((boundariesElement: PopperJS.Boundary) =>
+        this.setState({ boundariesElement }),
     );
 
     private toggleEscapeKey = handleBooleanChange(canEscapeKeyClose => this.setState({ canEscapeKeyClose }));
@@ -207,7 +201,7 @@ export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverE
                     <div style={{ marginTop: 5 }} />
                     <HTMLSelect
                         disabled={!preventOverflow.enabled}
-                        value={preventOverflow.boundariesElement.toString()}
+                        value={this.state.boundariesElement}
                         onChange={this.handleBoundaryChange}
                     >
                         <option value="scrollParent">scrollParent</option>

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -109,7 +109,7 @@ export class PopoverPortalExample extends React.PureComponent<IExampleProps, IPo
 
 const POPOVER_PROPS: IPopoverProps = {
     autoFocus: false,
-    boundariesElement: "window",
+    boundary: "window",
     enforceFocus: false,
     popoverClassName: "docs-popover-portal-example-popover",
     position: Position.BOTTOM,

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -109,10 +109,8 @@ export class PopoverPortalExample extends React.PureComponent<IExampleProps, IPo
 
 const POPOVER_PROPS: IPopoverProps = {
     autoFocus: false,
+    boundariesElement: "window",
     enforceFocus: false,
-    // not relevant to this example, but required in order for default
-    // modifiers to work (e.g. `hide`).
-    modifiers: { preventOverflow: { boundariesElement: "window" } },
     popoverClassName: "docs-popover-portal-example-popover",
     position: Position.BOTTOM,
 };


### PR DESCRIPTION
- `Popover` `boundariesElement` prop to quickly set both `flip` & `preventOverflow` Popper modifier behavior