### PR TITLE
Add menu item classnames

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -21,6 +21,9 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
     /** Item text, required for usability. */
     text: React.ReactNode;
 
+    /** Classname for text wrapper element. */
+    textClassName?: string;
+
     /** Whether this menu item should appear with an active state. */
     active?: boolean;
 
@@ -106,6 +109,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
             popoverProps,
             shouldDismissPopover,
             text,
+            textClassName,
             tagName: TagName = "a",
             ...htmlProps
         } = this.props;
@@ -128,7 +132,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
         const target = (
             <TagName {...htmlProps} {...(disabled ? DISABLED_PROPS : {})} className={anchorClasses}>
                 <Icon icon={icon} />
-                <Text className={Classes.FILL} ellipsize={!multiline}>
+                <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline}>
                     {text}
                 </Text>
                 {this.maybeRenderLabel(labelElement)}

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -52,6 +52,11 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
     labelElement?: React.ReactNode;
 
     /**
+     * Classname for the right-aligned label wrapper element.
+     */
+    labelClassName?: string;
+
+    /**
      * Whether the text should be allowed to wrap to multiple lines.
      * If `false`, text will be truncated with an ellipsis when it reaches `max-width`.
      * @default false
@@ -136,12 +141,12 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
     }
 
     private maybeRenderLabel(labelElement?: React.ReactNode) {
-        const { label } = this.props;
+        const { label, labelClassName } = this.props;
         if (label == null && labelElement == null) {
             return null;
         }
         return (
-            <span className={Classes.MENU_ITEM_LABEL}>
+            <span className={classNames(Classes.MENU_ITEM_LABEL, labelClassName)}>
                 {label}
                 {labelElement}
             </span>

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -21,9 +21,6 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
     /** Item text, required for usability. */
     text: React.ReactNode;
 
-    /** Classname for text wrapper element. */
-    textClassName?: string;
-
     /** Whether this menu item should appear with an active state. */
     active?: boolean;
 
@@ -50,14 +47,14 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
     label?: string;
 
     /**
+     * A space-delimited list of class names to pass along to the right-aligned label wrapper element.
+     */
+    labelClassName?: string;
+
+    /**
      * Right-aligned label content, useful for displaying hotkeys.
      */
     labelElement?: React.ReactNode;
-
-    /**
-     * Classname for the right-aligned label wrapper element.
-     */
-    labelClassName?: string;
 
     /**
      * Whether the text should be allowed to wrap to multiple lines.
@@ -84,6 +81,11 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
      * @default "a"
      */
     tagName?: keyof JSX.IntrinsicElements;
+
+    /**
+     * A space-delimited list of class names to pass along to the text wrapper element.
+     */
+    textClassName?: string;
 }
 
 export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {


### PR DESCRIPTION
Add two new props to menu item to allow you to apply a classname to the text and label wrapper elements