### PR TITLE
[core] Stop propagation on remove tag

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -436,6 +436,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     };
 
     private handleRemoveTag = (event: React.MouseEvent<HTMLSpanElement>) => {
+        event.stopPropagation();
         // using data attribute to simplify callback logic -- one handler for all children
         const index = +event.currentTarget.parentElement.getAttribute("data-tag-index");
         this.removeIndexFromValues(index);

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -262,5 +262,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         };
     }
 
-    private handleClear = () => this.setState({ films: [] });
+    private handleClear = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+        event.stopPropagation();
+        this.setState({ films: [] });
+    };
 }


### PR DESCRIPTION
## Fixes #3310

#### Checklist

- [ ] Includes tests
- [ ] Update documentation
- [x] Update example

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes #3310 by stopping event propagation when removing tags from `InputTag`.

#### Reviewers should focus on:

This PR assumes event propagation isn't required by anything else. Another approach would be to pass the event to consumers of `TagInput`, but unless the event is required internally for something else, this might not be necessary.

#### Screenshot

![tag-input-stop-propagation](https://user-images.githubusercontent.com/301030/78190102-44093c00-746b-11ea-8774-4cae17ae276f.gif)

<!-- Include an image of the most relevant user-facing change, if any. -->
