### PR TITLE
Fix 3882

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -158,6 +158,11 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
             if (input != null) {
                 this.inputElement = input;
 
+                // temporary fix for #3882
+                if (!this.props.alwaysRenderInput) {
+                    this.inputElement.focus();
+                }
+
                 if (this.state != null && this.state.isEditing) {
                     const supportsSelection = inputSupportsSelection(input);
                     if (supportsSelection) {


### PR DESCRIPTION
Add gated input.focus to reinstate previous behavior

#### Fixes #3882 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Reinstate crucial `input.focus()` in `<EditableText>`

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
