### PR TITLE
fix right element padding adjusting on update

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -129,13 +129,11 @@ export class InputGroup extends AbstractPureComponent2<IInputGroupProps & HTMLIn
     }
 
     public componentDidMount() {
-        if (this.rightElement != null) {
-            const { clientWidth } = this.rightElement;
-            // small threshold to prevent infinite loops
-            if (Math.abs(clientWidth - this.state.rightElementWidth) > 2) {
-                this.setState({ rightElementWidth: clientWidth });
-            }
-        }
+        this.updateInputWidth();
+    }
+
+    public componentDidUpdate() {
+        this.updateInputWidth();
     }
 
     private maybeRenderRightElement() {
@@ -148,5 +146,17 @@ export class InputGroup extends AbstractPureComponent2<IInputGroupProps & HTMLIn
                 {rightElement}
             </span>
         );
+    }
+
+    private updateInputWidth() {
+        if (this.rightElement != null) {
+            const { clientWidth } = this.rightElement;
+            // small threshold to prevent infinite loops
+            if (Math.abs(clientWidth - this.state.rightElementWidth) > 2) {
+                this.setState({ rightElementWidth: clientWidth });
+            }
+        } else {
+            this.setState({ rightElementWidth: DEFAULT_RIGHT_ELEMENT_WIDTH });
+        }
     }
 }

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -132,8 +132,10 @@ export class InputGroup extends AbstractPureComponent2<IInputGroupProps & HTMLIn
         this.updateInputWidth();
     }
 
-    public componentDidUpdate() {
-        this.updateInputWidth();
+    public componentDidUpdate(prevProps: IInputGroupProps & HTMLInputProps) {
+        if (prevProps.rightElement !== this.props.rightElement) {
+            this.updateInputWidth();
+        }
     }
 
     private maybeRenderRightElement() {


### PR DESCRIPTION
#### Fixes #3965

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Reverted a change that stopped updating input field padding when right element changed. Infinite update is fixed by a check to see if the rightElement prop changed.

#### Screenshot
Before
![bpbad](https://user-images.githubusercontent.com/61256233/74890687-a550d200-5339-11ea-9f84-ab77ad7e4ccd.gif)

After
![bp](https://user-images.githubusercontent.com/61256233/74890397-b77e4080-5338-11ea-9922-13b8adce5ca5.gif)
