### PR TITLE
Refactor to React 16.3+ lifecycle methods

### DIFF
--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -21,24 +21,37 @@ import { isNodeEnv } from "./utils";
  * An abstract component that Blueprint components can extend
  * in order to add some common functionality like runtime props validation.
  */
-export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
+export abstract class AbstractComponent<P, S, SS = {}> extends React.Component<P, S, SS> {
     /** Component displayName should be `public static`. This property exists to prevent incorrect usage. */
     protected displayName: never;
 
     // Not bothering to remove entries when their timeouts finish because clearing invalid ID is a no-op
     private timeoutIds: number[] = [];
 
-    constructor(props?: P, context?: any) {
+    protected constructor(props?: P, context?: any) {
         super(props, context);
         if (!isNodeEnv("production")) {
             this.validateProps(this.props);
         }
     }
 
-    public componentWillReceiveProps(nextProps: P & { children?: React.ReactNode }) {
+    public componentDidUpdate() {
         if (!isNodeEnv("production")) {
-            this.validateProps(nextProps);
+            this.validateProps(this.props);
         }
+    }
+
+    /**
+     * Ensures that the props specified for a component are valid.
+     * Implementations should check that props are valid and usually throw an Error if they are not.
+     * Implementations should not duplicate checks that the type system already guarantees.
+     *
+     * This method should be used instead of React's
+     * [propTypes](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) feature.
+     * Like propTypes, these runtime checks run only in development mode.
+     */
+    protected validateProps(_: P) {
+        // implement in subclass
     }
 
     public componentWillUnmount() {
@@ -67,17 +80,4 @@ export abstract class AbstractComponent<P, S> extends React.Component<P, S> {
             this.timeoutIds = [];
         }
     };
-
-    /**
-     * Ensures that the props specified for a component are valid.
-     * Implementations should check that props are valid and usually throw an Error if they are not.
-     * Implementations should not duplicate checks that the type system already guarantees.
-     *
-     * This method should be used instead of React's
-     * [propTypes](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) feature.
-     * Like propTypes, these runtime checks run only in development mode.
-     */
-    protected validateProps(_: P & { children?: React.ReactNode }) {
-        // implement in subclass
-    }
 }

--- a/packages/core/src/common/abstractPureComponent.ts
+++ b/packages/core/src/common/abstractPureComponent.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-import { isNodeEnv } from "./utils";
+import * as React from 'react';
+import { isNodeEnv } from './utils';
 
 /**
  * An abstract component that Blueprint components can extend
  * in order to add some common functionality like runtime props validation.
  */
-export abstract class AbstractPureComponent<P, S = {}> extends React.PureComponent<P, S> {
+export abstract class AbstractPureComponent<P, S = {}, SS = {}> extends React.PureComponent<P, S, SS> {
     /** Component displayName should be `public static`. This property exists to prevent incorrect usage. */
     protected displayName: never;
 
@@ -30,14 +30,14 @@ export abstract class AbstractPureComponent<P, S = {}> extends React.PureCompone
 
     constructor(props?: P, context?: any) {
         super(props, context);
-        if (!isNodeEnv("production")) {
+        if (!isNodeEnv('production')) {
             this.validateProps(this.props);
         }
     }
 
-    public componentWillReceiveProps(nextProps: P & { children?: React.ReactNode }) {
-        if (!isNodeEnv("production")) {
-            this.validateProps(nextProps);
+    public componentDidUpdate(_: P, __: S, ___: SS) {
+        if (!isNodeEnv('production')) {
+            this.validateProps(this.props);
         }
     }
 
@@ -77,7 +77,7 @@ export abstract class AbstractPureComponent<P, S = {}> extends React.PureCompone
      * [propTypes](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) feature.
      * Like propTypes, these runtime checks run only in development mode.
      */
-    protected validateProps(_: P & { children?: React.ReactNode }) {
+    protected validateProps(_: P) {
         // implement in subclass
     }
 }

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -118,6 +118,8 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
 }
 
 export class Alert extends AbstractPureComponent<IAlertProps, {}> {
+    state = {};
+
     public static defaultProps: IAlertProps = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -118,8 +118,6 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
 }
 
 export class Alert extends AbstractPureComponent<IAlertProps, {}> {
-    state = {};
-
     public static defaultProps: IAlertProps = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,
@@ -128,6 +126,7 @@ export class Alert extends AbstractPureComponent<IAlertProps, {}> {
     };
 
     public static displayName = `${DISPLAYNAME_PREFIX}.Alert`;
+    public state = {};
 
     public render() {
         const {

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -105,7 +105,12 @@ export enum AnimationStates {
     CLOSED,
 }
 
-export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseState> {
+export interface ICollapseSnapshot {
+    animationState?: AnimationStates;
+    height?: string;
+}
+
+export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseState, ICollapseSnapshot> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Collapse`;
 
     public static defaultProps: ICollapseProps = {
@@ -125,20 +130,25 @@ export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseSta
     // The most recent non-0 height (once a height has been measured - is 0 until then)
     private height: number = 0;
 
-    public componentWillReceiveProps(nextProps: ICollapseProps) {
-        if (this.props.isOpen !== nextProps.isOpen) {
+    public getSnapshotBeforeUpdate(prevProps: ICollapseProps): ICollapseSnapshot {
+        let snapshot: ICollapseSnapshot = {};
+        if (this.props.isOpen !== prevProps.isOpen) {
             this.clearTimeouts();
-            if (this.state.animationState !== AnimationStates.CLOSED && !nextProps.isOpen) {
-                this.setState({
+            if (this.state.animationState !== AnimationStates.CLOSED && !this.props.isOpen) {
+                snapshot = {
+                    ...snapshot,
                     animationState: AnimationStates.CLOSING_START,
                     height: `${this.height}px`,
-                });
-            } else if (this.state.animationState !== AnimationStates.OPEN && nextProps.isOpen) {
-                this.setState({
+                };
+            } else if (this.state.animationState !== AnimationStates.OPEN && this.props.isOpen) {
+                snapshot = {
+                    ...snapshot,
                     animationState: AnimationStates.OPEN_START,
-                });
+                };
             }
         }
+
+        return snapshot;
     }
 
     public render() {
@@ -184,11 +194,11 @@ export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseSta
         }
     }
 
-    public componentDidUpdate() {
+    public componentDidUpdate(_: ICollapseProps, __: ICollapseState, snapshot: ICollapseSnapshot) {
         if (this.contents != null && this.contents.clientHeight !== 0) {
             this.height = this.contents.clientHeight;
         }
-        if (this.state.animationState === AnimationStates.CLOSING_START) {
+        if (snapshot.animationState === AnimationStates.CLOSING_START) {
             this.setTimeout(() =>
                 this.setState({
                     animationState: AnimationStates.CLOSING,
@@ -197,7 +207,7 @@ export class Collapse extends AbstractPureComponent<ICollapseProps, ICollapseSta
             );
             this.setTimeout(() => this.onDelayedStateChange(), this.props.transitionDuration);
         }
-        if (this.state.animationState === AnimationStates.OPEN_START) {
+        if (snapshot.animationState === AnimationStates.OPEN_START) {
             this.setState({
                 animationState: AnimationStates.OPENING,
                 height: this.height + "px",

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -271,8 +271,12 @@ export class NumericInput extends AbstractPureComponent<
         );
     }
 
-    public componentDidUpdate(prevProps: INumericInputProps, prevState: INumericInputState, snapshot: INumericInputSnapshot) {
-        super.componentDidUpdate(prevProps, prevState, snapshot)
+    public componentDidUpdate(
+        prevProps: INumericInputProps,
+        prevState: INumericInputState,
+        snapshot: INumericInputSnapshot,
+    ) {
+        super.componentDidUpdate(prevProps, prevState, snapshot);
         if (this.state.shouldSelectAfterUpdate) {
             this.inputElement.setSelectionRange(0, this.state.value.length);
         }

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -158,6 +158,10 @@ export interface INumericInputState {
     value: string;
 }
 
+export interface INumericInputSnapshot {
+    value: string;
+}
+
 enum IncrementDirection {
     DOWN = -1,
     UP = +1,
@@ -179,7 +183,11 @@ const NON_HTML_PROPS: Array<keyof INumericInputProps> = [
 
 type ButtonEventHandlers = Required<Pick<React.HTMLAttributes<Element>, "onKeyDown" | "onMouseDown">>;
 
-export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumericInputProps, INumericInputState> {
+export class NumericInput extends AbstractPureComponent<
+    HTMLInputProps & INumericInputProps,
+    INumericInputState,
+    INumericInputSnapshot
+> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NumericInput`;
 
     public static VALUE_EMPTY = "";
@@ -198,12 +206,28 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumeri
         value: NumericInput.VALUE_EMPTY,
     };
 
+    public static getDerivedStateFromProps(props: INumericInputProps) {
+        const stepMaxPrecision = NumericInput.getStepMaxPrecision(props);
+
+        return { stepMaxPrecision };
+    }
+
     private static CONTINUOUS_CHANGE_DELAY = 300;
     private static CONTINUOUS_CHANGE_INTERVAL = 100;
 
+    // Value Helpers
+    // =============
+    private static getStepMaxPrecision(props: HTMLInputProps & INumericInputProps) {
+        if (props.minorStepSize != null) {
+            return Utils.countDecimalPlaces(props.minorStepSize);
+        } else {
+            return Utils.countDecimalPlaces(props.stepSize);
+        }
+    }
+
     public state: INumericInputState = {
         shouldSelectAfterUpdate: false,
-        stepMaxPrecision: this.getStepMaxPrecision(this.props),
+        stepMaxPrecision: NumericInput.getStepMaxPrecision(this.props),
         value: getValueOrEmptyValue(this.props.value),
     };
 
@@ -216,30 +240,22 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumeri
     private incrementButtonHandlers = this.getButtonEventHandlers(IncrementDirection.UP);
     private decrementButtonHandlers = this.getButtonEventHandlers(IncrementDirection.DOWN);
 
-    public componentWillReceiveProps(nextProps: HTMLInputProps & INumericInputProps) {
-        super.componentWillReceiveProps(nextProps);
-
-        const value = getValueOrEmptyValue(nextProps.value);
-
-        const didMinChange = nextProps.min !== this.props.min;
-        const didMaxChange = nextProps.max !== this.props.max;
+    public getSnapshotBeforeUpdate(prevProps: INumericInputProps): INumericInputSnapshot {
+        const didMinChange = prevProps.min !== this.props.min;
+        const didMaxChange = prevProps.max !== this.props.max;
         const didBoundsChange = didMinChange || didMaxChange;
+
+        const baseValue = prevProps.value !== this.props.value ? this.props.value : this.state.value;
+        const value = getValueOrEmptyValue(baseValue);
 
         const sanitizedValue =
             value !== NumericInput.VALUE_EMPTY
-                ? this.getSanitizedValue(value, /* delta */ 0, nextProps.min, nextProps.max)
+                ? this.getSanitizedValue(value, /* delta */ 0, this.props.min, this.props.max)
                 : NumericInput.VALUE_EMPTY;
 
-        const stepMaxPrecision = this.getStepMaxPrecision(nextProps);
-
-        // if a new min and max were provided that cause the existing value to fall
-        // outside of the new bounds, then clamp the value to the new valid range.
-        if (didBoundsChange && sanitizedValue !== this.state.value) {
-            this.setState({ stepMaxPrecision, value: sanitizedValue });
-            this.invokeValueCallback(sanitizedValue, this.props.onValueChange);
-        } else {
-            this.setState({ stepMaxPrecision, value });
-        }
+        return {
+            value: didBoundsChange ? sanitizedValue : value,
+        };
     }
 
     public render() {
@@ -255,9 +271,15 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumeri
         );
     }
 
-    public componentDidUpdate() {
+    public componentDidUpdate(prevProps: INumericInputProps, prevState: INumericInputState, snapshot: INumericInputSnapshot) {
+        super.componentDidUpdate(prevProps, prevState, snapshot)
         if (this.state.shouldSelectAfterUpdate) {
             this.inputElement.setSelectionRange(0, this.state.value.length);
+        }
+
+        this.setState({ value: snapshot.value });
+        if (this.state.value !== snapshot.value) {
+            this.invokeValueCallback(snapshot.value, this.props.onValueChange);
         }
     }
 
@@ -466,9 +488,6 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumeri
         Utils.safeInvoke(callback, +value, value);
     }
 
-    // Value Helpers
-    // =============
-
     private incrementValue(delta: number) {
         // pretend we're incrementing from 0 if currValue is empty
         const currValue = this.state.value || NumericInput.VALUE_ZERO;
@@ -498,14 +517,6 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & INumeri
         }
         const nextValue = toMaxPrecision(parseFloat(value) + delta, this.state.stepMaxPrecision);
         return clampValue(nextValue, min, max).toString();
-    }
-
-    private getStepMaxPrecision(props: HTMLInputProps & INumericInputProps) {
-        if (props.minorStepSize != null) {
-            return Utils.countDecimalPlaces(props.minorStepSize);
-        } else {
-            return Utils.countDecimalPlaces(props.stepSize);
-        }
     }
 
     private updateDelta(direction: IncrementDirection, e: React.MouseEvent | React.KeyboardEvent) {

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -41,7 +41,7 @@ export interface IHotkeysProps extends IProps {
     tabIndex?: number;
 }
 
-export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}> {
+export class Hotkeys extends AbstractPureComponent<IHotkeysProps, {}, {}> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Hotkeys`;
 
     public static defaultProps = {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -181,6 +181,7 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         const wrapperClasses = classNames(Classes.POPOVER_WRAPPER, className, {
             [Classes.FILL]: fill,
         });
+
         const wrapper = React.createElement(
             wrapperTagName,
             { className: wrapperClasses },
@@ -222,24 +223,21 @@ export class Popover extends AbstractPureComponent<IPopoverProps, IPopoverState>
         this.updateDarkParent();
     }
 
-    public componentWillReceiveProps(nextProps: IPopoverProps) {
-        super.componentWillReceiveProps(nextProps);
+    public componentDidUpdate(_: IPopoverProps, __: IPopoverState, snapshot: {}) {
+        super.componentDidUpdate(_, __, snapshot);
+        this.updateDarkParent();
 
-        const nextIsOpen = this.getIsOpen(nextProps);
+        const nextIsOpen = this.getIsOpen(this.props);
 
-        if (nextProps.isOpen != null && nextIsOpen !== this.state.isOpen) {
+        if (this.props.isOpen != null && nextIsOpen !== this.state.isOpen) {
             this.setOpenState(nextIsOpen);
             // tricky: setOpenState calls setState only if this.props.isOpen is
             // not controlled, so we need to invoke setState manually here.
             this.setState({ isOpen: nextIsOpen });
-        } else if (this.state.isOpen && nextProps.isOpen == null && nextProps.disabled) {
+        } else if (this.props.disabled && this.state.isOpen && this.props.isOpen == null) {
             // special case: close an uncontrolled popover when disabled is set to true
             this.setOpenState(false);
         }
-    }
-
-    public componentDidUpdate() {
-        this.updateDarkParent();
     }
 
     /**

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -200,8 +200,28 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
     }
 
     public componentDidUpdate(prevProps: IMultiSliderProps, prevState: ISliderState, ss: {}) {
-        super.componentDidUpdate(prevProps, prevState, ss)
+        super.componentDidUpdate(prevProps, prevState, ss);
         this.updateTickSize();
+    }
+
+    protected validateProps(props: IMultiSliderProps & IChildrenProps) {
+        if (props.stepSize <= 0) {
+            throw new Error(Errors.SLIDER_ZERO_STEP);
+        }
+        if (props.labelStepSize <= 0) {
+            throw new Error(Errors.SLIDER_ZERO_LABEL_STEP);
+        }
+
+        let anyInvalidChildren = false;
+        React.Children.forEach(props.children, child => {
+            // allow boolean coercion to omit nulls and false values
+            if (child && !Utils.isElementOfType(child, MultiSlider.Handle)) {
+                anyInvalidChildren = true;
+            }
+        });
+        if (anyInvalidChildren) {
+            throw new Error(Errors.MULTISLIDER_INVALID_CHILD);
+        }
     }
 
     private formatLabel(value: number): React.ReactChild {
@@ -417,26 +437,6 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
             const tickSizeRatio = 1 / ((this.props.max as number) - (this.props.min as number));
             const tickSize = trackSize * tickSizeRatio;
             this.setState({ tickSize, tickSizeRatio });
-        }
-    }
-
-    protected validateProps(props: IMultiSliderProps & IChildrenProps) {
-        if (props.stepSize <= 0) {
-            throw new Error(Errors.SLIDER_ZERO_STEP);
-        }
-        if (props.labelStepSize <= 0) {
-            throw new Error(Errors.SLIDER_ZERO_LABEL_STEP);
-        }
-
-        let anyInvalidChildren = false;
-        React.Children.forEach(props.children, child => {
-            // allow boolean coercion to omit nulls and false values
-            if (child && !Utils.isElementOfType(child, MultiSlider.Handle)) {
-                anyInvalidChildren = true;
-            }
-        });
-        if (anyInvalidChildren) {
-            throw new Error(Errors.MULTISLIDER_INVALID_CHILD);
         }
     }
 }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -194,10 +194,14 @@ export interface ITagInputState {
     isInputFocused: boolean;
 }
 
+export interface ITagInputSnapshot {
+    inputValue: string;
+}
+
 /** special value for absence of active tag */
 const NONE = -1;
 
-export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputState> {
+export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputState, ITagInputSnapshot> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TagInput`;
 
     public static defaultProps: Partial<ITagInputProps> & object = {
@@ -222,12 +226,13 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
         },
     };
 
-    public componentWillReceiveProps(nextProps: HTMLInputProps & ITagInputProps) {
-        super.componentWillReceiveProps(nextProps);
+    public getSnapshotBeforeUpdate(prevProps: Readonly<ITagInputProps>): ITagInputSnapshot {
+        return { inputValue: prevProps.inputValue !== this.props.inputValue ? this.props.inputValue : this.state.inputValue}
+    }
 
-        if (nextProps.inputValue !== this.props.inputValue) {
-            this.setState({ inputValue: nextProps.inputValue || "" });
-        }
+    public componentDidUpdate(_: ITagInputProps, __: ITagInputState, snapshot: ITagInputSnapshot) {
+        super.componentDidUpdate(_, __, snapshot);
+        this.setState(snapshot);
     }
 
     public render() {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -227,7 +227,9 @@ export class TagInput extends AbstractPureComponent<ITagInputProps, ITagInputSta
     };
 
     public getSnapshotBeforeUpdate(prevProps: Readonly<ITagInputProps>): ITagInputSnapshot {
-        return { inputValue: prevProps.inputValue !== this.props.inputValue ? this.props.inputValue : this.state.inputValue}
+        return {
+            inputValue: prevProps.inputValue !== this.props.inputValue ? this.props.inputValue : this.state.inputValue,
+        };
     }
 
     public componentDidUpdate(_: ITagInputProps, __: ITagInputState, snapshot: ITagInputSnapshot) {

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -67,7 +67,7 @@ describe("ContextMenu", () => {
         setTimeout(() => {
             assert.isTrue(document.querySelector(`.${Classes.CONTEXT_MENU}`) == null);
             done();
-        }, 110);
+        }, 200);
     });
 
     it("does not invoke previous onClose callback", () => {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -380,6 +380,7 @@ describe("<Popover>", () => {
             renderPopover()
                 .assertIsOpen(false)
                 .setProps({ isOpen: true })
+                .update()
                 .assertIsOpen();
         });
 
@@ -430,6 +431,7 @@ describe("<Popover>", () => {
                 renderPopover({ disabled: true, isOpen: true, onInteraction: onInteractionSpy })
                     .assertOnInteractionCalled(false)
                     .setProps({ disabled: false })
+                    .update()
                     .assertIsOpen()
                     .assertOnInteractionCalled();
             });
@@ -590,6 +592,7 @@ describe("<Popover>", () => {
                 .simulateTarget("click")
                 .assertIsOpen()
                 .setProps({ disabled: true })
+                .update()
                 .assertIsOpen(false);
         });
 

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -215,6 +215,25 @@ describe("<MultiSlider>", () => {
     });
 
     describe("validation", () => {
+        let expectedErrors = 0;
+        let actualErrors = 0;
+        function onError(e: ErrorEvent) {
+            e.preventDefault();
+            actualErrors++;
+        }
+
+        beforeEach(() => {
+            expectedErrors = 0;
+            actualErrors = 0;
+            window.addEventListener("error", onError);
+        });
+
+        afterEach(() => {
+            window.removeEventListener("error", onError);
+            expect(actualErrors).to.eq(expectedErrors);
+            expectedErrors = 0;
+        });
+
         it("throws an error if a child is not a slider handle", () => {
             expectPropValidationError(MultiSlider, { children: <span>Bad</span> as any });
         });

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -148,13 +148,14 @@ describe("<TagInput>", () => {
             wrapper.setProps({ inputProps: { value: NEW_VALUE } });
             wrapper.find("input").simulate("change", { currentTarget: { value: NEW_VALUE } });
             wrapper.simulate("blur");
+
             // Need setTimeout here to wait for focus to change after blur event
             setTimeout(() => {
                 assert.isTrue(onAdd.calledOnce);
                 assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
                 assert.equal(onAdd.args[0][1], "blur");
                 done();
-            });
+            }, 50);
         });
 
         it("is not invoked on blur when addOnBlur=true but inputValue is empty", done => {
@@ -549,6 +550,7 @@ describe("<TagInput>", () => {
         it("Updating inputValue updates input element", () => {
             const wrapper = mount(<TagInput inputValue="" values={VALUES} />);
             wrapper.setProps({ inputValue: NEW_VALUE });
+            wrapper.update();
             expect(wrapper.find("input").prop("value")).to.equal(NEW_VALUE);
         });
 


### PR DESCRIPTION
#### Fixes #3361 

#### Checklist

- [x] Includes tests
~- [ ] Update documentation~

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

React 17 will deprecated several lifecycle methods. While there is a workaround to keep using them with the `UNSAFE_` prefix, this will not work in older React versions. Migrating to the new lifecycle methods also enables us to make use of the polyfill plugin provided by the react team ( https://github.com/reactjs/react-lifecycles-compat )

This PR:
* replaces lifecycle methods
* adds polyfill plugin to support older react versions

#### Reviewers should focus on:
Since i am changing behavior of the basic building blocks of blueprint, feel free to test interactions with any and all components that either extend abstract components, or use these building blocks of the `core` package:
* popover
* alert
* multi slider
* numeric input
* hotkeys
* inputTag

