### PR TITLE
Add trackStyleBefore and trackStyleAfter to MultiSlider.Handle (#4116)

### DIFF
--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -54,7 +54,7 @@ export interface IHandleProps extends IProps {
     /** Intent for the track segment immediately before this handle. */
     intentBefore?: Intent;
 
-    /** Style to use for the track segment immediately after this handle, taking priority over trackStyleBefore */
+    /** Style to use for the track segment immediately after this handle, taking priority over `trackStyleBefore`. */
     trackStyleAfter?: React.CSSProperties;
 
     /** Style to use for the track segment immediately before this handle */

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Intent, IProps } from "../../common";
+import * as React from "react";
 
 export const HandleType = {
     /** A full handle appears as a small square. */
@@ -52,6 +53,12 @@ export interface IHandleProps extends IProps {
 
     /** Intent for the track segment immediately before this handle. */
     intentBefore?: Intent;
+
+    /** Style to use for the track segment immediately after this handle, taking priority over trackStyleBefore */
+    trackStyleAfter?: React.CSSProperties;
+
+    /** Style to use for the track segment immediately before this handle */
+    trackStyleBefore?: React.CSSProperties;
 
     /**
      * How this handle interacts with other handles.

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Intent, IProps } from "../../common";
 import * as React from "react";
+import { Intent, IProps } from "../../common";
 
 export const HandleType = {
     /** A full handle appears as a small square. */

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -271,9 +271,14 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         );
         const startOffset = formatPercentage(startRatio);
         const endOffset = formatPercentage(1 - endRatio);
-        const style: React.CSSProperties = this.props.vertical
+        const orientationStyle: React.CSSProperties = this.props.vertical
             ? { bottom: startOffset, top: endOffset, left: 0 }
             : { left: startOffset, right: endOffset, top: 0 };
+
+        const style: React.CSSProperties = {
+            ...orientationStyle,
+            ...(start.trackStyleAfter || end.trackStyleBefore || {}),
+        };
 
         const classes = classNames(Classes.SLIDER_PROGRESS, Classes.intentClass(this.getTrackIntent(start, end)));
         return <div key={`track-${index}`} className={classes} style={style} />;

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -261,6 +261,31 @@ describe("<MultiSlider>", () => {
                 ["20.00%", "0.00%"],
             ]);
         });
+
+        it("trackStyleBefore and trackStyleAfter work as intended", () => {
+            slider = mount(
+                <MultiSlider>
+                    <MultiSlider.Handle
+                        value={1}
+                        trackStyleBefore={{ background: "red" }}
+                        trackStyleAfter={{ background: "yellow" }}
+                    />
+                    <MultiSlider.Handle
+                        value={2}
+                        trackStyleBefore={{ background: "blue" }}
+                        trackStyleAfter={{ background: "purple" }}
+                    />
+                </MultiSlider>,
+            );
+
+            const trackBackgrounds = slider
+                .find(`.${Classes.SLIDER_PROGRESS}`)
+                .map(segment => segment.prop("style").background);
+
+            assert.equal(trackBackgrounds[0], "red");
+            assert.equal(trackBackgrounds[1], "yellow");
+            assert.equal(trackBackgrounds[2], "purple");
+        });
     });
 
     describe("validation", () => {


### PR DESCRIPTION
#### Fixes #4116

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Add the following props to `MultiSlider.Handle`:
- `trackStyleBefore?: React.CSSProperties` 
- `trackStyleAfter?: React.CSSProperties` (takes prescedence over trackStyleBefore)

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://user-images.githubusercontent.com/410028/82255020-3133c380-9954-11ea-864c-99a385efe307.png)
![image](https://user-images.githubusercontent.com/410028/82255033-38f36800-9954-11ea-9b95-c56f7eda1ebf.png)


