### PR TITLE
[Core] Fixed not applying intent color for icon inside menu component

### DIFF
--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -52,6 +52,15 @@ Styleguide menu
   @include menu-item();
   @include menu-item-intent();
 
+  #{$icon-classes} {
+    color: $pt-icon-color;
+    @each $intent, $colors in $pt-intent-colors {
+      &.#{$ns}-intent-#{$intent} {
+        @include intent-color($intent);
+      }
+    }
+  }
+
   &::before {
     // support pt-icon-* classes directly on this element
     @include pt-icon();
@@ -152,6 +161,15 @@ Styleguide menu-header
 
   .#{$ns}-menu-item {
     @include menu-item-intent($pt-dark-intent-text-colors);
+
+    #{$icon-classes} {
+      color: $pt-icon-color;
+      @each $intent, $colors in $pt-intent-colors {
+        &.#{$ns}-intent-#{$intent} {
+          @include intent-color($intent);
+        }
+      }
+    }
 
     &::before,
     > .#{$ns}-icon {

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Classes, Icon, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { Classes, Icon, Intent, Menu, MenuDivider, MenuItem } from '@blueprintjs/core'
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 
 export class MenuExample extends React.PureComponent<IExampleProps, {}> {
@@ -30,7 +30,7 @@ export class MenuExample extends React.PureComponent<IExampleProps, {}> {
                     <MenuItem icon="new-object" text="New object" />
                     <MenuItem icon="new-link" text="New link" />
                     <MenuDivider />
-                    <MenuItem icon="cog" labelElement={<Icon icon="share" />} text="Settings..." />
+                    <MenuItem icon={<Icon icon="cog" intent={Intent.PRIMARY} />} labelElement={<Icon icon="share" />} text="Settings..." />
                 </Menu>
                 <Menu className={Classes.ELEVATION_1}>
                     <MenuDivider title="Edit" />


### PR DESCRIPTION
#### Fixes #3593 


- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixed not applying intent color for icons inside menu component


![Screenshot_2019-06-13 Blueprint – Documentation copy](https://user-images.githubusercontent.com/2925620/59463824-2230c100-8e27-11e9-877c-2fc345c39de6.png)
![Screenshot_2019-06-13 Blueprint – Documentation](https://user-images.githubusercontent.com/2925620/59463830-252bb180-8e27-11e9-98f3-2a89cc0e5d0c.png)
