### PR TITLE
[core]fix(Dialog): add margin to dialog footer actions (#3848)

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -139,6 +139,7 @@ $dialog-padding: $pt-grid-size * 2 !default;
 .#{$ns}-dialog-footer-actions {
   display: flex;
   justify-content: flex-end;
+  margin: 0 $dialog-padding;
 
   .#{$ns}-button {
     margin-left: $pt-grid-size;


### PR DESCRIPTION
#### Fixes #3848 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added margin to DIALOG_FOOTER_ACTIONS

#### Reviewers should focus on:



#### Screenshot

<img width="587" alt="Screenshot 2019-11-18 at 23 56 35" src="https://user-images.githubusercontent.com/9706778/69093247-22308f00-0a5f-11ea-8548-451048318d88.png">

