### PR TITLE
Add type check for Overlay focus element.

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -437,6 +437,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
         if (
             this.props.enforceFocus &&
             this.containerElement != null &&
+            e.target instanceof Node &&
             !this.containerElement.contains(e.target as HTMLElement)
         ) {
             // prevent default focus behavior (sometimes auto-scrolls the page)


### PR DESCRIPTION
#### Fixes #3928

#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes #3928 by adding a type check when the event's target is not an HTML Element.

#### Reviewers should focus on:

I'd appreciate it if a maintainer would write a test for this case. I only reproduced this in our environment when debugging it, and honestly I'm currently not very strong in JavaScript circa 2020 (especially testing in it).

#### Screenshot

None, this was done in order to remove an error that showed up in the console, and caused the app to crash in development mode via create-react-app.

(also, queue joke for ex-Palantirian still making a code contribution to Blueprint)
