### PR TITLE
[table] fix: cell copy to clipboard works in IE11

### DIFF
--- a/packages/table/src/common/clipboard.ts
+++ b/packages/table/src/common/clipboard.ts
@@ -104,8 +104,7 @@ export const Clipboard = {
                     e.preventDefault();
                     const clipboardData = (e as any).clipboardData || (window as any).clipboardData;
                     if (clipboardData != null) {
-                        clipboardData.setData("text/html", elem.outerHTML);
-                        clipboardData.setData("text/plain", plaintext);
+                        clipboardData.setData("text", plaintext);
                     }
                 });
             }


### PR DESCRIPTION
#### Fixes #3758

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Use 'text' instead of 'text/html' or 'text/plain' in DataTransfer.setData so that table cell copy can work in IE11

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
