### PR TITLE
docs: allow scrolling the props table inside drawer

### DIFF
--- a/packages/docs-theme/src/styles/_api.scss
+++ b/packages/docs-theme/src/styles/_api.scss
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: column;
     margin: 0;
+    height: 100%;
   }
 
   .docs-interface-header {


### PR DESCRIPTION
#### Fixes

`.docs-modifiers-table` has an `overflow-auto` in an attempt to allow scrolling when it overflows it's container's height. Since `.docs-modifiers` is `display: flex`, it is filling to the height of it's children (docs-modifiers-table) so no overflow happens and you are un-able to scroll to see the rest of the props.

This has really been bothering me as I'm using the docs...so I've decided to fix it for you.

#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

Adding a height to `.docs-modifiers` will allow `.docs-modifiers-table` to overflow and you will be able to scroll the page.

#### Reviewers should focus on:

1. Open any drawer in the docs and try to scroll. 
2. Add a `height: 100%` to the `.docs-modifiers` element
3. You can scroll again, whoo

#### Screenshot

![May-29-2019 15-07-02](https://user-images.githubusercontent.com/7423098/58587645-7e8ac280-8223-11e9-81f4-1a390f3574fa.gif)
