### PR TITLE
chore: upgrade to Prettier 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "http-server": "^0.11.1",
     "lerna": "^2.11.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "sinon": "^7.3.2",
     "stylelint-config-palantir": "^4.0.0",
     "stylelint-scss": "^3.9.2",

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -233,9 +233,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         return (
             <div className={classes} onFocus={this.handleFocus} tabIndex={tabIndex}>
                 {alwaysRenderInput || this.state.isEditing ? this.renderInput(value) : undefined}
-                {shouldHideContents ? (
-                    undefined
-                ) : (
+                {shouldHideContents ? undefined : (
                     <span className={Classes.EDITABLE_TEXT_CONTENT} ref={this.refHandlers.content} style={contentStyle}>
                         {hasValue ? value : this.props.placeholder}
                     </span>

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -184,10 +184,7 @@ export function comboMatches(a: IKeyCombo, b: IKeyCombo) {
  * unshifted version. For example, `@` is equivalent to `shift+2`.
  */
 export const parseKeyCombo = (combo: string): IKeyCombo => {
-    const pieces = combo
-        .replace(/\s/g, "")
-        .toLowerCase()
-        .split("+");
+    const pieces = combo.replace(/\s/g, "").toLowerCase().split("+");
     let modifiers = 0;
     let key = null as string;
     for (let piece of pieces) {

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -94,10 +94,7 @@ describe("ContextMenu", () => {
             rightClickMe.simulate("contextmenu");
             assertContextMenuWasRendered();
 
-            rightClickMe
-                .find(RightClickMe)
-                .last()
-                .simulate("contextmenu");
+            rightClickMe.find(RightClickMe).last().simulate("contextmenu");
             assertContextMenuWasRendered(childItems.length);
         });
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -201,10 +201,7 @@ describe("<NumericInput>", () => {
             incrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
-            const inputElement = component
-                .find("input")
-                .first()
-                .getDOMNode();
+            const inputElement = component.find("input").first().getDOMNode();
             expect(onValueChangeSpy.calledOnceWithExactly(1, "1", inputElement)).to.be.true;
         });
 
@@ -629,10 +626,7 @@ describe("<NumericInput>", () => {
                 const newValue = component.state().value;
                 expect(newValue).to.equal("0");
 
-                const inputElement = component
-                    .find("input")
-                    .first()
-                    .getDOMNode();
+                const inputElement = component.find("input").first().getDOMNode();
                 expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
             });
 
@@ -706,10 +700,7 @@ describe("<NumericInput>", () => {
                 const newValue = component.state().value;
                 expect(newValue).to.equal("0");
 
-                const inputElement = component
-                    .find("input")
-                    .first()
-                    .getDOMNode();
+                const inputElement = component.find("input").first().getDOMNode();
                 expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
             });
 
@@ -740,10 +731,7 @@ describe("<NumericInput>", () => {
                     .simulate("mousedown");
                 expect(component.state().value).to.equal("2");
 
-                const inputElement = component
-                    .find("input")
-                    .first()
-                    .getDOMNode();
+                const inputElement = component.find("input").first().getDOMNode();
                 expect(onValueChangeSpy.calledOnceWithExactly(2, "2", inputElement)).to.be.true;
             });
         });

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -77,13 +77,7 @@ describe("<RadioGroup>", () => {
         const OPTIONS = [{ value: "text" }, { value: 23 }];
         const group = mount(<RadioGroup onChange={emptyHandler} options={OPTIONS} selectedValue="b" />);
         OPTIONS.forEach(props => {
-            assert.strictEqual(
-                findInput(group, props)
-                    .parents()
-                    .first()
-                    .text(),
-                props.value.toString(),
-            );
+            assert.strictEqual(findInput(group, props).parents().first().text(), props.value.toString());
         });
     });
 

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -136,10 +136,7 @@ describe("<Dialog>", () => {
                     dialog body
                 </Dialog>,
             );
-            dialog
-                .find(`.${Classes.DIALOG_HEADER}`)
-                .find(Button)
-                .simulate("click");
+            dialog.find(`.${Classes.DIALOG_HEADER}`).find(Button).simulate("click");
             assert.isTrue(onClose.calledOnce, "onClose not called");
         });
     });

--- a/packages/core/test/drawer/drawerTests.tsx
+++ b/packages/core/test/drawer/drawerTests.tsx
@@ -329,10 +329,7 @@ describe("<Drawer>", () => {
                     drawer body
                 </Drawer>,
             );
-            drawer
-                .find(`.${Classes.DRAWER_HEADER}`)
-                .find(Button)
-                .simulate("click");
+            drawer.find(`.${Classes.DRAWER_HEADER}`).find(Button).simulate("click");
             assert.isTrue(onClose.calledOnce, "onClose not called");
         });
     });

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -297,10 +297,7 @@ describe("<EditableText>", () => {
         }
 
         function simulateHelper(wrapper: ReactWrapper<any, {}>, value: string, e: IFakeKeyboardEvent) {
-            wrapper
-                .find("textarea")
-                .simulate("change", { target: { value } })
-                .simulate("keydown", e);
+            wrapper.find("textarea").simulate("change", { target: { value } }).simulate("keydown", e);
         }
     });
 });

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -103,10 +103,7 @@ describe("MenuItem", () => {
                 <Button />
             </Popover>,
         );
-        wrapper
-            .find(MenuItem)
-            .find("a")
-            .simulate("click");
+        wrapper.find(MenuItem).find("a").simulate("click");
         assert.isTrue(handleClose.notCalled);
     });
 
@@ -124,13 +121,7 @@ describe("MenuItem", () => {
             </MenuItem>,
         );
         assert.strictEqual(wrapper.find(Popover).prop("interactionKind"), popoverProps.interactionKind);
-        assert.notStrictEqual(
-            wrapper
-                .find(Popover)
-                .prop("popoverClassName")
-                .indexOf(popoverProps.popoverClassName),
-            0,
-        );
+        assert.notStrictEqual(wrapper.find(Popover).prop("popoverClassName").indexOf(popoverProps.popoverClassName), 0);
         assert.notStrictEqual(wrapper.find(Popover).prop("content"), popoverProps.content);
     });
 

--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -33,7 +33,7 @@ const ITEMS: ITestItem[] = IDS.map(id => ({ id }));
 const TestItem: React.SFC<ITestItem> = () => <div style={{ width: 10, flex: "0 0 auto" }} />;
 const TestOverflow: React.SFC<{ items: ITestItem[] }> = () => <div />;
 
-describe("<OverflowList>", function(this) {
+describe("<OverflowList>", function (this) {
     // these tests rely on DOM measurement which can be flaky, so we allow some retries
     this.retries(3);
 
@@ -58,11 +58,7 @@ describe("<OverflowList>", function(this) {
     });
 
     it("adds className to itself", () => {
-        assert.isTrue(
-            overflowList(30, { className: "winner" })
-                .find(".winner")
-                .exists(),
-        );
+        assert.isTrue(overflowList(30, { className: "winner" }).find(".winner").exists());
     });
 
     it("uses custom tagName", () => {

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -162,17 +162,11 @@ describe("<PanelStack>", () => {
         const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
         assert.equal(backButtonWithoutTitle.text(), "chevron-left");
 
-        const newPanelButtonOnNotEmpty = panelStackWrapper
-            .find("#new-panel-button")
-            .hostNodes()
-            .at(1);
+        const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
         assert.exists(newPanelButtonOnNotEmpty);
         newPanelButtonOnNotEmpty.simulate("click");
 
-        const backButtonWithTitle = panelStackWrapper
-            .findClass(Classes.PANEL_STACK_HEADER_BACK)
-            .hostNodes()
-            .at(1);
+        const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK).hostNodes().at(1);
         assert.equal(backButtonWithTitle.text(), "chevron-left");
     });
 

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -369,10 +369,7 @@ describe("<Popover>", () => {
             openOnTargetFocus?: boolean,
         ) {
             wrapper = renderPopover({ interactionKind, openOnTargetFocus, usePortal: true });
-            const targetElement = wrapper
-                .findClass(Classes.POPOVER_TARGET)
-                .childAt(0)
-                .getDOMNode();
+            const targetElement = wrapper.findClass(Classes.POPOVER_TARGET).childAt(0).getDOMNode();
 
             if (shouldTabIndexExist) {
                 assert.equal(targetElement.getAttribute("tabindex"), "0");
@@ -384,11 +381,7 @@ describe("<Popover>", () => {
 
     describe("in controlled mode", () => {
         it("state respects isOpen prop", () => {
-            renderPopover()
-                .assertIsOpen(false)
-                .setProps({ isOpen: true })
-                .update()
-                .assertIsOpen();
+            renderPopover().assertIsOpen(false).setProps({ isOpen: true }).update().assertIsOpen();
         });
 
         it("state does not update on user (click) interaction", () => {
@@ -401,9 +394,7 @@ describe("<Popover>", () => {
         });
 
         it("state does not update on user (key) interaction", () => {
-            renderPopover({ canEscapeKeyClose: true, isOpen: true })
-                .sendEscapeKey()
-                .assertIsOpen();
+            renderPopover({ canEscapeKeyClose: true, isOpen: true }).sendEscapeKey().assertIsOpen();
         });
 
         describe("disabled=true takes precedence over isOpen=true", () => {
@@ -514,10 +505,7 @@ describe("<Popover>", () => {
         });
 
         it("with defaultIsOpen=true, popover can still be closed", () => {
-            renderPopover({ defaultIsOpen: true })
-                .assertIsOpen()
-                .simulateTarget("click")
-                .assertIsOpen(false);
+            renderPopover({ defaultIsOpen: true }).assertIsOpen().simulateTarget("click").assertIsOpen(false);
         });
 
         it("CLICK_TARGET_ONLY works properly", () => {
@@ -641,16 +629,12 @@ describe("<Popover>", () => {
         afterEach(() => root.detach());
 
         it("shows tooltip on hover", () => {
-            root.find(`.${Classes.POPOVER_TARGET}`)
-                .last()
-                .simulate("mouseenter");
+            root.find(`.${Classes.POPOVER_TARGET}`).last().simulate("mouseenter");
             assert.lengthOf(root.find(`.${Classes.TOOLTIP}`), 1);
         });
 
         it("shows popover on click", () => {
-            root.find(`.${Classes.POPOVER_TARGET}`)
-                .first()
-                .simulate("click");
+            root.find(`.${Classes.POPOVER_TARGET}`).first().simulate("click");
             assert.lengthOf(root.find(`.${Classes.POPOVER}`), 1);
         });
     });

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -52,10 +52,7 @@ describe("<MultiSlider>", () => {
     describe("handles", () => {
         it("handle values are automatically sorted", () => {
             const slider = renderSlider({ values: [5, 10, 0], onRelease });
-            slider
-                .find(Handle)
-                .first()
-                .simulate("mousedown", { clientX: 0 });
+            slider.find(Handle).first().simulate("mousedown", { clientX: 0 });
             mouseUpHorizontal(0);
             assert.equal(onRelease.callCount, 1);
             assert.deepEqual(onRelease.firstCall.args[0], [0, 5, 10]);

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -189,10 +189,7 @@ describe("<Tabs>", () => {
         );
         assert.equal(wrapper.state("selectedTabId"), TAB_IDS[0]);
         // last Tab is inside nested
-        wrapper
-            .find(TAB)
-            .last()
-            .simulate("click");
+        wrapper.find(TAB).last().simulate("click");
         assert.equal(wrapper.state("selectedTabId"), TAB_IDS[0]);
         assert.isTrue(changeSpy.notCalled, "onChange invoked");
     });

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -114,10 +114,7 @@ describe("<TagInput>", () => {
         const onRemove = sinon.spy();
         // requires full mount to support data attributes and parentElement
         const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
-        wrapper
-            .find("button")
-            .at(1)
-            .simulate("click");
+        wrapper.find("button").at(1).simulate("click");
         assert.isTrue(onRemove.calledOnce);
         assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
     });
@@ -378,10 +375,7 @@ describe("<TagInput>", () => {
         it("is invoked when a tag is removed by clicking", () => {
             const onChange = sinon.stub();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            wrapper
-                .find("button")
-                .at(1)
-                .simulate("click");
+            wrapper.find("button").at(1).simulate("click");
             assert.isTrue(onChange.calledOnce);
             assert.deepEqual(onChange.args[0][0], [VALUES[0], VALUES[2]]);
         });
@@ -527,13 +521,7 @@ describe("<TagInput>", () => {
             wrapper.childAt(0).hasClass(Classes.DISABLED),
             `.${Classes.DISABLED} should be applied to tag-input`,
         );
-        assert.isTrue(
-            wrapper
-                .find(`.${Classes.INPUT_GHOST}`)
-                .first()
-                .prop("disabled"),
-            "input should be disabled",
-        );
+        assert.isTrue(wrapper.find(`.${Classes.INPUT_GHOST}`).first().prop("disabled"), "input should be disabled");
         wrapper.find(Tag).forEach(tag => {
             assert.lengthOf(tag.find("." + Classes.TAG_REMOVE), 0, "tag should not have tag-remove button");
         });
@@ -611,10 +599,7 @@ function runKeyPressTest(callbackName: "onKeyDown" | "onKeyUp", startIndex: numb
     wrapper.setState({ activeIndex: startIndex });
 
     const eventName = callbackName === "onKeyDown" ? "keydown" : "keyup";
-    wrapper
-        .find("input")
-        .simulate("focus")
-        .simulate(eventName, { which: Keys.ENTER });
+    wrapper.find("input").simulate("focus").simulate(eventName, { which: Keys.ENTER });
 
     assert.strictEqual(callbackSpy.callCount, 1, "container callback call count");
     assert.strictEqual(callbackSpy.firstCall.args[0].which, Keys.ENTER, "first arg (event)");

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -90,15 +90,9 @@ describe("<DateInput>", () => {
     it("Popover closes when first day of the month is blurred", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
         const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
-        wrapper
-            .find("input")
-            .simulate("focus")
-            .simulate("blur");
+        wrapper.find("input").simulate("focus").simulate("blur");
         // First day of month is the only .DayPicker-Day with tabIndex == 0
-        const tabbables = wrapper
-            .find(Popover)
-            .find(".DayPicker-Day")
-            .filter({ tabIndex: 0 });
+        const tabbables = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 });
         const firstDay = tabbables.getDOMNode() as HTMLElement;
         firstDay.dispatchEvent(createFocusEvent("blur"));
         // manually updating wrapper is required with enzyme 3
@@ -110,14 +104,8 @@ describe("<DateInput>", () => {
     it("Popover should not close if focus moves to previous day", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
         const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
-        wrapper
-            .find("input")
-            .simulate("focus")
-            .simulate("blur");
-        const tabbables = wrapper
-            .find(Popover)
-            .find(".DayPicker-Day")
-            .filter({ tabIndex: 0 });
+        wrapper.find("input").simulate("focus").simulate("blur");
+        const tabbables = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 });
         const firstDay = tabbables.getDOMNode() as HTMLElement;
         const lastDayOfPrevMonth = wrapper
             .find(Popover)
@@ -134,9 +122,7 @@ describe("<DateInput>", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
         const { root, changeSelect } = wrap(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
         root.setState({ isOpen: true });
-        root.find("input")
-            .simulate("focus")
-            .simulate("blur");
+        root.find("input").simulate("focus").simulate("blur");
         changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
         assert.isTrue(root.find(Popover).prop("isOpen"));
     });
@@ -145,9 +131,7 @@ describe("<DateInput>", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
         const { root, changeSelect } = wrap(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
         root.setState({ isOpen: true });
-        root.find("input")
-            .simulate("focus")
-            .simulate("blur");
+        root.find("input").simulate("focus").simulate("blur");
         changeSelect(Classes.DATEPICKER_YEAR_SELECT, 2016);
         assert.isTrue(root.find(Popover).prop("isOpen"));
     });
@@ -364,11 +348,7 @@ describe("<DateInput>", () => {
                     isOpen: true,
                 })
                 .update();
-            wrapper
-                .find(`.${Classes.DATEPICKER_DAY}`)
-                .first()
-                .simulate("click")
-                .update();
+            wrapper.find(`.${Classes.DATEPICKER_DAY}`).first().simulate("click").update();
             assert.isTrue(wrapper.state("isOpen"));
         });
 
@@ -447,10 +427,7 @@ describe("<DateInput>", () => {
                 />,
             );
             const value = "2/1/2030";
-            wrapper
-                .find("input")
-                .simulate("change", { target: { value } })
-                .simulate("blur");
+            wrapper.find("input").simulate("change", { target: { value } }).simulate("blur");
 
             assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
@@ -606,9 +583,7 @@ describe("<DateInput>", () => {
             root.setState({ isOpen: true });
             root.update();
 
-            getSelectedDays()
-                .at(0)
-                .simulate("click");
+            getSelectedDays().at(0).simulate("click");
 
             assert.isTrue(onChange.calledOnce);
             assert.deepEqual(onChange.firstCall.args, [DATE, true]);

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -130,15 +130,9 @@ describe("<DatePickerCaption>", () => {
         );
 
         return {
-            month: wrapper
-                .find(HTMLSelect)
-                .filter({ className: Classes.DATEPICKER_MONTH_SELECT })
-                .find("select"),
+            month: wrapper.find(HTMLSelect).filter({ className: Classes.DATEPICKER_MONTH_SELECT }).find("select"),
             root: wrapper,
-            year: wrapper
-                .find(HTMLSelect)
-                .filter({ className: Classes.DATEPICKER_YEAR_SELECT })
-                .find("select"),
+            year: wrapper.find(HTMLSelect).filter({ className: Classes.DATEPICKER_YEAR_SELECT }).find("select"),
         };
     }
 });

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -158,38 +158,28 @@ describe("<DatePicker>", () => {
             it("calls onMonthChange on button next click", () => {
                 const onMonthChange = sinon.spy();
                 const { root } = wrap(<DatePicker defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />);
-                root.find(".DayPicker-NavButton--next")
-                    .first()
-                    .simulate("click");
+                root.find(".DayPicker-NavButton--next").first().simulate("click");
                 assert.isTrue(onMonthChange.called);
             });
 
             it("calls onMonthChange on button prev click", () => {
                 const onMonthChange = sinon.spy();
                 const { root } = wrap(<DatePicker defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />);
-                root.find(".DayPicker-NavButton--prev")
-                    .first()
-                    .simulate("click");
+                root.find(".DayPicker-NavButton--prev").first().simulate("click");
                 assert.isTrue(onMonthChange.called);
             });
 
             it("calls onMonthChange on month select change", () => {
                 const onMonthChange = sinon.spy();
                 const { root } = wrap(<DatePicker defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />);
-                root.find({ className: Classes.DATEPICKER_MONTH_SELECT })
-                    .first()
-                    .find("select")
-                    .simulate("change");
+                root.find({ className: Classes.DATEPICKER_MONTH_SELECT }).first().find("select").simulate("change");
                 assert.isTrue(onMonthChange.called);
             });
 
             it("calls onMonthChange on year select change", () => {
                 const onMonthChange = sinon.spy();
                 const { root } = wrap(<DatePicker defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />);
-                root.find({ className: Classes.DATEPICKER_YEAR_SELECT })
-                    .first()
-                    .find("select")
-                    .simulate("change");
+                root.find({ className: Classes.DATEPICKER_YEAR_SELECT }).first().find("select").simulate("change");
                 assert.isTrue(onMonthChange.called);
             });
 
@@ -430,37 +420,16 @@ describe("<DatePicker>", () => {
         it("all shortcuts are displayed as inactive when none are selected", () => {
             const { root } = wrap(<DatePicker shortcuts={true} />);
 
-            assert.isFalse(
-                root
-                    .find(Shortcuts)
-                    .find(Menu)
-                    .find(MenuItem)
-                    .find(`.${CoreClasses.ACTIVE}`)
-                    .exists(),
-            );
+            assert.isFalse(root.find(Shortcuts).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`).exists());
         });
 
         it("corresponding shortcut is displayed as active when selected", () => {
             const selectedShortcut = 0;
             const { root } = wrap(<DatePicker shortcuts={true} selectedShortcutIndex={selectedShortcut} />);
 
-            assert.isTrue(
-                root
-                    .find(Shortcuts)
-                    .find(Menu)
-                    .find(MenuItem)
-                    .find(`.${CoreClasses.ACTIVE}`)
-                    .exists(),
-            );
+            assert.isTrue(root.find(Shortcuts).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`).exists());
 
-            assert.lengthOf(
-                root
-                    .find(Shortcuts)
-                    .find(Menu)
-                    .find(MenuItem)
-                    .find(`.${CoreClasses.ACTIVE}`),
-                1,
-            );
+            assert.lengthOf(root.find(Shortcuts).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`), 1);
 
             assert.isTrue(root.state("selectedShortcutIndex") === selectedShortcut);
         });
@@ -624,9 +593,7 @@ describe("<DatePicker>", () => {
                 />,
             );
             assert.isTrue(onChangeSpy.notCalled);
-            root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`)
-                .first()
-                .simulate("click");
+            root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
             assert.isTrue(onChangeSpy.calledOnce);
             const cbHour = onChangeSpy.firstCall.args[0].getHours();
             assert.strictEqual(cbHour, defaultValue.getHours() + 1);
@@ -702,10 +669,7 @@ describe("<DatePicker>", () => {
 
     it("selects the current day when Today is clicked", () => {
         const { root } = wrap(<DatePicker showActionsBar={true} />);
-        root.find({ className: Classes.DATEPICKER_FOOTER })
-            .find(Button)
-            .first()
-            .simulate("click");
+        root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).first().simulate("click");
 
         const today = new Date();
         const value = root.state("value");
@@ -717,10 +681,7 @@ describe("<DatePicker>", () => {
     it("clears the value when Clear is clicked", () => {
         const { getDay, root } = wrap(<DatePicker showActionsBar={true} />);
         getDay().simulate("click");
-        root.find({ className: Classes.DATEPICKER_FOOTER })
-            .find(Button)
-            .last()
-            .simulate("click");
+        root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).last().simulate("click");
         assert.isNull(root.state("value"));
     });
 
@@ -733,39 +694,20 @@ describe("<DatePicker>", () => {
                     wrapper.find(`.${Classes.DATEPICKER_DAY_SELECTED}`).map(d => +d.text()),
                     days,
                 ),
-            clickNextMonth: () =>
-                wrapper
-                    .find(Button)
-                    .last()
-                    .simulate("click"),
-            clickPreviousMonth: () =>
-                wrapper
-                    .find(Button)
-                    .first()
-                    .simulate("click"),
+            clickNextMonth: () => wrapper.find(Button).last().simulate("click"),
+            clickPreviousMonth: () => wrapper.find(Button).first().simulate("click"),
             clickShortcut: (index = 0) => {
-                wrapper
-                    .find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`)
-                    .hostNodes()
-                    .find("a")
-                    .at(index)
-                    .simulate("click");
+                wrapper.find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`).hostNodes().find("a").at(index).simulate("click");
             },
             getDay: (dayNumber = 1) =>
                 wrapper
                     .find(`.${Classes.DATEPICKER_DAY}`)
                     .filterWhere(day => day.text() === "" + dayNumber && !day.hasClass(Classes.DATEPICKER_DAY_OUTSIDE)),
-            months: wrapper
-                .find(HTMLSelect)
-                .filter({ className: Classes.DATEPICKER_MONTH_SELECT })
-                .find("select"),
+            months: wrapper.find(HTMLSelect).filter({ className: Classes.DATEPICKER_MONTH_SELECT }).find("select"),
             root: wrapper,
             setTimeInput: (precision: TimePrecision | "hour", value: number) =>
                 wrapper.find(`.${Classes.TIMEPICKER}-${precision}`).simulate("blur", { target: { value } }),
-            years: wrapper
-                .find(HTMLSelect)
-                .filter({ className: Classes.DATEPICKER_YEAR_SELECT })
-                .find("select"),
+            years: wrapper.find(HTMLSelect).filter({ className: Classes.DATEPICKER_YEAR_SELECT }).find("select"),
         };
     }
 });

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -2587,17 +2587,11 @@ describe("<DateRangeInput>", () => {
     });
 
     function getStartInput(root: WrappedComponentRoot): WrappedComponentInput {
-        return root
-            .find(InputGroup)
-            .first()
-            .find("input");
+        return root.find(InputGroup).first().find("input");
     }
 
     function getEndInput(root: WrappedComponentRoot): WrappedComponentInput {
-        return root
-            .find(InputGroup)
-            .last()
-            .find("input");
+        return root.find(InputGroup).last().find("input");
     }
 
     function getInputText(input: WrappedComponentInput) {

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -72,20 +72,8 @@ describe("<DateRangePicker>", () => {
         it("hides unnecessary nav buttons in contiguous months mode", () => {
             const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
             const wrapper = mount(<DateRangePicker defaultValue={defaultValue} />);
-            assert.isTrue(
-                wrapper
-                    .find(DatePickerNavbar)
-                    .at(0)
-                    .find(".DayPicker-NavButton--next")
-                    .isEmpty(),
-            );
-            assert.isTrue(
-                wrapper
-                    .find(DatePickerNavbar)
-                    .at(1)
-                    .find(".DayPicker-NavButton--prev")
-                    .isEmpty(),
-            );
+            assert.isTrue(wrapper.find(DatePickerNavbar).at(0).find(".DayPicker-NavButton--next").isEmpty());
+            assert.isTrue(wrapper.find(DatePickerNavbar).at(1).find(".DayPicker-NavButton--prev").isEmpty());
         });
 
         it("disables days according to custom modifiers in addition to default modifiers", () => {
@@ -771,19 +759,13 @@ describe("<DateRangePicker>", () => {
 
             it("should show a hovered range of [null, null] if day === end", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .clickDay(14)
-                    .mouseEnterDay(18);
+                left.clickDay(14).clickDay(18).clickDay(14).mouseEnterDay(18);
                 assertHoveredDays(null, null);
             });
 
             it("should show a hovered range of [day, end] if day < end", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .clickDay(14)
-                    .mouseEnterDay(14);
+                left.clickDay(14).clickDay(18).clickDay(14).mouseEnterDay(14);
                 assertHoveredDays(14, 18);
             });
         });
@@ -791,49 +773,37 @@ describe("<DateRangePicker>", () => {
         describe("when both start and end date are defined", () => {
             it("should show a hovered range of [null, end] if day === start", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .mouseEnterDay(14);
+                left.clickDay(14).clickDay(18).mouseEnterDay(14);
                 assertHoveredDays(null, 18);
             });
 
             it("should show a hovered range of [start, null] if day === end", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .mouseEnterDay(18);
+                left.clickDay(14).clickDay(18).mouseEnterDay(18);
                 assertHoveredDays(14, null);
             });
 
             it("should show a hovered range of [day, null] if start < day < end", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .mouseEnterDay(16);
+                left.clickDay(14).clickDay(18).mouseEnterDay(16);
                 assertHoveredDays(16, null);
             });
 
             it("should show a hovered range of [day, null] if day < start", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .mouseEnterDay(10);
+                left.clickDay(14).clickDay(18).mouseEnterDay(10);
                 assertHoveredDays(10, null);
             });
 
             it("should show a hovered range of [day, null] if day > end", () => {
                 const { left, assertHoveredDays } = render();
-                left.clickDay(14)
-                    .clickDay(18)
-                    .mouseEnterDay(22);
+                left.clickDay(14).clickDay(18).mouseEnterDay(22);
                 assertHoveredDays(22, null);
             });
 
             it("should show a hovered range of [null, null] if start === day === end", () => {
                 const { left, assertHoveredDays } = render({ allowSingleDayRange: true });
-                left.clickDay(14)
-                    .clickDay(14)
-                    .mouseEnterDay(14);
+                left.clickDay(14).clickDay(14).mouseEnterDay(14);
                 assertHoveredDays(null, null);
             });
         });
@@ -949,37 +919,16 @@ describe("<DateRangePicker>", () => {
         it("all shortcuts are displayed as inactive when none are selected", () => {
             const { wrapper } = render();
 
-            assert.isFalse(
-                wrapper
-                    .find(Shortcuts)
-                    .find(Menu)
-                    .find(MenuItem)
-                    .find(`.${Classes.ACTIVE}`)
-                    .exists(),
-            );
+            assert.isFalse(wrapper.find(Shortcuts).find(Menu).find(MenuItem).find(`.${Classes.ACTIVE}`).exists());
         });
 
         it("corresponding shortcut is displayed as active when selected", () => {
             const selectedShortcut = 0;
             const { wrapper } = render({ selectedShortcutIndex: selectedShortcut });
 
-            assert.isTrue(
-                wrapper
-                    .find(Shortcuts)
-                    .find(Menu)
-                    .find(MenuItem)
-                    .find(`.${Classes.ACTIVE}`)
-                    .exists(),
-            );
+            assert.isTrue(wrapper.find(Shortcuts).find(Menu).find(MenuItem).find(`.${Classes.ACTIVE}`).exists());
 
-            assert.lengthOf(
-                wrapper
-                    .find(Shortcuts)
-                    .find(Menu)
-                    .find(MenuItem)
-                    .find(`.${Classes.ACTIVE}`),
-                1,
-            );
+            assert.lengthOf(wrapper.find(Shortcuts).find(Menu).find(MenuItem).find(`.${Classes.ACTIVE}`), 1);
 
             assert.isTrue(wrapper.state("selectedShortcutIndex") === selectedShortcut);
         });
@@ -1107,9 +1056,7 @@ describe("<DateRangePicker>", () => {
         it("onHoverChange fired with `undefined` on mouseleave within a day", () => {
             const { left } = render({ initialMonth: new Date(2015, Months.JANUARY, 1) });
             assert.isTrue(onHoverChangeSpy.notCalled);
-            left.clickDay(1)
-                .findDay(5)
-                .simulate("mouseleave");
+            left.clickDay(1).findDay(5).simulate("mouseleave");
             assert.isTrue(onHoverChangeSpy.calledTwice);
             assert.isUndefined(onHoverChangeSpy.args[1][0]);
         });
@@ -1160,9 +1107,7 @@ describe("<DateRangePicker>", () => {
             const { assertSelectedDays, left } = render({
                 initialMonth: new Date(2015, Months.JANUARY, 1),
             });
-            left.clickDay(10)
-                .clickDay(14)
-                .clickDay(10);
+            left.clickDay(10).clickDay(14).clickDay(10);
             assertSelectedDays(14);
 
             left.clickDay(10).clickDay(14);
@@ -1382,10 +1327,7 @@ describe("<DateRangePicker>", () => {
                 return harness;
             },
             clickShortcut: (index = 0) => {
-                harness.shortcuts
-                    .find("a")
-                    .at(index)
-                    .simulate("click");
+                harness.shortcuts.find("a").at(index).simulate("click");
                 return harness;
             },
             getDays: (className: string) => {

--- a/packages/datetime/test/dateTimePickerTests.tsx
+++ b/packages/datetime/test/dateTimePickerTests.tsx
@@ -65,9 +65,7 @@ describe("<DateTimePicker>", () => {
             />,
         );
         assert.isTrue(onChangeSpy.notCalled);
-        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`)
-            .first()
-            .simulate("click");
+        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
         assert.isTrue(onChangeSpy.calledOnce);
         assert.deepEqual(onChangeSpy.firstCall.args[0], new Date(2012, 2, 5, 7, 5, 40));
     });
@@ -89,9 +87,7 @@ describe("<DateTimePicker>", () => {
             <DateTimePicker defaultValue={defaultValue} timePickerProps={{ showArrowButtons: true }} />,
         );
         getDay(5).simulate("click");
-        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`)
-            .first()
-            .simulate("click");
+        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
         getDay(15).simulate("click");
         assert.equal(root.state("timeValue").getHours(), defaultValue.getHours() + 1);
         assert.equal(root.state("timeValue").getMinutes(), defaultValue.getMinutes());

--- a/packages/docs-app/src/components/colorSchemes.tsx
+++ b/packages/docs-app/src/components/colorSchemes.tsx
@@ -162,16 +162,8 @@ export class ColorScheme extends React.PureComponent<IColorSchemeProps, IColorSc
         if (diverging) {
             // Split the basePalette into left and right, including the middle color in both.
             // Create individual bezier scales for each side. We'll choose which to use later.
-            const leftColors = chroma
-                .bezier(basePalette.slice(0, 3))
-                .scale()
-                .mode("lab")
-                .correctLightness(true);
-            const rightColors = chroma
-                .bezier(basePalette.slice(2, 5))
-                .scale()
-                .mode("lab")
-                .correctLightness(true);
+            const leftColors = chroma.bezier(basePalette.slice(0, 3)).scale().mode("lab").correctLightness(true);
+            const rightColors = chroma.bezier(basePalette.slice(2, 5)).scale().mode("lab").correctLightness(true);
 
             const result: string[] = [];
             for (let i = 0; i < steps; i++) {
@@ -182,11 +174,7 @@ export class ColorScheme extends React.PureComponent<IColorSchemeProps, IColorSc
             }
             return result;
         } else {
-            return chroma
-                .bezier(basePalette)
-                .scale()
-                .correctLightness(true)
-                .colors(steps);
+            return chroma.bezier(basePalette).scale().correctLightness(true).colors(steps);
         }
     };
 

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -50,15 +50,11 @@ const MIN_DATE_OPTIONS: IDateOption[] = [
     { label: "None", value: undefined },
     {
         label: "4 months ago",
-        value: moment()
-            .add(-4, "months")
-            .toDate(),
+        value: moment().add(-4, "months").toDate(),
     },
     {
         label: "1 year ago",
-        value: moment()
-            .add(-1, "years")
-            .toDate(),
+        value: moment().add(-1, "years").toDate(),
     },
 ];
 
@@ -66,9 +62,7 @@ const MAX_DATE_OPTIONS: IDateOption[] = [
     { label: "None", value: undefined },
     {
         label: "1 month ago",
-        value: moment()
-            .add(-1, "months")
-            .toDate(),
+        value: moment().add(-1, "months").toDate(),
     },
 ];
 

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -82,10 +82,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
 
         const initialContent = this.state.hasInitialContent ? (
             <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} />
-        ) : (
-            // explicit undefined (not null) for default behavior (show full list)
-            undefined
-        );
+        ) : // explicit undefined (not null) for default behavior (show full list)
+        undefined;
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -78,9 +78,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
 
         const initialContent = this.state.hasInitialContent ? (
             <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} />
-        ) : (
-            undefined
-        );
+        ) : undefined;
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 

--- a/packages/landing-app/src/logo.ts
+++ b/packages/landing-app/src/logo.ts
@@ -726,10 +726,7 @@ export class CanvasBuffer {
         if (bounds == null) {
             bounds = [0, 0, this.ctx.canvas.width, this.ctx.canvas.height];
         }
-        const args = []
-            .concat([this.ctx.canvas])
-            .concat(bounds)
-            .concat(bounds);
+        const args = [].concat([this.ctx.canvas]).concat(bounds).concat(bounds);
         ctx.drawImage.apply(ctx, args);
     }
 }
@@ -878,12 +875,7 @@ export class SceneRenderer extends CanvasRenderer {
             if (object instanceof Shape) {
                 const shape = object;
                 for (const face of shape.faces) {
-                    face.projected = face.points.map(point =>
-                        point
-                            .copy()
-                            .transform(transform)
-                            .round(),
-                    );
+                    face.projected = face.points.map(point => point.copy().transform(transform).round());
 
                     face.projectedCenter = P();
                     for (const p of face.projected) {
@@ -1169,27 +1161,15 @@ export function initializeLogo(canvas: HTMLCanvasElement, canvasBackground: HTML
             .multiply(Quaternion.xyAlt(accumX.value, -accumY.value).toMatrix())
             .multiply(M().translate(-1, -1, -1));
 
-        explodeGroups[0]
-            .restore()
-            .translate(accumExploder[0].value, 0, 0)
-            .transform(rotate);
-        explodeGroups[1]
-            .restore()
-            .translate(0, 0, accumExploder[1].value)
-            .transform(rotate);
+        explodeGroups[0].restore().translate(accumExploder[0].value, 0, 0).transform(rotate);
+        explodeGroups[1].restore().translate(0, 0, accumExploder[1].value).transform(rotate);
         explodeGroups[2]
             .restore()
             .translate(accumExploder[2].value, -2 * accumExploder[2].value, -accumExploder[2].value)
             .transform(rotate);
 
-        shadowGroups[0]
-            .restore()
-            .translate(accumExploder[0].value, SHADOW_DEPTH, 0)
-            .transform(rotate);
-        shadowGroups[1]
-            .restore()
-            .translate(0, SHADOW_DEPTH, accumExploder[1].value)
-            .transform(rotate);
+        shadowGroups[0].restore().translate(accumExploder[0].value, SHADOW_DEPTH, 0).transform(rotate);
+        shadowGroups[1].restore().translate(0, SHADOW_DEPTH, accumExploder[1].value).transform(rotate);
         shadowGroups[2]
             .restore()
             .translate(accumExploder[2].value, SHADOW_DEPTH, -accumExploder[2].value)

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -86,10 +86,7 @@ describe("<MultiSelect>", () => {
             selectedItems: [TOP_100_FILMS[1]],
         });
 
-        const firstTagRemoveButton = wrapper
-            .find(`.${CoreClasses.TAG_REMOVE}`)
-            .at(0)
-            .getDOMNode();
+        const firstTagRemoveButton = wrapper.find(`.${CoreClasses.TAG_REMOVE}`).at(0).getDOMNode();
         dispatchTestKeyboardEventWithCode(firstTagRemoveButton, "keyup", "Enter", Keys.ENTER);
 
         // checks for the bug in https://github.com/palantir/blueprint/issues/3674

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -79,9 +79,7 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
 
         it("clicking item invokes onItemSelect and changes active item", () => {
             const wrapper = render(testProps);
-            findItems(wrapper)
-                .at(4)
-                .simulate("click");
+            findItems(wrapper).at(4).simulate("click");
             assert.strictEqual(testProps.onItemSelect.args[0][0].rank, 6, "onItemSelect");
             assert.strictEqual(testProps.onActiveItemChange.args[0][0].rank, 6, "onActiveItemChange");
         });
@@ -93,9 +91,7 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
                 resetOnQuery: false,
                 resetOnSelect: true,
             });
-            findItems(wrapper)
-                .at(3)
-                .simulate("click");
+            findItems(wrapper).at(3).simulate("click");
             const ranks = testProps.onActiveItemChange.args.map(args => (args[0] as IFilm).rank);
             // clicking changes to 5, then resets to 1
             assert.deepEqual(ranks, [5, 1]);

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -337,10 +337,7 @@ function filterByYear(query: string, film: IFilm) {
 }
 
 function selectItem(wrapper: ReactWrapper<any, any>, index: number) {
-    wrapper
-        .find("a")
-        .at(index)
-        .simulate("click");
+    wrapper.find("a").at(index).simulate("click");
 }
 
 function inputValueRenderer(item: IFilm) {

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -136,9 +136,7 @@ const CELL_CONTENT_GENERATORS: { [name: string]: (ri: number, ci: number) => str
     [CellContent.EMPTY]: () => "",
     [CellContent.LONG_TEXT]: () => {
         const randomLength = getRandomInteger(LONG_TEXT_MIN_LENGTH, LONG_TEXT_MAX_LENGTH);
-        return getRandomString(randomLength)
-            .match(LONG_TEXT_WORD_SPLIT_REGEXP)
-            .join(" ");
+        return getRandomString(randomLength).match(LONG_TEXT_WORD_SPLIT_REGEXP).join(" ");
     },
     [CellContent.LARGE_JSON]: () => {
         return getRandomObject(LARGE_JSON_PROP_COUNT, LARGE_JSON_OBJECT_DEPTH);
@@ -194,9 +192,7 @@ function getRandomInteger(min: number, max: number): number {
 function getRandomString(length: number): string {
     let str = "";
     while (str.length < length) {
-        str += Math.random()
-            .toString(36)
-            .substr(2);
+        str += Math.random().toString(36).substr(2);
     }
     return str.substr(0, length);
 }
@@ -375,9 +371,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
     // ==========
 
     private generateColumnKey = () => {
-        return Math.random()
-            .toString(36)
-            .substring(7);
+        return Math.random().toString(36).substring(7);
     };
 
     // Renderers

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -388,9 +388,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
                 rowHeaderCellRenderer={this.renderLeftQuadrantRowHeader}
                 scrollContainerRef={this.quadrantRefHandlers[QuadrantType.LEFT].scrollContainer}
             />
-        ) : (
-            undefined
-        );
+        ) : undefined;
         const maybeTopLeftQuadrant = shouldRenderLeftQuadrants ? (
             <TableQuadrant
                 {...baseProps}
@@ -401,9 +399,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
                 rowHeaderCellRenderer={this.renderTopLeftQuadrantRowHeader}
                 scrollContainerRef={this.quadrantRefHandlers[QuadrantType.TOP_LEFT].scrollContainer}
             />
-        ) : (
-            undefined
-        );
+        ) : undefined;
 
         return (
             <div className={Classes.TABLE_QUADRANT_STACK}>

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -129,9 +129,7 @@ describe("<ColumnHeaderCell>", () => {
         function expectMenuToOpen(table: ElementHarness, menuClickSpy: sinon.SinonSpy) {
             table.find(`.${Classes.TABLE_COLUMN_HEADERS}`).mouse("mousemove");
             table.find(`.${Classes.TABLE_TH_MENU} .${CoreClasses.POPOVER_TARGET}`).mouse("click");
-            ElementHarness.document()
-                .find('[data-icon="export"]')
-                .mouse("click");
+            ElementHarness.document().find('[data-icon="export"]').mouse("click");
             expect(menuClickSpy.called).to.be.true;
         }
     });

--- a/packages/table/test/editableNameTests.tsx
+++ b/packages/table/test/editableNameTests.tsx
@@ -81,9 +81,7 @@ describe("<EditableName>", () => {
             .simulate("change", { target: { value: CHANGED_VALUE } });
         expect(onChangeSpy.firstCall.args).to.deep.equal([CHANGED_VALUE, INDEX]);
 
-        elem.find(EditableText)
-            .find("input")
-            .simulate("blur");
+        elem.find(EditableText).find("input").simulate("blur");
         expect(onChangeSpy.firstCall.args).to.deep.equal([CHANGED_VALUE, INDEX]);
     });
 });

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -70,10 +70,7 @@ describe("DragReorderable", () => {
             );
             const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-            element
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
             expect(callbacks.onReordering.called).to.be.false;
             expect(callbacks.onReordered.called).to.be.false;
             expect(callbacks.onSelection.called).to.be.false;
@@ -92,10 +89,7 @@ describe("DragReorderable", () => {
             );
             const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-            element
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
             expect(callbacks.onReordering.called).to.be.false;
             expect(callbacks.onReordered.called).to.be.false;
             expect(callbacks.onSelection.called).to.be.false;
@@ -118,10 +112,7 @@ describe("DragReorderable", () => {
             );
             const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-            element
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
             expect(callbacks.onReordering.called).to.be.false;
             expect(callbacks.onReordered.called).to.be.false;
             expect(callbacks.onSelection.called).to.be.false;
@@ -141,10 +132,7 @@ describe("DragReorderable", () => {
             );
             const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-            element
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
             expect(callbacks.onReordering.called).to.be.true;
             expect(callbacks.onReordered.called).to.be.true;
             expect(callbacks.onSelection.called).to.be.true;
@@ -270,10 +258,7 @@ describe("DragReorderable", () => {
             );
             const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-            element
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
             expect(callbacks.onSelection.called).to.be.false;
             expect(callbacks.onFocusedCell.called).to.be.false;
         });
@@ -324,10 +309,7 @@ describe("DragReorderable", () => {
             );
             const element = reorderable.find(ELEMENT_SELECTOR, OLD_INDEX);
 
-            element
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            element.mouse("mousedown").mouse("mousemove").mouse("mouseup");
 
             // called once on mousedown and again on mouseup
             expect(callbacks.onFocusedCell.calledTwice).to.be.true;

--- a/packages/table/test/resizableTests.tsx
+++ b/packages/table/test/resizableTests.tsx
@@ -126,11 +126,7 @@ describe("Resizable", () => {
         expect(target.element).to.exist;
 
         // drag resize handle to the right by 10 pixels
-        target
-            .mouse("mousemove")
-            .mouse("mousedown")
-            .mouse("mousemove", 10)
-            .mouse("mouseup", 10);
+        target.mouse("mousemove").mouse("mousedown").mouse("mousemove", 10).mouse("mouseup", 10);
 
         expect(onLayoutLock.called).to.be.true;
         expect(onLayoutLock.lastCall.args[0]).to.be.false;
@@ -145,12 +141,7 @@ describe("Resizable", () => {
         onSizeChanged.resetHistory();
 
         // double click the resize handle
-        target
-            .mouse("mousemove")
-            .mouse("mousedown")
-            .mouse("mouseup", 10)
-            .mouse("mousedown")
-            .mouse("mouseup", 10);
+        target.mouse("mousemove").mouse("mousedown").mouse("mouseup", 10).mouse("mousedown").mouse("mouseup", 10);
 
         expect(onLayoutLock.called).to.be.true;
         expect(onSizeChanged.called).to.be.false;

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -348,9 +348,7 @@ describe("DragSelectable", () => {
 
             // be sure to test "click"s as sequentional "mousedown"-"mouseup"s, because those
             // are the events we actually listen for deep in DragEvents.
-            getItem(component)
-                .mouse("mousedown")
-                .mouse("mouseup");
+            getItem(component).mouse("mousedown").mouse("mouseup");
 
             expect(onSelectionEnd.calledOnce).to.be.true;
             expect(onSelectionEnd.firstCall.args[0] === selectedRegions).to.be.true; // check for same instance
@@ -475,9 +473,7 @@ describe("DragSelectable", () => {
                 selectedRegions: [REGION],
             });
 
-            getItem(component)
-                .mouse("mousedown")
-                .mouse("mousemove");
+            getItem(component).mouse("mousedown").mouse("mousemove");
 
             expect(onSelection.calledTwice, "calls onSelection on mousemove").to.be.true;
             expect(
@@ -496,9 +492,7 @@ describe("DragSelectable", () => {
                 selectedRegions: [REGION],
             });
 
-            getItem(component)
-                .mouse("mousedown")
-                .mouse("mousemove");
+            getItem(component).mouse("mousedown").mouse("mousemove");
 
             expect(locateClick.calledTwice, "calls locateClick on mousemove").to.be.true;
             expect(locateDrag.called, "doesn't call locateDrag on mousemove").to.be.false;
@@ -581,10 +575,7 @@ describe("DragSelectable", () => {
 
             const component = mountDragSelectable({ onSelectionEnd, selectedRegions });
 
-            getItem(component)
-                .mouse("mousedown")
-                .mouse("mousemove")
-                .mouse("mouseup");
+            getItem(component).mouse("mousedown").mouse("mousemove").mouse("mouseup");
 
             expect(onSelectionEnd.calledOnce).to.be.true;
             expect(onSelectionEnd.firstCall.args[0] === selectedRegions).to.be.true;

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -47,10 +47,7 @@ describe("Selection", () => {
             createTableOfSize(3, 7, {}, { enableFocusedCell: true, onSelection, onFocusedCell }),
         );
 
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
 
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
@@ -65,10 +62,7 @@ describe("Selection", () => {
         const copyCellsStub = sinon.stub(Clipboard, "copyCells").returns(true);
         const table = harness.mount(createTableOfSize(3, 7, {}, { getCellClipboardData, onCopy }));
 
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         table.find(COLUMN_TH_SELECTOR).focus();
         table.find(COLUMN_TH_SELECTOR).keyboard("keydown", "C", true);
         expect(copyCellsStub.lastCall.args).to.deep.equal([[["A1"], ["A2"], ["A3"], ["A4"], ["A5"], ["A6"], ["A7"]]]);
@@ -89,10 +83,7 @@ describe("Selection", () => {
             ),
         );
 
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
         onSelection.resetHistory();
@@ -111,26 +102,17 @@ describe("Selection", () => {
         const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection, selectionModes }));
 
         // select a column to ensure it deselects when we click the row
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         onSelection.resetHistory();
 
         // select a row
-        table
-            .find(ROW_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(ROW_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         expect(onSelection.called, "onSelection should be called on select").to.equal(true);
         expect(onSelection.lastCall.args, "selected region should be first row").to.deep.equal([[Regions.row(0)]]);
         onSelection.resetHistory();
 
         // deselects on cmd+click
-        table
-            .find(ROW_TH_SELECTOR)
-            .mouse("mousedown", { metaKey: true })
-            .mouse("mouseup");
+        table.find(ROW_TH_SELECTOR).mouse("mousedown", { metaKey: true }).mouse("mouseup");
         expect(onSelection.called, "onSelection should be called on deselect").to.equal(true, "cmd+click to deselect");
         expect(onSelection.lastCall.args, "selected region should be empty").to.deep.equal([[]]);
         onSelection.resetHistory();
@@ -141,39 +123,27 @@ describe("Selection", () => {
         const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection }));
 
         // initial selection
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         expect(onSelection.called).to.equal(true, "first select");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);
         onSelection.resetHistory();
 
         // deselects on cmd+click
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown", { metaKey: true })
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown", { metaKey: true }).mouse("mouseup");
         expect(onSelection.called).to.equal(true, "cmd+click to deselect");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[]]);
         onSelection.resetHistory();
 
         // re-select
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown").mouse("mouseup");
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]], "second select");
         onSelection.resetHistory();
 
         // clears even with meta key
         const isMetaKeyDown = true;
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown", 0, 0, isMetaKeyDown)
-            .mouse("mouseup", 0, 0, isMetaKeyDown);
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown", 0, 0, isMetaKeyDown).mouse("mouseup", 0, 0, isMetaKeyDown);
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args).to.deep.equal([[]], "meta key clear");
     });
@@ -208,10 +178,7 @@ describe("Selection", () => {
         const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection, selectedRegionTransform }));
 
         // clicking adds transformed selection
-        table
-            .find(CELL_SELECTOR)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(CELL_SELECTOR).mouse("mousedown").mouse("mouseup");
 
         expect(onSelection.called).to.be.true;
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.row(1)]]);
@@ -239,10 +206,7 @@ describe("Selection", () => {
         const onSelection = sinon.spy();
         const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection }));
 
-        table
-            .find(COLUMN_TH_SELECTOR, 0)
-            .mouse("mousedown")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR, 0).mouse("mousedown").mouse("mouseup");
 
         expect(onSelection.called).to.equal(true, "first select called");
         expect(onSelection.lastCall.args.length).to.equal(1);
@@ -250,10 +214,7 @@ describe("Selection", () => {
         onSelection.resetHistory();
 
         const isMetaKeyDown = true;
-        table
-            .find(COLUMN_TH_SELECTOR, 1)
-            .mouse("mousedown", 0, 0, isMetaKeyDown)
-            .mouse("mouseup", 0, 0, isMetaKeyDown);
+        table.find(COLUMN_TH_SELECTOR, 1).mouse("mousedown", 0, 0, isMetaKeyDown).mouse("mouseup", 0, 0, isMetaKeyDown);
 
         expect(onSelection.called).to.equal(true, "second select called");
         expect(onSelection.lastCall.args.length).to.equal(1);
@@ -265,10 +226,7 @@ describe("Selection", () => {
         const table = harness.mount(createTableOfSize(3, 7, {}, { onSelection }));
 
         table.find(COLUMN_TH_SELECTOR).mouse("mousedown");
-        table
-            .find(COLUMN_TH_SELECTOR, 1)
-            .mouse("mousemove")
-            .mouse("mouseup");
+        table.find(COLUMN_TH_SELECTOR, 1).mouse("mousemove").mouse("mouseup");
 
         expect(onSelection.called).to.equal(true);
         expect(onSelection.lastCall.args.length).to.equal(1);
@@ -281,10 +239,7 @@ describe("Selection", () => {
 
         // initial selection
         const isMetaKeyDown = true;
-        table
-            .find(COLUMN_TH_SELECTOR)
-            .mouse("mousedown", 0, 0, isMetaKeyDown)
-            .mouse("mouseup", 0, 0, isMetaKeyDown);
+        table.find(COLUMN_TH_SELECTOR).mouse("mousedown", 0, 0, isMetaKeyDown).mouse("mouseup", 0, 0, isMetaKeyDown);
         expect(onSelection.called).to.equal(true, "first select");
         expect(onSelection.lastCall.args.length).to.equal(1);
         expect(onSelection.lastCall.args).to.deep.equal([[Regions.column(0)]]);

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -43,7 +43,7 @@ import { createStringOfLength, createTableOfSize } from "./mocks/table";
 // tslint:disable-next-line no-unnecessary-callback-wrapper
 const mount = (el: React.ReactElement<ITableProps>, options?: MountRendererProps) => untypedMount<Table>(el, options);
 
-describe("<Table>", function(this) {
+describe("<Table>", function (this) {
     // allow retrying failed tests here to reduce flakes.
     this.retries(2);
 
@@ -467,10 +467,7 @@ describe("<Table>", function(this) {
 
             // select the full table
             selectFullTable(table);
-            let columnHeader = table
-                .find(COLUMN_HEADER_SELECTOR)
-                .hostNodes()
-                .first();
+            let columnHeader = table.find(COLUMN_HEADER_SELECTOR).hostNodes().first();
             let rowHeader = table
                 .find(`.${Classes.TABLE_ROW_HEADERS}`)
                 .find(`.${Classes.TABLE_HEADER}`)
@@ -482,10 +479,7 @@ describe("<Table>", function(this) {
             // deselect the full table
             table.setProps({ selectedRegions: [] });
             table.update();
-            columnHeader = table
-                .find(COLUMN_HEADER_SELECTOR)
-                .hostNodes()
-                .first();
+            columnHeader = table.find(COLUMN_HEADER_SELECTOR).hostNodes().first();
             rowHeader = table
                 .find(`.${Classes.TABLE_ROW_HEADERS}`)
                 .find(`.${Classes.TABLE_HEADER}`)
@@ -746,11 +740,7 @@ describe("<Table>", function(this) {
             const rows = getRowHeadersWrapper(table);
             const resizeHandleTarget = getResizeHandle(rows, 0);
 
-            resizeHandleTarget
-                .mouse("mousemove")
-                .mouse("mousedown")
-                .mouse("mousemove", 0, 2)
-                .mouse("mouseup");
+            resizeHandleTarget.mouse("mousemove").mouse("mousedown").mouse("mousemove", 0, 2).mouse("mouseup");
 
             expect(rows.find(`.${Classes.TABLE_HEADER}`, 0).bounds().height).to.equal(3);
             expect(rows.find(`.${Classes.TABLE_HEADER}`, 1).bounds().height).to.equal(3);
@@ -769,11 +759,7 @@ describe("<Table>", function(this) {
             const resizeHandleTarget = getResizeHandle(columnHeader, 0);
 
             expect(() => {
-                resizeHandleTarget
-                    .mouse("mousemove")
-                    .mouse("mousedown")
-                    .mouse("mousemove", 0, 2)
-                    .mouse("mouseup");
+                resizeHandleTarget.mouse("mousemove").mouse("mousedown").mouse("mousemove", 0, 2).mouse("mouseup");
             }).not.to.throw();
         });
 
@@ -781,10 +767,7 @@ describe("<Table>", function(this) {
             const table = mountTable();
             const resizeHandleTarget = getResizeHandle(getRowHeadersWrapper(table), 0);
 
-            resizeHandleTarget
-                .mouse("mousemove")
-                .mouse("mousedown")
-                .mouse("mousemove", 0, 2);
+            resizeHandleTarget.mouse("mousemove").mouse("mousedown").mouse("mousemove", 0, 2);
             expect(table.find(`.${Classes.TABLE_SELECTION_REGION}`).exists()).to.be.false;
 
             resizeHandleTarget.mouse("mouseup");
@@ -838,11 +821,7 @@ describe("<Table>", function(this) {
             const frozenColumnResizeHandle = tableElement.find(resizeHandleSelector, FROZEN_COLUMN_INDEX);
 
             // double-click the frozen column's resize handle
-            frozenColumnResizeHandle
-                .mouse("mousedown")
-                .mouse("mouseup", 10)
-                .mouse("mousedown")
-                .mouse("mouseup", 10);
+            frozenColumnResizeHandle.mouse("mousedown").mouse("mouseup", 10).mouse("mousedown").mouse("mouseup", 10);
 
             const columnWidth = table.state.columnWidths[0];
             const quadrantWidth = parseInt(quadrantElement.style().width, 10);
@@ -995,10 +974,7 @@ describe("<Table>", function(this) {
             const length = 1;
             const offsetX = (newIndex + length) * COLUMN_WIDTH_IN_PX;
             const adjustedOffsetX = getAdjustedOffsetX(offsetX, reorderHandle);
-            reorderHandle
-                .mouse("mousedown")
-                .mouse("mousemove", adjustedOffsetX)
-                .mouse("mouseup", adjustedOffsetX);
+            reorderHandle.mouse("mousedown").mouse("mousemove", adjustedOffsetX).mouse("mouseup", adjustedOffsetX);
 
             // called once on mousedown (to select column 0), once on mouseup (to move the selection)
             expect(onSelection.callCount).to.equal(2);
@@ -1487,9 +1463,7 @@ describe("<Table>", function(this) {
         function mountTable(rowHeight = ROW_HEIGHT, colWidth = COL_WIDTH) {
             // need to explicitly `.fill` a new array with empty values for mapping to work
             const defineColumn = (_unused: any, i: number) => <Column key={i} cellRenderer={renderDummyCell} />;
-            const columns = Array(NUM_COLS)
-                .fill(undefined)
-                .map(defineColumn);
+            const columns = Array(NUM_COLS).fill(undefined).map(defineColumn);
 
             const table = mount(
                 <Table
@@ -1603,9 +1577,7 @@ describe("<Table>", function(this) {
         }
 
         function renderColumns(numCols: number) {
-            return Array(numCols)
-                .fill(undefined)
-                .map(renderColumn);
+            return Array(numCols).fill(undefined).map(renderColumn);
         }
 
         function renderColumn(_unused: any, i: number) {
@@ -1620,10 +1592,7 @@ describe("<Table>", function(this) {
         ) {
             // make the viewport small enough to fit only one cell
             updateLocatorElements(table, scrollLeft, scrollTop, COL_WIDTH, ROW_HEIGHT);
-            table
-                .find(TableQuadrant)
-                .first()
-                .simulate("scroll");
+            table.find(TableQuadrant).first().simulate("scroll");
 
             // delay to next frame to let throttled scroll logic execute first
             delayToNextFrame(callback);
@@ -1725,10 +1694,7 @@ describe("<Table>", function(this) {
     xdescribe("Persists column widths", () => {
         const expectHeaderWidth = (table: ElementHarness, index: number, width: number) => {
             expect(
-                table
-                    .find(`.${Classes.TABLE_COLUMN_HEADERS}`)
-                    .find(`.${Classes.TABLE_HEADER}`, index)
-                    .bounds().width,
+                table.find(`.${Classes.TABLE_COLUMN_HEADERS}`).find(`.${Classes.TABLE_HEADER}`, index).bounds().width,
             ).to.equal(width);
         };
 

--- a/packages/timezone/test/timezonePickerTests.tsx
+++ b/packages/timezone/test/timezonePickerTests.tsx
@@ -238,28 +238,18 @@ describe("<TimezonePicker>", () => {
     }
 
     function findQueryList(timezonePicker: TimezonePickerShallowWrapper) {
-        return findSelect(timezonePicker)
-            .shallow()
-            .find(QueryList.ofType<ITimezoneItem>());
+        return findSelect(timezonePicker).shallow().find(QueryList.ofType<ITimezoneItem>());
     }
 
     function findPopover(timezonePicker: TimezonePickerShallowWrapper) {
-        return findQueryList(timezonePicker)
-            .shallow()
-            .find(Popover);
+        return findQueryList(timezonePicker).shallow().find(Popover);
     }
 
     function findInputGroup(timezonePicker: TimezonePickerShallowWrapper) {
-        return findQueryList(timezonePicker)
-            .shallow()
-            .find(InputGroup);
+        return findQueryList(timezonePicker).shallow().find(InputGroup);
     }
 
     function clickFirstMenuItem(timezonePicker: TimezonePickerShallowWrapper): void {
-        findQueryList(timezonePicker)
-            .shallow()
-            .find(MenuItem)
-            .first()
-            .simulate("click");
+        findQueryList(timezonePicker).shallow().find(MenuItem).first().simulate("click");
     }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9413,10 +9413,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
Prettier [changed their method chain breaking heuristic](https://prettier.io/blog/2020/03/21/2.0.0.html), so there are a bunch of autoformatted lines changed in this PR.

I considered reducing our lineWidth as per Prettier's suggestions about this breaking change, but reducing to 100 cols produces an even larger diff:

```
 293 files changed, 6805 insertions(+), 1759 deletions(-)
```

...instead of the current:

```
39 files changed, 144 insertions(+), 583 deletions(-)
```

... so we're going to keep the line width as-is.