### PR TITLE
set button user select to none

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -109,6 +109,7 @@ $button-intents: (
   vertical-align: middle;
   text-align: left;
   font-size: $pt-font-size;
+  user-select: none;
 }
 
 @mixin pt-button-height($height) {


### PR DESCRIPTION
#### Fixes no issue

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Button text is currently selectable on right click. This PR simply sets user-select to none.

#### Screenshot
Before:
![image](https://user-images.githubusercontent.com/61256233/74995068-a1d64d00-5404-11ea-9d5f-5bf1f8825c56.png)