### PR TITLE
Fix PanelStack

### DIFF
--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -76,14 +76,17 @@ export class PanelStack extends AbstractPureComponent2<IPanelStackProps, IPanelS
 
     public componentDidUpdate(prevProps: IPanelStackProps, _prevState: IPanelStackState, _snapshot: {}) {
         super.componentDidUpdate(prevProps, _prevState, _snapshot);
+
+        // Always update local stack if stack prop changes
+        if (this.props.stack !== prevProps.stack && prevProps.stack != null) {
+            this.setState({ stack: this.props.stack.slice().reverse() });
+        }
+
+        // Only update animation direction if stack length changes
         const stackLength = this.props.stack != null ? this.props.stack.length : 0;
         const prevStackLength = prevProps.stack != null ? prevProps.stack.length : 0;
-
         if (stackLength !== prevStackLength && prevProps.stack != null) {
-            this.setState({
-                direction: prevProps.stack.length - this.props.stack.length < 0 ? "push" : "pop",
-                stack: this.props.stack.slice().reverse(),
-            });
+            this.setState({ direction: prevProps.stack.length - this.props.stack.length < 0 ? "push" : "pop" });
         }
     }
 


### PR DESCRIPTION
#### Fixes #3875

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix an issue where the PanelStack would not update when its props were changed.

In #3787 a change was made to only update the PanelStack if its stack length changed. Before that, a change to the stack would update the internal state of the animation and stack. This caused issues when 1) there were changes to the stack (but not its length) and 2) the component was animating, since it could trigger an animation in the opposite direction.

Unfortunately, it did not take into account that the stack could change without changing its length. This PR uses two different conditions to check if the stack has changed and if the animation direction needs to be updated.

This fixes an issue introduced in #3787. 

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
