### PR TITLE
[datetime] fix(DateRange): values are possibly null, not undefined

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -16,7 +16,7 @@
 
 import { Months } from "./months";
 
-export type DateRange = [Date | undefined, Date | undefined];
+export type DateRange = [Date | null, Date | null];
 
 export function isDateValid(date: Date | false | null): date is Date {
     return date instanceof Date && !isNaN(date.valueOf());

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -347,7 +347,8 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
     }
 
     private handleTimeChange = (newTime: Date, dateIndex: number) => {
-        Utils.safeInvoke(this.props.timePickerProps.onChange, newTime);
+        this.props.timePickerProps?.onChange?.(newTime);
+
         const { value, time } = this.state;
         const newValue = DateUtils.getDateTime(
             value[dateIndex] != null ? DateUtils.clone(value[dateIndex]) : new Date(),
@@ -357,7 +358,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
         newDateRange[dateIndex] = newValue;
         const newTimeRange: DateRange = [time[0], time[1]];
         newTimeRange[dateIndex] = newTime;
-        Utils.safeInvoke(this.props.onChange, newDateRange);
+        this.props.onChange?.(newDateRange);
         this.setState({ value: newDateRange, time: newTimeRange });
     };
 


### PR DESCRIPTION
fixes #3970
fixes #3838

For quite some time (since the beginning of this open source repo), the behavior for this component has been to use `null` to represent unbounded ranges. The type definition has been wrong about this, while the documentation was correct. I think the simplest and safest thing to do here is to fix the typedef to correctly declare `null` instead of `undefined`.