### PR TITLE
chore: refactor ref handler changes from #4093

### DIFF
--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -26,6 +26,7 @@ export * from "./elevation";
 export * from "./intent";
 export * from "./position";
 export * from "./props";
+export * from "./refs";
 
 import * as Classes from "./classes";
 import * as Keys from "./keys";

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -39,7 +39,7 @@ import * as Utils from "./utils";
  * export around for backwards compatibility.
  * @see https://github.com/palantir/blueprint/pull/4140
  */
-const UtilsWithRefUtils = { ...Utils, getRef };
+(Utils as any).getRef = getRef;
 
-export { Classes, Keys, UtilsWithRefUtils as Utils };
+export { Classes, Keys, Utils };
 // NOTE: Errors is not exported in public API

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -30,7 +30,16 @@ export * from "./refs";
 
 import * as Classes from "./classes";
 import * as Keys from "./keys";
+import { getRef } from "./refs";
 import * as Utils from "./utils";
 
-export { Classes, Keys, Utils };
+/**
+ * Utils.getRef() was added to the public API in @blueprintjs/core@3.27.0,
+ * but ref utils were refactored in the next version. We keep this additional
+ * export around for backwards compatibility.
+ * @see https://github.com/palantir/blueprint/pull/4140
+ */
+const UtilsWithRefUtils = { ...Utils, getRef };
+
+export { Classes, Keys, UtilsWithRefUtils as Utils };
 // NOTE: Errors is not exported in public API

--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -21,13 +21,13 @@ export interface IRefObject<T = HTMLElement> {
     readonly current: T | null;
 }
 
-export function isRefObject<T extends U, U = HTMLElement>(value: IRef<U> | undefined): value is IRefObject<T> {
+export function isRefObject<T extends HTMLElement>(value: IRef<T> | undefined | null): value is IRefObject<T> {
     return value != null && typeof (value as IRefObject<T>).current !== "undefined";
 }
 
 export type IRefCallback<T = HTMLElement> = (ref: T | null) => any;
 
-export function isRefCallback<T extends U, U = HTMLElement>(value: IRef<U> | undefined): value is IRefCallback<T> {
+export function isRefCallback<T extends HTMLElement>(value: IRef<T> | undefined): value is IRefCallback<T> {
     return typeof value === "function";
 }
 

--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -17,17 +17,17 @@
 export type IRef<T = HTMLElement> = IRefObject<T> | IRefCallback<T>;
 
 // compatible with React.Ref type in @types/react@^16
-export interface IRefObject<T> {
+export interface IRefObject<T = HTMLElement> {
     readonly current: T | null;
 }
 
-export function isRefObject<T>(value: IRef<T>): value is IRefObject<T> {
+export function isRefObject<T extends U, U = HTMLElement>(value: IRef<U> | undefined): value is IRefObject<T> {
     return value != null && typeof (value as IRefObject<T>).current !== "undefined";
 }
 
 export type IRefCallback<T = HTMLElement> = (ref: T | null) => any;
 
-export function isRefCallback<T>(value: IRef<T>): value is IRefCallback<T> {
+export function isRefCallback<T extends U, U = HTMLElement>(value: IRef<U> | undefined): value is IRefCallback<T> {
     return typeof value === "function";
 }
 

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -20,4 +20,3 @@ export * from "./functionUtils";
 export * from "./jsUtils";
 export * from "./reactUtils";
 export * from "./safeInvokeMember";
-export * from "./refUtils";

--- a/packages/core/src/common/utils/refUtils.ts
+++ b/packages/core/src/common/utils/refUtils.ts
@@ -14,16 +14,24 @@
  * limitations under the License.
  */
 
-export type IRef<T> = IRefObject<T> | IRefCallback<T>;
+export type IRef<T = HTMLElement> = IRefObject<T> | IRefCallback<T>;
 
 // compatible with React.Ref type in @types/react@^16
 export interface IRefObject<T> {
     readonly current: T | null;
 }
 
-export type IRefCallback<T> = (ref: T | null) => any;
+export function isRefObject<T>(value: IRef<T>): value is IRefObject<T> {
+    return value != null && typeof (value as IRefObject<T>).current !== "undefined";
+}
 
-export function getRef<T>(ref: T | IRefObject<T>) {
+export type IRefCallback<T = HTMLElement> = (ref: T | null) => any;
+
+export function isRefCallback<T>(value: IRef<T>): value is IRefCallback<T> {
+    return typeof value === "function";
+}
+
+export function getRef<T = HTMLElement>(ref: T | IRefObject<T>) {
     if (ref && (ref as IRefObject<T>).current) {
         return (ref as IRefObject<T>).current;
     }

--- a/packages/core/src/common/utils/refUtils.ts
+++ b/packages/core/src/common/utils/refUtils.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+export type IRef<T> = IRefObject<T> | IRefCallback<T>;
+
+// compatible with React.Ref type in @types/react@^16
 export interface IRefObject<T> {
     readonly current: T | null;
 }

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -39,7 +39,7 @@ export interface IButtonProps extends IActionProps {
     alignText?: Alignment;
 
     /** A ref handler or a ref object that receives the native HTML element backing this component. */
-    elementRef?: Utils.IRefCallback<HTMLElement> | Utils.IRefObject<HTMLElement>;
+    elementRef?: Utils.IRef;
 
     /** Whether this button should expand to fill its container. */
     fill?: boolean;
@@ -86,25 +86,20 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         isActive: false,
     };
 
-    protected getButtonRefHandler = (): Utils.IRefCallback<any> | Utils.IRefObject<any> => {
-        const elementRef = this.props.elementRef as Utils.IRefCallback<HTMLElement> | Utils.IRefObject<HTMLElement>;
-
-        if (elementRef && !Utils.isFunction(elementRef)) {
-            this.buttonRef = elementRef;
-
-            return elementRef;
-        }
-
-        return (ref: HTMLElement) => {
-            this.buttonRef = ref;
-
-            Utils.safeInvoke(elementRef as Utils.IRefCallback<HTMLElement>, ref);
-        };
-    };
-
     protected buttonRef: HTMLElement | Utils.IRefObject<HTMLElement>;
     protected refHandlers = {
-        button: this.getButtonRefHandler(),
+        button: () => {
+            const { elementRef } = this.props;
+            if (Utils.isRefCallback(elementRef)) {
+                return (ref: HTMLElement) => {
+                    this.buttonRef = ref;
+                    elementRef(ref);
+                };
+            } else if (Utils.isRefObject(elementRef)) {
+                this.buttonRef = elementRef;
+                return elementRef;
+            }
+        },
     };
 
     private currentKeyDown: number = null;

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -17,7 +17,18 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Alignment, Classes, IActionProps, Keys, MaybeElement, Utils } from "../../common";
+import {
+    AbstractPureComponent2,
+    Alignment,
+    Classes,
+    getRef,
+    IActionProps,
+    IRef,
+    IRefObject,
+    Keys,
+    MaybeElement,
+    Utils,
+} from "../../common";
 import { Icon, IconName } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
 
@@ -39,7 +50,7 @@ export interface IButtonProps extends IActionProps {
     alignText?: Alignment;
 
     /** A ref handler or a ref object that receives the native HTML element backing this component. */
-    elementRef?: Utils.IRef;
+    elementRef?: IRef;
 
     /** Whether this button should expand to fill its container. */
     fill?: boolean;
@@ -78,7 +89,7 @@ export interface IButtonState {
     isActive: boolean;
 }
 
-export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extends AbstractPureComponent2<
+export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>> extends AbstractPureComponent2<
     IButtonProps & H,
     IButtonState
 > {
@@ -86,21 +97,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
         isActive: false,
     };
 
-    protected buttonRef: HTMLElement | Utils.IRefObject<HTMLElement>;
-    protected refHandlers = {
-        button: () => {
-            const { elementRef } = this.props;
-            if (Utils.isRefCallback(elementRef)) {
-                return (ref: HTMLElement) => {
-                    this.buttonRef = ref;
-                    elementRef(ref);
-                };
-            } else if (Utils.isRefObject(elementRef)) {
-                this.buttonRef = elementRef;
-                return elementRef;
-            }
-        },
-    };
+    protected abstract buttonRef: HTMLElement | IRefObject<HTMLElement>;
 
     private currentKeyDown: number = null;
 
@@ -133,7 +130,6 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
             onClick: disabled ? undefined : this.props.onClick,
             onKeyDown: this.handleKeyDown,
             onKeyUp: this.handleKeyUp,
-            ref: this.refHandlers.button,
             tabIndex: disabled ? -1 : tabIndex,
         };
     }
@@ -150,18 +146,16 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<any>> extend
             }
         }
         this.currentKeyDown = e.which;
-        Utils.safeInvoke(this.props.onKeyDown, e);
+        this.props.onKeyDown?.(e);
     };
 
     protected handleKeyUp = (e: React.KeyboardEvent<any>) => {
         if (Keys.isKeyboardClick(e.which)) {
             this.setState({ isActive: false });
-
-            const buttonRef = Utils.getRef<HTMLElement>(this.buttonRef);
-            buttonRef.click();
+            getRef(this.buttonRef).click();
         }
         this.currentKeyDown = null;
-        Utils.safeInvoke(this.props.onKeyUp, e);
+        this.props.onKeyUp?.(e);
     };
 
     protected renderChildren(): React.ReactNode {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -50,7 +50,7 @@ export interface IButtonProps extends IActionProps {
     alignText?: Alignment;
 
     /** A ref handler or a ref object that receives the native HTML element backing this component. */
-    elementRef?: IRef;
+    elementRef?: IRef<any>;
 
     /** Whether this button should expand to fill its container. */
     fill?: boolean;
@@ -97,7 +97,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         isActive: false,
     };
 
-    protected abstract buttonRef: HTMLElement | IRefObject<HTMLElement>;
+    protected abstract buttonRef: HTMLElement | IRefObject<HTMLElement> | null;
 
     private currentKeyDown: number = null;
 

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -20,6 +20,7 @@
 import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
+import { IRefCallback, IRefObject, isRefObject } from "../../common/refs";
 import { AbstractButton, IButtonProps } from "./abstractButton";
 
 export { IButtonProps };
@@ -27,9 +28,22 @@ export { IButtonProps };
 export class Button extends AbstractButton<React.ButtonHTMLAttributes<HTMLButtonElement>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Button`;
 
+    protected buttonRef: HTMLButtonElement | IRefObject<HTMLButtonElement> | null;
+    protected handleRef = isRefObject<HTMLButtonElement>(this.props.elementRef)
+        ? (this.buttonRef = this.props.elementRef)
+        : (ref: HTMLButtonElement | null) => {
+              this.buttonRef = ref;
+              (this.props.elementRef as IRefCallback)?.(ref);
+          };
+
     public render() {
         return (
-            <button type="button" {...removeNonHTMLProps(this.props)} {...this.getCommonButtonProps()}>
+            <button
+                type="button"
+                ref={this.handleRef}
+                {...removeNonHTMLProps(this.props)}
+                {...this.getCommonButtonProps()}
+            >
                 {this.renderChildren()}
             </button>
         );
@@ -39,6 +53,14 @@ export class Button extends AbstractButton<React.ButtonHTMLAttributes<HTMLButton
 export class AnchorButton extends AbstractButton<React.AnchorHTMLAttributes<HTMLAnchorElement>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.AnchorButton`;
 
+    protected buttonRef: HTMLAnchorElement | IRefObject<HTMLAnchorElement> | null;
+    protected handleRef = isRefObject<HTMLAnchorElement>(this.props.elementRef)
+        ? (this.buttonRef = this.props.elementRef)
+        : (ref: HTMLAnchorElement | null) => {
+              this.buttonRef = ref;
+              (this.props.elementRef as IRefCallback)?.(ref);
+          };
+
     public render() {
         const { href, tabIndex = 0 } = this.props;
         const commonProps = this.getCommonButtonProps();
@@ -46,6 +68,7 @@ export class AnchorButton extends AbstractButton<React.AnchorHTMLAttributes<HTML
         return (
             <a
                 role="button"
+                ref={this.handleRef}
                 {...removeNonHTMLProps(this.props)}
                 {...commonProps}
                 href={commonProps.disabled ? undefined : href}

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
-import { AbstractPureComponent2, Classes, Utils } from "../../common";
+import { AbstractPureComponent2, Classes, IRef } from "../../common";
 import * as Errors from "../../common/errors";
 import {
     DISPLAYNAME_PREFIX,
@@ -46,7 +46,7 @@ export interface IInputGroupProps extends IControlledProps, IIntentProps, IProps
     fill?: boolean;
 
     /** Ref handler or a ref object that receives HTML `<input>` element backing this component. */
-    inputRef?: Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement>;
+    inputRef?: IRef<HTMLInputElement>;
 
     /**
      * Element to render on the left side of input.  This prop is mutually exclusive

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -189,11 +189,11 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
     private lastElementInPopover: HTMLElement | null = null;
 
     private refHandlers = {
-        input: isRefObject<HTMLInputElement>(this.props.inputProps.inputRef)
+        input: isRefObject<HTMLInputElement>(this.props.inputProps?.inputRef)
             ? (this.inputEl = this.props.inputProps.inputRef)
             : (ref: HTMLInputElement | null) => {
                   this.inputEl = ref;
-                  (this.props.inputProps.inputRef as IRefCallback<HTMLInputElement>)?.(ref);
+                  (this.props.inputProps?.inputRef as IRefCallback<HTMLInputElement>)?.(ref);
               },
     };
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -24,12 +24,16 @@ import {
     Boundary,
     Classes,
     DISPLAYNAME_PREFIX,
+    getRef,
     HTMLInputProps,
     IInputGroupProps,
     InputGroup,
     Intent,
     IPopoverProps,
     IProps,
+    IRefCallback,
+    IRefObject,
+    isRefObject,
     Keys,
     Popover,
     Position,
@@ -229,43 +233,21 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
 
     public static displayName = `${DISPLAYNAME_PREFIX}.DateRangeInput`;
 
-    protected getEndInputRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
-        const elementRef = this.props.endInputProps.inputRef;
-
-        if (elementRef && !Utils.isFunction(elementRef)) {
-            this.endInputRef = elementRef;
-
-            return elementRef;
-        }
-
-        return (ref: HTMLInputElement | null) => {
-            this.endInputRef = ref;
-
-            Utils.safeInvoke(elementRef as Utils.IRefCallback<HTMLInputElement>, ref);
-        };
-    };
-
-    protected getStartRefHandler = (): Utils.IRefCallback<HTMLInputElement> | Utils.IRefObject<HTMLInputElement> => {
-        const elementRef = this.props.startInputProps.inputRef;
-
-        if (elementRef && !Utils.isFunction(elementRef)) {
-            this.startInputRef = elementRef;
-
-            return elementRef;
-        }
-
-        return (ref: HTMLInputElement) => {
-            this.startInputRef = ref;
-
-            Utils.safeInvoke(elementRef as Utils.IRefCallback<HTMLInputElement>, ref);
-        };
-    };
-
-    private startInputRef: HTMLInputElement | Utils.IRefObject<HTMLInputElement>;
-    private endInputRef: HTMLInputElement | Utils.IRefObject<HTMLInputElement>;
+    private startInputRef: HTMLInputElement | IRefObject<HTMLInputElement> | null;
+    private endInputRef: HTMLInputElement | IRefObject<HTMLInputElement> | null;
     private refHandlers = {
-        endInputRef: this.getEndInputRefHandler(),
-        startInputRef: this.getStartRefHandler(),
+        endInputRef: isRefObject<HTMLInputElement>(this.props.endInputProps.inputRef)
+            ? (this.endInputRef = this.props.endInputProps.inputRef)
+            : (ref: HTMLInputElement | null) => {
+                  this.endInputRef = ref;
+                  (this.props.endInputProps.inputRef as IRefCallback<HTMLInputElement>)?.(ref);
+              },
+        startInputRef: isRefObject<HTMLInputElement>(this.props.startInputProps.inputRef)
+            ? (this.startInputRef = this.props.startInputProps.inputRef)
+            : (ref: HTMLInputElement | null) => {
+                  this.startInputRef = ref;
+                  (this.props.startInputProps.inputRef as IRefCallback<HTMLInputElement>)?.(ref);
+              },
     };
 
     public constructor(props: IDateRangeInputProps, context?: any) {
@@ -292,8 +274,8 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         super.componentDidUpdate(prevProps, prevState, snapshot);
         const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
 
-        const startInputRef = Utils.getRef<HTMLInputElement>(this.startInputRef);
-        const endInputRef = Utils.getRef<HTMLInputElement>(this.endInputRef);
+        const startInputRef = getRef<HTMLInputElement>(this.startInputRef);
+        const endInputRef = getRef<HTMLInputElement>(this.endInputRef);
 
         const shouldFocusStartInput = this.shouldFocusInputRef(isStartInputFocused, startInputRef);
         const shouldFocusEndInput = this.shouldFocusInputRef(isEndInputFocused, endInputRef);

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -89,7 +89,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
     private queryList: QueryList<T> | null = null;
     private previousFocusedElement: HTMLElement | undefined;
     private refHandlers = {
-        input: isRefObject<HTMLInputElement, HTMLInputElement>(this.props.inputProps?.inputRef)
+        input: isRefObject<HTMLInputElement>(this.props.inputProps?.inputRef)
             ? (this.inputEl = this.props.inputProps!.inputRef)
             : (ref: HTMLInputElement | null) => {
                   this.inputEl = ref;

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -119,7 +119,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
     private inputEl: HTMLInputElement | IRefObject<HTMLInputElement> | null = null;
     private queryList: QueryList<T> | null = null;
     private refHandlers = {
-        input: isRefObject<HTMLInputElement, HTMLInputElement>(this.props.inputProps?.inputRef)
+        input: isRefObject<HTMLInputElement>(this.props.inputProps?.inputRef)
             ? (this.inputEl = this.props.inputProps!.inputRef)
             : (ref: HTMLInputElement | null) => {
                   this.inputEl = ref;


### PR DESCRIPTION
Follow-up from #4093 (heads up @tanmoyopenroot) to be less verbose and move the ref utils & types to be exported from the top-level of the core package.

remaining to do in this PR:
- [x] restore `Utils.getRef` to maintain backwards compatibility