### PR TITLE
[core] fix(PanelStack): do not trigger unintended animations

### DIFF
--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -76,8 +76,10 @@ export class PanelStack extends AbstractPureComponent2<IPanelStackProps, IPanelS
 
     public componentDidUpdate(prevProps: IPanelStackProps, _prevState: IPanelStackState, _snapshot: {}) {
         super.componentDidUpdate(prevProps, _prevState, _snapshot);
+        const stackLength = this.props.stack != null ? this.props.stack.length : 0;
+        const prevStackLength = prevProps.stack != null ? prevProps.stack.length : 0;
 
-        if (this.props.stack !== prevProps.stack && prevProps.stack != null) {
+        if (stackLength !== prevStackLength && prevProps.stack != null) {
             this.setState({
                 direction: prevProps.stack.length - this.props.stack.length < 0 ? "push" : "pop",
                 stack: this.props.stack.slice().reverse(),


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix an issue where `<PanelStack />` could animate in the wrong direction.

`<PanelStack />` should only update its internal state via `componentDidUpdate()` when the `stack` length changes. Currently, pushing an item onto `stack` sets `direction: push`. As the `<PanelStack />` begins to animate, updating the `stack` without changing its length (i.e. updating a property in one of its `<IPanel />`s) will set `direction: pop`, leading to an unintended animation change.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
