### PR TITLE
Fix a controlled EditableText bug

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -170,7 +170,7 @@ export class EditableText extends AbstractPureComponent<IEditableTextProps, IEdi
 
     public render() {
         const { disabled, multiline } = this.props;
-        const value = this.props.value == null ? this.state.value : this.props.value;
+        const value = this.state.isEditing && this.props.value == null ? this.state.value : this.props.value;
         const hasValue = value != null && value !== "";
 
         const classes = classNames(


### PR DESCRIPTION
Fixes a bug where EditableText controlled value cannot be reset to undefined or null.

The comments in this file state that the point of mirroring the `props.value` to `state.value` is to maintain that value while the user
is editing. However, if the user is not editing, the edited line in question as is does not allow for the value of the component to be
reset to something undefined or null for emptiness.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
