### PR TITLE
Update _typography.scss

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -37,7 +37,7 @@ $headings: (
   "h4": (18px, 21px),
   "h5": (16px, 19px),
   "h6": (14px, 16px)
-);
+) !default;
 
 @each $tag, $props in $headings {
   %#{$tag} {


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add `default!` to heading font sizes and line heights. This enables overriding as per most (all?) of the other variables defined in scss.

#### Reviewers should focus on:

You can test this e.g. in a `create-react-app` project by creating a file (e.g. `index.scss`) containing the following code:

```scss
$headings: (
  "h1": (50px, 60px),
  "h2": (28px, 30px),
  "h3": (22px, 25px),
  "h4": (18px, 20px),
  "h5": (16px, 20px),
  "h6": (14px, 15px)
);

@import "~@blueprintjs/core/src/blueprint.scss";
```
After this, h1 tags should be 50px. This doesn't work without the `!default` tag as the value is subsequently overridden.

This is a pretty non-controversial change as it should have absolutely no effect unless you are _trying_ to override the heading styles.