### PR TITLE
[DatePicker] fix caption months support 

### DIFF
--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -23,7 +23,7 @@ export interface IDatePickerCaptionProps extends ICaptionElementProps {
     /** Callback invoked when the month or year `<select>` is changed. */
     onDateChange?: (date: Date) => void;
     reverseMonthAndYearMenus?: boolean;
-    months: [string, string, string, string, string, string, string, string, string, string, string, string];
+    months: string[];
 }
 
 export interface IDatePickerCaptionState {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -12,7 +12,10 @@ import * as Classes from "./common/classes";
 import { clone } from "./common/dateUtils";
 import { measureTextWidth } from "./common/utils";
 
-export interface IDatePickerCaptionProps extends CaptionElementProps {
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+type ICaptionElementProps = Omit<CaptionElementProps, "months">
+
+export interface IDatePickerCaptionProps extends ICaptionElementProps {
     maxDate: Date;
     minDate: Date;
     onMonthChange?: (month: number) => void;
@@ -20,6 +23,20 @@ export interface IDatePickerCaptionProps extends CaptionElementProps {
     /** Callback invoked when the month or year `<select>` is changed. */
     onDateChange?: (date: Date) => void;
     reverseMonthAndYearMenus?: boolean;
+    months: [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string
+    ]
 }
 
 export interface IDatePickerCaptionState {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -12,8 +12,8 @@ import * as Classes from "./common/classes";
 import { clone } from "./common/dateUtils";
 import { measureTextWidth } from "./common/utils";
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-type ICaptionElementProps = Omit<CaptionElementProps, "months">
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type ICaptionElementProps = Omit<CaptionElementProps, "months">;
 
 export interface IDatePickerCaptionProps extends ICaptionElementProps {
     maxDate: Date;
@@ -23,20 +23,7 @@ export interface IDatePickerCaptionProps extends ICaptionElementProps {
     /** Callback invoked when the month or year `<select>` is changed. */
     onDateChange?: (date: Date) => void;
     reverseMonthAndYearMenus?: boolean;
-    months: [
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string
-    ]
+    months: [string, string, string, string, string, string, string, string, string, string, string, string];
 }
 
 export interface IDatePickerCaptionState {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -36,17 +36,17 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
     private handleYearSelectChange = this.dateChangeHandler((d, year) => d.setFullYear(year), this.props.onYearChange);
 
     public render() {
-        const { date, locale, localeUtils, minDate, maxDate } = this.props;
+        const { date, locale, localeUtils, minDate, maxDate, months } = this.props;
         const minYear = minDate.getFullYear();
         const maxYear = maxDate.getFullYear();
         const displayMonth = date.getMonth();
         const displayYear = date.getFullYear();
 
         // build the list of available months, limiting based on minDate and maxDate as necessary
-        const months = localeUtils.getMonths(locale);
+        const monthsLabels = months ? months : localeUtils.getMonths(locale);
         const startMonth = displayYear === minYear ? minDate.getMonth() : 0;
         const endMonth = displayYear === maxYear ? maxDate.getMonth() + 1 : undefined;
-        const monthOptionElements = months
+        const monthOptionElements = monthsLabels
             .map<IOptionProps>((month, i) => ({ label: month, value: i }))
             .slice(startMonth, endMonth);
 
@@ -59,7 +59,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
             years.push({ value: displayYear, disabled: true });
         }
 
-        this.displayedMonthText = months[displayMonth];
+        this.displayedMonthText = monthsLabels[displayMonth];
 
         const monthSelect = (
             <HTMLSelect

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -36,17 +36,16 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
     private handleYearSelectChange = this.dateChangeHandler((d, year) => d.setFullYear(year), this.props.onYearChange);
 
     public render() {
-        const { date, locale, localeUtils, minDate, maxDate, months } = this.props;
+        const { date, locale, localeUtils, minDate, maxDate, months = localeUtils.getMonths(locale) } = this.props;
         const minYear = minDate.getFullYear();
         const maxYear = maxDate.getFullYear();
         const displayMonth = date.getMonth();
         const displayYear = date.getFullYear();
 
         // build the list of available months, limiting based on minDate and maxDate as necessary
-        const monthsLabels = months ? months : localeUtils.getMonths(locale);
         const startMonth = displayYear === minYear ? minDate.getMonth() : 0;
         const endMonth = displayYear === maxYear ? maxDate.getMonth() + 1 : undefined;
-        const monthOptionElements = monthsLabels
+        const monthOptionElements = months
             .map<IOptionProps>((month, i) => ({ label: month, value: i }))
             .slice(startMonth, endMonth);
 
@@ -59,7 +58,7 @@ export class DatePickerCaption extends React.PureComponent<IDatePickerCaptionPro
             years.push({ value: displayYear, disabled: true });
         }
 
-        this.displayedMonthText = monthsLabels[displayMonth];
+        this.displayedMonthText = months[displayMonth];
 
         const monthSelect = (
             <HTMLSelect

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -72,6 +72,13 @@ describe("<DatePickerCaption>", () => {
         assert.isTrue(options.last().prop("disabled"), "2017 is not disabled");
     });
 
+    it("renders localized month labels when supplied", () => {
+        const months = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"]
+        const { month } = renderDatePickerCaption({ months });
+        const options = month.find("option");
+        assert.deepEqual(options.map(mo => mo.text()), months);
+    });
+
     function renderDatePickerCaption(props?: Partial<IDatePickerCaptionProps>) {
         const wrapper = mount(
             <DatePickerCaption

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -85,8 +85,8 @@ describe("<DatePickerCaption>", () => {
             "Septembre",
             "Octobre",
             "Novembre",
-            "Décembre"
-        ] as any
+            "Décembre",
+        ] as any;
         const { month } = renderDatePickerCaption({ months });
         const options = month.find("option");
         assert.deepEqual(options.map(mo => mo.text()), months);

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -73,7 +73,20 @@ describe("<DatePickerCaption>", () => {
     });
 
     it("renders localized month labels when supplied", () => {
-        const months = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"]
+        const months = [
+            "Janvier",
+            "Février",
+            "Mars",
+            "Avril",
+            "Mai",
+            "Juin",
+            "Juillet",
+            "Août",
+            "Septembre",
+            "Octobre",
+            "Novembre",
+            "Décembre"
+        ] as any
         const { month } = renderDatePickerCaption({ months });
         const options = month.find("option");
         assert.deepEqual(options.map(mo => mo.text()), months);


### PR DESCRIPTION
#### Fixes #3265
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

In `datePickerCaption`, grab `months` from supplied props. If months is not defined, fall back on previously set `localeUtils.getMonths(locale)`. If `months` has been supplied via `dayPickerProps`, render month labels from that supplied array.

#### Reviewers should focus on:

Supply the following DateRangePicker props, and check that dropdown selection for months reflect the correct localized labels.

```
dayPickerProps={{
   months: ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"]
}}
```

#### Screenshot

<img width="461" alt="screen shot 2019-01-10 at 9 25 40 pm" src="https://user-images.githubusercontent.com/21165426/51009502-60475300-151e-11e9-9474-34b8029386bd.png">

