### PR TITLE
Add htmlTitle prop to Icon

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -65,6 +65,12 @@ export interface IIconProps extends IIntentProps, IProps {
      * explicit falsy value to disable.
      */
     title?: string | false | null;
+
+    /**
+     * String for the title attribute on the rendered element, which will appear
+     * as a tooltip in the browser.
+     */
+    htmlTitle?: string;
 }
 
 export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<HTMLElement>> {
@@ -88,6 +94,7 @@ export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<H
             intent,
             title = icon,
             tagName: TagName = "span",
+            htmlTitle,
             ...htmlprops
         } = this.props;
 
@@ -100,7 +107,7 @@ export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<H
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
 
         return (
-            <TagName {...htmlprops} className={classes}>
+            <TagName {...htmlprops} className={classes} title={htmlTitle}>
                 <svg fill={color} data-icon={icon} width={iconSize} height={iconSize} viewBox={viewBox}>
                     {title && <desc>{title}</desc>}
                     {paths}

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -25,6 +25,12 @@ export interface IIconProps extends IIntentProps, IProps {
     color?: string;
 
     /**
+     * String for the `title` attribute on the rendered element, which will appear
+     * as a native browser tooltip.
+     */
+    htmlTitle?: string;
+
+    /**
      * Name of a Blueprint UI icon, or an icon element, to render. This prop is
      * required because it determines the content of the component, but it can
      * be explicitly set to falsy values to render nothing.
@@ -65,12 +71,6 @@ export interface IIconProps extends IIntentProps, IProps {
      * explicit falsy value to disable.
      */
     title?: string | false | null;
-
-    /**
-     * String for the title attribute on the rendered element, which will appear
-     * as a tooltip in the browser.
-     */
-    htmlTitle?: string;
 }
 
 export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<HTMLElement>> {
@@ -90,11 +90,11 @@ export class Icon extends React.PureComponent<IIconProps & React.DOMAttributes<H
         const {
             className,
             color,
+            htmlTitle,
             iconSize = Icon.SIZE_STANDARD,
             intent,
             title = icon,
             tagName: TagName = "span",
-            htmlTitle,
             ...htmlprops
         } = this.props;
 

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -26,7 +26,7 @@ export interface IIconProps extends IIntentProps, IProps {
 
     /**
      * String for the `title` attribute on the rendered element, which will appear
-     * as a native browser tooltip.
+     * on hover as a native browser tooltip.
      */
     htmlTitle?: string;
 


### PR DESCRIPTION
#### Checklist
<!-- fill this section out if necessary, remove it otherwise -->

- [x] [Enable CircleCI for your fork](https://circleci.com/add-projects)
- [x] [Enable preview comments on CircleCI](https://github.com/palantir/blueprint/blob/develop/CONTRIBUTING.md#enable-preview-comments)
- [ ] Include tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Add an `htmlTitle` prop to `<Icon>` which gets applied as the HTML `title` attribute, and appears as the built in browser tooltip on hover

Helps address/provide workaround for #3214 

#### Reviewers should focus on:

<!-- fill this out -->

#### Screenshot

<!-- include an image of the most relevant user-facing change, if any -->
