### PR TITLE
Add directory details to packages/*/package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/core"
   },
   "keywords": [
     "palantir",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -56,7 +56,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/datetime"
   },
   "keywords": [
     "palantir",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -49,7 +49,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/docs-app"
   },
   "keywords": [
     "palantir",

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/docs-data"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN REPO ROOT"

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -48,7 +48,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/docs-theme"
   },
   "keywords": [
     "palantir",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -52,7 +52,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/icons"
   },
   "keywords": [
     "palantir",

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/karma-build-scripts"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -54,7 +54,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/labs"
   },
   "keywords": [
     "palantir",

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -31,7 +31,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/landing-app"
   },
   "keywords": [
     "blueprint",

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/node-build-scripts"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -54,7 +54,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/select"
   },
   "keywords": [
     "palantir",

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/table-dev-app"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN REPO ROOT"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -57,7 +57,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/table"
   },
   "keywords": [
     "palantir",

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/test-commons"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/test-react15/package.json
+++ b/packages/test-react15/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/test-react15"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN REPO ROOT"

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -57,7 +57,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/timezone"
   },
   "keywords": [
     "palantir",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/tslint-config"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:palantir/blueprint.git"
+    "url": "git@github.com:palantir/blueprint.git",
+    "directory": "packages/webpack-build-scripts"
   },
   "author": "Palantir Technologies",
   "license": "SEE LICENSE IN LICENSE"


### PR DESCRIPTION
#### Changes proposed in this pull request:

Specifying the directory as part of the `repository` field in a `package.json`
allows third party tools to provide better support when working with monorepos.
For example, it allows them to correctly construct a commit diff for a specific
package.

This format was accepted by npm in
[npm/rfcs#19](https://github.com/npm/rfcs/pull/19).

Specifically, we'd like to use this field to construct better commit diff links on Dependabot [update PRs](https://github.com/NCI-Agency/anet/pull/1172), taking you straight to [these commits](https://github.com/palantir/blueprint/commits/develop/packages/core).