### PR TITLE
Prepare release v3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-See **[3.0 Changelog](https://github.com/palantir/blueprint/wiki/3.0-Changelog)** wiki page for 3.x release notes.
+See **[3.x Changelog](https://github.com/palantir/blueprint/wiki/3.x-Changelog)** wiki page for 3.x release notes.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is optimized for building complex, data-dense web interfaces for _desktop app
 
 ## Latest changelog
 
-[**3.x Changelog and 3.0 migration guide ▸**](https://github.com/palantir/blueprint/wiki/3.0-Changelog)
+[**3.x Changelog and 3.0 migration guide ▸**](https://github.com/palantir/blueprint/wiki/3.x-Changelog)
 
 Blueprint 3.0 brings support for using multiple major versions of Blueprint on the same web page. This is possible through the removal of global styles and by deconflicting CSS selectors. It also restores support for React 15 as a peer dependency in most packages.
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,4 @@ running any of the dev scripts.
 
 ## License
 
-This project is made available under its own **Blueprint License**, based on Apache 2.0 License.
-
-The only modification is an additional section (paragraph 10) in which we ask
-that you do not pass off any derivative products as Palantir’s products, given
-that Blueprint is a design toolkit.
+This project is made available under the Apache 2.0 License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprintjs-monorepo",
-  "version": "3.14.1",
+  "version": "3.15.0",
   "private": true,
   "description": "A React UI toolkit for the web.",
   "workspaces": [

--- a/packages/docs-app/src/whats-new-3.0.md
+++ b/packages/docs-app/src/whats-new-3.0.md
@@ -18,6 +18,6 @@ Blueprint 3.0 supports multiple major versions of Blueprint on the same page thr
 - Many new components! Look for the <span class="@ns-tag @ns-intent-success @ns-minimal">new</span> tag in the sidebar.
 - Complete refactor of documentation content to focus on React usage and de-emphasize CSS/HTML usage.
 
-<a class="@ns-button @ns-intent-primary" href="https://github.com/palantir/blueprint/wiki/3.0-Changelog" target="_blank" style="margin-top: 30px;">
+<a class="@ns-button @ns-intent-primary" href="https://github.com/palantir/blueprint/wiki/3.x-Changelog" target="_blank" style="margin-top: 30px;">
     View the full changelog on the wiki
 </a>

--- a/packages/landing-app/src/index.html
+++ b/packages/landing-app/src/index.html
@@ -61,7 +61,7 @@
       <div class="landing-copyright">
         <div class="landing-container">
           <div id="copyright">© 2014–2018 Palantir Technologies</div>
-          <div>Licensed under <a href="https://github.com/palantir/blueprint/blob/develop/LICENSE" target="_blank">Blueprint License</a></div>
+          <div>Licensed under <a href="https://github.com/palantir/blueprint/blob/develop/LICENSE" target="_blank">Apache-2.0</a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### `@blueprintjs/core 3.15.0`

- Switch to standard Apache-2.0 license (#3457)
- Checkbox: fix indeterminate state update (#3409)
- TagInput: use undefined instead of null to hide clearButton (#3436)
- PanelStack: Add z-index to panel stack header to fix layout issue (#3414)
- TextArea: Add `growVertically` prop to allow component to grow height with input text (#3398)
- Drawer: Add `position` prop, deprecate `vertical` prop (#3386)

### `@blueprintjs/datetime 3.8.0`

- Switch to standard Apache-2.0 license (#3457)
- Fix react-day-picker API hyperlink in documentation (#3435)

### `@blueprintjs/icons 3.7.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/select 3.8.0`

- Switch to standard Apache-2.0 license (#3457)
- Select: hide QueryList item list when menuContent and createItemView are both null (#3426)
- MultiSelect: Enable pasting of multiple values (same as TagInput) (#3428) 

### `@blueprintjs/table 3.5.0`

- Switch to standard Apache-2.0 license (#3457)
- Fix resizable props documentation (#3400)

### `@blueprintjs/timezone 3.4.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/docs-theme 3.1.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/karma-build-scripts 0.10.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/node-build-scripts 0.9.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/test-commons 0.9.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/tslint-config 1.8.0`

- Switch to standard Apache-2.0 license (#3457)

### `@blueprintjs/webpack-build-scripts 0.8.0`

- Switch to standard Apache-2.0 license (#3457)