### PR TITLE
Solved bug when using fixed position in a child of a Collapse node

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -176,7 +176,9 @@ export class Collapse extends AbstractPureComponent2<ICollapseProps, ICollapseSt
 
         const contentsStyle = {
             // only use heightWhenOpen while closing
-            transform: displayWithTransform ? "translateY(0)" : `translateY(-${this.state.heightWhenOpen}px)`,
+            // If translate is equal to 0, we use a none transform, to avoid having problem if trying to use
+            // fixed position in a child of this node
+            transform: displayWithTransform ? "none" : `translateY(-${this.state.heightWhenOpen}px)`,
             // transitions don't work with height: auto
             transition: isAutoHeight ? "none" : undefined,
         };


### PR DESCRIPTION
#### Fixes #4004

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Removed transform in the CSS of the Collapse component, when the Collapse is fully uncollapsed, instead of having a transform of 0.

This enable the use of fixed position to be able to have a component following the cursor, on children of the collapse.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
