### PR TITLE
fix: eslint-config package reference, improve es-lint build script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 fixtures
 coverage
 __snapshots__
+src/generated

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "extends": [
         "./packages/eslint-config"
     ]

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -18,16 +18,14 @@ const path = require("path");
 module.exports = {
     env: {
         browser: true,
-        mocha: true,
-        node: true,
     },
     plugins: [
         "@typescript-eslint",
         "@typescript-eslint/tslint",
-        "@blueprintjs/blueprint"
+        "@blueprintjs/blueprint",
     ],
     extends: [
-        "plugin:@blueprintjs/blueprint/recommended"
+        "plugin:@blueprintjs/blueprint/recommended",
     ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
@@ -40,7 +38,16 @@ module.exports = {
     rules: {
         // run the tslint rules which are not yet converted (run inside eslint)
         "@typescript-eslint/tslint/config": ["error", {
-            "lintFile": path.resolve(__dirname, "./tslint.json")
-        }]
-    }
-}
+            "lintFile": path.resolve(__dirname, "./tslint.json"),
+        }],
+    },
+    overrides: [
+        {
+            files: ["test/**/*"],
+            env: {
+                browser: true,
+                mocha: true,
+            },
+        },
+    ],
+};

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,6 +4,7 @@
     "description": "ESLint configuration for @blueprintjs packages",
     "dependencies": {
         "@blueprintjs/eslint-plugin-blueprint": "^0.1.0",
+        "@blueprintjs/tslint-config": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^2.15.0",
         "@typescript-eslint/eslint-plugin-tslint": "^2.15.0",
         "@typescript-eslint/parser": "^2.15.0",

--- a/packages/eslint-config/tslint.json
+++ b/packages/eslint-config/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tslint-config",
+  "extends": "@blueprintjs/tslint-config",
   "rules": {
     "file-header": {
       "options": [

--- a/packages/node-build-scripts/es-lint.js
+++ b/packages/node-build-scripts/es-lint.js
@@ -31,7 +31,7 @@ if (process.argv.includes("--fix")) {
 }
 
 // ESLint will fail if provided with no files, so we expand the glob before running it
-const fileGlob = "{src,test}/**/*.{ts,tsx}";
+const fileGlob = "{src,test}/!(generated)/**/*.{ts,tsx}";
 const absoluteFileGlob = path.resolve(process.cwd(), fileGlob);
 const anyFilesToLint = glob.sync(absoluteFileGlob)
 if (anyFilesToLint.length === 0) {

--- a/packages/node-build-scripts/es-lint.js
+++ b/packages/node-build-scripts/es-lint.js
@@ -11,7 +11,7 @@
 const path = require("path");
 const fs = require("fs");
 const { junitReportPath } = require("./utils");
-const { spawn, execSync } = require("child_process");
+const { spawn } = require("child_process");
 const glob = require("glob");
 
 let format = "codeframe";
@@ -24,8 +24,7 @@ if (process.env.JUNIT_REPORT_PATH != null) {
     outputStream = fs.createWriteStream(out, { flags: "w+" });
 }
 
-const gitRoot = execSync("git rev-parse --show-toplevel").toString().trim();
-const commandLineOptions = ["-c", path.join(gitRoot, "./.eslintrc.json"), "--color", "-f", format];
+const commandLineOptions = ["--color", "-f", format];
 if (process.argv.includes("--fix")) {
     commandLineOptions.push("--fix")
 }

--- a/packages/node-build-scripts/es-lint.js
+++ b/packages/node-build-scripts/es-lint.js
@@ -11,8 +11,10 @@
 const path = require("path");
 const fs = require("fs");
 const { junitReportPath } = require("./utils");
-const { spawn } = require("child_process");
+const { execSync, spawn } = require("child_process");
 const glob = require("glob");
+
+const IGNORE_FILE_NAME = ".eslintignore";
 
 let format = "codeframe";
 let out;
@@ -24,18 +26,26 @@ if (process.env.JUNIT_REPORT_PATH != null) {
     outputStream = fs.createWriteStream(out, { flags: "w+" });
 }
 
+// additional args provided to es-lint script
 const additionalArgs = process.argv.filter(a => {
     // exclude engine and script name
     return ["node", "es-lint"].every(s => path.basename(a) !== s);
 });
+
+// by default, ESLint only looks for .eslintignore in the current directory, but it might exist at the project root
+const ignoreFilepath = findIgnoreFile();
+if (ignoreFilepath !== undefined) {
+    additionalArgs.push("--ignore-path", ignoreFilepath);
+}
+
 const commandLineOptions = ["--color", "-f", format, ...additionalArgs];
 
 // ESLint will fail if provided with no files, so we expand the glob before running it
-const fileGlob = "{src,test}/!(generated)/**/*.{ts,tsx}";
+const fileGlob = "{src,test}/**/*.{ts,tsx}";
 const absoluteFileGlob = path.resolve(process.cwd(), fileGlob);
 const anyFilesToLint = glob.sync(absoluteFileGlob)
 if (anyFilesToLint.length === 0) {
-    console.log(`Not running ESLint because no files match the glob "${fileGlob}"`)
+    console.log(`[node-build-scripts] Not running ESLint because no files match the glob "${fileGlob}"`)
     process.exit();
 }
 
@@ -47,3 +57,18 @@ eslint.stderr.pipe(process.stderr);
 eslint.on("close", code => {
     process.exitCode = code;
 });
+
+function findIgnoreFile() {
+    if (fs.existsSync(path.join(process.cwd(), IGNORE_FILE_NAME))) {
+        return undefined;
+    }
+
+    const gitRoot = execSync("git rev-parse --show-toplevel").toString().trim();
+    const rootIgnoreFilepath = path.join(gitRoot, IGNORE_FILE_NAME);
+    if (fs.existsSync(rootIgnoreFilepath)) {
+        console.log(`[node-build-scripts] Using ESLint ignore file path ${rootIgnoreFilepath}`)
+        return rootIgnoreFilepath;
+    }
+
+    return undefined;
+}

--- a/packages/node-build-scripts/es-lint.js
+++ b/packages/node-build-scripts/es-lint.js
@@ -24,10 +24,11 @@ if (process.env.JUNIT_REPORT_PATH != null) {
     outputStream = fs.createWriteStream(out, { flags: "w+" });
 }
 
-const commandLineOptions = ["--color", "-f", format];
-if (process.argv.includes("--fix")) {
-    commandLineOptions.push("--fix")
-}
+const additionalArgs = process.argv.filter(a => {
+    // exclude engine and script name
+    return ["node", "es-lint"].every(s => path.basename(a) !== s);
+});
+const commandLineOptions = ["--color", "-f", format, ...additionalArgs];
 
 // ESLint will fail if provided with no files, so we expand the glob before running it
 const fileGlob = "{src,test}/!(generated)/**/*.{ts,tsx}";


### PR DESCRIPTION
eslint-config:

- 🔧 fix package reference to `@blueprintjs/tslint-config`, allowing this package to be used outside the Blueprint monorepo

node-build-scripts:

- 🔧 fix(es-lint): use default ESLint resolution to find config file
- feat(es-lint): support resolution of `.eslintignore` file at the root of a git repo (useful for monorepos like Blueprint's)
- feat(es-lint): support arbitrary additional arguments to `eslint` CLI