### PR TITLE
Update abstract button props to match react's.

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -68,11 +68,11 @@ export interface IButtonProps extends IActionProps {
     small?: boolean;
 
     /**
-     * HTML `type` attribute of button. Common values are `"button"` and `"submit"`.
+     * HTML `type` attribute of button. Accepted values are `"button"`, `"submit"`, and `"reset"`.
      * Note that this prop has no effect on `AnchorButton`; it only affects `Button`.
      * @default "button"
      */
-    type?: string;
+    type?: "submit" | "reset" | "button";
 }
 
 export interface IButtonState {


### PR DESCRIPTION
#### Checklist

- [x] ~Includes tests~ should be a compile time only change
- [x] Update documentation

#### Changes proposed in this pull request:

React recently updated the typings for HTML button's `type` field from `string` to a more limited union. See: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1848 for the current types. 

This is currently an issue for folks on newer versions of react typings since `IButtonProps` is no longer assignable to the props for `Button`.