### PR TITLE
Suggest using `ContextMenuTarget` as a HOC

### DIFF
--- a/packages/core/src/components/context-menu/context-menu.md
+++ b/packages/core/src/components/context-menu/context-menu.md
@@ -57,8 +57,36 @@ class RightClickMe extends React.Component<{}, {}> {
 }
 ```
 
+If you're using Blueprint in Javascript, and don't have access to the Babel config (ie: using `create-react-app`), you won't be able to just use the decorator. You can, instead, use it as a [Higher-Order Component][react-hoc], and get to keep all the benefits of `ContextMenuTarget`:
+
+```jsx
+import { ContextMenuTarget, Menu, MenuItem } from "@blueprintjs/core";
+
+const RightClickMe = ContextMenuTarget(class RightClickMeWithContext extends React.Component {
+    render() {
+        // root element must support `onContextMenu`
+        return <div>{...}</div>;
+    }
+
+    renderContextMenu() {
+        // return a single element, or nothing to use default browser behavior
+        return (
+            <Menu>
+                <MenuItem onClick={this.handleSave} text="Save" />
+                <MenuItem onClick={this.handleDelete} text="Delete" />
+            </Menu>
+        );
+    }
+
+    onContextMenuClose() {
+        // Optional method called once the context menu is closed.
+    }
+});
+```
+
 [ts-decorator]: https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Decorators.md
 [wiki-cm]: https://en.wikipedia.org/wiki/Context_menu
+[react-hoc]: https://reactjs.org/docs/higher-order-components.html
 
 @## Imperative usage
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

Instead of falling back to the imperative API, suggest using `ContextMenuTarget`, where decorators are not an option. 
I couldn't find this suggestion in the docs. If the PR gets merged I can send one for the [hotkey decorator](https://blueprintjs.com/docs/#core/components/hotkeys.decorator) too.

I tested this locally already and I couldn't find any issues with this approach.