### PR TITLE
chore: upgrade (typescript-)eslint, adjust VSCode settings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,0 @@
-node_modules
-dist
-lib
-fixtures
-coverage
-__snapshots__
-**/src/generated

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,14 @@
     "root": true,
     "extends": [
         "./packages/eslint-config"
+    ],
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "lib",
+        "fixtures",
+        "coverage",
+        "__snapshots__",
+        "src/generated"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,9 +6,7 @@
     "giladgray.theme-blueprint",
     // for consistent editor settings:
     "EditorConfig.EditorConfig",
-    // for typescript source files:
-    "eg2.tslint",
-    // for sass source files:
-    "shinnn.stylelint",
+    // for TS and JS:
+    "dbaeumer.vscode-eslint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,8 @@
         "**/lib": true,
         "**/node_modules": true,
         "docs": true,
-        "site/docs": true
+        "site/docs": true,
+        "packages/docs-data/src/generated": true
     },
     "editor.insertSpaces": true,
     "editor.tabSize": 4,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,8 @@
     "editor.tabSize": 4,
     "[scss]": {
         "editor.tabSize": 2
-    }
+    },
+    "eslint.workingDirectories": [
+        { "pattern": "./packages/*" }
+    ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
     "lib/cjs/common/configureDom4.js"
   ],
   "bin": {
-    "upgrade-blueprint-2.0.0-rename": "./scripts/upgrade-blueprint-2.0.0-rename.sh",
-    "upgrade-blueprint-3.0.0-rename": "./scripts/upgrade-blueprint-3.0.0-rename.sh"
+    "upgrade-blueprint-2.0.0-rename": "scripts/upgrade-blueprint-2.0.0-rename.sh",
+    "upgrade-blueprint-3.0.0-rename": "scripts/upgrade-blueprint-3.0.0-rename.sh"
   },
   "scripts": {
     "clean": "rm -rf dist/* && rm -rf lib/*",

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -23,3 +23,12 @@ Enable this configuration in your ESLint configuration file (e.g. `.eslintrc.jso
     ]
 }
 ```
+
+### VSCode
+
+If you use VSCode, install the [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) to lint your code in the editor. We recommend enabling these global VSCode settings:
+
+```json
+"editor.formatOnSave": true,
+"eslint.format.enable": true
+```

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -26,7 +26,7 @@ Enable this configuration in your ESLint configuration file (e.g. `.eslintrc.jso
 
 ### VSCode
 
-If you use VSCode, install the [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) to lint your code in the editor. We recommend enabling these global VSCode settings:
+If you use VSCode, install the [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) plugin to lint your code in the editor. We recommend enabling these global VSCode settings:
 
 ```json
 "editor.formatOnSave": true,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -5,10 +5,10 @@
     "dependencies": {
         "@blueprintjs/eslint-plugin-blueprint": "^0.1.0",
         "@blueprintjs/tslint-config": "^2.0.0",
-        "@typescript-eslint/eslint-plugin": "^2.15.0",
-        "@typescript-eslint/eslint-plugin-tslint": "^2.15.0",
-        "@typescript-eslint/parser": "^2.15.0",
-        "eslint": "^6.7.2"
+        "@typescript-eslint/eslint-plugin": "^2.29.0",
+        "@typescript-eslint/eslint-plugin-tslint": "^2.29.0",
+        "@typescript-eslint/parser": "^2.29.0",
+        "eslint": "^6.8.0"
     },
     "repository": {
         "type": "git",

--- a/packages/eslint-plugin-blueprint/package.json
+++ b/packages/eslint-plugin-blueprint/package.json
@@ -9,10 +9,10 @@
         "test:jest-ci": "jest --ci --runInBand"
     },
     "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^2.11.0",
-        "@typescript-eslint/eslint-plugin-tslint": "^2.10.0",
-        "@typescript-eslint/parser": "^2.10.0",
-        "eslint": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^2.29.0",
+        "@typescript-eslint/eslint-plugin-tslint": "^2.29.0",
+        "@typescript-eslint/parser": "^2.29.0",
+        "eslint": "^6.8.0",
         "jest": "^24.9.0",
         "ts-jest": "^24.2.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,48 +635,48 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin-tslint@^2.10.0", "@typescript-eslint/eslint-plugin-tslint@^2.15.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.16.0.tgz#8e8573cc2560ddae5a8a30fc2eb6af10f1ff9658"
-  integrity sha512-F+In2z6VCWiI0J4P4OzUQY9UzT5y/0Xg6bHM6twoK5XmPdbR7zT9JzIZKLcXyr80XT5LbgHjnW6oPGp1O3W36g==
+"@typescript-eslint/eslint-plugin-tslint@^2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.29.0.tgz#1586c6f88043164b64a017e9952518c1b985299d"
+  integrity sha512-r8mZE1dfDLj7B65TLvAk9SvGCdoyD/ZbuqTDhKf2+MkdMC6R99+uznz2JJ8WG+T7E2i8i5OWDFQQEcWoNDKQvQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.16.0"
+    "@typescript-eslint/experimental-utils" "2.29.0"
     lodash "^4.17.15"
 
-"@typescript-eslint/eslint-plugin@^2.11.0", "@typescript-eslint/eslint-plugin@^2.15.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.16.0.tgz#bf339b7db824c7cc3fd1ebedbc88dd17016471af"
-  integrity sha512-TKWbeFAKRPrvKiR9GNxErQ8sELKqg1ZvXi6uho07mcKShBnCnqNpDQWP01FEvWKf0bxM2g7uQEI5MNjSNqvUpQ==
+"@typescript-eslint/eslint-plugin@^2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.29.0.tgz#c9efab7624e3dd6d144a0e4577a541d1bd42c2ac"
+  integrity sha512-X/YAY7azKirENm4QRpT7OVmzok02cSkqeIcLmdz6gXUQG4Hk0Fi9oBAynSAyNXeGdMRuZvjBa0c1Lu0dn/u6VA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.16.0"
-    eslint-utils "^1.4.3"
+    "@typescript-eslint/experimental-utils" "2.29.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.16.0.tgz#bba65685728c532e0ddc811a0376e8d38e671f77"
-  integrity sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==
+"@typescript-eslint/experimental-utils@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.29.0.tgz#3cb8060de9265ba131625a96bbfec31ba6d4a0fe"
+  integrity sha512-H/6VJr6eWYstyqjWXBP2Nn1hQJyvJoFdDtsHxGiD+lEP7piGnGpb/ZQd+z1ZSB1F7dN+WsxUDh8+S4LwI+f3jw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.16.0"
+    "@typescript-eslint/typescript-estree" "2.29.0"
     eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.15.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.16.0.tgz#d0c0135a8fdb915f670802ddd7c1ba457c1b4f9d"
-  integrity sha512-+w8dMaYETM9v6il1yYYkApMSiwgnqXWJbXrA94LAWN603vXHACsZTirJduyeBOJjA9wT6xuXe5zZ1iCUzoxCfw==
+"@typescript-eslint/parser@^2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.29.0.tgz#6e3c4e21ed6393dc05b9d8b47f0b7e731ef21c9c"
+  integrity sha512-H78M+jcu5Tf6m/5N8iiFblUUv+HJDguMSdFfzwa6vSg9lKR8Mk9BsgeSjO8l2EshKnJKcbv0e8IDDOvSNjl0EA==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.16.0"
-    "@typescript-eslint/typescript-estree" "2.16.0"
+    "@typescript-eslint/experimental-utils" "2.29.0"
+    "@typescript-eslint/typescript-estree" "2.29.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.16.0.tgz#b444943a76c716ed32abd08cbe96172d2ca0ab75"
-  integrity sha512-hyrCYjFHISos68Bk5KjUAXw0pP/455qq9nxqB1KkT67Pxjcfw+r6Yhcmqnp8etFL45UexCHUMrADHH7dI/m2WQ==
+"@typescript-eslint/typescript-estree@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.29.0.tgz#1be6612bb02fc37ac9f466521c1459a4744e8d3a"
+  integrity sha512-3YGbtnWy4az16Egy5Fj5CckkVlpIh0MADtAQza+jiMADRSKkjdpzZp/5WuvwK/Qib3Z0HtzrDFeWanS99dNhnA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -3973,12 +3973,19 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.7.2:
+eslint@^6.7.2, eslint@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==


### PR DESCRIPTION
eslint now works properly inline as a linter and formatter in vscode

![image](https://user-images.githubusercontent.com/723999/79796465-9da2af00-8323-11ea-840f-afb6fb8e2559.png)
