### PR TITLE
countDecimalPlaces for number type

### DIFF
--- a/packages/core/src/common/utils.ts
+++ b/packages/core/src/common/utils.ts
@@ -185,10 +185,10 @@ export function clamp(val: number, min: number, max: number) {
 
 /** Returns the number of decimal places in the given number. */
 export function countDecimalPlaces(num: number) {
-    if (typeof num !== "number" || Math.floor(num) === num) {
-        return 0;
-    }
-    return num.toString().split(".")[1].length;
+    if (!isFinite(num)) return 0;
+    let e = 1, p = 0;
+    while (Math.round(num * e) / e !== num) { e *= 10; p++; }
+    return p;
 }
 
 /**

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -101,6 +101,8 @@ describe("Utils", () => {
         assert.equal(Utils.countDecimalPlaces(1), 0);
         assert.equal(Utils.countDecimalPlaces(0.11), 2);
         assert.equal(Utils.countDecimalPlaces(-1.1111111111), 10);
+        assert.equal(Utils.countDecimalPlaces(1e-10), 10);
+        assert.equal(Utils.countDecimalPlaces(NaN), 0);
     });
 
     // TODO: not sure how to test this. perhaps with the help of https://github.com/alexreardon/raf-stub?


### PR DESCRIPTION
#### Fixes #3336

#### Checklist

- [x] Includes tests
- [x] Update documentation (same as current, the PR does not changes any behaviour nor interface)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

countDecimalPlaces returns decimal places for all number notations and do not covert the number to string (faster):

```
console.log(Utils.countDecimalPlaces(1e-10));
// expected output 10
console.log(Utils.countDecimalPlaces(NaN));
// expected output 0
```

#### Reviewers should focus on:

countDecimalPlaces from packages/core/src/common/utils.ts

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
