### PR TITLE
[examples] fix label id in formGroupExample

### DIFF
--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -80,11 +80,10 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                     inline={inline}
                     intent={intent}
                     label={label && "Label"}
-                    labelFor="text-input"
                     labelInfo={requiredLabel && "(required)"}
                 >
-                    <Switch id="text-input" label="Engage the hyperdrive" disabled={disabled} />
-                    <Switch id="text-input" label="Initiate thrusters" disabled={disabled} />
+                    <Switch label="Engage the hyperdrive" disabled={disabled} />
+                    <Switch label="Initiate thrusters" disabled={disabled} />
                 </FormGroup>
             </Example>
         );


### PR DESCRIPTION
Previous version used duplicate id attributes, which is invalid.

It also had the label for the group of switches have a target,
where it probably makes sense for it not to.

No visual changes.