### PR TITLE
Fix TagInput's Tags overflowing the container

### DIFF
--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -36,6 +36,8 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 
     align-self: stretch;
     margin-top: $tag-input-padding;
     margin-right: $tag-input-icon-padding;
+    // allow tags to ellipse and not overflow the container
+    min-width: 0;
 
     // use the larger, conventional input padding when there are no tags and no left icon present.
     // see: https://github.com/palantir/blueprint/issues/2872


### PR DESCRIPTION

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Flexboxes default values for `min-width` is always `auto`. This means that that the size for that element will be at least its contents size.

This problem shows in the TagInput component where if the tag is too large it's going to overflow the container ignoring the parent width. The fix for that is just setting min-width to be 0 in the container (tag-input-values).

#### Screenshot

Before: 
![image](https://user-images.githubusercontent.com/680445/59348686-0e4a6980-8d18-11e9-88f6-568157006992.png)

After:
![image](https://user-images.githubusercontent.com/680445/59348679-05599800-8d18-11e9-88b4-5137374556ca.png)
