### PR TITLE
[core] fix(Toast): long words in toast messages no longer break container layout

### DIFF
--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -144,6 +144,7 @@ $toast-margin: $pt-grid-size * 2 !default;
 .#{$ns}-toast-message {
   flex: 1 1 auto;
   padding: centered-text($toast-height);
+  word-break: break-word;
 }
 
 .#{$ns}-toast-container {


### PR DESCRIPTION
add word-break for long toast strings

#### Fixes #0762

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot
![Screen Shot 2019-07-01 at 9 56 17 AM](https://user-images.githubusercontent.com/37882611/60453655-966cb200-9be6-11e9-9262-08767a24bbed.png)

<!-- Include an image of the most relevant user-facing change, if any. -->
