### PR TITLE
Event propagation stopped when Tag is closed on enter key press

### DIFF
--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -148,6 +148,7 @@ export class Tag extends React.PureComponent<ITagProps, {}> {
     }
 
     private onRemoveClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
         Utils.safeInvoke(this.props.onRemove, e, this.props);
     };
 }


### PR DESCRIPTION
#### Fixes #3674 

#### Changes proposed in this pull request:

Event propagation is stopped when tag close icon is focused and enter key is pressed

#### Reviewers should focus on:

Impact on multiSelects and tag-inputs

#### Screenshot
![TagClose](https://user-images.githubusercontent.com/25343161/61950906-f29bd980-afcc-11e9-9501-9e9f8d3a7d6b.gif)


