### PR TITLE
[core] fix(Toast): bottom shadow is no longer clipped

### DIFF
--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -173,8 +173,6 @@ $toast-margin: $pt-grid-size * 2 !default;
 
   &.#{$ns}-toast-container-top {
     top: 0;
-    // clear opposite side cuz .#{$ns}-overlay has all sides 0'ed
-    bottom: auto;
   }
 
   &.#{$ns}-toast-container-bottom {


### PR DESCRIPTION
#### Fixes #3723

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

removed a ```bottom: auto; ``` css line as it was cutting off the shadow of a toast and doesn't seem to add any other functionality.  

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
