### PR TITLE
[core] fix(NumericInput): enforce numeric chars only with IME

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -41,7 +41,6 @@ import { InputGroup } from "./inputGroup";
 import {
     clampValue,
     getValueOrEmptyValue,
-    isFloatingPointNumericCharacter,
     isValidNumericKeyboardEvent,
     isValueNumeric,
     sanitizeNumericInput,

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -25,13 +25,13 @@ import {
     DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IIntentProps,
+    Intent,
     IProps,
     Keys,
     MaybeElement,
     Position,
     removeNonHTMLProps,
     Utils,
-    Intent,
 } from "../../common";
 import * as Errors from "../../common/errors";
 

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -44,6 +44,7 @@ import {
     isFloatingPointNumericCharacter,
     isValidNumericKeyboardEvent,
     isValueNumeric,
+    sanitizeNumericInput,
     toMaxPrecision,
 } from "./numericInputUtils";
 
@@ -359,6 +360,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
                 onFocus={this.handleInputFocus}
                 onBlur={this.handleInputBlur}
                 onChange={this.handleInputChange}
+                onCompositionEnd={this.handleCompositionEnd}
                 onKeyDown={this.handleInputKeyDown}
                 onKeyPress={this.handleInputKeyPress}
                 onPaste={this.handleInputPaste}
@@ -474,6 +476,14 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         Utils.safeInvoke(this.props.onKeyDown, e);
     };
 
+    private handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+        const { value } = e.target as HTMLInputElement;
+
+        if (this.props.allowNumericCharactersOnly) {
+            this.setState({ value: sanitizeNumericInput(value) });
+        }
+    };
+
     private handleInputKeyPress = (e: React.KeyboardEvent) => {
         // we prohibit keystrokes in onKeyPress instead of onKeyDown, because
         // e.key is not trustworthy in onKeyDown in all browsers.
@@ -495,10 +505,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         let nextValue = value;
         if (this.props.allowNumericCharactersOnly && this.didPasteEventJustOccur) {
             this.didPasteEventJustOccur = false;
-            const valueChars = value.split("");
-            const sanitizedValueChars = valueChars.filter(isFloatingPointNumericCharacter);
-            const sanitizedValue = sanitizedValueChars.join("");
-            nextValue = sanitizedValue;
+            nextValue = sanitizeNumericInput(value);
         }
 
         this.setState({ shouldSelectAfterUpdate: false, value: nextValue });

--- a/packages/core/src/components/forms/numericInputUtils.ts
+++ b/packages/core/src/components/forms/numericInputUtils.ts
@@ -78,7 +78,7 @@ export function isValidNumericKeyboardEvent(e: React.KeyboardEvent) {
  * https://www.w3.org/TR/2012/WD-html-markup-20120329/input.number.html#input.number.attrs.value
  */
 const FLOATING_POINT_NUMBER_CHARACTER_REGEX = /^[Ee0-9\+\-\.]$/;
-export function isFloatingPointNumericCharacter(character: string) {
+function isFloatingPointNumericCharacter(character: string) {
     return FLOATING_POINT_NUMBER_CHARACTER_REGEX.test(character);
 }
 

--- a/packages/core/src/components/forms/numericInputUtils.ts
+++ b/packages/core/src/components/forms/numericInputUtils.ts
@@ -95,3 +95,20 @@ export function toMaxPrecision(value: number, maxPrecision: number) {
     const scaleFactor = Math.pow(10, maxPrecision);
     return Math.round(value * scaleFactor) / scaleFactor;
 }
+
+/**
+ * Convert Japanese full-width numbers, e.g. '５', to ASCII, e.g. '5'
+ * This should be called before performing any other numeric string input validation.
+ */
+function convertFullWidthNumbersToAscii(value: string) {
+    return value.replace(/[\uFF10-\uFF19]/g, m => String.fromCharCode(m.charCodeAt(0) - 0xfee0));
+}
+
+/**
+ * Convert full-width (Japanese) numbers to ASCII, and strip all characters that are not valid floating-point numeric characters
+ */
+export function sanitizeNumericInput(value: string) {
+    const valueChars = convertFullWidthNumbersToAscii(value).split("");
+    const sanitizedValueChars = valueChars.filter(isFloatingPointNumericCharacter);
+    return sanitizedValueChars.join("");
+}


### PR DESCRIPTION
Close loophole where IMEs could be used to inject invalid characters, and handle Japanese full-width number input.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

Whether I should be using preventDefault or any other HTML event API things in my handler (doesn't seem necessary, but maybe there are edge cases?).

#### Screenshot

Before:

![buggy-numeric-input](https://user-images.githubusercontent.com/8685581/83235647-2d623580-a1cd-11ea-81de-b1f8051a9d33.gif)

After:

![fixed-numeric-input](https://user-images.githubusercontent.com/8685581/83235706-42d75f80-a1cd-11ea-883a-c3cdf954a600.gif)
