### PR TITLE
[core] fix: Explicitly declare dom4 side effects

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,10 @@
   "style": "lib/css/blueprint.css",
   "unpkg": "dist/core.bundle.js",
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "lib/esm/components/index.js",
+    "lib/esnext/components/index.js",
+    "lib/cjs/components/index.js"
   ],
   "bin": {
     "upgrade-blueprint-2.0.0-rename": "./scripts/upgrade-blueprint-2.0.0-rename.sh",


### PR DESCRIPTION
#### Changes proposed in this pull request:

This change explicitly declares the [dom4 side effect](https://github.com/palantir/blueprint/blob/3eef70e0b8b1bcce9de0836dbe2e28deff3ee8d9/packages/core/src/components/index.ts#L21) that is necessary for Blueprint to work in IE11 so that Webpack doesn't tree-shake it away.

Without this change, Webpack was stripping dom4 out of my build, which resulted in my app working fine in modern browsers but throwing errors such as this one in IE11:

```
Object doesn't support property or method 'closest'
```

I've tested this change locally by editing the `package.json` file in my `node_modules/@blueprintjs/core` directory and it works! IE11 no longer throws errors when the build includes this.
