### PR TITLE
Fix repeated classname in MultiSelect inputProps

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -121,7 +121,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         // add our own inputProps.className so that we can reference it in event handlers
         const inputProps = {
             ...tagInputProps.inputProps,
-            className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT)
+            className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT),
         };
 
         const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -119,8 +119,10 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         }
 
         // add our own inputProps.className so that we can reference it in event handlers
-        const { inputProps = {} } = tagInputProps;
-        inputProps.className = classNames(inputProps.className, Classes.MULTISELECT_TAG_INPUT_INPUT);
+        const inputProps = {
+            ...tagInputProps.inputProps,
+            className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT)
+        };
 
         const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {
             if (method === "paste") {


### PR DESCRIPTION
#### Fixes #4048

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Changed code in MultiSelect to stop corrupting existing `inputProps`.

#### Reviewers should focus on:

Not related to this PR, but BP should consider taking a similar approach for other components to avoid corrupting props.  It is an anti-pattern for components to mutate its own props.
