### PR TITLE
Change activeItem when items change

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -196,7 +196,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             this.shouldCheckActiveItemInViewport = true;
             this.setState({ activeItem: nextProps.activeItem });
         }
-        if (nextProps.query != null) {
+        if (nextProps.query != null && nextProps.query !== this.props.query) {
             this.setQuery(nextProps.query, nextProps.resetOnQuery, nextProps);
         }
     }
@@ -278,7 +278,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             activeIndex < 0 ||
             isItemDisabled(getActiveItem(this.state.activeItem), activeIndex, props.itemDisabled);
 
-        if (hasQueryChanged && shouldUpdateActiveItem) {
+        if (shouldUpdateActiveItem) {
             this.setActiveItem(getFirstEnabledItem(filteredItems, props.itemDisabled));
         }
     }

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -20,7 +20,7 @@ import * as sinon from "sinon";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IQueryListProps } from "@blueprintjs/select";
-import { IFilm, renderFilm, TOP_100_FILMS } from "@blueprintjs/docs-app";
+import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import {
     IQueryListRendererProps,
     IQueryListState,

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -20,7 +20,7 @@ import * as sinon from "sinon";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IQueryListProps } from "@blueprintjs/select";
-import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
+import { IFilm, renderFilm, TOP_100_FILMS } from "@blueprintjs/docs-app";
 import {
     IQueryListRendererProps,
     IQueryListState,
@@ -134,6 +134,20 @@ describe("<QueryList>", () => {
             filmQueryList.setProps({
                 items: [TOP_100_FILMS[1]],
                 query: "123",
+            });
+            assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[1]);
+        });
+
+        it("ensure activeItem changes on when no longer in new items", () => {
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                items: [TOP_100_FILMS[0]],
+                query: "abc",
+            };
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
+            filmQueryList.setProps({
+                items: [TOP_100_FILMS[1]],
             });
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[1]);
         });


### PR DESCRIPTION
#### Fixes #3507 

Seems https://github.com/palantir/blueprint/pull/3072 broke the activeItem changing when items change. This is a better fix for the original issue.

#### Checklist

- [ X ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- setQuery runs when when query changes
- remove the guard in part of setQuery to see if the query changed

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
