### PR TITLE
Add optional "areValuesEqual" comparator prop to QueryList and related components

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -9,8 +9,11 @@
  * An `itemListRenderer` receives this object as its sole argument.
  */
 export interface IItemListRendererProps<T> {
-    /** The currently focused item (for keyboard interactions). */
-    activeItem: T | null;
+    /**
+     * The currently focused item (for keyboard interactions), or `undefined` to
+     * indicate that no item is active
+     */
+    activeItem: T | undefined;
 
     /**
      * Array of items filtered by `itemListPredicate` or `itemPredicate`.

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -12,12 +12,21 @@ import { ItemListPredicate, ItemPredicate } from "./predicate";
 /** Reusable generic props for a component that operates on a filterable, selectable list of `items`. */
 export interface IListItemsProps<T> extends IProps {
     /**
-     * The currently focused item for keyboard interactions, or `null` to
+     * The currently focused item for keyboard interactions, or `undefined` to
      * indicate that no item is active. If omitted, this prop will be
      * uncontrolled (managed by the component's state). Use `onActiveItemChange`
      * to listen for updates.
      */
-    activeItem?: T | null;
+    activeItem?: T;
+
+    /**
+     * Equality test implementation to determine if two values are representative of the same item.
+     * If not specified, then simple strict equality is used by default.
+     * @param valueA - A value.
+     * @param valueB - Another value.
+     * @return true if the two values are equivalent.
+     */
+    areValuesEqual?: (valueA: T, valueB: T) => boolean;
 
     /** Array of items in the list. */
     items: T[];
@@ -85,7 +94,7 @@ export interface IListItemsProps<T> extends IProps {
      * in the list, selecting an item makes it active, and changing the query may reset it to
      * the first item in the list if it no longer matches the filter.
      */
-    onActiveItemChange?: (activeItem: T | null) => void;
+    onActiveItemChange?: (activeItem: T | undefined) => void;
 
     /**
      * Callback invoked when an item from the list is selected,

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -71,7 +71,6 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
             <this.TypedQueryList
                 {...restProps}
                 initialContent={initialContent}
-                onItemSelect={this.props.onItemSelect}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
             />

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -45,11 +45,11 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     defaultSelectedItem?: T;
 
     /**
-     * The currently selected item, or `null` to indicate that no item is selected.
+     * The currently selected item, or `undefined` to indicate that no item is selected.
      * If omitted, this prop will be uncontrolled (managed by the component's state).
      * Use `onItemSelect` to listen for updates.
      */
-    selectedItem?: T | null;
+    selectedItem?: T | undefined;
 
     /**
      * Whether the popover opens on key down or when the input is focused.
@@ -63,7 +63,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
 
 export interface ISuggestState<T> {
     isOpen: boolean;
-    selectedItem: T | null;
+    selectedItem: T | undefined;
 }
 
 export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestState<T>> {
@@ -115,7 +115,9 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     public componentWillReceiveProps(nextProps: ISuggestProps<T>) {
         // If the selected item prop changes, update the underlying state.
-        if (nextProps.selectedItem !== undefined && nextProps.selectedItem !== this.state.selectedItem) {
+        // NOTE: Cannot simply compare to `undefined` here because `undefined` can be
+        //       explicitly provided as a controlled value to indicate no selected item.
+        if ("selectedItem" in nextProps && nextProps.selectedItem !== this.state.selectedItem) {
             this.setState({ selectedItem: nextProps.selectedItem });
         }
     }
@@ -199,7 +201,9 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             nextOpenState = false;
         }
         // the internal state should only change when uncontrolled.
-        if (this.props.selectedItem === undefined) {
+        // NOTE: Cannot simply compare to `undefined` here because `undefined` can be
+        //       explicitly provided as a controlled value to indicate no selected item.
+        if (!("selectedItem" in this.props)) {
             this.setState({
                 isOpen: nextOpenState,
                 selectedItem: item,
@@ -212,14 +216,16 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvoke(this.props.onItemSelect, item, event);
     };
 
-    private getInitialSelectedItem(): T | null {
+    private getInitialSelectedItem(): T | undefined {
         // controlled > uncontrolled > default
-        if (this.props.selectedItem !== undefined) {
+        // NOTE: Cannot simply compare to `undefined` here because `undefined` can be
+        //       explicitly provided as a controlled value to indicate no selected item.
+        if ("selectedItem" in this.props) {
             return this.props.selectedItem;
         } else if (this.props.defaultSelectedItem !== undefined) {
             return this.props.defaultSelectedItem;
         } else {
-            return null;
+            return undefined;
         }
     }
 

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -241,22 +241,27 @@ describe("Suggest", () => {
     describe("Controlled Mode", () => {
         it("initialize the selectedItem with the given value", () => {
             const selectedItem = TOP_100_FILMS[0];
-            assert.isNotNull(selectedItem, "The selected item we test must not be null");
+            assert.isDefined(selectedItem, "The selected item we test must not be undefined");
             const wrapper = suggest({ selectedItem });
             assert.strictEqual(wrapper.state().selectedItem, selectedItem);
         });
         it("propagates the selectedItem with new values", () => {
             const selectedItem = TOP_100_FILMS[0];
-            assert.isNotNull(selectedItem, "The selected item we test must not be null");
+            assert.isDefined(selectedItem, "The selected item we test must not be undefined");
             const wrapper = suggest();
-            assert.isNull(wrapper.state().selectedItem);
+            assert.isUndefined(wrapper.state().selectedItem);
             wrapper.setProps({ selectedItem });
             assert.strictEqual(wrapper.state().selectedItem, selectedItem);
+
+            // controlled prop value of `undefined` is handled as controlled prop instead of
+            // misunderstood as absent optional prop triggering uncontrolled mode
+            wrapper.setProps({ selectedItem: undefined });
+            assert.strictEqual(wrapper.state().selectedItem, undefined);
         });
         it("when new item selected, it should respect the selectedItem prop", () => {
             const selectedItem = TOP_100_FILMS[0];
             const ITEM_INDEX = 4;
-            assert.isNotNull(selectedItem, "The selected item we test must not be null");
+            assert.isDefined(selectedItem, "The selected item we test must not be undefined");
             const wrapper = suggest({ selectedItem });
             simulateFocus(wrapper);
             selectItem(wrapper, ITEM_INDEX);
@@ -269,12 +274,12 @@ describe("Suggest", () => {
         it("preserves the empty selection", () => {
             const ITEM_INDEX = 4;
             const selectedItem = TOP_100_FILMS[0];
-            const wrapper = suggest({ selectedItem: null });
-            assert.isNull(wrapper.state().selectedItem);
+            const wrapper = suggest({ selectedItem: undefined });
+            assert.isUndefined(wrapper.state().selectedItem);
             simulateFocus(wrapper);
             selectItem(wrapper, ITEM_INDEX);
             assert.isTrue(handlers.onItemSelect.called, "onItemSelect should be called after selection");
-            assert.isNull(wrapper.state().selectedItem, "the underlying state should not change");
+            assert.isUndefined(wrapper.state().selectedItem, "the underlying state should not change");
             wrapper.setProps({ selectedItem });
             assert.strictEqual(wrapper.state().selectedItem, selectedItem, "the selectedItem should be updated");
         });


### PR DESCRIPTION
equality test implementation for non-primitive item types.

#### Fixes #2998, #1340

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

1. Add new optional `areValuesEqual` comparator to `QueryList` and related components. If supplied, then this is used instead of strict equality to compare item values (for finding the index of the active item, testing if a given item is "active"). This enables using components like `MultiSelect` and `Suggest` with non-primitive data types where strict equality is insufficient for testing equivalency.
1. Use `undefined` instead of `null` to represent absence of selected/active item.

#### Reviewers should focus on:

1. Are there any (in)equality checks or array searches I missed that need to be updated to use the new `areValuesEqual` prop?
1. Does the switch from `null` to `undefined` go against project code style? There seems to be a general preference in Typescript to avoid `null` and prefer `undefined`, which is why I switched it. But I could revert this part of the change if this project prefers to use `null`. I personally think `undefined` makes more sense, and it leaves `null` available as a valid item value if necessary to represent an item that has no value.
1. Will the switch from `null` to `undefined` to represent "nothing active/selected" cause any obscure problems?
1. Is there any documentation I need to update, beyond the code documentation I already added?
1. Any suggestions for unit tests? `Suggest` already had a relevant unit test that was easy to update to confirm correct controlled/uncontrolled behavior with respect to `undefined` values, but the other components seem to be lacking completeness of unit tests that allows me to easily add tests to cover the new functionality. I know I'm lacking test coverage, and do have some ideas for adding more tests, but I wanted to get some preliminary feedback before investing too much effort into this.

#### Screenshot

N/A