### PR TITLE
Consumers of DateRangeInput can now disable specific date inputs.

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -339,9 +339,9 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
         }
     }
+
     private renderInputGroup = (boundary: Boundary) => {
         const inputProps = this.getInputProps(boundary);
-
         const handleInputEvent = boundary === Boundary.START ? this.handleStartInputEvent : this.handleEndInputEvent;
 
         return (

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -339,7 +339,6 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
         }
     }
-    
     private renderInputGroup = (boundary: Boundary) => {
         const inputProps = this.getInputProps(boundary);
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -339,7 +339,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
         }
     }
-
+    
     private renderInputGroup = (boundary: Boundary) => {
         const inputProps = this.getInputProps(boundary);
 
@@ -348,8 +348,8 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         return (
             <InputGroup
                 autoComplete="off"
+                disabled={inputProps.disabled || this.props.disabled}
                 {...inputProps}
-                disabled={this.props.disabled}
                 intent={this.isInputInErrorState(boundary) ? Intent.DANGER : inputProps.intent}
                 inputRef={this.getInputRef(boundary)}
                 onBlur={handleInputEvent}

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -136,6 +136,36 @@ describe("<DateRangeInput>", () => {
     });
 
     describe("startInputProps and endInputProps", () => {
+        it("startInput is disabled when startInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} startInputProps={{ disabled: true }} />);
+            const startInput = getStartInput(root);
+
+            startInput.simulate("click");
+            expect(root.find(Popover).prop("isOpen")).to.be.false;
+            expect(startInput.prop("disabled")).to.be.true;
+        });
+
+        it("endInput is not disabled when startInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} startInputProps={{ disabled: true }} />);
+            const endInput = getEndInput(root);
+            expect(endInput.prop("disabled")).to.be.false;
+        });
+
+        it("endInput is disabled when endInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} endInputProps={{ disabled: true }} />);
+            const endInput = getEndInput(root);
+
+            endInput.simulate("click");
+            expect(root.find(Popover).prop("isOpen")).to.be.false;
+            expect(endInput.prop("disabled")).to.be.true;
+        });
+
+        it("startInput is not disabled when endInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} endInputProps={{ disabled: true }} />);
+            const startInput = getStartInput(root);
+            expect(startInput.prop("disabled")).to.be.false;
+        });
+
         describe("startInputProps", () => {
             runTestSuite(getStartInput, inputGroupProps => {
                 return mount(<DateRangeInput {...DATE_FORMAT} startInputProps={inputGroupProps} />);


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/3606

#### Checklist

- [x]  Includes tests
- [ ] Update documentation (possibly not necessary?)

#### Changes proposed in this pull request:

The `disabled` prop will first read from `getInputProps` before `this.props.disabled`.

#### Reviewers should focus on:

Ensuring tests cover all use cases.
