### PR TITLE
fix: lifecycle methods in MultiSlider, Resizable, and TableBodyCell

### DIFF
--- a/packages/core/src/common/abstractComponent2.ts
+++ b/packages/core/src/common/abstractComponent2.ts
@@ -22,6 +22,13 @@ import { isNodeEnv } from "./utils";
  * in order to add some common functionality like runtime props validation.
  */
 export abstract class AbstractComponent2<P, S = {}, SS = {}> extends React.Component<P, S, SS> {
+    // unsafe lifecycle methods
+    public componentWillUpdate: never;
+    public componentWillReceiveProps: never;
+    public componentWillMount: never;
+    // this should be static, not an instance method
+    public getDerivedStateFromProps: never;
+
     /** Component displayName should be `public static`. This property exists to prevent incorrect usage. */
     protected displayName: never;
 

--- a/packages/core/src/common/abstractPureComponent2.ts
+++ b/packages/core/src/common/abstractPureComponent2.ts
@@ -23,7 +23,11 @@ import { isNodeEnv } from "./utils";
  */
 export abstract class AbstractPureComponent2<P, S = {}, SS = {}> extends React.PureComponent<P, S, SS> {
     // unsafe lifecycle method
+    public componentWillUpdate: never;
     public componentWillReceiveProps: never;
+    public componentWillMount: never;
+    // this should be static, not an instance method
+    public getDerivedStateFromProps: never;
 
     /** Component displayName should be `public static`. This property exists to prevent incorrect usage. */
     protected displayName: never;

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -150,8 +150,6 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
     };
 
     private handleElements: Handle[] = [];
-    // private handleProps: IHandleProps[];
-
     private trackElement: HTMLElement | null;
 
     public getSnapshotBeforeUpdate(prevProps: IMultiSliderProps): null {

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -33,12 +33,6 @@ import { argMin, fillValues, formatPercentage } from "./sliderUtils";
 const MultiSliderHandle: React.SFC<IHandleProps> = () => null;
 MultiSliderHandle.displayName = `${DISPLAYNAME_PREFIX}.MultiSliderHandle`;
 
-// TODO: move this to props.ts in a follow up PR
-/** A convenience type for React's optional children prop. */
-export interface IChildrenProps {
-    children?: React.ReactNode;
-}
-
 export interface ISliderBaseProps extends IProps {
     /**
      * Whether the slider is non-interactive.
@@ -140,7 +134,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     public static Handle = MultiSliderHandle;
 
-    public static getDerivedStateFromProps(props: IMultiSliderProps & IChildrenProps) {
+    public static getDerivedStateFromProps(props: IMultiSliderProps) {
         return { labelPrecision: MultiSlider.getLabelPrecision(props) };
     }
 
@@ -156,9 +150,19 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
     };
 
     private handleElements: Handle[] = [];
-    private handleProps: IHandleProps[];
+    // private handleProps: IHandleProps[];
 
     private trackElement: HTMLElement | null;
+
+    public getSnapshotBeforeUpdate(prevProps: IMultiSliderProps): null {
+        const prevHandleProps = getSortedInteractiveHandleProps(prevProps);
+        const newHandleProps = getSortedInteractiveHandleProps(this.props);
+        if (newHandleProps.length !== prevHandleProps.length) {
+            // clear refs
+            this.handleElements = [];
+        }
+        return null;
+    }
 
     public render() {
         const classes = classNames(
@@ -182,18 +186,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
     }
 
     public componentDidMount() {
-        this.handleProps = getSortedInteractiveHandleProps(this.props);
         this.updateTickSize();
-    }
-
-    public getSnapshotBeforeUpdate(): {} | null {
-        const newHandleProps = getSortedInteractiveHandleProps(this.props);
-        if (newHandleProps.length !== this.handleProps.length) {
-            this.handleElements = [];
-        }
-        this.handleProps = newHandleProps;
-
-        return null;
     }
 
     public componentDidUpdate(prevProps: IMultiSliderProps, prevState: ISliderState, ss: {}) {
@@ -201,7 +194,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         this.updateTickSize();
     }
 
-    protected validateProps(props: IMultiSliderProps & IChildrenProps) {
+    protected validateProps(props: React.PropsWithChildren<IMultiSliderProps>) {
         if (props.stepSize <= 0) {
             throw new Error(Errors.SLIDER_ZERO_STEP);
         }
@@ -290,17 +283,20 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     private renderHandles() {
         const { disabled, max, min, stepSize, vertical } = this.props;
-        if (!this.handleProps) {
+        const handleProps = getSortedInteractiveHandleProps(this.props);
+
+        if (handleProps.length === 0) {
             return null;
         }
-        return this.handleProps.map(({ value, type }, index) => (
+
+        return handleProps.map(({ value, type }, index) => (
             <Handle
                 className={classNames({
                     [Classes.START]: type === HandleType.START,
                     [Classes.END]: type === HandleType.END,
                 })}
                 disabled={disabled}
-                key={`${index}-${this.handleProps.length}`}
+                key={`${index}-${handleProps.length}`}
                 label={this.formatLabel(value)}
                 max={max}
                 min={min}
@@ -366,7 +362,8 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
     };
 
     private getNewHandleValues(newValue: number, oldIndex: number) {
-        const oldValues = this.handleProps.map(handle => handle.value);
+        const handleProps = getSortedInteractiveHandleProps(this.props);
+        const oldValues = handleProps.map(handle => handle.value);
         const newValues = oldValues.slice();
         newValues[oldIndex] = newValue;
         newValues.sort((left, right) => left - right);
@@ -387,19 +384,23 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     private findFirstLockedHandleIndex(startIndex: number, endIndex: number): number {
         const inc = startIndex < endIndex ? 1 : -1;
+        const handleProps = getSortedInteractiveHandleProps(this.props);
+
         for (let index = startIndex + inc; index !== endIndex + inc; index += inc) {
-            if (this.handleProps[index].interactionKind !== HandleInteractionKind.PUSH) {
+            if (handleProps[index].interactionKind !== HandleInteractionKind.PUSH) {
                 return index;
             }
         }
+
         return -1;
     }
 
     private handleChange = (newValues: number[]) => {
-        const oldValues = this.handleProps.map(handle => handle.value);
+        const handleProps = getSortedInteractiveHandleProps(this.props);
+        const oldValues = handleProps.map(handle => handle.value);
         if (!Utils.arraysEqual(newValues, oldValues)) {
             Utils.safeInvoke(this.props.onChange, newValues);
-            this.handleProps.forEach((handle, index) => {
+            handleProps.forEach((handle, index) => {
                 if (oldValues[index] !== newValues[index]) {
                     Utils.safeInvoke(handle.onChange, newValues[index]);
                 }
@@ -408,8 +409,9 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
     };
 
     private handleRelease = (newValues: number[]) => {
+        const handleProps = getSortedInteractiveHandleProps(this.props);
         Utils.safeInvoke(this.props.onRelease, newValues);
-        this.handleProps.forEach((handle, index) => {
+        handleProps.forEach((handle, index) => {
             Utils.safeInvoke(handle.onRelease, newValues[index]);
         });
     };
@@ -445,11 +447,14 @@ function getLabelPrecision({ labelPrecision, stepSize }: IMultiSliderProps) {
     return labelPrecision == null ? Utils.countDecimalPlaces(stepSize) : labelPrecision;
 }
 
-function getSortedInteractiveHandleProps(props: IChildrenProps): IHandleProps[] {
+function getSortedInteractiveHandleProps(props: React.PropsWithChildren<IMultiSliderProps>): IHandleProps[] {
     return getSortedHandleProps(props, childProps => childProps.interactionKind !== HandleInteractionKind.NONE);
 }
 
-function getSortedHandleProps({ children }: IChildrenProps, predicate: (props: IHandleProps) => boolean = () => true) {
+function getSortedHandleProps(
+    { children }: React.PropsWithChildren<IMultiSliderProps>,
+    predicate: (props: IHandleProps) => boolean = () => true,
+) {
     const maybeHandles = React.Children.map(children, child =>
         Utils.isElementOfType(child, MultiSlider.Handle) && predicate(child.props) ? child.props : null,
     );

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -306,6 +306,9 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
         const { getIndexClass, selectedRegions } = this.props;
 
         const cell = this.props.headerCellRenderer(index);
+        if (cell == null) {
+            return null;
+        }
 
         const isLoading = cell.props.loading != null ? cell.props.loading : this.props.loading;
         const isSelected = this.props.isCellSelected(index);

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -101,6 +101,8 @@ export class Resizable extends AbstractPureComponent2<IResizableProps, IResizeab
         return null;
     }
 
+    public state: IResizeableState = Resizable.getDerivedStateFromProps(this.props, null);
+
     public componentDidUpdate(prevProps: IResizableProps) {
         if (prevProps.size !== this.props.size) {
             this.setState(Resizable.getDerivedStateFromProps(this.props, null));

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -625,11 +625,6 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
     private rowHeaderElement: HTMLElement;
     private scrollContainerElement: HTMLElement;
 
-    // when true, we'll need to imperatively synchronize quadrant views after
-    // the update. this variable lets us avoid expensively diff'ing columnWidths
-    // and rowHeights in <TableQuadrantStack> on each update.
-    private didUpdateColumnOrRowSizes = false;
-
     // this value is set to `true` when all cells finish mounting for the first
     // time. it serves as a signal that we can switch to batch rendering.
     private didCompletelyMount = false;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -472,21 +472,28 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
     public static getDerivedStateFromProps(props: ITableProps, state: ITableState) {
         const {
             children,
-            columnWidths = [],
             defaultColumnWidth,
             defaultRowHeight,
             enableFocusedCell,
             focusedCell,
             numRows,
-            rowHeights = [],
             selectedRegions = [],
             selectionModes,
         } = props;
 
+        let { columnWidths, rowHeights } = props;
+        if (columnWidths == null) {
+            columnWidths = state.columnWidths == null ? [] : state.columnWidths;
+        }
+        if (rowHeights == null) {
+            rowHeights = state.rowHeights == null ? [] : state.rowHeights;
+        }
+
+        let { didUpdateColumnOrRowSizes } = state;
+
         const newChildrenArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
         const didChildrenChange = newChildrenArray !== state.childrenArray;
         const numCols = newChildrenArray.length;
-        let didUpdateColumnOrRowSizes = false;
 
         let newColumnWidths = columnWidths;
         if (columnWidths !== state.columnWidths || didChildrenChange) {
@@ -910,6 +917,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
     public getSnapshotBeforeUpdate() {
         const { viewportRect } = this.state;
 
+        this.validateGrid();
         const tableBottom = this.grid.getCumulativeHeightAt(this.grid.numRows - 1);
         const tableRight = this.grid.getCumulativeWidthAt(this.grid.numCols - 1);
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -956,7 +956,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
         }
     }
 
-    protected validateProps(props: ITableProps) {
+    protected validateProps() {
         const { children, columnWidths, numFrozenColumns, numFrozenRows, numRows, rowHeights } = this.props;
         const numColumns = React.Children.count(children);
 
@@ -987,8 +987,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
             console.warn(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING);
         }
 
-        const propsOrColsChanged = numColumns !== React.Children.count(props.children);
-        if (propsOrColsChanged && numFrozenColumns != null && numFrozenColumns > numColumns) {
+        if (numFrozenColumns != null && numFrozenColumns > numColumns) {
             console.warn(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING);
         }
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -490,7 +490,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
     public grid: Grid;
     public locator: Locator;
 
-    private childrenArray: Array<React.ReactElement<IColumnProps>>;
+    private childrenArray: Array<React.ReactElement<IColumnProps>> = [];
     private columnIdToIndex: { [key: string]: number };
 
     private resizeSensorDetach: () => void;
@@ -1319,11 +1319,15 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
 
     private getColumnProps(columnIndex: number) {
         const column = this.childrenArray[columnIndex] as React.ReactElement<IColumnProps>;
-        return column.props;
+        return column === undefined ? undefined : column.props;
     }
 
     private columnHeaderCellRenderer = (columnIndex: number) => {
         const props = this.getColumnProps(columnIndex);
+        if (props === undefined) {
+            return null;
+        }
+
         const { id, loadingOptions, cellRenderer, columnHeaderCellRenderer, ...spreadableProps } = props;
 
         const columnLoading = this.hasLoadingOption(loadingOptions, ColumnLoadingOption.HEADER);
@@ -1470,6 +1474,11 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
     };
 
     private bodyCellRenderer = (rowIndex: number, columnIndex: number) => {
+        const columnProps = this.getColumnProps(columnIndex);
+        if (columnProps === undefined) {
+            return null;
+        }
+
         const {
             id,
             loadingOptions,
@@ -1478,7 +1487,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
             name,
             nameRenderer,
             ...restColumnProps
-        } = this.getColumnProps(columnIndex);
+        } = columnProps;
 
         const cell = cellRenderer(rowIndex, columnIndex);
         const { loading = this.hasLoadingOption(loadingOptions, ColumnLoadingOption.CELLS) } = cell.props;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -425,11 +425,25 @@ export interface ITableState {
      * performance enhancements.
      */
     viewportRect?: Rect;
+
+    columnIdToIndex: { [key: string]: number };
+
+    childrenArray: Array<React.ReactElement<IColumnProps>>;
+
+    // when true, we'll need to imperatively synchronize quadrant views after
+    // the update. this variable lets us avoid expensively diff'ing columnWidths
+    // and rowHeights in <TableQuadrantStack> on each update.
+    didUpdateColumnOrRowSizes: boolean;
+}
+
+export interface ITableSnapshot {
+    nextScrollTop: number;
+    nextScrollLeft: number;
 }
 
 @HotkeysTarget
 @polyfill
-export class Table extends AbstractComponent2<ITableProps, ITableState> {
+export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSnapshot> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Table`;
 
     public static defaultProps: ITableProps = {
@@ -454,6 +468,99 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
     public static childContextTypes: React.ValidationMap<
         IColumnInteractionBarContextTypes
     > = columnInteractionBarContextTypes;
+
+    public static getDerivedStateFromProps(props: ITableProps, state: ITableState) {
+        const {
+            children,
+            columnWidths = [],
+            defaultColumnWidth,
+            defaultRowHeight,
+            enableFocusedCell,
+            focusedCell,
+            numRows,
+            rowHeights = [],
+            selectedRegions = [],
+            selectionModes,
+        } = props;
+
+        const newChildrenArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
+        const didChildrenChange = newChildrenArray !== state.childrenArray;
+        const numCols = newChildrenArray.length;
+        let didUpdateColumnOrRowSizes = false;
+
+        let newColumnWidths = columnWidths;
+        if (columnWidths !== state.columnWidths || didChildrenChange) {
+            // Try to maintain widths of columns by looking up the width of the
+            // column that had the same `ID` prop. If none is found, use the
+            // previous width at the same index.
+            const previousColumnWidths = newChildrenArray.map(
+                (child: React.ReactElement<IColumnProps>, index: number) => {
+                    const mappedIndex = state.columnIdToIndex[child.props.id];
+                    return state.columnWidths[mappedIndex != null ? mappedIndex : index];
+                },
+            );
+
+            // Make sure the width/height arrays have the correct length, but keep
+            // as many existing widths/heights as possible. Also, apply the
+            // sparse width/heights from props.
+            newColumnWidths = Utils.arrayOfLength(newColumnWidths, numCols, defaultColumnWidth);
+            newColumnWidths = Utils.assignSparseValues(newColumnWidths, previousColumnWidths);
+            newColumnWidths = Utils.assignSparseValues(newColumnWidths, columnWidths);
+        }
+
+        let newRowHeights = rowHeights;
+        if (rowHeights !== state.rowHeights || numRows !== state.rowHeights.length) {
+            newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
+            newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
+        }
+
+        if (
+            !CoreUtils.arraysEqual(newColumnWidths, state.columnWidths) ||
+            !CoreUtils.arraysEqual(newRowHeights, state.rowHeights)
+        ) {
+            // grid invalidation is required after changing this flag,
+            // which happens at the end of this method.
+            didUpdateColumnOrRowSizes = true;
+        }
+
+        let newSelectedRegions = selectedRegions;
+        if (selectedRegions == null) {
+            // if we're in uncontrolled mode, filter out all selected regions that don't
+            // fit in the current new table dimensions
+            newSelectedRegions = selectedRegions.filter(region => {
+                const regionCardinality = Regions.getRegionCardinality(region);
+                return (
+                    Table.isSelectionModeEnabled(props, regionCardinality, selectionModes) &&
+                    Regions.isRegionValidForTable(region, numRows, numCols)
+                );
+            });
+        }
+
+        const newFocusedCell = FocusedCellUtils.getInitialFocusedCell(
+            enableFocusedCell,
+            focusedCell,
+            state.focusedCell,
+            newSelectedRegions,
+        );
+
+        const nextState = {
+            childrenArray: newChildrenArray,
+            columnIdToIndex: didChildrenChange ? Table.createColumnIdIndex(newChildrenArray) : state.columnIdToIndex,
+            columnWidths: newColumnWidths,
+            didUpdateColumnOrRowSizes,
+            focusedCell: newFocusedCell,
+            numFrozenColumnsClamped: clampNumFrozenColumns(props),
+            numFrozenRowsClamped: clampNumFrozenRows(props),
+            rowHeights: newRowHeights,
+            selectedRegions: newSelectedRegions,
+        };
+
+        if (!CoreUtils.deepCompareKeys(state, nextState, Table.SHALLOW_COMPARE_STATE_KEYS_BLACKLIST)) {
+            return nextState;
+        }
+
+        return null;
+    }
 
     // these default values for `resizeRowsByApproximateHeight` have been
     // fine-tuned to work well with default Table font styles.
@@ -487,11 +594,18 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         return columnIdToIndex;
     }
 
+    private static isSelectionModeEnabled(
+        props: ITableProps,
+        selectionMode: RegionCardinality,
+        selectionModes = props.selectionModes,
+    ) {
+        const { children, numRows } = props;
+        const numColumns = React.Children.count(children);
+        return selectionModes.indexOf(selectionMode) >= 0 && numRows > 0 && numColumns > 0;
+    }
+
     public grid: Grid;
     public locator: Locator;
-
-    private childrenArray: Array<React.ReactElement<IColumnProps>> = [];
-    private columnIdToIndex: { [key: string]: number };
 
     private resizeSensorDetach: () => void;
 
@@ -525,13 +639,13 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
 
         const { children, columnWidths, defaultRowHeight, defaultColumnWidth, numRows, rowHeights } = this.props;
 
-        this.childrenArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
-        this.columnIdToIndex = Table.createColumnIdIndex(this.childrenArray);
+        const childrenArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
+        const columnIdToIndex = Table.createColumnIdIndex(childrenArray);
 
         // Create height/width arrays using the lengths from props and
         // children, the default values from props, and finally any sparse
         // arrays passed into props.
-        let newColumnWidths = this.childrenArray.map(() => defaultColumnWidth);
+        let newColumnWidths = childrenArray.map(() => defaultColumnWidth);
         newColumnWidths = Utils.assignSparseValues(newColumnWidths, columnWidths);
         let newRowHeights = Utils.times(numRows, () => defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
@@ -545,7 +659,10 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         );
 
         this.state = {
+            childrenArray,
+            columnIdToIndex,
             columnWidths: newColumnWidths,
+            didUpdateColumnOrRowSizes: false,
             focusedCell,
             isLayoutLocked: false,
             isReordering: false,
@@ -612,8 +729,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         }
 
         this.invalidateGrid();
-        this.didUpdateColumnOrRowSizes = true;
-        this.setState({ rowHeights });
+        this.setState({ didUpdateColumnOrRowSizes: true, rowHeights });
     }
 
     /**
@@ -635,8 +751,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         }
         const rowHeights = Array(this.state.rowHeights.length).fill(tallest);
         this.invalidateGrid();
-        this.didUpdateColumnOrRowSizes = true;
-        this.setState({ rowHeights });
+        this.setState({ didUpdateColumnOrRowSizes: true, rowHeights });
     }
 
     /**
@@ -716,7 +831,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
                 [Classes.TABLE_REORDERING]: this.state.isReordering,
                 [Classes.TABLE_NO_VERTICAL_SCROLL]: this.shouldDisableVerticalScroll(),
                 [Classes.TABLE_NO_HORIZONTAL_SCROLL]: this.shouldDisableHorizontalScroll(),
-                [Classes.TABLE_SELECTION_ENABLED]: this.isSelectionModeEnabled(RegionCardinality.CELLS),
+                [Classes.TABLE_SELECTION_ENABLED]: Table.isSelectionModeEnabled(this.props, RegionCardinality.CELLS),
                 [Classes.TABLE_NO_ROWS]: numRows === 0,
             },
             className,
@@ -797,114 +912,47 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         this.didCompletelyMount = false;
     }
 
-    public componentDidUpdate(prevProps: ITableProps, prevState: ITableState, snapshot?: {}) {
-        super.componentDidUpdate(prevProps, prevState, snapshot);
-        const {
-            children,
-            columnWidths,
-            defaultColumnWidth,
-            defaultRowHeight,
-            enableFocusedCell,
-            focusedCell,
-            forceRerenderOnSelectionChange,
-            numRows,
-            rowHeights,
-            selectedRegions,
-            selectionModes,
-        } = this.props;
+    public getSnapshotBeforeUpdate() {
+        const { viewportRect } = this.state;
 
-        const didChildrenChange = prevProps.children !== children;
-        const newChildArray = didChildrenChange
-            ? (React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>)
-            : this.childrenArray;
-        const numCols = newChildArray.length;
+        const tableBottom = this.grid.getCumulativeHeightAt(this.grid.numRows - 1);
+        const tableRight = this.grid.getCumulativeWidthAt(this.grid.numCols - 1);
+
+        const nextScrollTop =
+            tableBottom < viewportRect.top + viewportRect.height
+                ? // scroll the last row into view
+                  Math.max(0, tableBottom - viewportRect.height)
+                : viewportRect.top;
+
+        const nextScrollLeft =
+            tableRight < viewportRect.left + viewportRect.width
+                ? // scroll the last column into view
+                  Math.max(0, tableRight - viewportRect.width)
+                : viewportRect.left;
+
+        return { nextScrollLeft, nextScrollTop };
+    }
+
+    public componentDidUpdate(prevProps: ITableProps, prevState: ITableState, snapshot: ITableSnapshot) {
+        super.componentDidUpdate(prevProps, prevState, snapshot);
+
+        const didChildrenChange =
+            (React.Children.toArray(this.props.children) as Array<React.ReactElement<IColumnProps>>) !==
+            this.state.childrenArray;
 
         let shouldInvalidateGrid = false;
-        let newColumnWidths = this.state.columnWidths;
-        if (
-            defaultColumnWidth !== prevProps.defaultColumnWidth ||
-            columnWidths !== prevProps.columnWidths ||
-            didChildrenChange
-        ) {
-            // Try to maintain widths of columns by looking up the width of the
-            // column that had the same `ID` prop. If none is found, use the
-            // previous width at the same index.
-            const previousColumnWidths = newChildArray.map((child: React.ReactElement<IColumnProps>, index: number) => {
-                const mappedIndex = this.columnIdToIndex[child.props.id];
-                return this.state.columnWidths[mappedIndex != null ? mappedIndex : index];
-            });
-
-            // Make sure the width/height arrays have the correct length, but keep
-            // as many existing widths/heights as possible. Also, apply the
-            // sparse width/heights from props.
-            newColumnWidths = Utils.arrayOfLength(newColumnWidths, numCols, defaultColumnWidth);
-            newColumnWidths = Utils.assignSparseValues(newColumnWidths, previousColumnWidths);
-            newColumnWidths = Utils.assignSparseValues(newColumnWidths, columnWidths);
-
+        if (this.props.columnWidths !== prevState.columnWidths || didChildrenChange) {
+            shouldInvalidateGrid = true;
+        }
+        if (this.props.rowHeights !== prevState.rowHeights || this.props.numRows !== prevProps.numRows) {
+            shouldInvalidateGrid = true;
+        }
+        if (this.props.forceRerenderOnSelectionChange && this.props.selectedRegions !== prevProps.selectedRegions) {
             shouldInvalidateGrid = true;
         }
 
-        let newRowHeights = this.state.rowHeights;
-        if (
-            defaultRowHeight !== prevProps.defaultRowHeight ||
-            rowHeights !== prevProps.rowHeights ||
-            numRows !== prevProps.numRows
-        ) {
-            newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
-            newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
-            shouldInvalidateGrid = true;
-        }
-
-        if (
-            !CoreUtils.arraysEqual(newColumnWidths, this.state.columnWidths) ||
-            !CoreUtils.arraysEqual(newRowHeights, this.state.rowHeights)
-        ) {
-            // grid invalidation is required after changing this flag,
-            // which happens at the end of this method.
-            this.didUpdateColumnOrRowSizes = true;
-        }
-
-        let newSelectedRegions = selectedRegions;
-        if (forceRerenderOnSelectionChange && newSelectedRegions !== prevProps.selectedRegions) {
-            shouldInvalidateGrid = true;
-        }
-        if (selectedRegions == null) {
-            // if we're in uncontrolled mode, filter out all selected regions that don't
-            // fit in the current new table dimensions
-            newSelectedRegions = this.state.selectedRegions.filter(region => {
-                const regionCardinality = Regions.getRegionCardinality(region);
-                return (
-                    this.isSelectionModeEnabled(regionCardinality, selectionModes) &&
-                    Regions.isRegionValidForTable(region, numRows, numCols)
-                );
-            });
-        }
-
-        const newFocusedCell = FocusedCellUtils.getInitialFocusedCell(
-            enableFocusedCell,
-            focusedCell,
-            this.state.focusedCell,
-            newSelectedRegions,
-        );
-
-        if (didChildrenChange) {
-            this.childrenArray = newChildArray;
-            this.columnIdToIndex = Table.createColumnIdIndex(this.childrenArray);
-        }
         if (shouldInvalidateGrid) {
             this.invalidateGrid();
-        }
-        const nextState = {
-            columnWidths: newColumnWidths,
-            focusedCell: newFocusedCell,
-            numFrozenColumnsClamped: clampNumFrozenColumns(this.props),
-            numFrozenRowsClamped: clampNumFrozenRows(this.props),
-            rowHeights: newRowHeights,
-            selectedRegions: newSelectedRegions,
-        };
-
-        if (!CoreUtils.deepCompareKeys(prevState, nextState, Table.SHALLOW_COMPARE_STATE_KEYS_BLACKLIST)) {
-            this.setState(nextState);
         }
 
         if (this.locator != null) {
@@ -912,12 +960,14 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
             this.updateLocator();
         }
 
-        if (this.didUpdateColumnOrRowSizes) {
+        if (this.state.didUpdateColumnOrRowSizes) {
             this.quadrantStackInstance.synchronizeQuadrantViews();
-            this.didUpdateColumnOrRowSizes = false;
+            this.setState({
+                didUpdateColumnOrRowSizes: false,
+            });
         }
 
-        this.maybeScrollTableIntoView();
+        this.syncViewportPosition(snapshot);
     }
 
     protected validateProps(props: ITableProps) {
@@ -1088,7 +1138,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
     }
 
     private maybeRenderSelectAllHotkey() {
-        if (this.isSelectionModeEnabled(RegionCardinality.FULL_TABLE)) {
+        if (Table.isSelectionModeEnabled(this.props, RegionCardinality.FULL_TABLE)) {
             return (
                 <Hotkey
                     key="select-all-hotkey"
@@ -1260,7 +1310,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
 
     private renderMenu = (refHandler: (ref: HTMLElement) => void) => {
         const classes = classNames(Classes.TABLE_MENU, {
-            [Classes.TABLE_SELECTION_ENABLED]: this.isSelectionModeEnabled(RegionCardinality.FULL_TABLE),
+            [Classes.TABLE_SELECTION_ENABLED]: Table.isSelectionModeEnabled(this.props, RegionCardinality.FULL_TABLE),
         });
         return (
             <div className={classes} ref={refHandler} onMouseDown={this.handleMenuMouseDown}>
@@ -1274,27 +1324,6 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         // thus, if shift is pressed we shouldn't move the focused cell.
         this.selectAll(!e.shiftKey);
     };
-
-    private maybeScrollTableIntoView() {
-        const { viewportRect } = this.state;
-
-        const tableBottom = this.grid.getCumulativeHeightAt(this.grid.numRows - 1);
-        const tableRight = this.grid.getCumulativeWidthAt(this.grid.numCols - 1);
-
-        const nextScrollTop =
-            tableBottom < viewportRect.top + viewportRect.height
-                ? // scroll the last row into view
-                  Math.max(0, tableBottom - viewportRect.height)
-                : viewportRect.top;
-
-        const nextScrollLeft =
-            tableRight < viewportRect.left + viewportRect.width
-                ? // scroll the last column into view
-                  Math.max(0, tableRight - viewportRect.width)
-                : viewportRect.left;
-
-        this.syncViewportPosition(nextScrollLeft, nextScrollTop);
-    }
 
     private selectAll = (shouldUpdateFocusedCell: boolean) => {
         const selectionHandler = this.getEnabledSelectionHandler(RegionCardinality.FULL_TABLE);
@@ -1318,7 +1347,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
     };
 
     private getColumnProps(columnIndex: number) {
-        const column = this.childrenArray[columnIndex] as React.ReactElement<IColumnProps>;
+        const column = this.state.childrenArray[columnIndex] as React.ReactElement<IColumnProps>;
         return column === undefined ? undefined : column.props;
     }
 
@@ -1374,7 +1403,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         } = this.props;
 
         const classes = classNames(Classes.TABLE_COLUMN_HEADERS, {
-            [Classes.TABLE_SELECTION_ENABLED]: this.isSelectionModeEnabled(RegionCardinality.FULL_COLUMNS),
+            [Classes.TABLE_SELECTION_ENABLED]: Table.isSelectionModeEnabled(this.props, RegionCardinality.FULL_COLUMNS),
         });
 
         const columnIndices = this.grid.getColumnIndicesInRect(viewportRect, enableGhostCells);
@@ -1435,7 +1464,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         } = this.props;
 
         const classes = classNames(Classes.TABLE_ROW_HEADERS, {
-            [Classes.TABLE_SELECTION_ENABLED]: this.isSelectionModeEnabled(RegionCardinality.FULL_ROWS),
+            [Classes.TABLE_SELECTION_ENABLED]: Table.isSelectionModeEnabled(this.props, RegionCardinality.FULL_ROWS),
         });
 
         const rowIndices = this.grid.getRowIndicesInRect(viewportRect, enableGhostCells);
@@ -1570,14 +1599,8 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         return this.state.verticalGuides != null || this.state.horizontalGuides != null;
     }
 
-    private isSelectionModeEnabled(selectionMode: RegionCardinality, selectionModes = this.props.selectionModes) {
-        const { children, numRows } = this.props;
-        const numColumns = React.Children.count(children);
-        return selectionModes.indexOf(selectionMode) >= 0 && numRows > 0 && numColumns > 0;
-    }
-
     private getEnabledSelectionHandler(selectionMode: RegionCardinality) {
-        if (!this.isSelectionModeEnabled(selectionMode)) {
+        if (!Table.isSelectionModeEnabled(this.props, selectionMode)) {
             // If the selection mode isn't enabled, return a callback that
             // will clear the selection. For example, if row selection is
             // disabled, clicking on the row header will clear the table's
@@ -1786,8 +1809,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         }
 
         this.invalidateGrid();
-        this.didUpdateColumnOrRowSizes = true;
-        this.setState({ columnWidths });
+        this.setState({ didUpdateColumnOrRowSizes: true, columnWidths });
 
         const { onColumnWidthChanged } = this.props;
         if (onColumnWidthChanged != null) {
@@ -1813,8 +1835,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
         }
 
         this.invalidateGrid();
-        this.didUpdateColumnOrRowSizes = true;
-        this.setState({ rowHeights });
+        this.setState({ didUpdateColumnOrRowSizes: true, rowHeights });
 
         const { onRowHeightChanged } = this.props;
         if (onRowHeightChanged != null) {
@@ -2040,10 +2061,10 @@ export class Table extends AbstractComponent2<ITableProps, ITableState> {
             nextScrollLeft = viewportBounds.left + scrollDelta;
         }
 
-        this.syncViewportPosition(nextScrollLeft, nextScrollTop);
+        this.syncViewportPosition({ nextScrollLeft, nextScrollTop });
     };
 
-    private syncViewportPosition(nextScrollLeft: number, nextScrollTop: number) {
+    private syncViewportPosition({ nextScrollLeft, nextScrollTop }: ITableSnapshot) {
         const { viewportRect } = this.state;
 
         const didScrollTopChange = nextScrollTop !== viewportRect.top;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -928,16 +928,11 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
             (React.Children.toArray(this.props.children) as Array<React.ReactElement<IColumnProps>>) !==
             this.state.childrenArray;
 
-        let shouldInvalidateGrid = false;
-        if (this.props.columnWidths !== prevState.columnWidths || didChildrenChange) {
-            shouldInvalidateGrid = true;
-        }
-        if (this.props.rowHeights !== prevState.rowHeights || this.props.numRows !== prevProps.numRows) {
-            shouldInvalidateGrid = true;
-        }
-        if (this.props.forceRerenderOnSelectionChange && this.props.selectedRegions !== prevProps.selectedRegions) {
-            shouldInvalidateGrid = true;
-        }
+        const shouldInvalidateGrid =
+            didChildrenChange ||
+            this.props.columnWidths !== prevState.columnWidths ||
+            (this.props.rowHeights !== prevState.rowHeights || this.props.numRows !== prevProps.numRows) ||
+            (this.props.forceRerenderOnSelectionChange && this.props.selectedRegions !== prevProps.selectedRegions);
 
         if (shouldInvalidateGrid) {
             this.invalidateGrid();
@@ -957,9 +952,8 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
 
         if (didUpdateColumnOrRowSizes) {
             this.quadrantStackInstance.synchronizeQuadrantViews();
+            this.syncViewportPosition(snapshot);
         }
-
-        this.syncViewportPosition(snapshot);
     }
 
     protected validateProps(props: ITableProps) {

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -472,7 +472,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
             enableFocusedCell,
             focusedCell,
             numRows,
-            selectedRegions = [],
+            selectedRegions,
             selectionModes,
         } = props;
 
@@ -518,7 +518,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
         if (selectedRegions == null) {
             // if we're in uncontrolled mode, filter out all selected regions that don't
             // fit in the current new table dimensions
-            newSelectedRegions = selectedRegions.filter(region => {
+            newSelectedRegions = state.selectedRegions.filter(region => {
                 const regionCardinality = Regions.getRegionCardinality(region);
                 return (
                     Table.isSelectionModeEnabled(props, regionCardinality, selectionModes) &&

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -476,12 +476,13 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
             selectionModes,
         } = props;
 
+        // assign values from state if uncontrolled
         let { columnWidths, rowHeights } = props;
         if (columnWidths == null) {
-            columnWidths = state.columnWidths == null ? [] : state.columnWidths;
+            columnWidths = state.columnWidths;
         }
         if (rowHeights == null) {
-            rowHeights = state.rowHeights == null ? [] : state.rowHeights;
+            rowHeights = state.rowHeights;
         }
 
         const newChildrenArray = React.Children.toArray(children) as Array<React.ReactElement<IColumnProps>>;
@@ -956,8 +957,8 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
         }
     }
 
-    protected validateProps() {
-        const { children, columnWidths, numFrozenColumns, numFrozenRows, numRows, rowHeights } = this.props;
+    protected validateProps(props: ITableProps) {
+        const { children, columnWidths, numFrozenColumns, numFrozenRows, numRows, rowHeights } = props;
         const numColumns = React.Children.count(children);
 
         // do cheap error-checking first.

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent2, Utils as CoreUtils } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -55,7 +55,7 @@ export interface ITableBodyProps extends ISelectableProps, ITableBodyCellsProps 
 
 const DEEP_COMPARE_KEYS: Array<keyof ITableBodyProps> = ["selectedRegions"];
 
-export class TableBody extends React.Component<ITableBodyProps, {}> {
+export class TableBody extends AbstractComponent2<ITableBodyProps> {
     public static defaultProps = {
         loading: false,
         renderMode: RenderMode.BATCH,

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -109,8 +109,9 @@ export class TableBodyCells extends AbstractComponent2<ITableBodyCellsProps> {
     }
 
     public componentDidUpdate(prevProps: ITableBodyCellsProps) {
-        const resetKeysBlacklist = { exclude: BATCHER_RESET_PROP_KEYS_BLACKLIST };
-        const shouldResetBatcher = !CoreUtils.shallowCompareKeys(prevProps, this.props, resetKeysBlacklist);
+        const shouldResetBatcher = !CoreUtils.shallowCompareKeys(prevProps, this.props, {
+            exclude: BATCHER_RESET_PROP_KEYS_BLACKLIST,
+        });
         if (shouldResetBatcher) {
             this.batcher.reset();
         }
@@ -145,8 +146,7 @@ export class TableBodyCells extends AbstractComponent2<ITableBodyCellsProps> {
             this.batcher.idleCallback(() => this.forceUpdate());
         }
 
-        const cells: Array<React.ReactElement<any>> = this.batcher.getList();
-        return cells;
+        return this.batcher.getList();
     }
 
     private renderAllCells() {

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -182,7 +182,10 @@ export class TableBodyCells extends AbstractComponent2<ITableBodyCellsProps> {
 
     private renderCell = (rowIndex: number, columnIndex: number, extremaClasses: string[], isGhost: boolean) => {
         const { cellRenderer, focusedCell, loading, grid } = this.props;
-        const baseCell = isGhost ? emptyCellRenderer() : cellRenderer(rowIndex, columnIndex);
+        let baseCell = isGhost ? emptyCellRenderer() : cellRenderer(rowIndex, columnIndex);
+        // cellRenderer still may return null
+        baseCell = baseCell == null ? emptyCellRenderer() : baseCell;
+
         const className = classNames(
             cellClassNames(rowIndex, columnIndex),
             extremaClasses,

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent2, IProps, Utils as CoreUtils } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -84,7 +84,7 @@ const BATCHER_RESET_PROP_KEYS_BLACKLIST: Array<keyof ITableBodyCellsProps> = [
     "rowIndexStart",
 ];
 
-export class TableBodyCells extends React.Component<ITableBodyCellsProps, {}> {
+export class TableBodyCells extends AbstractComponent2<ITableBodyCellsProps> {
     public static defaultProps = {
         renderMode: RenderMode.BATCH,
     };
@@ -108,15 +108,12 @@ export class TableBodyCells extends React.Component<ITableBodyCellsProps, {}> {
         );
     }
 
-    public componentWillUpdate(nextProps?: ITableBodyCellsProps) {
+    public componentDidUpdate(prevProps: ITableBodyCellsProps) {
         const resetKeysBlacklist = { exclude: BATCHER_RESET_PROP_KEYS_BLACKLIST };
-        const shouldResetBatcher = !CoreUtils.shallowCompareKeys(this.props, nextProps, resetKeysBlacklist);
+        const shouldResetBatcher = !CoreUtils.shallowCompareKeys(prevProps, this.props, resetKeysBlacklist);
         if (shouldResetBatcher) {
             this.batcher.reset();
         }
-    }
-
-    public componentDidUpdate() {
         this.maybeInvokeOnCompleteRender();
     }
 

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -122,8 +122,8 @@ describe("Selection", () => {
             .find(ROW_TH_SELECTOR)
             .mouse("mousedown")
             .mouse("mouseup");
-        expect(onSelection.called).to.equal(true);
-        expect(onSelection.lastCall.args).to.deep.equal([[Regions.row(0)]]);
+        expect(onSelection.called, "onSelection should be called on select").to.equal(true);
+        expect(onSelection.lastCall.args, "selected region should be first row").to.deep.equal([[Regions.row(0)]]);
         onSelection.resetHistory();
 
         // deselects on cmd+click
@@ -131,9 +131,8 @@ describe("Selection", () => {
             .find(ROW_TH_SELECTOR)
             .mouse("mousedown", { metaKey: true })
             .mouse("mouseup");
-        expect(onSelection.called).to.equal(true, "cmd+click to deselect");
-        expect(onSelection.lastCall.args.length).to.equal(1);
-        expect(onSelection.lastCall.args).to.deep.equal([[]]);
+        expect(onSelection.called, "onSelection should be called on deselect").to.equal(true, "cmd+click to deselect");
+        expect(onSelection.lastCall.args, "selected region should be empty").to.deep.equal([[]]);
         onSelection.resetHistory();
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -1314,11 +1314,14 @@ describe("<Table>", function(this) {
                     const { component } = mountTable();
                     component.simulate("keyDown", createKeyEventConfig(component, key, keyCode));
                     expect(component.state("viewportRect")[attrToCheck]).to.equal(expectedOffset);
-                    expect(onVisibleCellsChange.calledThrice).to.be.true;
+                    expect(onVisibleCellsChange.callCount, "onVisibleCellsChange call count").to.equal(6);
 
                     const rowIndices: IRowIndices = { rowIndexStart: 0, rowIndexEnd: NUM_ROWS - 1 };
                     const columnIndices: IColumnIndices = { columnIndexStart: 0, columnIndexEnd: NUM_COLS - 1 };
-                    expect(onVisibleCellsChange.lastCall.calledWith(rowIndices, columnIndices)).to.be.true;
+                    expect(
+                        onVisibleCellsChange.lastCall.calledWith(rowIndices, columnIndices),
+                        "onVisibleCellsChange row/col indices",
+                    ).to.be.true;
                 });
             }
         });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -605,7 +605,7 @@ describe("<Table>", function(this) {
 
             expect(onCompleteRenderSpy.callCount, "call count on mount").to.equal(1);
             table.setProps({ numRows: 2 }); // still small enough to fit in one batch
-            expect(onCompleteRenderSpy.callCount, "call count on update").to.equal(3);
+            expect(onCompleteRenderSpy.callCount, "call count on update").to.equal(2);
         });
     });
 

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -1647,21 +1647,19 @@ describe("<Table>", function(this) {
                 after(() => consoleWarn.restore());
 
                 it("should print a warning when numFrozenRows > numRows", () => {
-                    const table = mount(<Table numRows={1} numFrozenRows={2} />);
+                    mount(<Table numRows={1} numFrozenRows={2} />);
                     expect(consoleWarn.calledOnce);
                     expect(consoleWarn.firstCall.args).to.deep.equal([Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING]);
-                    table.unmount();
                 });
 
                 it("should print a warning when numFrozenColumns > num <Column>s", () => {
-                    const table = mount(
+                    mount(
                         <Table numFrozenColumns={2}>
                             <Column />
                         </Table>,
                     );
                     expect(consoleWarn.calledOnce);
                     expect(consoleWarn.firstCall.args).to.deep.equal([Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING]);
-                    table.unmount();
                 });
             });
         });


### PR DESCRIPTION
#### Fixes  #3767

#### Changes proposed in this pull request:

Fixes some bugs from #3702 around the use of new lifecycle methods in `MultiSlider`, `Resizable` (table package), `Table`, and `TableBodyCells`.



#### Screenshot

Using the example from the bug report:

![2019-10-07 18 45 03](https://user-images.githubusercontent.com/723999/66354567-38f9a700-e933-11e9-9222-123bad3c8fab.gif)


