### PR TITLE
Corrected the type of Popover's onInteraction prop

### DIFF
--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -97,7 +97,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * Callback invoked in controlled mode when the popover open state *would*
      * change due to user interaction.
      */
-    onInteraction?: (nextOpenState: boolean) => void;
+    onInteraction?: (nextOpenState: boolean, e?: React.SyntheticEvent<HTMLElement>) => void;
 
     /**
      * Whether the popover should open when its target is focused. If `true`,


### PR DESCRIPTION
In pr [#2617](https://github.com/palantir/blueprint/pull/2617) the type of the `onInteraction` prop was [changed](https://github.com/palantir/blueprint/commit/f111cdccd166053cded030fbcbab60239d6e5d17#diff-526f9b7061d074b106ee2b67a5dafc14L122) to no longer include the event as the second argument (added as part of [#2340](https://github.com/palantir/blueprint/issues/2430)). However the the code still [conforms to the previous interface](https://github.com/palantir/blueprint/blob/9728e61b420eda381cedce06166a4caf6b958bc4/packages/core/src/components/popover/popover.tsx#L501). All I've done is change it back to what it was so I've not included tests, docs changes etc. 🙂

