### PR TITLE
fixed typo

### DIFF
--- a/packages/core/src/components/forms/checkbox.md
+++ b/packages/core/src/components/forms/checkbox.md
@@ -7,7 +7,7 @@ indeterminate states.
 
 @## Props
 
-Use the `checked` prop instead of `value` in controlled mode to avoid typings
+Use the `checked` prop instead of `value` in controlled mode to avoid typing
 issues. Enable the `indeterminate` prop for a third in-between state.
 
 ```tsx


### PR DESCRIPTION
changed this line "Use the `checked` prop instead of `value` in controlled mode to avoid typings" to "Use the `checked` prop instead of `value` in controlled mode to avoid typing"

removed "s" from typing.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
