### PR TITLE
[core] fix(Switch): tweak dark theme hover/active colors

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -305,8 +305,8 @@ $control-indicator-spacing: $pt-grid-size !default;
   $dark-switch-background-color-active: rgba($black, 0.9) !default;
   $dark-switch-background-color-disabled: $dark-button-background-color-disabled !default;
   $dark-switch-checked-background-color: $control-checked-background-color !default;
-  $dark-switch-checked-background-color-hover: $blue4 !default;
-  $dark-switch-checked-background-color-active: $blue5 !default;
+  $dark-switch-checked-background-color-hover: $control-checked-background-color-hover !default;
+  $dark-switch-checked-background-color-active: $control-checked-background-color-active !default;
   $dark-switch-checked-background-color-disabled: rgba($blue1, 0.5) !default;
 
   $switch-indicator-background-color: $white !default;


### PR DESCRIPTION
Fixes #3599

### Before
![2019-07-01 15 49 30](https://user-images.githubusercontent.com/723999/60462707-09425100-9c18-11e9-901c-8dc5303ec955.gif)

### After


![2019-07-01 15 49 43](https://user-images.githubusercontent.com/723999/60462709-0ba4ab00-9c18-11e9-95d2-635d2f7881ed.gif)

