### PR TITLE
[Spinner] SIZE_SMALL = 20

### DIFF
--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -29,8 +29,13 @@ const MIN_STROKE_WIDTH = 16;
 export interface ISpinnerProps extends IProps, IIntentProps {
     /**
      * Width and height of the spinner in pixels. The size cannot be less than
-     * 10px. Constants are available for common sizes: `Spinner.SIZE_SMALL`,
-     * `Spinner.SIZE_STANDARD`, `Spinner.SIZE_LARGE`.
+     * 10px.
+     *
+     * Constants are available for common sizes:
+     * - `Spinner.SIZE_SMALL = 20px`
+     * - `Spinner.SIZE_STANDARD = 50px`
+     * - `Spinner.SIZE_LARGE = 100px`
+     *
      * @default Spinner.SIZE_STANDARD = 50
      */
     size?: number;
@@ -53,7 +58,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
 export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Spinner`;
 
-    public static readonly SIZE_SMALL = 24;
+    public static readonly SIZE_SMALL = 20;
     public static readonly SIZE_STANDARD = 50;
     public static readonly SIZE_LARGE = 100;
 

--- a/packages/core/test/isotest.js
+++ b/packages/core/test/isotest.js
@@ -22,6 +22,9 @@ describe("Core isomorphic rendering", () => {
         Dialog: {
             props: { isOpen: true, usePortal: false },
         },
+        Drawer: {
+            props: { isOpen: true, usePortal: false },
+        },
         Hotkey: {
             props: hotkeyProps,
         },


### PR DESCRIPTION
#### Changes proposed in this pull request:

- change `Spinner.SIZE_SMALL` from 24 to 20 so it fits with other sizes used in blueprint. 24 was unique...
