### PR TITLE
[datetime] fix(TimePicker): allow more natural text entry

### DIFF
--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -70,6 +70,16 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     &:focus {
       box-shadow: input-transition-shadow($input-shadow-color-focus, true);
     }
+
+    @each $intent, $color in $pt-intent-colors {
+      &.#{$ns}-intent-#{$intent} {
+        @include pt-input-intent($color);
+
+        .#{$ns}-dark & {
+          @include pt-dark-input-intent($color);
+        }
+      }
+    }
   }
 
   .#{$ns}-timepicker-ampm-select {

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -19,6 +19,7 @@ import {
     DISPLAYNAME_PREFIX,
     HTMLSelect,
     Icon,
+    Intent,
     IProps,
     Keys,
     Utils as BlueprintUtils,
@@ -229,9 +230,15 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     }
 
     private renderInput(className: string, unit: TimeUnit, value: string) {
+        const isValid = isTimeUnitValid(unit, parseInt(value, 10));
+
         return (
             <input
-                className={classNames(Classes.TIMEPICKER_INPUT, className)}
+                className={classNames(
+                    Classes.TIMEPICKER_INPUT,
+                    { [CoreClasses.intentClass(Intent.DANGER)]: !isValid },
+                    className,
+                )}
                 onBlur={this.getInputBlurHandler(unit)}
                 onChange={this.getInputChangeHandler(unit)}
                 onFocus={this.handleFocus}
@@ -261,12 +268,26 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
 
     // begin method definitions: event handlers
 
-    private getInputBlurHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
+    private getInputChangeHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
         const text = getStringValueFromInputEvent(e);
-        this.updateTime(parseInt(text, 10), unit);
+        switch (unit) {
+            case TimeUnit.HOUR_12:
+            case TimeUnit.HOUR_24:
+                this.setState({ hourText: text });
+                break;
+            case TimeUnit.MINUTE:
+                this.setState({ minuteText: text });
+                break;
+            case TimeUnit.SECOND:
+                this.setState({ secondText: text });
+                break;
+            case TimeUnit.MS:
+                this.setState({ millisecondText: text });
+                break;
+        }
     };
 
-    private getInputChangeHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
+    private getInputBlurHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
         const text = getStringValueFromInputEvent(e);
         this.updateTime(parseInt(text, 10), unit);
     };

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Keys } from "@blueprintjs/core";
+import { Intent, Keys } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
@@ -22,10 +22,11 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
+import { Classes as CoreClasses } from "@blueprintjs/core";
 import { Classes, ITimePickerProps, TimePicker, TimePrecision } from "../src/index";
 import { assertTimeIs, createTimeObject } from "./common/dateTestUtils";
 
-describe("<TimePicker>", () => {
+describe.only("<TimePicker>", () => {
     let testsContainerElement: Element;
     let timePicker: TimePicker;
     let onTimePickerChange: sinon.SinonSpy;
@@ -145,13 +146,25 @@ describe("<TimePicker>", () => {
         assert.strictEqual(hourInput.value, "2");
     });
 
-    it("does not allow invalid text entry", () => {
+    it("allows invalid text entry, but shows visual indicator", () => {
         renderTimePicker();
         const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
         assert.strictEqual(hourInput.value, "0");
 
         hourInput.value = "ab";
         TestUtils.Simulate.change(hourInput);
+        assert.strictEqual(hourInput.value, "ab");
+        assert.isTrue(hourInput.classList.contains(CoreClasses.intentClass(Intent.DANGER)));
+    });
+
+    it("reverts to saved value after invalid text entry is blurred", () => {
+        renderTimePicker();
+        const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
+        assert.strictEqual(hourInput.value, "0");
+
+        hourInput.value = "ab";
+        TestUtils.Simulate.change(hourInput);
+        TestUtils.Simulate.blur(hourInput);
         assert.strictEqual(hourInput.value, "0");
     });
 

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Intent, Keys } from "@blueprintjs/core";
+import { Classes as CoreClasses, Intent, Keys } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
@@ -22,11 +22,10 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
-import { Classes as CoreClasses } from "@blueprintjs/core";
 import { Classes, ITimePickerProps, TimePicker, TimePrecision } from "../src/index";
 import { assertTimeIs, createTimeObject } from "./common/dateTestUtils";
 
-describe.only("<TimePicker>", () => {
+describe("<TimePicker>", () => {
     let testsContainerElement: Element;
     let timePicker: TimePicker;
     let onTimePickerChange: sinon.SinonSpy;


### PR DESCRIPTION
#### Fixes #3648

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Text input is no longer immediately validated and rejected inside TimePicker. Instead, a "danger" intent is applied to the input if it is invalid, and the update is rejected upon blur.


#### Screenshot

![2019-10-01 14 37 26](https://user-images.githubusercontent.com/723999/65990194-24ac3a80-e459-11e9-9507-92ba677f71b5.gif)

