### PR TITLE
[core] feat(EditableText): add alwaysRenderInput experimental feature

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -148,20 +148,25 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         type: "text",
     };
 
+    private inputElement?: HTMLInputElement | HTMLTextAreaElement;
     private valueElement: HTMLSpanElement;
     private refHandlers = {
         content: (spanElement: HTMLSpanElement) => {
             this.valueElement = spanElement;
         },
         input: (input: HTMLInputElement | HTMLTextAreaElement) => {
-            if (input != null && this.state != null && this.state.isEditing) {
-                const supportsSelection = inputSupportsSelection(input);
-                if (supportsSelection) {
-                    const { length } = input.value;
-                    input.setSelectionRange(this.props.selectAllOnFocus ? 0 : length, length);
-                }
-                if (!supportsSelection || !this.props.selectAllOnFocus) {
-                    input.scrollLeft = input.scrollWidth;
+            if (input != null) {
+                this.inputElement = input;
+
+                if (this.state != null && this.state.isEditing) {
+                    const supportsSelection = inputSupportsSelection(input);
+                    if (supportsSelection) {
+                        const { length } = input.value;
+                        input.setSelectionRange(this.props.selectAllOnFocus ? 0 : length, length);
+                    }
+                    if (!supportsSelection || !this.props.selectAllOnFocus) {
+                        input.scrollLeft = input.scrollWidth;
+                    }
                 }
             }
         },
@@ -277,8 +282,15 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
     };
 
     private handleFocus = () => {
-        if (!this.props.disabled) {
+        const { alwaysRenderInput, disabled, selectAllOnFocus } = this.props;
+
+        if (!disabled) {
             this.setState({ isEditing: true });
+        }
+
+        if (alwaysRenderInput && selectAllOnFocus && this.inputElement != null) {
+            const { length } = this.inputElement.value;
+            this.inputElement.setSelectionRange(0, length);
         }
     };
 

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -24,6 +24,19 @@ import { Browser } from "../../compatibility";
 
 export interface IEditableTextProps extends IIntentProps, IProps {
     /**
+     * EXPERIMENTAL FEATURE.
+     *
+     * When true, this forces the component to _always_ render an editable input (or textarea)
+     * both when the component is focussed and unfocussed, instead of the component's default
+     * behavior of switching between a text span and a text input upon interaction.
+     *
+     * This behavior can help in certain applications where, for example, a custom right-click
+     * context menu is used to supply clipboard copy and paste functionality.
+     * @default false
+     */
+    alwaysRenderInput?: boolean;
+
+    /**
      * If `true` and in multiline mode, the `enter` key will trigger onConfirm and `mod+enter`
      * will insert a newline. If `false`, the key bindings are inverted such that `enter`
      * adds a newline.
@@ -123,6 +136,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
     public static displayName = `${DISPLAYNAME_PREFIX}.EditableText`;
 
     public static defaultProps: IEditableTextProps = {
+        alwaysRenderInput: false,
         confirmOnEnterKey: false,
         defaultValue: "",
         disabled: false,
@@ -140,8 +154,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
             this.valueElement = spanElement;
         },
         input: (input: HTMLInputElement | HTMLTextAreaElement) => {
-            if (input != null) {
-                input.focus();
+            if (input != null && this.state != null && this.state.isEditing) {
                 const supportsSelection = inputSupportsSelection(input);
                 if (supportsSelection) {
                     const { length } = input.value;
@@ -168,7 +181,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
     }
 
     public render() {
-        const { disabled, multiline } = this.props;
+        const { alwaysRenderInput, disabled, multiline } = this.props;
         const value = this.props.value == null ? this.state.value : this.props.value;
         const hasValue = value != null && value !== "";
 
@@ -198,15 +211,25 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
             };
         }
 
-        // make enclosing div focusable when not editing, so it can still be tabbed to focus
-        // (when editing, input itself is focusable so div doesn't need to be)
-        const tabIndex = this.state.isEditing || disabled ? null : 0;
+        // If we are always rendering an input, then NEVER make the container div focusable.
+        // Otherwise, make container div focusable when not editing, so it can still be tabbed
+        // to focus (when the input is rendered, it is itself focusable so container div doesn't need to be)
+        const tabIndex = alwaysRenderInput || this.state.isEditing || disabled ? null : 0;
+
+        // we need the contents to be rendered while editing so that we can measure their height
+        // and size the container element responsively
+        const shouldHideContents = alwaysRenderInput && !this.state.isEditing;
+
         return (
             <div className={classes} onFocus={this.handleFocus} tabIndex={tabIndex}>
-                {this.maybeRenderInput(value)}
-                <span className={Classes.EDITABLE_TEXT_CONTENT} ref={this.refHandlers.content} style={contentStyle}>
-                    {hasValue ? value : this.props.placeholder}
-                </span>
+                {alwaysRenderInput || this.state.isEditing ? this.renderInput(value) : undefined}
+                {shouldHideContents ? (
+                    undefined
+                ) : (
+                    <span className={Classes.EDITABLE_TEXT_CONTENT} ref={this.refHandlers.content} style={contentStyle}>
+                        {hasValue ? value : this.props.placeholder}
+                    </span>
+                )}
             </div>
         );
     }
@@ -296,11 +319,8 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         }
     };
 
-    private maybeRenderInput(value: string) {
+    private renderInput(value: string) {
         const { maxLength, multiline, type, placeholder } = this.props;
-        if (!this.state.isEditing) {
-            return undefined;
-        }
         const props: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> = {
             className: Classes.EDITABLE_TEXT_INPUT,
             maxLength,
@@ -308,13 +328,18 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
             onChange: this.handleTextChange,
             onKeyDown: this.handleKeyEvent,
             placeholder,
-            style: {
-                height: this.state.inputHeight,
-                lineHeight: !multiline && this.state.inputHeight != null ? `${this.state.inputHeight}px` : null,
-                width: multiline ? "100%" : this.state.inputWidth,
-            },
             value,
         };
+
+        const { inputHeight, inputWidth } = this.state;
+        if (inputHeight !== 0 && inputWidth !== 0) {
+            props.style = {
+                height: inputHeight,
+                lineHeight: !multiline && inputHeight != null ? `${inputHeight}px` : null,
+                width: multiline ? "100%" : inputWidth,
+            };
+        }
+
         return multiline ? (
             <textarea ref={this.refHandlers.input} {...props} />
         ) : (

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -24,6 +24,7 @@ import { IntentSelect } from "./common/intentSelect";
 const INPUT_ID = "EditableTextExample-max-length";
 
 export interface IEditableTextExampleState {
+    alwaysRenderInput?: boolean;
     confirmOnEnterKey?: boolean;
     intent?: Intent;
     maxLength?: number;
@@ -33,6 +34,7 @@ export interface IEditableTextExampleState {
 
 export class EditableTextExample extends React.PureComponent<IExampleProps, IEditableTextExampleState> {
     public state: IEditableTextExampleState = {
+        alwaysRenderInput: true,
         confirmOnEnterKey: false,
         report: "",
         selectAllOnFocus: false,
@@ -41,12 +43,14 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
     private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
     private toggleSelectAll = handleBooleanChange(selectAllOnFocus => this.setState({ selectAllOnFocus }));
     private toggleSwap = handleBooleanChange(confirmOnEnterKey => this.setState({ confirmOnEnterKey }));
+    private toggleAlwaysRenderInput = handleBooleanChange(alwaysRenderInput => this.setState({ alwaysRenderInput }));
 
     public render() {
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <H1>
                     <EditableText
+                        alwaysRenderInput={this.state.alwaysRenderInput}
                         intent={this.state.intent}
                         maxLength={this.state.maxLength}
                         placeholder="Edit title..."
@@ -54,6 +58,7 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                     />
                 </H1>
                 <EditableText
+                    alwaysRenderInput={this.state.alwaysRenderInput}
                     intent={this.state.intent}
                     maxLength={this.state.maxLength}
                     maxLines={12}
@@ -94,6 +99,11 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                 <Switch checked={this.state.confirmOnEnterKey} onChange={this.toggleSwap}>
                     Swap keypress for confirm and newline (multiline only)
                 </Switch>
+                <Switch
+                    checked={this.state.alwaysRenderInput}
+                    label="Always render input"
+                    onChange={this.toggleAlwaysRenderInput}
+                />
             </>
         );
     }


### PR DESCRIPTION
#### Fixes #3839

#### Checklist

- [ ] Includes tests ("experimental" 🙃)
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add new prop `alwaysRenderInput` to make the component render an input which can, in theory, retain focus across `isEditing={true|false}` interactions.

#### Reviewers should focus on:

Does this work in practice to solve the linked bug

Note that, at least right now, it doesn't work well with Blueprint's ContextMenu.

#### Screenshot

![2019-11-12 19 22 39](https://user-images.githubusercontent.com/723999/68721884-dc1c8c80-0581-11ea-9d25-d0eed462c2f5.gif)

