### PR TITLE
update contributing notes: DO NOT enable Circle for forks.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,20 @@
 #### Fixes #0000
 
 #### Checklist
-<!-- fill this section out if necessary, remove it otherwise -->
 
-- [ ] [Enable CircleCI for your fork](https://circleci.com/add-projects)
-- [ ] [Enable preview comments on CircleCI](https://github.com/palantir/blueprint/blob/develop/CONTRIBUTING.md#enable-preview-comments)
-- [ ] Include tests
+- [ ] Includes tests
 - [ ] Update documentation
+
+<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->
 
 #### Changes proposed in this pull request:
 
-<!-- fill this out -->
+<!-- Fill this out. -->
 
 #### Reviewers should focus on:
 
-<!-- fill this out -->
+<!-- Fill this out. -->
 
 #### Screenshot
 
-<!-- include an image of the most relevant user-facing change, if any -->
+<!-- Include an image of the most relevant user-facing change, if any. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,9 @@ A typical contributor workflow looks like this:
       `yarn lint` to be 100% safe.
     - TypeScript lint errors can often be automatically fixed by TSLint. Run lint fixes with `yarn lint-fix`.
 1. Submit a Pull Request on GitHub and fill out the template.
-    - :warning: __DO NOT enable CircleCI for your fork of Blueprint.__ Our build
-      will run on your fork when you open a PR. You can run relevant parts of
-      the build locally by inspecting the config or
+    - ⚠️ __DO NOT enable CircleCI for your fork of Blueprint.__ Our build
+      will run on your fork when you open a PR. You can run NPM scripts locally
+      to validate before pushing code.
 1. Team members will review your code and merge it after approvals.
     - You may be asked to make modifications to code style or to fix bugs you may have not noticed.
     - Please respond to comments in a timely fashion (even if to tell us you need more time).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,28 +41,12 @@ A typical contributor workflow looks like this:
       `yarn lint` to be 100% safe.
     - TypeScript lint errors can often be automatically fixed by TSLint. Run lint fixes with `yarn lint-fix`.
 1. Submit a Pull Request on GitHub and fill out the template.
+    - :warning: __DO NOT enable CircleCI for your fork of Blueprint.__ Our build
+      will run on your fork when you open a PR. You can run relevant parts of
+      the build locally by inspecting the config or
 1. Team members will review your code and merge it after approvals.
     - You may be asked to make modifications to code style or to fix bugs you may have not noticed.
     - Please respond to comments in a timely fashion (even if to tell us you need more time).
     - _Do not_ amend commits and `push --force` as they break the PR history. Please add more commits; we squash each PR to a single commit on merge.
 1. Hooray, you contributed! :tophat:
 
-### Enable preview comments
-
-The team relies on PR "preview comments" for immediate feedback on features during development.
-Forkers must manually enable comments by defining the `GH_AUTH_TOKEN` environment variable on
-CircleCI.
-
-If you're developing on a fork of Blueprint:
-
-1. Navigate to [CircleCI](https://circleci.com/add-projects), log in using your GitHub account,
-and click **"Build project"** for your fork of Blueprint.
-1. Navigate to the [token settings](https://github.com/settings/tokens) on GitHub and create a user
-token with the `public_repo` scope.
-1. Navigate to your CircleCI repo settings: `https://circleci.com/gh/<username>/blueprint/edit#env-vars`
-and create a new environment variable called `GH_AUTH_TOKEN` with the token you created earlier.
-The end result should look like so:
-
-    ![image](https://cloud.githubusercontent.com/assets/464822/22609529/6845d7e6-ea16-11e6-8a8e-444057bc4687.png)
-1. When a build passes, a comment will be automatically posted to your PR that links to the
-generated artifacts containing your changes.


### PR DESCRIPTION
ran through a flow with @gabeboning and turns out the build works best when folks __DO NOT__ enable it on their forks. we've had issues with build parallelism and with the preview comments that are all resolved if contributors just leverage our build configuration instead of enabling their own.