### PR TITLE
set clearButton ternary to return undefined

### DIFF
--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -76,7 +76,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 
-        const clearButton = 
+        const clearButton =
             films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : undefined;
 
         return (

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -76,7 +76,12 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 
-        const clearButton = films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : undefined;
+        const clearButton = films.length > 0 ? (
+            <Button icon="cross" minimal={true} onClick={this.handleClear} /> 
+        ) : (
+            // rightElement takes an Element | undefined, so pass undefined as fallback
+            undefined
+        );
 
         return (
             <Example options={this.renderOptions()} {...this.props}>

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -76,12 +76,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 
-        const clearButton = films.length > 0 ? (
-            <Button icon="cross" minimal={true} onClick={this.handleClear} /> 
-        ) : (
-            // rightElement takes an Element | undefined, so pass undefined as fallback
-            undefined
-        );
+        const clearButton = 
+            films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : undefined;
 
         return (
             <Example options={this.renderOptions()} {...this.props}>

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -76,7 +76,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 
-        const clearButton = films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : null;
+        const clearButton = films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : undefined;
 
         return (
             <Example options={this.renderOptions()} {...this.props}>


### PR DESCRIPTION
#### Changes proposed in this pull request:

Change secondary return on ternary operator to be undefined rather than null. The rightElement property of tagInputProps takes either an Element or undefined, but not null. The current example has it being passed null if the length of films is 0. 

#### Screenshot
![errorMultiSelect](https://user-images.githubusercontent.com/28321156/54771697-2b214600-4bdc-11e9-9548-175e19c0fc24.PNG)

