### PR TITLE
[core] fix(TagInput): add intent styling when component is active

### DIFF
--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -113,6 +113,12 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 
   &.#{$ns}-active {
     box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
     background-color: $input-background-color;
+
+    @each $intent, $color in $pt-intent-text-colors {
+      &.#{$ns}-intent-#{$intent} {
+        box-shadow: input-transition-shadow($color, true), $input-box-shadow-focus;
+      }
+    }
   }
 
   .#{$ns}-dark &,

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -137,6 +137,12 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) / 
       box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true),
                   $pt-dark-input-box-shadow;
       background-color: $dark-input-background-color;
+
+      @each $intent, $color in $pt-intent-text-colors {
+        &.#{$ns}-intent-#{$intent} {
+          box-shadow: input-transition-shadow($color, true), $pt-dark-input-box-shadow;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
#### Fixes #3847 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Add `intent` to `active` class
<!-- Fill this out. -->

#### Screenshot
![Screenshot from 2019-11-17 10-03-25](https://user-images.githubusercontent.com/25791025/69003083-db894a80-0921-11ea-81b8-f2e41788f484.png)

<!-- Include an image of the most relevant user-facing change, if any. -->
