### PR TITLE
[core] fix(EditableText): allow setting value to null in controlled mode

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -250,7 +250,8 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
 
     public componentDidUpdate(prevProps: IEditableTextProps, prevState: IEditableTextState) {
         const state: IEditableTextState = {};
-        if (this.props.value != null && this.props.value !== prevProps.value) {
+        // allow setting the value to undefined/null in controlled mode
+        if (this.props.value !== prevProps.value && (prevProps.value != null || this.props.value != null)) {
             state.value = this.props.value;
         }
         if (this.props.isEditing != null && this.props.isEditing !== prevProps.isEditing) {

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -40,6 +40,13 @@ describe("<EditableText>", () => {
         assert.isFalse(editable.state("isEditing"));
     });
 
+    it("allows resetting controlled value to undefined or null", () => {
+        const editable = shallow(<EditableText isEditing={false} placeholder="placeholder" value="alphabet" />);
+        assert.strictEqual(editable.text(), "alphabet");
+        editable.setProps({ value: null });
+        assert.strictEqual(editable.text(), "placeholder");
+    });
+
     describe("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");


### PR DESCRIPTION
issue raised in #3742 