### PR TITLE
remove space before :focus

### DIFF
--- a/packages/core/src/_accessibility.scss
+++ b/packages/core/src/_accessibility.scss
@@ -5,7 +5,7 @@
   @include focus-outline();
 }
 
-.#{$ns}-focus-disabled :focus {
+.#{$ns}-focus-disabled:focus {
   // override any focus outline anywhere
   // stylelint-disable declaration-no-important
   outline: none !important;


### PR DESCRIPTION
#### Fixes 
1. blueprint.css  a space between ``.bp3-focus-disabled :focus``
2. remove the space in template

![image](https://user-images.githubusercontent.com/22271544/61870063-b35b8300-af0f-11e9-80e5-95af90a5d6db.png)

