### PR TITLE
fix(suggest): check for refObject or callback on popup interaction

### DIFF
--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -275,7 +275,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
 
     private handlePopoverInteraction = (nextOpenState: boolean) =>
         requestAnimationFrame(() => {
-            if (this.inputEl != null && this.inputEl !== document.activeElement) {
+            if (this.inputEl != null && getRef<HTMLInputElement>(this.inputEl) !== document.activeElement) {
                 // the input is no longer focused so we can close the popover
                 this.setState({ isOpen: false });
             }


### PR DESCRIPTION
#### Fixes #4138 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
check for `refObject` or `callback` on popup interaction

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
Visual Test
<img width="447" alt="Screenshot 2020-05-23 at 6 38 07 AM" src="https://user-images.githubusercontent.com/25791025/82718413-ff0dc300-9cbf-11ea-8dd6-05bc4a665cf7.png">

Code used to test
<img width="587" alt="Screenshot 2020-05-23 at 6 37 40 AM" src="https://user-images.githubusercontent.com/25791025/82718427-0fbe3900-9cc0-11ea-815b-bb5fb07bb491.png">


