### PR TITLE
[table] fix(EditableCell): support tabIndex prop correctly

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -190,8 +190,10 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
     }
 
     public renderHotkeys() {
+        const { tabIndex } = this.props;
+
         return (
-            <Hotkeys>
+            <Hotkeys tabIndex={tabIndex}>
                 <Hotkey
                     key="edit-cell"
                     label="Edit the currently focused cell"

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -21,7 +21,7 @@ import * as sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";
 import * as TableClasses from "../src/common/classes";
-import { EditableCell } from "../src/index";
+import { Cell, EditableCell } from "../src/index";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 
 describe("<EditableCell>", () => {
@@ -33,6 +33,22 @@ describe("<EditableCell>", () => {
     it("renders loading state", () => {
         const editableCellHarness = mount(<EditableCell loading={true} value="test-value-5000" />);
         expectCellLoading(editableCellHarness.first().getDOMNode(), CellType.BODY_CELL);
+    });
+
+    it("renders cell with default tabIndex as zero", () => {
+        const tabIndex = 0;
+        const elem = mount(<EditableCell value="test-value-5000" />);
+        const cellInstance = elem.find(Cell).instance() as Cell;
+
+        expect(cellInstance.props.tabIndex).to.equal(tabIndex);
+    });
+
+    it("renders cell with tabIndex", () => {
+        const tabIndex = 1;
+        const elem = mount(<EditableCell tabIndex={tabIndex} value="test-value-5000" />);
+        const cellInstance = elem.find(Cell).instance() as Cell;
+
+        expect(cellInstance.props.tabIndex).to.equal(tabIndex);
     });
 
     it("renders new value if props.value changes", () => {


### PR DESCRIPTION
#### Fixes #3641 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Pass `tabIndex` prop from `<EditableCell` to `<Hotkeys`
