### PR TITLE
Fix crashing on inputs with type number.

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -78,6 +78,7 @@ export interface IEditableTextProps extends IIntentProps, IProps {
     /**
      * Whether the entire text field should be selected on focus.
      * If `false`, the cursor is placed at the end of the text.
+     * This prop is ignored on inputs with type other then text, search, url, tel and password. See https://html.spec.whatwg.org/multipage/input.html#do-not-apply for details.
      * @default false
      */
     selectAllOnFocus?: boolean;
@@ -142,9 +143,12 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
         input: (input: HTMLInputElement | HTMLTextAreaElement) => {
             if (input != null) {
                 input.focus();
-                const { length } = input.value;
-                input.setSelectionRange(this.props.selectAllOnFocus ? 0 : length, length);
-                if (!this.props.selectAllOnFocus) {
+                const supportsSelection = inputSupportsSelection(input)
+                if (supportsSelection) {
+                    const { length } = input.value;
+                    input.setSelectionRange(this.props.selectAllOnFocus ? 0 : length, length);
+                }
+                if (!supportsSelection || !this.props.selectAllOnFocus) {
                     input.scrollLeft = input.scrollWidth;
                 }
             }
@@ -317,8 +321,8 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
         return multiline ? (
             <textarea ref={this.refHandlers.input} {...props} />
         ) : (
-            <input ref={this.refHandlers.input} type={type} {...props} />
-        );
+                <input ref={this.refHandlers.input} type={type} {...props} />
+            );
     }
 
     private updateInputDimensions() {
@@ -390,5 +394,23 @@ function insertAtCaret(el: HTMLTextAreaElement, text: string) {
         el.value = `${before}${text}${after}`;
         el.selectionStart = selectionStart + len;
         el.selectionEnd = selectionStart + len;
+    }
+}
+
+function inputSupportsSelection(input: HTMLInputElement | HTMLTextAreaElement) {
+    switch (input.type) {
+        // HTMLTextAreaElement
+        case "textarea":
+            return true;
+        // HTMLInputElement
+        // see  https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+        case "text":
+        case "search":
+        case "tel":
+        case "url":
+        case "password":
+            return true;
+        default:
+            return false;
     }
 }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -403,7 +403,7 @@ function inputSupportsSelection(input: HTMLInputElement | HTMLTextAreaElement) {
         case "textarea":
             return true;
         // HTMLInputElement
-        // see  https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+        // see https://html.spec.whatwg.org/multipage/input.html#do-not-apply
         case "text":
         case "search":
         case "tel":

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -143,7 +143,7 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
         input: (input: HTMLInputElement | HTMLTextAreaElement) => {
             if (input != null) {
                 input.focus();
-                const supportsSelection = inputSupportsSelection(input)
+                const supportsSelection = inputSupportsSelection(input);
                 if (supportsSelection) {
                     const { length } = input.value;
                     input.setSelectionRange(this.props.selectAllOnFocus ? 0 : length, length);
@@ -321,8 +321,8 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
         return multiline ? (
             <textarea ref={this.refHandlers.input} {...props} />
         ) : (
-                <input ref={this.refHandlers.input} type={type} {...props} />
-            );
+            <input ref={this.refHandlers.input} type={type} {...props} />
+        );
     }
 
     private updateInputDimensions() {


### PR DESCRIPTION
HTMLInputElement supports `selectAllOnFocus` method only on inputs
with type text, search, url, tel and password.

#### Fixes #3671

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Check type of `HTMLInputElement` in `EditableText` component before calling `selectAllOnFocus` method because it throws on inputs with certain types.

#### Reviewers should focus on:

Should `inputSupportsSelection` function be left in `editableText.tsx` or placed somewhere in `common/utils` or extracted and published as a standalone npm module?

