### PR TITLE
Use Blueprint Pre component in Collapse example

### DIFF
--- a/packages/core/src/components/collapse/collapse.md
+++ b/packages/core/src/components/collapse/collapse.md
@@ -32,9 +32,9 @@ export class CollapseExample extends React.Component<{}, ICollapseExampleState> 
                     {this.state.isOpen ? "Hide" : "Show"} build logs
                 </Button>
                 <Collapse isOpen={this.state.isOpen}>
-                    <pre>
+                    <Pre>
                         Dummy text.
-                    </pre>
+                    </Pre>
                 </Collapse>
             </div>
         );


### PR DESCRIPTION
Blueprint contains a lint rule that fails when you use non-Blueprint versions of certain HTML components, including `pre`. This PR modifies the documentation for the `Collapse` component to use the Blueprint `Pre` component instead of HTML `pre` to avoid the lint rule failure.