### PR TITLE
[datetime]fix (dateRangeInput): DateRangeInput should not close on selection when time inputs receive key presses

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -756,10 +756,10 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             }
             // cases when TimePicker is shown
             if (currentStartDate == null) {
-                return false;
+                currentStartDate = new Date();
             }
             if (currentEndDate == null) {
-                return false;
+                currentEndDate = new Date();
             }
             // case to check if the user has changed TimePicker values
             if (

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -410,6 +410,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
 
             endHoverString = null;
         } else if (this.props.closeOnSelection) {
+            isOpen = this.getIsOpenValueWhenDateChanges(selectedStart, selectedEnd);
             isStartInputFocused = false;
 
             if (this.props.timePrecision == null && didSubmitWithEnter) {
@@ -421,7 +422,6 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
                 isEndInputFocused = false;
                 boundaryToModify = Boundary.END;
             }
-            isOpen = this.getIsOpenValueWhenDateChanges(selectedStart, selectedEnd);
         } else if (this.state.lastFocusedField === Boundary.START) {
             // keep the start field focused
             if (this.props.timePrecision == null) {
@@ -743,22 +743,13 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
                 return false;
             }
 
-            let currentStartDate: Date = new Date(new Date().setHours(0, 0, 0, 0));
-            let currentEndDate: Date = new Date(new Date().setHours(0, 0, 0, 0));
+            const fallbackDate = new Date(new Date().setHours(0, 0, 0, 0));
+            const [selectedStart, selectedEnd] = this.getSelectedRange([fallbackDate, fallbackDate]);
 
-            if (this.isControlled()) {
-                const [selectedStart, selectedEnd] = this.props.value;
-                currentStartDate = selectedStart != null ? selectedStart : currentStartDate;
-                currentEndDate = selectedEnd != null ? selectedEnd : currentEndDate;
-            } else {
-                const { selectedStart, selectedEnd } = this.state;
-                currentStartDate = selectedStart != null ? selectedStart : currentStartDate;
-                currentEndDate = selectedEnd != null ? selectedEnd : currentEndDate;
-            }
             // case to check if the user has changed TimePicker values
             if (
-                areSameTime(currentStartDate, nextSelectedStart) === true &&
-                areSameTime(currentEndDate, nextSelectedEnd) === true
+                areSameTime(selectedStart, nextSelectedStart) === true &&
+                areSameTime(selectedEnd, nextSelectedEnd) === true
             ) {
                 return false;
             }
@@ -779,7 +770,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         }
     };
 
-    private getSelectedRange = () => {
+    private getSelectedRange = (fallbackRange?: [Date, Date]) => {
         let selectedStart: Date;
         let selectedEnd: Date;
 
@@ -796,8 +787,9 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         const doBoundaryDatesOverlap = this.doBoundaryDatesOverlap(selectedStart, Boundary.START);
         const dateRange = [selectedStart, doBoundaryDatesOverlap ? undefined : selectedEnd];
 
-        return dateRange.map((selectedBound: Date | undefined) => {
-            return this.isDateValidAndInRange(selectedBound) ? selectedBound : undefined;
+        return dateRange.map((selectedBound: Date | undefined, index: number) => {
+            const fallbackDate = fallbackRange != null ? fallbackRange[index] : undefined;
+            return this.isDateValidAndInRange(selectedBound) ? selectedBound : fallbackDate;
         }) as DateRange;
     };
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -36,7 +36,7 @@ import {
     Utils,
 } from "@blueprintjs/core";
 
-import { areSameTime, DateRange, isDateValid, isDayInRange } from "./common/dateUtils";
+import { areSameTime, clone, DateRange, isDateValid, isDayInRange } from "./common/dateUtils";
 import * as Errors from "./common/errors";
 import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
@@ -743,23 +743,17 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
                 return false;
             }
 
-            let currentStartDate: Date;
-            let currentEndDate: Date;
+            let currentStartDate: Date = new Date(new Date().setHours(0, 0, 0, 0));
+            let currentEndDate: Date = new Date(new Date().setHours(0, 0, 0, 0));
 
             if (this.isControlled()) {
                 const [selectedStart, selectedEnd] = this.props.value;
-                currentStartDate = selectedStart;
-                currentEndDate = selectedEnd;
+                currentStartDate = selectedStart != null ? clone(selectedStart) : currentStartDate;
+                currentEndDate = selectedEnd != null ? clone(selectedEnd) : currentEndDate;
             } else {
-                currentStartDate = this.state.selectedStart;
-                currentEndDate = this.state.selectedEnd;
-            }
-            // cases when TimePicker is shown
-            if (currentStartDate == null) {
-                currentStartDate = new Date(new Date().setHours(0, 0, 0, 0));
-            }
-            if (currentEndDate == null) {
-                currentEndDate = new Date(new Date().setHours(0, 0, 0, 0));
+                const { selectedStart, selectedEnd } = this.state;
+                currentStartDate = selectedStart != null ? clone(selectedStart) : currentStartDate;
+                currentEndDate = selectedEnd != null ? clone(selectedEnd) : currentEndDate;
             }
             // case to check if the user has changed TimePicker values
             if (

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -36,7 +36,7 @@ import {
     Utils,
 } from "@blueprintjs/core";
 
-import { areSameTime, clone, DateRange, isDateValid, isDayInRange } from "./common/dateUtils";
+import { areSameTime, DateRange, isDateValid, isDayInRange } from "./common/dateUtils";
 import * as Errors from "./common/errors";
 import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
@@ -748,12 +748,12 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
 
             if (this.isControlled()) {
                 const [selectedStart, selectedEnd] = this.props.value;
-                currentStartDate = selectedStart != null ? clone(selectedStart) : currentStartDate;
-                currentEndDate = selectedEnd != null ? clone(selectedEnd) : currentEndDate;
+                currentStartDate = selectedStart != null ? selectedStart : currentStartDate;
+                currentEndDate = selectedEnd != null ? selectedEnd : currentEndDate;
             } else {
                 const { selectedStart, selectedEnd } = this.state;
-                currentStartDate = selectedStart != null ? clone(selectedStart) : currentStartDate;
-                currentEndDate = selectedEnd != null ? clone(selectedEnd) : currentEndDate;
+                currentStartDate = selectedStart != null ? selectedStart : currentStartDate;
+                currentEndDate = selectedEnd != null ? selectedEnd : currentEndDate;
             }
             // case to check if the user has changed TimePicker values
             if (

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -756,10 +756,10 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             }
             // cases when TimePicker is shown
             if (currentStartDate == null) {
-                currentStartDate = new Date();
+                currentStartDate = new Date(new Date().setHours(0, 0, 0, 0));
             }
             if (currentEndDate == null) {
-                currentEndDate = new Date();
+                currentEndDate = new Date(new Date().setHours(0, 0, 0, 0));
             }
             // case to check if the user has changed TimePicker values
             if (

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -369,6 +369,14 @@ describe("<DateRangeInput>", () => {
             getDayElement(10).simulate("click");
             expect(root.state("isOpen")).to.be.false;
         });
+
+        it("if closeOnSelection=true && timePrecision != null, popover closes when full date range is selected", () => {
+            const { root, getDayElement } = wrap(<DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />);
+            root.setState({ isOpen: true });
+            getDayElement(1).simulate("click");
+            getDayElement(10).simulate("click");
+            expect(root.state("isOpen")).to.be.false;
+        });
     });
 
     it("accepts contiguousCalendarMonths prop and passes it to the date range picker", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -371,7 +371,9 @@ describe("<DateRangeInput>", () => {
         });
 
         it("if closeOnSelection=true && timePrecision != null, popover closes when full date range is selected", () => {
-            const { root, getDayElement } = wrap(<DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />);
+            const { root, getDayElement } = wrap(
+                <DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
+            );
             root.setState({ isOpen: true });
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -173,16 +173,32 @@ describe("<DateRangeInput>", () => {
             expect(root.find(Popover).prop("isOpen")).to.be.true;
         });
 
+        it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
+            const { root } = wrap(
+                <DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
+                testsContainerElement,
+            );
+
+            root.setState({ isOpen: true });
+            keyDownOnInput(DateClasses.TIMEPICKER_HOUR, Keys.ARROW_UP);
+            root.update();
+            keyDownOnInput(DateClasses.TIMEPICKER_HOUR, Keys.ARROW_UP, 1);
+            root.update();
+            expect(root.find(Popover).prop("isOpen")).to.be.true;
+        });
+
         afterEach(() => {
             ReactDOM.unmountComponentAtNode(testsContainerElement);
         });
 
-        function keyDownOnInput(className: string, key: number) {
-            TestUtils.Simulate.keyDown(findTimePickerInputElement(className), { which: key });
+        function keyDownOnInput(className: string, key: number, inputElementIndex: number = 0) {
+            TestUtils.Simulate.keyDown(findTimePickerInputElement(className, inputElementIndex), { which: key });
         }
 
-        function findTimePickerInputElement(className: string) {
-            return document.querySelector(`.${DateClasses.TIMEPICKER_INPUT}.${className}`) as HTMLInputElement;
+        function findTimePickerInputElement(className: string, inputElementIndex: number = 0) {
+            return document.querySelectorAll(`.${DateClasses.TIMEPICKER_INPUT}.${className}`)[
+                inputElementIndex
+            ] as HTMLInputElement;
         }
     });
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -155,7 +155,25 @@ describe("<DateRangeInput>", () => {
             expect(isEndInputFocused(root), "end input focus to be false").to.be.false;
         });
 
-        after(() => {
+        it("when timePrecision != null && closeOnSelection=true && <TimePicker /> values is changed popover should not close", () => {
+            const { root, getDayElement } = wrap(
+                <DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
+                testsContainerElement,
+            );
+
+            root.setState({ isOpen: true });
+
+            getDayElement(1).simulate("click");
+            getDayElement(10).simulate("click");
+
+            root.setState({ isOpen: true });
+
+            keyDownOnInput(DateClasses.TIMEPICKER_HOUR, Keys.ARROW_UP);
+            root.update();
+            expect(root.find(Popover).prop("isOpen")).to.be.true;
+        });
+
+        afterEach(() => {
             ReactDOM.unmountComponentAtNode(testsContainerElement);
         });
 


### PR DESCRIPTION
#### Fixes #3655 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:
Selected date in the state and the changed date are checked using the `areSameTime` date-util to 
determine if the user has changed any `<TimePicker />` values. If timepicker values are updated then the popover is kept open.

#### Screenshot
![bp3-gif-of the-bug-fixed-showing-that-date-input-is-not-closed-when-timepicker-value-changes](https://thumbs.gfycat.com/OrdinaryWaryBaldeagle-small.gif)
