### PR TITLE
Fix DatePicker unit test

### DIFF
--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -512,7 +512,10 @@ describe("<DatePicker>", () => {
 
         it("onChange fired when month is changed", () => {
             const onChange = sinon.spy();
-            const { getDay, clickNextMonth } = wrap(<DatePicker onChange={onChange} />);
+            // must use an initial month otherwise clicking next month in december will fail
+            const { getDay, clickNextMonth } = wrap(
+                <DatePicker initialMonth={new Date(2015, Months.JANUARY, 12)} onChange={onChange} />,
+            );
             assert.isTrue(onChange.notCalled);
             getDay().simulate("click");
             assert.isTrue(onChange.calledOnce, "expected onChange called");


### PR DESCRIPTION
DatePicker unit tests started failing in December because
it relied on being able to press "next month". This change
sets the initial month to January.


#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

DatePicker unit tests started failing in December because
it relied on being able to press "next month". This change
sets the initial month to January

#### Reviewers should focus on:

Green unit tests

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
