### PR TITLE
Fix disabled option color in dark mode for Firefox

### DIFF
--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -85,6 +85,10 @@ Styleguide select
       color: $pt-dark-text-color;
     }
 
+    option:disabled {
+      color: $pt-dark-text-color-disabled;
+    }
+
     &::after {
       color: $pt-dark-icon-color;
     }


### PR DESCRIPTION
In Firefox when using dark mode all option elements are styled the same regardless of if they are disabled or not. Reproduced with Firefox for Mac OS and Windows.

#### Changes proposed in this pull request:

Set the color for option:disabled to $pt-dark-text-color-disabled

#### Screenshot

In the select "bar" is disabled. Edit: Updated to show correct screenshots.

Before:
<img width="185" alt="Screen Shot 2020-02-17 at 5 07 00 PM" src="https://user-images.githubusercontent.com/5770094/74696663-4dde2500-51c6-11ea-9944-abd32b7cf8b4.png">
After:
<img width="200" alt="Screen Shot 2020-02-17 at 5 18 06 PM" src="https://user-images.githubusercontent.com/5770094/74696664-4dde2500-51c6-11ea-8d2b-8145df2a0ca9.png">


