### PR TITLE
Create-able Select components

### DIFF
--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -185,8 +185,8 @@ export const filmSelectProps = {
 
 export function createFilm(title: string): IFilm {
     return {
+        rank: 100 + Math.floor(Math.random() * 100 + 1),
         title,
         year: new Date().getFullYear(),
-        rank: 100 + Math.floor(Math.random() * 100 + 1),
     };
 }

--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -182,3 +182,11 @@ export const filmSelectProps = {
     itemRenderer: renderFilm,
     items: TOP_100_FILMS,
 };
+
+export function createFilm(title: string): IFilm {
+    return {
+        title,
+        year: new Date().getFullYear(),
+        rank: 100 + Math.floor(Math.random() * 100 + 1),
+    };
+}

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -23,6 +23,7 @@ export interface IMultiSelectExampleState {
     popoverMinimal: boolean;
     resetOnSelect: boolean;
     tagMinimal: boolean;
+    allowCreate: boolean;
 }
 
 export class MultiSelectExample extends React.PureComponent<IExampleProps, IMultiSelectExampleState> {
@@ -34,6 +35,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         popoverMinimal: true,
         resetOnSelect: true,
         tagMinimal: false,
+        allowCreate: false,
     };
 
     private handleKeyDownChange = this.handleSwitchChange("openOnKeyDown");
@@ -42,6 +44,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
     private handleTagMinimalChange = this.handleSwitchChange("tagMinimal");
     private handleIntentChange = this.handleSwitchChange("intent");
     private handleInitialContentChange = this.handleSwitchChange("hasInitialContent");
+    private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
 
     public render() {
         const { films, hasInitialContent, tagMinimal, popoverMinimal, ...flags } = this.state;
@@ -49,6 +52,9 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
             intent: this.state.intent ? INTENTS[index % INTENTS.length] : Intent.NONE,
             minimal: tagMinimal,
         });
+
+        const maybeCreateItemFromQuery = this.state.allowCreate ? this.handleCreateFilmFromQuery : undefined;
+        const maybeCreateItemRenderer = this.state.allowCreate ? this.renderCreateFilmOption : null;
 
         const initialContent = this.state.hasInitialContent ? (
             <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} />
@@ -72,6 +78,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     tagRenderer={this.renderTag}
                     tagInputProps={{ tagProps: getTagProps, onRemove: this.handleTagRemove, rightElement: clearButton }}
                     selectedItems={this.state.films}
+                    createItemFromQuery={maybeCreateItemFromQuery}
+                    createItemRenderer={maybeCreateItemRenderer}
                 />
             </Example>
         );
@@ -95,6 +103,11 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     label="Use initial content"
                     checked={this.state.hasInitialContent}
                     onChange={this.handleInitialContentChange}
+                />
+                <Switch
+                    label="Allow creating new items"
+                    checked={this.state.allowCreate}
+                    onChange={this.handleAllowCreateChange}
                 />
                 <H5>Tag props</H5>
                 <Switch
@@ -137,6 +150,14 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         );
     };
 
+    private renderCreateFilmOption = (query: string) => (
+        <MenuItem
+            icon={"add"}
+            text={`Create "${query}"`}
+            shouldDismissPopover={false}
+        />
+    );
+
     private handleTagRemove = (_tag: string, index: number) => {
         this.deselectFilm(index);
     };
@@ -173,4 +194,12 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
     }
 
     private handleClear = () => this.setState({ films: [] });
+
+    private handleCreateFilmFromQuery(query: string): IFilm {
+        return {
+            title: query,
+            year: new Date().getFullYear(),
+            rank: 100 + Math.floor(Math.random() * 100 + 1),
+        };
+    }
 }

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -19,15 +19,16 @@ export interface IMultiSelectExampleState {
     films: IFilm[];
     hasInitialContent: boolean;
     intent: boolean;
+    allowCreate: boolean;
     openOnKeyDown: boolean;
     popoverMinimal: boolean;
     resetOnSelect: boolean;
     tagMinimal: boolean;
-    allowCreate: boolean;
 }
 
 export class MultiSelectExample extends React.PureComponent<IExampleProps, IMultiSelectExampleState> {
     public state: IMultiSelectExampleState = {
+        allowCreate: false,
         films: [],
         hasInitialContent: false,
         intent: false,
@@ -35,7 +36,6 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         popoverMinimal: true,
         resetOnSelect: true,
         tagMinimal: false,
-        allowCreate: false,
     };
 
     private handleKeyDownChange = this.handleSwitchChange("openOnKeyDown");
@@ -53,15 +53,14 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
             minimal: tagMinimal,
         });
 
-        const maybeCreateItemFromQuery = this.state.allowCreate ? createFilm : undefined;
-        const maybeCreateItemRenderer = this.state.allowCreate ? this.renderCreateFilmOption : null;
-
         const initialContent = this.state.hasInitialContent ? (
             <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} />
         ) : (
             // explicit undefined (not null) for default behavior (show full list)
             undefined
         );
+        const maybeCreateItemFromQuery = this.state.allowCreate ? createFilm : undefined;
+        const maybeCreateItemRenderer = this.state.allowCreate ? this.renderCreateFilmOption : null;
 
         const clearButton = films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : null;
 
@@ -105,7 +104,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     onChange={this.handleInitialContentChange}
                 />
                 <Switch
-                    label="Allow creating new items"
+                    label="Allow creating new films"
                     checked={this.state.allowCreate}
                     onChange={this.handleAllowCreateChange}
                 />

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 import { Button, H5, Intent, ITagProps, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { ItemRenderer, MultiSelect } from "@blueprintjs/select";
-import { filmSelectProps, IFilm, TOP_100_FILMS } from "./films";
+import { createFilm, filmSelectProps, IFilm, TOP_100_FILMS } from "./films";
 
 const FilmMultiSelect = MultiSelect.ofType<IFilm>();
 
@@ -53,7 +53,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
             minimal: tagMinimal,
         });
 
-        const maybeCreateItemFromQuery = this.state.allowCreate ? this.handleCreateFilmFromQuery : undefined;
+        const maybeCreateItemFromQuery = this.state.allowCreate ? createFilm : undefined;
         const maybeCreateItemRenderer = this.state.allowCreate ? this.renderCreateFilmOption : null;
 
         const initialContent = this.state.hasInitialContent ? (
@@ -151,12 +151,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
     };
 
     private renderCreateFilmOption = (query: string, handleClick: React.MouseEventHandler<HTMLElement>) => (
-        <MenuItem
-            icon={"add"}
-            text={`Create "${query}"`}
-            onClick={handleClick}
-            shouldDismissPopover={false}
-        />
+        <MenuItem icon="add" text={`Create "${query}"`} onClick={handleClick} shouldDismissPopover={false} />
     );
 
     private handleTagRemove = (_tag: string, index: number) => {
@@ -195,12 +190,4 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
     }
 
     private handleClear = () => this.setState({ films: [] });
-
-    private handleCreateFilmFromQuery(query: string): IFilm {
-        return {
-            title: query,
-            year: new Date().getFullYear(),
-            rank: 100 + Math.floor(Math.random() * 100 + 1),
-        };
-    }
 }

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -150,10 +150,11 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         );
     };
 
-    private renderCreateFilmOption = (query: string) => (
+    private renderCreateFilmOption = (query: string, handleClick: React.MouseEventHandler<HTMLElement>) => (
         <MenuItem
             icon={"add"}
             text={`Create "${query}"`}
+            onClick={handleClick}
             shouldDismissPopover={false}
         />
     );

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -9,11 +9,12 @@ import * as React from "react";
 import { Button, H5, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Select } from "@blueprintjs/select";
-import { filmSelectProps, IFilm, TOP_100_FILMS } from "./films";
+import { createFilm, filmSelectProps, IFilm, TOP_100_FILMS } from "./films";
 
 const FilmSelect = Select.ofType<IFilm>();
 
 export interface ISelectExampleState {
+    allowCreate: boolean;
     film: IFilm;
     filterable: boolean;
     hasInitialContent: boolean;
@@ -27,6 +28,7 @@ export interface ISelectExampleState {
 
 export class SelectExample extends React.PureComponent<IExampleProps, ISelectExampleState> {
     public state: ISelectExampleState = {
+        allowCreate: false,
         disableItems: false,
         disabled: false,
         film: TOP_100_FILMS[0],
@@ -38,6 +40,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
         resetOnSelect: false,
     };
 
+    private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
     private handleDisabledChange = this.handleSwitchChange("disabled");
     private handleFilterableChange = this.handleSwitchChange("filterable");
     private handleInitialContentChange = this.handleSwitchChange("hasInitialContent");
@@ -55,12 +58,16 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
         ) : (
             undefined
         );
+        const maybeCreateItemFromQuery = this.state.allowCreate ? createFilm : undefined;
+        const maybeCreateItemRenderer = this.state.allowCreate ? this.renderCreateFilmOption : null;
 
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <FilmSelect
                     {...filmSelectProps}
                     {...flags}
+                    createItemFromQuery={maybeCreateItemFromQuery}
+                    createItemRenderer={maybeCreateItemRenderer}
                     disabled={disabled}
                     itemDisabled={this.isItemDisabled}
                     initialContent={initialContent}
@@ -110,6 +117,11 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     checked={this.state.disableItems}
                     onChange={this.handleItemDisabledChange}
                 />
+                <Switch
+                    label="Allow creating new items"
+                    checked={this.state.allowCreate}
+                    onChange={this.handleAllowCreateChange}
+                />
                 <H5>Popover props</H5>
                 <Switch
                     label="Minimal popover style"
@@ -119,6 +131,10 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
             </>
         );
     }
+
+    private renderCreateFilmOption = (query: string, handleClick: React.MouseEventHandler<HTMLElement>) => (
+        <MenuItem icon="add" text={`Create "${query}"`} onClick={handleClick} shouldDismissPopover={false} />
+    );
 
     private handleValueChange = (film: IFilm) => this.setState({ film });
 

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -99,6 +99,18 @@ export interface IListItemsProps<T> extends IProps {
     onQueryChange?: (query: string, event?: React.ChangeEvent<HTMLInputElement>) => void;
 
     /**
+     * If provided, allows new items to be created with the current query string.
+     * This is invoked when user interaction causes a new item to be created, either by pressing the `enter` key or
+     * by clicking on the "Create Item" option. It transforms a query string into an item type.
+     */
+    createItemFromQuery?: (query: string) => T;
+
+    /**
+     * Custom renderer to transform the current query string into a selectable "Create Item" option.
+     */
+    createItemRenderer?: (query: string, handleClick: React.MouseEventHandler<HTMLElement>) => JSX.Element | undefined;
+
+    /**
      * Whether the active item should be reset to the first matching item _every
      * time the query changes_ (via prop or by user input).
      * @default true

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -29,6 +29,11 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
      * Receives an object with props that should be applied to elements as necessary.
      */
     renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
+
+    /**
+     * Any additional view rendered at the end of the query list.
+     */
+    additionalElementRenderer?: (query: string) => JSX.Element;
 }
 
 /**
@@ -216,9 +221,10 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     /** default `itemListRenderer` implementation */
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
-        const { initialContent, noResults } = this.props;
+        const { initialContent, noResults, additionalElementRenderer } = this.props;
         const menuContent = renderFilteredItems(listProps, noResults, initialContent);
-        return <Menu ulRef={listProps.itemsParentRef}>{menuContent}</Menu>;
+        const additionalElement = Utils.safeInvoke(additionalElementRenderer, this.state.query);
+        return <Menu ulRef={listProps.itemsParentRef}>{menuContent}{additionalElement}</Menu>;
     };
 
     /** wrapper around `itemRenderer` to inject props */

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -33,7 +33,7 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
     /**
      * Any additional view rendered at the end of the query list.
      */
-    additionalElementRenderer?: (query: string) => JSX.Element;
+    additionalElementRenderer?: (query: string) => JSX.Element | undefined;
 }
 
 /**

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -218,11 +218,17 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
         const { initialContent, noResults, createItemFromQuery, createItemRenderer } = this.props;
 
-        // omit noResults if createItemFromQuery and createItemRenderer are both supplied
-        const maybeNoResults = (createItemFromQuery && createItemRenderer) ? undefined : noResults;
+        // omit noResults if createItemFromQuery and createItemRenderer are both supplied, and query is not empty
+        const maybeNoResults =
+            createItemFromQuery && createItemRenderer && this.state.query !== "" ? undefined : noResults;
         const menuContent = renderFilteredItems(listProps, maybeNoResults, initialContent);
-        const createItemView = this.renderCreateItemMenuItem(this.state.query);
-        return <Menu ulRef={listProps.itemsParentRef}>{menuContent}{createItemView}</Menu>;
+        const createItemView = this.state.query !== "" ? this.renderCreateItemMenuItem(this.state.query) : null;
+        return (
+            <Menu ulRef={listProps.itemsParentRef}>
+                {menuContent}
+                {createItemView}
+            </Menu>
+        );
     };
 
     /** wrapper around `itemRenderer` to inject props */
@@ -243,11 +249,11 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     };
 
     private renderCreateItemMenuItem = (query: string) => {
-        const handleClick: React.MouseEventHandler<HTMLElement> = (evt) => {
+        const handleClick: React.MouseEventHandler<HTMLElement> = evt => {
             this.handleItemCreate(query, evt);
-        }
+        };
         return Utils.safeInvoke(this.props.createItemRenderer, query, handleClick);
-    }
+    };
 
     private getActiveElement() {
         if (this.itemsParentRef != null) {
@@ -277,7 +283,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             Utils.safeInvoke(this.props.onItemSelect, item, evt);
             this.setQuery("", true);
         }
-    }
+    };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         this.setActiveItem(item);

--- a/packages/select/src/components/select/multi-select.md
+++ b/packages/select/src/components/select/multi-select.md
@@ -4,7 +4,7 @@ Use `MultiSelect<T>` for choosing multiple items in a list. The component render
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">Generic components and custom filtering</h4>
-    For more information on controlled usage, generic components and custom filtering, visit the documentation for [`Select<T>`](#select/select-component).
+    For more information on controlled usage, generic components, creating new items, and custom filtering, visit the documentation for [`Select<T>`](#select/select-component).
 </div>
 
 @reactExample MultiSelectExample

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -56,7 +56,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
      * If `noResults` is also defined, this props takes priority and the other will be ignored.
      * Ignored if `createItemFromQuery` is omitted.
      */
-    createItemRenderer?: (query: string) => JSX.Element;
+    createItemRenderer?: (query: string, handleClick: React.MouseEventHandler<HTMLElement>) => JSX.Element;
 }
 
 export interface IMultiSelectState {
@@ -112,7 +112,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
-                additionalElementRenderer={creatable ? createItemRenderer : undefined}
+                additionalElementRenderer={creatable ? this.renderCreateItemMenuItem : undefined}
             />
         );
     }
@@ -164,6 +164,13 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         );
     };
 
+    private renderCreateItemMenuItem = (query: string) => {
+        const handleClick: React.MouseEventHandler<HTMLElement> = (evt) => {
+            this.handleItemCreate([query], evt);
+        }
+        return Utils.safeInvoke(this.props.createItemRenderer, query, handleClick);
+    }
+
     private handleItemSelect = (item: T, evt?: React.SyntheticEvent<HTMLElement>) => {
         if (this.input != null) {
             this.input.focus();
@@ -171,7 +178,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         Utils.safeInvoke(this.props.onItemSelect, item, evt);
     };
 
-    private handleItemCreate = (queries: string[]) => {
+    private handleItemCreate = (queries: string[], evt?: React.SyntheticEvent<HTMLElement>) => {
         const { createItemFromQuery } = this.props;
         if (createItemFromQuery == null) {
             return;
@@ -179,8 +186,9 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
 
         queries.forEach(query => {
             const item = createItemFromQuery(query);
-            Utils.safeInvoke(this.props.onItemSelect, item, undefined);
+            Utils.safeInvoke(this.props.onItemSelect, item, evt);
         });
+        this.resetQuery();
     }
 
     private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {
@@ -232,4 +240,6 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             }
         };
     };
+
+    private resetQuery = () => this.queryList && this.queryList.setQuery("", true);
 }

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -79,6 +79,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
     public render() {
         // omit props specific to this component, spread the rest.
         const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+
         return (
             <this.TypedQueryList
                 {...restProps}

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -82,6 +82,12 @@ This controlled usage allows you to implement all sorts of advanced behavior on
 top of the basic `Select` interactions, such as windowed filtering for large
 data sets.
 
+@## Creating new items
+
+Use the `createItemFromQuery` prop to allow `Select<T>` to create new items. `createItemFromQuery` specifies how to turn a
+user-entered query string into an item of type `<T>` that `Select` understands. You should also provide the `createItemRenderer`
+prop to render a custom `MenuItem` to indicate that users can create new items.
+
 @## JavaScript API
 
 @interface ISelectProps

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -119,4 +119,34 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
             assert.equal(testProps.onItemSelect.lastCall.args[0], activeItem);
         });
     });
+
+    describe("create", () => {
+        const testCreateProps = {
+            ...testProps,
+            createItemFromQuery: sinon.spy(),
+            createItemRenderer: () => <textarea />,
+        };
+
+        it("renders create item if filtering returns empty list", () => {
+            const wrapper = render({
+                ...testCreateProps,
+                items: [],
+                noResults: <address />,
+                query: "non-existent film name",
+            });
+            assert.lengthOf(wrapper.find("address"), 0, "should not find noResults");
+            assert.lengthOf(wrapper.find(`textarea`), 1, "should find createItem");
+        });
+
+        it("enter invokes createItemFromQuery", () => {
+            const wrapper = render({
+                ...testCreateProps,
+                items: [],
+                noResults: <address />,
+                query: "non-existent film name",
+            });
+            findInput(wrapper).simulate("keyup", { keyCode: Keys.ENTER });
+            assert.equal(testCreateProps.createItemFromQuery.args[0][0], "non-existent film name");
+        });
+    });
 }


### PR DESCRIPTION
#### Fixes #1710 

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:
- Select components, via `IListItemsProps`, now takes two additional props:
  * `createItemFromQuery?: (query: string) => T` which converts a query to a new item; if this prop is present, the select component is considered "create-able";
  * `createItemRenderer?: (query: string, handleClick: React.MouseEventHandler<HTMLElement>) => JSX.Element | undefined` which could be used to render a custom `MenuItem` at the end of the list, that represents "create a new element from query".
- If the component is create-able, when a query returns no results, pressing "enter" key will create a new item with the current query;
