### PR TITLE
[docs-app] feat(BreadcrumbsExample): render current as input

### DIFF
--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -117,7 +117,7 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
     };
 }
 
-/* eslint-disable @typescript-eslint/tslint/max-classes-per-file */
+/* tslint:disable max-classes-per-file */
 class BreadcrumbInput extends React.PureComponent<IBreadcrumbProps & { defaultValue: string | undefined }> {
     public state = {
         text: this.props.defaultValue ?? "",

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -16,11 +16,23 @@
 
 import * as React from "react";
 
-import { Boundary, Breadcrumbs, Card, H5, IBreadcrumbProps, Label, RadioGroup, Slider } from "@blueprintjs/core";
+import {
+    Boundary,
+    Breadcrumbs,
+    Card,
+    Checkbox,
+    H5,
+    IBreadcrumbProps,
+    InputGroup,
+    Label,
+    RadioGroup,
+    Slider,
+} from "@blueprintjs/core";
 import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 export interface IBreadcrumbsExampleState {
     collapseFrom: Boundary;
+    renderCurrentAsInput: boolean;
     width: number;
 }
 
@@ -41,6 +53,7 @@ const ITEMS: IBreadcrumbProps[] = [
 export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBreadcrumbsExampleState> {
     public state: IBreadcrumbsExampleState = {
         collapseFrom: Boundary.START,
+        renderCurrentAsInput: false,
         width: 50,
     };
 
@@ -58,6 +71,12 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
                     options={COLLAPSE_FROM_RADIOS}
                     selectedValue={this.state.collapseFrom.toString()}
                 />
+                <Checkbox
+                    name="renderCurrent"
+                    label="Render current breadcrumb as input"
+                    onChange={this.handleChangeRenderCurrentAsInput}
+                    checked={this.state.renderCurrentAsInput}
+                />
                 <H5>Example</H5>
                 <Label>Width</Label>
                 <Slider
@@ -71,11 +90,15 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
             </>
         );
 
-        const { collapseFrom, width } = this.state;
+        const { collapseFrom, renderCurrentAsInput, width } = this.state;
         return (
             <Example options={options} {...this.props}>
                 <Card elevation={0} style={{ width: `${width}%` }}>
-                    <Breadcrumbs collapseFrom={collapseFrom} items={ITEMS} />
+                    <Breadcrumbs
+                        collapseFrom={collapseFrom}
+                        items={ITEMS}
+                        currentBreadcrumbRenderer={renderCurrentAsInput ? this.renderBreadcrumbInput : undefined}
+                    />
                 </Card>
             </Example>
         );
@@ -86,4 +109,28 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
     }
 
     private handleChangeWidth = (width: number) => this.setState({ width });
+    private handleChangeRenderCurrentAsInput = () =>
+        this.setState({ renderCurrentAsInput: !this.state.renderCurrentAsInput });
+
+    private renderBreadcrumbInput = ({ text }: IBreadcrumbProps) => {
+        return <BreadcrumbInput defaultValue={typeof text === "string" ? text : undefined} />;
+    };
+}
+
+/* eslint-disable @typescript-eslint/tslint/max-classes-per-file */
+class BreadcrumbInput extends React.PureComponent<IBreadcrumbProps & { defaultValue: string | undefined }> {
+    public state = {
+        text: this.props.defaultValue ?? "",
+    };
+
+    public render() {
+        const { text } = this.state;
+        return <InputGroup placeholder="rename me" value={text} onChange={this.handleChange} />;
+    }
+
+    private handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+        this.setState({
+            text: (event.target as HTMLInputElement).value,
+        });
+    };
 }


### PR DESCRIPTION
#### Allows testing of #3969

#### Screenshot

![image](https://user-images.githubusercontent.com/723999/75478261-a56d5500-596b-11ea-87d1-8827afdd4068.png)
