### PR TITLE
Add a docs-theme table for rendering methods

### DIFF
--- a/packages/docs-data/compile-docs-data.js
+++ b/packages/docs-data/compile-docs-data.js
@@ -80,8 +80,7 @@ function transformDocumentalistData(key, value) {
         // reverse the list so highest version is first (easier indexing)
         return Array.from(majors.values()).reverse();
     }
-    // remove all class declarations as they're currently unused and only increase bundle size
-    if (value != null && value.kind !== "class") {
+    if (value != null) {
         return replaceNS(value);
     }
     return undefined;

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,15 +24,23 @@ export interface IModifierTableProps {
 
     /** Title of the first column, describing the type of each row in the table. */
     title: string;
+
+    /** Title of the second column */
+    descriptionTitle?: string;
 }
 
-export const ModifierTable: React.SFC<IModifierTableProps> = ({ children, emptyMessage, title }) => (
+export const ModifierTable: React.SFC<IModifierTableProps> = ({
+    children,
+    descriptionTitle = "Description",
+    emptyMessage,
+    title,
+}) => (
     <div className={classNames("docs-modifiers-table", Classes.RUNNING_TEXT)}>
         <HTMLTable>
             <thead>
                 <tr>
                     <th>{title}</th>
-                    <th>Description</th>
+                    <th>{descriptionTitle}</th>
                 </tr>
             </thead>
             <tbody>{isEmpty(children) ? renderEmptyState(emptyMessage) : children}</tbody>

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/docs-theme/src/components/typescript/methodTable.tsx
+++ b/packages/docs-theme/src/components/typescript/methodTable.tsx
@@ -1,0 +1,130 @@
+/*!
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Code, Intent, IProps, Tag } from "@blueprintjs/core";
+import { isTag, ITsMethod, ITsParameter, ITsSignature } from "@documentalist/client";
+import classNames from "classnames";
+import * as React from "react";
+import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";
+import { ModifierTable } from "../modifierTable";
+import { ApiHeader } from "./apiHeader";
+import { DeprecatedTag } from "./deprecatedTag";
+
+export type Renderer<T> = (props: T) => React.ReactNode;
+
+export interface IMethodTableProps extends IProps {
+    data: ITsMethod;
+}
+
+// tslint:disable:blueprint-html-components - rendered inside RUNNING_TEXT
+export class MethodTable extends React.PureComponent<IMethodTableProps> {
+    public static contextTypes = DocumentationContextTypes;
+    public static displayName = "Docs2.MethodTable";
+
+    public context: IDocumentationContext;
+
+    public render() {
+        const { data } = this.props;
+        const propRows = [...data.signatures]
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((entry: ITsSignature) => entry.parameters.map(parameter => this.renderPropRow(parameter)));
+        return (
+            <div className={classNames("docs-modifiers", this.props.className)}>
+                <ApiHeader {...data} />
+                <ModifierTable emptyMessage="No return" title="Returns" descriptionTitle="">
+                    {this.renderReturnSignature(data.signatures[0])}
+                </ModifierTable>
+                <ModifierTable emptyMessage="This parameter is empty." title="Parameters">
+                    {propRows}
+                </ModifierTable>
+            </div>
+        );
+    }
+
+    private renderPropRow = (parameter: ITsParameter) => {
+        const { renderBlock, renderType } = this.context;
+        const {
+            flags: { isDeprecated, isExternal, isOptional },
+            name,
+        } = parameter;
+        const { documentation } = parameter;
+
+        // ignore props marked with `@internal` tag (this tag is in contents instead of in flags)
+        if (
+            documentation != null &&
+            documentation.contents != null &&
+            documentation.contents.some(val => isTag(val) && val.tag === "internal")
+        ) {
+            return null;
+        }
+
+        const classes = classNames("docs-prop-name", {
+            "docs-prop-is-deprecated": isDeprecated === true || typeof isDeprecated === "string",
+            "docs-prop-is-internal": !isExternal,
+            "docs-prop-is-required": !isOptional,
+        });
+
+        const typeInfo = (
+            <>
+                <strong>{renderType(parameter.type)}</strong>
+            </>
+        );
+
+        return (
+            <tr key={name}>
+                <td className={classes}>
+                    <Code>{name}</Code>
+                </td>
+                <td className="docs-prop-details">
+                    <Code className="docs-prop-type">{typeInfo}</Code>
+                    <div className="docs-prop-description">{renderBlock(documentation)}</div>
+                    <div className="docs-prop-tags">{this.renderTags(parameter)}</div>
+                </td>
+            </tr>
+        );
+    };
+
+    private renderTags(entry: ITsParameter) {
+        const {
+            flags: { isDeprecated, isOptional },
+        } = entry;
+        return (
+            <>
+                {!isOptional && <Tag children="Required" intent={Intent.SUCCESS} minimal={true} />}
+                <DeprecatedTag isDeprecated={isDeprecated} />
+            </>
+        );
+    }
+
+    private renderReturnSignature(entry?: ITsSignature) {
+        if (entry == null) {
+            return null;
+        }
+        const { renderBlock, renderType } = this.context;
+        const { returnType } = entry;
+
+        return (
+            <tr key={name}>
+                <td className="docs-prop-name">
+                    <Code className="docs-prop-type">{renderType(returnType)}</Code>
+                </td>
+                <td className="docs-prop-details">
+                    <div className="docs-prop-description">{renderBlock(entry.documentation)}</div>
+                </td>
+            </tr>
+        );
+    }
+}

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import { ITag } from "@documentalist/client";
 import * as React from "react";
 import { CssExample } from "./css";
 import { Heading } from "./heading";
+import { Method } from "./method";
 import { SeeTag } from "./see";
 import { TypescriptExample } from "./typescript";
 
@@ -26,6 +27,7 @@ export function createDefaultRenderers(): Record<string, React.ComponentType<ITa
         css: CssExample,
         heading: Heading,
         interface: TypescriptExample,
+        method: Method,
         page: () => null,
         see: SeeTag,
     };

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/docs-theme/src/tags/index.ts
+++ b/packages/docs-theme/src/tags/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ export interface ITagRendererMap {
 export * from "./css";
 export * from "./defaults";
 export * from "./heading";
+export * from "./method";
 export * from "./reactDocs";
 export * from "./reactExample";
 export * from "./see";

--- a/packages/docs-theme/src/tags/index.ts
+++ b/packages/docs-theme/src/tags/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import { IProps } from "@blueprintjs/core";
-import { isTsMethod, ITag, ITypescriptPluginData } from "@documentalist/client";
+import { isTsClass, isTsMethod, ITag, ITsClass, ITypescriptPluginData } from "@documentalist/client";
 import * as React from "react";
 import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
 import { MethodTable } from "../components/typescript/methodTable";
@@ -23,7 +23,17 @@ import { MethodTable } from "../components/typescript/methodTable";
 export const Method: React.SFC<ITag & IProps> = ({ className, value }, { getDocsData }: IDocumentationContext) => {
     const { typescript } = getDocsData() as ITypescriptPluginData;
     const member = typescript[value];
+
     if (member === undefined) {
+        const possibleClass = value.split(".")[0];
+        const possibleClassMethod = value.split(".")[1];
+        const classMember = typescript[possibleClass] as ITsClass;
+        if (isTsClass(classMember) && possibleClassMethod) {
+            const classMethod = classMember.methods.find(method => method.name === possibleClassMethod);
+            if (isTsMethod(classMethod)) {
+                return <MethodTable className={className} data={classMethod} />;
+            }
+        }
         throw new Error(`Unknown @method ${name}`);
     } else if (isTsMethod(member)) {
         return <MethodTable className={className} data={member} />;

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IProps } from "@blueprintjs/core";
+import { isTsMethod, ITag, ITypescriptPluginData } from "@documentalist/client";
+import * as React from "react";
+import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
+import { MethodTable } from "../components/typescript/methodTable";
+
+export const Method: React.SFC<ITag & IProps> = ({ className, value }, { getDocsData }: IDocumentationContext) => {
+    const { typescript } = getDocsData() as ITypescriptPluginData;
+    const member = typescript[value];
+    if (member === undefined) {
+        throw new Error(`Unknown @method ${name}`);
+    } else if (isTsMethod(member)) {
+        return <MethodTable className={className} data={member} />;
+    } else {
+        throw new Error(`"@method ${name}": unknown member kind "${(member as any).kind}"`);
+    }
+};
+Method.contextTypes = DocumentationContextTypes;
+Method.displayName = "Docs2.Method";

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
  *

--- a/packages/table/src/docs/table-api.md
+++ b/packages/table/src/docs/table-api.md
@@ -16,66 +16,22 @@ number of rows (`numRows` prop) as well as a set of `Column` children.
 
 @### Instance methods
 
-- `resizeRowsByTallestCell(columnIndices?: number | number[]): void` &ndash; Resizes all rows in the
-    table to the height of the tallest visible cell in the specified columns. If no indices are
-    provided, defaults to using the tallest visible cell from all columns in view.
-- `resizeRowsByApproximateHeight(getCellText?: ICellMapper<string>, options?: IResizeRowsByApproximateHeightOptions)`
-    &ndash; __Experimental!__ Resizes every row in the table to fit its
-    maximum-height cell content. Since rows in view are the only ones present in
-    the DOM, this method merely _approximates_ the height of cell content based
-    on average letter width and line height.
 
-    This has two implications: (1) results are best when each cell contains plain
-    text with an internally consistent style, and (2) results may not be perfect.
+@method Table.resizeRowsByTallestCell
 
-    Approximation parameters can be configured for the entire table or on a
-    per-cell basis. Default values are fine-tuned to work well with default
-    `Table` font styles. Here are the available options:
+@method Table.resizeRowsByApproximateHeight
 
-    ```tsx
-interface IResizeRowsByApproximateHeightOptions {
-    /**
-     * Approximate width (in pixels) of an average character of text.
-     */
-    getApproximateCharWidth?: number | ICellMapper<number>;
 
-    /**
-     * Approximate height (in pixels) of an average line of text.
-     */
-    getApproximateLineHeight?: number | ICellMapper<number>;
+`ICellMapper` is just a function that takes a cell-coordinate and returns a generic type:
 
-    /**
-     * Sum of horizontal paddings (in pixels) from the left __and__ right sides
-     * of the cell.
-     */
-    getCellHorizontalPadding?: number | ICellMapper<number>;
 
-    /**
-     * Number of extra lines to add in case the calculation is imperfect.
-     */
-    getNumBufferLines?: number | ICellMapper<number>;
-}
-    ```
 
-    `ICellMapper` is just a function that takes a cell-coordinate and returns a generic type:
+```tsx
+type ICellMapper<T> = (rowIndex: number, columnIndex: number) => T;
+```
 
-    ```tsx
-    type ICellMapper<T> = (rowIndex: number, columnIndex: number) => T;
-    ```
 
-- `scrollToRegion(region: IRegion): void` &ndash; Scrolls the table to the target [region](#table/api.region) in a
-   fashion appropriate to the target region's cardinality:
-    - `CELLS`: Scroll the top-left cell in the target region to the top-left corner of the viewport.
-    - `FULL_ROWS`: Scroll the top-most row in the target region to the top of the viewport.
-    - `FULL_COLUMNS`: Scroll the left-most column in the target region to the left side of the viewport.
-    - `FULL_TABLE`: Scroll the top-left cell in the table to the top-left corner of the viewport.
-
-  If there are active frozen rows and/or columns, the target region will be positioned in the top-left
-  corner of the non-frozen area (unless the target region itself is in the frozen area).
-
-  If the target region is close to the bottom-right corner of the table, this function will simply
-  scroll the target region as close to the top-left as possible until the bottom-right corner is
-  reached.
+@method Table.scrollToRegion
 
 @## Column
 
@@ -215,6 +171,7 @@ const cardinalities = [
 ];
 ```
 
+@method Regions.getRegionCardinality
 
 @## TruncatedFormat
 


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Add a table to docs-theme render methods

Use a @method tag to render methods

#### Reviewers should focus on:

Similar functionality to the interface table but for methods

#### Screenshot

Before:

<img width="802" alt="Screen Shot 2020-05-22 at 11 19 17" src="https://user-images.githubusercontent.com/65172332/82660543-78ef6f00-9c22-11ea-9755-8da4a92f5390.png">

After:

<img width="837" alt="Screen Shot 2020-05-22 at 11 47 03" src="https://user-images.githubusercontent.com/65172332/82660577-860c5e00-9c22-11ea-9b55-d95792773691.png">

