### PR TITLE
Fix setState calls using updater functions

### DIFF
--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -46,13 +46,13 @@ export class PanelStackExample extends React.PureComponent<IExampleProps, IPanel
     }
 
     private addToPanelStack = (newPanel: IPanel) => {
-        this.setState({ currentPanelStack: [newPanel, ...this.state.currentPanelStack] });
+        this.setState(state => ({ currentPanelStack: [newPanel, ...state.currentPanelStack] }));
     };
 
     private removeFromPanelStack = (_lastPanel: IPanel) => {
         // In this example, the last panel is always the one closed.
         // Using `this.props.closePanel()` is one way to violate this.
-        this.setState({ currentPanelStack: this.state.currentPanelStack.slice(1) });
+        this.setState(state => ({ currentPanelStack: state.currentPanelStack.slice(1) }));
     };
 }
 


### PR DESCRIPTION
React does not guarantee that the state changes are applied immediately. It is best practice to use an updater function if the new state relies on the current state.

#### Fixes #3242

#### Changes proposed in this pull request:

Replacing simple `setState` merges with updater functions `state => newState` since state updates may be asynchronous and/or delayed.
