### PR TITLE
Right element for EditableText

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -128,6 +128,7 @@ export const EDITABLE_TEXT_CONTENT = `${EDITABLE_TEXT}-content`;
 export const EDITABLE_TEXT_EDITING = `${EDITABLE_TEXT}-editing`;
 export const EDITABLE_TEXT_INPUT = `${EDITABLE_TEXT}-input`;
 export const EDITABLE_TEXT_PLACEHOLDER = `${EDITABLE_TEXT}-placeholder`;
+export const EDITABLE_TEXT_ACTION = `${EDITABLE_TEXT}-action`;
 
 export const FLEX_EXPANDER = `${NS}-flex-expander`;
 

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -157,6 +157,6 @@
 
 .#{$ns}-editable-text-action {
   position: absolute;
-  top: 0;
   right: 0;
+  top: 0;
 }

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -154,3 +154,9 @@
     word-wrap: break-word;
   }
 }
+
+.#{$ns}-editable-text-action {
+  position: absolute;
+  top: 0;
+  right: 0;
+}

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -19,7 +19,7 @@ import { mount, ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { EditableText } from "../../src";
+import { Classes, EditableText } from "../../src";
 import * as Keys from "../../src/common/keys";
 
 describe("<EditableText>", () => {
@@ -45,6 +45,19 @@ describe("<EditableText>", () => {
         assert.strictEqual(editable.text(), "alphabet");
         editable.setProps({ value: null });
         assert.strictEqual(editable.text(), "placeholder");
+    });
+
+    it(`does not render right element when not editing`, () => {
+        const action = mount(<EditableText isEditing={false} rightElement={<address />} />);
+        assert.lengthOf(action.find("address"), 0);
+    });
+
+    it(`renders right element inside .${Classes.EDITABLE_TEXT_ACTION} after input`, () => {
+        const action = mount(<EditableText isEditing={true} rightElement={<address />} />)
+            .children()
+            .childAt(1);
+        assert.isTrue(action.hasClass(Classes.EDITABLE_TEXT_ACTION));
+        assert.lengthOf(action.find("address"), 1);
     });
 
     describe("when editing", () => {

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -16,7 +16,18 @@
 
 import * as React from "react";
 
-import { Classes, EditableText, FormGroup, H1, H5, Intent, NumericInput, Switch } from "@blueprintjs/core";
+import {
+    Button,
+    Classes,
+    EditableText,
+    FormGroup,
+    H1,
+    H5,
+    Intent,
+    NumericInput,
+    Switch,
+    Tooltip,
+} from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -30,6 +41,8 @@ export interface IEditableTextExampleState {
     maxLength?: number;
     report?: string;
     selectAllOnFocus?: boolean;
+    showRightElement: boolean;
+    showTitle: boolean;
 }
 
 export class EditableTextExample extends React.PureComponent<IExampleProps, IEditableTextExampleState> {
@@ -38,14 +51,36 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
         confirmOnEnterKey: false,
         report: "",
         selectAllOnFocus: false,
+        showRightElement: false,
+        showTitle: true,
     };
 
     private handleIntentChange = handleStringChange((intent: Intent) => this.setState({ intent }));
     private toggleSelectAll = handleBooleanChange(selectAllOnFocus => this.setState({ selectAllOnFocus }));
     private toggleSwap = handleBooleanChange(confirmOnEnterKey => this.setState({ confirmOnEnterKey }));
     private toggleAlwaysRenderInput = handleBooleanChange(alwaysRenderInput => this.setState({ alwaysRenderInput }));
+    private toggleShowRightElement = handleBooleanChange(showRightElement => this.setState({ showRightElement }));
 
     public render() {
+        const { showTitle } = this.state;
+
+        const lockButton = (
+            <Tooltip content={`${showTitle ? "Hide" : "Show"} Title`}>
+                <Button
+                    icon={showTitle ? "eye-open" : "eye-off"}
+                    intent={Intent.PRIMARY}
+                    minimal={true}
+                    onClick={this.handleLockClick}
+                />
+            </Tooltip>
+        );
+
+        const clearButton = (
+            <Tooltip content="Clear text">
+                <Button icon="cross" intent={Intent.DANGER} minimal={true} onClick={this.handleClearClick} />
+            </Tooltip>
+        );
+
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <H1>
@@ -54,7 +89,9 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                         intent={this.state.intent}
                         maxLength={this.state.maxLength}
                         placeholder="Edit title..."
+                        rightElement={this.state.showRightElement ? lockButton : undefined}
                         selectAllOnFocus={this.state.selectAllOnFocus}
+                        type={showTitle ? "text" : "password"}
                     />
                 </H1>
                 <EditableText
@@ -65,6 +102,7 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                     minLines={3}
                     multiline={true}
                     placeholder="Edit report... (controlled, multiline)"
+                    rightElement={this.state.showRightElement ? clearButton : undefined}
                     selectAllOnFocus={this.state.selectAllOnFocus}
                     confirmOnEnterKey={this.state.confirmOnEnterKey}
                     value={this.state.report}
@@ -104,6 +142,11 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                     label="Always render input"
                     onChange={this.toggleAlwaysRenderInput}
                 />
+                <Switch
+                    checked={this.state.showRightElement}
+                    label="Right element"
+                    onChange={this.toggleShowRightElement}
+                />
             </>
         );
     }
@@ -117,4 +160,6 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
             this.setState({ maxLength, report });
         }
     };
+    private handleLockClick = () => this.setState({ showTitle: !this.state.showTitle });
+    private handleClearClick = () => this.setState({ report: "" });
 }


### PR DESCRIPTION
#### Fixes #2185

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

For some use cases, it's helpful to have right element in the EditableText. This PR enables to render right element in EditableText by using `rightElement` prop similar to InputGroup.

#### Reviewers should focus on:

- `updateInputDimensions` function to update the padding
- `maybeRenderRightElement` function and the way how it handles the visibility of the element and focus (there might be better way to handle this)

#### Screenshot

<img width="448" alt="Screen Shot 2020-06-12 at 03 11 07" src="https://user-images.githubusercontent.com/4068390/84454287-69c87380-ac5a-11ea-998a-2cb27dc669c4.png">

