### PR TITLE
Drawer default prop warning fix

### DIFF
--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -79,7 +79,6 @@ export class Drawer extends AbstractPureComponent<IDrawerProps, {}> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Drawer`;
     public static defaultProps: IDrawerProps = {
         canOutsideClickClose: true,
-        isCloseButtonShown: true,
         isOpen: false,
         style: {},
         vertical: false,
@@ -115,7 +114,9 @@ export class Drawer extends AbstractPureComponent<IDrawerProps, {}> {
     }
 
     private maybeRenderCloseButton() {
-        if (this.props.isCloseButtonShown) {
+        // `isCloseButtonShown` can't be defaulted through default props because of props validation
+        // so this check actually defaults it to true if it is not defined (== null)
+        if (this.props.isCloseButtonShown || this.props.isCloseButtonShown == null) {
             return (
                 <Button
                     aria-label="Close"

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -115,8 +115,8 @@ export class Drawer extends AbstractPureComponent<IDrawerProps, {}> {
 
     private maybeRenderCloseButton() {
         // `isCloseButtonShown` can't be defaulted through default props because of props validation
-        // so this check actually defaults it to true if it is not defined (== null)
-        if (this.props.isCloseButtonShown || this.props.isCloseButtonShown == null) {
+        // so this check actually defaults it to true (fails only if directly set to false)
+        if (this.props.isCloseButtonShown !== false) {
             return (
                 <Button
                     aria-label="Close"


### PR DESCRIPTION
Updated 'isCloseButtonShown' prop at 'Drawer' not to be defaulted regularly (through defaultProps) because of prop validation would throw error for default props (title == null && isCloseButtonShown == true).

#### Fixes #3380 

#### Checklist

- [x] Includes tests - no need, behavior not chanaged
- [x] Update documentation - no need, documentation remains the same

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Simply updated the way of defaulting `isCloseButtonShown` prop, to avoid unnecessary warnings.

#### Reviewers should focus on:

Nothing specific, small PR

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
