### PR TITLE
Fix render bug with multislider track fill

### DIFF
--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -267,7 +267,9 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
 
     private renderTrackFill(index: number, start: IHandleProps, end: IHandleProps) {
         // ensure startRatio <= endRatio
-        const [startRatio, endRatio] = [this.getOffsetRatio(start.value), this.getOffsetRatio(end.value)].sort();
+        const [startRatio, endRatio] = [this.getOffsetRatio(start.value), this.getOffsetRatio(end.value)].sort(
+            (left, right) => left - right
+        );
         const startOffset = formatPercentage(startRatio);
         const endOffset = formatPercentage(1 - endRatio);
         const style: React.CSSProperties = this.props.vertical

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -268,7 +268,7 @@ export class MultiSlider extends AbstractPureComponent<IMultiSliderProps, ISlide
     private renderTrackFill(index: number, start: IHandleProps, end: IHandleProps) {
         // ensure startRatio <= endRatio
         const [startRatio, endRatio] = [this.getOffsetRatio(start.value), this.getOffsetRatio(end.value)].sort(
-            (left, right) => left - right
+            (left, right) => left - right,
         );
         const startOffset = formatPercentage(startRatio);
         const endOffset = formatPercentage(1 - endRatio);

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -219,7 +219,6 @@ describe("<MultiSlider>", () => {
                     <MultiSlider.Handle value={1.2e-7} intentBefore="warning" intentAfter="warning" />
                     <MultiSlider.Handle value={0.2} intentBefore="danger" intentAfter="success" />
                 </MultiSlider>,
-                { attachTo: testsContainerElement },
             );
             const locations = slider.find(`.${Classes.SLIDER_PROGRESS}`).map(segment => {
                 const match = segment.prop("style");

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -212,6 +212,21 @@ describe("<MultiSlider>", () => {
                 assert.isNull(segment.prop("className").match(/-intent-(\w+)/));
             });
         });
+
+        it("track section positioning is correct", () => {
+            slider = mount(
+                <MultiSlider max={1}>
+                    <MultiSlider.Handle value={1.2e-7} intentBefore="warning" intentAfter="warning" />
+                    <MultiSlider.Handle value={0.2} intentBefore="danger" intentAfter="success" />
+                </MultiSlider>,
+                { attachTo: testsContainerElement },
+            );
+            const locations = slider.find(`.${Classes.SLIDER_PROGRESS}`).map(segment => {
+                const match = segment.prop("style");
+                return [match.left, match.right];
+            });
+            assert.deepEqual(locations, [["0.00%", "100.00%"], ["0.00%", "80.00%"], ["20.00%", "0.00%"]]);
+        });
     });
 
     describe("validation", () => {


### PR DESCRIPTION
#### Checklist

- [ x ] Includes tests
- [  ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes a bug in the rendering of a multislider's track. As the values were sorted with a vanilla alphabetical .sort() rounding errors such as 1.2e-7 were sorted as higher than the value 1. This resulted in a track style of {left: "20.00%", right: "100.00%"}, which would not render on chrome (other browsers not tested)

#### Reviewers should focus on:

Fairly simple change, would appreciate comments on the test as i'm new to frontend

