### PR TITLE
[Core] Checkbox: fix indeterminate state update

### DIFF
--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -252,7 +252,7 @@ export class Checkbox extends React.PureComponent<ICheckboxProps, ICheckboxState
     }
 
     private updateIndeterminate() {
-        if (this.state.indeterminate != null) {
+        if (this.input != null) {
             this.input.indeterminate = this.state.indeterminate;
         }
     }


### PR DESCRIPTION
Fixes #3408

I don't think `input.indeterminate` should ever be null, but we can avoid the snapshot testing bug raised in #3408 by simply checking if `this.input` is a valid ref.