### PR TITLE
[core] docs(Toaster): fix position prop comment

### DIFF
--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -87,9 +87,6 @@ export interface IToasterProps extends IProps {
 
     /**
      * Position of `Toaster` within its container.
-     *
-     * Note that only `TOP` and `BOTTOM` are supported because Toaster only
-     * supports the top and bottom edge positioning.
      * @default Position.TOP
      */
     position?: ToasterPosition;


### PR DESCRIPTION
According to https://github.com/palantir/blueprint/blob/06a186c90758bbdca604ed6d7bf639c3d05b1fa0/packages/core/src/components/toast/toaster.tsx#L91 only top and bottom are supported.
