### PR TITLE
Fix accidental markdown strikethrough

### DIFF
--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -3,8 +3,8 @@
 Popovers display floating content next to a target element.
 
 `Popover` is built on top of the [__Popper.js__](https://popper.js.org) library.
-Popper.js is a small (~6kb) library that offers a powerful, customizable
-positioning engine and operates at blazing speed (~60fps).
+Popper.js is a small (`~6kb`) library that offers a powerful, customizable
+positioning engine and operates at blazing speed (`~60fps`).
 
 @reactExample PopoverExample
 


### PR DESCRIPTION
- Incorrectly showed up as strikethrough text on https://blueprintjs.com/docs/#core/components/popover