### PR TITLE
Icon prop takes svg path string array

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -61,8 +61,8 @@ export interface IActionProps extends IIntentProps, IProps {
     /** Whether this action is non-interactive. */
     disabled?: boolean;
 
-    /** Name of a Blueprint UI icon (or an icon element) to render before the text. */
-    icon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to render before the text. */
+    icon?: IconName | MaybeElement | string[];
 
     /** Click event handler. */
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -58,8 +58,8 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
      */
     confirmButtonText?: string;
 
-    /** Name of a Blueprint UI icon (or an icon element) to display on the left side. */
-    icon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to display on the left side. */
+    icon?: IconName | MaybeElement | string[];
 
     /**
      * The intent to be applied to the confirm (right-most) button and the icon (if provided).

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -71,8 +71,8 @@ export interface IButtonProps extends IActionProps {
     /** Whether this button should use outlined styles. */
     outlined?: boolean;
 
-    /** Name of a Blueprint UI icon (or an icon element) to render after the text. */
-    rightIcon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to render after the text. */
+    rightIcon?: IconName | MaybeElement | string[];
 
     /** Whether this button should use small styles. */
     small?: boolean;
@@ -92,7 +92,7 @@ export interface IButtonState {
 export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>> extends AbstractPureComponent2<
     IButtonProps & H,
     IButtonState
-> {
+    > {
     public state = {
         isActive: false,
     };

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -34,12 +34,12 @@ import { Icon, IconName } from "../icon/icon";
 /** This component also supports the full range of HTML `<div>` props. */
 export interface ICalloutProps extends IIntentProps, IProps, HTMLDivProps {
     /**
-     * Name of a Blueprint UI icon (or an icon element) to render on the left side.
+     * Name of a Blueprint UI icon (or an icon element, or array of path strings) to render on the left side.
      *
      * If this prop is omitted or `undefined`, the `intent` prop will determine a default icon.
      * If this prop is explicitly `null`, no icon will be displayed (regardless of `intent`).
      */
-    icon?: IconName | MaybeElement;
+    icon?: IconName | MaybeElement | string[];
 
     /**
      * Visual intent color to apply to background, title, and icon.
@@ -82,7 +82,7 @@ export class Callout extends AbstractPureComponent2<ICalloutProps> {
         );
     }
 
-    private getIconName(icon?: ICalloutProps["icon"], intent?: Intent): IconName | MaybeElement {
+    private getIconName(icon?: ICalloutProps["icon"], intent?: Intent): IconName | MaybeElement | string[] {
         // 1. no icon
         if (icon === null) {
             return undefined;

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -39,11 +39,11 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
     hasBackdrop?: boolean;
 
     /**
-     * Name of a Blueprint UI icon (or an icon element) to render in the
+     * Name of a Blueprint UI icon (or an icon element, or array of path strings) to render in the
      * dialog's header. Note that the header will only be rendered if `title` is
      * provided.
      */
-    icon?: IconName | MaybeElement;
+    icon?: IconName | MaybeElement | string[];
 
     /**
      * Whether to show the close button in the dialog's header.

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -28,11 +28,11 @@ import { IBackdropProps, IOverlayableProps, Overlay } from "../overlay/overlay";
 
 export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps {
     /**
-     * Name of a Blueprint UI icon (or an icon element) to render in the
+     * Name of a Blueprint UI icon (or an icon element, or array of path strings) to render in the
      * drawer's header. Note that the header will only be rendered if `title` is
      * provided.
      */
-    icon?: IconName | MaybeElement;
+    icon?: IconName | MaybeElement | string[];
 
     /**
      * Whether to show the close button in the dialog's header.
@@ -126,9 +126,9 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
             size == null
                 ? style
                 : {
-                      ...style,
-                      [(realPosition ? isPositionHorizontal(realPosition) : vertical) ? "height" : "width"]: size,
-                  };
+                    ...style,
+                    [(realPosition ? isPositionHorizontal(realPosition) : vertical) ? "height" : "width"]: size,
+                };
         return (
             <Overlay {...this.props} className={Classes.OVERLAY_CONTAINER}>
                 <div className={classes} style={styleProp}>

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -59,7 +59,7 @@ export interface IInputGroupProps extends IControlledProps, IIntentProps, IProps
      * before the user's cursor.  This prop is mutually exclusive with `leftElement`.
      * Usage with content is deprecated.  Use `leftElement` for elements.
      */
-    leftIcon?: IconName | MaybeElement;
+    leftIcon?: IconName | MaybeElement | string[];
 
     /** Whether this input should use large styles. */
     large?: boolean;

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -93,9 +93,9 @@ export interface INumericInputProps extends IIntentProps, IProps {
     large?: boolean;
 
     /**
-     * Name of a Blueprint UI icon (or an icon element) to render on the left side of input.
+     * Name of a Blueprint UI icon (or an icon element, or array of path strings) to render on the left side of input.
      */
-    leftIcon?: IconName | MaybeElement;
+    leftIcon?: IconName | MaybeElement | string[];
 
     /**
      * The increment between successive values when <kbd>shift</kbd> is held.

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -53,6 +53,11 @@ import { IconNames } from "@blueprintjs/icons";
 
 // can pass all valid HTML props
 <Icon icon="add" onClick={this.handleAdd} onKeyDown={this.handleAddKeys} />
+
+// custom icons can be passed via an svg path string array
+<Icon icon={["M8,0 16,8 8,16 0,8z"]} />
+// ...or through a custom rendered jsx element
+<Icon icon={<svg viewBox="0 0 16 16"><path d="M8,0 16,8 8,16 0,8z" /></svg>} />
 ```
 
 ```html

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -42,7 +42,7 @@ export interface INonIdealStateProps extends IProps {
     description?: React.ReactChild;
 
     /** The name of a Blueprint icon or a JSX Element (such as `<Spinner/>`) to render above the title. */
-    icon?: IconName | MaybeElement;
+    icon?: IconName | MaybeElement | string[];
 
     /** The title of the non-ideal state. */
     title?: React.ReactNode;

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -80,8 +80,8 @@ export interface ITagInputProps extends IIntentProps, IProps {
     /** Whether the tag input should use a large size. */
     large?: boolean;
 
-    /** Name of a Blueprint UI icon (or an icon element) to render on the left side of the input. */
-    leftIcon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to render on the left side of the input. */
+    leftIcon?: IconName | MaybeElement | string[];
 
     /**
      * Callback invoked when new tags are added by the user pressing `enter` on the input.

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -43,8 +43,8 @@ export interface ITagProps extends IProps, IIntentProps, React.HTMLAttributes<HT
      */
     fill?: boolean;
 
-    /** Name of a Blueprint UI icon (or an icon element) to render before the children. */
-    icon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to render before the children. */
+    icon?: IconName | MaybeElement | string[];
 
     /**
      * Whether the tag should visually respond to user interactions. If set
@@ -89,8 +89,8 @@ export interface ITagProps extends IProps, IIntentProps, React.HTMLAttributes<HT
      */
     onRemove?: (e: React.MouseEvent<HTMLButtonElement>, tagProps: ITagProps) => void;
 
-    /** Name of a Blueprint UI icon (or an icon element) to render after the children. */
-    rightIcon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to render after the children. */
+    rightIcon?: IconName | MaybeElement | string[];
 
     /**
      * Whether this tag should have rounded ends.

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -33,8 +33,8 @@ export interface IToastProps extends IProps, IIntentProps {
      */
     action?: IActionProps & ILinkProps;
 
-    /** Name of a Blueprint UI icon (or an icon element) to render before the message. */
-    icon?: IconName | MaybeElement;
+    /** Name of a Blueprint UI icon (or an icon element, or array of path strings) to render before the message. */
+    icon?: IconName | MaybeElement | string[];
 
     /** Message to display in the body of the toast. */
     message: React.ReactNode;

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -43,9 +43,9 @@ export interface ITreeNode<T = {}> extends IProps {
     hasCaret?: boolean;
 
     /**
-     * The name of a Blueprint icon (or an icon element) to render next to the node's label.
+     * The name of a Blueprint icon (or an icon element, or array of path strings) to render next to the node's label.
      */
-    icon?: IconName | MaybeElement;
+    icon?: IconName | MaybeElement | string[];
 
     /**
      * A unique identifier for the node.
@@ -125,12 +125,12 @@ export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>> {
             disabled === true
                 ? {}
                 : {
-                      onClick: this.handleClick,
-                      onContextMenu: this.handleContextMenu,
-                      onDoubleClick: this.handleDoubleClick,
-                      onMouseEnter: this.handleMouseEnter,
-                      onMouseLeave: this.handleMouseLeave,
-                  };
+                    onClick: this.handleClick,
+                    onContextMenu: this.handleContextMenu,
+                    onDoubleClick: this.handleDoubleClick,
+                    onMouseEnter: this.handleMouseEnter,
+                    onMouseLeave: this.handleMouseLeave,
+                };
 
         return (
             <li className={classes}>

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -18,7 +18,7 @@ import { assert } from "chai";
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { IconName } from "@blueprintjs/icons";
+import { IconName, IconSvgPaths16, IconNames } from "@blueprintjs/icons";
 
 import { Classes, Icon, IIconProps, Intent } from "../../src";
 
@@ -80,6 +80,13 @@ describe("<Icon>", () => {
     it("desc defaults to icon name", () => {
         const icon = shallow(<Icon icon="airplane" />);
         assert.equal(icon.find("desc").text(), "airplane");
+    });
+
+    it("icon from name renders same as path", () => {
+        const iconName = IconNames.PHONE;
+        const iconFromName = shallow(<Icon icon={iconName} />);
+        const iconFromPath = shallow(<Icon icon={IconSvgPaths16[iconName]} />);
+        assert.equal(iconFromName.find("path").prop("d"), iconFromPath.find("path").prop("d"));
     });
 
     /** Asserts that rendered icon has given className. */

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -18,7 +18,7 @@ import { assert } from "chai";
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { IconName, IconSvgPaths16, IconNames } from "@blueprintjs/icons";
+import { IconName, IconNames, IconSvgPaths16 } from "@blueprintjs/icons";
 
 import { Classes, Icon, IIconProps, Intent } from "../../src";
 

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -24,7 +24,8 @@ export class MenuExample extends React.PureComponent<IExampleProps> {
         return (
             <Example className="docs-menu-example" options={false} {...this.props}>
                 <Menu className={Classes.ELEVATION_1}>
-                    <MenuItem icon={<PalantirLogo />} text="Custom SVG icon" />
+                    <MenuItem icon={<PalantirLogo />} text="Custom SVG element" />
+                    <MenuItem icon={[PALANTIR_LOGO_PATH]} text="Custom SVG path" />
                     <MenuDivider />
                     <MenuItem icon="new-text-box" text="New text box" />
                     <MenuItem icon="new-object" text="New object" />
@@ -69,6 +70,8 @@ export class MenuExample extends React.PureComponent<IExampleProps> {
         );
     }
 }
+
+const PALANTIR_LOGO_PATH = "M13.4,11.6L8,13.9l-5.4-2.3l-0.9,1.7L8,16l6.3-2.7L13.4,11.6L13.4,11.6z M8,10.3c-2.3,0-4.2-1.9-4.2-4.2c0-2.3,1.9-4.2,4.2-4.2s4.2,1.9,4.2,4.2C12.2,8.4,10.3,10.3,8,10.3L8,10.3z M8,0C4.7,0,2,2.7,2,6.1c0,3.3,2.7,6.1,6,6.1c3.3,0,6-2.7,6-6.1S11.3,0,8,0z"
 
 const PalantirLogo: React.SFC = () => (
     <svg className={Classes.ICON} width="16" height="16" viewBox="0 0 18 23" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
#### Fixes Nothing
Its a new feature...

#### Checklist

- [x] Includes test (only one)
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
The icon prop on icon and other components now takes a `string[]` of svg paths. This way, we can use custom icons with the same general appearance of the native icons. Wrapping in a custom svg element is too much extra.

#### Reviewers should focus on:
- The `Icon` component and the `Icon.renderSvgPaths` function
- Anywhere there is an `icon` prop
- The prop `icon?: IconName | MaybeElement | string[]` appears a lot and could even be abstracted to:
  - `icon?: IconProp`
  - `export declare type IconProp = IconName | MaybeElement | string[]`

<!-- Fill this out. -->

#### Screenshot
<img width="995" alt="Screen Shot 2020-06-05 at 7 32 32 PM" src="https://user-images.githubusercontent.com/6248614/83934236-2c4c7d80-a764-11ea-9543-ac57774197fe.png">
<img width="995" alt="Screen Shot 2020-06-05 at 7 34 57 PM" src="https://user-images.githubusercontent.com/6248614/83934238-30789b00-a764-11ea-8260-830386a09ca7.png">

<!-- Include an image of the most relevant user-facing change, if any. -->

Thanks for making such a well done design system!
