### PR TITLE
[Documentation] Missing s from documentation hotkeys.md doc

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeys.md
+++ b/packages/core/src/components/hotkeys/hotkeys.md
@@ -59,7 +59,7 @@ Wrap your `Hotkey`s in the `Hotkeys` element. For example:
 <Hotkeys>
     <Hotkey label="Quit" combo="ctrl+q" global onKeyDown={handleQuit} />
     <Hotkey label="Save" combo="ctrl+s" group="File" onKeyDown={handleSave} />
-</Hotkey>
+</Hotkeys>
 ```
 
 @interface IHotkeysProps


### PR DESCRIPTION
Missing s from documentation