### PR TITLE
add mouseenter and mouseleave events to treenode

### DIFF
--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -50,6 +50,16 @@ export interface ITreeProps<T = {}> extends IProps {
      * Invoked when the caret of a collapsed node is clicked.
      */
     onNodeExpand?: TreeEventHandler<T>;
+
+    /**
+     * Invoked when the mouse is moved over a node.
+     */
+    onNodeMouseEnter?: TreeEventHandler<T>;
+
+    /**
+     * Invoked when the mouse is moved out of a node.
+     */
+    onNodeMouseLeave?: TreeEventHandler<T>;
 }
 
 export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
@@ -105,6 +115,8 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
                     onCollapse={this.handleNodeCollapse}
                     onDoubleClick={this.handleNodeDoubleClick}
                     onExpand={this.handleNodeExpand}
+                    onMouseEnter={this.handleNodeMouseEnter}
+                    onMouseLeave={this.handleNodeMouseLeave}
                     path={elementPath}
                 >
                     {this.renderNodes(node.childNodes, elementPath)}
@@ -142,6 +154,14 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>, {}> {
 
     private handleNodeExpand = (node: TreeNode<T>, e: React.MouseEvent<HTMLElement>) => {
         this.handlerHelper(this.props.onNodeExpand, node, e);
+    };
+
+    private handleNodeMouseEnter = (node: TreeNode<T>, e: React.MouseEvent<HTMLElement>) => {
+        this.handlerHelper(this.props.onNodeMouseEnter, node, e);
+    };
+
+    private handleNodeMouseLeave = (node: TreeNode<T>, e: React.MouseEvent<HTMLElement>) => {
+        this.handlerHelper(this.props.onNodeMouseLeave, node, e);
     };
 
     private handlerHelper(handlerFromProps: TreeEventHandler, node: TreeNode<T>, e: React.MouseEvent<HTMLElement>) {

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -73,6 +73,8 @@ export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
     onContextMenu?: (node: TreeNode<T>, e: React.MouseEvent<HTMLDivElement>) => void;
     onDoubleClick?: (node: TreeNode<T>, e: React.MouseEvent<HTMLDivElement>) => void;
     onExpand?: (node: TreeNode<T>, e: React.MouseEvent<HTMLSpanElement>) => void;
+    onMouseEnter?: (node: TreeNode<T>, e: React.MouseEvent<HTMLDivElement>) => void;
+    onMouseLeave?: (node: TreeNode<T>, e: React.MouseEvent<HTMLDivElement>) => void;
     path: number[];
 }
 
@@ -106,6 +108,8 @@ export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
                     onClick={this.handleClick}
                     onContextMenu={this.handleContextMenu}
                     onDoubleClick={this.handleDoubleClick}
+                    onMouseEnter={this.handleMouseEnter}
+                    onMouseLeave={this.handleMouseLeave}
                     ref={this.handleContentRef}
                 >
                     {this.maybeRenderCaret()}
@@ -158,5 +162,13 @@ export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>, {}> {
 
     private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
         safeInvoke(this.props.onDoubleClick, this, e);
+    };
+
+    private handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+        safeInvoke(this.props.onMouseEnter, this, e);
+    };
+
+    private handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
+        safeInvoke(this.props.onMouseLeave, this, e);
     };
 }

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -96,6 +96,8 @@ describe("<Tree>", () => {
         const onNodeContextMenu = spy();
         const onNodeDoubleClick = spy();
         const onNodeExpand = spy();
+        const onNodeMouseEnter = spy();
+        const onNodeMouseLeave = spy();
 
         const contents = createDefaultContents();
         contents[3].isExpanded = true;
@@ -107,6 +109,8 @@ describe("<Tree>", () => {
             onNodeContextMenu,
             onNodeDoubleClick,
             onNodeExpand,
+            onNodeMouseEnter,
+            onNodeMouseLeave,
         });
 
         tree.find(`.c0 > .${Classes.TREE_NODE_CONTENT}`).simulate("click");
@@ -130,6 +134,14 @@ describe("<Tree>", () => {
         tree.find(`.c0 > .${Classes.TREE_NODE_CONTENT}`).simulate("contextmenu");
         assert.isTrue(onNodeContextMenu.calledOnce);
         assert.deepEqual(onNodeContextMenu.args[0][1], [0]);
+
+        tree.find(`.c2 > .${Classes.TREE_NODE_CONTENT}`).simulate("mouseenter");
+        assert.isTrue(onNodeMouseEnter.calledOnce);
+        assert.deepEqual(onNodeMouseEnter.args[0][1], [2]);
+
+        tree.find(`.c2 > .${Classes.TREE_NODE_CONTENT}`).simulate("mouseleave");
+        assert.isTrue(onNodeMouseLeave.calledOnce);
+        assert.deepEqual(onNodeMouseLeave.args[0][1], [2]);
     });
 
     it("icons are rendered correctly if present", () => {


### PR DESCRIPTION
#### Fixes #3168

#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] [Enable preview comments on CircleCI](https://github.com/palantir/blueprint/blob/develop/CONTRIBUTING.md#enable-preview-comments)
- [x] Include tests
- [x] Update documentation (I think this is automatic from the TS annotations?)

#### Changes proposed in this pull request:

Adds `onNodeMouseEnter` and `onNodeMouseLeave` event handlers to a `Tree`.

#### Reviewers should focus on:

Naming of new props
