### PR TITLE
Update `<Overlay>` transitionDuration comment

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -51,7 +51,7 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
      * This is used by React `CSSTransition` to know when a transition completes and must match
      * the duration of the animation in CSS. Only set this prop if you override Blueprint's default
      * transitions with new transitions of a different length.
-     * @default 100
+     * @default 300
      */
     transitionDuration?: number;
 


### PR DESCRIPTION
The default is actually 300: https://github.com/gabeboning/blueprint/blob/develop/packages/core/src/components/overlay/overlay.tsx#L176

This updates the comment/documentation to match. 