### PR TITLE
[docs] show optional isDarkTheme parameter in ContextMenu API docs

### DIFF
--- a/packages/core/src/components/context-menu/context-menu.md
+++ b/packages/core/src/components/context-menu/context-menu.md
@@ -94,7 +94,7 @@ The imperative API provides a single static `ContextMenu` object, enforcing the
 principle that only one context menu can be open at a time. This API is ideal
 for programmatically triggered menus or for non-React apps.
 
-- `ContextMenu.show(menu: JSX.Element, offset: IOffset, onClose?: () => void): void`
+- `ContextMenu.show(menu: JSX.Element, offset: IOffset, onClose?: () => void, isDarkTheme?: boolean): void`
 
   Show the given element at the given offset from the top-left corner of the
   viewport. Showing a menu closes the previously shown one automatically. The


### PR DESCRIPTION
To make it more obvious that you can manually create a dark context menu, as raised in https://github.com/palantir/blueprint/issues/3229
