### PR TITLE
Add directory to repository details in package.json files

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -56,7 +56,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/datetime"
   },
   "keywords": [
     "palantir",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -52,7 +52,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/icons"
   },
   "keywords": [
     "palantir",

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -54,7 +54,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/labs"
   },
   "keywords": [
     "palantir",

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/node-build-scripts"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -54,7 +54,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/select"
   },
   "keywords": [
     "palantir",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -57,7 +57,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/table"
   },
   "keywords": [
     "palantir",

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/test-commons"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -57,7 +57,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/timezone"
   },
   "keywords": [
     "palantir",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/tslint-config"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/webpack-build-scripts"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"


### PR DESCRIPTION
Specifying the directory as part of the `repository` field in a `package.json` allows third party tools to provide better support when working with monorepos. For example, it allows them to correctly construct a commit diff for a specific package.

This format was accepted by npm in https://github.com/npm/rfcs/pull/19.
