### PR TITLE
Update MultiSelect Popover target-click work-around for controlled usage

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -184,11 +184,12 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             if (this.input != null && this.input !== document.activeElement) {
                 // the input is no longer focused so we can close the popover
                 this.setState({ isOpen: false });
+                Utils.safeInvokeMember(this.props.popoverProps, "onInteraction", false);
             } else if (!this.props.openOnKeyDown) {
                 // open the popover when focusing the tag input
                 this.setState({ isOpen: true });
+                Utils.safeInvokeMember(this.props.popoverProps, "onInteraction", true);
             }
-            Utils.safeInvokeMember(this.props.popoverProps, "onInteraction", nextOpenState);
         });
 
     private handlePopoverOpened = (node: HTMLElement) => {


### PR DESCRIPTION
MultiSelect is backed by Popover, which closes itself whenever the `target` is clicked:
https://github.com/palantir/blueprint/blob/a98ac28dc5079a728fa40d8c4d31faa98b569001/packages/core/src/components/popover/popover.tsx#L518-L528

For a MultiSelect, the `target` is the search input.
Uncontrolled usage is protected by a check against the `activeElement` before changing state. Controlled usage (specifically, the call to `onInteraction`) does not have this protection.