### PR TITLE
[DRP] Shortcuts support changing time & docs

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -33,17 +33,23 @@ import { Shortcuts } from "./shortcuts";
 import { TimePicker } from "./timePicker";
 
 export interface IDateRangeShortcut {
+    /** Shortcut label that appears in the list. */
     label: string;
+
+    /**
+     * Date range represented by this shortcut. Note that time components of a
+     * shortcut are ignored by default; set `includeTime: true` to respect them.
+     */
     dateRange: DateRange;
 
     /**
-     * By default, clicking a shortcut does not change the time of the date range picker, but instead
-     * takes the date components of the `dateRange` and combines it with the currently selected time.
-     * Setting `shouldChangeTime` to `true` will override this behavior and allow shortcuts to change
-     * the selected time as well.
+     * Set this prop to `true` to allow this shortcut to change the selected
+     * times as well as the dates. By default, time components of a shortcut are
+     * ignored; clicking a shortcut takes the date components of the `dateRange`
+     * and combines them with the currently selected time.
      * @default false
      */
-    shouldChangeTime?: boolean;
+    includeTime?: boolean;
 }
 
 export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
@@ -505,8 +511,8 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
     };
 
     private handleShortcutClick = (shortcut: IDateRangeShortcut) => {
-        const { dateRange, shouldChangeTime } = shortcut;
-        if (shouldChangeTime) {
+        const { dateRange, includeTime } = shortcut;
+        if (includeTime) {
             const newDateRange: DateRange = [dateRange[0], dateRange[1]];
             const newTimeRange: DateRange = [dateRange[0], dateRange[1]];
             const nextState = getStateChange(

--- a/packages/datetime/src/daterangepicker.md
+++ b/packages/datetime/src/daterangepicker.md
@@ -15,6 +15,28 @@ Semantically:
 * `[someDate, null]` represents a date range where a single endpoint is known.
 * `[someDate, someOtherDate]` represents a full date range where both endpoints are known.
 
+@## Shortcuts
+
+The menu on the left of the calendars provides "shortcuts" that allow users to
+quickly select common date ranges. The items in this menu are controlled through
+the `shortcuts` prop: `true` to show presets (default), `false` to hide, or an
+array of `IDateRangeShortcut` objects to define custom shortcuts.
+
+The **preset shortcuts** can be seen in the example above. They are as follows:
+
+- Today (only appears if `allowSingleDayRange={true}`)
+- Yesterday (only appears if `allowSingleDayRange={true}`)
+- Past week
+- Past month
+- Past 3 months
+- Past 6 months
+- Past year
+- Past 2 years
+
+**Custom shortcuts** use the following interface:
+
+@interface IDateRangeShortcut
+
 @## Props
 
 Use the `onChange` prop to listen for changes to the set date range. You can

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -17,7 +17,7 @@ import * as DateUtils from "../src/common/dateUtils";
 import * as Errors from "../src/common/errors";
 import { Months } from "../src/common/months";
 import { DatePickerNavbar } from "../src/datePickerNavbar";
-import { IDateRangePickerState } from "../src/dateRangePicker";
+import { IDateRangePickerState, IDateRangeShortcut } from "../src/dateRangePicker";
 import {
     Classes as DateClasses,
     DateRange,
@@ -904,74 +904,47 @@ describe("<DateRangePicker>", () => {
         });
 
         it("custom shortcuts set the displayed months correctly when start month changes", () => {
-            const dateRange = [
-                new Date(2016, Months.JANUARY, 1, 10, 20, 30),
-                new Date(2016, Months.DECEMBER, 31, 10, 20, 30),
-            ] as DateRange;
-
-            const test = (shouldChangeTime: boolean) => {
-                const { left, right } = render({
-                    initialMonth: new Date(2015, Months.JANUARY, 1),
-                    shortcuts: [{ label: "custom shortcut", dateRange, shouldChangeTime }],
-                }).clickShortcut();
-                assert.isTrue(onChangeSpy.calledOnce);
-                left.assertMonthYear(Months.JANUARY, 2016);
-                right.assertMonthYear(Months.FEBRUARY, 2016);
-            };
-
-            test(true);
-            test(false);
+            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
+            const { left, right } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+                shortcuts: [{ label: "custom shortcut", dateRange }],
+            }).clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            left.assertMonthYear(Months.JANUARY, 2016);
+            right.assertMonthYear(Months.FEBRUARY, 2016);
         });
 
         it(
             "custom shortcuts set the displayed months correctly when start month changes " +
                 "and contiguousCalendarMonths is false",
             () => {
-                const dateRange = [
-                    new Date(2016, Months.JANUARY, 1, 10, 20, 30),
-                    new Date(2016, Months.DECEMBER, 31, 10, 20, 30),
-                ] as DateRange;
-
-                const test = (shouldChangeTime: boolean) => {
-                    const { left, right } = render({
-                        contiguousCalendarMonths: false,
-                        initialMonth: new Date(2015, Months.JANUARY, 1),
-                        shortcuts: [{ label: "custom shortcut", dateRange, shouldChangeTime }],
-                    }).clickShortcut();
-                    assert.isTrue(onChangeSpy.calledOnce);
-                    left.assertMonthYear(Months.JANUARY, 2016);
-                    right.assertMonthYear(Months.DECEMBER, 2016);
-                };
-
-                test(true);
-                test(false);
+                const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
+                const { left, right } = render({
+                    contiguousCalendarMonths: false,
+                    initialMonth: new Date(2015, Months.JANUARY, 1),
+                    shortcuts: [{ label: "custom shortcut", dateRange }],
+                }).clickShortcut();
+                assert.isTrue(onChangeSpy.calledOnce);
+                left.assertMonthYear(Months.JANUARY, 2016);
+                right.assertMonthYear(Months.DECEMBER, 2016);
             },
         );
 
         it("custom shortcuts set the displayed months correctly when start month stays the same", () => {
-            const dateRange = [
-                new Date(2016, Months.JANUARY, 1, 10, 20, 30),
-                new Date(2016, Months.DECEMBER, 31, 10, 20, 30),
-            ] as DateRange;
+            const dateRange = [new Date(2016, Months.JANUARY, 1), new Date(2016, Months.DECEMBER, 31)] as DateRange;
+            const { clickShortcut, left, right } = render({
+                initialMonth: new Date(2016, Months.JANUARY, 1),
+                shortcuts: [{ label: "custom shortcut", dateRange }],
+            });
 
-            const test = (shouldChangeTime: boolean) => {
-                const { clickShortcut, left, right } = render({
-                    initialMonth: new Date(2016, Months.JANUARY, 1),
-                    shortcuts: [{ label: "custom shortcut", dateRange, shouldChangeTime }],
-                });
+            clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            left.assertMonthYear(Months.JANUARY, 2016);
+            right.assertMonthYear(Months.FEBRUARY, 2016);
 
-                clickShortcut();
-                assert.isTrue(onChangeSpy.calledOnce);
-                left.assertMonthYear(Months.JANUARY, 2016);
-                right.assertMonthYear(Months.FEBRUARY, 2016);
-
-                clickShortcut();
-                left.assertMonthYear(Months.JANUARY, 2016);
-                right.assertMonthYear(Months.FEBRUARY, 2016);
-            };
-
-            test(true);
-            test(false);
+            clickShortcut();
+            left.assertMonthYear(Months.JANUARY, 2016);
+            right.assertMonthYear(Months.FEBRUARY, 2016);
         });
     });
 
@@ -1174,21 +1147,21 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(onChangeSpy.firstCall.args[0][0] as Date, new Date()));
         });
 
-        it("clicking a shortcut with shouldChangeTime=false doesn't change time", () => {
+        it("clicking a shortcut with includeTime=false doesn't change time", () => {
             render({ timePrecision: "minute", defaultValue: defaultRange }).clickShortcut();
             assert.isTrue(DateUtils.areSameTime(onChangeSpy.firstCall.args[0][0] as Date, defaultRange[0]));
         });
 
-        it("clicking a shortcut with shouldChangeTime=true changes time", () => {
+        it("clicking a shortcut with includeTime=true changes time", () => {
             const endTime = defaultRange[1];
             const startTime = new Date(defaultRange[1].getTime());
             startTime.setHours(startTime.getHours() - 2);
 
-            const shortcuts = [
+            const shortcuts: IDateRangeShortcut[] = [
                 {
                     dateRange: [startTime, endTime] as DateRange,
-                    label: "custom shortcut",
-                    shouldChangeTime: true,
+                    includeTime: true,
+                    label: "shortcut with time",
                 },
             ];
 


### PR DESCRIPTION
#### Follow-up from #3223 

#### Changes proposed in this pull request:

- more obvious naming: `shouldChangeTime` &rArr; `includeTime`.
    - this is **NOT AN API BREAK** as the original PR that added this prop was _merged today 1/17_ and this PR _will merge before_ the next release.
- 📖 add `Shortcuts` section to DRP docs
- revert unnecessary test changes.

(cc @yixunx)