### PR TITLE
fix: ensured that Alert text does not overflow

### DIFF
--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.#{$ns}-alert-contents {
+  word-break: break-word;
+}
+
 .#{$ns}-alert-footer {
   display: flex;
   flex-direction: row-reverse;


### PR DESCRIPTION
#### Fixes #4145

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

add a word-break in for alert-contents

#### Reviewers should focus on:

Ensuring content inside Alert breaks the large word in order to prevent content from going off
the Alert container. 

#### Screenshot

![image](https://user-images.githubusercontent.com/28187128/82617197-afbd8900-9c12-11ea-9c10-9b7b0b715ab7.png)
