### PR TITLE
[core] feat: spread data-* props to HTML elements

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -155,6 +155,11 @@ export function removeNonHTMLProps(
 
     return invalidProps.reduce(
         (prev, curr) => {
+            // Props with hyphens (e.g. data-*) are always considered html props
+            if (curr.indexOf("-") !== -1) {
+                return prev;
+            }
+
             if (prev.hasOwnProperty(curr)) {
                 delete (prev as any)[curr];
             }

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -47,6 +47,11 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             assert.equal(wrapper.text(), "some text");
         });
 
+        it("renders the button text prop", () => {
+            const wrapper = mount(<Button data-test-foo="bar" />);
+            assert.isTrue(!!wrapper.find('[data-test-foo="bar"]'));
+        });
+
         it("wraps string children in spans", () => {
             // so text can be hidden when loading
             const wrapper = button({}, true, "raw string", <em>not a string</em>);

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -49,7 +49,7 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
 
         it("renders the button text prop", () => {
             const wrapper = mount(<Button data-test-foo="bar" />);
-            assert.isTrue(!!wrapper.find('[data-test-foo="bar"]'));
+            assert.isTrue(wrapper.find('[data-test-foo="bar"]').exists());
         });
 
         it("wraps string children in spans", () => {


### PR DESCRIPTION
#### Fixes #3210

#### Checklist

- [x] Includes tests

#### Changes proposed in this pull request:

This PR changes `removeNonHTMLProps` so that it ignores any prop with hyphens.  Typescript has a special rule to ignore hyphenated props (such as `data-foo`) during JSX attribute validation.  It is not common to use hyphenated attributes for React props, as those props are not valid JS identifiers, so it is best to assume that any prop with a hyphen is intended for the rendered element.  

https://www.typescriptlang.org/docs/handbook/jsx.html#attribute-type-checking

This will help in tests scenarios where data-attributes are used as test selectors.
