### PR TITLE
[datetime] feat(DateInput): add fill prop

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -82,6 +82,11 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
     defaultValue?: Date;
 
     /**
+     * Whether the component should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
      * Props to pass to the [input group](#core/components/text-inputs.input-group).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `type` is fixed to "text" and `ref` is not supported; use `inputRef` instead.
@@ -205,6 +210,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         return (
             <Popover
                 isOpen={this.state.isOpen && !this.props.disabled}
+                fill={this.props.fill}
                 {...popoverProps}
                 autoFocus={false}
                 className={classNames(popoverProps.className, this.props.className)}

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -265,6 +265,7 @@ describe("<DateInput>", () => {
                 popoverProps={{
                     autoFocus: true,
                     content: "fail",
+                    fill: true,
                     onOpening,
                     position: Position.TOP,
                     usePortal: false,
@@ -276,6 +277,7 @@ describe("<DateInput>", () => {
         const popover = wrapper.find(Popover);
         assert.strictEqual(popover.prop("autoFocus"), false, "autoFocus cannot be changed");
         assert.notStrictEqual(popover.prop("content"), "fail", "content cannot be changed");
+        assert.strictEqual(popover.prop("fill"), true);
         assert.strictEqual(popover.prop("position"), Position.TOP);
         assert.strictEqual(popover.prop("usePortal"), false);
         assert.isTrue(onOpening.calledOnce);

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -27,6 +27,7 @@ export interface IDateInputExampleState {
     closeOnSelection: boolean;
     date: Date | null;
     disabled: boolean;
+    fill: boolean;
     format: IDateFormatProps;
     reverseMonthAndYearMenus: boolean;
     timePrecision: TimePrecision | undefined;
@@ -37,6 +38,7 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
         closeOnSelection: true,
         date: null,
         disabled: false,
+        fill: false,
         format: FORMATS[0],
         reverseMonthAndYearMenus: false,
         timePrecision: undefined,
@@ -44,6 +46,7 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
 
     private toggleSelection = handleBooleanChange(closeOnSelection => this.setState({ closeOnSelection }));
     private toggleDisabled = handleBooleanChange(disabled => this.setState({ disabled }));
+    private toggleFill = handleBooleanChange(fill => this.setState({ fill }));
     private toggleReverseMenus = handleBooleanChange(reverse => this.setState({ reverseMonthAndYearMenus: reverse }));
     private toggleTimePrecision = handleStringChange((timePrecision: TimePrecision | "none") =>
         this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
@@ -66,12 +69,20 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
     }
 
     protected renderOptions() {
-        const { closeOnSelection, disabled, reverseMonthAndYearMenus: reverse, format, timePrecision } = this.state;
+        const {
+            closeOnSelection,
+            disabled,
+            fill,
+            reverseMonthAndYearMenus: reverse,
+            format,
+            timePrecision,
+        } = this.state;
         return (
             <>
                 <H5>Props</H5>
                 <Switch label="Close on selection" checked={closeOnSelection} onChange={this.toggleSelection} />
                 <Switch label="Disabled" checked={disabled} onChange={this.toggleDisabled} />
+                <Switch label="Fill" checked={fill} onChange={this.toggleFill} />
                 <Switch label="Reverse month and year menus" checked={reverse} onChange={this.toggleReverseMenus} />
                 <FormatSelect format={format} onChange={this.handleFormatChange} />
                 <PrecisionSelect

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -486,6 +486,12 @@
   align-items: center;
 }
 
+#{example("DateInputExample")} {
+  .docs-example > * {
+    margin: 0 0 20px 0;
+  }
+}
+
 //
 // TABLE
 //


### PR DESCRIPTION
#### Fixes #751

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `fill` prop to DateInput which is forwarded to the contained Popover.
