### PR TITLE
[Tabs] add panelClassName prop

### DIFF
--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -38,6 +38,11 @@ export interface ITabProps extends IProps {
     panel?: JSX.Element;
 
     /**
+     * Space-delimited string of class names applied to tab panel container.
+     */
+    panelClassName?: string;
+
+    /**
      * Content of tab title element, rendered in a list above the active panel.
      * Can also be set via React `children`.
      */

--- a/packages/core/src/components/tabs/tabs.md
+++ b/packages/core/src/components/tabs/tabs.md
@@ -17,7 +17,7 @@ import { Tab, Tabs } from "@blueprintjs/core";
 
 <Tabs id="TabsExample" onChange={this.handleTabChange} selectedTabId="rx">
     <Tab id="ng" title="Angular" panel={<AngularPanel />} />
-    <Tab id="mb" title="Ember" panel={<EmberPanel />} />
+    <Tab id="mb" title="Ember" panel={<EmberPanel />} panelClassName="ember-panel" />
     <Tab id="rx" title="React" panel={<ReactPanel />} />
     <Tab id="bb" disabled title="Backbone" panel={<BackbonePanel />} />
     <Tabs.Expander />

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -274,7 +274,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
     }
 
     private renderTabPanel = (tab: TabElement) => {
-        const { className, panel, id } = tab.props;
+        const { className, panel, id, panelClassName } = tab.props;
         if (panel === undefined) {
             return undefined;
         }
@@ -282,7 +282,7 @@ export class Tabs extends AbstractPureComponent<ITabsProps, ITabsState> {
             <div
                 aria-labelledby={generateTabTitleId(this.props.id, id)}
                 aria-hidden={id !== this.state.selectedTabId}
-                className={classNames(Classes.TAB_PANEL, className)}
+                className={classNames(Classes.TAB_PANEL, className, panelClassName)}
                 id={generateTabPanelId(this.props.id, id)}
                 key={id}
                 role="tabpanel"

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -92,6 +92,30 @@ describe("<Tabs>", () => {
         assert.lengthOf(wrapper.find(`.${Classes.TAB_LIST}.${Classes.LARGE}`), 1);
     });
 
+    it("attaches className to both tab and panel container if set", () => {
+        const tabClassName = "tabClassName";
+        const wrapper = mount(
+            <Tabs id={ID}>
+                <Tab id="first" title="First" className={tabClassName} panel={<Panel title="first" />} />,
+                <Tab id="second" title="Second" className={tabClassName} panel={<Panel title="second" />} />,
+                <Tab id="third" title="Third" className={tabClassName} panel={<Panel title="third" />} />,
+            </Tabs>,
+        );
+        assert.lengthOf(wrapper.find(`.${tabClassName}`), 6);
+    });
+
+    it("attaches panelClassName to panel container if set", () => {
+        const panelClassName = "secondPanelClassName";
+        const wrapper = mount(
+            <Tabs id={ID}>
+                <Tab id="first" title="First" panel={<Panel title="first" />} />,
+                <Tab id="second" title="Second" panelClassName={panelClassName} panel={<Panel title="second" />} />,
+                <Tab id="third" title="Third" panel={<Panel title="third" />} />,
+            </Tabs>,
+        );
+        assert.lengthOf(wrapper.find(`.${panelClassName}`), 1);
+    });
+
     it("renderActiveTabPanelOnly only renders active tab panel", () => {
         const wrapper = mount(
             <Tabs id={ID} renderActiveTabPanelOnly={true}>

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -101,7 +101,7 @@ describe("<Tabs>", () => {
                 <Tab id="third" title="Third" className={tabClassName} panel={<Panel title="third" />} />,
             </Tabs>,
         );
-        assert.lengthOf(wrapper.find(`.${tabClassName}`), 6);
+        assert.lengthOf(wrapper.find(`.${tabClassName}`), 9);
     });
 
     it("attaches panelClassName to panel container if set", () => {

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -75,7 +75,7 @@ export class TabsExample extends React.PureComponent<IExampleProps, ITabsExample
                 >
                     <Tab id="rx" title="React" panel={<ReactPanel />} />
                     <Tab id="ng" title="Angular" panel={<AngularPanel />} />
-                    <Tab id="mb" title="Ember" panel={<EmberPanel />} />
+                    <Tab id="mb" title="Ember" panel={<EmberPanel />} panelClassName="ember-panel" />
                     <Tab id="bb" disabled={true} title="Backbone" panel={<BackbonePanel />} />
                     <Tabs.Expander />
                     <InputGroup className={Classes.FILL} type="text" placeholder="Search..." />


### PR DESCRIPTION
Related to #3317, but doesn't really fix it. 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This PR adds a `panelClassName` prop to Tab component to let users add a class name to tab panel container. An existing `className` prop affects _both_ tab and tab panel, which is not always desirable.  

#### Reviewers should focus on:

I think I have updated prop description in tabs/tab.tsx correctly but I couldn't figure out how to get it displayed in docs. I need help to check if panelClassName prop description is correctly displayed.

