### PR TITLE
Add vertical padding to "Tag" component for large style

### DIFF
--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -12,6 +12,7 @@ $tag-margin: ($pt-input-height - $tag-height) / 2 !default;
 
 $tag-height-large: $pt-grid-size * 3 !default;
 $tag-line-height-large: $pt-icon-size-large !default;
+$tag-padding-large-top: ($tag-height-large - $tag-line-height-large) / 2 !default;
 $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 
 $tag-icon-spacing: ($tag-height - 12px) / 2 !default;
@@ -70,7 +71,7 @@ $tag-round-adjustment: 2px !default;
   line-height: $tag-line-height-large;
   min-height: $tag-height-large;
   min-width: $tag-height-large;
-  padding: 0 $tag-padding-large;
+  padding: $tag-padding-large-top $tag-padding-large;
 
   &.#{$ns}-round {
     padding-left: $tag-padding-large + $tag-round-adjustment;

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -12,7 +12,6 @@ $tag-margin: ($pt-input-height - $tag-height) / 2 !default;
 
 $tag-height-large: $pt-grid-size * 3 !default;
 $tag-line-height-large: $pt-icon-size-large !default;
-$tag-padding-large-top: ($tag-height-large - $tag-line-height-large) / 2 !default;
 $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 
 $tag-icon-spacing: ($tag-height - 12px) / 2 !default;
@@ -71,7 +70,7 @@ $tag-round-adjustment: 2px !default;
   line-height: $tag-line-height-large;
   min-height: $tag-height-large;
   min-width: $tag-height-large;
-  padding: $tag-padding-large-top $tag-padding-large;
+  padding: ($tag-padding-large / 2) $tag-padding-large;
 
   &.#{$ns}-round {
     padding-left: $tag-padding-large + $tag-round-adjustment;


### PR DESCRIPTION
#### Fixes #4037 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Add vertical padding to "Tag" component for large style

#### Reviewers should focus on:

Ratio between horizontal and vertical padding value should be decided. For default style, the ratio  between horizontal and vertical padding is 3 to 2. However, I followed 2 to 1 ratio for large style which is the current ratio for single line large tags.

#### Screenshot

There is no visual change for single line content.

For multiline content, the old version is:
![image](https://user-images.githubusercontent.com/26118454/80418018-6d3cb100-88df-11ea-91e7-dd098bb4cd2f.png)
The updated version for multiline content is:
![image](https://user-images.githubusercontent.com/26118454/80417956-4e3e1f00-88df-11ea-9fdb-1dd8b7d33a0e.png)
