### PR TITLE
[TimezonePicker] Support a custom target via <children>

### DIFF
--- a/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+import { Colors, Icon, Intent, Tooltip } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { getTimezoneMetadata } from "@blueprintjs/timezone";
+import React from "react";
+
+export interface ICustomTimezoneTargetProps {
+    timezone: string;
+}
+
+export interface ICustomTimezoneTargetState {
+    isHovering: boolean;
+}
+
+// This is a little component that isn't meant to see the light of day outside
+// the TimezonePickerExample. Coding style is thus a *little* scrappy.
+export class CustomTimezoneTarget extends React.PureComponent<ICustomTimezoneTargetProps, ICustomTimezoneTargetState> {
+    public state: ICustomTimezoneTargetState = {
+        isHovering: false,
+    };
+
+    public render() {
+        const { isHovering } = this.state;
+        return (
+            <Tooltip content={this.getTooltipContent()}>
+                <div
+                    onMouseEnter={this.handleMouseEnter}
+                    onMouseLeave={this.handleMouseLeave}
+                    style={{ cursor: "pointer" }}
+                >
+                    <Icon icon={IconNames.GLOBE} intent={isHovering ? Intent.PRIMARY : undefined} />
+                    &nbsp;
+                    <Icon color={Colors.GRAY1} icon={IconNames.CARET_DOWN} />
+                </div>
+            </Tooltip>
+        );
+    }
+
+    private getTooltipContent() {
+        const { timezone } = this.props;
+
+        if (timezone == null || timezone.length === 0) {
+            return "No selection";
+        }
+
+        const { abbreviation, offsetAsString } = getTimezoneMetadata(timezone);
+
+        return (
+            <span>
+                GMT {offsetAsString}
+                <span style={{ color: Colors.GRAY4 }}>{abbreviation ? ` (${abbreviation})` : ""}</span>
+            </span>
+        );
+    }
+
+    private handleMouseEnter = () => this.setState({ isHovering: true });
+    private handleMouseLeave = () => this.setState({ isHovering: false });
+}

--- a/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
@@ -9,18 +9,21 @@ import { IconNames } from "@blueprintjs/icons";
 import { getTimezoneMetadata } from "@blueprintjs/timezone";
 import React from "react";
 
-export interface ICustomTimezoneTargetProps {
+export interface ICustomTimezonePickerTargetProps {
     timezone: string;
 }
 
-export interface ICustomTimezoneTargetState {
+export interface ICustomTimezonePickerTargetState {
     isHovering: boolean;
 }
 
 // This is a little component that isn't meant to see the light of day outside
 // the TimezonePickerExample. Coding style is thus a *little* scrappy.
-export class CustomTimezoneTarget extends React.PureComponent<ICustomTimezoneTargetProps, ICustomTimezoneTargetState> {
-    public state: ICustomTimezoneTargetState = {
+export class CustomTimezonePickerTarget extends React.PureComponent<
+    ICustomTimezonePickerTargetProps,
+    ICustomTimezonePickerTargetState
+> {
+    public state: ICustomTimezonePickerTargetState = {
         isHovering: false,
     };
 

--- a/packages/docs-app/src/examples/timezone-examples/components/index.ts
+++ b/packages/docs-app/src/examples/timezone-examples/components/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+export * from "./customTimezoneTarget";

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -6,12 +6,14 @@
 
 import * as React from "react";
 
-import { H5, Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { TimezoneDisplayFormat, TimezonePicker } from "@blueprintjs/timezone";
+import { CustomTimezoneTarget } from "./components";
 
 export interface ITimezonePickerExampleState {
     disabled: boolean;
+    showCustomTarget: boolean;
     showLocalTimezone: boolean;
     targetDisplayFormat: TimezoneDisplayFormat;
     timezone: string;
@@ -20,6 +22,7 @@ export interface ITimezonePickerExampleState {
 export class TimezonePickerExample extends React.PureComponent<IExampleProps, ITimezonePickerExampleState> {
     public state: ITimezonePickerExampleState = {
         disabled: false,
+        showCustomTarget: false,
         showLocalTimezone: true,
         targetDisplayFormat: TimezoneDisplayFormat.COMPOSITE,
         timezone: "",
@@ -27,18 +30,20 @@ export class TimezonePickerExample extends React.PureComponent<IExampleProps, IT
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
     private handleShowLocalChange = handleBooleanChange(showLocalTimezone => this.setState({ showLocalTimezone }));
+    private handleCustomChildChange = handleBooleanChange(showCustomTarget => this.setState({ showCustomTarget }));
     private handleFormatChange = handleStringChange((targetDisplayFormat: TimezoneDisplayFormat) =>
         this.setState({ targetDisplayFormat }),
     );
 
     public render() {
-        const { timezone, targetDisplayFormat, disabled, showLocalTimezone } = this.state;
+        const { timezone, targetDisplayFormat, disabled, showCustomTarget, showLocalTimezone } = this.state;
 
         const options = (
             <>
                 <H5>Props</H5>
                 <Switch checked={showLocalTimezone} label="Show local timezone" onChange={this.handleShowLocalChange} />
                 <Switch checked={disabled} label="Disabled" onChange={this.handleDisabledChange} />
+                <Switch checked={showCustomTarget} label="Custom target" onChange={this.handleCustomChildChange} />
                 <RadioGroup
                     label="Display format"
                     onChange={this.handleFormatChange}
@@ -58,11 +63,18 @@ export class TimezonePickerExample extends React.PureComponent<IExampleProps, IT
                     value={timezone}
                     onChange={this.handleTimezoneChange}
                     valueDisplayFormat={targetDisplayFormat}
+                    popoverProps={{ position: Position.BOTTOM }}
                     showLocalTimezone={showLocalTimezone}
                     disabled={disabled}
-                />
+                >
+                    {showCustomTarget ? this.renderCustomTarget() : undefined}
+                </TimezonePicker>
             </Example>
         );
+    }
+
+    private renderCustomTarget() {
+        return <CustomTimezoneTarget timezone={this.state.timezone} />;
     }
 
     private handleTimezoneChange = (timezone: string) => this.setState({ timezone });

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -43,7 +43,6 @@ export class TimezonePickerExample extends React.PureComponent<IExampleProps, IT
                 <H5>Props</H5>
                 <Switch checked={showLocalTimezone} label="Show local timezone" onChange={this.handleShowLocalChange} />
                 <Switch checked={disabled} label="Disabled" onChange={this.handleDisabledChange} />
-                <Switch checked={showCustomTarget} label="Custom target" onChange={this.handleCustomChildChange} />
                 <RadioGroup
                     label="Display format"
                     onChange={this.handleFormatChange}
@@ -54,6 +53,8 @@ export class TimezonePickerExample extends React.PureComponent<IExampleProps, IT
                     <Radio label="Name" value={TimezoneDisplayFormat.NAME} />
                     <Radio label="Offset" value={TimezoneDisplayFormat.OFFSET} />
                 </RadioGroup>
+                <H5>Example</H5>
+                <Switch checked={showCustomTarget} label="Custom target" onChange={this.handleCustomChildChange} />
             </>
         );
 

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { TimezoneDisplayFormat, TimezonePicker } from "@blueprintjs/timezone";
-import { CustomTimezoneTarget } from "./components";
+import { CustomTimezonePickerTarget } from "./components";
 
 export interface ITimezonePickerExampleState {
     disabled: boolean;
@@ -74,7 +74,7 @@ export class TimezonePickerExample extends React.PureComponent<IExampleProps, IT
     }
 
     private renderCustomTarget() {
-        return <CustomTimezoneTarget timezone={this.state.timezone} />;
+        return <CustomTimezonePickerTarget timezone={this.state.timezone} />;
     }
 
     private handleTimezoneChange = (timezone: string) => this.setState({ timezone });

--- a/packages/timezone/src/common/errors.ts
+++ b/packages/timezone/src/common/errors.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the terms of the LICENSE file distributed with this project.
+ */
+
+const ns = "[Blueprint]";
+
+export const TIMEZONE_PICKER_WARN_TOO_MANY_CHILDREN =
+    ns +
+    ` <TimezonePicker> supports up to one child; additional children are ignored.` +
+    ` If a child is present, it it will be rendered in place of the default button target.`;

--- a/packages/timezone/src/components/index.ts
+++ b/packages/timezone/src/components/index.ts
@@ -4,4 +4,5 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+export * from "./timezone-picker/timezoneMetadata";
 export * from "./timezone-picker/timezonePicker";

--- a/packages/timezone/src/components/timezone-picker/timezone-picker.md
+++ b/packages/timezone/src/components/timezone-picker/timezone-picker.md
@@ -27,7 +27,7 @@ the user's timezone.
 By default, the component will show a clickable button target,
 which will display the selected timezone formatted according to `valueDisplayFormat`.
 The button can also be managed via `disabled`, `placeholder`, and more generally via `buttonProps`.
-You can show a custom element instead the default button by passing a child; in this case,
+You can show a custom element instead of the default button by passing a single-element child; in this case,
 all button-specific props will be ignored:
 
 ```tsx

--- a/packages/timezone/src/components/timezone-picker/timezone-picker.md
+++ b/packages/timezone/src/components/timezone-picker/timezone-picker.md
@@ -24,6 +24,18 @@ using the most populous location for each offset.
 Moment Timezone uses a similar [heuristic for guessing](http://momentjs.com/timezone/docs/#/using-timezones/guessing-user-timezone/)
 the user's timezone.
 
+By default, the component will show a clickable button target,
+which will display the selected timezone formatted according to `valueDisplayFormat`.
+The button can also be managed via `disabled`, `placeholder`, and more generally via `buttonProps`.
+You can show a custom element instead the default button by passing a child; in this case,
+all button-specific props will be ignored:
+
+```tsx
+<TimezonePicker value={...} onChange={...}>
+    <Icon icon="globe" />
+</TimezontPicker>
+```
+
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h4 class="@ns-heading">Local timezone detection</h4>
     We detect the local timezone when the `showLocalTimezone` prop is enabled and cannot guarantee correctness in all browsers.

--- a/packages/timezone/src/components/timezone-picker/timezoneMetadata.ts
+++ b/packages/timezone/src/components/timezone-picker/timezoneMetadata.ts
@@ -17,7 +17,7 @@ export interface ITimezoneMetadata {
     population: number | undefined;
 }
 
-export function getTimezoneMetadata(timezone: string, date: Date): ITimezoneMetadata {
+export function getTimezoneMetadata(timezone: string, date: Date = new Date()): ITimezoneMetadata {
     const timestamp = date.getTime();
     const zone = moment.tz.zone(timezone);
     const zonedDate = moment.tz(timestamp, timezone);

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -22,6 +22,7 @@ import {
 } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Select } from "@blueprintjs/select";
 import * as Classes from "../../common/classes";
+import * as Errors from "../../common/errors";
 import { formatTimezone, TimezoneDisplayFormat } from "./timezoneDisplayFormat";
 import { getInitialTimezoneItems, getTimezoneItems, ITimezoneItem } from "./timezoneItems";
 
@@ -38,12 +39,6 @@ export interface ITimezonePickerProps extends IProps {
      * Callback invoked when the user selects a timezone.
      */
     onChange: (timezone: string) => void;
-
-    /**
-     * This component does not support children.
-     * Use `value`, `valueDisplayFormat` and `buttonProps` to customize the button child.
-     */
-    children?: never;
 
     /**
      * The date to use when formatting timezone offsets.
@@ -66,6 +61,7 @@ export interface ITimezonePickerProps extends IProps {
 
     /**
      * Format to use when displaying the selected (or default) timezone within the target element.
+     * This prop will be ignored if a custom child is provided.
      * @default TimezoneDisplayFormat.OFFSET
      */
     valueDisplayFormat?: TimezoneDisplayFormat;
@@ -76,7 +72,10 @@ export interface ITimezonePickerProps extends IProps {
      */
     placeholder?: string;
 
-    /** Props to spread to the target `Button`. */
+    /**
+     * Props to spread to the target `Button`.
+     * This prop will be ignored if a custom child is provided.
+     */
     buttonProps?: Partial<IButtonProps>;
 
     /**
@@ -124,7 +123,7 @@ export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, 
     }
 
     public render() {
-        const { className, disabled, inputProps, popoverProps } = this.props;
+        const { children, className, disabled, inputProps, popoverProps } = this.props;
         const { query } = this.state;
 
         const finalInputProps: IInputGroupProps & HTMLInputProps = {
@@ -151,7 +150,7 @@ export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, 
                 disabled={disabled}
                 onQueryChange={this.handleQueryChange}
             >
-                {this.renderButton()}
+                {children != null ? children : this.renderButton()}
             </TypedSelect>
         );
     }
@@ -164,6 +163,13 @@ export class TimezonePicker extends AbstractPureComponent<ITimezonePickerProps, 
         }
         if (nextInputProps.value !== undefined && this.state.query !== nextInputProps.value) {
             this.setState({ query: nextInputProps.value });
+        }
+    }
+
+    protected validateProps(props: IPopoverProps & { children?: React.ReactNode }) {
+        const childrenCount = React.Children.count(props.children);
+        if (childrenCount > 1) {
+            console.warn(Errors.TIMEZONE_PICKER_WARN_TOO_MANY_CHILDREN);
         }
     }
 

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -49,7 +49,7 @@ export interface ITimezonePickerProps extends IProps {
 
     /**
      * Whether this component is non-interactive.
-     * This prop will be ignored if a custom child is provided.
+     * This prop will be ignored if `children` is provided.
      * @default false
      */
     disabled?: boolean;
@@ -62,21 +62,21 @@ export interface ITimezonePickerProps extends IProps {
 
     /**
      * Format to use when displaying the selected (or default) timezone within the target element.
-     * This prop will be ignored if a custom child is provided.
+     * This prop will be ignored if `children` is provided.
      * @default TimezoneDisplayFormat.OFFSET
      */
     valueDisplayFormat?: TimezoneDisplayFormat;
 
     /**
      * Text to show when no timezone has been selected (`value === undefined`).
-     * This prop will be ignored if a custom child is provided.
+     * This prop will be ignored if `children` is provided.
      * @default "Select timezone..."
      */
     placeholder?: string;
 
     /**
      * Props to spread to the target `Button`.
-     * This prop will be ignored if a custom child is provided.
+     * This prop will be ignored if `children` is provided.
      */
     buttonProps?: Partial<IButtonProps>;
 

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -49,6 +49,7 @@ export interface ITimezonePickerProps extends IProps {
 
     /**
      * Whether this component is non-interactive.
+     * This prop will be ignored if a custom child is provided.
      * @default false
      */
     disabled?: boolean;
@@ -68,6 +69,7 @@ export interface ITimezonePickerProps extends IProps {
 
     /**
      * Text to show when no timezone has been selected (`value === undefined`).
+     * This prop will be ignored if a custom child is provided.
      * @default "Select timezone..."
      */
     placeholder?: string;

--- a/packages/timezone/test/timezonePickerTests.tsx
+++ b/packages/timezone/test/timezonePickerTests.tsx
@@ -201,6 +201,18 @@ describe("<TimezonePicker>", () => {
         }
     });
 
+    it("renders a custom target via <children>", () => {
+        const timezonePicker = shallow(
+            <TimezonePicker {...DEFAULT_PROPS}>
+                <span className="foo">Hello world</span>
+            </TimezonePicker>,
+        );
+        const button = timezonePicker.find(Button);
+        const span = timezonePicker.find(".foo");
+        assert.lengthOf(button, 0, "expected no button");
+        assert.lengthOf(span, 1, "expected custom target with class '.foo'");
+    });
+
     function findSelect(timezonePicker: TimezonePickerShallowWrapper) {
         return timezonePicker.find<ISelectProps<ITimezoneItem>>(Select);
     }


### PR DESCRIPTION
#### (No issue)

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

- 🌈 __Enhancement__: In `<TimezonePicker>`, support a custom target instead of the default button by passing a custom child.
    - Only one child is supported; providing more than one will print a console warning in dev mode.
    - If a custom child is provided, all button-specific props will be ignored (i.e., `buttonProps`, `disabled`, `placeholder`, `valueDisplayFormat`).
- 🌈 __Enhancement__: Export `getTimezoneMetadata()` from `packages/timezone` to enable easy, arbitrary timezone formatting in custom targets.
    - Necessary for some internal work.
- Other:
    - _Update example_: Add "Custom target" toggle that shows the globe icon GIF'd below.
    - _Update tests_.
    - _Update docs_.

#### Reviewers should focus on:

- __Q:__ Can you help me organize the documentation for `<TimezonePicker>`? Feels busy right now.
- I added a non-exported `<CustomTimezonePickerTarget>` component that has a fairly scrappy implementation. This more or less mirrors what I need to build; hence, this is what motivated exporting `getTimezoneMetdata()` from the `timezone` package.

#### Screenshot

![2019-01-15 16 13 57](https://user-images.githubusercontent.com/443450/51218294-969b1e80-18e0-11e9-8651-81794809fb26.gif)
