### PR TITLE
[Datetime] Fix typing values into TimePicker's fields

### DIFF
--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -263,28 +263,8 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     };
 
     private getInputChangeHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
-        const TWO_DIGITS = /^\d{0,2}$/;
-        const THREE_DIGITS = /^\d{0,3}$/;
         const text = getStringValueFromInputEvent(e);
-
-        let isValid = false;
-        switch (unit) {
-            case TimeUnit.HOUR_24:
-            case TimeUnit.HOUR_12:
-            case TimeUnit.MINUTE:
-            case TimeUnit.SECOND:
-                isValid = TWO_DIGITS.test(text);
-                break;
-            case TimeUnit.MS:
-                isValid = THREE_DIGITS.test(text);
-                break;
-            default:
-                throw Error("Invalid TimeUnit");
-        }
-
-        if (isValid) {
-            this.updateTime(parseInt(text, 10), unit);
-        }
+        this.updateTime(parseInt(text, 10), unit);
     };
 
     private getInputKeyDownHandler = (unit: TimeUnit) => (e: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
#### Fixes #3581 #3595 #3586

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

I couldn't find any way to write a test case for this. Changing input via `TestUtils.Simulate.change()` does not solve the problem since it enters a whole value. I've also tried with `TestUtils.Simulate.keyDown()` but no luck. I didn't have enough time to think about it, so I'll decide to open a PR. Maybe someone else has an idea how to test this?

![fixed-time-picker](https://user-images.githubusercontent.com/2925620/59760158-ef0c8880-9291-11e9-8981-d4d4e1b19728.gif)

