### PR TITLE
Fixed bug where new timeout prop passed to toastr update was ignored

### DIFF
--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -79,7 +79,9 @@ export class Toast extends AbstractPureComponent<IToastProps, {}> {
     }
 
     public componentDidUpdate(prevProps: IToastProps) {
-        if (prevProps.timeout <= 0 && this.props.timeout > 0) {
+        if (prevProps.timeout !== this.props.timeout && this.props.timeout > 0) {
+            this.startTimeout();
+        } else if (prevProps.timeout <= 0 && this.props.timeout > 0) {
             this.startTimeout();
         } else if (prevProps.timeout > 0 && this.props.timeout <= 0) {
             this.clearTimeouts();


### PR DESCRIPTION
#### Fixes #3107 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

When using keys to update a toast you should also be able to pass in a new timeout prop. This lets you show a toast while something is loading for example and then hide it once it finishes.

#### Reviewers should focus on:

connects https://github.com/palantir/blueprint/issues/3107

