### PR TITLE
[core] fix(HotkeysTarget): typo with keyUp & keyDown in HotkeysTarget

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -97,17 +97,22 @@ export function HotkeysTarget<T extends IConstructor<IHotkeysTargetComponent>>(W
                 if (this.localHotkeysEvents.count() > 0) {
                     const tabIndex = hotkeys.props.tabIndex === undefined ? 0 : hotkeys.props.tabIndex;
 
-                    const { keyDown: existingKeyDown, keyUp: existingKeyUp } = element.props;
-                    const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+                    const { onKeyDown: existingKeyDown, onKeyUp: existingKeyUp } = element.props;
+
+                    const handleKeyDownWrapper = (e: React.KeyboardEvent<HTMLElement>) => {
                         this.localHotkeysEvents.handleKeyDown(e.nativeEvent as KeyboardEvent);
                         safeInvoke(existingKeyDown, e);
                     };
 
-                    const onKeyUp = (e: React.KeyboardEvent<HTMLElement>) => {
+                    const handleKeyUpWrapper = (e: React.KeyboardEvent<HTMLElement>) => {
                         this.localHotkeysEvents.handleKeyUp(e.nativeEvent as KeyboardEvent);
                         safeInvoke(existingKeyUp, e);
                     };
-                    return React.cloneElement(element, { tabIndex, onKeyDown, onKeyUp });
+                    return React.cloneElement(element, {
+                        onKeyDown: handleKeyDownWrapper,
+                        onKeyUp: handleKeyUpWrapper,
+                        tabIndex,
+                    });
                 }
             }
             return element;

--- a/packages/core/test/hotkeys/hotkeysTests.tsx
+++ b/packages/core/test/hotkeys/hotkeysTests.tsx
@@ -16,7 +16,7 @@
 
 // tslint:disable max-classes-per-file
 
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import { SinonSpy, spy } from "sinon";
@@ -77,6 +77,8 @@ describe("Hotkeys", () => {
             disabled?: boolean;
             preventDefault?: boolean;
             stopPropagation?: boolean;
+            onKeyUp?: React.KeyboardEventHandler<HTMLElement>;
+            onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
         }
 
         @HotkeysTarget
@@ -128,7 +130,7 @@ describe("Hotkeys", () => {
 
             public render() {
                 return (
-                    <div>
+                    <div onKeyUp={this.props.onKeyUp} onKeyDown={this.props.onKeyDown}>
                         <input type="text" />
                         <input type="number" />
                         <input type="password" />
@@ -232,6 +234,22 @@ describe("Hotkeys", () => {
             expect(handleKeyDown.called).to.be.true;
             const testCombo = getKeyComboString(handleKeyDown.firstCall.args[0]);
             expect(testCombo).to.equal(combo);
+        });
+
+        it("invokes onKeyUp & onKeyDown props", () => {
+            const handlers = {
+                onKeyDown: spy(),
+                onKeyUp: spy(),
+            };
+
+            comp = mount(<TestComponent {...handlers} />, { attachTo });
+            const node = comp.getDOMNode();
+
+            dispatchTestKeyboardEvent(node, "keydown", "1");
+            assert.equal(handlers.onKeyDown.callCount, 1);
+            assert.equal(handlers.onKeyUp.callCount, 0);
+            dispatchTestKeyboardEvent(node, "keyup", "1");
+            assert.equal(handlers.onKeyUp.callCount, 1);
         });
 
         function runHotkeySuiteForKeyEvent(eventName: "keydown" | "keyup") {


### PR DESCRIPTION
#### Fixes #3643

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:
Fixed typo of `keyDown` & `keyUp` props in `@HotkeysTarget` to `onKeyDown` & `onKeyUp`.

