### PR TITLE
Fill Popover Buttons in <ButtonGroup />

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -117,6 +117,12 @@ Styleguide button-group
     }
   }
 
+  .#{$ns}-popover-wrapper,
+  .#{$ns}-popover-target {
+    display: flex;
+    flex: 1 1 auto;
+  }
+
   /*
   Responsive
 
@@ -188,10 +194,6 @@ Styleguide button-group
       margin-right: 0 !important; // stylelint-disable-line declaration-no-important
       // needed to ensure buttons take up the full width when wrapped in a Popover:
       width: 100%;
-    }
-
-    .#{$ns}-popover-target {
-      display: block;
     }
 
     &:not(.#{$ns}-minimal) {

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -13,6 +13,7 @@ import { FileMenu } from "./common/fileMenu";
 
 export interface IButtonGroupPopoverExampleState {
     alignText: Alignment;
+    fill: boolean;
     large: boolean;
     minimal: boolean;
     vertical: boolean;
@@ -21,11 +22,13 @@ export interface IButtonGroupPopoverExampleState {
 export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps, IButtonGroupPopoverExampleState> {
     public state: IButtonGroupPopoverExampleState = {
         alignText: Alignment.CENTER,
+        fill: false,
         large: false,
         minimal: false,
         vertical: false,
     };
 
+    private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
@@ -34,6 +37,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
         const options = (
             <>
                 <H5>Props</H5>
+                <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
@@ -56,7 +60,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
         const rightIconName: IconName = vertical ? "caret-right" : "caret-down";
         const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
         return (
-            <Popover content={<FileMenu />} position={position}>
+            <Popover content={<FileMenu />} position={position} usePortal={false}>
                 <Button rightIcon={rightIconName} icon={iconName} text={text} />
             </Popover>
         );

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -60,7 +60,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps
         const rightIconName: IconName = vertical ? "caret-right" : "caret-down";
         const position = vertical ? Position.RIGHT_TOP : Position.BOTTOM_LEFT;
         return (
-            <Popover content={<FileMenu />} position={position} usePortal={false}>
+            <Popover content={<FileMenu />} position={position}>
                 <Button rightIcon={rightIconName} icon={iconName} text={text} />
             </Popover>
         );

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -458,6 +458,13 @@
   }
 }
 
+#{example("ButtonGroupExample")},
+#{example("ButtonGroupPopoverExample")} {
+  .docs-example > * {
+    margin: 0;
+  }
+}
+
 //
 // DATETIME
 //


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update <ButtonGroup /> styling to allow Popover Buttons nested in ButtonGroups to fill up all available space.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

**Before:**
<img width="802" alt="image" src="https://user-images.githubusercontent.com/831708/52527819-d0fb9f80-2c83-11e9-9b7f-08a8b271d0e4.png">

**After:**
<img width="812" alt="image" src="https://user-images.githubusercontent.com/831708/52527807-91cd4e80-2c83-11e9-9139-c0f1efcd3e82.png">
