### PR TITLE
Fixed: Incorrect selection of years on right side when clicking throu…

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -704,7 +704,7 @@ function getStateChange(
             // If the selected month isn't in either of the displayed months, then
             //   - set the left DayPicker to be the selected month
             //   - set the right DayPicker to +1
-            if (nextValueStartView.isSameMonth(nextValueEndView)) {
+            if (nextValueStartView.isSame(nextValueEndView)) {
                 if (leftView.isSame(nextValueStartView) || rightView.isSame(nextValueStartView)) {
                     // do nothing
                 } else {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -1018,6 +1018,24 @@ describe("<DateRangePicker>", () => {
             left.assertMonthYear(Months.JANUARY, 2016);
             right.assertMonthYear(Months.FEBRUARY, 2016);
         });
+
+        it("custom shortcuts set the displayed dates correctly when month stays the same but not years and contiguousCalendarMonths is false", () => {
+            const dateRange = [new Date(2014, Months.JUNE, 1), new Date(2015, Months.JUNE, 1)] as DateRange;
+            const { clickShortcut, left, right } = render({
+                contiguousCalendarMonths: false,
+                initialMonth: new Date(2015, Months.JUNE, 1),
+                shortcuts: [{ label: "custom shortcut", dateRange }],
+            });
+
+            clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            left.assertMonthYear(Months.JUNE, 2014);
+            right.assertMonthYear(Months.JUNE, 2015);
+
+            clickShortcut();
+            left.assertMonthYear(Months.JUNE, 2014);
+            right.assertMonthYear(Months.JUNE, 2015);
+        });
     });
 
     describe("when uncontrolled", () => {


### PR DESCRIPTION
…gh years on shortcuts while contiguousCalendarMonths=false

#### Fixes #0000

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Compare the entire dates and not only months

#### Reviewers should focus on:

Date range picker component

#### Screenshot

**Before the fix:** 

![image](https://user-images.githubusercontent.com/5659009/79358784-aeac8400-7f0f-11ea-99a5-3cfa5064a0ba.png)

![image](https://user-images.githubusercontent.com/5659009/79358844-c3891780-7f0f-11ea-94fe-45c86e77f8ec.png)

![image](https://user-images.githubusercontent.com/5659009/79358898-d7cd1480-7f0f-11ea-9cb8-07492a891d7f.png)


**After the fix:** 

![image](https://user-images.githubusercontent.com/5659009/79306857-edb4e800-7ec3-11ea-80df-62c6d02db4ac.png)

![image](https://user-images.githubusercontent.com/5659009/79306903-045b3f00-7ec4-11ea-98e2-6118c44da82d.png)

![image](https://user-images.githubusercontent.com/5659009/79306948-1806a580-7ec4-11ea-9cf0-72061e657452.png)

![image](https://user-images.githubusercontent.com/5659009/79306993-2bb20c00-7ec4-11ea-919e-7bf2e68bee8c.png)
