### PR TITLE
changing bp-dialog css to have {user-select: initial;} 

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -71,7 +71,7 @@ $dialog-padding: $pt-grid-size * 2 !default;
   width: $pt-grid-size * 50;
   padding-bottom: $pt-grid-size * 2;
   pointer-events: all;
-  user-select: text;
+  user-select: initial;
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
https://github.com/palantir/blueprint/issues/3004

#### Fixes #3004

#### Changes proposed in this pull request:

Removing `user-select: text;` and replacing it with `user-select: initial;`

#### Reviewers should focus on:

Whether numeric form inputs in dialogs can have their text selected (they shouldn't) and whether this change affects anything else. 
