### PR TITLE
fix: fix react-day-picker api link broken

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -51,7 +51,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
 
     /**
      * Props to pass to ReactDayPicker. See API documentation
-     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     * [here](http://react-day-picker.js.org/api/DayPicker).
      *
      * The following props are managed by the component and cannot be configured:
      * `canChangeMonth`, `captionElement`, `fromMonth` (use `minDate`), `month` (use

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -26,7 +26,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Props to pass to ReactDayPicker. See API documentation
-     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     * [here](http://react-day-picker.js.org/api/DayPicker).
      *
      * The following props are managed by the component and cannot be configured:
      * `canChangeMonth`, `captionElement`, `fromMonth` (use `minDate`), `month` (use

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -12,7 +12,7 @@ import { ITimePickerProps, TimePrecision } from "./timePicker";
 // also we need an interface for the dictionary without `today` and `outside` injected by r-d-p.
 /**
  * Collection of functions that determine which modifier classes get applied to which days.
- * See the [**react-day-picker** documentation](http://react-day-picker.js.org/Modifiers.html) to learn more.
+ * See the [**react-day-picker** documentation](http://react-day-picker.js.org/api/ModifiersUtils) to learn more.
  */
 export interface IDatePickerModifiers {
     [name: string]: (date: Date) => boolean;
@@ -50,7 +50,7 @@ export interface IDatePickerBaseProps {
     /**
      * Collection of functions that determine which modifier classes get applied to which days.
      * Each function should accept a `Date` and return a boolean.
-     * See the [**react-day-picker** documentation](http://react-day-picker.js.org/Modifiers.html) to learn more.
+     * See the [**react-day-picker** documentation](http://react-day-picker.js.org/api/ModifiersUtils) to learn more.
      */
     modifiers?: IDatePickerModifiers;
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -56,7 +56,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatP
 
     /**
      * Props to pass to ReactDayPicker. See API documentation
-     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     * [here](http://react-day-picker.js.org/api/DayPicker).
      *
      * The following props are managed by the component and cannot be configured:
      * `canChangeMonth`, `captionElement`, `numberOfMonths`, `fromMonth` (use

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -59,7 +59,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     contiguousCalendarMonths?: boolean;
     /**
      * Props to pass to ReactDayPicker. See API documentation
-     * [here](http://react-day-picker.js.org/docs/api-daypicker.html).
+     * [here](http://react-day-picker.js.org/api/DayPicker).
      *
      * The following props are managed by the component and cannot be configured:
      * `canChangeMonth`, `captionElement`, `numberOfMonths`, `fromMonth` (use


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The origin link to `http://react-day-picker.js.org/Modifiers.html` is 404, and it can not be redirected to a correct page.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
