### PR TITLE
Add example to import variables into Less file

### DIFF
--- a/packages/core/src/docs/colors.md
+++ b/packages/core/src/docs/colors.md
@@ -45,12 +45,25 @@ interface design — take a look at [core colors](#colors.core-colors) instead.
 Blueprint provides variables for colors in Sass, Less, and JavaScript.
 [Semantic aliases for common colors](#core/variables.color-aliases) are also provided in Sass and Less.
 
+Example in Sass:
+
 ```css.scss
 @import "~@blueprintjs/core/lib/scss/variables";
 
 .rule {
     color: $pt-link-color;
     background: $black;
+}
+```
+
+Example in Less:
+
+```css.less
+@import "~@blueprintjs/core/lib/less/variables";
+
+.rule {
+    color: @pt-link-color;
+    background: @black;
 }
 ```
 


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

I was a little puzzled that I could not import colors into my less file, until I realized that the example given in the documentation was only for Sass, so I added an example for Less.

#### Reviewers should focus on:

Whether this adheres to your documentation style.
