### PR TITLE
Only create new item on keyup if it follows a keydown to work around …

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -131,14 +131,15 @@ export interface IQueryListState<T> {
     /** The original `items` array filtered by `itemListPredicate` or `itemPredicate`. */
     filteredItems: T[];
 
-    /** The current query string. */
-    query: string;
-
-    /** Whether the previous key-down event was for the enter key. This allows us to create new items on enter key KeyUp
+    /**
+     * Whether the previous key-down event was for the enter key. This allows us to create new items on enter key KeyUp
      * IFF it follows an enter key KeyDown, which allows us to avoid accidentally creating a new item on the key-up event
      * following IME character selection confirmation. (https://github.com/palantir/blueprint/issues/4128)
      */
     previousKeyDownWasEnter: boolean;
+
+    /** The current query string. */
+    query: string;
 }
 
 export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryListState<T>> {
@@ -186,8 +187,8 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                     : props.initialActiveItem ?? getFirstEnabledItem(filteredItems, props.itemDisabled),
             createNewItem,
             filteredItems,
-            query,
             previousKeyDownWasEnter: false,
+            query,
         };
     }
 


### PR DESCRIPTION
#### Fixes #4128

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Only create a new item on enter key key-up if it follows an enter key key-down directly.

#### Reviewers should focus on:

Whether there are any keyboard-input situations in which this change introduces a regression.

#### Screenshot

Before (notice that confirming input immediately creates a new item):

![broken-japanese-input](https://user-images.githubusercontent.com/8685581/82399204-904a2300-9a8f-11ea-9277-0c03cfd271b3.gif)

After (notice that an explicit enter key-press is necessary after confirming input to create a new item, as is the desired behavior):

![fixed-japanese-input](https://user-images.githubusercontent.com/8685581/82399216-9b9d4e80-9a8f-11ea-852f-5e42d5374bcb.gif)




