### PR TITLE
[docs] fix wrapping docs title

### DIFF
--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -148,7 +148,6 @@ Lefthand navigation menu
 
 .docs-nav-title {
   @include pt-flex-container(row);
-  flex-wrap: wrap;
   align-items: center;
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

remove `flex-wrap` cuz this shouldn't wrap?

#### Screenshot
seen in Chrome 79:
![image](https://user-images.githubusercontent.com/464822/71046050-edf6cf80-20eb-11ea-81cc-e4d14940c050.png)



