### PR TITLE
[OverflowList] Always re-render items

### DIFF
--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -11,7 +11,7 @@ import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
+import { safeInvoke, shallowCompareKeys } from "../../common/utils";
 import { IResizeEntry, ResizeSensor } from "../resize-sensor/resizeSensor";
 
 /** @internal - do not expose this type */
@@ -100,7 +100,7 @@ export interface IOverflowListState<T> {
     visible: T[];
 }
 
-export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, IOverflowListState<T>> {
+export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOverflowListState<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.OverflowList`;
 
     public static defaultProps: Partial<IOverflowListProps<any>> = {
@@ -157,7 +157,9 @@ export class OverflowList<T> extends React.PureComponent<IOverflowListProps<T>, 
     }
 
     public componentDidUpdate(_prevProps: IOverflowListProps<T>, prevState: IOverflowListState<T>) {
-        this.repartition(false);
+        if (!shallowCompareKeys(prevState, this.state)) {
+            this.repartition(false);
+        }
         const { direction, overflow, lastOverflowCount } = this.state;
         if (
             // if a resize operation has just completed (transition to NONE)

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -156,6 +156,10 @@ export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOve
         }
     }
 
+    public shouldComponentUpdate(_nextProps: IOverflowListProps<T>, nextState: IOverflowListState<T>) {
+        return !(this.state !== nextState && shallowCompareKeys(this.state, nextState));
+    }
+
     public componentDidUpdate(_prevProps: IOverflowListProps<T>, prevState: IOverflowListState<T>) {
         if (!shallowCompareKeys(prevState, this.state)) {
             this.repartition(false);

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -157,6 +157,11 @@ export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOve
     }
 
     public shouldComponentUpdate(_nextProps: IOverflowListProps<T>, nextState: IOverflowListState<T>) {
+        // We want this component to always re-render, even when props haven't changed, so that
+        // changes in the renderers' behavior can be reflected.
+        // The following statement prevents re-rendering only in the case where the state changes
+        // identity (i.e. setState was called), but the state is still the same when
+        // shallow-compared to the previous state.
         return !(this.state !== nextState && shallowCompareKeys(this.state, nextState));
     }
 

--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -57,11 +57,11 @@ describe("<OverflowList>", function(this) {
             .waitForResize()).assertVisibleItems(...IDS);
     });
 
-    it("shows fewer after shrinking", () => {
-        overflowList(45)
+    it("shows fewer after shrinking", async () => {
+        (await overflowList(45)
             .assertVisibleItemSplit(4)
             .setWidth(15)
-            .assertVisibleItemSplit(1);
+            .waitForResize()).assertVisibleItemSplit(1);
     });
 
     it("shows at least minVisibleItems", () => {


### PR DESCRIPTION
The `OverflowList` is a `PureComponent`, which means it only re-renders when props don’t shallow equal previous props. The way I’m using it allows all props to remain the same, but the renderer methods’ behavior can still change (some additional data is loaded which changes how an item is rendered). This doesn’t trigger a re-render in the overflow list, so the renderers are never called again, which means the change never gets rendered.

This PR changes the `OverflowList` to be a regular `Component`, so that it always re-renders, even when props shallow-equal previous props.