### PR TITLE
 [select] fix(MultiSelect): create new item with IME 

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -166,6 +166,25 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
      */
     private expectedNextActiveItem: T | ICreateNewItem | null = null;
 
+    /**
+     * Flag which is set to true while in between a "keydown" event and its
+     * corresponding "keyup" event.
+     *
+     * N.B. This is distinct from a "keypress" event, which we are in
+     * uninterested in since we care about all keys, not just those which
+     * produce character outputs.
+     *
+     * When entering text via an IME (https://en.wikipedia.org/wiki/Input_method),
+     * the enter key is pressed to confirm the character(s) to be input from a list
+     * of options. The operating system intercepts the ENTER "keydown" event and
+     * prevents it from propagating to the application, but "keyup" is still
+     * fired, triggering a spurious event which this component does not expect.
+     *
+     * To work around this quirk, we keep track of "real" key presses by setting
+     * this flag in handleKeyDown.
+     */
+    private isKeyPressed = false;
+
     public constructor(props: IQueryListProps<T>, context?: any) {
         super(props, context);
 
@@ -469,16 +488,19 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                 this.setActiveItem(nextActiveItem);
             }
         }
+
+        this.isKeyPressed = true;
         Utils.safeInvoke(this.props.onKeyDown, event);
     };
 
     private handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
         const { onKeyUp } = this.props;
         const { activeItem } = this.state;
-        // using keyup for enter to play nice with Button's keyboard clicking.
-        // if we were to process enter on keydown, then Button would click itself on keyup
-        // and the popvoer would re-open out of our control :(.
-        if (event.keyCode === Keys.ENTER) {
+        // We handle ENTER in keyup here to play nice with the Button component's keyboard
+        // clicking. Button is commonly used as the only child of Select. If we were to
+        // instead process ENTER on keydown, then Button would click itself on keyup and
+        // the Select popover would re-open.
+        if (this.isKeyPressed && event.keyCode === Keys.ENTER) {
             event.preventDefault();
             if (activeItem == null || isCreateNewItem(activeItem)) {
                 this.handleItemCreate(this.state.query, event);
@@ -486,6 +508,8 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                 this.handleItemSelect(activeItem, event);
             }
         }
+
+        this.isKeyPressed = false;
         Utils.safeInvoke(onKeyUp, event);
     };
 

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -167,15 +167,11 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     private expectedNextActiveItem: T | ICreateNewItem | null = null;
 
     /**
-     * Flag which is set to true while in between a "keydown" event and its
+     * Flag which is set to true while in between an ENTER "keydown" event and its
      * corresponding "keyup" event.
      *
-     * N.B. This is distinct from a "keypress" event, which we are in
-     * uninterested in since we care about all keys, not just those which
-     * produce character outputs.
-     *
      * When entering text via an IME (https://en.wikipedia.org/wiki/Input_method),
-     * the enter key is pressed to confirm the character(s) to be input from a list
+     * the ENTER key is pressed to confirm the character(s) to be input from a list
      * of options. The operating system intercepts the ENTER "keydown" event and
      * prevents it from propagating to the application, but "keyup" is still
      * fired, triggering a spurious event which this component does not expect.
@@ -183,7 +179,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
      * To work around this quirk, we keep track of "real" key presses by setting
      * this flag in handleKeyDown.
      */
-    private isKeyPressed = false;
+    private isEnterKeyPressed = false;
 
     public constructor(props: IQueryListProps<T>, context?: any) {
         super(props, context);
@@ -487,29 +483,31 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             if (nextActiveItem != null) {
                 this.setActiveItem(nextActiveItem);
             }
+        } else if (keyCode === Keys.ENTER) {
+            this.isEnterKeyPressed = true;
         }
 
-        this.isKeyPressed = true;
         Utils.safeInvoke(this.props.onKeyDown, event);
     };
 
     private handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
         const { onKeyUp } = this.props;
         const { activeItem } = this.state;
-        // We handle ENTER in keyup here to play nice with the Button component's keyboard
-        // clicking. Button is commonly used as the only child of Select. If we were to
-        // instead process ENTER on keydown, then Button would click itself on keyup and
-        // the Select popover would re-open.
-        if (this.isKeyPressed && event.keyCode === Keys.ENTER) {
+
+        if (event.keyCode === Keys.ENTER && this.isEnterKeyPressed) {
+            // We handle ENTER in keyup here to play nice with the Button component's keyboard
+            // clicking. Button is commonly used as the only child of Select. If we were to
+            // instead process ENTER on keydown, then Button would click itself on keyup and
+            // the Select popover would re-open.
             event.preventDefault();
             if (activeItem == null || isCreateNewItem(activeItem)) {
                 this.handleItemCreate(this.state.query, event);
             } else {
                 this.handleItemSelect(activeItem, event);
             }
+            this.isEnterKeyPressed = false;
         }
 
-        this.isKeyPressed = false;
         Utils.safeInvoke(onKeyUp, event);
     };
 

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -145,6 +145,7 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
 
         it("enter invokes onItemSelect with active item", () => {
             const wrapper = render(testProps);
+            findInput(wrapper).simulate("keydown", { keyCode: Keys.ENTER });
             findInput(wrapper).simulate("keyup", { keyCode: Keys.ENTER });
             const activeItem = testProps.onActiveItemChange.lastCall.args[0];
             assert.equal(testProps.onItemSelect.lastCall.args[0], activeItem);


### PR DESCRIPTION
#### Fixes #4128

thanks to @AaronJRubin for the proposal in #4134... this is a slightly different implementation which avoids using `this.state` since this boolean flag shouldn't cause a re-render of the component

#### Checklist

- [x] Includes tests
- N/A ~Update documentation~

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->


