### PR TITLE
do not hack date if showing singleMonthOnly

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -194,7 +194,7 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
         // subtracting one avoids that weird, wraparound state (#289).
         const initialMonthEqualsMinMonth = DateUtils.areSameMonth(initialMonth, props.minDate);
         const initalMonthEqualsMaxMonth = DateUtils.areSameMonth(initialMonth, props.maxDate);
-        if (!initialMonthEqualsMinMonth && initalMonthEqualsMaxMonth) {
+        if (!props.singleMonthOnly && !initialMonthEqualsMinMonth && initalMonthEqualsMaxMonth) {
             initialMonth.setMonth(initialMonth.getMonth() - 1);
         }
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -308,6 +308,13 @@ describe("<DateRangePicker>", () => {
             render({ maxDate, minDate, value }).left.assertMonthYear(Months.APRIL, 2007);
         });
 
+        it("has correct initial month on singleMonthOnly and maxDate == initialMonth", () => {
+            const maxDate = new Date(2019, Months.MAY, 6);
+            const minDate = new Date(2019, Months.MARCH, 3);
+            const initialMonth = maxDate;
+            render({ singleMonthOnly: true, maxDate, minDate, initialMonth }).left.assertMonthYear(Months.MAY, 2019);
+        });
+
         it("is (endDate - 1 month) if only endDate is set", () => {
             const value = [null, new Date(2007, Months.APRIL, 4)] as DateRange;
             render({ value }).left.assertMonthYear(Months.MARCH, 2007);


### PR DESCRIPTION
#### Fixes #3432

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add a check to prevent hacking the initial month if singleMonthOnly is true. This was causing it to render the previous month if initialMonth was the same month as maxDate.

I think line 197 only considered for when two months are shown. (See the comment on line 191)

#### Reviewers should focus on:

Any details about DateRangePicker that I may be unaware of. I recreated the issue locally and tested the fix with a yarn link. Here is a code snippet that will recreate the issue: 
```
  <DateRangePicker singleMonthOnly initialMonth={new Date(2019, Months.MAY, 6)} minDate={new Date(2019, Months.MARCH, 3)} maxDate={new Date(2019, Months.MAY, 6)}/>
```
