### PR TITLE
Update recommended tslint extension for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     // for consistent editor settings:
     "EditorConfig.EditorConfig",
     // for typescript source files:
-    "eg2.tslint",
+    "ms-vscode.vscode-typescript-tslint-plugin",
     // for sass source files:
     "shinnn.stylelint",
   ]


### PR DESCRIPTION
#### Changes proposed in this pull request:

[eg2.tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) has been deprecated in favor of [vscode-typescript-tslint-plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin), see https://marketplace.visualstudio.com/items?itemName=eg2.tslint for more info.

#### Reviewers should focus on:

Whether this new extension should be recommended or not.

