### PR TITLE
[core] Fix number of clicks required to use HTMLSelect inside ControlGroup in Firefox

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -106,7 +106,6 @@ Styleguide control-group
 
     &:focus {
       // establish new stacking context so focus state covers neighbors
-      position: relative;
       z-index: index($control-group-stack, "button-focus");
     }
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -100,12 +100,12 @@ Styleguide control-group
   .#{$ns}-button,
   .#{$ns}-html-select select,
   .#{$ns}-select select {
+    @include new-render-layer();
     z-index: index($control-group-stack, "button-default");
     // inherit radius since it's most likely to be zero
     border-radius: inherit;
 
     &:focus {
-      // establish new stacking context so focus state covers neighbors
       z-index: index($control-group-stack, "button-focus");
     }
 


### PR DESCRIPTION
#### Fixes #3554

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Removed `position: relative;` which was there to create a new stacking context.

#### Reviewers should focus on:
Not sure why this caused the issue but there is already `z-index` to create a stacking context, `position: relative` may not be needed.
