### PR TITLE
Add control of hasBackdrop prop in Dialog

### DIFF
--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -33,12 +33,6 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
     isOpen: boolean;
 
     /**
-     * Dialog always has a backdrop so this prop is excluded from the public API.
-     * @internal
-     */
-    hasBackdrop?: boolean;
-
-    /**
      * Name of a Blueprint UI icon (or an icon element) to render in the
      * dialog's header. Note that the header will only be rendered if `title` is
      * provided.
@@ -76,13 +70,14 @@ export class Dialog extends AbstractPureComponent2<IDialogProps, {}> {
     public static defaultProps: IDialogProps = {
         canOutsideClickClose: true,
         isOpen: false,
+        hasBackdrop: true,
     };
 
     public static displayName = `${DISPLAYNAME_PREFIX}.Dialog`;
 
     public render() {
         return (
-            <Overlay {...this.props} className={Classes.OVERLAY_SCROLL_CONTAINER} hasBackdrop={true}>
+            <Overlay {...this.props} className={Classes.OVERLAY_SCROLL_CONTAINER}>
                 <div className={Classes.DIALOG_CONTAINER}>
                     <div className={classNames(Classes.DIALOG, this.props.className)} style={this.props.style}>
                         {this.maybeRenderHeader()}

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -69,8 +69,8 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
 export class Dialog extends AbstractPureComponent2<IDialogProps, {}> {
     public static defaultProps: IDialogProps = {
         canOutsideClickClose: true,
-        isOpen: false,
         hasBackdrop: true,
+        isOpen: false,
     };
 
     public static displayName = `${DISPLAYNAME_PREFIX}.Dialog`;

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -27,6 +27,7 @@ export interface IDialogExampleState {
     enforceFocus: boolean;
     isOpen: boolean;
     usePortal: boolean;
+    hasBackdrop: boolean;
 }
 export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IDialogExampleState> {
     public state: IDialogExampleState = {
@@ -36,6 +37,7 @@ export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintE
         enforceFocus: true,
         isOpen: false,
         usePortal: true,
+        hasBackdrop: true,
     };
 
     private handleAutoFocusChange = handleBooleanChange(autoFocus => this.setState({ autoFocus }));
@@ -43,6 +45,7 @@ export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintE
     private handleEscapeKeyChange = handleBooleanChange(canEscapeKeyClose => this.setState({ canEscapeKeyClose }));
     private handleUsePortalChange = handleBooleanChange(usePortal => this.setState({ usePortal }));
     private handleOutsideClickChange = handleBooleanChange(val => this.setState({ canOutsideClickClose: val }));
+    private handleHashBackdropChange = handleBooleanChange(hasBackdrop => this.setState({ hasBackdrop }));
 
     public render() {
         return (
@@ -103,7 +106,7 @@ export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintE
     }
 
     private renderOptions() {
-        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, usePortal } = this.state;
+        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, usePortal, hasBackdrop } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -118,6 +121,7 @@ export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintE
                     onChange={this.handleOutsideClickChange}
                 />
                 <Switch checked={canEscapeKeyClose} label="Escape key to close" onChange={this.handleEscapeKeyChange} />
+                <Switch checked={hasBackdrop} label="Has backdrop" onChange={this.handleHashBackdropChange} />
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -35,9 +35,9 @@ export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintE
         canEscapeKeyClose: true,
         canOutsideClickClose: true,
         enforceFocus: true,
+        hasBackdrop: true,
         isOpen: false,
         usePortal: true,
-        hasBackdrop: true,
     };
 
     private handleAutoFocusChange = handleBooleanChange(autoFocus => this.setState({ autoFocus }));


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

Sometimes I want to reuse Dialog component but without a backdrop.  
I even don't understand why dialog is required to have it 

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/10484318/81740851-4ae19080-94a6-11ea-84d9-7c85ff02a2c3.png">

