### PR TITLE
Use variable $drawer-padding

### DIFF
--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -179,14 +179,14 @@ $drawer-default-size: 50%;
   position: relative;
   border-radius: 0;
   box-shadow: 0 1px 0 $pt-divider-black;
-  min-height: $pt-icon-size-large + $dialog-padding;
-  padding: $dialog-padding / 4;
-  padding-left: $dialog-padding;
+  min-height: $pt-icon-size-large + $drawer-padding;
+  padding: $drawer-padding / 4;
+  padding-left: $drawer-padding;
 
   .#{$ns}-icon-large,
   .#{$ns}-icon {
     flex: 0 0 auto;
-    margin-right: $dialog-padding / 2;
+    margin-right: $drawer-padding / 2;
     color: $pt-icon-color;
   }
 
@@ -197,7 +197,7 @@ $drawer-default-size: 50%;
     line-height: inherit;
 
     &:last-child {
-      margin-right: $dialog-padding;
+      margin-right: $drawer-padding;
     }
   }
 
@@ -221,7 +221,7 @@ $drawer-default-size: 50%;
   flex: 0 0 auto;
   position: relative;
   box-shadow: inset 0 1px 0 $pt-divider-black;
-  padding: $dialog-padding/2 $dialog-padding;
+  padding: $drawer-padding/2 $drawer-padding;
 
   .#{$ns}-dark & {
     box-shadow: inset 0 1px 0 $pt-dark-divider-black;


### PR DESCRIPTION
Correcting use of $dialog-padding to $drawer-padding

#### Fixes #0000

#### Checklist

- [ ] Includes tests (N/A; Bugfix)
- [ ] Update documentation (N/A; Bugfix)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Can't isolate drawer.scss because it incorrectly uses $dialog-padding variable instead of $drawer-padding

#### Reviewers should focus on:

I guess build of individual components? Specifically, the Drawer component styles

#### Screenshot

N/A
