### PR TITLE
[DateRangePicker] Remove unused styling in daterangepicker.scss

### DIFF
--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -23,31 +23,13 @@
     justify-content: space-around;
   }
 
-  .#{$ns}-daterangepicker-shortcuts + .DayPicker {
-    border-left: 1px solid $pt-divider-black;
-    min-width: $datepicker-min-width + $pt-grid-size;
-    padding-left: $datepicker-padding;
-  }
-
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
-  &.#{$ns}-daterangepicker-contiguous {
-    .DayPicker {
-      min-width: ($datepicker-min-width * 2) + $pt-grid-size;
-    }
-
-    .#{$ns}-daterangepicker-shortcuts + .DayPicker {
-      min-width: ($datepicker-min-width + $pt-grid-size) * 2;
-    }
+  &.#{$ns}-daterangepicker-contiguous .DayPicker {
+    min-width: ($datepicker-min-width * 2) + $pt-grid-size;
   }
 
-  &.#{$ns}-daterangepicker-single-month {
-    .DayPicker {
-      min-width: $datepicker-min-width;
-    }
-
-    .#{$ns}-daterangepicker-shortcuts + .DayPicker {
-      min-width: $datepicker-min-width + $pt-grid-size;
-    }
+  &.#{$ns}-daterangepicker-single-month .DayPicker {
+    min-width: $datepicker-min-width;
   }
 
   .DayPicker-Day {


### PR DESCRIPTION
#### Changes proposed in this pull request:

https://github.com/palantir/blueprint/blob/628f4aebdce04b605a5cc124f1edeb773dc24cdd/packages/datetime/src/dateRangePicker.tsx#L271-L286

`Shortcuts` never has an immediate sibling of class `DayPicker`, so these styles don't apply anymore.