### PR TITLE
fix TextArea inputRef update event

### DIFF
--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -66,6 +66,15 @@ export class TextArea extends AbstractPureComponent2<ITextAreaProps, ITextAreaSt
             });
         }
     }
+    public componentDidUpdate(prevProps: ITextAreaProps) {
+        if (
+            prevProps.inputRef &&
+            this.props.inputRef &&
+            prevProps.inputRef.toString() !== this.props.inputRef.toString()
+        ) {
+            this.props.inputRef(this.internalTextAreaRef);
+        }
+    }
     public render() {
         const { className, fill, inputRef, intent, large, small, growVertically, ...htmlProps } = this.props;
 

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -65,4 +65,16 @@ describe("<TextArea>", () => {
         const scrollHeightInPixels = `${(textarea.getDOMNode() as HTMLElement).scrollHeight}px`;
         assert.equal((textarea.getDOMNode() as HTMLElement).style.height, scrollHeightInPixels);
     });
+    it("updates on ref change", () => {
+        let textArea: HTMLTextAreaElement | null = null;
+        let textAreaNew: HTMLTextAreaElement | null = null;
+        const textAreaRefCallback = (ref: HTMLTextAreaElement | null) => (textArea = ref);
+        const textAreaNewRefCallback = (ref: HTMLTextAreaElement | null) => (textAreaNew = ref);
+
+        const textAreawrapper = mount(<TextArea id="textarea" inputRef={textAreaRefCallback} />);
+        assert.instanceOf(textArea, HTMLTextAreaElement);
+
+        textAreawrapper.setProps({ inputRef: textAreaNewRefCallback });
+        assert.instanceOf(textAreaNew, HTMLTextAreaElement);
+    });
 });


### PR DESCRIPTION
#### Fixes #4072

#### Checklist

- [X] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

TextArea should call updated inputRef prop with the current DOM element.

