### PR TITLE
Fix for NumericInput throws type error when value=null #3479

### DIFF
--- a/packages/core/src/components/forms/numeric-input.md
+++ b/packages/core/src/components/forms/numeric-input.md
@@ -106,7 +106,7 @@ import * as SomeLibrary from "some-library";
 
 export class NumericInputExample extends React.Component<{}, { value?: number |
 string }> {
-    public state = { value: null };
+    public state = { value: NumericInput.VALUE_EMPTY };
 
     public render() {
         return (


### PR DESCRIPTION
#### Fixes #3479

#### Checklist

- Updated documentation

#### Changes proposed in this pull request:

Made initial state of NumericInput value as NumericInput.VALUE_EMPTY instead of null

#### Reviewers should focus on:

NumericInput documentation update
