### PR TITLE
[DateRangePicker] Fix caption behavior in contiguous month mode

### DIFF
--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -135,8 +135,12 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
   left: 0;
   height: $pt-button-height;
 
-  > :first-child {
+  > .DayPicker-NavButton--prev {
     margin-right: auto;
+  }
+
+  > .DayPicker-NavButton--next {
+    margin-left: auto;
   }
 }
 

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -32,11 +32,11 @@
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous {
     .DayPicker {
-      min-width: ($datepicker-min-width * 2) + $pt-grid-size;
+      min-width: $datepicker-min-width + $pt-grid-size;
     }
 
     .#{$ns}-daterangepicker-shortcuts + .DayPicker {
-      min-width: ($datepicker-min-width + $pt-grid-size) * 2;
+      min-width: $datepicker-min-width + $pt-grid-size;
     }
   }
 

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -15,6 +15,9 @@ import { areSameMonth } from "./common/dateUtils";
 export interface IDatePickerNavbarProps extends NavbarElementProps {
     maxDate: Date;
     minDate: Date;
+
+    hideLeftNavButton?: boolean;
+    hideRightNavButton?: boolean;
 }
 
 export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps> {
@@ -23,20 +26,24 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
 
         return (
             <div className={classNames(Classes.DATEPICKER_NAVBAR, classes.navBar)}>
-                <Button
-                    className={classes.navButtonPrev}
-                    disabled={areSameMonth(month, minDate)}
-                    icon="chevron-left"
-                    minimal={true}
-                    onClick={this.handlePreviousClick}
-                />
-                <Button
-                    className={classes.navButtonNext}
-                    disabled={areSameMonth(month, maxDate)}
-                    icon="chevron-right"
-                    minimal={true}
-                    onClick={this.handleNextClick}
-                />
+                {this.props.hideLeftNavButton || (
+                    <Button
+                        className={classes.navButtonPrev}
+                        disabled={areSameMonth(month, minDate)}
+                        icon="chevron-left"
+                        minimal={true}
+                        onClick={this.handlePreviousClick}
+                    />
+                )}
+                {this.props.hideRightNavButton || (
+                    <Button
+                        className={classes.navButtonNext}
+                        disabled={areSameMonth(month, maxDate)}
+                        icon="chevron-right"
+                        minimal={true}
+                        onClick={this.handleNextClick}
+                    />
+                )}
             </div>
         );
     }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -224,7 +224,10 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
     public componentWillReceiveProps(nextProps: IDateRangePickerProps) {
         super.componentWillReceiveProps(nextProps);
 
-        if (!DateUtils.areRangesEqual(this.props.value, nextProps.value)) {
+        if (
+            !DateUtils.areRangesEqual(this.props.value, nextProps.value) ||
+            this.props.contiguousCalendarMonths !== nextProps.contiguousCalendarMonths
+        ) {
             const nextState = getStateChange(
                 this.props.value,
                 nextProps.value,
@@ -669,6 +672,13 @@ function getStateChange(
             rightView,
             value: nextValue,
         };
+    } else if (contiguousCalendarMonths === true) {
+        // contiguousCalendarMonths is toggled on.
+        // If the previous leftView and rightView are not contiguous, then set the right DayPicker to left + 1
+        if (!state.leftView.getNextMonth().isSameMonth(state.rightView)) {
+            const nextRightView = state.leftView.getNextMonth();
+            return { rightView: nextRightView };
+        }
     }
 
     return {};

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -332,7 +332,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
     };
 
     private renderCalendars(isShowingOneMonth: boolean) {
-        const { contiguousCalendarMonths, dayPickerProps, locale, localeUtils, maxDate, minDate } = this.props;
+        const { dayPickerProps, locale, localeUtils, maxDate, minDate } = this.props;
         const dayPickerBaseProps: DayPickerProps = {
             locale,
             localeUtils,
@@ -346,15 +346,15 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             selectedDays: this.state.value,
         };
 
-        if (contiguousCalendarMonths || isShowingOneMonth) {
+        if (isShowingOneMonth) {
             return (
                 <DayPicker
                     {...dayPickerBaseProps}
                     captionElement={this.renderSingleCaption}
-                    navbarElement={this.renderNavbar}
+                    navbarElement={this.renderSingleNavbar}
                     fromMonth={minDate}
                     month={this.state.leftView.getFullDate()}
-                    numberOfMonths={isShowingOneMonth ? 1 : 2}
+                    numberOfMonths={1}
                     onMonthChange={this.handleLeftMonthChange}
                     toMonth={maxDate}
                 />
@@ -366,7 +366,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
                     {...dayPickerBaseProps}
                     canChangeMonth={true}
                     captionElement={this.renderLeftCaption}
-                    navbarElement={this.renderNavbar}
+                    navbarElement={this.renderLeftNavbar}
                     fromMonth={minDate}
                     month={this.state.leftView.getFullDate()}
                     numberOfMonths={1}
@@ -378,7 +378,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
                     {...dayPickerBaseProps}
                     canChangeMonth={true}
                     captionElement={this.renderRightCaption}
-                    navbarElement={this.renderNavbar}
+                    navbarElement={this.renderRightNavbar}
                     fromMonth={DateUtils.getDateNextMonth(minDate)}
                     month={this.state.rightView.getFullDate()}
                     numberOfMonths={1}
@@ -389,8 +389,26 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         }
     }
 
-    private renderNavbar = (navbarProps: NavbarElementProps) => (
+    private renderSingleNavbar = (navbarProps: NavbarElementProps) => (
         <DatePickerNavbar {...navbarProps} maxDate={this.props.maxDate} minDate={this.props.minDate} />
+    );
+
+    private renderLeftNavbar = (navbarProps: NavbarElementProps) => (
+        <DatePickerNavbar
+            {...navbarProps}
+            hideRightNavButton={this.props.contiguousCalendarMonths}
+            maxDate={this.props.maxDate}
+            minDate={this.props.minDate}
+        />
+    );
+
+    private renderRightNavbar = (navbarProps: NavbarElementProps) => (
+        <DatePickerNavbar
+            {...navbarProps}
+            hideLeftNavButton={this.props.contiguousCalendarMonths}
+            maxDate={this.props.maxDate}
+            minDate={this.props.minDate}
+        />
     );
 
     private renderSingleCaption = (captionProps: CaptionElementProps) => (
@@ -513,7 +531,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
 
     private updateLeftView(leftView: MonthAndYear) {
         let rightView = this.state.rightView.clone();
-        if (!leftView.isBefore(rightView)) {
+        if (!leftView.isBefore(rightView) || this.props.contiguousCalendarMonths) {
             rightView = leftView.getNextMonth();
         }
         this.setViews(leftView, rightView);
@@ -521,7 +539,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
 
     private updateRightView(rightView: MonthAndYear) {
         let leftView = this.state.leftView.clone();
-        if (!rightView.isAfter(leftView)) {
+        if (!rightView.isAfter(leftView) || this.props.contiguousCalendarMonths) {
             leftView = rightView.getPreviousMonth();
         }
         this.setViews(leftView, rightView);
@@ -550,7 +568,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         }
 
         let rightView = this.state.rightView.clone();
-        if (!leftView.isBefore(rightView)) {
+        if (!leftView.isBefore(rightView) || this.props.contiguousCalendarMonths) {
             rightView = leftView.getNextMonth();
         }
 
@@ -573,7 +591,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         }
 
         let leftView = this.state.leftView.clone();
-        if (!rightView.isAfter(leftView)) {
+        if (!rightView.isAfter(leftView) || this.props.contiguousCalendarMonths) {
             leftView = rightView.getPreviousMonth();
         }
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -339,7 +339,7 @@ describe("<DateRangePicker>", () => {
         });
     });
 
-    describe("left/right calendar when not sequential", () => {
+    describe("left/right calendar", () => {
         function assertFirstLastMonths(monthSelect: ReactWrapper, first: Months, last: Months) {
             const options = monthSelect.find("option");
             assert.equal(options.first().prop("value"), first);
@@ -374,6 +374,94 @@ describe("<DateRangePicker>", () => {
             assertFirstLastMonths(monthSelect, Months.FEBRUARY, Months.DECEMBER);
         });
 
+        it("right calendar shows the month containing the selected end date", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.JULY, 5);
+            render({ contiguousCalendarMonths: false, value: [startDate, endDate] }).right.assertMonthYear(Months.JULY);
+        });
+
+        it("right calendar shows the month immediately after the left view if startDate === endDate month", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.MAY, 15);
+            render({ contiguousCalendarMonths: false, value: [startDate, endDate] }).right.assertMonthYear(Months.JUNE);
+        });
+    });
+
+    describe("left/right calendar when contiguous", () => {
+        it("changing left calendar with month dropdown shifts left to the selected month", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right } = render({ initialMonth });
+            left.assertMonthYear(Months.MAY);
+            right.assertMonthYear(Months.JUNE);
+            left.monthSelect.simulate("change", { target: { value: Months.AUGUST } });
+            left.assertMonthYear(Months.AUGUST);
+            right.assertMonthYear(Months.SEPTEMBER);
+        });
+
+        it("changing right calendar with month dropdown shifts right to the selected month", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right } = render({ initialMonth });
+            left.assertMonthYear(Months.MAY);
+            right.assertMonthYear(Months.JUNE);
+            right.monthSelect.simulate("change", { target: { value: Months.AUGUST } });
+            left.assertMonthYear(Months.JULY);
+            right.assertMonthYear(Months.AUGUST);
+        });
+
+        it("changing left calendar with year dropdown shifts left to the selected year", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertMonthYear(Months.MAY);
+            right.assertMonthYear(Months.JUNE);
+            left.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertMonthYear(Months.MAY, NEW_YEAR);
+            right.assertMonthYear(Months.JUNE, NEW_YEAR);
+        });
+
+        it("changing right calendar with year dropdown shifts right to the selected year", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertMonthYear(Months.MAY);
+            right.assertMonthYear(Months.JUNE);
+            right.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertMonthYear(Months.MAY, NEW_YEAR);
+            right.assertMonthYear(Months.JUNE, NEW_YEAR);
+        });
+
+        it("when calendar is between December and January, changing left calendar with year dropdown shifts left to the selected year", () => {
+            const INITIAL_YEAR = 2015;
+            const initialMonth = new Date(INITIAL_YEAR, Months.DECEMBER, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertMonthYear(Months.DECEMBER, INITIAL_YEAR);
+            right.assertMonthYear(Months.JANUARY, INITIAL_YEAR + 1);
+            left.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertMonthYear(Months.DECEMBER, NEW_YEAR);
+            right.assertMonthYear(Months.JANUARY, NEW_YEAR + 1);
+        });
+
+        it("when calendar is between December and January, changing right calendar with year dropdown shifts right to the selected year", () => {
+            const INITIAL_YEAR = 2015;
+            const initialMonth = new Date(INITIAL_YEAR, Months.DECEMBER, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertMonthYear(Months.DECEMBER, INITIAL_YEAR);
+            right.assertMonthYear(Months.JANUARY, INITIAL_YEAR + 1);
+            right.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertMonthYear(Months.DECEMBER, NEW_YEAR - 1);
+            right.assertMonthYear(Months.JANUARY, NEW_YEAR);
+        });
+    });
+
+    describe("left/right calendar when not contiguous", () => {
         it("left calendar can be altered independently of right calendar", () => {
             const initialMonth = new Date(2015, Months.MAY, 5);
             const { left, clickNavButton } = render({ initialMonth, contiguousCalendarMonths: false });
@@ -453,18 +541,6 @@ describe("<DateRangePicker>", () => {
             clickNavButton("prev", 1);
             left.assertMonthYear(Months.APRIL);
             right.assertMonthYear(Months.MAY);
-        });
-
-        it("right calendar shows the month containing the selected end date", () => {
-            const startDate = new Date(2017, Months.MAY, 5);
-            const endDate = new Date(2017, Months.JULY, 5);
-            render({ contiguousCalendarMonths: false, value: [startDate, endDate] }).right.assertMonthYear(Months.JULY);
-        });
-
-        it("right calendar shows the month immediately after the left view if startDate === endDate month", () => {
-            const startDate = new Date(2017, Months.MAY, 5);
-            const endDate = new Date(2017, Months.MAY, 15);
-            render({ contiguousCalendarMonths: false, value: [startDate, endDate] }).right.assertMonthYear(Months.JUNE);
         });
     });
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -61,9 +61,21 @@ describe("<DateRangePicker>", () => {
         it("hides unnecessary nav buttons in contiguous months mode", () => {
             const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
             const wrapper = mount(<DateRangePicker defaultValue={defaultValue} />);
-            assert.isTrue(wrapper.find(DatePickerNavbar).at(0).find(".DayPicker-NavButton--next").isEmpty());
-            assert.isTrue(wrapper.find(DatePickerNavbar).at(1).find(".DayPicker-NavButton--prev").isEmpty());
-        })
+            assert.isTrue(
+                wrapper
+                    .find(DatePickerNavbar)
+                    .at(0)
+                    .find(".DayPicker-NavButton--next")
+                    .isEmpty(),
+            );
+            assert.isTrue(
+                wrapper
+                    .find(DatePickerNavbar)
+                    .at(1)
+                    .find(".DayPicker-NavButton--prev")
+                    .isEmpty(),
+            );
+        });
 
         it("disables days according to custom modifiers in addition to default modifiers", () => {
             const disableFridays = { daysOfWeek: [5] };

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -58,6 +58,13 @@ describe("<DateRangePicker>", () => {
             assert.equal(firstWeekday.prop("weekday"), selectedFirstDay);
         });
 
+        it("hides unnecessary nav buttons in contiguous months mode", () => {
+            const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
+            const wrapper = mount(<DateRangePicker defaultValue={defaultValue} />);
+            assert.isTrue(wrapper.find(DatePickerNavbar).at(0).find(".DayPicker-NavButton--next").isEmpty());
+            assert.isTrue(wrapper.find(DatePickerNavbar).at(1).find(".DayPicker-NavButton--prev").isEmpty());
+        })
+
         it("disables days according to custom modifiers in addition to default modifiers", () => {
             const disableFridays = { daysOfWeek: [5] };
             const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
@@ -140,6 +147,7 @@ describe("<DateRangePicker>", () => {
                 const onMonthChange = sinon.spy();
                 wrap(<DateRangePicker defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />).clickNavButton(
                     "next",
+                    1,
                 );
                 assert.isTrue(onMonthChange.called);
             });


### PR DESCRIPTION
#### Fixes #3178 

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] Include tests
- ~Update documentation~

#### Changes proposed in this pull request:

The linked bug happens in contiguous month mode, because the `DatePickerCaption` component on both months control `leftView`. With this fix, we now render two `DayPicker`s whose captions have different behaviors.

- Display two `DayPicker`s whose `DatePickerCaption` has different behaviors in contiguous month mode
- Allow hiding individual nav buttons in `DatePickerNavbar` to keep rendering consistent in contiguous mode

![date-range-picker](https://user-images.githubusercontent.com/4718844/49315884-2c0f5a00-f4bd-11e8-9e6b-5b6312f03fe8.gif)
