### PR TITLE
[QueryList] Initialize activeItem state correctly based on prop.

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -109,7 +109,14 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         super(props, context);
         const { query = "" } = this.props;
         const filteredItems = getFilteredItems(query, this.props);
-        this.state = { activeItem: getFirstEnabledItem(filteredItems, this.props.itemDisabled), filteredItems, query };
+        this.state = {
+            activeItem:
+                props.activeItem !== undefined
+                    ? props.activeItem
+                    : getFirstEnabledItem(filteredItems, this.props.itemDisabled),
+            filteredItems,
+            query,
+        };
     }
 
     public render() {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -111,8 +111,8 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         const filteredItems = getFilteredItems(query, this.props);
         this.state = {
             activeItem:
-                props.activeItem !== undefined
-                    ? props.activeItem
+                this.props.activeItem !== undefined
+                    ? this.props.activeItem
                     : getFirstEnabledItem(filteredItems, this.props.itemDisabled),
             filteredItems,
             query,

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -156,7 +156,7 @@ describe("<QueryList>", () => {
         it("initializes to controlled activeItem prop (non-null)", () => {
             const props: IQueryListProps<IFilm> = {
                 ...testProps,
-                // List is not filtered, amd item at index 11 is explicitly chosen as activeItem
+                // List is not filtered, and item at index 11 is explicitly chosen as activeItem
                 activeItem: TOP_100_FILMS[11],
             };
 

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -11,7 +11,13 @@ import * as sinon from "sinon";
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IQueryListProps } from "@blueprintjs/select";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
-import { IQueryListRendererProps, IQueryListState, ItemListPredicate, ItemListRenderer, QueryList } from "../src/index";
+import {
+    IQueryListRendererProps,
+    IQueryListState,
+    ItemListPredicate,
+    ItemListRenderer,
+    QueryList
+} from "../src/index";
 
 describe("<QueryList>", () => {
     const FilmQueryList = QueryList.ofType<IFilm>();
@@ -89,6 +95,8 @@ describe("<QueryList>", () => {
             filmQueryList.setState({ query: "query" });
             filmQueryList.setState({ activeItem: undefined });
             assert.equal(testProps.onActiveItemChange.callCount, 0);
+
+            filmQueryList.unmount();
         });
 
         it("ensure onActiveItemChange is not called updating props and query doesn't change", () => {
@@ -102,6 +110,8 @@ describe("<QueryList>", () => {
             const filmQueryList: ReactWrapper<IQueryListProps<IFilm>> = mount(<FilmQueryList {...props} />);
             filmQueryList.setProps(props);
             assert.equal(testProps.onActiveItemChange.callCount, 0);
+
+            filmQueryList.unmount();
         });
 
         it("ensure activeItem changes on query change", () => {
@@ -119,6 +129,59 @@ describe("<QueryList>", () => {
                 query: "123",
             });
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[1]);
+
+            filmQueryList.unmount();
+        });
+    });
+
+    describe("activeItem state initialization", () => {
+        it("initializes to first filtered item when uncontrolled", () => {
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                // Filter down to only item at index 11, so item at index 11 should be
+                // chosen as default activeItem
+                itemPredicate: (_query, item) => item === TOP_100_FILMS[11],
+                query: "123",
+            };
+
+            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
+                <FilmQueryList {...props} />,
+            );
+
+            assert(filmQueryList.state().activeItem === TOP_100_FILMS[11]);
+
+            filmQueryList.unmount();
+        });
+
+        it("initializes to controlled activeItem prop (non-null)", () => {
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                // List is not filtered, amd item at index 11 is explicitly chosen as activeItem
+                activeItem: TOP_100_FILMS[11],
+            };
+
+            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
+                <FilmQueryList {...props} />,
+            );
+
+            assert(filmQueryList.state().activeItem === TOP_100_FILMS[11]);
+
+            filmQueryList.unmount();
+        });
+
+        it("initializes to controlled activeItem prop (null)", () => {
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                activeItem: null,
+            };
+
+            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
+                <FilmQueryList {...props} />,
+            );
+
+            assert(filmQueryList.state().activeItem === null);
+
+            filmQueryList.unmount();
         });
     });
 

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -11,13 +11,9 @@ import * as sinon from "sinon";
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IQueryListProps } from "@blueprintjs/select";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
-import {
-    IQueryListRendererProps,
-    IQueryListState,
-    ItemListPredicate,
-    ItemListRenderer,
-    QueryList
-} from "../src/index";
+import { IQueryListRendererProps, IQueryListState, ItemListPredicate, ItemListRenderer, QueryList } from "../src/index";
+
+type FilmQueryListWrapper = ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>>;
 
 describe("<QueryList>", () => {
     const FilmQueryList = QueryList.ofType<IFilm>();
@@ -95,8 +91,6 @@ describe("<QueryList>", () => {
             filmQueryList.setState({ query: "query" });
             filmQueryList.setState({ activeItem: undefined });
             assert.equal(testProps.onActiveItemChange.callCount, 0);
-
-            filmQueryList.unmount();
         });
 
         it("ensure onActiveItemChange is not called updating props and query doesn't change", () => {
@@ -107,11 +101,9 @@ describe("<QueryList>", () => {
                 items: [myItem],
                 query: "",
             };
-            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>> = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
             filmQueryList.setProps(props);
             assert.equal(testProps.onActiveItemChange.callCount, 0);
-
-            filmQueryList.unmount();
         });
 
         it("ensure activeItem changes on query change", () => {
@@ -120,17 +112,13 @@ describe("<QueryList>", () => {
                 items: [TOP_100_FILMS[0]],
                 query: "abc",
             };
-            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
-                <FilmQueryList {...props} />,
-            );
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
             filmQueryList.setProps({
                 items: [TOP_100_FILMS[1]],
                 query: "123",
             });
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[1]);
-
-            filmQueryList.unmount();
         });
     });
 
@@ -143,14 +131,8 @@ describe("<QueryList>", () => {
                 itemPredicate: (_query, item) => item === TOP_100_FILMS[11],
                 query: "123",
             };
-
-            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
-                <FilmQueryList {...props} />,
-            );
-
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
             assert(filmQueryList.state().activeItem === TOP_100_FILMS[11]);
-
-            filmQueryList.unmount();
         });
 
         it("initializes to controlled activeItem prop (non-null)", () => {
@@ -159,14 +141,8 @@ describe("<QueryList>", () => {
                 // List is not filtered, and item at index 11 is explicitly chosen as activeItem
                 activeItem: TOP_100_FILMS[11],
             };
-
-            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
-                <FilmQueryList {...props} />,
-            );
-
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
             assert(filmQueryList.state().activeItem === TOP_100_FILMS[11]);
-
-            filmQueryList.unmount();
         });
 
         it("initializes to controlled activeItem prop (null)", () => {
@@ -174,14 +150,8 @@ describe("<QueryList>", () => {
                 ...testProps,
                 activeItem: null,
             };
-
-            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
-                <FilmQueryList {...props} />,
-            );
-
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
             assert(filmQueryList.state().activeItem === null);
-
-            filmQueryList.unmount();
         });
     });
 


### PR DESCRIPTION
#### Fixes (unreported bug)

#### Checklist

- [x] Includes tests
- [x] Update documentation (N/A)

#### Changes proposed in this pull request:

Fix a bug in QueryList where `activeItem` state is always initialized to first filtered enabled item, completely ignoring the potentially controlled `activeItem` prop.

#### Reviewers should focus on:

Is there any related controlled vs uncontrolled behavior of `activeItem` that may also be incorrect?

#### Screenshot

N/A