### PR TITLE
Export IDateRangeInputProps from @blueprintjs/datetime.

### DIFF
--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -31,6 +31,6 @@ export { DateInput, IDateInputProps } from "./dateInput";
 export { DatePicker, IDatePickerProps } from "./datePicker";
 export { IDatePickerModifiers } from "./datePickerCore";
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
-export { DateRangeInput } from "./dateRangeInput";
+export { DateRangeInput, IDateRangeInputProps } from "./dateRangeInput";
 export { DateRangePicker, IDateRangePickerProps, IDateRangeShortcut } from "./dateRangePicker";
 export { ITimePickerProps, TimePicker, TimePrecision } from "./timePicker";


### PR DESCRIPTION
#### Fixes #3820

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

Export `IDateRangeInputProps` in the same fashion as other component proptypes.

#### Reviewers should focus on:

Probably the single line of the diff.
