### PR TITLE
[core] feat(Drawer): add Sass variables for background color

### DIFF
--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -11,12 +11,15 @@ $drawer-padding: $pt-grid-size * 2 !default;
 
 $drawer-default-size: 50%;
 
+$drawer-background-color: $white !default;
+$dark-drawer-background-color: $dark-gray4 !default;
+
 .#{$ns}-drawer {
   display: flex;
   flex-direction: column;
   margin: 0;
   box-shadow: $pt-elevation-shadow-4;
-  background: $white;
+  background: $drawer-background-color;
   padding: 0;
 
   &:focus {
@@ -167,7 +170,7 @@ $drawer-default-size: 50%;
   &.#{$ns}-dark,
   .#{$ns}-dark & {
     box-shadow: $pt-dark-dialog-box-shadow;
-    background: $dark-gray4;
+    background: $dark-drawer-background-color;
     color: $pt-dark-text-color;
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:
I added the variables `$drawer-background-color` and `$dark-drawer-background-color`. So colors can be set in variables, not overridden in CSS

#### Reviewers should focus on:
Drawer component

#### Screenshot
N/A
