### PR TITLE
Fix dialog css docs

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -16,7 +16,7 @@ Markup:
     <div class="#{$ns}-dialog-header">
       <span class="#{$ns}-icon-large #{$ns}-icon-inbox"></span>
       <h4 class="#{$ns}-heading">Dialog header</h4>
-      <button aria-label="Close" class="#{$ns}-dialog-close-button #{$ns}-icon-small-cross"></button>
+      <button aria-label="Close" class="#{$ns}-dialog-close-button #{$ns}-button #{$ns}-minimal #{$ns}-icon-cross"></button>
     </div>
     <div class="#{$ns}-dialog-body">
       This dialog hasn't been wired up with any open or close interactions.


### PR DESCRIPTION
#### Changes proposed in this pull request:

Fixes the dialog css docs for the dialog close button:

- Leave the noop `{ns}-dialog-close-button` class
- Add `{ns}-button}` and `{ns}-minimal}` classes
- Change icon from small cross to cross

#### Screenshot

Previously on dialog css docs:

![screen shot 2019-01-07 at 2 26 10 pm](https://user-images.githubusercontent.com/993321/50790630-6d99de80-128d-11e9-8536-12fb4b12932f.png)

Next week on dialog css docs:

![screen shot 2019-01-07 at 3 03 49 pm](https://user-images.githubusercontent.com/993321/50790639-78547380-128d-11e9-8c82-e4ace4d2da71.png)

