### PR TITLE
Fix crashing Select component

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -578,7 +578,6 @@ export function getFirstEnabledItem<T>(
     if (items.length === 0) {
         return null;
     }
-    console.log('s', startIndex)
     // remember where we started to prevent an infinite loop
     let index = startIndex;
     const maxIndex = items.length - 1;
@@ -588,6 +587,6 @@ export function getFirstEnabledItem<T>(
         if (!isItemDisabled(items[index], index, itemDisabled)) {
             return items[index];
         }
-    } while (index !== startIndex);
+    } while (index !== startIndex && startIndex !== -1);
     return null;
 }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -578,6 +578,7 @@ export function getFirstEnabledItem<T>(
     if (items.length === 0) {
         return null;
     }
+    console.log('s', startIndex)
     // remember where we started to prevent an infinite loop
     let index = startIndex;
     const maxIndex = items.length - 1;

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -130,6 +130,14 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
             assert.equal((testProps.onActiveItemChange.lastCall.args[0] as IFilm).rank, 20);
         });
 
+        it("arrow up/down does not invokes onActiveItemChange, when all items are disabled", () => {
+            const wrapper = render({ ...testProps, itemDisabled: () => true });
+            findInput(wrapper).simulate("keydown", { keyCode: Keys.ARROW_DOWN });
+            assert.isNull(testProps.onActiveItemChange.lastCall);
+            findInput(wrapper).simulate("keyup", { keyCode: Keys.ARROW_UP });
+            assert.isNull(testProps.onActiveItemChange.lastCall);
+        });
+
         it("enter invokes onItemSelect with active item", () => {
             const wrapper = render(testProps);
             findInput(wrapper).simulate("keyup", { keyCode: Keys.ENTER });


### PR DESCRIPTION
#### Fixes #3388

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix crashing Select component, when trying to naivagte using keyboard, but all items are disabled

[`Docs preview`](https://25903-71939872-gh.circle-artifacts.com/0/home/circleci/project/packages/docs-app/dist/index.html#select/select-component)