### PR TITLE
Fix ItemListRenderer return type

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -63,7 +63,7 @@ export interface IItemListRendererProps<T> {
 }
 
 /** Type alias for a function that renders the list of items. */
-export type ItemListRenderer<T> = (itemListProps: IItemListRendererProps<T>) => JSX.Element;
+export type ItemListRenderer<T> = (itemListProps: IItemListRendererProps<T>) => JSX.Element | null;
 
 /**
  * `ItemListRenderer` helper method for rendering each item in `filteredItems`,


### PR DESCRIPTION
ItemListRenderer is expected to return `null` because [it's default implementation](https://github.com/palantir/blueprint/blob/c96f8d2f0f0d4684574bc90a989691df404e35a8/packages/select/src/components/query-list/queryList.tsx#L333-L351) can return null