### PR TITLE
[Tooltip] allow HOVER interactions

### DIFF
--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -35,6 +35,13 @@ export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
     hoverOpenDelay?: number;
 
     /**
+     * The kind of hover interaction that triggers the display of the tooltip.
+     * Tooltips do not support click interactions.
+     * @default PopoverInteractionKind.HOVER_TARGET_ONLY
+     */
+    interactionKind?: typeof PopoverInteractionKind.HOVER | typeof PopoverInteractionKind.HOVER_TARGET_ONLY;
+
+    /**
      * Indicates how long (in milliseconds) the tooltip's appear/disappear
      * transition takes. This is used by React `CSSTransition` to know when a
      * transition completes and must match the duration of the animation in CSS.
@@ -62,11 +69,11 @@ export class Tooltip extends React.PureComponent<ITooltipProps, {}> {
 
         return (
             <Popover
+                interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}
                 enforceFocus={false}
-                interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
                 lazy={true}
                 popoverClassName={classes}
                 portalContainer={this.props.portalContainer}


### PR DESCRIPTION
#### Fixes #3184

#### Changes proposed in this pull request:

- Add `Tooltip` `interactionKind` prop that supports `HOVER | HOVER_TARGET_ONLY` (defaults to the latter, as always).
