### PR TITLE
Edited typo of `Tab`s to `Tabs`

### DIFF
--- a/packages/core/src/components/tabs/tabs.md
+++ b/packages/core/src/components/tabs/tabs.md
@@ -10,7 +10,7 @@ not require translating between arbitrary indices and tab names. It does,
 however, require that every `Tab` have a _locally unique `id` value_.
 
 Arbitrary elements are supported in the tab list, and order is respected. Yes,
-you can even insert things _between_ `Tab`s.
+you can even insert things _between_ `Tabs`.
 
 ```tsx
 import { Tab, Tabs } from "@blueprintjs/core";


### PR DESCRIPTION
#### Fixes 
I think there is a typo in the documentation so I made the following change as indicated in the revision history. 
#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
N/A
<!-- Fill this out. -->

#### Reviewers should focus on:
N/A
<!-- Fill this out. -->

#### Screenshot
N/A
<!-- Include an image of the most relevant user-facing change, if any. -->
