### PR TITLE
[core] feat(Tab): spread HTML props to rendered div

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -124,6 +124,8 @@ const INVALID_PROPS = [
     "minimal",
     "onChildrenMount",
     "onRemove",
+    "panel", // ITabProps
+    "panelClassName", // ITabProps
     "popoverProps",
     "rightElement",
     "rightIcon",

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -18,11 +18,11 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 export type TabId = string | number;
 
-export interface ITabProps extends IProps {
+export interface ITabProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
      * Content of tab title, rendered in a list above the active panel.
      * Can also be set via the `title` prop.

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX } from "../../common/props";
+import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { ITabProps, TabId } from "./tab";
 
 export interface ITabTitleProps extends ITabProps {
@@ -37,22 +37,23 @@ export class TabTitle extends AbstractPureComponent2<ITabTitleProps, {}> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TabTitle`;
 
     public render() {
-        const { disabled, id, parentId, selected } = this.props;
+        const { className, children, disabled, id, parentId, selected, title, ...htmlProps } = this.props;
         return (
             <div
+                {...removeNonHTMLProps(htmlProps)}
                 aria-controls={generateTabPanelId(parentId, id)}
                 aria-disabled={disabled}
                 aria-expanded={selected}
                 aria-selected={selected}
-                className={classNames(Classes.TAB, this.props.className)}
+                className={classNames(Classes.TAB, className)}
                 data-tab-id={id}
                 id={generateTabTitleId(parentId, id)}
                 onClick={disabled ? undefined : this.handleClick}
                 role="tab"
                 tabIndex={disabled ? undefined : 0}
             >
-                {this.props.title}
-                {this.props.children}
+                {title}
+                {children}
             </div>
         );
     }

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -150,6 +150,16 @@ describe("<Tabs>", () => {
         });
     });
 
+    it("sets arbitrary data-* attributes on Tab elements", () => {
+        const tabs = TAB_IDS.map(id => (
+            <Tab id={id} key={id} panel={<Panel title={id} />} title={id} data-arbitrary-attr="foo" />
+        ));
+        const wrapper = mount(<Tabs id={ID}>{tabs}</Tabs>);
+        wrapper.find(TAB).forEach(title => {
+            assert.strictEqual((title.getDOMNode() as HTMLElement).getAttribute("data-arbitrary-attr"), "foo");
+        });
+    });
+
     it("clicking selected tab still fires onChange", () => {
         const tabId = TAB_IDS[0];
         const changeSpy = spy();


### PR DESCRIPTION
#### Part of #3763 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Spread extra props sent to the `<Tab>` onto the rendered `<div>` in the implementation of `<TabTitle>`.

