### PR TITLE
Removed es6-shim from @blueprintjs/table for 1.x version

### DIFF
--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -42,6 +42,15 @@ dependencies:
   npm install --save react react-dom react-addons-css-transition-group
   ```
 
+1. Note that since the minimum supported version of React is [v16](https://reactjs.org/blog/2017/09/26/react-v16.0.html),
+all of its [JavaScript Environment Requirements](https://reactjs.org/docs/javascript-environment-requirements.html) apply to
+Blueprint as well. Some Blueprint components use the following ES2015 features:
+  - `Map`
+  - `Set`
+   We recommend polyfilling these features using [es6-shim](https://github.com/paulmillr/es6-shim) or
+  [core-js](https://github.com/zloirock/core-js).
+
+
 1. After installation, you'll be able to import the React components in your application:
 
   ```tsx

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@blueprintjs/core": "^1.36.1",
     "classnames": "^2.2",
-    "es6-shim": "^0.35",
     "pure-render-decorator": "^1.1",
     "tslib": "^1.5.0"
   },

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -4,8 +4,6 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import "es6-shim";
-
 export { Cell, ICellProps, ICellRenderer } from "./cell/cell";
 
 export { EditableCell, IEditableCellProps } from "./cell/editableCell";

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -4,8 +4,6 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import "es6-shim";
-
 import { Menu, MenuItem } from "@blueprintjs/core";
 import { expect } from "chai";
 import { shallow } from "enzyme";

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -4,8 +4,6 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import "es6-shim";
-
 import { expect } from "chai";
 import * as sinon from "sinon";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,10 +2428,6 @@ es6-set@~0.1.5:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
-es6-shim@^0.35:
-  version "0.35.3"
-  resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.3.tgz#9bfb7363feffff87a6cdb6cd93e405ec3c4b6f26"
-
 es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"


### PR DESCRIPTION
#### Fixes #522
The fixes for this issue were not backported to the 1.x version. This PR aims to do this.