### PR TITLE
Fixed issues in toastr timeouts

### DIFF
--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -80,11 +80,12 @@ export class Toast extends AbstractPureComponent<IToastProps, {}> {
 
     public componentDidUpdate(prevProps: IToastProps) {
         if (prevProps.timeout !== this.props.timeout && this.props.timeout > 0) {
+            this.clearTimeouts();
             this.startTimeout();
         } else if (prevProps.timeout <= 0 && this.props.timeout > 0) {
             this.startTimeout();
         } else if (prevProps.timeout > 0 && this.props.timeout <= 0) {
-            this.clearTimeouts();
+            this.triggerDismiss(false);
         }
     }
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

I recently pushed a change to fix an issue with toasts where new timeout props were getting ignored. Now I just found a similar issue where the old timeout would still trigger and clear the toast anyways.

Separately why is the third condition to clearTimeouts. That would make the toastr stay forever. Shouldn't it just trigger the dismiss immediately?