### PR TITLE
[Suggest] add `disabled` and `resetOnClose` props

### DIFF
--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -18,8 +18,9 @@ export interface ISuggestExampleState {
     film: IFilm;
     minimal: boolean;
     openOnKeyDown: boolean;
-    resetOnSelect: boolean;
+    resetOnClose: boolean;
     resetOnQuery: boolean;
+    resetOnSelect: boolean;
 }
 
 export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestExampleState> {
@@ -28,6 +29,7 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
         film: TOP_100_FILMS[0],
         minimal: true,
         openOnKeyDown: false,
+        resetOnClose: false,
         resetOnQuery: true,
         resetOnSelect: false,
     };
@@ -35,6 +37,7 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
     private handleCloseOnSelectChange = this.handleSwitchChange("closeOnSelect");
     private handleOpenOnKeyDownChange = this.handleSwitchChange("openOnKeyDown");
     private handleMinimalChange = this.handleSwitchChange("minimal");
+    private handleResetOnCloseChange = this.handleSwitchChange("resetOnClose");
     private handleResetOnQueryChange = this.handleSwitchChange("resetOnQuery");
     private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
 
@@ -67,6 +70,11 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
                     label="Open popover on key down"
                     checked={this.state.openOnKeyDown}
                     onChange={this.handleOpenOnKeyDownChange}
+                />
+                <Switch
+                    label="Reset on close"
+                    checked={this.state.resetOnClose}
+                    onChange={this.handleResetOnCloseChange}
                 />
                 <Switch
                     label="Reset on query"

--- a/packages/select/src/components/select/suggest.md
+++ b/packages/select/src/components/select/suggest.md
@@ -1,6 +1,9 @@
 @# Suggest
 
-`Suggest` behaves similarly to [`Select`](#select/select-component), except it renders a text input as the `Popover` target instead of arbitrary children.
+`Suggest` behaves similarly to [`Select`](#select/select-component), except it
+renders a text input as the `Popover` target instead of arbitrary children. This
+text [`InputGroup`](#core/components/text-inputs.input-group) can be customized
+using `inputProps`.
 
 @reactExample SuggestExample
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -28,6 +28,9 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
      */
     closeOnSelect?: boolean;
 
+    /** Whether the input field should be disabled. */
+    disabled?: boolean;
+
     /**
      * Props to spread to the query `InputGroup`. To control this input, use
      * `query` and `onQueryChange` instead of `inputProps.value` and
@@ -108,7 +111,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { inputProps, popoverProps, ...restProps } = this.props;
+        const { disabled, inputProps, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
@@ -162,13 +165,14 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 onOpened={this.handlePopoverOpened}
             >
                 <InputGroup
+                    disabled={this.props.disabled}
                     {...inputProps}
-                    placeholder={inputPlaceholder}
                     inputRef={this.refHandlers.input}
                     onChange={listProps.handleQueryChange}
                     onFocus={this.handleInputFocus}
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTargetKeyUpHandler(handleKeyUp)}
+                    placeholder={inputPlaceholder}
                     value={inputValue}
                 />
                 <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>


### PR DESCRIPTION
#### Fixes #3270 

#### Changes proposed in this pull request:

- new `disabled` prop to quickly disable the entire thing.
- new `resetOnClose` prop resets active item & query when the popover closes, a la corresponding prop on `Select`.