### PR TITLE
Include index.js files in sideEffects list

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,8 +10,14 @@
   "unpkg": "dist/core.bundle.js",
   "sideEffects": [
     "*.css",
+    "lib/esm/index.js",
+    "lib/esm/components/index.js",
     "lib/esm/common/configureDom4.js",
+    "lib/esnext/index.js",
+    "lib/esnext/components/index.js",
     "lib/esnext/common/configureDom4.js",
+    "lib/cjs/index.js",
+    "lib/cjs/components/index.js",
     "lib/cjs/common/configureDom4.js"
   ],
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,13 +10,10 @@
   "unpkg": "dist/core.bundle.js",
   "sideEffects": [
     "*.css",
-    "lib/esm/index.js",
     "lib/esm/components/index.js",
     "lib/esm/common/configureDom4.js",
-    "lib/esnext/index.js",
     "lib/esnext/components/index.js",
     "lib/esnext/common/configureDom4.js",
-    "lib/cjs/index.js",
     "lib/cjs/components/index.js",
     "lib/cjs/common/configureDom4.js"
   ],


### PR DESCRIPTION
Unfortunately, breaking the dom4 inclusion out to `configureDom4.js` in https://github.com/palantir/blueprint/pull/3868 allowed it to get tree-shaken away, again. We need to include the `index.js` files that include it in our side effects list so that webpack evaluates them.

My understanding of what was happening, following the model laid out [in the Webpack docs](https://webpack.js.org/guides/tree-shaking/#clarifying-tree-shaking-and-sideeffects), is:
* We import directly from the root `index.js` file, so it was included
* We don't import directly from the `components/index.js`, so it was skipped
* Since `components/index.js` was skipped, `configureDom4.js` was also skipped (even though it has side effects)

Previously, https://github.com/palantir/blueprint/pull/3867 included `components/index.js` in the side effects list, so it wasn't skipped and dom4 was included.

I don't think I _technically_ need to list the root `index.js` file in the `sideEffects` list for this to work, since we will almost always have imports from there, but it here should guarantee that dom4 is always included, even if using submodule imports.

