### PR TITLE
[core] fix(NumericInput): correct rounding of default value

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -213,12 +213,12 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         const didValuePropChange = props.value !== state.prevValueProp;
         const value = getValueOrEmptyValue(didValuePropChange ? props.value : state.value);
 
+        const stepMaxPrecision = NumericInput.getStepMaxPrecision(props);
+
         const sanitizedValue =
             value !== NumericInput.VALUE_EMPTY
-                ? NumericInput.getSanitizedValue(value, /* delta */ 0, props.min, props.max)
+                ? NumericInput.getSanitizedValue(value, stepMaxPrecision, props.min, props.max)
                 : NumericInput.VALUE_EMPTY;
-
-        const stepMaxPrecision = NumericInput.getStepMaxPrecision(props);
 
         // if a new min and max were provided that cause the existing value to fall
         // outside of the new bounds, then clamp the value to the new valid range.

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -893,6 +893,16 @@ describe("<NumericInput>", () => {
             expect(component.find(InputGroup).find(Button)).to.exist;
         });
 
+        it("passed decimal value should be rounded by stepSize", () => {
+            const component = mount(<NumericInput value={9.001} min={0} />);
+            expect(component.find("input").prop("value")).to.equal("9");
+        });
+
+        it("passed decimal value should be rounded by minorStepSize", () => {
+            const component = mount(<NumericInput value={"9.01"} min={0} minorStepSize={0.01} />);
+            expect(component.find("input").prop("value")).to.equal("9.01");
+        });
+
         it("changes max precision of displayed value to that of the smallest step size defined", () => {
             const component = mount(<NumericInput majorStepSize={1} stepSize={0.1} minorStepSize={0.001} />);
             const incrementButton = component.find(Button).first();


### PR DESCRIPTION
Fixes #3889 

#### Checklist

- [x] Includes tests
- [ ] ~Update documentation~

#### Changes proposed in this pull request:

Fixed situation when pass to `NumericInput` value as float number and it rounds incorrectly
