### PR TITLE
Allow shortcuts to change time in Date Range Picker

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -41,6 +41,7 @@ export interface IDateRangeShortcut {
      * takes the date components of the `dateRange` and combines it with the currently selected time.
      * Setting `shouldChangeTime` to `true` will override this behavior and allow shortcuts to change
      * the selected time as well.
+     * @default false
      */
     shouldChangeTime?: boolean;
 }
@@ -508,8 +509,14 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         if (shouldChangeTime) {
             const newDateRange: DateRange = [dateRange[0], dateRange[1]];
             const newTimeRange: DateRange = [dateRange[0], dateRange[1]];
+            const nextState = getStateChange(
+                this.state.value,
+                dateRange,
+                this.state,
+                this.props.contiguousCalendarMonths,
+            );
+            this.setState({ ...nextState, time: newTimeRange });
             Utils.safeInvoke(this.props.onChange, newDateRange);
-            this.setState({ value: newDateRange, time: newTimeRange });
         } else {
             this.handleNextState(dateRange);
         }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -35,6 +35,14 @@ import { TimePicker } from "./timePicker";
 export interface IDateRangeShortcut {
     label: string;
     dateRange: DateRange;
+
+    /**
+     * By default, clicking a shortcut does not change the time of the date range picker, but instead
+     * takes the date components of the `dateRange` and combines it with the currently selected time.
+     * Setting `shouldChangeTime` to `true` will override this behavior and allow shortcuts to change
+     * the selected time as well.
+     */
+    shouldChangeTime?: boolean;
 }
 
 export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
@@ -282,7 +290,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             <Shortcuts
                 key="shortcuts"
                 {...{ allowSingleDayRange, maxDate, minDate, shortcuts }}
-                onShortcutClick={this.handleNextState}
+                onShortcutClick={this.handleShortcutClick}
             />,
             <Divider key="div" />,
         ];
@@ -493,6 +501,18 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         this.handleDayMouseEnter(day, modifiers, e);
 
         this.handleNextState(nextValue);
+    };
+
+    private handleShortcutClick = (shortcut: IDateRangeShortcut) => {
+        const { dateRange, shouldChangeTime } = shortcut;
+        if (shouldChangeTime) {
+            const newDateRange: DateRange = [dateRange[0], dateRange[1]];
+            const newTimeRange: DateRange = [dateRange[0], dateRange[1]];
+            Utils.safeInvoke(this.props.onChange, newDateRange);
+            this.setState({ value: newDateRange, time: newTimeRange });
+        } else {
+            this.handleNextState(dateRange);
+        }
     };
 
     private handleNextState = (nextValue: DateRange) => {

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -12,6 +12,7 @@ import { clone, DateRange, isDayRangeInRange } from "./common/dateUtils";
 export interface IDateRangeShortcut {
     label: string;
     dateRange: DateRange;
+    shouldChangeTime?: boolean;
 }
 
 export interface IShortcutsProps {
@@ -19,7 +20,7 @@ export interface IShortcutsProps {
     minDate: Date;
     maxDate: Date;
     shortcuts: IDateRangeShortcut[] | true;
-    onShortcutClick: (shortcut: DateRange) => void;
+    onShortcutClick: (shortcut: IDateRangeShortcut) => void;
 }
 
 export class Shortcuts extends React.PureComponent<IShortcutsProps> {
@@ -34,7 +35,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
                 className={Classes.POPOVER_DISMISS_OVERRIDE}
                 disabled={!this.isShortcutInRange(s.dateRange)}
                 key={i}
-                onClick={this.getShorcutClickHandler(s.dateRange)}
+                onClick={this.getShorcutClickHandler(s)}
                 text={s.label}
             />
         ));
@@ -42,8 +43,8 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
         return <Menu className={DATERANGEPICKER_SHORTCUTS}>{shortcutElements}</Menu>;
     }
 
-    private getShorcutClickHandler(nextValue: DateRange) {
-        return () => this.props.onShortcutClick(nextValue);
+    private getShorcutClickHandler(shortcut: IDateRangeShortcut) {
+        return () => this.props.onShortcutClick(shortcut);
     }
 
     private isShortcutInRange(shortcutDateRange: DateRange) {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -1147,9 +1147,26 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(onChangeSpy.firstCall.args[0][0] as Date, new Date()));
         });
 
-        it("clicking a shortcut doesn't change time", () => {
+        it("clicking a shortcut with shouldChangeTime=false doesn't change time", () => {
             render({ timePrecision: "minute", defaultValue: defaultRange }).clickShortcut();
             assert.isTrue(DateUtils.areSameTime(onChangeSpy.firstCall.args[0][0] as Date, defaultRange[0]));
+        });
+
+        it("clicking a shortcut with shouldChangeTime=true changes time", () => {
+            const endTime = defaultRange[1];
+            const startTime = new Date(defaultRange[1].getTime());
+            startTime.setHours(startTime.getHours() - 2);
+
+            const shortcuts = [
+                {
+                    dateRange: [startTime, endTime] as DateRange,
+                    label: "custom shortcut",
+                    shouldChangeTime: true,
+                },
+            ];
+
+            render({ timePrecision: "minute", defaultValue: defaultRange, shortcuts }).clickShortcut();
+            assert.equal(onChangeSpy.firstCall.args[0][0] as Date, startTime);
         });
 
         it("selecting and unselecting a day doesn't change time", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -951,7 +951,7 @@ describe("<DateRangePicker>", () => {
         it("custom shortcuts set the displayed months correctly when start month stays the same", () => {
             const dateRange = [
                 new Date(2016, Months.JANUARY, 1, 10, 20, 30),
-                new Date(2016, Months.DECEMBER, 31, 10, 20, 30)
+                new Date(2016, Months.DECEMBER, 31, 10, 20, 30),
             ] as DateRange;
 
             const test = (shouldChangeTime: boolean) => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -904,47 +904,74 @@ describe("<DateRangePicker>", () => {
         });
 
         it("custom shortcuts set the displayed months correctly when start month changes", () => {
-            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
-            const { left, right } = render({
-                initialMonth: new Date(2015, Months.JANUARY, 1),
-                shortcuts: [{ label: "custom shortcut", dateRange }],
-            }).clickShortcut();
-            assert.isTrue(onChangeSpy.calledOnce);
-            left.assertMonthYear(Months.JANUARY, 2016);
-            right.assertMonthYear(Months.FEBRUARY, 2016);
+            const dateRange = [
+                new Date(2016, Months.JANUARY, 1, 10, 20, 30),
+                new Date(2016, Months.DECEMBER, 31, 10, 20, 30),
+            ] as DateRange;
+
+            const test = (shouldChangeTime: boolean) => {
+                const { left, right } = render({
+                    initialMonth: new Date(2015, Months.JANUARY, 1),
+                    shortcuts: [{ label: "custom shortcut", dateRange, shouldChangeTime }],
+                }).clickShortcut();
+                assert.isTrue(onChangeSpy.calledOnce);
+                left.assertMonthYear(Months.JANUARY, 2016);
+                right.assertMonthYear(Months.FEBRUARY, 2016);
+            };
+
+            test(true);
+            test(false);
         });
 
         it(
             "custom shortcuts set the displayed months correctly when start month changes " +
                 "and contiguousCalendarMonths is false",
             () => {
-                const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
-                const { left, right } = render({
-                    contiguousCalendarMonths: false,
-                    initialMonth: new Date(2015, Months.JANUARY, 1),
-                    shortcuts: [{ label: "custom shortcut", dateRange }],
-                }).clickShortcut();
-                assert.isTrue(onChangeSpy.calledOnce);
-                left.assertMonthYear(Months.JANUARY, 2016);
-                right.assertMonthYear(Months.DECEMBER, 2016);
+                const dateRange = [
+                    new Date(2016, Months.JANUARY, 1, 10, 20, 30),
+                    new Date(2016, Months.DECEMBER, 31, 10, 20, 30),
+                ] as DateRange;
+
+                const test = (shouldChangeTime: boolean) => {
+                    const { left, right } = render({
+                        contiguousCalendarMonths: false,
+                        initialMonth: new Date(2015, Months.JANUARY, 1),
+                        shortcuts: [{ label: "custom shortcut", dateRange, shouldChangeTime }],
+                    }).clickShortcut();
+                    assert.isTrue(onChangeSpy.calledOnce);
+                    left.assertMonthYear(Months.JANUARY, 2016);
+                    right.assertMonthYear(Months.DECEMBER, 2016);
+                };
+
+                test(true);
+                test(false);
             },
         );
 
         it("custom shortcuts set the displayed months correctly when start month stays the same", () => {
-            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
-            const { clickShortcut, left, right } = render({
-                initialMonth: new Date(2016, Months.JANUARY, 1),
-                shortcuts: [{ label: "custom shortcut", dateRange }],
-            });
+            const dateRange = [
+                new Date(2016, Months.JANUARY, 1, 10, 20, 30),
+                new Date(2016, Months.DECEMBER, 31, 10, 20, 30)
+            ] as DateRange;
 
-            clickShortcut();
-            assert.isTrue(onChangeSpy.calledOnce);
-            left.assertMonthYear(Months.JANUARY, 2016);
-            right.assertMonthYear(Months.FEBRUARY, 2016);
+            const test = (shouldChangeTime: boolean) => {
+                const { clickShortcut, left, right } = render({
+                    initialMonth: new Date(2016, Months.JANUARY, 1),
+                    shortcuts: [{ label: "custom shortcut", dateRange, shouldChangeTime }],
+                });
 
-            clickShortcut();
-            left.assertMonthYear(Months.JANUARY, 2016);
-            right.assertMonthYear(Months.FEBRUARY, 2016);
+                clickShortcut();
+                assert.isTrue(onChangeSpy.calledOnce);
+                left.assertMonthYear(Months.JANUARY, 2016);
+                right.assertMonthYear(Months.FEBRUARY, 2016);
+
+                clickShortcut();
+                left.assertMonthYear(Months.JANUARY, 2016);
+                right.assertMonthYear(Months.FEBRUARY, 2016);
+            };
+
+            test(true);
+            test(false);
         });
     });
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/3186

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

To avoid breaking backcompat (i.e. clicking on shortcut only changes the date by default), I added an optional parameter to `IDateRangeShortcut` to let users specify that a certain shortcut should be allowed to change the time as well as date.
