### PR TITLE
Remove popover dismiss class from DateRangePicker shortcuts

### DIFF
--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Menu, MenuItem } from "@blueprintjs/core";
+import { Menu, MenuItem } from "@blueprintjs/core";
 import React from "react";
 import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
 import { clone, DateRange, isDayRangeInRange } from "./common/dateUtils";
@@ -46,7 +46,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
 
         const shortcutElements = shortcuts.map((s, i) => (
             <MenuItem
-                className={Classes.POPOVER_DISMISS_OVERRIDE}
+                shouldDismissPopover={false}
                 disabled={!this.isShortcutInRange(s.dateRange)}
                 key={i}
                 onClick={this.getShorcutClickHandler(s)}

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Button } from "@blueprintjs/core";
+import { Button, Classes as CoreClasses } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -1167,6 +1167,11 @@ describe("<DateRangePicker>", () => {
 
             render({ timePrecision: "minute", defaultValue: defaultRange, shortcuts }).clickShortcut();
             assert.equal(onChangeSpy.firstCall.args[0][0] as Date, startTime);
+        });
+
+        it("shortcuts do not dismiss popovers", () => {
+            const { shortcuts } = render();
+            assert.isFalse(shortcuts.find(`.${CoreClasses.POPOVER_DISMISS}`).exists());
         });
 
         it("selecting and unselecting a day doesn't change time", () => {


### PR DESCRIPTION
#### Fixes #3338 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Correctly prevent DateRangePicker shortcuts from dismissing popovers

#### Reviewers should focus on:

Shortcuts are implemented using MenuItems, which receive the POPOVER_DISMISS class by default. In order to prevent this behaviour, DateRangePicker adds the POPOVER_DISMISS_OVERRIDE class. However, when an element has both classes, the former takes priority and the override has no effect. This change uses the shouldDismissPopover prop of MenuItem to achieve the desired behaviour.

#### Screenshot

N/A
