### PR TITLE
[ControlGroup] fix disappearing caret on focus of HTMLSelect in ControlGroup

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -156,7 +156,10 @@ Styleguide control-group
 
   // keep the select-menu carets on top of everything always (particularly when
   // .#{$ns}-selects are focused).
-  .#{$ns}-select::after {
+  .#{$ns}-select::after,
+  .#{$ns}-html-select::after,
+  .#{$ns}-select > .#{$ns}-icon,
+  .#{$ns}-html-select > .#{$ns}-icon {
     z-index: index($control-group-stack, "select-caret");
   }
 


### PR DESCRIPTION
#### Fixes #3003

#### Changes proposed in this pull request:

Caret-specific z-index on focus was set for `.bp3-select`, but not for `.bp3-html-select`.

#### Reviewers should focus on:

Caret icon when you focus a `HTMLSelect` in a `ControlGroup`.