### PR TITLE
[Callout] support title only

### DIFF
--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -57,6 +57,10 @@ Styleguide callout
     margin-top: 0;
     margin-bottom: $pt-grid-size / 2;
     line-height: $pt-icon-size-large;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .#{$ns}-dark & {


### PR DESCRIPTION
#### Changes proposed in this pull request:

- remove bottom margin when a Callout contains only a title (no body text)