### PR TITLE
Export DateUtils

### DIFF
--- a/packages/datetime/src/common/dateRange.ts
+++ b/packages/datetime/src/common/dateRange.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type DateRange = [Date | null, Date | null];

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
+import { DateRange } from "./dateRange";
 import { Months } from "./months";
-
-export type DateRange = [Date | null, Date | null];
 
 export function isDateValid(date: Date | false | null): date is Date {
     return date instanceof Date && !isNaN(date.valueOf());

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -36,7 +36,8 @@ import {
     Utils,
 } from "@blueprintjs/core";
 
-import { areSameTime, DateRange, isDateValid, isDayInRange } from "./common/dateUtils";
+import { DateRange } from "./common/dateRange";
+import { areSameTime, isDateValid, isDayInRange } from "./common/dateUtils";
 import * as Errors from "./common/errors";
 import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -21,8 +21,8 @@ import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarEle
 import { polyfill } from "react-lifecycles-compat";
 
 import * as DateClasses from "./common/classes";
+import { DateRange } from "./common/dateRange";
 import * as DateUtils from "./common/dateUtils";
-import DateRange = DateUtils.DateRange;
 
 import * as Errors from "./common/errors";
 import { MonthAndYear } from "./common/monthAndYear";

--- a/packages/datetime/src/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/dateRangeSelectionStrategy.ts
@@ -15,7 +15,8 @@
  */
 
 import { Boundary } from "@blueprintjs/core";
-import { areSameDay, DateRange } from "./common/dateUtils";
+import { DateRange } from "./common/dateRange";
+import { areSameDay } from "./common/dateUtils";
 
 export interface IDateRangeSelectionState {
     /**

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -15,16 +15,17 @@
  */
 
 import * as classes from "./common/classes";
+import * as DateUtils from "./common/dateUtils";
 
 // re-exporting these symbols to preserve compatility
 import { DayModifiers as IDatePickerDayModifiers, LocaleUtils } from "react-day-picker";
 
 type IDatePickerLocaleUtils = typeof LocaleUtils;
-export { IDatePickerLocaleUtils, IDatePickerDayModifiers };
+export { DateUtils, IDatePickerLocaleUtils, IDatePickerDayModifiers };
 
 export const Classes = classes;
 
-export { DateRange } from "./common/dateUtils";
+export { DateRange } from "./common/dateRange";
 export { Months } from "./common/months";
 export { IDateFormatProps } from "./dateFormat";
 export { DateInput, IDateInputProps } from "./dateInput";

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -17,7 +17,8 @@
 import { Classes, Menu, MenuItem } from "@blueprintjs/core";
 import * as React from "react";
 import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
-import { clone, DateRange, isDayRangeInRange } from "./common/dateUtils";
+import { DateRange } from "./common/dateRange";
+import { clone, isDayRangeInRange } from "./common/dateUtils";
 import { TimePrecision } from "./timePicker";
 
 export interface IDateShortcutBase {


### PR DESCRIPTION
When I develop a custom wrapper component for DateInput, I find utility functions in `./dateTime/src/common/dateUtils` pretty useful. I would like them to be exported, same as `Utils` from `packages/core`
