### PR TITLE
[table] fix: column resize calculation on header double click

### DIFF
--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-const CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT = "bp-table-text-no-measure";
+// used to exclude icons from column header measure
+export const CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT = "bp-table-text-no-measure";
+// supposed width of the icons placeholder
+const EXCLUDED_ICON_PLACEHOLDER_WIDTH = 16;
 
 /**
  * Since Firefox doesn't provide a computed "font" property, we manually
@@ -350,23 +353,20 @@ export const Utils = {
  * exclude an element's text from the computation.
  */
 function measureTextContentWithExclusions(context: CanvasRenderingContext2D, element: Element): TextMetrics {
-    // We only expect one or zero excluded elements in this subtree
-    // We don't have a need for more than one, so we avoid that complexity altogether.
-    const elementToExclude = element.querySelector(`.${CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT}`);
-    let removedElementParent: Element | undefined;
-    let removedElementNextSibling: Node | undefined;
-
-    if (elementToExclude != null) {
-        removedElementParent = elementToExclude.parentElement;
-        removedElementNextSibling = elementToExclude.nextSibling;
-        removedElementParent.removeChild(elementToExclude);
+    const elementsToExclude = element.querySelectorAll(`.${CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT}`);
+    let excludedElementsWidth = 0;
+    if (elementsToExclude && elementsToExclude.length) {
+        elementsToExclude.forEach((e) => {
+            const excludedMetrics = context.measureText(e.textContent);
+            excludedElementsWidth += excludedMetrics.width - EXCLUDED_ICON_PLACEHOLDER_WIDTH;
+        });
     }
 
     const metrics = context.measureText(element.textContent);
+    const metricsWithExclusions = {
+        ...metrics,
+        width: metrics.width - excludedElementsWidth,
+    };
 
-    if (elementToExclude != null) {
-        removedElementParent.insertBefore(elementToExclude, removedElementNextSibling);
-    }
-
-    return metrics;
+    return metricsWithExclusions;
 }

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -28,6 +28,7 @@ import {
 } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
+import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
 import { columnInteractionBarContextTypes, IColumnInteractionBarContextTypes } from "../common/context";
 import { LoadableContent } from "../common/loadableContent";
 import { HeaderCell, IHeaderCellProps } from "./headerCell";
@@ -194,9 +195,13 @@ export class ColumnHeaderCell extends AbstractPureComponent<IColumnHeaderCellPro
             return undefined;
         }
 
-        const classes = classNames(Classes.TABLE_TH_MENU_CONTAINER, {
-            [Classes.TABLE_TH_MENU_OPEN]: this.state.isActive,
-        });
+        const classes = classNames(
+            Classes.TABLE_TH_MENU_CONTAINER,
+            CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT,
+            {
+                [Classes.TABLE_TH_MENU_OPEN]: this.state.isActive,
+            }
+        );
 
         return (
             <div className={classes}>

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -28,9 +28,9 @@ import {
 } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
-import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
 import { columnInteractionBarContextTypes, IColumnInteractionBarContextTypes } from "../common/context";
 import { LoadableContent } from "../common/loadableContent";
+import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
 import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
 export interface IColumnNameProps {
@@ -195,13 +195,9 @@ export class ColumnHeaderCell extends AbstractPureComponent<IColumnHeaderCellPro
             return undefined;
         }
 
-        const classes = classNames(
-            Classes.TABLE_TH_MENU_CONTAINER,
-            CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT,
-            {
-                [Classes.TABLE_TH_MENU_OPEN]: this.state.isActive,
-            }
-        );
+        const classes = classNames(Classes.TABLE_TH_MENU_CONTAINER, CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT, {
+            [Classes.TABLE_TH_MENU_OPEN]: this.state.isActive,
+        });
 
         return (
             <div className={classes}>

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -379,7 +379,9 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             : this.wrapInDragReorderable(
                   index,
                   <div className={Classes.TABLE_REORDER_HANDLE_TARGET}>
-                      <div className={classNames(Classes.TABLE_REORDER_HANDLE, CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT)}>
+                      <div
+                          className={classNames(Classes.TABLE_REORDER_HANDLE, CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT)}
+                      >
                           <Icon icon="drag-handle-vertical" />
                       </div>
                   </div>,

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -21,6 +21,7 @@ import * as React from "react";
 import { Grid } from "../common";
 import { IFocusedCellCoordinates } from "../common/cell";
 import * as Classes from "../common/classes";
+import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
 import { DragEvents } from "../interactions/dragEvents";
 import { IClientCoordinates, ICoordinateData } from "../interactions/draggable";
 import { DragReorderable, IReorderableProps } from "../interactions/reorderable";
@@ -378,7 +379,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
             : this.wrapInDragReorderable(
                   index,
                   <div className={Classes.TABLE_REORDER_HANDLE_TARGET}>
-                      <div className={Classes.TABLE_REORDER_HANDLE}>
+                      <div className={classNames(Classes.TABLE_REORDER_HANDLE, CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT)}>
                           <Icon icon="drag-handle-vertical" />
                       </div>
                   </div>,


### PR DESCRIPTION
#### Fixes #3731

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- fixes `ColumnHeader.handleResizeDoubleClick` with enabled ColumnReordering and menuRenderer
- added `bp-table-text-no-measure` class to header's maybeRenderReorderHandle
- added `bp-table-text-no-measure` class to columnHeaderCell's maybeRenderDropdownMenu
- modified **packages/table/src/common/utils.ts** `measureTextContentWithExclusions` logic

#### Reviewers should focus on:

- I searched through the code, `measureTextContentWithExclusions` is used only at `handleResizeDoubleClick`, so I assumed that it would be ok to modify it
- I modified `measureTextContentWithExclusions` as it is possible to have both ColumnReordering and menuRenderer icons inside header
- I removed dom manipulations at `measureTextContentWithExclusions`, and replaced it with metrics computation
- added `EXCLUDED_ICON_PLACEHOLDER_WIDTH` constant to add spacing to auto-resize width at the place of that icons
- `CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT` is exported and used at `header.tsx` and `columnHeaderCell.tsx`

