### PR TITLE
Include tabIndex for date picker shortcuts

### DIFF
--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -92,7 +92,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
             />
         ));
 
-        return <Menu className={DATERANGEPICKER_SHORTCUTS}>{shortcutElements}</Menu>;
+        return <Menu className={DATERANGEPICKER_SHORTCUTS} tabIndex={0}>{shortcutElements}</Menu>;
     }
 
     private getShorcutClickHandler = (shortcut: IDateRangeShortcut, index: number) => () => {

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -92,7 +92,11 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
             />
         ));
 
-        return <Menu className={DATERANGEPICKER_SHORTCUTS} tabIndex={0}>{shortcutElements}</Menu>;
+        return (
+            <Menu className={DATERANGEPICKER_SHORTCUTS} tabIndex={0}>
+                {shortcutElements}
+            </Menu>
+        );
     }
 
     private getShorcutClickHandler = (shortcut: IDateRangeShortcut, index: number) => () => {


### PR DESCRIPTION
#### Fixes no issue

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
This ensures event.relatedTarget is properly populated when the date input box is blurred by clicking on the date picker popover shortcuts.

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
