### PR TITLE
[core] feat(Breadcrumb): render icon if provided through props

### DIFF
--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -53,7 +53,8 @@ Styleguide breadcrumbs
 .#{$ns}-breadcrumb,
 .#{$ns}-breadcrumb-current,
 .#{$ns}-breadcrumbs-collapsed {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   font-size: $pt-font-size-large;
 }
 
@@ -70,6 +71,10 @@ Styleguide breadcrumbs
   &.#{$ns}-disabled {
     cursor: not-allowed;
     color: $pt-text-color-disabled;
+  }
+
+  .#{$ns}-icon {
+    margin-right: $pt-grid-size / 2;
   }
 }
 

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -35,9 +35,13 @@ export const Breadcrumb: React.SFC<IBreadcrumbProps> = breadcrumbProps => {
         },
         breadcrumbProps.className,
     );
+
+    const icon = breadcrumbProps.icon !== undefined ? <Icon icon={breadcrumbProps.icon} /> : undefined;
+
     if (breadcrumbProps.href == null && breadcrumbProps.onClick == null) {
         return (
             <span className={classes}>
+                {icon}
                 {breadcrumbProps.text}
                 {breadcrumbProps.children}
             </span>
@@ -51,7 +55,7 @@ export const Breadcrumb: React.SFC<IBreadcrumbProps> = breadcrumbProps => {
             tabIndex={breadcrumbProps.disabled ? null : 0}
             target={breadcrumbProps.target}
         >
-            {breadcrumbProps.icon ? <Icon icon={breadcrumbProps.icon} /> : undefined}
+            {icon}
             {breadcrumbProps.text}
             {breadcrumbProps.children}
         </a>

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -36,7 +36,7 @@ export const Breadcrumb: React.SFC<IBreadcrumbProps> = breadcrumbProps => {
         breadcrumbProps.className,
     );
 
-    const icon = breadcrumbProps.icon !== undefined ? <Icon icon={breadcrumbProps.icon} /> : undefined;
+    const icon = breadcrumbProps.icon != null ? <Icon icon={breadcrumbProps.icon} /> : undefined;
 
     if (breadcrumbProps.href == null && breadcrumbProps.onClick == null) {
         return (

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 
 import * as Classes from "../../common/classes";
 import { IActionProps, ILinkProps } from "../../common/props";
+import { Icon } from "../icon/icon";
 
 export interface IBreadcrumbProps extends IActionProps, ILinkProps {
     /** Whether this breadcrumb is the current breadcrumb. */
@@ -50,6 +51,7 @@ export const Breadcrumb: React.SFC<IBreadcrumbProps> = breadcrumbProps => {
             tabIndex={breadcrumbProps.disabled ? null : 0}
             target={breadcrumbProps.target}
         >
+            {breadcrumbProps.icon ? <Icon icon={breadcrumbProps.icon} /> : undefined}
             {breadcrumbProps.text}
             {breadcrumbProps.children}
         </a>

--- a/packages/core/test/breadcrumbs/breadcrumbTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbTests.tsx
@@ -19,7 +19,6 @@ import { shallow } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { IconNames } from "@blueprintjs/icons";
 import { Breadcrumb, Classes, Icon } from "../../src/index";
 
 describe("Breadcrumb", () => {
@@ -54,6 +53,6 @@ describe("Breadcrumb", () => {
 
     it("renders an icon if one is provided", () => {
         assert.lengthOf(shallow(<Breadcrumb />).find(Icon), 0);
-        assert.lengthOf(shallow(<Breadcrumb icon={IconNames.BLANK} />).find(Icon), 1);
+        assert.lengthOf(shallow(<Breadcrumb icon="folder-close" />).find(Icon), 1);
     });
 });

--- a/packages/core/test/breadcrumbs/breadcrumbTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbTests.tsx
@@ -19,7 +19,8 @@ import { shallow } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { Breadcrumb, Classes } from "../../src/index";
+import { IconNames } from "@blueprintjs/icons";
+import { Breadcrumb, Classes, Icon } from "../../src/index";
 
 describe("Breadcrumb", () => {
     it("renders its contents", () => {
@@ -49,5 +50,10 @@ describe("Breadcrumb", () => {
     it("renders a span tag if it's not clickable", () => {
         assert.lengthOf(shallow(<Breadcrumb />).find("a"), 0);
         assert.lengthOf(shallow(<Breadcrumb />).find("span"), 1);
+    });
+
+    it("renders an icon if one is provided", () => {
+        assert.lengthOf(shallow(<Breadcrumb />).find(Icon), 0);
+        assert.lengthOf(shallow(<Breadcrumb icon={IconNames.BLANK} />).find(Icon), 1);
     });
 });


### PR DESCRIPTION
#### Fixes #3743 

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Display `<Breadcrumb />`'s `icon` prop.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<img width="473" alt="Screen Shot 2019-10-21 at 7 33 32 AM" src="https://user-images.githubusercontent.com/831708/67201806-23758a00-f3d5-11e9-8667-0755b67e7602.png">
