### PR TITLE
Date range picker inconsistency when single day range and time precis…

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -289,11 +289,11 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             return null;
         }
 
-        const { allowSingleDayRange, maxDate, minDate } = this.props;
+        const { allowSingleDayRange, maxDate, minDate, timePrecision } = this.props;
         return [
             <Shortcuts
                 key="shortcuts"
-                {...{ allowSingleDayRange, maxDate, minDate, shortcuts }}
+                {...{ allowSingleDayRange, maxDate, minDate, shortcuts, timePrecision }}
                 onShortcutClick={this.handleShortcutClick}
             />,
             <Divider key="div" />,

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -18,6 +18,7 @@ import { Classes, Menu, MenuItem } from "@blueprintjs/core";
 import * as React from "react";
 import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
 import { clone, DateRange, isDayRangeInRange } from "./common/dateUtils";
+import { TimePrecision } from "./timePicker";
 
 export interface IDateRangeShortcut {
     /** Shortcut label that appears in the list. */
@@ -44,6 +45,7 @@ export interface IShortcutsProps {
     minDate: Date;
     maxDate: Date;
     shortcuts: IDateRangeShortcut[] | true;
+    timePrecision: TimePrecision;
     onShortcutClick: (shortcut: IDateRangeShortcut) => void;
 }
 
@@ -51,7 +53,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
     public render() {
         const shortcuts =
             this.props.shortcuts === true
-                ? createDefaultShortcuts(this.props.allowSingleDayRange)
+                ? createDefaultShortcuts(this.props.allowSingleDayRange, this.props.timePrecision !== undefined)
                 : this.props.shortcuts;
 
         const shortcutElements = shortcuts.map((s, i) => (
@@ -80,7 +82,7 @@ function createShortcut(label: string, dateRange: DateRange): IDateRangeShortcut
     return { dateRange, label };
 }
 
-function createDefaultShortcuts(allowSingleDayRange: boolean) {
+function createDefaultShortcuts(allowSingleDayRange: boolean, hasTimePrecision: boolean) {
     const today = new Date();
     const makeDate = (action: (d: Date) => void) => {
         const returnVal = clone(today);
@@ -89,6 +91,7 @@ function createDefaultShortcuts(allowSingleDayRange: boolean) {
         return returnVal;
     };
 
+    const tomorrow = makeDate(() => null);
     const yesterday = makeDate(d => d.setDate(d.getDate() - 2));
     const oneWeekAgo = makeDate(d => d.setDate(d.getDate() - 7));
     const oneMonthAgo = makeDate(d => d.setMonth(d.getMonth() - 1));
@@ -98,7 +101,10 @@ function createDefaultShortcuts(allowSingleDayRange: boolean) {
     const twoYearsAgo = makeDate(d => d.setFullYear(d.getFullYear() - 2));
 
     const singleDayShortcuts = allowSingleDayRange
-        ? [createShortcut("Today", [today, today]), createShortcut("Yesterday", [yesterday, yesterday])]
+        ? [
+              createShortcut("Today", [today, hasTimePrecision ? tomorrow : today]),
+              createShortcut("Yesterday", [yesterday, hasTimePrecision ? today : yesterday]),
+          ]
         : [];
 
     return [

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -899,6 +899,19 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(today, value[1]));
         });
 
+        it("shortcuts fire onChange with correct values when single day range and allowSingleDayRange enabled", () => {
+            render({ allowSingleDayRange: true, timePrecision: "minute" }).clickShortcut();
+
+            const today = new Date();
+            const tomorrow = DateUtils.clone(today);
+            tomorrow.setDate(today.getDate() + 1);
+
+            assert.isTrue(onChangeSpy.calledOnce);
+            const value = onChangeSpy.args[0][0];
+            assert.isTrue(DateUtils.areSameDay(today, value[0]));
+            assert.isTrue(DateUtils.areSameDay(tomorrow, value[1]));
+        });
+
         it("custom shortcuts select the correct values", () => {
             const dateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)] as DateRange;
             render({


### PR DESCRIPTION
#### Fixes #3449

#### Checklist

-  Includes tests

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

If the date range picker has single day range and timePrecision set, selecting today or tomorrow shortcut will make the 'to date' as corresponding next day.

