### PR TITLE
[select] fix: do not call itemRenderer when Select is disabled

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -311,22 +311,23 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     /** wrapper around `itemRenderer` to inject props */
     private renderItem = (item: T, index: number) => {
-        if (this.props.disabled) {
-            return null;
+        if (this.props.disabled !== true) {
+            const { activeItem, query } = this.state;
+            const matchesPredicate = this.state.filteredItems.indexOf(item) >= 0;
+            const modifiers: IItemModifiers = {
+                active: executeItemsEqual(this.props.itemsEqual, getActiveItem(activeItem), item),
+                disabled: isItemDisabled(item, index, this.props.itemDisabled),
+                matchesPredicate,
+            };
+            return this.props.itemRenderer(item, {
+                handleClick: e => this.handleItemSelect(item, e),
+                index,
+                modifiers,
+                query,
+            });
         }
-        const { activeItem, query } = this.state;
-        const matchesPredicate = this.state.filteredItems.indexOf(item) >= 0;
-        const modifiers: IItemModifiers = {
-            active: executeItemsEqual(this.props.itemsEqual, getActiveItem(activeItem), item),
-            disabled: isItemDisabled(item, index, this.props.itemDisabled),
-            matchesPredicate,
-        };
-        return this.props.itemRenderer(item, {
-            handleClick: e => this.handleItemSelect(item, e),
-            index,
-            modifiers,
-            query,
-        });
+
+        return null;
     };
 
     private renderCreateItemMenuItem = (query: string) => {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -51,7 +51,7 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
     renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
 
     /** 
-     * Indicates if 'Select' is disabled
+     * Whether the prop `itemRenderer` should be invoked.
      * @default false
      */
     disabled?: boolean;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -51,7 +51,7 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
     renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
 
     /**
-     * Whether the prop `itemRenderer` should be invoked.
+     * Whether the list is disabled.
      * @default false
      */
     disabled?: boolean;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -50,12 +50,11 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
      */
     renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
 
-    /** 
+    /**
      * Whether the prop `itemRenderer` should be invoked.
      * @default false
      */
     disabled?: boolean;
-
 }
 
 /**
@@ -134,8 +133,8 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
     public static displayName = `${DISPLAYNAME_PREFIX}.QueryList`;
 
     public static defaultProps = {
+        disabled: false,
         resetOnQuery: true,
-        disabled: false
     };
 
     public static ofType<T>() {
@@ -312,7 +311,9 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     /** wrapper around `itemRenderer` to inject props */
     private renderItem = (item: T, index: number) => {
-        if (this.props.disabled) return null
+        if (this.props.disabled) {
+            return null;
+        }
         const { activeItem, query } = this.state;
         const matchesPredicate = this.state.filteredItems.indexOf(item) >= 0;
         const modifiers: IItemModifiers = {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -49,6 +49,13 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
      * Receives an object with props that should be applied to elements as necessary.
      */
     renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
+
+    /** 
+     * Indicates if 'Select' is disabled
+     * @default false
+     */
+    disabled?: boolean;
+
 }
 
 /**
@@ -128,6 +135,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     public static defaultProps = {
         resetOnQuery: true,
+        disabled: false
     };
 
     public static ofType<T>() {
@@ -304,6 +312,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
 
     /** wrapper around `itemRenderer` to inject props */
     private renderItem = (item: T, index: number) => {
+        if (this.props.disabled) return null
         const { activeItem, query } = this.state;
         const matchesPredicate = this.state.filteredItems.indexOf(item) >= 0;
         const modifiers: IItemModifiers = {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -42,6 +42,7 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
 
     /**
      * Whether the component is non-interactive.
+     * If true, the list's item renderer will not be called.
      * Note that you'll also need to disable the component's children, if appropriate.
      * @default false
      */

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -72,7 +72,7 @@ describe("<Select>", () => {
     });
 
     it("disabled=false calls itemRenderer", () => {
-        select({ disabled: false })
+        select({ disabled: false });
         assert.equal(handlers.itemRenderer.callCount, 100);
     });
 

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -66,6 +66,16 @@ describe("<Select>", () => {
         assert.strictEqual(wrapper.find(Popover).prop("disabled"), true);
     });
 
+    it("disabled=true doesn't call itemRenderer", () => {
+        select({ disabled: true });
+        assert.equal(handlers.itemRenderer.callCount, 0);
+    });
+
+    it("disabled=false calls itemRenderer", () => {
+        select({ disabled: false })
+        assert.equal(handlers.itemRenderer.callCount, 100);
+    });
+
     it("inputProps value and onChange are ignored", () => {
         const inputProps = { value: "nailed it", onChange: sinon.spy() };
         const input = select({ inputProps }).find("input");


### PR DESCRIPTION
#### Fixes #3366

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:
Added `disabled?: boolean` props to `QueryList` explicitly and handled `itemRenderer` invocation accordingly.