### PR TITLE
[select] feat(Suggest): sync activeItem with selectedItem on popover close

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -486,7 +486,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         return getFirstEnabledItem(this.state.filteredItems, this.props.itemDisabled, direction, startIndex);
     }
 
-    private setActiveItem(activeItem: T | ICreateNewItem | null) {
+    public setActiveItem(activeItem: T | ICreateNewItem | null) {
         this.expectedNextActiveItem = activeItem;
         if (this.props.activeItem === undefined) {
             // indicate that the active item may need to be scrolled into view after update.

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -289,6 +289,21 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         }
     }
 
+    public setActiveItem(activeItem: T | ICreateNewItem | null) {
+        this.expectedNextActiveItem = activeItem;
+        if (this.props.activeItem === undefined) {
+            // indicate that the active item may need to be scrolled into view after update.
+            this.shouldCheckActiveItemInViewport = true;
+            this.setState({ activeItem });
+        }
+
+        if (isCreateNewItem(activeItem)) {
+            Utils.safeInvoke(this.props.onActiveItemChange, null, true);
+        } else {
+            Utils.safeInvoke(this.props.onActiveItemChange, activeItem, false);
+        }
+    }
+
     /** default `itemListRenderer` implementation */
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
         const { initialContent, noResults } = this.props;
@@ -484,21 +499,6 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             }
         }
         return getFirstEnabledItem(this.state.filteredItems, this.props.itemDisabled, direction, startIndex);
-    }
-
-    public setActiveItem(activeItem: T | ICreateNewItem | null) {
-        this.expectedNextActiveItem = activeItem;
-        if (this.props.activeItem === undefined) {
-            // indicate that the active item may need to be scrolled into view after update.
-            this.shouldCheckActiveItemInViewport = true;
-            this.setState({ activeItem });
-        }
-
-        if (isCreateNewItem(activeItem)) {
-            Utils.safeInvoke(this.props.onActiveItemChange, null, true);
-        } else {
-            Utils.safeInvoke(this.props.onActiveItemChange, activeItem, false);
-        }
     }
 
     private isCreateItemRendered(): boolean {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -31,6 +31,12 @@ import {
 
 export interface IQueryListProps<T> extends IListItemsProps<T> {
     /**
+     * Initial active item, useful if the parent component is controlling its selectedItem but
+     * not activeItem.
+     */
+    initialActiveItem?: T;
+
+    /**
      * Callback invoked when user presses a key, after processing `QueryList`'s own key events
      * (up/down to navigate active item). This callback is passed to `renderer` and (along with
      * `onKeyUp`) can be attached to arbitrary content elements to support keyboard selection.
@@ -171,7 +177,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             activeItem:
                 props.activeItem !== undefined
                     ? props.activeItem
-                    : getFirstEnabledItem(filteredItems, props.itemDisabled),
+                    : props.initialActiveItem ?? getFirstEnabledItem(filteredItems, props.itemDisabled),
             createNewItem,
             filteredItems,
             query,

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -129,6 +129,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         return (
             <this.TypedQueryList
                 {...restProps}
+                initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}
                 ref={this.refHandlers.queryList}
                 renderer={this.renderQueryList}
@@ -140,6 +141,11 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         // If the selected item prop changes, update the underlying state.
         if (this.props.selectedItem !== undefined && this.props.selectedItem !== this.state.selectedItem) {
             this.setState({ selectedItem: this.props.selectedItem });
+        }
+
+        if (this.state.isOpen === false && prevState.isOpen === true) {
+            // just closed, likely by keyboard interaction
+            this.maybeResetActiveItemToSelectedItem();
         }
 
         if (this.state.isOpen && !prevState.isOpen && this.queryList != null) {
@@ -286,19 +292,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     };
 
     private handlePopoverClosed = (element: HTMLElement) => {
-        // The activeItem should always be the selectedItem when the Popover is first opened
-        // if the activeItem prop is not set. Set the activeItem on close so that there isn't
-        // a flash of the activeItem on screen.
-        const shouldResetActiveItemToSelectedItem =
-            this.props.activeItem === undefined && this.state.selectedItem !== null && !this.props.resetOnSelect;
-
-        if (this.queryList !== null && shouldResetActiveItemToSelectedItem) {
-            // If the selectedItem prop is set then use it.
-            // If not fall back to component state.
-            const selectedItem = this.props.selectedItem ?? this.state.selectedItem;
-            this.queryList.setActiveItem(selectedItem);
-        }
-
+        this.maybeResetActiveItemToSelectedItem();
         Utils.safeInvokeMember(this.props.popoverProps, "onClosed", element);
     };
 
@@ -338,4 +332,16 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             Utils.safeInvokeMember(this.props.inputProps, "onKeyUp", evt);
         };
     };
+
+    private maybeResetActiveItemToSelectedItem() {
+        // The activeItem should always be the selectedItem when the Popover is first opened
+        // if the activeItem prop is not set. Set the activeItem on close so that there isn't
+        // a flash of the activeItem on screen.
+        const shouldResetActiveItemToSelectedItem =
+            this.props.activeItem === undefined && this.state.selectedItem !== null && !this.props.resetOnSelect;
+
+        if (this.queryList !== null && shouldResetActiveItemToSelectedItem) {
+            this.queryList.setActiveItem(this.props.selectedItem ?? this.state.selectedItem);
+        }
+    }
 }

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -289,11 +289,8 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         // The activeItem should always be the selectedItem when the Popover is first opened
         // if the activeItem prop is not set. Set the activeItem on close so that there isn't
         // a flash of the activeItem on screen.
-        const shouldResetActiveItemToSelectedItem = (
-            this.props.activeItem === undefined &&
-            this.state.selectedItem &&
-            !this.props.resetOnSelect
-        );
+        const shouldResetActiveItemToSelectedItem =
+            this.props.activeItem === undefined && this.state.selectedItem && !this.props.resetOnSelect;
 
         if (this.queryList && shouldResetActiveItemToSelectedItem) {
             // If the selectedItem prop is set then use it.

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -125,7 +125,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     public render() {
         // omit props specific to this component, spread the rest.
         const { disabled, inputProps, popoverProps, ...restProps } = this.props;
-
         return (
             <this.TypedQueryList
                 {...restProps}
@@ -145,7 +144,10 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
         if (this.state.isOpen === false && prevState.isOpen === true) {
             // just closed, likely by keyboard interaction
-            this.maybeResetActiveItemToSelectedItem();
+            // wait until the transition ends so there isn't a flash of content in the popover
+            setTimeout(() => {
+                this.maybeResetActiveItemToSelectedItem();
+            }, this.props.popoverProps?.transitionDuration ?? Popover.defaultProps.transitionDuration);
         }
 
         if (this.state.isOpen && !prevState.isOpen && this.queryList != null) {
@@ -328,9 +330,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     };
 
     private maybeResetActiveItemToSelectedItem() {
-        // The activeItem should always be the selectedItem when the Popover is first opened
-        // if the activeItem prop is not set. Set the activeItem on close so that there isn't
-        // a flash of the activeItem on screen.
         const shouldResetActiveItemToSelectedItem =
             this.props.activeItem === undefined && this.state.selectedItem !== null && !this.props.resetOnSelect;
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -185,7 +185,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpening={this.handlePopoverOpening}
                 onOpened={this.handlePopoverOpened}
-                onClosed={this.handlePopoverClosed}
             >
                 <InputGroup
                     autoComplete={autoComplete}
@@ -289,11 +288,6 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             this.queryList.scrollActiveItemIntoView();
         }
         Utils.safeInvokeMember(this.props.popoverProps, "onOpened", node);
-    };
-
-    private handlePopoverClosed = (element: HTMLElement) => {
-        this.maybeResetActiveItemToSelectedItem();
-        Utils.safeInvokeMember(this.props.popoverProps, "onClosed", element);
     };
 
     private getTargetKeyDownHandler = (

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -179,6 +179,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpening={this.handlePopoverOpening}
                 onOpened={this.handlePopoverOpened}
+                onClosed={this.handlePopoverClosed}
             >
                 <InputGroup
                     autoComplete={autoComplete}
@@ -282,6 +283,26 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             this.queryList.scrollActiveItemIntoView();
         }
         Utils.safeInvokeMember(this.props.popoverProps, "onOpened", node);
+    };
+
+    private handlePopoverClosed = (node: HTMLElement) => {
+        // The activeItem should always be the selectedItem when the Popover is first opened
+        // if the activeItem prop is not set. Set the activeItem on close so that there isn't
+        // a flash of the activeItem on screen.
+        const shouldResetActiveItemToSelectedItem = (
+            this.props.activeItem === undefined &&
+            this.state.selectedItem &&
+            !this.props.resetOnSelect
+        );
+
+        if (this.queryList && shouldResetActiveItemToSelectedItem) {
+            // If the selectedItem prop is set then use it.
+            // If not fall back to component state.
+            const selectedItem = this.props.selectedItem || this.state.selectedItem;
+            this.queryList.setActiveItem(selectedItem);
+        }
+
+        Utils.safeInvokeMember(this.props.popoverProps, "onClosed", node);
     };
 
     private getTargetKeyDownHandler = (

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -285,21 +285,21 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         Utils.safeInvokeMember(this.props.popoverProps, "onOpened", node);
     };
 
-    private handlePopoverClosed = (node: HTMLElement) => {
+    private handlePopoverClosed = (element: HTMLElement) => {
         // The activeItem should always be the selectedItem when the Popover is first opened
         // if the activeItem prop is not set. Set the activeItem on close so that there isn't
         // a flash of the activeItem on screen.
         const shouldResetActiveItemToSelectedItem =
-            this.props.activeItem === undefined && this.state.selectedItem && !this.props.resetOnSelect;
+            this.props.activeItem === undefined && this.state.selectedItem !== null && !this.props.resetOnSelect;
 
-        if (this.queryList && shouldResetActiveItemToSelectedItem) {
+        if (this.queryList !== null && shouldResetActiveItemToSelectedItem) {
             // If the selectedItem prop is set then use it.
             // If not fall back to component state.
-            const selectedItem = this.props.selectedItem || this.state.selectedItem;
+            const selectedItem = this.props.selectedItem ?? this.state.selectedItem;
             this.queryList.setActiveItem(selectedItem);
         }
 
-        Utils.safeInvokeMember(this.props.popoverProps, "onClosed", node);
+        Utils.safeInvokeMember(this.props.popoverProps, "onClosed", element);
     };
 
     private getTargetKeyDownHandler = (

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -99,8 +99,9 @@ describe("Suggest", () => {
             assert.strictEqual(scrollActiveItemIntoViewSpy.callCount, 1, "should call scrollActiveItemIntoView");
         });
 
-        it("sets active item to the selected item when the popover is closed", () => {
-            const wrapper = suggest({ selectedItem: TOP_100_FILMS[10] });
+        it("sets active item to the selected item when the popover is closed", (done) => {
+            // transition duration shorter than timeout below to ensure it's done
+            const wrapper = suggest({ selectedItem: TOP_100_FILMS[10], popoverProps: { transitionDuration: 5 } });
             const queryList = ((wrapper.instance() as Suggest<IFilm>) as any).queryList as QueryList<IFilm>; // private ref
 
             assert.deepEqual(
@@ -121,7 +122,10 @@ describe("Suggest", () => {
 
             wrapper.update();
             wrapper.find(QueryList).update();
-            assert.deepEqual(queryList.state.activeItem, wrapper.state().selectedItem);
+            setTimeout(() => {
+                assert.deepEqual(queryList.state.activeItem, wrapper.state().selectedItem);
+                done();
+            }, 10);
         });
 
         function checkKeyDownDoesNotOpenPopover(wrapper: ReactWrapper<any, any>, which: number) {

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -99,6 +99,26 @@ describe("Suggest", () => {
             assert.strictEqual(scrollActiveItemIntoViewSpy.callCount, 1, "should call scrollActiveItemIntoView");
         });
 
+        it("sets active item to the selected item when the popover is closed", () => {
+            const ITEM_INDEX = 4;
+            const wrapper = suggest();
+            const queryList = ((wrapper.instance() as Suggest<IFilm>) as any).queryList; // private ref
+            console.log("INITIAL STATE", queryList.state.activeItem, wrapper.state().selectedItem)
+            simulateFocus(wrapper);
+            assert.isTrue(wrapper.state().isOpen);
+            selectItem(wrapper, ITEM_INDEX);
+            assert.isFalse(wrapper.state().isOpen);
+            simulateFocus(wrapper);
+            assert.isTrue(wrapper.state().isOpen);
+            simulateKeyDown(wrapper, Keys.ARROW_DOWN);
+            console.log("AFTER KEY DOWN", queryList.state.activeItem, wrapper.state().selectedItem)
+            console.log("BEFORE BLUR", queryList.state.activeItem, wrapper.state().selectedItem)
+            simulateKeyDown(wrapper, Keys.ESCAPE);
+            assert.isFalse(wrapper.state().isOpen);
+            console.log("AFTER BLUR", queryList.state.activeItem, wrapper.state().selectedItem)
+            assert.deepEqual(queryList.state.activeItem, wrapper.state().selectedItem);
+        });
+
         function checkKeyDownDoesNotOpenPopover(wrapper: ReactWrapper<any, any>, which: number) {
             simulateKeyDown(wrapper, which);
             assert.isFalse(wrapper.state().isOpen, "should not open popover");

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -99,7 +99,7 @@ describe("Suggest", () => {
             assert.strictEqual(scrollActiveItemIntoViewSpy.callCount, 1, "should call scrollActiveItemIntoView");
         });
 
-        it("sets active item to the selected item when the popover is closed", (done) => {
+        it("sets active item to the selected item when the popover is closed", done => {
             // transition duration shorter than timeout below to ensure it's done
             const wrapper = suggest({ selectedItem: TOP_100_FILMS[10], popoverProps: { transitionDuration: 5 } });
             const queryList = ((wrapper.instance() as Suggest<IFilm>) as any).queryList as QueryList<IFilm>; // private ref

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -22,7 +22,7 @@ import * as sinon from "sinon";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import { ISuggestProps, ISuggestState, Suggest } from "../src/components/select/suggest";
-import { IItemRendererProps } from "../src/index";
+import { IItemRendererProps, QueryList } from "../src/index";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("Suggest", () => {
@@ -100,22 +100,27 @@ describe("Suggest", () => {
         });
 
         it("sets active item to the selected item when the popover is closed", () => {
-            const ITEM_INDEX = 4;
-            const wrapper = suggest();
-            const queryList = ((wrapper.instance() as Suggest<IFilm>) as any).queryList; // private ref
-            console.log("INITIAL STATE", queryList.state.activeItem, wrapper.state().selectedItem)
+            const wrapper = suggest({ selectedItem: TOP_100_FILMS[10] });
+            const queryList = ((wrapper.instance() as Suggest<IFilm>) as any).queryList as QueryList<IFilm>; // private ref
+
+            assert.deepEqual(
+                queryList.state.activeItem,
+                wrapper.state().selectedItem,
+                "QueryList activeItem should be set to the controlled selectedItem if prop is provided",
+            );
+
             simulateFocus(wrapper);
             assert.isTrue(wrapper.state().isOpen);
-            selectItem(wrapper, ITEM_INDEX);
-            assert.isFalse(wrapper.state().isOpen);
-            simulateFocus(wrapper);
-            assert.isTrue(wrapper.state().isOpen);
-            simulateKeyDown(wrapper, Keys.ARROW_DOWN);
-            console.log("AFTER KEY DOWN", queryList.state.activeItem, wrapper.state().selectedItem)
-            console.log("BEFORE BLUR", queryList.state.activeItem, wrapper.state().selectedItem)
+
+            const newActiveItem = TOP_100_FILMS[11];
+            queryList.setActiveItem(newActiveItem);
+            assert.deepEqual(queryList.state.activeItem, newActiveItem);
+
             simulateKeyDown(wrapper, Keys.ESCAPE);
             assert.isFalse(wrapper.state().isOpen);
-            console.log("AFTER BLUR", queryList.state.activeItem, wrapper.state().selectedItem)
+
+            wrapper.update();
+            wrapper.find(QueryList).update();
             assert.deepEqual(queryList.state.activeItem, wrapper.state().selectedItem);
         });
 


### PR DESCRIPTION
Make setActiveItem public so the parent components can reset the activeItem
when necessary.
When the Suggest Popover is closed and there is a selectedItem the activeItem
should always be set to selectedItem.  When the Popover is opened again the
value of the component is reflected correctly.

#### Fixes #3769 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Make setActiveItem in the QueryList component a public function so that parent components can call it.  I saw similar behavior in setQuery already and I believe this is a decent compromise so that parent components (Select, Suggest, any other components that are added to this library in the future) do not have to add the boilerplate of keeping track of the active item since QueryList already does this.  It is only in the case of closing a Popover that this "reset" needs to happen.

#### Reviewers should focus on:

The public / private function change. Also when trying to add a test to this I was having trouble getting the Popover onClosed function to fire.  The code works in browser but not during test execution.  Here is the code that I would like to add to suggestTests.tsx but I think that I'm missing some configuration that is allowing the child components to fire events.  To me it looks like the code should work but I may be missing something obvious.

```
it("sets active item to the selected item when the popover is closed", () => {
    const ITEM_INDEX = 4;
    const wrapper = suggest();
    const queryList = ((wrapper.instance() as Suggest<IFilm>) as any).queryList; // private ref
    console.log("INITIAL STATE", queryList.state.activeItem, wrapper.state().selectedItem)
    simulateFocus(wrapper);
    assert.isTrue(wrapper.state().isOpen);
    selectItem(wrapper, ITEM_INDEX);
    assert.isFalse(wrapper.state().isOpen);
    simulateFocus(wrapper);
    assert.isTrue(wrapper.state().isOpen);
    simulateKeyDown(wrapper, Keys.ARROW_DOWN);
    console.log("AFTER KEY DOWN", queryList.state.activeItem, wrapper.state().selectedItem)
    console.log("BEFORE BLUR", queryList.state.activeItem, wrapper.state().selectedItem)
    simulateKeyDown(wrapper, Keys.ESCAPE);
    assert.isFalse(wrapper.state().isOpen);
    console.log("AFTER BLUR", queryList.state.activeItem, wrapper.state().selectedItem)
    assert.deepEqual(queryList.state.activeItem, wrapper.state().selectedItem);
});
```

Also if the test issue is resolved in this PR I'd suggest we also make this change for the Select component so that behavior is consistent throughout the library.  I could either include those changes in this commit or open another PR after.  Let me know the preferred way.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
