### PR TITLE
Table props documentation updates

### DIFF
--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -44,7 +44,7 @@ export interface IHeaderProps extends ILockableLayout, IReorderableProps, ISelec
 
     /**
      * Enables/disables the resize interaction.
-     * @default false
+     * @default true
      */
     isResizable?: boolean;
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -164,7 +164,7 @@ export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
 
     /**
      * If `false`, disables resizing of rows.
-     * @default false
+     * @default true
      */
     enableRowResizing?: boolean;
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
Prop documentation updates for `ITableProps.enableRowResizing` and `IHeaderProps.isResizeble` to show that they both default to true instead of false.
The underlying [Resizable Component](https://github.com/zelein/blueprint/blob/develop/packages/table/src/interactions/resizable.tsx#L19) defaults to true and can be seen on [L77](https://github.com/zelein/blueprint/blob/develop/packages/table/src/interactions/resizable.tsx#L77) defaulting to true

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
