### PR TITLE
[Drawer] one size prop and tests

### DIFF
--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -10,35 +10,38 @@ $drawer-margin: ($pt-grid-size * 3) 0 !default;
 $drawer-padding: $pt-grid-size * 2 !default;
 
 .#{$ns}-drawer {
-  @include react-transition-phase(
-    "#{$ns}-overlay",
-    "enter",
-    (transform: (translateX(100%), translateX(0))),
-    $pt-transition-duration * 2,
-    $pt-transition-ease,
-    $before: "&"
-  );
-  @include react-transition-phase(
-    "#{$ns}-overlay",
-    "exit",
-    (transform: (translateX(100%), translateX(0))),
-    $pt-transition-duration,
-    $before: "&"
-  );
   display: flex;
   flex-direction: column;
-  top: 0;
-  right: 0;
-  bottom: 0;
   margin: 0;
   box-shadow: $pt-elevation-shadow-4;
   background: $white;
-  width: 95%;
-  max-width: 800px;
   padding: 0;
 
   &:focus {
     outline: 0;
+  }
+
+  &:not(.#{$ns}-vertical) {
+    @include react-transition-phase(
+      "#{$ns}-overlay",
+      "enter",
+      (transform: (translateX(100%), translateX(0))),
+      $pt-transition-duration * 2,
+      $pt-transition-ease,
+      $before: "&"
+    );
+    @include react-transition-phase(
+      "#{$ns}-overlay",
+      "exit",
+      (transform: (translateX(100%), translateX(0))),
+      $pt-transition-duration,
+      $before: "&"
+    );
+
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 25%;
   }
 
   &.#{$ns}-vertical {
@@ -57,37 +60,11 @@ $drawer-padding: $pt-grid-size * 2 !default;
       $pt-transition-duration,
       $before: "&"
     );
-    top: auto;
+
+    right: 0;
     bottom: 0;
     left: 0;
-    width: 100%;
-    max-width: 100%;
-    height: 95%;
-    max-height: 600px;
-
-    &.#{$ns}-large {
-      width: 100%;
-      max-width: 100%;
-      height: 95%;
-      max-height: 900px;
-    }
-
-    &.#{$ns}-small {
-      width: 100%;
-      max-width: 100%;
-      height: 95%;
-      max-height: 300px;
-    }
-  }
-
-  &.#{$ns}-large {
-    width: 95%;
-    max-width: 1200px;
-  }
-
-  &.#{$ns}-small {
-    width: 95%;
-    max-width: 400px;
+    height: 25%;
   }
 
   &.#{$ns}-dark,

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -19,7 +19,7 @@ import { IBackdropProps, IOverlayableProps, Overlay } from "../overlay/overlay";
 export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps {
     /**
      * Name of a Blueprint UI icon (or an icon element) to render in the
-     * dialog's header. Note that the header will only be rendered if `title` is
+     * drawer's header. Note that the header will only be rendered if `title` is
      * provided.
      */
     icon?: IconName | JSX.Element;
@@ -37,11 +37,7 @@ export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps 
      */
     isOpen: boolean;
 
-    /** Whether this drawer should use large styles. */
-    large?: boolean;
-
-    /** Whether this drawer should use small styles. */
-    small?: boolean;
+    size?: number | string;
 
     /**
      * CSS styles to apply to the dialog.
@@ -69,34 +65,27 @@ export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps 
 }
 
 export class Drawer extends AbstractPureComponent<IDrawerProps, {}> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.Drawer`;
     public static defaultProps: IDrawerProps = {
         canOutsideClickClose: true,
+        isCloseButtonShown: true,
         isOpen: false,
-        large: false,
-        small: false,
+        style: {},
         vertical: false,
     };
 
-    public static displayName = `${DISPLAYNAME_PREFIX}.Drawer`;
+    public static readonly SIZE_SMALL = 300;
+    public static readonly SIZE_STANDARD = "50%";
+    public static readonly SIZE_LARGE = "75%";
 
     public render() {
-        const classes = classNames(
-            Classes.DRAWER,
-            {
-                [Classes.LARGE]: this.props.large,
-                [Classes.SMALL]: this.props.small,
-                [Classes.VERTICAL]: this.props.vertical,
-            },
-            this.props.className,
-        );
+        const { size, style, vertical } = this.props;
+        const classes = classNames(Classes.DRAWER, { [Classes.VERTICAL]: vertical }, this.props.className);
+        const styleProp = size == null ? style : { ...style, [vertical ? "height" : "width"]: size };
         // small drawer should not use a backdrop
         return (
-            <Overlay
-                {...this.props}
-                className={Classes.OVERLAY_CONTAINER}
-                hasBackdrop={this.props.hasBackdrop || !this.props.small}
-            >
-                <div className={classes} style={this.props.style}>
+            <Overlay {...this.props} className={Classes.OVERLAY_CONTAINER}>
+                <div className={classes} style={styleProp}>
                     {this.maybeRenderHeader()}
                     {this.props.children}
                 </div>
@@ -116,9 +105,7 @@ export class Drawer extends AbstractPureComponent<IDrawerProps, {}> {
     }
 
     private maybeRenderCloseButton() {
-        // show close button if prop is undefined or null
-        // this gives us a behavior as if the default value were `true`
-        if (this.props.isCloseButtonShown !== false) {
+        if (this.props.isCloseButtonShown) {
             return (
                 <Button
                     aria-label="Close"
@@ -129,14 +116,14 @@ export class Drawer extends AbstractPureComponent<IDrawerProps, {}> {
                 />
             );
         } else {
-            return undefined;
+            return null;
         }
     }
 
     private maybeRenderHeader() {
         const { icon, title } = this.props;
         if (title == null) {
-            return undefined;
+            return null;
         }
         return (
             <div className={Classes.DRAWER_HEADER}>

--- a/packages/core/test/drawer/drawerTests.tsx
+++ b/packages/core/test/drawer/drawerTests.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { assert } from "chai";
+import { mount } from "enzyme";
+import * as React from "react";
+import { spy } from "sinon";
+
+import * as Keys from "../../src/common/keys";
+import { Button, Classes, Drawer, H4, Icon } from "../../src/index";
+
+describe("<Drawer>", () => {
+    it("renders its content correctly", () => {
+        const dialog = mount(
+            <Drawer isOpen={true} usePortal={false}>
+                {createDrawerContents()}
+            </Drawer>,
+        );
+        [
+            Classes.DRAWER,
+            Classes.DRAWER_BODY,
+            Classes.DRAWER_FOOTER,
+            Classes.DRAWER_HEADER,
+            Classes.OVERLAY_BACKDROP,
+        ].forEach(className => {
+            assert.lengthOf(dialog.find(`.${className}`), 1, `missing ${className}`);
+        });
+    });
+
+    it("portalClassName appears on Portal", () => {
+        const TEST_CLASS = "test-class";
+        const dialog = mount(
+            <Drawer isOpen={true} portalClassName={TEST_CLASS}>
+                {createDrawerContents()}
+            </Drawer>,
+        );
+        assert.isDefined(document.querySelector(`.${Classes.PORTAL}.${TEST_CLASS}`));
+        dialog.unmount();
+    });
+
+    it("renders contents to specified container correctly", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        mount(
+            <Drawer isOpen={true} portalContainer={container}>
+                {createDrawerContents()}
+            </Drawer>,
+        );
+        assert.lengthOf(container.getElementsByClassName(Classes.DIALOG), 1, `missing ${Classes.DIALOG}`);
+        document.body.removeChild(container);
+    });
+
+    it("attempts to close when overlay backdrop element is moused down", () => {
+        const onClose = spy();
+        const dialog = mount(
+            <Drawer isOpen={true} onClose={onClose} usePortal={false}>
+                {createDrawerContents()}
+            </Drawer>,
+        );
+        dialog.find(`.${Classes.OVERLAY_BACKDROP}`).simulate("mousedown");
+        assert.isTrue(onClose.calledOnce);
+    });
+
+    it("doesn't close when canOutsideClickClose=false and overlay backdrop element is moused down", () => {
+        const onClose = spy();
+        const dialog = mount(
+            <Drawer canOutsideClickClose={false} isOpen={true} onClose={onClose} usePortal={false}>
+                {createDrawerContents()}
+            </Drawer>,
+        );
+        dialog.find(`.${Classes.OVERLAY_BACKDROP}`).simulate("mousedown");
+        assert.isTrue(onClose.notCalled);
+    });
+
+    it("doesn't close when canEscapeKeyClose=false and escape key is pressed", () => {
+        const onClose = spy();
+        const dialog = mount(
+            <Drawer canEscapeKeyClose={false} isOpen={true} onClose={onClose} usePortal={false}>
+                {createDrawerContents()}
+            </Drawer>,
+        );
+        dialog.simulate("keydown", { which: Keys.ESCAPE });
+        assert.isTrue(onClose.notCalled);
+    });
+
+    it("supports overlay lifecycle props", () => {
+        const onOpening = spy();
+        mount(
+            <Drawer isOpen={true} onOpening={onOpening}>
+                body
+            </Drawer>,
+        );
+        assert.isTrue(onOpening.calledOnce);
+    });
+
+    describe("header", () => {
+        it(`renders .${Classes.DRAWER_HEADER} if title prop is given`, () => {
+            const dialog = mount(
+                <Drawer isOpen={true} title="Hello!" usePortal={false}>
+                    dialog body
+                </Drawer>,
+            );
+            assert.match(dialog.find(`.${Classes.DRAWER_HEADER}`).text(), /^Hello!/);
+        });
+
+        it(`renders close button if isCloseButtonShown={true}`, () => {
+            const dialog = mount(
+                <Drawer isCloseButtonShown={true} isOpen={true} title="Hello!" usePortal={false}>
+                    dialog body
+                </Drawer>,
+            );
+            assert.lengthOf(dialog.find(`.${Classes.DRAWER_HEADER}`).find(Button), 1);
+
+            dialog.setProps({ isCloseButtonShown: false });
+            assert.lengthOf(dialog.find(`.${Classes.DRAWER_HEADER}`).find(Button), 0);
+        });
+
+        it("clicking close button triggers onClose", () => {
+            const onClose = spy();
+            const dialog = mount(
+                <Drawer isCloseButtonShown={true} isOpen={true} onClose={onClose} title="Hello!" usePortal={false}>
+                    dialog body
+                </Drawer>,
+            );
+            dialog
+                .find(`.${Classes.DRAWER_HEADER}`)
+                .find(Button)
+                .simulate("click");
+            assert.isTrue(onClose.calledOnce, "onClose not called");
+        });
+    });
+
+    it("only adds its className in one location", () => {
+        const dialog = mount(<Drawer className="foo" isOpen={true} title="title" usePortal={false} />);
+        assert.lengthOf(dialog.find(".foo").hostNodes(), 1);
+    });
+
+    // everything else about Drawer is tested by Overlay
+
+    function createDrawerContents(): JSX.Element[] {
+        return [
+            <div className={Classes.DRAWER_HEADER} key={0}>
+                <Icon icon="inbox" iconSize={Icon.SIZE_LARGE} />
+                <H4>Drawer header</H4>
+            </div>,
+            <div className={Classes.DRAWER_BODY} key={1}>
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna alqua. Ut enim ad minimum veniam, quis nostrud exercitation ullamco laboris nisi ut
+                    aliquip ex ea commodo consequat.
+                </p>
+            </div>,
+            <div className={Classes.DRAWER_FOOTER} key={2}>
+                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                    <Button text="Secondary" />
+                    <Button className={Classes.INTENT_PRIMARY} type="submit" text="Primary" />
+                </div>
+            </div>,
+        ];
+    }
+});

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -6,8 +6,8 @@
 
 import * as React from "react";
 
-import { Button, Classes, Code, Drawer, H5, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Button, Classes, Code, Divider, Drawer, H5, HTMLSelect, IOptionProps, Label, Switch } from "@blueprintjs/core";
+import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IBlueprintExampleData } from "../../tags/reactExamples";
 
 export interface IDrawerExampleState {
@@ -16,8 +16,7 @@ export interface IDrawerExampleState {
     canOutsideClickClose: boolean;
     enforceFocus: boolean;
     isOpen: boolean;
-    large: boolean;
-    small: boolean;
+    size: string;
     usePortal: boolean;
     vertical: boolean;
 }
@@ -27,9 +26,8 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
         canEscapeKeyClose: true,
         canOutsideClickClose: true,
         enforceFocus: true,
-        isOpen: false,
-        large: false,
-        small: false,
+        isOpen: true,
+        size: undefined,
         usePortal: true,
         vertical: false,
     };
@@ -40,8 +38,7 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
     private handleUsePortalChange = handleBooleanChange(usePortal => this.setState({ usePortal }));
     private handleOutsideClickChange = handleBooleanChange(val => this.setState({ canOutsideClickClose: val }));
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
-    private handleLargeChange = handleBooleanChange(large => this.setState({ large, ...(large && { small: false }) }));
-    private handleSmallChange = handleBooleanChange(small => this.setState({ small, ...(small && { large: false }) }));
+    private handleSizeChange = handleStringChange(size => this.setState({ size }));
 
     public render() {
         return (
@@ -95,6 +92,12 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
         return (
             <>
                 <H5>Props</H5>
+                <Label>
+                    Size
+                    <HTMLSelect options={SIZES} onChange={this.handleSizeChange} />
+                </Label>
+                <Switch checked={this.state.vertical} label="Vertical" onChange={this.handleVerticalChange} />
+                <Divider />
                 <Switch checked={autoFocus} label="Auto focus" onChange={this.handleAutoFocusChange} />
                 <Switch checked={enforceFocus} label="Enforce focus" onChange={this.handleEnforceFocusChange} />
                 <Switch checked={usePortal} onChange={this.handleUsePortalChange}>
@@ -106,9 +109,6 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
                     onChange={this.handleOutsideClickChange}
                 />
                 <Switch checked={canEscapeKeyClose} label="Escape key to close" onChange={this.handleEscapeKeyChange} />
-                <Switch checked={this.state.vertical} label="Vertical" onChange={this.handleVerticalChange} />
-                <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
-                <Switch checked={this.state.small} label="Small" onChange={this.handleSmallChange} />
             </>
         );
     }
@@ -116,3 +116,12 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
     private handleOpen = () => this.setState({ isOpen: true });
     private handleClose = () => this.setState({ isOpen: false });
 }
+
+const SIZES: Array<string | IOptionProps> = [
+    { label: "Default", value: undefined },
+    { label: "Small", value: Drawer.SIZE_SMALL },
+    { label: "Standard", value: Drawer.SIZE_STANDARD },
+    { label: "Large", value: Drawer.SIZE_LARGE },
+    "37%",
+    "444px",
+];


### PR DESCRIPTION
- merge `small` and `large` into one `size` prop that accepts any CSS size value (`string | number`).
- provide `Drawer.SIZE_*` constants with predetermined size values.
- add unit tests (straight up copied from `Dialog` but we need something to start with).