### PR TITLE
[select] Default autoComplete for text input in <Suggest> to "off"

### DIFF
--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -153,7 +153,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         const { fill, inputProps = {}, popoverProps = {} } = this.props;
         const { isOpen, selectedItem } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
-        const { placeholder = "Search..." } = inputProps;
+        const { autoComplete = "off", placeholder = "Search..." } = inputProps;
 
         const selectedItemText = selectedItem ? this.props.inputValueRenderer(selectedItem) : "";
         // placeholder shows selected item while open.
@@ -183,6 +183,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 onOpened={this.handlePopoverOpened}
             >
                 <InputGroup
+                    autoComplete={autoComplete}
                     disabled={this.props.disabled}
                     {...inputProps}
                     inputRef={this.refHandlers.input}


### PR DESCRIPTION
#### Fixes #0000

No issue yet

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

Please advise if these items are needed.  inputProps are already documented and this commit just sets a default.

#### Changes proposed in this pull request:

Set the default autocomplete HTML attribute to "off" so that browser drop downs don't render in front of the component menu options.

#### Reviewers should focus on:

The default value set by this commit
