### PR TITLE
Circle bot logs artifact URLs if auth token is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/sinon": "^4.1.2",
     "@types/webpack": "^3.8.8",
     "chai": "^4.1.2",
-    "circle-github-bot": "^1.0.0",
+    "circle-github-bot": "^2.0.1",
     "cross-env": "^5.1.3",
     "gh-pages": "^1.1.0",
     "http-server": "^0.11.1",

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -3,20 +3,22 @@
 // Submits a comment to the change PR or commit with links to artifacts that
 // show the results of the code change being applied.
 
+const bot = require("circle-github-bot").create();
+
+const ARTIFACTS = {
+    "packages/docs-app/dist/index.html": "documentation",
+    "packages/landing-app/dist/index.html": "landing",
+    "packages/table-dev-app/dist/index.html": "table",
+};
+
 if (!process.env.GH_AUTH_TOKEN) {
-    console.error("Missing GH_AUTH_TOKEN env var, refusing to run.");
+    // simply log artifact URLs if auth token is missed (typical on forks)
+    Object.keys(ARTIFACTS).forEach(path => console.log(`${ARTIFACTS[path]}: ${bot.artifactUrl(path)}`))
     process.exit();
 }
 
-const bot = require("circle-github-bot").create();
-
-const links = [
-    bot.artifactLink("packages/docs-app/dist/index.html", "documentation"),
-    bot.artifactLink("packages/landing-app/dist/index.html", "landing"),
-    bot.artifactLink("packages/table-dev-app/dist/index.html", "table"),
-].join(" | ");
-
-bot.comment(`
-<h3>${bot.env.commitMessage}</h3>
+const links = Object.keys(ARTIFACTS).map(path => bot.artifactLink(path, ARTIFACTS[path])).join(" | ")
+bot.comment(process.env.GH_AUTH_TOKEN, `
+<h3>${bot.commitMessage()}</h3>
 Previews: <strong>${links}</strong>
 `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,10 +1305,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circle-github-bot@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/circle-github-bot/-/circle-github-bot-1.0.0.tgz#ed86b3a8003c3f9a4ef0e7c4311f6c4e58fdafdb"
-  integrity sha512-O03FawVUz4px4Pky+lcUbLv1PFkH0LLJMMzyj2/8oQ9IF2XrktYj9jM+R5lK/2nZJXj7A+DSrv5cakr3UlOaDA==
+circle-github-bot@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/circle-github-bot/-/circle-github-bot-2.0.1.tgz#feefa4c7f788ce842307e00d290d264728689f69"
+  integrity sha512-uTEX8RIjUVdvtILxEG3AXI2G9X0wZYrN/Y67IIvrosjM/nt/QBdogpDXbkVsNQmhmQYqqFguWUgt50z6UMIoXw==
 
 circular-dependency-plugin@^4.3.0:
   version "4.4.0"


### PR DESCRIPTION
#### Changes proposed in this pull request:

This should improve the OSS contribution experience. The preview bot will now log artifact URLs directly to Circle console if `GH_AUTH_TOKEN` is missing. This means no more digging through Artifacts tab or pestering users to add this auth token.