### PR TITLE
Add z-index to panel stack header

### DIFF
--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -13,6 +13,7 @@
   display: flex;
   flex-shrink: 0;
   align-items: center;
+  z-index: 1;
   box-shadow: 0 1px $pt-divider-black;
   height: $pt-grid-size * 3;
 


### PR DESCRIPTION
#### Fixes #3413

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add a z-index property to the panel-stack-header class to not allow later DOM elements to overlay

#### Reviewers should focus on:

Potential other solutions

