### PR TITLE
Shortcuts now check closeOnSelection to  decise shouldDismissPopover

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -108,6 +108,12 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * If this prop is provided, the component acts in a controlled manner.
      */
     value?: DateRange;
+
+    /**
+     * Whether the calendar popover should close when a date range is fully selected.
+     * @default true
+     */
+    closeOnSelection?: boolean;
 }
 
 // leftView and rightView controls the DayPicker displayed month
@@ -274,11 +280,11 @@ export class DateRangePicker extends AbstractPureComponent<IDateRangePickerProps
             return null;
         }
 
-        const { allowSingleDayRange, maxDate, minDate } = this.props;
+        const { allowSingleDayRange, maxDate, minDate, closeOnSelection } = this.props;
         return [
             <Shortcuts
                 key="shortcuts"
-                {...{ allowSingleDayRange, maxDate, minDate, shortcuts }}
+                {...{ allowSingleDayRange, maxDate, minDate, shortcuts, closeOnSelection }}
                 onShortcutClick={this.handleShortcutClick}
             />,
             <Divider key="div" />,

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Classes, Menu, MenuItem } from "@blueprintjs/core";
+import { Menu, MenuItem } from "@blueprintjs/core";
 import React from "react";
 import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
 import { clone, DateRange, isDayRangeInRange } from "./common/dateUtils";
@@ -35,6 +35,7 @@ export interface IShortcutsProps {
     maxDate: Date;
     shortcuts: IDateRangeShortcut[] | true;
     onShortcutClick: (shortcut: IDateRangeShortcut) => void;
+    closeOnSelection?: boolean;
 }
 
 export class Shortcuts extends React.PureComponent<IShortcutsProps> {
@@ -46,7 +47,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
 
         const shortcutElements = shortcuts.map((s, i) => (
             <MenuItem
-                className={Classes.POPOVER_DISMISS_OVERRIDE}
+                shouldDismissPopover={!!this.props.closeOnSelection}
                 disabled={!this.isShortcutInRange(s.dateRange)}
                 key={i}
                 onClick={this.getShorcutClickHandler(s)}

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -4,7 +4,7 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
-import { Button } from "@blueprintjs/core";
+import { Button, Classes as CoreClasses } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -1167,6 +1167,16 @@ describe("<DateRangePicker>", () => {
 
             render({ timePrecision: "minute", defaultValue: defaultRange, shortcuts }).clickShortcut();
             assert.equal(onChangeSpy.firstCall.args[0][0] as Date, startTime);
+        });
+
+        it("shortcuts with closeOnSelection=false do not dismiss popovers", () => {
+            const { shortcuts } = render({ closeOnSelection: false });
+            assert.isFalse(shortcuts.find(`.${CoreClasses.POPOVER_DISMISS}`).exists());
+        });
+
+        it("shortcuts with closeOnSelect=true do not dismiss popovers", () => {
+            const { shortcuts } = render({ closeOnSelection: true });
+            assert.isTrue(shortcuts.find(`.${CoreClasses.POPOVER_DISMISS}`).exists());
         });
 
         it("selecting and unselecting a day doesn't change time", () => {


### PR DESCRIPTION
#### Fixes #3338 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Correctly prevent DateRangePicker shortcuts from dismissing popovers

#### Reviewers should focus on:

Components on the way to Shortcuts are already getting the `closeOnSelection` props. I added it to Shortcuts in order for it to know if it should pass `shouldDismissPopover` to the MenuItem (which used to manually get the className).
Also first real PR, so I feel code style etc.. needs some improvement and would love constructive inputs.

#### Screenshot
N/A

Thanks!
