### PR TITLE
[Popover/DateInput] fix tabIndex & inputRef support

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -296,7 +296,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     };
 
     private renderTarget = (referenceProps: ReferenceChildrenProps) => {
-        const { targetClassName, targetTagName: TagName } = this.props;
+        const { openOnTargetFocus, targetClassName, targetTagName: TagName } = this.props;
         const { isOpen } = this.state;
         const isHoverInteractionKind = this.isHoverInteractionKind();
 
@@ -316,14 +316,16 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         targetProps.ref = referenceProps.ref;
 
         const rawTarget = Utils.ensureElement(this.understandChildren().target);
-        const { tabIndex = 0 } = rawTarget.props;
+        const rawTabIndex = rawTarget.props.tabIndex;
+        // ensure target is focusable if relevant prop enabled
+        const tabIndex = rawTabIndex == null && openOnTargetFocus && isHoverInteractionKind ? 0 : rawTabIndex;
         const clonedTarget: JSX.Element = React.cloneElement(rawTarget, {
             className: classNames(rawTarget.props.className, {
                 [Classes.ACTIVE]: isOpen && !isHoverInteractionKind,
             }),
             // force disable single Tooltip child when popover is open (BLUEPRINT-552)
             disabled: isOpen && Utils.isElementOfType(rawTarget, Tooltip) ? true : rawTarget.props.disabled,
-            tabIndex: this.props.openOnTargetFocus && isHoverInteractionKind ? tabIndex : undefined,
+            tabIndex,
         });
         return (
             <ResizeSensor onResize={this.handlePopoverResize}>

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -18,13 +18,11 @@ describe("<InputGroup>", () => {
         assert.isTrue(input.childAt(1).hasClass(Classes.INPUT));
     });
 
-    it("supports custom style", () => {
-        const input = mount(<InputGroup leftIcon="star" style={{ background: "yellow" }} />);
-        const inputElement = input
-            .find("input")
-            .first()
-            .getDOMNode() as HTMLElement;
+    it("supports custom props", () => {
+        const input = mount(<InputGroup leftIcon="star" style={{ background: "yellow" }} tabIndex={4} />);
+        const inputElement = input.find("input").getDOMNode() as HTMLElement;
         assert.equal(inputElement.style.background, "yellow");
+        assert.equal(inputElement.tabIndex, 4);
     });
 
     it(`renders right element inside .${Classes.INPUT_ACTION} after input`, () => {
@@ -51,5 +49,12 @@ describe("<InputGroup>", () => {
 
         group.setProps({ type: "password" });
         assert.strictEqual(group.find("input").prop("type"), "password");
+    });
+
+    it("supports inputRef", () => {
+        let input: HTMLInputElement | null = null;
+        // tslint:disable-next-line:jsx-no-lambda
+        mount(<InputGroup inputRef={ref => (input = ref)} />);
+        assert.instanceOf(input, HTMLInputElement);
     });
 });

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -22,7 +22,6 @@ import {
     Utils,
 } from "@blueprintjs/core";
 
-import { safeInvoke } from "../../core/lib/esm/common/utils";
 import * as Classes from "./common/classes";
 import { isDateValid, isDayInRange } from "./common/dateUtils";
 import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
@@ -232,7 +231,7 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
     private inputRef = (ref: HTMLInputElement | null) => {
         this.inputEl = ref;
         const { inputProps = {} } = this.props;
-        safeInvoke(inputProps.inputRef, ref);
+        Utils.safeInvoke(inputProps.inputRef, ref);
     };
 
     private isDateInRange(value: Date) {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -42,13 +42,19 @@ describe("<DateInput>", () => {
         assert.isTrue(popoverTarget.hasClass(CLASS_2));
     });
 
-    it("supports custom input style", () => {
-        const wrapper = mount(<DateInput {...DATE_FORMAT} inputProps={{ style: { background: "yellow" } }} />);
-        const inputElement = wrapper
-            .find("input")
-            .first()
-            .getDOMNode() as HTMLElement;
+    it("supports custom input props", () => {
+        const wrapper = mount(
+            <DateInput {...DATE_FORMAT} inputProps={{ style: { background: "yellow" }, tabIndex: 4 }} />,
+        );
+        const inputElement = wrapper.find("input").getDOMNode() as HTMLInputElement;
         assert.equal(inputElement.style.background, "yellow");
+        assert.equal(inputElement.tabIndex, 4);
+    });
+
+    it("supports inputProps.inputRef", () => {
+        let input: HTMLInputElement | null = null;
+        mount(<DateInput {...DATE_FORMAT} inputProps={{ inputRef: ref => (input = ref) }} />);
+        assert.instanceOf(input, HTMLInputElement);
     });
 
     it("Popover opens on input focus", () => {


### PR DESCRIPTION
#### Fixes #3169 

#### Changes proposed in this pull request:

- fix Popover's injection of `tabIndex` into target element
    - previously it would remove any `tabIndex` unless a condition was met. 
    - now the condition ensures that _some_ tabIndex is set, and uses prop otherwise.

cc @kittle31