### PR TITLE
[core] feat(NumericInput): disable buttons when value at min/max

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -327,13 +327,13 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         return (
             <ButtonGroup className={Classes.FIXED} key="button-group" vertical={true}>
                 <Button
-                    disabled={disabled || +value >= max}
+                    disabled={disabled || (value !== "" && +value >= max)}
                     icon="chevron-up"
                     intent={intent}
                     {...this.incrementButtonHandlers}
                 />
                 <Button
-                    disabled={disabled || +value <= min}
+                    disabled={disabled || (value !== "" && +value <= min)}
                     icon="chevron-down"
                     intent={intent}
                     {...this.decrementButtonHandlers}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -321,12 +321,23 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
     // ==============
 
     private renderButtons() {
-        const { intent } = this.props;
+        const { intent, max, min } = this.props;
+        const { value } = this.state;
         const disabled = this.props.disabled || this.props.readOnly;
         return (
             <ButtonGroup className={Classes.FIXED} key="button-group" vertical={true}>
-                <Button disabled={disabled} icon="chevron-up" intent={intent} {...this.incrementButtonHandlers} />
-                <Button disabled={disabled} icon="chevron-down" intent={intent} {...this.decrementButtonHandlers} />
+                <Button
+                    disabled={disabled || +value >= max}
+                    icon="chevron-up"
+                    intent={intent}
+                    {...this.incrementButtonHandlers}
+                />
+                <Button
+                    disabled={disabled || +value <= min}
+                    icon="chevron-down"
+                    intent={intent}
+                    {...this.decrementButtonHandlers}
+                />
             </ButtonGroup>
         );
     }

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -867,6 +867,26 @@ describe("<NumericInput>", () => {
     });
 
     describe("Other", () => {
+        it("disables the increment button when the value is greater than or equal to max", () => {
+            const component = mount(<NumericInput value={100} max={100} />);
+
+            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(Button).first();
+
+            expect(decrementButton.props().disabled).to.be.false;
+            expect(incrementButton.props().disabled).to.be.true;
+        });
+
+        it("disables the decrement button when the value is less than or equal to min", () => {
+            const component = mount(<NumericInput value={-10} min={-10} />);
+
+            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(Button).first();
+
+            expect(decrementButton.props().disabled).to.be.true;
+            expect(incrementButton.props().disabled).to.be.false;
+        });
+
         it("disables the input field and buttons when disabled is true", () => {
             const component = mount(<NumericInput disabled={true} />);
 


### PR DESCRIPTION
#### Fixes #804

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
When the value of a NumericInput is at max disable the increment button and when the value is at min disable the decrement button.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot
<img width="568" alt="Screen Shot 2020-04-17 at 9 29 13 PM" src="https://user-images.githubusercontent.com/5770094/79624855-a52f4180-80f2-11ea-81e1-caf395d6d9e4.png">
<img width="561" alt="Screen Shot 2020-04-17 at 9 29 57 PM" src="https://user-images.githubusercontent.com/5770094/79624894-f6d7cc00-80f2-11ea-8eef-33d6d1dec563.png">
