### PR TITLE
[DRP] dedupe shortcuts prop types

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -29,28 +29,10 @@ import {
 } from "./datePickerCore";
 import { DatePickerNavbar } from "./datePickerNavbar";
 import { DateRangeSelectionStrategy } from "./dateRangeSelectionStrategy";
-import { Shortcuts } from "./shortcuts";
+import { IDateRangeShortcut, Shortcuts } from "./shortcuts";
 import { TimePicker } from "./timePicker";
 
-export interface IDateRangeShortcut {
-    /** Shortcut label that appears in the list. */
-    label: string;
-
-    /**
-     * Date range represented by this shortcut. Note that time components of a
-     * shortcut are ignored by default; set `includeTime: true` to respect them.
-     */
-    dateRange: DateRange;
-
-    /**
-     * Set this prop to `true` to allow this shortcut to change the selected
-     * times as well as the dates. By default, time components of a shortcut are
-     * ignored; clicking a shortcut takes the date components of the `dateRange`
-     * and combines them with the currently selected time.
-     * @default false
-     */
-    includeTime?: boolean;
-}
+export { IDateRangeShortcut };
 
 export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     /**

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -10,9 +10,23 @@ import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
 import { clone, DateRange, isDayRangeInRange } from "./common/dateUtils";
 
 export interface IDateRangeShortcut {
+    /** Shortcut label that appears in the list. */
     label: string;
+
+    /**
+     * Date range represented by this shortcut. Note that time components of a
+     * shortcut are ignored by default; set `includeTime: true` to respect them.
+     */
     dateRange: DateRange;
-    shouldChangeTime?: boolean;
+
+    /**
+     * Set this prop to `true` to allow this shortcut to change the selected
+     * times as well as the dates. By default, time components of a shortcut are
+     * ignored; clicking a shortcut takes the date components of the `dateRange`
+     * and combines them with the currently selected time.
+     * @default false
+     */
+    includeTime?: boolean;
 }
 
 export interface IShortcutsProps {


### PR DESCRIPTION
#### Follow-up from #3293

#### Changes proposed in this pull request:

- turns out `IDateRangeShortcut` was defined _differently (after #3293)_ in two separate files!
- thankfully, this PR is __not__ an API BREAK because the offending type (in shortcuts.tsx) was not exported from the package root (or used at all outside its home file).
