### PR TITLE
[DateTime] Add TimePicker input customisation

### DIFF
--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -148,6 +148,10 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
 
     public static displayName = `${DISPLAYNAME_PREFIX}.TimePicker`;
 
+    private static renderDivider(text = ":") {
+        return <span className={Classes.TIMEPICKER_DIVIDER_TEXT}>{text}</span>;
+    }
+
     public constructor(props?: ITimePickerProps, context?: any) {
         super(props, context);
 
@@ -180,12 +184,12 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 </div>
                 <div className={Classes.TIMEPICKER_INPUT_ROW}>
                     {this.renderInput(Classes.TIMEPICKER_HOUR, hourUnit, this.state.hourText)}
-                    {this.renderDivider()}
+                    {TimePicker.renderDivider()}
                     {this.renderInput(Classes.TIMEPICKER_MINUTE, TimeUnit.MINUTE, this.state.minuteText)}
-                    {shouldRenderSeconds && this.renderDivider()}
+                    {shouldRenderSeconds && TimePicker.renderDivider()}
                     {shouldRenderSeconds &&
                         this.renderInput(Classes.TIMEPICKER_SECOND, TimeUnit.SECOND, this.state.secondText)}
-                    {shouldRenderMilliseconds && this.renderDivider(".")}
+                    {shouldRenderMilliseconds && TimePicker.renderDivider(".")}
                     {shouldRenderMilliseconds &&
                         this.renderInput(Classes.TIMEPICKER_MILLISECOND, TimeUnit.MS, this.state.millisecondText)}
                 </div>
@@ -234,10 +238,6 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 <Icon icon={isDirectionUp ? "chevron-up" : "chevron-down"} />
             </span>
         );
-    }
-
-    private renderDivider(text = ":") {
-        return <span className={Classes.TIMEPICKER_DIVIDER_TEXT}>{text}</span>;
     }
 
     private renderInput(className: string, unit: TimeUnit, value: string) {

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -62,6 +62,11 @@ export interface ITimePickerProps extends IProps {
     disabled?: boolean;
 
     /**
+     * Props passed through to each rendered input element.
+     */
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+
+    /**
      * Callback invoked when the user changes the time.
      */
     onChange?: (newTime: Date) => void;
@@ -230,21 +235,24 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     }
 
     private renderInput(className: string, unit: TimeUnit, value: string) {
+        const { disabled, inputProps } = this.props;
         const isValid = isTimeUnitValid(unit, parseInt(value, 10));
 
         return (
             <input
+                {...inputProps}
                 className={classNames(
                     Classes.TIMEPICKER_INPUT,
                     { [CoreClasses.intentClass(Intent.DANGER)]: !isValid },
                     className,
+                    inputProps ? inputProps.className : "",
                 )}
                 onBlur={this.getInputBlurHandler(unit)}
                 onChange={this.getInputChangeHandler(unit)}
                 onFocus={this.handleFocus}
                 onKeyDown={this.getInputKeyDownHandler(unit)}
                 value={value}
-                disabled={this.props.disabled}
+                disabled={disabled}
             />
         );
     }
@@ -285,11 +293,17 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 this.setState({ millisecondText: text });
                 break;
         }
+        if (this.props.inputProps) {
+            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(this.props.inputProps.onChange, e);
+        }
     };
 
     private getInputBlurHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
         const text = getStringValueFromInputEvent(e);
         this.updateTime(parseInt(text, 10), unit);
+        if (this.props.inputProps) {
+            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(this.props.inputProps.onBlur, e);
+        }
     };
 
     private getInputKeyDownHandler = (unit: TimeUnit) => (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -300,11 +314,18 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 (e.currentTarget as HTMLInputElement).blur();
             },
         });
+        if (this.props.inputProps) {
+            BlueprintUtils.safeInvoke<React.KeyboardEvent<HTMLInputElement>, void>(this.props.inputProps.onKeyDown, e);
+        }
     };
 
     private handleFocus = (e: React.SyntheticEvent<HTMLInputElement>) => {
         if (this.props.selectAllOnFocus) {
             e.currentTarget.select();
+        }
+
+        if (this.props.inputProps) {
+            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(this.props.inputProps.onFocus, e);
         }
     };
 

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -299,18 +299,26 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 this.setState({ millisecondText: text });
                 break;
         }
-        if (this.props.inputProps) {
-            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(this.props.inputProps.onChange, e);
-        }
+        this.maybeInvokeInputEventHandler("onChange", e);
     };
 
     private getInputBlurHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
         const text = getStringValueFromInputEvent(e);
         this.updateTime(parseInt(text, 10), unit);
-        if (this.props.inputProps) {
-            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(this.props.inputProps.onBlur, e);
-        }
+        this.maybeInvokeInputEventHandler("onBlur", e);
     };
+
+    private maybeInvokeInputEventHandler(
+        handlerName: "onChange" | "onBlur" | "onKeyDown" | "onFocus",
+        event: React.SyntheticEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
+    ) {
+        if (this.props.inputProps != null) {
+            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(
+                this.props.inputProps[handlerName],
+                event,
+            );
+        }
+    }
 
     private getInputKeyDownHandler = (unit: TimeUnit) => (e: React.KeyboardEvent<HTMLInputElement>) => {
         handleKeyEvent(e, {
@@ -320,9 +328,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 (e.currentTarget as HTMLInputElement).blur();
             },
         });
-        if (this.props.inputProps) {
-            BlueprintUtils.safeInvoke<React.KeyboardEvent<HTMLInputElement>, void>(this.props.inputProps.onKeyDown, e);
-        }
+        this.maybeInvokeInputEventHandler("onKeyDown", e);
     };
 
     private handleFocus = (e: React.SyntheticEvent<HTMLInputElement>) => {
@@ -330,9 +336,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
             e.currentTarget.select();
         }
 
-        if (this.props.inputProps) {
-            BlueprintUtils.safeInvoke<React.SyntheticEvent<HTMLInputElement>, void>(this.props.inputProps.onFocus, e);
-        }
+        this.maybeInvokeInputEventHandler("onFocus", e);
     };
 
     private handleAmPmChange = (e: React.SyntheticEvent<HTMLSelectElement>) => {

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -67,6 +67,12 @@ export interface ITimePickerProps extends IProps {
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 
     /**
+     * Custom input component that will be used instead of a pure input element.
+     * Needs to have the same interface as a normal input.
+     */
+    inputComponent?: React.ComponentType<React.InputHTMLAttributes<HTMLInputElement>>;
+
+    /**
      * Callback invoked when the user changes the time.
      */
     onChange?: (newTime: Date) => void;
@@ -235,26 +241,26 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
     }
 
     private renderInput(className: string, unit: TimeUnit, value: string) {
-        const { disabled, inputProps } = this.props;
+        const { disabled, inputProps, inputComponent: CustomInputComponent } = this.props;
         const isValid = isTimeUnitValid(unit, parseInt(value, 10));
 
-        return (
-            <input
-                {...inputProps}
-                className={classNames(
-                    Classes.TIMEPICKER_INPUT,
-                    { [CoreClasses.intentClass(Intent.DANGER)]: !isValid },
-                    className,
-                    inputProps ? inputProps.className : "",
-                )}
-                onBlur={this.getInputBlurHandler(unit)}
-                onChange={this.getInputChangeHandler(unit)}
-                onFocus={this.handleFocus}
-                onKeyDown={this.getInputKeyDownHandler(unit)}
-                value={value}
-                disabled={disabled}
-            />
-        );
+        const props: React.InputHTMLAttributes<HTMLInputElement> = {
+            ...inputProps,
+            className: classNames(
+                Classes.TIMEPICKER_INPUT,
+                { [CoreClasses.intentClass(Intent.DANGER)]: !isValid },
+                className,
+                inputProps ? inputProps.className : "",
+            ),
+            disabled,
+            onBlur: this.getInputBlurHandler(unit),
+            onChange: this.getInputChangeHandler(unit),
+            onFocus: this.handleFocus,
+            onKeyDown: this.getInputKeyDownHandler(unit),
+            value,
+        };
+
+        return CustomInputComponent ? <CustomInputComponent {...props} /> : <input {...props} />;
     }
 
     private maybeRenderAmPm() {

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -22,6 +22,7 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
+import classNames from "classnames";
 import { Classes, ITimePickerProps, TimePicker, TimePrecision } from "../src/index";
 import { assertTimeIs, createTimeObject } from "./common/dateTestUtils";
 
@@ -282,6 +283,19 @@ describe("<TimePicker>", () => {
         assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
         keyDownOnInput(Classes.TIMEPICKER_MILLISECOND, Keys.ARROW_DOWN);
         assertTimeIs(timePicker.state.value, 0, 0, 0, 0);
+    });
+
+    describe("with custom input component", () => {
+        const CustomInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+            <input {...props} className={classNames(props.className, "custom-input")} type="text" />
+        );
+
+        it("renders input components", () => {
+            const wrapper = mount(<TimePicker inputComponent={CustomInput} />);
+            assert.lengthOf(wrapper.find(CustomInput), 2);
+            assert.lengthOf(wrapper.find(`input.${Classes.TIMEPICKER_HOUR}`), 1);
+            assert.lengthOf(wrapper.find(`input.${Classes.TIMEPICKER_MINUTE}`), 1);
+        });
     });
 
     describe("Time range - minTime and maxTime props", () => {

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -60,6 +60,57 @@ describe("<TimePicker>", () => {
         assert.lengthOf(document.querySelectorAll(selector), 1);
     });
 
+    it("passes down input props correctly", () => {
+        const onBlur = sinon.spy();
+        const onChange = sinon.spy();
+        const onClick = sinon.spy();
+        const onFocus = sinon.spy();
+        const onKeyDown = sinon.spy();
+
+        renderTimePicker({ inputProps: { className: "foo", onBlur, onChange, onFocus, onKeyDown, onClick } });
+
+        assert.lengthOf(document.querySelectorAll(".foo"), 2);
+
+        const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
+
+        TestUtils.Simulate.blur(hourInput);
+        assert.isTrue(onBlur.calledOnce);
+
+        TestUtils.Simulate.change(hourInput);
+        assert.isTrue(onChange.calledOnce);
+
+        TestUtils.Simulate.click(hourInput);
+        assert.isTrue(onClick.calledOnce);
+
+        TestUtils.Simulate.focus(hourInput);
+        assert.isTrue(onFocus.calledOnce);
+
+        TestUtils.Simulate.keyDown(hourInput);
+        assert.isTrue(onKeyDown.calledOnce);
+
+        const minuteInput = findInputElement(Classes.TIMEPICKER_MINUTE);
+        onBlur.resetHistory();
+        onChange.resetHistory();
+        onClick.resetHistory();
+        onFocus.resetHistory();
+        onKeyDown.resetHistory();
+
+        TestUtils.Simulate.blur(minuteInput);
+        assert.isTrue(onBlur.calledOnce);
+
+        TestUtils.Simulate.change(minuteInput);
+        assert.isTrue(onChange.calledOnce);
+
+        TestUtils.Simulate.click(minuteInput);
+        assert.isTrue(onClick.calledOnce);
+
+        TestUtils.Simulate.focus(minuteInput);
+        assert.isTrue(onFocus.calledOnce);
+
+        TestUtils.Simulate.keyDown(minuteInput);
+        assert.isTrue(onKeyDown.calledOnce);
+    });
+
     it("arrow buttons allow looping", () => {
         renderTimePicker({
             defaultValue: new Date(2015, 1, 1, 0, 0, 59, 999),

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Classes, H5, HTMLSelect, Switch } from "@blueprintjs/core";
+import { Classes, Colors, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { Example, handleNumberChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import * as React from "react";
 import { PrecisionSelect } from "./common/precisionSelect";
@@ -28,6 +28,7 @@ export interface ITimePickerExampleState {
     selectAllOnFocus?: boolean;
     showArrowButtons?: boolean;
     disabled?: boolean;
+    inputComponent?: React.ComponentType<React.HTMLProps<HTMLInputElement>>;
     minTime?: Date;
     maxTime?: Date;
     useAmPm?: boolean;
@@ -44,6 +45,10 @@ enum MaximumHours {
     NINE_PM = 21,
     TWO_AM = 2,
 }
+
+const CustomInput = (props: React.HTMLProps<HTMLInputElement>) => (
+    <input {...props} style={{ backgroundColor: Colors.BLUE4 }} />
+);
 
 export class TimePickerExample extends React.PureComponent<IExampleProps, ITimePickerExampleState> {
     public state = {
@@ -78,6 +83,11 @@ export class TimePickerExample extends React.PureComponent<IExampleProps, ITimeP
                     label="Show arrow buttons"
                     onChange={this.toggleShowArrowButtons}
                 />
+                <Switch
+                    checked={!!this.state.inputComponent}
+                    label="Use custom input"
+                    onChange={this.toggleCustomInput}
+                />
                 <Switch checked={this.state.disabled} label="Disabled" onChange={this.toggleDisabled} />
                 <Switch checked={this.state.useAmPm} label="Use AM/PM" onChange={this.toggleUseAmPm} />
                 <PrecisionSelect value={this.state.precision} onChange={this.handlePrecisionChange} />
@@ -111,6 +121,10 @@ export class TimePickerExample extends React.PureComponent<IExampleProps, ITimeP
 
     private toggleDisabled = () => {
         this.setState({ disabled: !this.state.disabled });
+    };
+
+    private toggleCustomInput = () => {
+        this.setState(prevState => ({ inputComponent: !prevState.inputComponent ? CustomInput : undefined }));
     };
 
     private toggleUseAmPm = () => {


### PR DESCRIPTION
#### Fixes #3801

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
This PR introduces two changes to the `TimePicker` component:
* Adding an `inputProps` prop that is handed down to all input elements rendered by the `TimePicker` (analogous to  https://github.com/palantir/blueprint/blob/develop/packages/datetime/src/dateInput.tsx#L89 )
* Adding an `inputComponent` prop that enables users to pass their own `input` implementations to the `TimePicker` to be used by it instead of pure input elements.

#### Reviewers should focus on:

<!-- Fill this out. -->
I was unsure about which tests of the `TimePicker` test suite i would want to repeat for a version using a custom input element. Realistically, i think the typing is strict enough to ensure that any element passed to `inputComponent` adheres to the same interface as the native input element, but i am open to suggestions.