### PR TITLE
Remove dom4 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@types/chai": "^4.1.0",
     "@types/classnames": "^2.2.3",
-    "@types/dom4": "^2.0.0",
     "@types/enzyme": "^3.1.6",
     "@types/enzyme-adapter-react-16": "^1.0.1",
     "@types/mocha": "^2.2.46",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,9 +41,7 @@
   },
   "dependencies": {
     "@blueprintjs/icons": "^3.5.0",
-    "@types/dom4": "^2.0.0",
     "classnames": "^2.2",
-    "dom4": "^2.0.1",
     "normalize.css": "^8.0.0",
     "popper.js": "^1.14.1",
     "react-popper": "^1.0.0",

--- a/packages/core/src/common/browserSupport.ts
+++ b/packages/core/src/common/browserSupport.ts
@@ -14,7 +14,7 @@ export function addDomTokenListItems(classList: DOMTokenList, classes: string[])
     }
 }
 
-export function removeElement(childNode: ChildNode) {
+export function removeElement(childNode: Node) {
     // Remark: IE11 does not support childNode.remove()
     const parent = childNode.parentNode;
     if (parent !== null) {

--- a/packages/core/src/common/browserSupport.ts
+++ b/packages/core/src/common/browserSupport.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
 export function elementClosest(element: Element, selector: string): Element | null {
     let ancestor: Element | null = element;
     while (ancestor !== null && !ancestor.matches(selector)) {
@@ -11,13 +17,5 @@ export function addDomTokenListItems(classList: DOMTokenList, classes: string[])
     // Remark: IE11 does not support calling classList.add() with more than one argument
     for (const item of classes) {
         classList.add(item);
-    }
-}
-
-export function removeElement(childNode: Node) {
-    // Remark: IE11 does not support childNode.remove()
-    const parent = childNode.parentNode;
-    if (parent !== null) {
-        parent.removeChild(childNode);
     }
 }

--- a/packages/core/src/common/browserSupport.ts
+++ b/packages/core/src/common/browserSupport.ts
@@ -1,0 +1,23 @@
+export function elementClosest(element: Element, selector: string): Element | null {
+    let ancestor: Element | null = element;
+    while (ancestor !== null && !ancestor.matches(selector)) {
+        ancestor = element.parentElement;
+    }
+
+    return ancestor;
+}
+
+export function addDomTokenListItems(classList: DOMTokenList, classes: string[]) {
+    // Remark: IE11 does not support calling classList.add() with more than one argument
+    for (const item of classes) {
+        classList.add(item);
+    }
+}
+
+export function removeElement(childNode: ChildNode) {
+    // Remark: IE11 does not support childNode.remove()
+    const parent = childNode.parentNode;
+    if (parent !== null) {
+        parent.removeChild(childNode);
+    }
+}

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -15,6 +15,7 @@ import { safeInvoke } from "../../common/utils";
 import { IOverlayLifecycleProps } from "../overlay/overlay";
 import { Popover } from "../popover/popover";
 import { PopperModifiers } from "../popover/popoverSharedProps";
+import { removeElement } from '../../common/browserSupport';
 
 export interface IOffset {
     left: number;
@@ -147,7 +148,7 @@ export function isOpen() {
 function remove() {
     if (contextMenuElement != null) {
         ReactDOM.unmountComponentAtNode(contextMenuElement);
-        contextMenuElement.remove();
+        removeElement(contextMenuElement);
         contextMenuElement = null;
         contextMenu = null;
     }

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -15,7 +15,6 @@ import { safeInvoke } from "../../common/utils";
 import { IOverlayLifecycleProps } from "../overlay/overlay";
 import { Popover } from "../popover/popover";
 import { PopperModifiers } from "../popover/popoverSharedProps";
-import { removeElement } from '../../common/browserSupport';
 
 export interface IOffset {
     left: number;
@@ -148,7 +147,7 @@ export function isOpen() {
 function remove() {
     if (contextMenuElement != null) {
         ReactDOM.unmountComponentAtNode(contextMenuElement);
-        removeElement(contextMenuElement);
+        document.body.removeChild(contextMenuElement);
         contextMenuElement = null;
         contextMenu = null;
     }

--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -7,11 +7,12 @@
 import classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-
 import { Classes } from "../../common";
+import { removeElement } from '../../common/browserSupport';
 import { Dialog, IDialogProps } from "../../components";
 import { Hotkey, IHotkeyProps } from "./hotkey";
 import { Hotkeys } from "./hotkeys";
+
 
 export interface IHotkeysDialogProps extends IDialogProps {
     /**
@@ -48,7 +49,7 @@ class HotkeysDialog {
     public unmount() {
         if (this.container != null) {
             ReactDOM.unmountComponentAtNode(this.container);
-            this.container.remove();
+            removeElement(this.container);
             delete this.container;
         }
     }

--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -8,11 +8,9 @@ import classNames from "classnames";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Classes } from "../../common";
-import { removeElement } from '../../common/browserSupport';
 import { Dialog, IDialogProps } from "../../components";
 import { Hotkey, IHotkeyProps } from "./hotkey";
 import { Hotkeys } from "./hotkeys";
-
 
 export interface IHotkeysDialogProps extends IDialogProps {
     /**
@@ -49,7 +47,7 @@ class HotkeysDialog {
     public unmount() {
         if (this.container != null) {
             ReactDOM.unmountComponentAtNode(this.container);
-            removeElement(this.container);
+            document.body.removeChild(this.container);
             delete this.container;
         }
     }

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -4,14 +4,6 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-declare function require(moduleName: string): any; // declare node.js "require" so that we can conditionally import
-if (typeof window !== "undefined" && typeof document !== "undefined") {
-    // we're in browser
-    // tslint:disable-next-line:no-var-requires
-    require("dom4"); // only import actual dom4 if we're in the browser (not server-compatible)
-    // we'll still need dom4 types for the TypeScript to compile, these are included in package.json
-}
-
 import * as contextMenu from "./context-menu/contextMenu";
 export const ContextMenu = contextMenu;
 

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -8,10 +8,10 @@ import { ValidationMap } from "prop-types";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import { addDomTokenListItems } from "../../common/browserSupport";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { addDomTokenListItems, removeElement } from "../../common/browserSupport";
 import { isFunction } from "../../common/utils";
 
 /** Detect if `React.createPortal()` API method does not exist. */
@@ -105,7 +105,9 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
                 ReactDOM.unmountComponentAtNode(this.portalElement);
             }
 
-            removeElement(this.portalElement);
+            if (this.props.container) {
+                this.props.container.removeChild(this.portalElement);
+            }
         }
     }
 

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -11,6 +11,7 @@ import * as ReactDOM from "react-dom";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { addDomTokenListItems, removeElement } from "../../common/browserSupport";
 import { isFunction } from "../../common/utils";
 
 /** Detect if `React.createPortal()` API method does not exist. */
@@ -103,7 +104,8 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
             if (cannotCreatePortal) {
                 ReactDOM.unmountComponentAtNode(this.portalElement);
             }
-            this.portalElement.remove();
+
+            removeElement(this.portalElement);
         }
     }
 
@@ -128,6 +130,6 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
 
 function maybeAddClass(classList: DOMTokenList, className?: string) {
     if (className != null && className !== "") {
-        classList.add(...className.split(" "));
+        addDomTokenListItems(classList, className.split(" "));
     }
 }

--- a/packages/datetime/src/common/utils.ts
+++ b/packages/datetime/src/common/utils.ts
@@ -4,14 +4,6 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-function removeElement(childNode: Node) {
-    // Remark: IE11 does not support childNode.remove()
-    const parent = childNode.parentNode;
-    if (parent !== null) {
-        parent.removeChild(childNode);
-    }
-}
-
 /**
  * Measure width in pixels of a string displayed with styles provided by `className`.
  * Should only be used if measuring can't be done with existing DOM elements.
@@ -26,7 +18,7 @@ export function measureTextWidth(text: string, className = "", containerElement 
 
     containerElement.appendChild(span);
     const spanWidth = span.offsetWidth;
-    removeElement(span);
+    containerElement.removeChild(span);
 
     return spanWidth;
 }

--- a/packages/datetime/src/common/utils.ts
+++ b/packages/datetime/src/common/utils.ts
@@ -4,6 +4,14 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+function removeElement(childNode: ChildNode) {
+    // Remark: IE11 does not support childNode.remove()
+    const parent = childNode.parentNode;
+    if (parent !== null) {
+        parent.removeChild(childNode);
+    }
+}
+
 /**
  * Measure width in pixels of a string displayed with styles provided by `className`.
  * Should only be used if measuring can't be done with existing DOM elements.
@@ -18,7 +26,7 @@ export function measureTextWidth(text: string, className = "", containerElement 
 
     containerElement.appendChild(span);
     const spanWidth = span.offsetWidth;
-    span.remove();
+    removeElement(span);
 
     return spanWidth;
 }

--- a/packages/datetime/src/common/utils.ts
+++ b/packages/datetime/src/common/utils.ts
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-function removeElement(childNode: ChildNode) {
+function removeElement(childNode: Node) {
     // Remark: IE11 does not support childNode.remove()
     const parent = childNode.parentNode;
     if (parent !== null) {

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -29,7 +29,6 @@
     "@types/downloadjs": "^1.4.0",
     "chroma-js": "^1.3.4",
     "classnames": "^2.2.5",
-    "dom4": "^2.0.1",
     "downloadjs": "^1.4.7",
     "moment": "^2.18.1",
     "normalize.css": "^8.0.0",

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -5,7 +5,6 @@
 
 // tslint:disable-next-line:no-submodule-imports
 import "@blueprintjs/test-commons/polyfill";
-import "dom4";
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -19,7 +19,6 @@
     "@blueprintjs/core": "^3.0.0",
     "@blueprintjs/table": "^3.0.0",
     "classnames": "^2.2.5",
-    "dom4": "^2.0.1",
     "normalize.css": "^8.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,11 +45,6 @@
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.3.tgz#3f0ff6873da793870e20a260cada55982f38a9e5"
   integrity sha512-x15/Io+JdzrkM9gnX6SWUs/EmqQzd65TD9tcZIAQ1VIdb93XErNuYmB7Yho8JUCE189ipUSESsWvGvYXRRIvYA==
 
-"@types/dom4@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.0.tgz#00dc42fed6b36a7a6dabb8f7a9c9e678ee644e05"
-  integrity sha512-8daxuqQvjHC2EaOfEC99ayfoiaaAVW+Mmm+3Uf0NDi9c5yarbFLXAU/BgSXLJgnbExSIokpvGDAZsYW82kg5Dg==
-
 "@types/downloadjs@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/downloadjs/-/downloadjs-1.4.0.tgz#d356ccdbea1c3622f233aebff7e58cc6598309ed"
@@ -2787,11 +2782,6 @@ dom-serializer@0, dom-serializer@^0.1.0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
-
-dom4@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/dom4/-/dom4-2.0.1.tgz#03000cbea1ec33b3dde8cfd7a0cf77587d27e9d5"
-  integrity sha512-pfO0omEczRlJAjJHV1iViFt10jN70cfkqlBjZ4D9mLvv4CvK3aypYAmIHjxlcZtu3gTQu/PtMz+vzezUM/W0pg==
 
 domain-browser@^1.1.1:
   version "1.1.7"


### PR DESCRIPTION
This PR removes internal usage of the `dom4` polyfill to improve page interop with other libraries. This should **not** change blueprint's own browser compatibility matrix: any DOM features not present in older supported browsers, like IE11, are still accommodated here.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Description

The following features related to dom4 were investigated for compatibility and support, with notes by item. The word "supported" below refers to support in Blueprint's IE11+, modern-ish Firefox and modern-ish Chrome. If I have that wrong, I'm happy to revisit with more detailed notes and make those corrections. Thanks!

- Element#remove()
    - Not supported in IE11, so I've preferred the equivalent element.parentElement.removeChild()
- Events
    - KeyboardEvent#which supported
    - KeyboardEvent#keyCode supported
    - Event#stopPropagation(), Event#stopImmediatePropagation(), and Event#preventDefault() aren't touched by dom4
    - We don't use any Event constructors
- DOMTokenList#add (element.classList)
    - Only one argument allowed in IE11, so I've introduced addDomTokenListItems() utility
- DOMTokenList#toggle (element.classList)
    - No second argument to toggle allowed in IE11, but we don't use it.
- Element#closest()
    - Not supported in IE11, so I've introduced closestElement() utility
- Element#matches() [needed by our Element#closest() ponyfill]
    - Supported
- Node#contains()
    - Supported
