### PR TITLE
Improved documentation for localization of Datetime components

### DIFF
--- a/packages/datetime/src/datepicker.md
+++ b/packages/datetime/src/datepicker.md
@@ -102,13 +102,20 @@ import { LocaleUtils } from "react-day-picker";
 
 By supplying a `locale: string` and `localeUtils: LocaleUtils` prop to these Blueprint components, you can
 customize how dates are rendered, which day of the week is the first column, etc.
+You will need to overwrite the functions of `LocaleUtil` by your own.
 [See the interface definition for more details](https://github.com/gpbl/react-day-picker/blob/v7.3.0/types/utils.d.ts#L5).
 
 Although `@blueprintjs/datetime` and `react-day-picker` do not explicitly require `moment.js` as a dependency,
 you may wish to use Moment's implementation of localization so that you do not have to write these functions yourself.
-The import from `react-day-picker` shown above gives you a utility object containing functions which do just that; you
-may use it like so:
+
+To use moment for your localization, make sure to include `moment` in your dependencies and use `MomentLocaleUtils` 
+from `react-day-picker/moment` as follow:
 
 ```tsx
-<DatePicker locale="fr" localeUtils={LocaleUtils} />
+import MomentLocaleUtils from 'react-day-picker/moment'
+import 'moment/locale/fr';
+
+<DatePicker locale="fr" localeUtils={MomentLocaleUtils} />
 ```
+
+More detailed examples can be found in the [**react-day-picker** documentation](https://react-day-picker.js.org/docs/localization/).


### PR DESCRIPTION
#### Fixes

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Improved the documentation for the localization of Datetime components.
The current example doesnt work, as it is using the default LocaleUtil implementation which just implements english language ( https://github.com/gpbl/react-day-picker/blob/v7.3.0/src/LocaleUtils.js )

I've added an example following the example in the documentation of react-day-picker to implement localization using moment  ( http://react-day-picker.js.org/docs/localization ), and added a link pointing towards this page, for people needing more detailed example on how to actually override the LocaleUtil functions on the default implementation.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->