### PR TITLE
[core] fix(Popover): only apply active class to target in uncontrolled mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,11 +7,12 @@
         "docs": true
     },
     "search.exclude": {
-      "**/node_modules": true,
-      "**/build": true,
-      "**/coverage": true,
-      "**/dist": true,
-      "docs": true
+        "**/build": true,
+        "**/coverage": true,
+        "**/dist": true,
+        "**/node_modules": true,
+        "docs": true,
+        "site/docs": true
     },
     "editor.insertSpaces": true,
     "editor.tabSize": 4,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -333,6 +333,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
     private renderTarget = (referenceProps: ReferenceChildrenProps) => {
         const { fill, openOnTargetFocus, targetClassName, targetProps = {} } = this.props;
         const { isOpen } = this.state;
+        const isControlled = this.isControlled();
         const isHoverInteractionKind = this.isHoverInteractionKind();
         let { targetTagName } = this.props;
         if (fill) {
@@ -365,7 +366,9 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         const tabIndex = rawTabIndex == null && openOnTargetFocus && isHoverInteractionKind ? 0 : rawTabIndex;
         const clonedTarget: JSX.Element = React.cloneElement(rawTarget, {
             className: classNames(rawTarget.props.className, {
-                [Classes.ACTIVE]: isOpen && !isHoverInteractionKind,
+                // this class is mainly useful for button targets; we should only apply it for uncontrolled popovers
+                // when they are opened by a user interaction
+                [Classes.ACTIVE]: isOpen && !isControlled && !isHoverInteractionKind,
             }),
             // force disable single Tooltip child when popover is open (BLUEPRINT-552)
             disabled: isOpen && Utils.isElementOfType(rawTarget, Tooltip) ? true : rawTarget.props.disabled,
@@ -394,6 +397,8 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
             target: targetChild == null ? targetProp : targetChild,
         };
     }
+
+    private isControlled = () => this.props.isOpen !== undefined;
 
     private getIsOpen(props: IPopoverProps) {
         // disabled popovers should never be allowed to open.

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -489,6 +489,11 @@ describe("<Popover>", () => {
                 assert.isTrue(onInteraction.calledWith(false));
             });
         });
+
+        it("does not apply active class to target when open", () => {
+            wrapper = renderPopover({ interactionKind: PopoverInteractionKind.CLICK, isOpen: true });
+            wrapper.assertFindClass(Classes.ACTIVE, false);
+        });
     });
 
     describe("in uncontrolled mode", () => {
@@ -593,6 +598,12 @@ describe("<Popover>", () => {
             renderPopover({ onInteraction: () => false });
             assert.strictEqual(warnSpy.firstCall.args[0], Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
             warnSpy.restore();
+        });
+
+        it("does apply active class to target when open", () => {
+            wrapper = renderPopover({ interactionKind: PopoverInteractionKind.CLICK });
+            wrapper.simulateTarget("click");
+            wrapper.assertFindClass(Classes.ACTIVE, true);
         });
     });
 


### PR DESCRIPTION
Fixes #3437 