### PR TITLE
[Core] Fixed incorrect intent color for <Icon /> inside <Tree />

### DIFF
--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -25,6 +25,10 @@ $pt-dark-intent-text-colors: (
   "danger" : $red5,
 ) !default;
 
+@mixin intent-color($intentName) {
+  color: map-get($pt-intent-colors, $intentName);
+}
+
 @mixin position-all($position, $value) {
   position: $position;
   top: $value;

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -47,6 +47,12 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
 .#{$ns}-tree {
   #{$icon-classes} {
     color: $pt-icon-color;
+
+    @each $intent, $colors in $pt-intent-colors {
+      &.#{$ns}-intent-#{$intent} {
+        @include intent-color($intent);
+      }
+    }
   }
 }
 

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-import { Classes, Icon, ITreeNode, Position, Tooltip, Tree } from "@blueprintjs/core";
+import { Classes, Icon, Intent, ITreeNode, Position, Tooltip, Tree } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ITreeExampleState {
@@ -93,7 +93,7 @@ const INITIAL_STATE: ITreeNode[] = [
             },
             {
                 id: 3,
-                icon: "tag",
+                icon: <Icon icon="tag" intent={Intent.PRIMARY} className={Classes.TREE_NODE_ICON} />,
                 label: "Organic meditation gluten-free, sriracha VHS drinking vinegar beard man.",
             },
             {


### PR DESCRIPTION
#### Fixes #3042 

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

Fixed not applying intent color for icons inside tree component

#### Reviewers should focus on:
Is there a better solution to fix this?

#### Screenshot
![preview](https://user-images.githubusercontent.com/2925620/52678761-1ee9ff00-2f33-11e9-8eca-2e3992221a10.png)

https://68-144397854-gh.circle-artifacts.com/0/home/circleci/project/packages/docs-app/dist/index.html#core/components/tree

