### PR TITLE
Add internal text to switch component

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -126,9 +126,11 @@ export const INPUT_ACTION = `${INPUT}-action`;
 
 export const CONTROL = `${NS}-control`;
 export const CONTROL_INDICATOR = `${CONTROL}-indicator`;
+export const CONTROL_INDICATOR_CHILD = `${CONTROL_INDICATOR}-child`;
 export const CHECKBOX = `${NS}-checkbox`;
 export const RADIO = `${NS}-radio`;
 export const SWITCH = `${NS}-switch`;
+export const SWITCH_INNER_TEXT = `${SWITCH}-inner-text`;
 export const FILE_INPUT = `${NS}-file-input`;
 export const FILE_UPLOAD_INPUT = `${NS}-file-upload-input`;
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -284,8 +284,11 @@ $control-indicator-spacing: $pt-grid-size !default;
   $switch-width: 1.75em !default;
   $switch-indicator-margin: 2px !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
+
   $switch-indicator-text-font-size: .6em; //@KEVINNG MAKE THIS RIGHT
   $switch-indicator-text-line-height: 1.7em; //@KEVINNG MAKE THIS RIGHT
+  $switch-indicator-text-outside-margin: .75em; //@KEVINNG MAKE THIS RIGHT
+  $switch-indicator-text-inside-margin: 1.75em; //@KEVINNG MAKE THIS RIGHT
 
   $switch-background-color: rgba($gray4, 0.5) !default;
   $switch-background-color-hover: rgba($gray2, 0.5) !default;
@@ -410,15 +413,15 @@ $control-indicator-spacing: $pt-grid-size !default;
       text-align: center;
 
       &.#{$ns}-switch-active-text {
-        padding-left: 0.5em;
-        padding-right: 1.5em;
+        margin-left: $switch-indicator-text-outside-margin;
+        margin-right: $switch-indicator-text-inside-margin;
         visibility: hidden;
         line-height: 0;
       }
 
       &.#{$ns}-switch-inactive-text {
-        padding-left: 1.5em;
-        padding-right: 0.5em;
+        margin-left: $switch-indicator-text-inside-margin;
+        margin-right: $switch-indicator-text-outside-margin;
         visibility: visible;
         line-height: $switch-indicator-text-line-height;
       }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -285,10 +285,12 @@ $control-indicator-spacing: $pt-grid-size !default;
   $switch-indicator-margin: 2px !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
 
-  $switch-indicator-text-font-size: 0.6em; //@KEVINNG MAKE THIS RIGHT
-  $switch-indicator-text-line-height: 1.7em; //@KEVINNG MAKE THIS RIGHT
-  $switch-indicator-text-outside-margin: 0.75em; //@KEVINNG MAKE THIS RIGHT
-  $switch-indicator-text-inside-margin: 1.75em; //@KEVINNG MAKE THIS RIGHT
+  $switch-indicator-child-height: 1em;
+  $switch-indicator-child-outside-margin: 0.5em;
+  $switch-indicator-child-inside-margin: 1.2em;
+
+  $switch-indicator-text-font-size: 0.5em;
+  $switch-indicator-text-line-height: 2em; //to match height of parent
 
   $switch-background-color: rgba($gray4, 0.5) !default;
   $switch-background-color-hover: rgba($gray2, 0.5) !default;
@@ -374,7 +376,7 @@ $control-indicator-spacing: $pt-grid-size !default;
 
     input:checked ~ .#{$ns}-control-indicator::before {
       right: 0;
-      left: auto;
+      left: calc(100% - 1em);
     }
 
     &.#{$ns}-large {
@@ -408,34 +410,37 @@ $control-indicator-spacing: $pt-grid-size !default;
       }
     }
 
-    .#{$ns}-control-indicator-child {
+    .#{$ns}-switch-inner-text {
       text-align: center;
+      line-height: $switch-indicator-text-line-height;
       font-size: $switch-indicator-text-font-size;
+    }
 
-      &.#{$ns}-switch-active-text {
+    .#{$ns}-control-indicator-child {
+      &:first-child {
         visibility: hidden;
-        margin-right: $switch-indicator-text-inside-margin;
-        margin-left: $switch-indicator-text-outside-margin;
-        line-height: 0;
+        margin-right: $switch-indicator-child-inside-margin;
+        margin-left: $switch-indicator-child-outside-margin;
+        height: 0;
       }
 
-      &.#{$ns}-switch-inactive-text {
+      &:last-child {
         visibility: visible;
-        margin-right: $switch-indicator-text-outside-margin;
-        margin-left: $switch-indicator-text-inside-margin;
-        line-height: $switch-indicator-text-line-height;
+        margin-right: $switch-indicator-child-outside-margin;
+        margin-left: $switch-indicator-child-inside-margin;
+        height: $switch-indicator-child-height;
       }
     }
 
-    input:checked ~ .#{$ns}-control-indicator {
-      .#{$ns}-switch-active-text {
+    input:checked ~ .#{$ns}-control-indicator .#{$ns}-control-indicator-child {
+      &:first-child {
         visibility: visible;
-        line-height: $switch-indicator-text-line-height;
+        height: $switch-indicator-child-height;
       }
 
-      .#{$ns}-switch-inactive-text {
+      &:last-child {
         visibility: hidden;
-        line-height: 0;
+        height: 0;
       }
     }
   }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -374,7 +374,6 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      right: 0;
       left: calc(100% - 1em);
     }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -285,9 +285,9 @@ $control-indicator-spacing: $pt-grid-size !default;
   $switch-indicator-margin: 2px !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
 
-  $switch-indicator-text-font-size: .6em; //@KEVINNG MAKE THIS RIGHT
+  $switch-indicator-text-font-size: 0.6em; //@KEVINNG MAKE THIS RIGHT
   $switch-indicator-text-line-height: 1.7em; //@KEVINNG MAKE THIS RIGHT
-  $switch-indicator-text-outside-margin: .75em; //@KEVINNG MAKE THIS RIGHT
+  $switch-indicator-text-outside-margin: 0.75em; //@KEVINNG MAKE THIS RIGHT
   $switch-indicator-text-inside-margin: 1.75em; //@KEVINNG MAKE THIS RIGHT
 
   $switch-background-color: rgba($gray4, 0.5) !default;
@@ -355,8 +355,8 @@ $control-indicator-spacing: $pt-grid-size !default;
       // override default button styles, never have a box-shadow here.
       // stylelint-disable-next-line declaration-no-important
       box-shadow: none !important;
-      min-width: $switch-width;
       width: auto;
+      min-width: $switch-width;
       transition: background-color $pt-transition-duration $pt-transition-ease;
 
       &::before {
@@ -373,8 +373,8 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      left: auto;
       right: 0;
+      left: auto;
     }
 
     &.#{$ns}-large {
@@ -409,20 +409,20 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     .#{$ns}-control-indicator-child {
-      font-size: $switch-indicator-text-font-size;
       text-align: center;
+      font-size: $switch-indicator-text-font-size;
 
       &.#{$ns}-switch-active-text {
-        margin-left: $switch-indicator-text-outside-margin;
-        margin-right: $switch-indicator-text-inside-margin;
         visibility: hidden;
+        margin-right: $switch-indicator-text-inside-margin;
+        margin-left: $switch-indicator-text-outside-margin;
         line-height: 0;
       }
 
       &.#{$ns}-switch-inactive-text {
-        margin-left: $switch-indicator-text-inside-margin;
-        margin-right: $switch-indicator-text-outside-margin;
         visibility: visible;
+        margin-right: $switch-indicator-text-outside-margin;
+        margin-left: $switch-indicator-text-inside-margin;
         line-height: $switch-indicator-text-line-height;
       }
     }
@@ -432,6 +432,7 @@ $control-indicator-spacing: $pt-grid-size !default;
         visibility: visible;
         line-height: $switch-indicator-text-line-height;
       }
+
       .#{$ns}-switch-inactive-text {
         visibility: hidden;
         line-height: 0;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -289,8 +289,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   $switch-indicator-child-outside-margin: 0.5em;
   $switch-indicator-child-inside-margin: 1.2em;
 
-  $switch-indicator-text-font-size: 0.5em;
-  $switch-indicator-text-line-height: 2em; //to match height of parent
+  $switch-indicator-text-font-size: 0.7em;
 
   $switch-background-color: rgba($gray4, 0.5) !default;
   $switch-background-color-hover: rgba($gray2, 0.5) !default;
@@ -412,7 +411,6 @@ $control-indicator-spacing: $pt-grid-size !default;
 
     .#{$ns}-switch-inner-text {
       text-align: center;
-      line-height: $switch-indicator-text-line-height;
       font-size: $switch-indicator-text-font-size;
     }
 
@@ -421,26 +419,26 @@ $control-indicator-spacing: $pt-grid-size !default;
         visibility: hidden;
         margin-right: $switch-indicator-child-inside-margin;
         margin-left: $switch-indicator-child-outside-margin;
-        height: 0;
+        line-height: 0;
       }
 
       &:last-child {
         visibility: visible;
         margin-right: $switch-indicator-child-outside-margin;
         margin-left: $switch-indicator-child-inside-margin;
-        height: $switch-indicator-child-height;
+        line-height: $switch-indicator-child-height;
       }
     }
 
     input:checked ~ .#{$ns}-control-indicator .#{$ns}-control-indicator-child {
       &:first-child {
         visibility: visible;
-        height: $switch-indicator-child-height;
+        line-height: $switch-indicator-child-height;
       }
 
       &:last-child {
         visibility: hidden;
-        height: 0;
+        line-height: 0;
       }
     }
   }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -284,6 +284,8 @@ $control-indicator-spacing: $pt-grid-size !default;
   $switch-width: 1.75em !default;
   $switch-indicator-margin: 2px !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
+  $switch-indicator-text-font-size: .6em; //@KEVINNG MAKE THIS RIGHT
+  $switch-indicator-text-line-height: 1.7em; //@KEVINNG MAKE THIS RIGHT
 
   $switch-background-color: rgba($gray4, 0.5) !default;
   $switch-background-color-hover: rgba($gray2, 0.5) !default;
@@ -351,7 +353,7 @@ $control-indicator-spacing: $pt-grid-size !default;
       // stylelint-disable-next-line declaration-no-important
       box-shadow: none !important;
       min-width: $switch-width;
-      width: auto; //$switch-width;
+      width: auto;
       transition: background-color $pt-transition-duration $pt-transition-ease;
 
       &::before {
@@ -404,7 +406,8 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     .#{$ns}-control-indicator-child {
-      font-size: 0.75em;
+      font-size: $switch-indicator-text-font-size;
+      text-align: center;
 
       &.#{$ns}-switch-active-text {
         padding-left: 0.5em;
@@ -415,16 +418,16 @@ $control-indicator-spacing: $pt-grid-size !default;
 
       &.#{$ns}-switch-inactive-text {
         padding-left: 1.5em;
-        padding-right:.5em;
+        padding-right: 0.5em;
         visibility: visible;
-        line-height: 1.25em;
+        line-height: $switch-indicator-text-line-height;
       }
     }
 
     input:checked ~ .#{$ns}-control-indicator {
       .#{$ns}-switch-active-text {
         visibility: visible;
-        line-height: 1.25em;
+        line-height: $switch-indicator-text-line-height;
       }
       .#{$ns}-switch-inactive-text {
         visibility: hidden;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -374,6 +374,7 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
+      // 1em is size of indicator
       left: calc(100% - 1em);
     }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -350,7 +350,8 @@ $control-indicator-spacing: $pt-grid-size !default;
       // override default button styles, never have a box-shadow here.
       // stylelint-disable-next-line declaration-no-important
       box-shadow: none !important;
-      width: $switch-width;
+      min-width: $switch-width;
+      width: auto; //$switch-width;
       transition: background-color $pt-transition-duration $pt-transition-ease;
 
       &::before {
@@ -367,8 +368,8 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      // 1em is size of indicator
-      left: $switch-width - 1em;
+      left: auto;
+      right: 0;
     }
 
     &.#{$ns}-large {
@@ -399,6 +400,35 @@ $control-indicator-spacing: $pt-grid-size !default;
       input:checked ~ .#{$ns}-control-indicator::before {
         // inset shadow so it forms a dark line instead of blurring into the blue
         box-shadow: inset $dark-button-box-shadow;
+      }
+    }
+
+    .#{$ns}-control-indicator-child {
+      font-size: 0.75em;
+
+      &.#{$ns}-switch-active-text {
+        padding-left: 0.5em;
+        padding-right: 1.5em;
+        visibility: hidden;
+        line-height: 0;
+      }
+
+      &.#{$ns}-switch-inactive-text {
+        padding-left: 1.5em;
+        padding-right:.5em;
+        visibility: visible;
+        line-height: 1.25em;
+      }
+    }
+
+    input:checked ~ .#{$ns}-control-indicator {
+      .#{$ns}-switch-active-text {
+        visibility: visible;
+        line-height: 1.25em;
+      }
+      .#{$ns}-switch-inactive-text {
+        visibility: hidden;
+        line-height: 0;
       }
     }
   }

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -134,14 +134,12 @@ const Control: React.SFC<IControlInternalProps> = ({
 export interface ISwitchProps extends IControlProps {
     /**
      * String to display within the switch control component when the switch is checked/on.
-     *
      * @default ${innerLabel}
      */
     innerLabelChecked?: string;
 
     /**
      * String to display within the switch control component when the switch is unchecked/off.
-     *
      * @default null
      */
     innerLabel?: string;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -82,6 +82,7 @@ export interface IControlProps extends IProps, HTMLInputProps {
 interface IControlInternalProps extends IControlProps {
     type: "checkbox" | "radio";
     typeClassName: string;
+    indicatorChildren?: React.ReactNode[];
 }
 
 /**
@@ -92,6 +93,7 @@ const Control: React.SFC<IControlInternalProps> = ({
     alignIndicator,
     children,
     className,
+    indicatorChildren,
     inline,
     inputRef,
     label,
@@ -117,7 +119,7 @@ const Control: React.SFC<IControlInternalProps> = ({
     return (
         <TagName className={classes} style={style}>
             <input {...htmlProps} ref={inputRef} type={type} />
-            <span className={Classes.CONTROL_INDICATOR} />
+            <span className={Classes.CONTROL_INDICATOR}>{indicatorChildren}</span>
             {label}
             {labelElement}
             {children}
@@ -129,13 +131,36 @@ const Control: React.SFC<IControlInternalProps> = ({
 // Switch
 //
 
-export interface ISwitchProps extends IControlProps {}
+export interface ISwitchProps extends IControlProps {
+    activeText?: string;
+    inactiveText?: string;
+}
 
 export class Switch extends React.PureComponent<ISwitchProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Switch`;
-
+    private switchText = [
+        <div
+            key={`${Classes.SWITCH}-active-text`}
+            className={classNames(`${Classes.CONTROL_INDICATOR}-child`, `${Classes.SWITCH}-active-text`)}
+        >
+            {this.props.activeText}
+        </div>,
+        <div
+            key={`${Classes.SWITCH}-inactive-text`}
+            className={classNames(`${Classes.CONTROL_INDICATOR}-child`, `${Classes.SWITCH}-inactive-text`)}
+        >
+            {this.props.inactiveText}
+        </div>,
+    ];
     public render() {
-        return <Control {...this.props} type="checkbox" typeClassName={Classes.SWITCH} />;
+        return (
+            <Control
+                {...this.props}
+                type="checkbox"
+                typeClassName={Classes.SWITCH}
+                indicatorChildren={this.switchText}
+            />
+        );
     }
 }
 

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -133,31 +133,38 @@ const Control: React.SFC<IControlInternalProps> = ({
 
 export interface ISwitchProps extends IControlProps {
     /**
-     * String to display within the switch control component when the switch is checked/on. Defaults to innerLabel.
+     * String to display within the switch control component when the switch is checked/on.
+     *
+     * @default ${innerLabel}
      */
     innerLabelChecked?: string;
 
     /**
-     * String to display within the switch control component when the switch is unchecked/off. Defaults to "".
+     * String to display within the switch control component when the switch is unchecked/off.
+     *
+     * @default null
      */
     innerLabel?: string;
 }
 
 export class Switch extends React.PureComponent<ISwitchProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Switch`;
-    private childClassName = `${Classes.CONTROL_INDICATOR}-child`;
-    private textClassName = `${Classes.SWITCH}-inner-text`;
 
     public render() {
         const { innerLabelChecked, innerLabel, ...controlProps } = this.props;
-        const switchLabels = [
-            <div key={`${Classes.SWITCH}-checked-text`} className={this.childClassName}>
-                <div className={this.textClassName}> {innerLabelChecked ? innerLabelChecked : innerLabel} </div>
-            </div>,
-            <div key={`${Classes.SWITCH}-unchecked-text`} className={this.childClassName}>
-                <div className={this.textClassName}> {innerLabel} </div>
-            </div>,
-        ];
+        const switchLabels =
+            innerLabel || innerLabelChecked
+                ? [
+                      <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
+                          <div className={Classes.SWITCH_INNER_TEXT}>
+                              {innerLabelChecked ? innerLabelChecked : innerLabel}
+                          </div>
+                      </div>,
+                      <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>
+                          <div className={Classes.SWITCH_INNER_TEXT}>{innerLabel}</div>
+                      </div>,
+                  ]
+                : null;
         return (
             <Control
                 {...controlProps}

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -133,14 +133,15 @@ const Control: React.SFC<IControlInternalProps> = ({
 
 export interface ISwitchProps extends IControlProps {
     /**
-     * String to display within the switch control component when the switch is checked/on.
-     * @default ${innerLabel}
+     * Text to display inside the switch indicator when checked.
+     * If `innerLabel` is provided and this prop is omitted, then `innerLabel`
+     * will be used for both states.
+     * @default innerLabel
      */
     innerLabelChecked?: string;
 
     /**
-     * String to display within the switch control component when the switch is unchecked/off.
-     * @default null
+     * Text to display inside the switch indicator when unchecked.
      */
     innerLabel?: string;
 }

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -132,8 +132,15 @@ const Control: React.SFC<IControlInternalProps> = ({
 //
 
 export interface ISwitchProps extends IControlProps {
-    activeText?: string;
-    inactiveText?: string;
+    /**
+     * String to display within the switch control component when the switch is active ("on").
+     */
+    internalTextActive?: string;
+
+    /**
+     * String to display within the switch control component when the switch is inactive ("off").
+     */
+    internalTextInactive?: string;
 }
 
 export class Switch extends React.PureComponent<ISwitchProps> {
@@ -143,13 +150,13 @@ export class Switch extends React.PureComponent<ISwitchProps> {
             key={`${Classes.SWITCH}-active-text`}
             className={classNames(`${Classes.CONTROL_INDICATOR}-child`, `${Classes.SWITCH}-active-text`)}
         >
-            {this.props.activeText}
+            {this.props.internalTextActive}
         </div>,
         <div
             key={`${Classes.SWITCH}-inactive-text`}
             className={classNames(`${Classes.CONTROL_INDICATOR}-child`, `${Classes.SWITCH}-inactive-text`)}
         >
-            {this.props.inactiveText}
+            {this.props.internalTextInactive}
         </div>,
     ];
     public render() {

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -150,16 +150,21 @@ export class Switch extends React.PureComponent<ISwitchProps> {
 
     public render() {
         const { innerLabelChecked, innerLabel, ...controlProps } = this.props;
-        const switchText = [
+        const switchLabels = [
             <div key={`${Classes.SWITCH}-checked-text`} className={this.childClassName}>
-                <div className={this.textClassName}> {innerLabelChecked || innerLabel} </div>
+                <div className={this.textClassName}> {innerLabelChecked ? innerLabelChecked : innerLabel} </div>
             </div>,
             <div key={`${Classes.SWITCH}-unchecked-text`} className={this.childClassName}>
                 <div className={this.textClassName}> {innerLabel} </div>
             </div>,
         ];
         return (
-            <Control {...controlProps} type="checkbox" typeClassName={Classes.SWITCH} indicatorChildren={switchText} />
+            <Control
+                {...controlProps}
+                type="checkbox"
+                typeClassName={Classes.SWITCH}
+                indicatorChildren={switchLabels}
+            />
         );
     }
 }

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -82,7 +82,7 @@ export interface IControlProps extends IProps, HTMLInputProps {
 interface IControlInternalProps extends IControlProps {
     type: "checkbox" | "radio";
     typeClassName: string;
-    indicatorChildren?: React.ReactNode[];
+    indicatorChildren?: React.ReactNode;
 }
 
 /**
@@ -133,40 +133,33 @@ const Control: React.SFC<IControlInternalProps> = ({
 
 export interface ISwitchProps extends IControlProps {
     /**
-     * String to display within the switch control component when the switch is active ("on").
+     * String to display within the switch control component when the switch is checked/on. Defaults to innerLabel.
      */
-    internalTextActive?: string;
+    innerLabelChecked?: string;
 
     /**
-     * String to display within the switch control component when the switch is inactive ("off").
+     * String to display within the switch control component when the switch is unchecked/off. Defaults to "".
      */
-    internalTextInactive?: string;
+    innerLabel?: string;
 }
 
 export class Switch extends React.PureComponent<ISwitchProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Switch`;
-    private switchText = [
-        <div
-            key={`${Classes.SWITCH}-active-text`}
-            className={classNames(`${Classes.CONTROL_INDICATOR}-child`, `${Classes.SWITCH}-active-text`)}
-        >
-            {this.props.internalTextActive}
-        </div>,
-        <div
-            key={`${Classes.SWITCH}-inactive-text`}
-            className={classNames(`${Classes.CONTROL_INDICATOR}-child`, `${Classes.SWITCH}-inactive-text`)}
-        >
-            {this.props.internalTextInactive}
-        </div>,
-    ];
+    private childClassName = `${Classes.CONTROL_INDICATOR}-child`;
+    private textClassName = `${Classes.SWITCH}-inner-text`;
+
     public render() {
+        const { innerLabelChecked, innerLabel, ...controlProps } = this.props;
+        const switchText = [
+            <div key={`${Classes.SWITCH}-checked-text`} className={this.childClassName}>
+                <div className={this.textClassName}> {innerLabelChecked || innerLabel} </div>
+            </div>,
+            <div key={`${Classes.SWITCH}-unchecked-text`} className={this.childClassName}>
+                <div className={this.textClassName}> {innerLabel} </div>
+            </div>,
+        ];
         return (
-            <Control
-                {...this.props}
-                type="checkbox"
-                typeClassName={Classes.SWITCH}
-                indicatorChildren={this.switchText}
-            />
+            <Control {...controlProps} type="checkbox" typeClassName={Classes.SWITCH} indicatorChildren={switchText} />
         );
     }
 }

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -33,12 +33,37 @@ describe("Controls:", () => {
 
     controlsTests(Switch, "checkbox", Classes.SWITCH, () => {
         describe("internal text", () => {
-            const switchWithText = mount(<Switch innerLabelChecked="Checked text" innerLabel="Unchecked text" />);
-            it("renders internal text", () => {
-                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH}-inner-text`);
-                assert.lengthOf(innerTextNodes, 2);
+            it("renders both innerLabels when both defined", () => {
+                const switchWithText = mount(<Switch innerLabelChecked="checked" innerLabel="unchecked" />);
+                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
+                const checkedTest = innerTextNodes.first().text();
                 const uncheckedText = innerTextNodes.last().text();
-                assert.equal(uncheckedText.trim(), "Unchecked text");
+                assert.lengthOf(innerTextNodes, 2);
+                assert.equal(checkedTest.trim(), "checked");
+                assert.equal(uncheckedText.trim(), "unchecked");
+            });
+            it("does not render innerLabel components when neither defined", () => {
+                const switchWithoutText = mount(<Switch />);
+                const innerTextNodes = switchWithoutText.find(`.${Classes.SWITCH_INNER_TEXT}`);
+                assert.lengthOf(innerTextNodes, 0);
+            });
+            it("renders innerLabel when innerLabelChecked is undefined", () => {
+                const switchWithText = mount(<Switch innerLabel="onlyInnerLabel" />);
+                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
+                const checkedText = innerTextNodes.last().text();
+                const uncheckedText = innerTextNodes.first().text();
+                assert.lengthOf(innerTextNodes, 2);
+                assert.equal(checkedText.trim(), "onlyInnerLabel");
+                assert.equal(checkedText.trim(), uncheckedText.trim());
+            });
+            it("renders innerLabelChecked only when checked", () => {
+                const switchWithText = mount(<Switch innerLabelChecked="onlyChecked" />);
+                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
+                const checked = innerTextNodes.first().text();
+                const uncheckedText = innerTextNodes.last().text();
+                assert.lengthOf(innerTextNodes, 2);
+                assert.equal(checked.trim(), "onlyChecked");
+                assert.equal(uncheckedText.trim(), "");
             });
         });
     });

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -31,7 +31,14 @@ describe("Controls:", () => {
         });
     });
 
-    controlsTests(Switch, "checkbox", Classes.SWITCH);
+    controlsTests(Switch, "checkbox", Classes.SWITCH, () => {
+        describe("internal text", () => {
+            const switchWithText = mount(<Switch activeText="Active Text" inactiveText="Inactive Text" />);
+            it("renders internal text", () => {
+                assert.equal(switchWithText.find(`.${Classes.SWITCH}-active-text`).text(), "Active Text");
+            });
+        });
+    });
 
     controlsTests(Radio, "radio", Classes.RADIO);
 

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -52,7 +52,6 @@ describe("Controls:", () => {
                 const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
                 const checkedText = innerTextNodes.last().text();
                 const uncheckedText = innerTextNodes.first().text();
-                assert.lengthOf(innerTextNodes, 2);
                 assert.equal(checkedText.trim(), "onlyInnerLabel");
                 assert.equal(checkedText.trim(), uncheckedText.trim());
             });
@@ -61,7 +60,6 @@ describe("Controls:", () => {
                 const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
                 const checked = innerTextNodes.first().text();
                 const uncheckedText = innerTextNodes.last().text();
-                assert.lengthOf(innerTextNodes, 2);
                 assert.equal(checked.trim(), "onlyChecked");
                 assert.equal(uncheckedText.trim(), "");
             });

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -36,8 +36,9 @@ describe("Controls:", () => {
             const switchWithText = mount(<Switch innerLabelChecked="Checked text" innerLabel="Unchecked text" />);
             it("renders internal text", () => {
                 const innerTextNodes = switchWithText.find(`.${Classes.SWITCH}-inner-text`);
-                assert.equal(innerTextNodes.first().text(), "Checked text");
-                assert.equal(innerTextNodes.last().text(), "Unchecked text");
+                assert.lengthOf(innerTextNodes, 2);
+                const uncheckedText = innerTextNodes.last().text();
+                assert.equal(uncheckedText.trim(), "Unchecked text");
             });
         });
     });
@@ -60,7 +61,7 @@ describe("Controls:", () => {
             it("supports JSX children", () => {
                 const control = mountControl({}, <span className="jsx-child" key="jsx" />, "Label Text");
                 assert.lengthOf(control.find(".jsx-child"), 1);
-                assert.equal(control.text(), "Label Text");
+                assert.equal(control.text().trim(), "Label Text");
             });
 
             it("supports JSX labelElement", () => {
@@ -69,7 +70,7 @@ describe("Controls:", () => {
 
                 const control = mountControl({ labelElement: <strong>boom</strong> });
                 assert.lengthOf(control.find("strong"), 1);
-                assert.equal(control.text(), "boom");
+                assert.equal(control.text().trim(), "boom");
             });
 
             if (moreTests != null) {

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -33,7 +33,9 @@ describe("Controls:", () => {
 
     controlsTests(Switch, "checkbox", Classes.SWITCH, () => {
         describe("internal text", () => {
-            const switchWithText = mount(<Switch activeText="Active Text" inactiveText="Inactive Text" />);
+            const switchWithText = mount(
+                <Switch internalTextActive="Active Text" internalTextInactive="Inactive Text" />,
+            );
             it("renders internal text", () => {
                 assert.equal(switchWithText.find(`.${Classes.SWITCH}-active-text`).text(), "Active Text");
             });

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -33,11 +33,11 @@ describe("Controls:", () => {
 
     controlsTests(Switch, "checkbox", Classes.SWITCH, () => {
         describe("internal text", () => {
-            const switchWithText = mount(
-                <Switch internalTextActive="Active Text" internalTextInactive="Inactive Text" />,
-            );
+            const switchWithText = mount(<Switch innerLabelChecked="Checked text" innerLabel="Unchecked text" />);
             it("renders internal text", () => {
-                assert.equal(switchWithText.find(`.${Classes.SWITCH}-active-text`).text(), "Active Text");
+                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH}-inner-text`);
+                assert.equal(innerTextNodes.first().text(), "Checked text");
+                assert.equal(innerTextNodes.last().text(), "Unchecked text");
             });
         });
     });

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -19,6 +19,13 @@ export class SwitchExample extends CheckboxExample {
                     <Switch {...this.state} labelElement={<strong>Enabled</strong>} />
                     <Switch {...this.state} labelElement={<em>Public</em>} />
                     <Switch {...this.state} labelElement={<u>Cooperative</u>} defaultChecked={true} />
+                    <Switch
+                        {...this.state}
+                        labelElement={"Containing Text"}
+                        activeText="activeText"
+                        inactiveText="inactiveText"
+                    />
+
                 </div>
                 <small style={{ width: "100%", textAlign: "center" }}>
                     This example uses <Code>labelElement</Code> to demonstrate JSX labels.

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -22,8 +22,8 @@ export class SwitchExample extends CheckboxExample {
                     <Switch
                         {...this.state}
                         labelElement={"Containing Text"}
-                        internalTextActive="activeText"
-                        internalTextInactive="inactiveText"
+                        innerLabelChecked="checked"
+                        innerLabel="unchecked"
                     />
                 </div>
                 <small style={{ width: "100%", textAlign: "center" }}>

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -25,7 +25,6 @@ export class SwitchExample extends CheckboxExample {
                         internalTextActive="activeText"
                         internalTextInactive="inactiveText"
                     />
-
                 </div>
                 <small style={{ width: "100%", textAlign: "center" }}>
                     This example uses <Code>labelElement</Code> to demonstrate JSX labels.

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -19,12 +19,7 @@ export class SwitchExample extends CheckboxExample {
                     <Switch {...this.state} labelElement={<strong>Enabled</strong>} />
                     <Switch {...this.state} labelElement={<em>Public</em>} />
                     <Switch {...this.state} labelElement={<u>Cooperative</u>} defaultChecked={true} />
-                    <Switch
-                        {...this.state}
-                        labelElement={"Containing Text"}
-                        innerLabelChecked="checked"
-                        innerLabel="unchecked"
-                    />
+                    <Switch {...this.state} labelElement={"Containing Text"} innerLabelChecked="on" innerLabel="off" />
                 </div>
                 <small style={{ width: "100%", textAlign: "center" }}>
                     This example uses <Code>labelElement</Code> to demonstrate JSX labels.

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -22,8 +22,8 @@ export class SwitchExample extends CheckboxExample {
                     <Switch
                         {...this.state}
                         labelElement={"Containing Text"}
-                        activeText="activeText"
-                        inactiveText="inactiveText"
+                        internalTextActive="activeText"
+                        internalTextInactive="inactiveText"
                     />
 
                 </div>


### PR DESCRIPTION
#### Fixes #3320 

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This adds the ability to put text inside a switch when both active and inactive. 

#### Reviewers should focus on:

Is structuring these text elements as children of the control indicator appropriate? 
Whats the best way to ensure appropriate font size/vertical spacing in both regular and large switch mode? 

#### Screenshot

