### PR TITLE
Update tooltip docs

### DIFF
--- a/packages/core/src/components/tooltip/tooltip.md
+++ b/packages/core/src/components/tooltip/tooltip.md
@@ -31,7 +31,7 @@ prop is not supported.
 
 When creating a tooltip, you must specify both:
 - its _content_ via the `content` prop, and
-- its _target_ as a single child element or string.
+- its _target_ as a single child element (required if using any of the target props) or string.
 
 The content will appear in a contrasting popover when the target is hovered.
 

--- a/packages/core/src/components/tooltip/tooltip.md
+++ b/packages/core/src/components/tooltip/tooltip.md
@@ -31,7 +31,9 @@ prop is not supported.
 
 When creating a tooltip, you must specify both:
 - its _content_ via the `content` prop, and
-- its _target_ as a single child element (required if using any of the target props) or string.
+- its _target_ as either:
+    - a single child element, or
+    - an instrinsic element string identifier (N.B. this doesn't work if you are using any of the target props, so use an element instead, i.e. `<div>...</div>` instead of `"div"`).
 
 The content will appear in a contrasting popover when the target is hovered.
 


### PR DESCRIPTION
#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

- Tooltips fails when using any of the target props if the target is a string, since there is nowhere to give the props to - eg. `targetClassName`