### PR TITLE
chore: upgrade to typescript 3.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sinon": "^7.2.4",
     "stylelint-config-palantir": "^3.1.1",
     "stylelint-scss": "^3.8.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "yarn-deduplicate": "^1.1.1"
   },
   "resolutions": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
     "sass-inline-svg": "^1.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.1.2"
   },
   "repository": {

--- a/packages/core/src/common/utils/compareUtils.ts
+++ b/packages/core/src/common/utils/compareUtils.ts
@@ -96,26 +96,6 @@ export function deepCompareKeys(objA: any, objB: any, keys?: Array<string | numb
 }
 
 /**
- * Returns a descriptive object for each key whose values are shallowly unequal
- * between two provided objects. Useful for debugging shouldComponentUpdate.
- */
-export function getShallowUnequalKeyValues<T extends object>(
-    objA: T,
-    objB: T,
-    keys?: IKeyBlacklist<T> | IKeyWhitelist<T>,
-) {
-    // default param values let null values pass through, so we have to take
-    // this more thorough approach
-    const definedObjA = objA == null ? {} : objA;
-    const definedObjB = objB == null ? {} : objB;
-
-    const filteredKeys = _filterKeys(definedObjA, definedObjB, keys == null ? { exclude: [] } : keys);
-    return _getUnequalKeyValues(definedObjA, definedObjB, filteredKeys, (a, b, key) => {
-        return shallowCompareKeys(a, b, { include: [key] });
-    });
-}
-
-/**
  * Returns a descriptive object for each key whose values are deeply unequal
  * between two provided objects. Useful for debugging shouldComponentUpdate.
  */
@@ -158,7 +138,7 @@ function _isSimplePrimitiveType(value: any) {
 function _filterKeys<T>(objA: T, objB: T, keys: IKeyBlacklist<T> | IKeyWhitelist<T>) {
     if (_isWhitelist(keys)) {
         return keys.include;
-    } else {
+    } else if (_isBlacklist(keys)) {
         const keysA = Object.keys(objA);
         const keysB = Object.keys(objB);
 
@@ -171,10 +151,16 @@ function _filterKeys<T>(objA: T, objB: T, keys: IKeyBlacklist<T> | IKeyWhitelist
         // return the remaining keys as an array
         return Object.keys(keySet) as Array<keyof T>;
     }
+
+    return [];
 }
 
 function _isWhitelist<T>(keys: any): keys is IKeyWhitelist<T> {
     return keys != null && (keys as IKeyWhitelist<T>).include != null;
+}
+
+function _isBlacklist<T>(keys: any): keys is IKeyBlacklist<T> {
+    return keys != null && (keys as IKeyBlacklist<T>).exclude != null;
 }
 
 function _arrayToObject(arr: any[]) {

--- a/packages/core/test/common/utils/compareUtilsTests.ts
+++ b/packages/core/test/common/utils/compareUtilsTests.ts
@@ -269,60 +269,6 @@ describe("CompareUtils", () => {
         });
     });
 
-    describe("getShallowUnequalKeyValues", () => {
-        describe("with `keys` defined as whitelist", () => {
-            describe("returns empty array if the specified values are shallowly equal", () => {
-                runTest([], { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, wl(["a", "c"]));
-            });
-
-            describe("returns unequal key/values if any specified values are not shallowly equal", () => {
-                // identical objects, but different instances
-                runTest(
-                    [{ key: "a", valueA: [1, "2", true], valueB: [1, "2", true] }],
-                    { a: [1, "2", true] },
-                    { a: [1, "2", true] },
-                    wl(["a"]),
-                );
-                // different primitive-type values
-                runTest([{ key: "a", valueA: 1, valueB: 2 }], { a: 1 }, { a: 2 }, wl(["a"]));
-            });
-        });
-
-        describe("with `keys` defined as blacklist", () => {
-            describe("returns empty array if the specified values are shallowly equal", () => {
-                runTest([], { a: 1, b: [1, 2, 3], c: "3" }, { b: [1, 2, 3], a: 1, c: "3" }, bl(["b"]));
-            });
-
-            describe("returns unequal keys/values if any specified values are not shallowly equal", () => {
-                runTest(
-                    [{ key: "a", valueA: [1, "2", true], valueB: [1, "2", true] }],
-                    { a: [1, "2", true] },
-                    { a: [1, "2", true] },
-                    bl(["b", "c"]),
-                );
-                runTest([{ key: "a", valueA: 1, valueB: 2 }], { a: 1 }, { a: 2 }, bl(["b"]));
-            });
-        });
-
-        describe("with `keys` not defined", () => {
-            describe("returns empty array if values are shallowly equal", () => {
-                runTest([], { a: 1, b: "2", c: true }, { a: 1, b: "2", c: true });
-                runTest([], undefined, undefined);
-                runTest([], null, undefined);
-            });
-
-            describe("returns unequal key/values if any specified values are not shallowly equal", () => {
-                runTest([{ key: "a", valueA: 1, valueB: 2 }], { a: 1 }, { a: 2 });
-            });
-        });
-
-        function runTest(expectedResult: any[], a: any, b: any, keys?: IKeyBlacklist<IKeys> | IKeyWhitelist<IKeys>) {
-            it(getCompareTestDescription(a, b, keys), () => {
-                expect(CompareUtils.getShallowUnequalKeyValues(a, b, keys)).to.deep.equal(expectedResult);
-            });
-        }
-    });
-
     describe("getDeepUnequalKeyValues", () => {
         describe("with `keys` defined", () => {
             describe("returns empty array if only the specified values are deeply equal", () => {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -51,7 +51,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.1.2"
   },
   "repository": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -43,7 +43,7 @@
     "npm-run-all": "^4.1.5",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.3.0"
   },
   "repository": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -47,7 +47,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.1.2"
   },
   "repository": {

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -49,7 +49,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.1.2"
   },
   "repository": {

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -26,7 +26,7 @@
     "stylelint-junit-formatter": "^0.2.1",
     "svgo": "^1.2.2",
     "tslint": "^5.12.1",
-    "typescript": "~3.2.4"
+    "typescript": "~3.5.3"
   },
   "repository": {
     "type": "git",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -49,7 +49,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.1.2"
   },
   "repository": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -51,7 +51,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack": "^4.27.1",
     "webpack-dev-server": "^3.1.0"
   },

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "react": "^16.2.0",
-    "typescript": "~3.2.4"
+    "typescript": "~3.5.3"
   },
   "repository": {
     "type": "git",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -52,7 +52,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "typescript": "~3.2.4",
+    "typescript": "~3.5.3",
     "webpack-cli": "^3.1.2"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10567,10 +10567,15 @@ typedoc@0.14.2, typedoc@^0.15.0-0:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.2.x, typescript@~3.2.4:
+typescript@3.2.x:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
⚠️ Breaking changes ⚠️ 

- [core] Removed `getShallowUnequalKeyValues` utility function. This function was not used in any blueprint packages or palantir internal repos, so it feels safe enough to remove.