### PR TITLE
Add support for callback ref and ref hook

### DIFF
--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -20,4 +20,4 @@ export * from "./functionUtils";
 export * from "./jsUtils";
 export * from "./reactUtils";
 export * from "./safeInvokeMember";
-export * from './refUtils';
+export * from "./refUtils";

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -20,3 +20,4 @@ export * from "./functionUtils";
 export * from "./jsUtils";
 export * from "./reactUtils";
 export * from "./safeInvokeMember";
+export * from './refUtils';

--- a/packages/core/src/common/utils/refUtils.ts
+++ b/packages/core/src/common/utils/refUtils.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export interface IRefObject<T> {
     readonly current: T | null;
 }
@@ -5,10 +21,7 @@ export interface IRefObject<T> {
 export type IRefCallback<T> = (ref: T | null) => any;
 
 export function getRef<T>(ref: T | IRefObject<T>) {
-    if (
-        ref &&
-        (ref as IRefObject<T>).current
-    ) {
+    if (ref && (ref as IRefObject<T>).current) {
         return (ref as IRefObject<T>).current;
     }
 

--- a/packages/core/src/common/utils/refUtils.ts
+++ b/packages/core/src/common/utils/refUtils.ts
@@ -1,0 +1,16 @@
+export interface IRefObject<T> {
+    readonly current: T | null;
+}
+
+export type IRefCallback<T> = (ref: T | null) => any;
+
+export function getRef<T>(ref: T | IRefObject<T>) {
+    if (
+        ref &&
+        (ref as IRefObject<T>).current
+    ) {
+        return (ref as IRefObject<T>).current;
+    }
+
+    return ref as T;
+}

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -86,13 +86,10 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         isActive: false,
     };
 
-    protected getButtonRefHandler = (): (Utils.IRefCallback<any> | Utils.IRefObject<any>) => {
-        const elementRef = this.props.elementRef as (Utils.IRefCallback<HTMLElement> | Utils.IRefObject<HTMLElement>);
+    protected getButtonRefHandler = (): Utils.IRefCallback<any> | Utils.IRefObject<any> => {
+        const elementRef = this.props.elementRef as Utils.IRefCallback<HTMLElement> | Utils.IRefObject<HTMLElement>;
 
-        if (
-            elementRef &&
-            !Utils.isFunction(elementRef)
-        ) {
+        if (elementRef && !Utils.isFunction(elementRef)) {
             this.buttonRef = elementRef;
 
             return elementRef;
@@ -107,7 +104,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
 
     protected buttonRefCallback = (ref: HTMLElement | Utils.IRefObject<HTMLElement>) => {
         this.buttonRef = ref;
-    }
+    };
 
     protected buttonRef: HTMLElement | Utils.IRefObject<HTMLElement>;
     protected refHandlers = {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -88,7 +88,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
 
     protected getAbstractButtonRef = (): React.Ref<any> => {
         if (this.props.elementRef && !Utils.isFunction(this.props.elementRef)) {
-            this.buttonRef = this.props.elementRef as React.RefObject<HTMLElement>
+            this.buttonRef = this.props.elementRef as React.RefObject<HTMLElement>;
 
             return this.props.elementRef;
         }
@@ -96,9 +96,9 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         return (ref: HTMLElement) => {
             this.buttonRef = ref;
 
-            Utils.safeInvoke(this.props.elementRef as ((ref: HTMLElement | null) => any), ref);
-        }
-    }
+            Utils.safeInvoke(this.props.elementRef as (ref: HTMLElement | null) => any, ref);
+        };
+    };
 
     protected buttonRef: HTMLElement | React.RefObject<HTMLElement>;
     protected refHandlers = {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -102,10 +102,6 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         };
     };
 
-    protected buttonRefCallback = (ref: HTMLElement | Utils.IRefObject<HTMLElement>) => {
-        this.buttonRef = ref;
-    };
-
     protected buttonRef: HTMLElement | Utils.IRefObject<HTMLElement>;
     protected refHandlers = {
         button: this.getButtonRefHandler(),

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -46,7 +46,7 @@ export interface IInputGroupProps extends IControlledProps, IIntentProps, IProps
     fill?: boolean;
 
     /** Ref handler that receives HTML `<input>` element backing this component. */
-    inputRef?: (ref: HTMLInputElement | null) => any;
+    inputRef?: React.Ref<HTMLInputElement>;
 
     /**
      * Element to render on the left side of input.  This prop is mutually exclusive

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
-import { AbstractPureComponent2, Classes } from "../../common";
+import { AbstractPureComponent2, Classes, Utils } from "../../common";
 import * as Errors from "../../common/errors";
 import {
     DISPLAYNAME_PREFIX,
@@ -45,8 +45,8 @@ export interface IInputGroupProps extends IControlledProps, IIntentProps, IProps
      */
     fill?: boolean;
 
-    /** Ref handler that receives HTML `<input>` element backing this component. */
-    inputRef?: React.Ref<HTMLInputElement>;
+    /** Ref handler or a ref object that receives HTML `<input>` element backing this component. */
+    inputRef?: Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>;
 
     /**
      * Element to render on the left side of input.  This prop is mutually exclusive

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -103,22 +103,24 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             checkClickTriggeredOnKeyUp(done, {}, { which: Keys.SPACE });
         });
 
-        it("matches buttonRef with elementRef using createRef", done => {
-            const elementRef = React.createRef<HTMLElement>();
+        if (typeof React.createRef !== "undefined") {
+            it("matches buttonRef with elementRef using createRef", done => {
+                const elementRef = React.createRef<HTMLElement>();
 
-            const wrapper = button(
-                {
-                    elementRef,
-                },
-                true,
-            );
+                const wrapper = button(
+                    {
+                        elementRef,
+                    },
+                    true,
+                );
 
-            // wait for the whole lifecycle to run
-            setTimeout(() => {
-                assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef.current);
-                done();
-            }, 0);
-        });
+                // wait for the whole lifecycle to run
+                setTimeout(() => {
+                    assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef.current);
+                    done();
+                }, 0);
+            });
+        }
 
         it("matches buttonRef with elementRef using callback", done => {
             let elementRef: HTMLElement = null;
@@ -140,24 +142,26 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             }, 0);
         });
 
-        it("matches buttonRef with elementRef using useRef", done => {
-            let elementRef: React.MutableRefObject<HTMLElement>;
-            const Component = component;
+        if (typeof React.useRef !== "undefined") {
+            it("matches buttonRef with elementRef using useRef", done => {
+                let elementRef: React.MutableRefObject<HTMLElement>;
+                const Component = component;
 
-            const Test = () => {
-                elementRef = React.useRef<HTMLButtonElement>(null);
+                const Test = () => {
+                    elementRef = React.useRef<HTMLButtonElement>(null);
 
-                return <Component elementRef={elementRef} />;
-            };
+                    return <Component elementRef={elementRef} />;
+                };
 
-            const wrapper = mount(<Test />);
+                const wrapper = mount(<Test />);
 
-            // wait for the whole lifecycle to run
-            setTimeout(() => {
-                assert.equal(elementRef.current, (wrapper.find(Component).instance() as any).buttonRef.current);
-                done();
-            }, 0);
-        });
+                // wait for the whole lifecycle to run
+                setTimeout(() => {
+                    assert.equal(elementRef.current, (wrapper.find(Component).instance() as any).buttonRef.current);
+                    done();
+                }, 0);
+            });
+        }
 
         function button(props: IButtonProps, useMount = false, ...children: React.ReactNode[]) {
             const element = React.createElement(component, props, ...children);

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -106,9 +106,12 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
         it("matches buttonRef with elementRef using createRef", done => {
             const elementRef = React.createRef<HTMLElement>();
 
-            const wrapper = button({
-                elementRef,
-            }, true);
+            const wrapper = button(
+                {
+                    elementRef,
+                },
+                true,
+            );
 
             // wait for the whole lifecycle to run
             setTimeout(() => {
@@ -119,11 +122,16 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
 
         it("matches buttonRef with elementRef using callback", done => {
             let elementRef: HTMLElement = null;
-            const buttonRefCallback = (ref: HTMLElement) => { elementRef = ref};
+            const buttonRefCallback = (ref: HTMLElement) => {
+                elementRef = ref;
+            };
 
-            const wrapper = button({
-                elementRef: buttonRefCallback
-            }, true);
+            const wrapper = button(
+                {
+                    elementRef: buttonRefCallback,
+                },
+                true,
+            );
 
             // wait for the whole lifecycle to run
             setTimeout(() => {
@@ -139,10 +147,8 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             const Test = () => {
                 elementRef = React.useRef<HTMLButtonElement>(null);
 
-                return (
-                    <Component elementRef={elementRef} />
-                );
-            }
+                return <Component elementRef={elementRef} />;
+            };
 
             const wrapper = mount(<Test />);
 

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -103,6 +103,56 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             checkClickTriggeredOnKeyUp(done, {}, { which: Keys.SPACE });
         });
 
+        it("matches buttonRef with elementRef using createRef", done => {
+            const elementRef = React.createRef<HTMLElement>();
+
+            const wrapper = button({
+                elementRef,
+            }, true);
+
+            // wait for the whole lifecycle to run
+            setTimeout(() => {
+                assert.equal(elementRef.current, (wrapper.instance() as any ).buttonRef.current);
+                done();
+            }, 0);
+        });
+
+        it("matches buttonRef with elementRef using callback", done => {
+            let elementRef: HTMLElement = null;
+            const buttonRefCallback = (ref: HTMLElement) => { elementRef = ref};
+
+            const wrapper = button({
+                elementRef: buttonRefCallback
+            }, true);
+
+            // wait for the whole lifecycle to run
+            setTimeout(() => {
+                assert.equal(elementRef, (wrapper.instance() as any ).buttonRef);
+                done();
+            }, 0);
+        });
+
+        it("matches buttonRef with elementRef using useRef", done => {
+            let elementRef: React.MutableRefObject<HTMLElement>;
+            const Component = component;
+
+            const Test = () => {
+                elementRef = React.useRef<HTMLButtonElement>(null);
+
+                return (
+                    <Component elementRef={elementRef} />
+                );
+            }
+
+            const wrapper = mount(<Test />);
+
+            // wait for the whole lifecycle to run
+            setTimeout(() => {
+                assert.equal(elementRef.current, (wrapper.find(Component).instance() as any ).buttonRef.current);
+                done();
+            }, 0);
+        });
+
         function button(props: IButtonProps, useMount = false, ...children: React.ReactNode[]) {
             const element = React.createElement(component, props, ...children);
             return useMount ? mount(element) : shallow(element);

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -112,7 +112,7 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
 
             // wait for the whole lifecycle to run
             setTimeout(() => {
-                assert.equal(elementRef.current, (wrapper.instance() as any ).buttonRef.current);
+                assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef.current);
                 done();
             }, 0);
         });
@@ -127,7 +127,7 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
 
             // wait for the whole lifecycle to run
             setTimeout(() => {
-                assert.equal(elementRef, (wrapper.instance() as any ).buttonRef);
+                assert.equal(elementRef, (wrapper.instance() as any).buttonRef);
                 done();
             }, 0);
         });
@@ -148,7 +148,7 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
 
             // wait for the whole lifecycle to run
             setTimeout(() => {
-                assert.equal(elementRef.current, (wrapper.find(Component).instance() as any ).buttonRef.current);
+                assert.equal(elementRef.current, (wrapper.find(Component).instance() as any).buttonRef.current);
                 done();
             }, 0);
         });

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -180,9 +180,34 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         valueString: null,
     };
 
-    private inputEl: HTMLInputElement | null = null;
+    private getInputRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
+        const { inputProps = {} } = this.props;
+
+        const elementRef = inputProps.inputRef;
+
+        if (
+            elementRef &&
+            !Utils.isFunction(elementRef)
+        ) {
+            this.inputEl = elementRef.current;
+
+            return elementRef;
+        }
+
+        return (ref: HTMLInputElement | null) => {
+            this.inputEl = ref;
+
+            Utils.safeInvoke(elementRef as Utils.IRefCallback<HTMLInputElement>, ref);
+        };
+    };
+
+    private inputEl: HTMLInputElement | Utils.IRefObject<HTMLInputElement> | null = null;
     private popoverContentEl: HTMLElement | null = null;
     private lastElementInPopover: HTMLElement | null = null;
+
+    private refHandlers = {
+        input: this.getInputRefHandler(),
+    };
 
     public componentWillUnmount() {
         super.componentWillUnmount();
@@ -240,7 +265,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
                     type="text"
                     {...inputProps}
                     disabled={this.props.disabled}
-                    inputRef={this.inputRef}
+                    inputRef={this.refHandlers.input}
                     onBlur={this.handleInputBlur}
                     onChange={this.handleInputChange}
                     onClick={this.handleInputClick}
@@ -258,12 +283,6 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             this.setState({ value: this.props.value });
         }
     }
-
-    private inputRef = (ref: HTMLInputElement | null) => {
-        this.inputEl = ref;
-        const { inputProps = {} } = this.props;
-        Utils.safeInvoke(inputProps.inputRef as (ref: HTMLInputElement | null) => any, ref);
-    };
 
     private isDateInRange(value: Date) {
         return isDayInRange(value, [this.props.minDate, this.props.maxDate]);
@@ -393,7 +412,9 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             this.setState({ isOpen: false });
         } else if (e.which === Keys.ESCAPE) {
             this.setState({ isOpen: false });
-            this.inputEl.blur();
+
+            const inputEl = Utils.getRef<HTMLInputElement>(this.inputEl);
+            inputEl.blur();
         }
         this.safeInvokeInputProp("onKeyDown", e);
     };

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -262,7 +262,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
     private inputRef = (ref: HTMLInputElement | null) => {
         this.inputEl = ref;
         const { inputProps = {} } = this.props;
-        Utils.safeInvoke(inputProps.inputRef, ref);
+        Utils.safeInvoke(inputProps.inputRef as (ref: HTMLInputElement | null) => any, ref);
     };
 
     private isDateInRange(value: Date) {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -185,10 +185,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
 
         const elementRef = inputProps.inputRef;
 
-        if (
-            elementRef &&
-            !Utils.isFunction(elementRef)
-        ) {
+        if (elementRef && !Utils.isFunction(elementRef)) {
             this.inputEl = elementRef.current;
 
             return elementRef;

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -229,13 +229,10 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
 
     public static displayName = `${DISPLAYNAME_PREFIX}.DateRangeInput`;
 
-    protected getEndInputRefHandler = (): (Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>) => {
+    protected getEndInputRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
         const elementRef = this.props.endInputProps.inputRef;
 
-        if (
-            elementRef &&
-            !Utils.isFunction(elementRef)
-        ) {
+        if (elementRef && !Utils.isFunction(elementRef)) {
             this.endInputRef = elementRef;
 
             return elementRef;
@@ -248,7 +245,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         };
     };
 
-    protected getStartRefHandler = (): (Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>) => {
+    protected getStartRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
         const elementRef = this.props.startInputProps.inputRef;
 
         if (!Utils.isFunction(elementRef)) {

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -248,7 +248,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
     protected getStartRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
         const elementRef = this.props.startInputProps.inputRef;
 
-        if (!Utils.isFunction(elementRef)) {
+        if (elementRef && !Utils.isFunction(elementRef)) {
             this.startInputRef = elementRef;
 
             return elementRef;
@@ -257,7 +257,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         return (ref: HTMLInputElement) => {
             this.startInputRef = ref;
 
-            Utils.safeInvoke(elementRef, ref);
+            Utils.safeInvoke(elementRef as Utils.IRefCallback<HTMLInputElement>, ref);
         };
     };
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -229,17 +229,46 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
 
     public static displayName = `${DISPLAYNAME_PREFIX}.DateRangeInput`;
 
-    private startInputRef: HTMLInputElement;
-    private endInputRef: HTMLInputElement;
-    private refHandlers = {
-        endInputRef: (ref: HTMLInputElement) => {
+    protected getEndInputRefHandler = (): (Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>) => {
+        const elementRef = this.props.endInputProps.inputRef;
+
+        if (
+            elementRef &&
+            !Utils.isFunction(elementRef)
+        ) {
+            this.endInputRef = elementRef;
+
+            return elementRef;
+        }
+
+        return (ref: HTMLInputElement | null) => {
             this.endInputRef = ref;
-            Utils.safeInvoke(this.props.endInputProps.inputRef as (ref: HTMLInputElement | null) => any, ref);
-        },
-        startInputRef: (ref: HTMLInputElement) => {
+
+            Utils.safeInvoke(elementRef as Utils.IRefCallback<HTMLInputElement>, ref);
+        };
+    };
+
+    protected getStartRefHandler = (): (Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>) => {
+        const elementRef = this.props.startInputProps.inputRef;
+
+        if (!Utils.isFunction(elementRef)) {
+            this.startInputRef = elementRef;
+
+            return elementRef;
+        }
+
+        return (ref: HTMLInputElement) => {
             this.startInputRef = ref;
-            Utils.safeInvoke(this.props.startInputProps.inputRef as (ref: HTMLInputElement | null) => any, ref);
-        },
+
+            Utils.safeInvoke(elementRef, ref);
+        };
+    };
+
+    private startInputRef: HTMLInputElement | Utils.IRefObject<HTMLInputElement>;
+    private endInputRef: HTMLInputElement | Utils.IRefObject<HTMLInputElement>;
+    private refHandlers = {
+        endInputRef: this.getEndInputRefHandler(),
+        startInputRef: this.getStartRefHandler(),
     };
 
     public constructor(props: IDateRangeInputProps, context?: any) {
@@ -266,19 +295,22 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         super.componentDidUpdate(prevProps, prevState, snapshot);
         const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
 
-        const shouldFocusStartInput = this.shouldFocusInputRef(isStartInputFocused, this.startInputRef);
-        const shouldFocusEndInput = this.shouldFocusInputRef(isEndInputFocused, this.endInputRef);
+        const startInputRef = Utils.getRef<HTMLInputElement>(this.startInputRef);
+        const endInputRef = Utils.getRef<HTMLInputElement>(this.endInputRef);
+
+        const shouldFocusStartInput = this.shouldFocusInputRef(isStartInputFocused, startInputRef);
+        const shouldFocusEndInput = this.shouldFocusInputRef(isEndInputFocused, endInputRef);
 
         if (shouldFocusStartInput) {
-            this.startInputRef.focus();
+            startInputRef.focus();
         } else if (shouldFocusEndInput) {
-            this.endInputRef.focus();
+            endInputRef.focus();
         }
 
         if (isStartInputFocused && shouldSelectAfterUpdate) {
-            this.startInputRef.select();
+            startInputRef.select();
         } else if (isEndInputFocused && shouldSelectAfterUpdate) {
-            this.endInputRef.select();
+            endInputRef.select();
         }
 
         let nextState: IDateRangeInputState = {};

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -234,11 +234,11 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
     private refHandlers = {
         endInputRef: (ref: HTMLInputElement) => {
             this.endInputRef = ref;
-            Utils.safeInvoke(this.props.endInputProps.inputRef, ref);
+            Utils.safeInvoke(this.props.endInputProps.inputRef as (ref: HTMLInputElement | null) => any, ref);
         },
         startInputRef: (ref: HTMLInputElement) => {
             this.startInputRef = ref;
-            Utils.safeInvoke(this.props.startInputProps.inputRef, ref);
+            Utils.safeInvoke(this.props.startInputProps.inputRef as (ref: HTMLInputElement | null) => any, ref);
         },
     };
 

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -86,7 +86,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {
             this.input = ref;
-            Utils.safeInvokeMember(this.props.inputProps, "inputRef", ref);
+            Utils.safeInvokeMember(this.props.inputProps as { inputRef: (ref: HTMLInputElement | null) => any }, "inputRef", ref);
         },
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -81,7 +81,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
 
     private TypedQueryList = QueryList.ofType<T>();
 
-    private getInputRefHandler = (): (Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>) => {
+    private getInputRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
         if (!this.props.inputProps?.inputRef) {
             return (ref: HTMLInputElement | null) => {
                 this.input = ref;
@@ -90,10 +90,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
 
         const elementRef = this.props.inputProps.inputRef;
 
-        if (
-            elementRef &&
-            !Utils.isFunction(elementRef)
-        ) {
+        if (elementRef && !Utils.isFunction(elementRef)) {
             this.input = elementRef;
 
             return elementRef;

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -86,7 +86,11 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {
             this.input = ref;
-            Utils.safeInvokeMember(this.props.inputProps as { inputRef: (ref: HTMLInputElement | null) => any }, "inputRef", ref);
+            Utils.safeInvokeMember(
+                this.props.inputProps as { inputRef: (ref: HTMLInputElement | null) => any },
+                "inputRef",
+                ref,
+            );
         },
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -111,7 +111,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
         selectedItem: this.getInitialSelectedItem(),
     };
 
-    private getInputRefHandler = (): (Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>) => {
+    private getInputRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
         if (!this.props.inputProps?.inputRef) {
             return (ref: HTMLInputElement | null) => {
                 this.input = ref;
@@ -120,10 +120,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
         const elementRef = this.props.inputProps.inputRef;
 
-        if (
-            elementRef &&
-            !Utils.isFunction(elementRef)
-        ) {
+        if (elementRef && !Utils.isFunction(elementRef)) {
             this.input = elementRef;
 
             return elementRef;

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -117,7 +117,11 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {
             this.input = ref;
-            Utils.safeInvokeMember(this.props.inputProps as { inputRef: (ref: HTMLInputElement | null) => any }, "inputRef", ref);
+            Utils.safeInvokeMember(
+                this.props.inputProps as { inputRef: (ref: HTMLInputElement | null) => any },
+                "inputRef",
+                ref,
+            );
         },
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -117,7 +117,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     private refHandlers = {
         input: (ref: HTMLInputElement | null) => {
             this.input = ref;
-            Utils.safeInvokeMember(this.props.inputProps, "inputRef", ref);
+            Utils.safeInvokeMember(this.props.inputProps as { inputRef: (ref: HTMLInputElement | null) => any }, "inputRef", ref);
         },
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };


### PR DESCRIPTION
#### Fixes #4064 

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
Add support for `callback ref` and `ref hook` for `Button`, `Anchor Button` and `InputGroup`

#### Reviewers should focus on:

<!-- Fill this out. -->
Typing for the props(`elementRef`, `inputRef`)