### PR TITLE
[MultiSelect] Enable pasting of multiple values (same as TagInput)

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -15,6 +15,26 @@ import * as Utils from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { ITagProps, Tag } from "../tag/tag";
 
+/**
+ * An enumeration of methods in which a `TagInput` value might have been added.
+ */
+export enum TagInputAddMethod {
+    /** Indicates that a value was added in the default fasion, via manual selection. */
+    DEFAULT = "default",
+
+    /**
+     * Indicates that a value was added when the `TagInput` lost focus. This is
+     * only possible when `addOnBlur=true`.
+     */
+    BLUR = "blur",
+
+    /**
+     * Indicates that a value was added via paste. This is only possible when
+     * `addOnPaste=true`.
+     */
+    PASTE = "paste",
+}
+
 export interface ITagInputProps extends IIntentProps, IProps {
     /**
      * If true, `onAdd` will be invoked when the input loses focus.
@@ -74,7 +94,7 @@ export interface ITagInputProps extends IIntentProps, IProps {
      * returns `false`. This is useful if the provided `value` is somehow invalid and should
      * not be added as a tag.
      */
-    onAdd?: (values: string[]) => boolean | void;
+    onAdd?: (values: string[], method: TagInputAddMethod) => boolean | void;
 
     /**
      * Callback invoked when new tags are added or removed. Receives the updated list of `values`:
@@ -260,10 +280,10 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         );
     }
 
-    private addTags = (value: string) => {
+    private addTags = (value: string, method: TagInputAddMethod = TagInputAddMethod.DEFAULT) => {
         const { inputValue, onAdd, onChange, values } = this.props;
         const newValues = this.getValues(value);
-        let shouldClearInput = Utils.safeInvoke(onAdd, newValues) !== false && inputValue === undefined;
+        let shouldClearInput = Utils.safeInvoke(onAdd, newValues, method) !== false && inputValue === undefined;
         // avoid a potentially expensive computation if this prop is omitted
         if (Utils.isFunction(onChange)) {
             shouldClearInput = onChange([...values, ...newValues]) !== false && shouldClearInput;
@@ -342,7 +362,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
             // defer this check using rAF so activeElement will have updated.
             if (!currentTarget.contains(document.activeElement)) {
                 if (this.props.addOnBlur && this.state.inputValue !== undefined && this.state.inputValue.length > 0) {
-                    this.addTags(this.state.inputValue);
+                    this.addTags(this.state.inputValue, TagInputAddMethod.BLUR);
                 }
                 this.setState({ activeIndex: NONE, isInputFocused: false });
             }
@@ -367,7 +387,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         let activeIndexToEmit = activeIndex;
 
         if (event.which === Keys.ENTER && value.length > 0) {
-            this.addTags(value);
+            this.addTags(value, TagInputAddMethod.DEFAULT);
         } else if (selectionEnd === 0 && this.props.values.length > 0) {
             // cursor at beginning of input allows interaction with tags.
             // use selectionEnd to verify cursor position and no text selection.
@@ -405,7 +425,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         }
 
         event.preventDefault();
-        this.addTags(value);
+        this.addTags(value, TagInputAddMethod.PASTE);
     };
 
     private handleRemoveTag = (event: React.MouseEvent<HTMLSpanElement>) => {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -16,24 +16,15 @@ import { Icon, IconName } from "../icon/icon";
 import { ITagProps, Tag } from "../tag/tag";
 
 /**
- * An enumeration of methods in which a `TagInput` value might have been added.
+ * A type reflecting the manner in which a `TagInput` value was added.
+ * - `"default"` - indicates that a value was added in the default fasion, via
+ *   manual selection.
+ * - `"blur"` - indicates that a value was added when the `TagInput` lost focus.
+ *   This is only possible when `addOnBlur=true`.
+ * - `"paste"` - indicates that a value was added via paste. This is only
+ *   possible when `addOnPaste=true`.
  */
-export enum TagInputAddMethod {
-    /** Indicates that a value was added in the default fasion, via manual selection. */
-    DEFAULT = "default",
-
-    /**
-     * Indicates that a value was added when the `TagInput` lost focus. This is
-     * only possible when `addOnBlur=true`.
-     */
-    BLUR = "blur",
-
-    /**
-     * Indicates that a value was added via paste. This is only possible when
-     * `addOnPaste=true`.
-     */
-    PASTE = "paste",
-}
+export type TagInputAddMethod = "default" | "blur" | "paste";
 
 export interface ITagInputProps extends IIntentProps, IProps {
     /**
@@ -280,7 +271,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         );
     }
 
-    private addTags = (value: string, method: TagInputAddMethod = TagInputAddMethod.DEFAULT) => {
+    private addTags = (value: string, method: TagInputAddMethod = "default") => {
         const { inputValue, onAdd, onChange, values } = this.props;
         const newValues = this.getValues(value);
         let shouldClearInput = Utils.safeInvoke(onAdd, newValues, method) !== false && inputValue === undefined;
@@ -362,7 +353,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
             // defer this check using rAF so activeElement will have updated.
             if (!currentTarget.contains(document.activeElement)) {
                 if (this.props.addOnBlur && this.state.inputValue !== undefined && this.state.inputValue.length > 0) {
-                    this.addTags(this.state.inputValue, TagInputAddMethod.BLUR);
+                    this.addTags(this.state.inputValue, "blur");
                 }
                 this.setState({ activeIndex: NONE, isInputFocused: false });
             }
@@ -387,7 +378,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         let activeIndexToEmit = activeIndex;
 
         if (event.which === Keys.ENTER && value.length > 0) {
-            this.addTags(value, TagInputAddMethod.DEFAULT);
+            this.addTags(value, "default");
         } else if (selectionEnd === 0 && this.props.values.length > 0) {
             // cursor at beginning of input allows interaction with tags.
             // use selectionEnd to verify cursor position and no text selection.
@@ -425,7 +416,7 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         }
 
         event.preventDefault();
-        this.addTags(value, TagInputAddMethod.PASTE);
+        this.addTags(value, "paste");
     };
 
     private handleRemoveTag = (event: React.MouseEvent<HTMLSpanElement>) => {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -16,9 +16,8 @@ import { Icon, IconName } from "../icon/icon";
 import { ITagProps, Tag } from "../tag/tag";
 
 /**
- * A type reflecting the manner in which a `TagInput` value was added.
- * - `"default"` - indicates that a value was added in the default fasion, via
- *   manual selection.
+ * The method in which a `TagInput` value was added.
+ * - `"default"` - indicates that a value was added by manual selection.
  * - `"blur"` - indicates that a value was added when the `TagInput` lost focus.
  *   This is only possible when `addOnBlur=true`.
  * - `"paste"` - indicates that a value was added via paste. This is only

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -128,6 +128,7 @@ describe("<TagInput>", () => {
             pressEnterInInput(wrapper, NEW_VALUE);
             assert.isTrue(onAdd.calledOnce);
             assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
+            assert.deepEqual(onAdd.args[0][1], "default");
         });
 
         it("is invoked on blur when addOnBlur=true", done => {
@@ -140,6 +141,8 @@ describe("<TagInput>", () => {
             // Need setTimeout here to wait for focus to change after blur event
             setTimeout(() => {
                 assert.isTrue(onAdd.calledOnce);
+                assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
+                assert.equal(onAdd.args[0][1], "blur");
                 done();
             });
         });
@@ -183,6 +186,7 @@ describe("<TagInput>", () => {
                 wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
                 assert.isTrue(onAdd.calledOnce);
                 assert.deepEqual(onAdd.args[0][0], ["pasted"]);
+                assert.equal(onAdd.args[0][1], "paste");
             });
 
             it("is not invoked on paste if the text does not include a delimiter", () => {

--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -210,6 +210,10 @@ export function areFilmsEqual(filmA: IFilm, filmB: IFilm) {
     return filmA.title.toLowerCase() === filmB.title.toLowerCase();
 }
 
+export function doesFilmEqualQuery(film: IFilm, query: string) {
+    return film.title.toLowerCase() === query.toLowerCase();
+}
+
 export function arrayContainsFilm(films: IFilm[], filmToFind: IFilm): boolean {
     return films.some((film: IFilm) => film.title === filmToFind.title);
 }

--- a/packages/docs-app/src/examples/select-examples/films.tsx
+++ b/packages/docs-app/src/examples/select-examples/films.tsx
@@ -152,8 +152,15 @@ export const renderCreateFilmOption = (
     />
 );
 
-export const filterFilm: ItemPredicate<IFilm> = (query, film) => {
-    return `${film.rank}. ${film.title.toLowerCase()} ${film.year}`.indexOf(query.toLowerCase()) >= 0;
+export const filterFilm: ItemPredicate<IFilm> = (query, film, _index, exactMatch) => {
+    const normalizedTitle = film.title.toLowerCase();
+    const normalizedQuery = query.toLowerCase();
+
+    if (exactMatch) {
+        return normalizedTitle === normalizedQuery;
+    } else {
+        return `${film.rank}. ${normalizedTitle} ${film.year}`.indexOf(normalizedQuery) >= 0;
+    }
 };
 
 function highlightText(text: string, query: string) {

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -13,7 +13,6 @@ import {
     areFilmsEqual,
     arrayContainsFilm,
     createFilm,
-    doesFilmEqualQuery,
     filmSelectProps,
     IFilm,
     maybeAddCreatedFilmToArrays,

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -89,7 +89,6 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     initialContent={initialContent}
                     itemRenderer={this.renderFilm}
                     itemsEqual={areFilmsEqual}
-                    itemEqualsQuery={doesFilmEqualQuery}
                     // we may customize the default filmSelectProps.items by
                     // adding newly created items to the list, so pass our own
                     items={this.state.items}

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -35,6 +35,13 @@ export interface IListItemsProps<T> extends IProps {
     items: T[];
 
     /**
+     * Whether the provided item fully matches the provided value. This is used
+     * to match pasted values to existing items, so that items can be emitted
+     * via `onItemsPaste`.
+     */
+    itemEqualsQuery?: (item: T, query: string) => boolean;
+
+    /**
      * Specifies how to test if two items are equal. By default, simple strict
      * equality (`===`) is used to compare two items.
      *
@@ -129,6 +136,11 @@ export interface IListItemsProps<T> extends IProps {
      * typically by clicking or pressing `enter` key.
      */
     onItemSelect: (item: T, event?: React.SyntheticEvent<HTMLElement>) => void;
+
+    /**
+     * Callback invoked when multiple items are selected at once via pasting.
+     */
+    onItemsPaste?: (items: T[]) => void;
 
     /**
      * Callback invoked when the query string changes.

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -35,13 +35,6 @@ export interface IListItemsProps<T> extends IProps {
     items: T[];
 
     /**
-     * Whether the provided item fully matches the provided value. This is used
-     * to match pasted values to existing items, so that items can be emitted
-     * via `onItemsPaste`.
-     */
-    itemEqualsQuery?: (item: T, query: string) => boolean;
-
-    /**
      * Specifies how to test if two items are equal. By default, simple strict
      * equality (`===`) is used to compare two items.
      *
@@ -73,11 +66,21 @@ export interface IListItemsProps<T> extends IProps {
     itemListPredicate?: ItemListPredicate<T>;
 
     /**
-     * Customize querying of individual items. Return `true` to keep the item, `false` to hide.
-     * This method will be invoked once for each item, so it should be performant. For more complex
-     * queries, use `itemListPredicate` to operate once on the entire array.
+     * Customize querying of individual items.
      *
-     * This prop is ignored if `itemListPredicate` is also defined.
+     * __Filtering a list of items.__ This function is invoked to filter the
+     * list of items as a query is typed. Return `true` to keep the item, or
+     * `false` to hide. This method is invoked once for each item, so it should
+     * be performant. For more complex queries, use `itemListPredicate` to
+     * operate once on the entire array. For the purposes of filtering the list,
+     * this prop is ignored if `itemListPredicate` is also defined.
+     *
+     * __Matching a pasted value to an item.__ This function is also invoked to
+     * match a pasted value to an existing item if possible. In this case, the
+     * function will receive `exactMatch=true`, and the function should return
+     * true only if the item _exactly_ matches the query. For the purposes of
+     * matching pasted values, this prop will be invoked even if
+     * `itemListPredicate` is defined.
      */
     itemPredicate?: ItemPredicate<T>;
 

--- a/packages/select/src/common/predicate.ts
+++ b/packages/select/src/common/predicate.ts
@@ -5,29 +5,13 @@
  */
 
 /**
- * Customize querying of entire `items` array. Return new list of items.
- * This method can reorder, add, or remove items at will.
- * (Supports filter algorithms that operate on the entire set, rather than individual items.)
- *
- * If defined with `itemPredicate`, this prop takes priority and the other will be ignored.
+ * A custom predicate for returning an entirely new `items` array based on the provided query.
+ * See usage sites in `IListItemsProps`.
  */
 export type ItemListPredicate<T> = (query: string, items: T[]) => T[];
 
 /**
- * Customize querying of individual items.
- *
- * __Filtering a list of items.__ This function is invoked to filter the list of
- * items as a query is typed. Return `true` to keep the item, or `false` to
- * hide. This method is invoked once for each item, so it should be performant.
- * For more complex queries, use `itemListPredicate` to operate once on the
- * entire array. For the purposes of filtering the list, this prop is ignored if
- * `itemListPredicate` is also defined.
- *
- * __Matching a pasted value to an item.__ This function is also invoked to
- * match a pasted value to an existing item if possible. In this case, the
- * function will receive `exactMatch=true`, and the function should return true
- * only if the item _exactly_ matches the query. For the purposes of matching
- * pasted values, this prop will be invoked even if `itemListPredicate` is
- * defined.
+ * A custom predicate for filtering items based on the provided query.
+ * See usage sites in `IListItemsProps`.
  */
 export type ItemPredicate<T> = (query: string, item: T, index?: number, exactMatch?: boolean) => boolean;

--- a/packages/select/src/common/predicate.ts
+++ b/packages/select/src/common/predicate.ts
@@ -14,10 +14,20 @@
 export type ItemListPredicate<T> = (query: string, items: T[]) => T[];
 
 /**
- * Customize querying of individual items. Return `true` to keep the item, `false` to hide.
- * This method will be invoked once for each item, so it should be performant. For more complex
- * queries, use `itemListPredicate` to operate once on the entire array.
+ * Customize querying of individual items.
  *
- * If defined with `itemListPredicate`, this prop will be ignored.
+ * __Filtering a list of items.__ This function is invoked to filter the list of
+ * items as a query is typed. Return `true` to keep the item, or `false` to
+ * hide. This method is invoked once for each item, so it should be performant.
+ * For more complex queries, use `itemListPredicate` to operate once on the
+ * entire array. For the purposes of filtering the list, this prop is ignored if
+ * `itemListPredicate` is also defined.
+ *
+ * __Matching a pasted value to an item.__ This function is also invoked to
+ * match a pasted value to an existing item if possible. In this case, the
+ * function will receive `exactMatch=true`, and the function should return true
+ * only if the item _exactly_ matches the query. For the purposes of matching
+ * pasted values, this prop will be invoked even if `itemListPredicate` is
+ * defined.
  */
-export type ItemPredicate<T> = (query: string, item: T, index?: number) => boolean;
+export type ItemPredicate<T> = (query: string, item: T, index?: number, exactMatch?: boolean) => boolean;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -57,17 +57,17 @@ export interface IQueryListRendererProps<T>  // Omit `createNewItem`, because it
     /**
      * Handler that should be invoked when the user pastes one or more values.
      *
-     * This callback will use `itemEqualsQuery` to find a subset of `items`
-     * exactly matching the pasted `values` provided, then it will invoke
-     * `onItemsPaste` with those found items. Each pasted value that does not
-     * exactly match an item will be ignored.
+     * This callback will use `itemPredicate` with `exactMatch=true` to find a
+     * subset of `items` exactly matching the pasted `values` provided, then it
+     * will invoke `onItemsPaste` with those found items. Each pasted value that
+     * does not exactly match an item will be ignored.
      *
      * If creating items is enabled (by providing both `createNewItemFromQuery`
      * and `createNewItemRenderer`), then pasted values that do not exactly
      * match an existing item will emit a new item as created via
      * `createNewItemFromQuery`.
      *
-     * If `itemEqualsQuery` returns multiple matching items for a particular
+     * If `itemPredicate` returns multiple matching items for a particular
      * `value`, then only the first matching item will be emitted.
      */
     handlePaste: (values: string[]) => void;
@@ -498,12 +498,13 @@ function pxToNumber(value: string | null) {
     return value == null ? 0 : parseInt(value.slice(0, -2), 10);
 }
 
-function getMatchingItem<T>(query: string, { items, itemEqualsQuery }: IQueryListProps<T>): T | undefined {
-    if (Utils.isFunction(itemEqualsQuery)) {
+function getMatchingItem<T>(query: string, { items, itemPredicate }: IQueryListProps<T>): T | undefined {
+    if (Utils.isFunction(itemPredicate)) {
         // .find() doesn't exist in ES5. Alternative: use a for loop instead of
         // .filter() so that we can return as soon as we find the first match.
-        for (const item of items) {
-            if (itemEqualsQuery(item, query)) {
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (itemPredicate(query, item, i, true)) {
                 return item;
             }
         }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -480,7 +480,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             // this check is unfortunately O(N) on the number of items, but
             // alas, hiding the "Create Item" option when it exactly matches an
             // existing item is much clearer.
-            !this.wouldCreatedItemMatchSomeExistingItem(this.state.createNewItem)
+            !this.wouldCreatedItemMatchSomeExistingItem()
         );
     }
 
@@ -488,11 +488,11 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         return this.props.createNewItemFromQuery != null && this.props.createNewItemRenderer != null;
     }
 
-    private wouldCreatedItemMatchSomeExistingItem(item: T | undefined) {
+    private wouldCreatedItemMatchSomeExistingItem() {
         // search only the filtered items, not the full items list, because we
         // only need to check items that match the current query.
-        return this.state.filteredItems.some(filteredItem =>
-            executeItemsEqual(this.props.itemsEqual, filteredItem, item),
+        return this.state.filteredItems.some(item =>
+            executeItemsEqual(this.props.itemsEqual, item, this.state.createNewItem),
         );
     }
 }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -480,7 +480,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             // this check is unfortunately O(N) on the number of items, but
             // alas, hiding the "Create Item" option when it exactly matches an
             // existing item is much clearer.
-            !this.doesItemMatchSomeExistingItem(this.state.createNewItem)
+            !this.wouldCreatedItemMatchSomeExistingItem(this.state.createNewItem)
         );
     }
 
@@ -488,10 +488,12 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         return this.props.createNewItemFromQuery != null && this.props.createNewItemRenderer != null;
     }
 
-    private doesItemMatchSomeExistingItem(item: T | undefined, validItems: T[] = this.state.filteredItems) {
+    private wouldCreatedItemMatchSomeExistingItem(item: T | undefined) {
         // search only the filtered items, not the full items list, because we
         // only need to check items that match the current query.
-        return validItems.some(filteredItem => executeItemsEqual(this.props.itemsEqual, filteredItem, item));
+        return this.state.filteredItems.some(filteredItem =>
+            executeItemsEqual(this.props.itemsEqual, filteredItem, item),
+        );
     }
 }
 

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -67,10 +67,10 @@ export interface IQueryListRendererProps<T>  // Omit `createNewItem`, because it
      * match an existing item will emit a new item as created via
      * `createNewItemFromQuery`.
      *
-     * If `itemPredicate` returns multiple matching items for a particular
-     * `value`, then only the first matching item will be emitted.
+     * If `itemPredicate` returns multiple matching items for a particular query
+     * in `queries`, then only the first matching item will be emitted.
      */
-    handlePaste: (values: string[]) => void;
+    handlePaste: (queries: string[]) => void;
 
     /**
      * Keyboard handler for up/down arrow keys to shift the active item.
@@ -369,7 +369,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         }
     };
 
-    private handlePaste = (values: string[]) => {
+    private handlePaste = (queries: string[]) => {
         const { createNewItemFromQuery, onItemsPaste } = this.props;
 
         let nextActiveItem: T | undefined;
@@ -377,21 +377,21 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         // Find an exising item that exactly matches each pasted value, or
         // create a new item if possible. Ignore unmatched values if creating
         // items is disabled.
-        const pastedItemsToEmit = values.reduce<T[]>((agg, value) => {
-            const equalItem = getMatchingItem(value, this.props);
+        const pastedItemsToEmit = [];
+
+        for (const query of queries) {
+            const equalItem = getMatchingItem(query, this.props);
 
             if (equalItem !== undefined) {
                 nextActiveItem = equalItem;
-                agg.push(equalItem);
+                pastedItemsToEmit.push(equalItem);
             } else if (this.canCreateItems()) {
-                const newItem = Utils.safeInvoke(createNewItemFromQuery, value);
+                const newItem = Utils.safeInvoke(createNewItemFromQuery, query);
                 if (newItem !== undefined) {
-                    agg.push(newItem);
+                    pastedItemsToEmit.push(newItem);
                 }
             }
-
-            return agg;
-        }, []);
+        }
 
         // UX nicety: update the active item if we matched with at least one
         // existing item.
@@ -399,7 +399,6 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             this.setActiveItem(nextActiveItem);
         }
 
-        // No need to update the active item.
         Utils.safeInvoke(onItemsPaste, pastedItemsToEmit);
     };
 

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -373,6 +373,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         const { createNewItemFromQuery, onItemsPaste } = this.props;
 
         let nextActiveItem: T | undefined;
+        const nextQueries = [];
 
         // Find an exising item that exactly matches each pasted value, or
         // create a new item if possible. Ignore unmatched values if creating
@@ -390,8 +391,15 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
                 if (newItem !== undefined) {
                     pastedItemsToEmit.push(newItem);
                 }
+            } else {
+                nextQueries.push(query);
             }
         }
+
+        // UX nicety: combine all unmatched queries into a single
+        // comma-separated query in the input, so we don't lose any information.
+        // And don't reset the active item; we'll do that ourselves below.
+        this.setQuery(nextQueries.join(", "), false);
 
         // UX nicety: update the active item if we matched with at least one
         // existing item.

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -84,7 +84,6 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             <this.TypedQueryList
                 {...restProps}
                 onItemSelect={this.handleItemSelect}
-                onItemsPaste={this.handleItemsPaste}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
@@ -142,10 +141,6 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             this.input.focus();
         }
         Utils.safeInvoke(this.props.onItemSelect, item, evt);
-    };
-
-    private handleItemsPaste = (items: T[]) => {
-        Utils.safeInvoke(this.props.onItemsPaste, items);
     };
 
     private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -14,6 +14,7 @@ import {
     Popover,
     Position,
     TagInput,
+    TagInputAddMethod,
     Utils,
 } from "@blueprintjs/core";
 import { Classes, IListItemsProps } from "../../common";
@@ -83,6 +84,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             <this.TypedQueryList
                 {...restProps}
                 onItemSelect={this.handleItemSelect}
+                onItemsPaste={this.handleItemsPaste}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
@@ -92,7 +94,13 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const { tagInputProps = {}, popoverProps = {}, selectedItems = [], placeholder } = this.props;
-        const { handleKeyDown, handleKeyUp } = listProps;
+        const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
+
+        const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {
+            if (method === TagInputAddMethod.PASTE) {
+                handlePaste(values);
+            }
+        };
 
         return (
             <Popover
@@ -117,6 +125,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         inputRef={this.refHandlers.input}
                         inputValue={listProps.query}
+                        onAdd={handleTagInputAdd}
                         onInputChange={listProps.handleQueryChange}
                         values={selectedItems.map(this.props.tagRenderer)}
                     />
@@ -133,6 +142,10 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             this.input.focus();
         }
         Utils.safeInvoke(this.props.onItemSelect, item, evt);
+    };
+
+    private handleItemsPaste = (items: T[]) => {
+        Utils.safeInvoke(this.props.onItemsPaste, items);
     };
 
     private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -97,7 +97,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 
         const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {
-            if (method === TagInputAddMethod.PASTE) {
+            if (method === "paste") {
                 handlePaste(values);
             }
         };

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -207,6 +207,7 @@ describe("<QueryList>", () => {
             assert.isTrue(onItemsPaste.calledOnce);
             assert.deepEqual(onItemsPaste.args[0][0], [TOP_100_FILMS[0]]);
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
+            assert.deepEqual(filmQueryList.state().query, "");
         });
 
         it("convert multiple pasted values into items", () => {
@@ -228,25 +229,28 @@ describe("<QueryList>", () => {
             assert.deepEqual(onItemsPaste.args[0][0], [item1, item2, item3]);
             // Highlight the last item pasted.
             assert.deepEqual(filmQueryList.state().activeItem, item3);
+            assert.deepEqual(filmQueryList.state().query, "");
         });
 
-        it("ignores unrecognized values by default", () => {
+        it("concatenates unrecognized values into the ghost input by default", () => {
             const { filmQueryList, handlePaste } = mountForPasteTest();
 
-            const item1 = TOP_100_FILMS[6];
-            const item3 = TOP_100_FILMS[3];
+            const item2 = TOP_100_FILMS[6];
+            const item4 = TOP_100_FILMS[3];
 
-            const pastedValue1 = item1.title;
-            const pastedValue2 = "unrecognized";
-            const pastedValue3 = item3.title;
+            const pastedValue1 = "unrecognized1";
+            const pastedValue2 = item2.title;
+            const pastedValue3 = "unrecognized2";
+            const pastedValue4 = item4.title;
 
-            handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+            handlePaste([pastedValue1, pastedValue2, pastedValue3, pastedValue4]);
 
             assert.isTrue(onItemsPaste.calledOnce);
             // Emits just the 2 valid items.
-            assert.deepEqual(onItemsPaste.args[0][0], [item1, item3]);
+            assert.deepEqual(onItemsPaste.args[0][0], [item2, item4]);
             // Highlight the last item pasted.
-            assert.deepEqual(filmQueryList.state().activeItem, item3);
+            assert.deepEqual(filmQueryList.state().activeItem, item4);
+            assert.deepEqual(filmQueryList.state().query, "unrecognized1, unrecognized2");
         });
 
         it("creates new items out of unrecognized values if 'Create item' option is enabled", () => {
@@ -275,6 +279,7 @@ describe("<QueryList>", () => {
             assert.deepEqual(onItemsPaste.args[0][0], [item1, item2, createdItem]);
             // Highlight the last *already existing* item pasted.
             assert.deepEqual(filmQueryList.state().activeItem, item2);
+            assert.deepEqual(filmQueryList.state().query, "");
         });
     });
 });

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -11,7 +11,14 @@ import * as sinon from "sinon";
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IQueryListProps } from "@blueprintjs/select";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
-import { IQueryListRendererProps, IQueryListState, ItemListPredicate, ItemListRenderer, QueryList } from "../src/index";
+import {
+    IQueryListRendererProps,
+    IQueryListState,
+    ItemListPredicate,
+    ItemListRenderer,
+    ItemPredicate,
+    QueryList,
+} from "../src/index";
 
 type FilmQueryListWrapper = ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>>;
 
@@ -157,5 +164,117 @@ describe("<QueryList>", () => {
 
     describe("scrolling", () => {
         it("brings active item into view");
+    });
+
+    describe("pasting", () => {
+        const onItemsPaste = sinon.spy();
+
+        const itemPredicate: ItemPredicate<IFilm> = (query: string, film: IFilm, _i?: number, exactMatch?: boolean) => {
+            return exactMatch === true ? query.toLowerCase() === film.title.toLowerCase() : true;
+        };
+
+        function mountForPasteTest(overrideProps: Partial<IQueryListProps<IFilm>> = {}) {
+            // Placeholder. This will be overwritten by the mounted component.
+            let handlePaste: (queries: string[]) => void;
+
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                itemPredicate,
+                onItemsPaste,
+                renderer: sinon.spy((listItemsProps: IQueryListRendererProps<IFilm>) => {
+                    handlePaste = listItemsProps.handlePaste;
+                    return testProps.renderer(listItemsProps);
+                }),
+                ...overrideProps,
+            };
+
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            // `handlePaste` will have been set by now, because `props.renderer`
+            // will have been called.
+            return { filmQueryList, handlePaste: handlePaste! };
+        }
+
+        afterEach(() => {
+            onItemsPaste.resetHistory();
+        });
+
+        it("converts 1 pasted value into an item", () => {
+            const { filmQueryList, handlePaste } = mountForPasteTest();
+
+            const pastedValue = TOP_100_FILMS[0].title;
+            handlePaste([pastedValue]);
+
+            assert.isTrue(onItemsPaste.calledOnce);
+            assert.deepEqual(onItemsPaste.args[0][0], [TOP_100_FILMS[0]]);
+            assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
+        });
+
+        it("convert multiple pasted values into items", () => {
+            const { filmQueryList, handlePaste } = mountForPasteTest();
+
+            // Paste items in unsorted order for fun.
+            const item1 = TOP_100_FILMS[6];
+            const item2 = TOP_100_FILMS[0];
+            const item3 = TOP_100_FILMS[3];
+
+            const pastedValue1 = item1.title;
+            const pastedValue2 = item2.title;
+            const pastedValue3 = item3.title;
+
+            handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+
+            assert.isTrue(onItemsPaste.calledOnce);
+            // Emits all three items.
+            assert.deepEqual(onItemsPaste.args[0][0], [item1, item2, item3]);
+            // Highlight the last item pasted.
+            assert.deepEqual(filmQueryList.state().activeItem, item3);
+        });
+
+        it("ignores unrecognized values by default", () => {
+            const { filmQueryList, handlePaste } = mountForPasteTest();
+
+            const item1 = TOP_100_FILMS[6];
+            const item3 = TOP_100_FILMS[3];
+
+            const pastedValue1 = item1.title;
+            const pastedValue2 = "unrecognized";
+            const pastedValue3 = item3.title;
+
+            handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+
+            assert.isTrue(onItemsPaste.calledOnce);
+            // Emits just the 2 valid items.
+            assert.deepEqual(onItemsPaste.args[0][0], [item1, item3]);
+            // Highlight the last item pasted.
+            assert.deepEqual(filmQueryList.state().activeItem, item3);
+        });
+
+        it("creates new items out of unrecognized values if 'Create item' option is enabled", () => {
+            const createdRank = 0;
+            const createdYear = 2019;
+
+            const { filmQueryList, handlePaste } = mountForPasteTest({
+                // Must pass these two props to enable the "Create item" option.
+                createNewItemFromQuery: query => ({ title: query, rank: createdRank, year: createdYear }),
+                createNewItemRenderer: () => <div>Create item</div>,
+            });
+
+            const item1 = TOP_100_FILMS[6];
+            const item2 = TOP_100_FILMS[3];
+
+            const pastedValue1 = item1.title;
+            const pastedValue2 = item2.title;
+            // Paste this item last.
+            const pastedValue3 = "unrecognized";
+
+            handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+            const createdItem = { title: "unrecognized", rank: createdRank, year: createdYear };
+
+            assert.isTrue(onItemsPaste.calledOnce);
+            // Emits 2 existing items and 1 newly created item.
+            assert.deepEqual(onItemsPaste.args[0][0], [item1, item2, createdItem]);
+            // Highlight the last *already existing* item pasted.
+            assert.deepEqual(filmQueryList.state().activeItem, item2);
+        });
     });
 });


### PR DESCRIPTION
#### (No issue)

### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

### Changes proposed in this pull request:

Allow pasting of multiple values in `MultiSelect`.

#### Given:

The clipboard contains separated values (where the separator is configurable via `tagInputProps.separator`):

![image](https://user-images.githubusercontent.com/443450/54570304-4d785100-499b-11e9-9e64-55c31e367cc0.png)

#### You can now:

* Select multiple _existing_ items on paste:
    ![2019-03-18 16 29 21](https://user-images.githubusercontent.com/443450/54570337-6da81000-499b-11e9-9023-b83c9323409b.gif)
* _(If the "Create item" option is enabled)_
    Select a combination of _existing_ and _newly created_ items on paste:
    ![2019-03-18 16 34 22](https://user-images.githubusercontent.com/443450/54570440-b52e9c00-499b-11e9-9827-9a862cc3f4e2.gif)

* _(If the "Create item" option is enabled)_
    Select all _newly created_ items on paste:
    ![2019-03-18 16 36 55](https://user-images.githubusercontent.com/443450/54570524-10608e80-499c-11e9-8226-e85d0ace7238.gif)

* _(UX nicety)_
   If a pasted value is already selected, set that item as the active item on paste:
    _In general, the code moves the active item to the final existing item amongst the pasted values._
    ![2019-03-18 16 39 15](https://user-images.githubusercontent.com/443450/54570639-836a0500-499c-11e9-944f-70526381f835.gif)


### Reviewers should focus on:

I originally tried to implement this outside of `MultiSelect` in a wrapping component (by listening to `tagInputProps.onAdd`, which is invoked when values are added via paste), but that didn't work.

First, note that adding values via pasting does _not_ invoke our normal on-select listeners, but it does still invoke `tagInputProps.onAdd`. Thus, we have to explicitly invoke `onItemSelect` or similar from within `tagInputProps.onAdd` in order for pasted values to be emitted.

Unfortunately, when you emit `onItemSelect` from `tagInputProps.onAdd`, you end up double-invoking it in the default selection case, which leads to a bug. In particular, pressing <kbd>Enter</kbd> or clicking to select an item will emit `onItemSelect` from `tagInputProps.onAdd`, then by the time the `MultiSelect` change handler is invoked, the pasted value will already be selected, and it would  be toggled to _deselected_ immediately.

In this PR, I now have `TagInput`'s `onAdd` emit a second parameter of type `TagInputAddMethod`, which tells callers _how_ the emitted values were added (`default`, on `blur`, or on `paste`).¹  Only if the values were added via `paste` do I take special action to select matching items or create new ones if possible; otherwise, I don't do anything, and the `MultiSelect` component behaves just as before. The second parameter here can be safely ignored, which avoids API breaks.

---

¹ This consolidates logic, because parent components won't need to do any key listening to figure out if a particular keydown will trigger a paste.

❌ In that world, you might have to do something 🤡clowny like this:
```tsx
class MyWrapper extends React.PureComponent {
    private wasLastKeyDownAPasteOperation = false; 

    // render a MultiSelect, and pass tagInputProps: { onAdd: this.handleTagInputAdd } 
    private handleKeyDown(e) {
        this.wasLastKeyDownAPasteOperation = e.which === Keys.LETTER_V && e.metaKey;
    }
    private handleTagInputAdd(values: string) {
        if (this.wasLastKeyDownAPasteOperation) {
            // Then we know the values were added on paste, which would have
            // bypassed our normal key and click selection listeners. We'll need
            // to emit the values manually. 
        }
    }
}
```


### Screenshot

See above.
