### PR TITLE
Fix build error caused by react-day-picker@7.3.2

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.23.0",
     "classnames": "^2.2",
-    "react-day-picker": "7.3.2",
+    "react-day-picker": "^7.4.0",
     "tslib": "~1.10.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
I've been fighting with the following issue on Netlify:

```
3:29:01 PM: Creating an optimized production build...
3:32:56 PM: Failed to compile.
3:32:56 PM: ./node_modules/react-day-picker/lib/src/Weekday.js
3:32:56 PM: SyntaxError: /opt/build/repo/node_modules/react-day-picker/lib/src/Weekday.js: Unexpected character '' (1:0)
3:32:56 PM: > 1 | 
3:32:56 PM:     | ^
3:32:56 PM:     at parser.next (<anonymous>)
```

Upgrading react-day-picker to v7.4.0 fixes the building error