### PR TITLE
Update Lerna URL in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ then [check out the "help wanted" label](https://github.com/palantir/blueprint/l
 
 ## Development
 
-[Lerna](https://lernajs.io/) manages inter-package dependencies in this monorepo.
+[Lerna](https://lerna.js.org/) manages inter-package dependencies in this monorepo.
 Builds are orchestrated via `lerna run` and NPM scripts.
 
 __Prerequisites__: Node.js v8+, Yarn v1.10+


### PR DESCRIPTION
#### Checklist

- [ ] ~Includes tests~
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The Lerna URL in the README ([lernajs.io](https://lernajs.io)) refers to a page that doesn't work-- Presumably an old URL. This updates it to the working homepage for that project-- [lerna.js.org](https://lerna.js.org).

#### Reviewers should focus on:

The single link that I changed :)
