### PR TITLE
[datetime] Fix DateInput under Internet Explorer 11

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -379,8 +379,16 @@ export class DateInput extends AbstractPureComponent<IDateInputProps, IDateInput
 
     // focus DOM event listener (not React event)
     private handlePopoverBlur = (e: FocusEvent) => {
-        const relatedTarget = e.relatedTarget as HTMLElement;
-        if (relatedTarget == null || !this.popoverContentEl.contains(relatedTarget)) {
+        let relatedTarget = e.relatedTarget as HTMLElement;
+        if (relatedTarget == null) {
+            // Support IE11 (#2924)
+            relatedTarget = document.activeElement as HTMLElement;
+        }
+        // Beware: this.popoverContentEl is sometimes null under Chrome
+        if (
+            relatedTarget == null ||
+            (this.popoverContentEl != null && !this.popoverContentEl.contains(relatedTarget))
+        ) {
             this.handleClosePopover();
         } else if (relatedTarget != null) {
             this.unregisterPopoverBlurHandler();


### PR DESCRIPTION
#### Fixes palantir/blueprint#2924

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
Add support for IE11 by using this check: https://stackoverflow.com/a/49325196
Tested under IE11, Firefox (60 ESR) and Chrome (73).

#### Reviewers should focus on:

<!-- Fill this out. -->
Note: testing under IE11 was slightly hindered by the fact that `yarn dev` (or `yarn dev:datetime`) gives an error: 
![Screenshot - 090419 - 15:06:34](https://user-images.githubusercontent.com/445238/55805184-34684900-5ade-11e9-80ae-fb9ca4967e4e.png)
so I had to test it using our own application. And while testing the fix under Chrome, it turned out that `this.popoverContentEl` was sometimes `null` (hence the comment and the extra check).
Also, `yarn.lock` in `develop` appears out of date.