### PR TITLE
Add intent support for controls (checkbox, radio, switch)

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -12,35 +12,38 @@ $dark-control-background-color: $dark-button-background-color !default;
 $dark-control-background-color-hover: $dark-button-background-color-hover !default;
 $dark-control-background-color-active: $dark-button-background-color-active !default;
 
-$control-checked-background-color: nth(map-get($button-intents, "primary"), 1) !default;
-$control-checked-background-color-hover: nth(map-get($button-intents, "primary"), 2) !default;
-$control-checked-background-color-active: nth(map-get($button-intents, "primary"), 3) !default;
-
 $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
 $control-indicator-spacing: $pt-grid-size !default;
 
 @mixin control-checked-colors($selector: ":checked") {
-  input#{$selector} ~ .#{$ns}-control-indicator {
+  input#{$selector} ~ .#{$ns}-control-indicator:not([class*="#{$ns}-intent-"]) {
+    @include pt-control-intent(
+      nth(map-get($button-intents, "primary"), 1),
+      nth(map-get($button-intents, "primary"), 2),
+      nth(map-get($button-intents, "primary"), 3));
     box-shadow: $button-intent-box-shadow;
-    background-color: $control-checked-background-color;
     background-image: $button-intent-gradient;
     color: $white;
   }
 
+  // intents
+  @each $intent, $colors in $button-intents {
+    input#{$selector} ~ .#{$ns}-control-indicator.#{$ns}-intent-#{$intent} {
+      @include pt-control-intent($colors...);
+    }
+  }
+
   &:hover input#{$selector} ~ .#{$ns}-control-indicator {
     box-shadow: $button-intent-box-shadow;
-    background-color: $control-checked-background-color-hover;
   }
 
   input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
     box-shadow: $button-intent-box-shadow-active;
-    background: $control-checked-background-color-active;
   }
 
   input:disabled#{$selector} ~ .#{$ns}-control-indicator {
     box-shadow: none;
-    background: rgba($control-checked-background-color, 0.5);
   }
 
   .#{$ns}-dark & {
@@ -50,18 +53,31 @@ $control-indicator-spacing: $pt-grid-size !default;
 
     &:hover input#{$selector} ~ .#{$ns}-control-indicator {
       box-shadow: $dark-button-intent-box-shadow;
-      background-color: $control-checked-background-color-hover;
     }
 
     input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
       box-shadow: $dark-button-intent-box-shadow-active;
-      background-color: $control-checked-background-color-active;
     }
 
     input:disabled#{$selector} ~ .#{$ns}-control-indicator {
       box-shadow: none;
-      background: rgba($control-checked-background-color-active, 0.5);
     }
+  }
+}
+
+@mixin pt-control-intent($default-color, $hover-color, $active-color) {
+  background-color: $default-color;
+
+  &:hover {
+    background-color: $hover-color;
+  }
+
+  input:not(:disabled):active#{$selector} {
+    background-color: $active-color;
+  }
+
+  input:disabled#{$selector} {
+    background-color: rgba($default-color, 0.5);
   }
 }
 

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -13,10 +13,10 @@ import * as React from "react";
 
 import { Alignment } from "../../common/alignment";
 import * as Classes from "../../common/classes";
-import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps, IIntentProps } from "../../common/props";
 import { safeInvoke } from "../../common/utils";
 
-export interface IControlProps extends IProps, HTMLInputProps {
+export interface IControlProps extends IProps, IIntentProps, HTMLInputProps {
     // NOTE: HTML props are duplicated here to provide control-specific documentation
 
     /**
@@ -114,6 +114,7 @@ const Control: React.SFC<IControlInternalProps> = ({
             [Classes.LARGE]: large,
         },
         Classes.alignmentClass(alignIndicator),
+        Classes.intentClass(this.props.intent),
         className,
     );
     return (

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -6,15 +6,17 @@
 
 import * as React from "react";
 
-import { Alignment, Checkbox, H5, Label, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Alignment, Checkbox, H5, Label, Switch, Intent } from "@blueprintjs/core";
+import { Example, handleBooleanChange, IExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 import { AlignmentSelect } from "./common/alignmentSelect";
+import { IntentSelect } from './common/intentSelect';
 
 export interface ICheckboxExampleState {
     alignIndicator: Alignment;
     disabled: boolean;
     inline: boolean;
     large: boolean;
+    intent: Intent;
     value?: string;
 }
 
@@ -24,6 +26,7 @@ export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckbo
         disabled: false,
         inline: false,
         large: false,
+        intent: Intent.NONE
     };
 
     public render() {
@@ -33,6 +36,7 @@ export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckbo
                 <Switch checked={this.state.disabled} label="Disabled" onChange={this.handleDisabledChange} />
                 <Switch checked={this.state.inline} label="Inline" onChange={this.handleInlineChange} />
                 <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
+                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <AlignmentSelect
                     align={this.state.alignIndicator}
                     allowCenter={false}
@@ -65,4 +69,5 @@ export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckbo
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
     private handleInlineChange = handleBooleanChange(inline => this.setState({ inline }));
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
+    private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
 }


### PR DESCRIPTION
#### Fixes #3233, #855

#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add support for an intent class to controls (`Checkbox`, `Radio`, and `Switch`)

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
