### PR TITLE
fix: render items when no query

### DIFF
--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -65,7 +65,7 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { initialContent = null, isOpen, inputProps, overlayProps, ...restProps } = this.props;
+        const { initialContent, isOpen, inputProps, overlayProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -43,6 +43,15 @@ describe("<QueryList>", () => {
         });
     });
 
+    describe("rendering", () => {
+        it("items are rendered by default if there is no query", () => {
+            const itemRenderer = sinon.spy(() => <li className="foo">foo</li>);
+            const wrapper = shallow(<FilmQueryList {...testProps} itemRenderer={itemRenderer} />);
+            assert.lengthOf(wrapper.find("li.foo"), 20, "should find elements");
+            assert.equal(itemRenderer.callCount, 20);
+        });
+    });
+
     describe("filtering", () => {
         it("itemPredicate filters each item by query", () => {
             const predicate = sinon.spy((query: string, film: IFilm) => film.year === +query);

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -35,6 +35,11 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
     });
 
     describe("common behavior", () => {
+        it("renders all items when given an empty query and no initialContent", () => {
+            render({ ...testProps, query: "" });
+            assert.equal(testProps.itemRenderer.callCount, 20);
+        });
+
         it("itemRenderer is called for each child", () => {
             const wrapper = render(testProps);
             // each item is rendered once


### PR DESCRIPTION
#### Fixes #3160 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

In the Omnibar component, as per the documentation [here](https://blueprintjs.com/docs/#select/omnibar), if `initialContent` is omitted, all items will be rendered, however that's not the case, because in the method [here](https://github.com/palantir/blueprint/blob/develop/packages/select/src/common/itemListRenderer.ts#L63) the condition fails, since `initialContent` is passed as `null`.

The change proposed, is to remove the default value of `initialContent` in Omnibar component, and let it be `undefined`.

#### Reviewers should focus on:

Omnibar component and QueryList HOC.
