### PR TITLE
Do not pass labelClassName to HTML element.

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -116,6 +116,7 @@ export class MenuItem extends React.PureComponent<IMenuItemProps & React.AnchorH
             disabled,
             icon,
             intent,
+            labelClassName,
             labelElement,
             multiline,
             popoverProps,


### PR DESCRIPTION
Error in console:
```
react-dom.development.js?4646:545 Warning: React does not recognize the `labelClassName` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `labelclassname` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in a (created by Blueprint3.MenuItem)
    in li (created by Blueprint3.MenuItem)
    in Blueprint3.MenuItem (created by HomePage)
    in ul (created by Blueprint3.Menu)
    in Blueprint3.Menu (created by HomePage)
...
```