### PR TITLE
[datetime] feat(DateRangePicker): add active menu styles to shortcuts

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -210,7 +210,7 @@ export function convert24HourMeridiem(hour: number, toPm: boolean): number {
     if (hour < 0 || hour > 23) {
         throw new Error(`hour must be between [0,23] inclusive: got ${hour}`);
     }
-    return toPm ? hour % 12 + 12 : hour % 12;
+    return toPm ? (hour % 12) + 12 : hour % 12;
 }
 
 export function getIsPmFrom24Hour(hour: number): boolean {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -469,7 +469,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         Utils.safeInvoke(this.props.onChange, selectedRange);
     };
 
-    private handleShortcutChange = (selectedShortcutIndex: number) => {
+    private handleShortcutChange = (_: IDateRangeShortcut, selectedShortcutIndex: number) => {
         this.setState({ selectedShortcutIndex });
     };
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -184,6 +184,8 @@ export interface IDateRangeInputState {
 
     shouldSelectAfterUpdate?: boolean;
     wasLastFocusChangeDueToHover?: boolean;
+
+    selectedShortcutIndex?: number;
 }
 
 interface IStateKeysAndValuesObject {
@@ -252,6 +254,7 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
             formattedMinDateString: this.getFormattedMinMaxDateString(props, "minDate"),
             isOpen: false,
             selectedEnd,
+            selectedShortcutIndex: -1,
             selectedStart,
         };
     }
@@ -276,13 +279,16 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
     }
 
     public render() {
+        const { selectedShortcutIndex } = this.state;
         const { popoverProps = {} } = this.props;
 
         const popoverContent = (
             <DateRangePicker
                 {...this.props}
+                selectedShortcutIndex={selectedShortcutIndex}
                 boundaryToModify={this.state.boundaryToModify}
                 onChange={this.handleDateRangePickerChange}
+                onShortcutChange={this.handleShortcutChange}
                 onHoverChange={this.handleDateRangePickerHoverChange}
                 value={this.getSelectedRange()}
             />
@@ -461,6 +467,10 @@ export class DateRangeInput extends AbstractPureComponent<IDateRangeInputProps, 
         }
 
         Utils.safeInvoke(this.props.onChange, selectedRange);
+    };
+
+    private handleShortcutChange = (selectedShortcutIndex: number) => {
+        this.setState({ selectedShortcutIndex });
     };
 
     private handleDateRangePickerHoverChange = (

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -100,7 +100,6 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
 
     /**
      * Called when the `shortcuts` props is enabled and the user changes the shortcut.
-     * When triggered, it will pass the selected `shortcut` and its index which is optional.
      */
     onShortcutChange?: (shortcut: IDateRangeShortcut, index: number) => void;
 
@@ -114,7 +113,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     shortcuts?: boolean | IDateRangeShortcut[];
 
     /**
-     * The currently selected `shortcut`.
+     * The currently selected shortcut.
      * If this prop is provided, the component acts in a controlled manner.
      */
     selectedShortcutIndex?: number;

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -102,7 +102,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      * Called when the `shortcuts` props is enabled and the user changes the shortcut.
      * When triggered, it will pass the selected `shortcut` and its index which is optional.
      */
-    onShortcutChange?: (shortcut: IDateRangeShortcut, index?: number) => void;
+    onShortcutChange?: (shortcut: IDateRangeShortcut, index: number) => void;
 
     /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -46,36 +46,46 @@ export interface IShortcutsProps {
     maxDate: Date;
     shortcuts: IDateRangeShortcut[] | true;
     timePrecision: TimePrecision;
-    onShortcutClick: (shortcut: IDateRangeShortcut) => void;
+    selectedShortcutIndex?: number;
+    onShortcutClick: (shortcut: IDateRangeShortcut, index: number) => void;
 }
 
 export class Shortcuts extends React.PureComponent<IShortcutsProps> {
+    public static defaultProps: Partial<IShortcutsProps> = {
+        selectedShortcutIndex: -1,
+    };
+
     public render() {
         const shortcuts =
             this.props.shortcuts === true
                 ? createDefaultShortcuts(this.props.allowSingleDayRange, this.props.timePrecision !== undefined)
                 : this.props.shortcuts;
 
-        const shortcutElements = shortcuts.map((s, i) => (
+        const shortcutElements = shortcuts.map((shortcut, index) => (
             <MenuItem
+                active={this.props.selectedShortcutIndex === index}
                 className={Classes.POPOVER_DISMISS_OVERRIDE}
-                disabled={!this.isShortcutInRange(s.dateRange)}
-                key={i}
-                onClick={this.getShorcutClickHandler(s)}
-                text={s.label}
+                disabled={!this.isShortcutInRange(shortcut.dateRange)}
+                key={index}
+                onClick={this.getShorcutClickHandler(shortcut, index)}
+                text={shortcut.label}
             />
         ));
 
         return <Menu className={DATERANGEPICKER_SHORTCUTS}>{shortcutElements}</Menu>;
     }
 
-    private getShorcutClickHandler(shortcut: IDateRangeShortcut) {
-        return () => this.props.onShortcutClick(shortcut);
-    }
+    private getShorcutClickHandler = (shortcut: IDateRangeShortcut, index: number) => () => {
+        const { onShortcutClick } = this.props;
 
-    private isShortcutInRange(shortcutDateRange: DateRange) {
-        return isDayRangeInRange(shortcutDateRange, [this.props.minDate, this.props.maxDate]);
-    }
+        onShortcutClick(shortcut, index);
+    };
+
+    private isShortcutInRange = (shortcutDateRange: DateRange) => {
+        const { minDate, maxDate } = this.props;
+
+        return isDayRangeInRange(shortcutDateRange, [minDate, maxDate]);
+    };
 }
 
 function createShortcut(label: string, dateRange: DateRange): IDateRangeShortcut {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -399,6 +399,19 @@ describe("<DateRangeInput>", () => {
         expect(root.find(DateRangePicker).prop("shortcuts")).to.be.false;
     });
 
+    it("should set the selectedShortcutIndex state when when click on the shortcut", () => {
+        const selectedShortcut = 1;
+        const { root } = wrap(<DateRangeInput {...DATE_FORMAT} />);
+
+        root.setState({ isOpen: true });
+        root.find(DateRangePicker)
+            .find(`.${DateClasses.DATERANGEPICKER_SHORTCUTS}`)
+            .find("a")
+            .at(selectedShortcut)
+            .simulate("click");
+        expect(root.state("selectedShortcutIndex")).equals(selectedShortcut);
+    });
+
     it("pressing Shift+Tab in the start field blurs the start field and closes the popover", () => {
         const startInputProps = { onKeyDown: sinon.spy() };
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} {...{ startInputProps }} />);

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -399,7 +399,7 @@ describe("<DateRangeInput>", () => {
         expect(root.find(DateRangePicker).prop("shortcuts")).to.be.false;
     });
 
-    it("should set the selectedShortcutIndex state when when click on the shortcut", () => {
+    it("should update the selectedShortcutIndex state when clicking on a shortcut", () => {
         const selectedShortcut = 1;
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} />);
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Button } from "@blueprintjs/core";
+import { Button, Classes, Menu } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -37,6 +37,7 @@ import {
     TimePicker,
     TimePrecision,
 } from "../src/index";
+import { Shortcuts } from "../src/shortcuts";
 import { assertDayDisabled } from "./common/dateTestUtils";
 
 describe("<DateRangePicker>", () => {
@@ -910,6 +911,43 @@ describe("<DateRangePicker>", () => {
             const value = onChangeSpy.args[0][0];
             assert.isTrue(DateUtils.areSameDay(today, value[0]));
             assert.isTrue(DateUtils.areSameDay(tomorrow, value[1]));
+        });
+
+        it("shortcuts without active menu style", () => {
+            const { wrapper } = render();
+
+            assert.isFalse(
+                wrapper
+                    .find(Shortcuts)
+                    .find(Menu)
+                    .find(`.${Classes.ACTIVE}`)
+                    .exists(),
+            );
+        });
+
+        it("shortcuts with active menu style", () => {
+            const selectedShortcut = 1;
+            const { wrapper } = render({ selectedShortcutIndex: selectedShortcut });
+
+            assert.isTrue(
+                wrapper
+                    .find(Shortcuts)
+                    .find(Menu)
+                    .find(`.${Classes.ACTIVE}`)
+                    .exists(),
+            );
+        });
+
+        it("should call onShortcutChangeSpy on selecting a shortcut ", () => {
+            const selectedShortcut = 1;
+            const onShortcutChangeSpy = sinon.spy();
+            const { clickShortcut } = render({ onShortcutChange: onShortcutChangeSpy });
+
+            clickShortcut(selectedShortcut);
+
+            assert.isTrue(onChangeSpy.calledOnce);
+            assert.isTrue(onShortcutChangeSpy.calledOnce);
+            assert.isTrue(onShortcutChangeSpy.calledWith(selectedShortcut));
         });
 
         it("custom shortcuts select the correct values", () => {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Button, Classes, Menu } from "@blueprintjs/core";
+import { Button, Classes, Menu, MenuItem } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -913,19 +913,20 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(DateUtils.areSameDay(tomorrow, value[1]));
         });
 
-        it("shortcuts without active menu style", () => {
+        it("all shortcuts are displayed as inactive when none are selected", () => {
             const { wrapper } = render();
 
             assert.isFalse(
                 wrapper
                     .find(Shortcuts)
                     .find(Menu)
+                    .find(MenuItem)
                     .find(`.${Classes.ACTIVE}`)
                     .exists(),
             );
         });
 
-        it("shortcuts with active menu style", () => {
+        it("corresponding shortcut is displayed as active when selected", () => {
             const selectedShortcut = 1;
             const { wrapper } = render({ selectedShortcutIndex: selectedShortcut });
 
@@ -933,9 +934,21 @@ describe("<DateRangePicker>", () => {
                 wrapper
                     .find(Shortcuts)
                     .find(Menu)
+                    .find(MenuItem)
                     .find(`.${Classes.ACTIVE}`)
                     .exists(),
             );
+
+            assert.lengthOf(
+                wrapper
+                    .find(Shortcuts)
+                    .find(Menu)
+                    .find(MenuItem)
+                    .find(`.${Classes.ACTIVE}`),
+                1,
+            );
+
+            assert.isTrue(wrapper.state("selectedShortcutIndex") === selectedShortcut);
         });
 
         it("should call onShortcutChangeSpy on selecting a shortcut ", () => {
@@ -947,7 +960,7 @@ describe("<DateRangePicker>", () => {
 
             assert.isTrue(onChangeSpy.calledOnce);
             assert.isTrue(onShortcutChangeSpy.calledOnce);
-            assert.isTrue(onShortcutChangeSpy.calledWith(selectedShortcut));
+            assert.isTrue(onShortcutChangeSpy.lastCall.lastArg === selectedShortcut);
         });
 
         it("custom shortcuts select the correct values", () => {

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -39,6 +39,7 @@ export interface IDateRangePickerExampleState {
     reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
     timePrecision?: TimePrecision;
+    selectedShortcutIndex?: number;
 }
 
 interface IDateOption {
@@ -80,6 +81,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
         maxDateIndex: 0,
         minDateIndex: 0,
         reverseMonthAndYearMenus: false,
+        selectedShortcutIndex: -1,
         shortcuts: true,
         singleMonthOnly: false,
     };
@@ -112,6 +114,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateChange}
+                    onShortcutChange={this.handleShortcutChange}
                 />
                 <MomentDateRange withTime={props.timePrecision !== undefined} range={this.state.dateRange} />
             </Example>
@@ -172,6 +175,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
     }
 
     private handleDateChange = (dateRange: DateRange) => this.setState({ dateRange });
+    private handleShortcutChange = (selectedShortcutIndex: number) => this.setState({ selectedShortcutIndex });
 
     private renderSelectMenu(
         label: string,

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -39,7 +39,6 @@ export interface IDateRangePickerExampleState {
     reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
     timePrecision?: TimePrecision;
-    selectedShortcutIndex?: number;
 }
 
 interface IDateOption {
@@ -81,7 +80,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
         maxDateIndex: 0,
         minDateIndex: 0,
         reverseMonthAndYearMenus: false,
-        selectedShortcutIndex: -1,
         shortcuts: true,
         singleMonthOnly: false,
     };
@@ -114,7 +112,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateChange}
-                    onShortcutChange={this.handleShortcutChange}
                 />
                 <MomentDateRange withTime={props.timePrecision !== undefined} range={this.state.dateRange} />
             </Example>
@@ -175,7 +172,6 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
     }
 
     private handleDateChange = (dateRange: DateRange) => this.setState({ dateRange });
-    private handleShortcutChange = (selectedShortcutIndex: number) => this.setState({ selectedShortcutIndex });
 
     private renderSelectMenu(
         label: string,


### PR DESCRIPTION
#### Fixes #3683 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
add `selectedShortcutIndex` and `onShortcutChange` props to `<DateRangePicker`
