### PR TITLE
Improve NumericInput and AbstractButton internals

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -134,6 +134,16 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         };
     }
 
+    // A disabled element cannot be active, there're are cases where
+    // this situation can happen (NumericInput buttons), hence the need
+    // to check if disabled prop has been passed and change isActive
+    // accordingly
+    public componentDidUpdate() {
+        if (this.state.isActive && this.props.disabled) {
+            this.setState({ isActive: false });
+        }
+    }
+
     // we're casting as `any` to get around a somewhat opaque safeInvoke error
     // that "Type argument candidate 'KeyboardEvent<T>' is not a valid type
     // argument because it is not a supertype of candidate
@@ -149,6 +159,8 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         this.props.onKeyDown?.(e);
     };
 
+    // Keyup event won't fire on a disabled element, so componentDidUpdate
+    // will take care of those cases and set isActive to false
     protected handleKeyUp = (e: React.KeyboardEvent<any>) => {
         if (Keys.isKeyboardClick(e.which)) {
             this.setState({ isActive: false });

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -134,7 +134,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         };
     }
 
-    // A disabled element cannot be active, there're are cases where
+    // A disabled element cannot be active, but there are cases where
     // this situation can happen (NumericInput buttons), hence the need
     // to check if disabled prop has been passed and change isActive
     // accordingly

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -163,8 +163,6 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         this.props.onKeyDown?.(e);
     };
 
-    // Keyup event won't fire on a disabled element, so componentDidUpdate
-    // will take care of those cases and set isActive to false
     protected handleKeyUp = (e: React.KeyboardEvent<any>) => {
         if (Keys.isKeyboardClick(e.which)) {
             this.setState({ isActive: false });

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -105,7 +105,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
     // this situation can happen (NumericInput buttons), hence the need
     // to check if disabled prop has been passed and change isActive
     // accordingly
-    protected static getDerivedStateFromProps(props: IButtonProps, state: IButtonState) {
+    public static getDerivedStateFromProps(props: IButtonProps, state: IButtonState) {
         if (state.isActive && props.disabled) {
             return {
                 isActive: false,

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -101,6 +101,20 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
 
     private currentKeyDown: number = null;
 
+    // A disabled element cannot be active, but there are cases where
+    // this situation can happen (NumericInput buttons), hence the need
+    // to check if disabled prop has been passed and change isActive
+    // accordingly
+    protected static getDerivedStateFromProps(props: IButtonProps, state: IButtonState) {
+        if (state.isActive && props.disabled) {
+            return {
+                isActive: false,
+            };
+        }
+
+        return null;
+    }
+
     public abstract render(): JSX.Element;
 
     protected getCommonButtonProps() {
@@ -132,16 +146,6 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
             onKeyUp: this.handleKeyUp,
             tabIndex: disabled ? -1 : tabIndex,
         };
-    }
-
-    // A disabled element cannot be active, but there are cases where
-    // this situation can happen (NumericInput buttons), hence the need
-    // to check if disabled prop has been passed and change isActive
-    // accordingly
-    public componentDidUpdate() {
-        if (this.state.isActive && this.props.disabled) {
-            this.setState({ isActive: false });
-        }
     }
 
     // we're casting as `any` to get around a somewhat opaque safeInvoke error

--- a/packages/core/src/components/forms/_numeric-input.scss
+++ b/packages/core/src/components/forms/_numeric-input.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  // fix button border radii when the buttons are on the left
+  // fix button border radius when the buttons are on the left
   .#{$ns}-button-group.#{$ns}-vertical {
     &:first-child > .#{$ns}-button {
       &:first-child {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -151,12 +151,7 @@ export interface INumericInputProps extends IIntentProps, IProps {
     onButtonClick?(valueAsNumber: number, valueAsString: string): void;
 
     /** The callback invoked when the value changes due to typing, arrow keys, or button clicks. */
-    onValueChange?(
-        valueAsNumber: number,
-        valueAsString: string,
-        inputElement: HTMLInputElement | null,
-        instance: NumericInput,
-    ): void;
+    onValueChange?(valueAsNumber: number, valueAsString: string, inputElement: HTMLInputElement | null): void;
 }
 
 export interface INumericInputState {
@@ -300,7 +295,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
 
         if (!didControlledValueChange && this.state.value !== prevState.value) {
             const { value: valueAsString } = this.state;
-            this.props.onValueChange?.(+valueAsString, valueAsString, this.inputElement, this);
+            this.props.onValueChange?.(+valueAsString, valueAsString, this.inputElement);
         }
     }
 

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -36,7 +36,7 @@ import {
 import * as Errors from "../../common/errors";
 
 import { ButtonGroup } from "../button/buttonGroup";
-import { Button } from "../button/buttons";
+import { AnchorButton } from "../button/buttons";
 import { ControlGroup } from "./controlGroup";
 import { InputGroup } from "./inputGroup";
 import {
@@ -338,13 +338,13 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         const disabled = this.props.disabled || this.props.readOnly;
         return (
             <ButtonGroup className={Classes.FIXED} key="button-group" vertical={true}>
-                <Button
+                <AnchorButton
                     disabled={disabled || (value !== "" && +value >= max)}
                     icon="chevron-up"
                     intent={intent}
                     {...this.incrementButtonHandlers}
                 />
-                <Button
+                <AnchorButton
                     disabled={disabled || (value !== "" && +value <= min)}
                     icon="chevron-down"
                     intent={intent}
@@ -427,21 +427,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         document.removeEventListener("mouseup", this.stopContinuousChange);
     };
 
-    // If limit is reached and mouseup event occurs on top of the disabled button
-    // stopContinuousChange will never be fired, hence the need to check each
-    // iterarion of handleContinuousChange
-    private limitReachedOnContinuousChange = () => {
-        const min = this.props.min ?? -Infinity;
-        const max = this.props.max ?? Infinity;
-        if (Number(this.state.value) <= min || Number(this.state.value) >= max) {
-            this.stopContinuousChange();
-            return true;
-        }
-        return false;
-    };
-
     private handleContinuousChange = () => {
-        if (this.limitReachedOnContinuousChange()) return;
         const nextValue = this.incrementValue(this.delta);
         this.props.onButtonClick?.(+nextValue, nextValue);
     };

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -202,8 +202,7 @@ describe("<NumericInput>", () => {
             dispatchMouseEvent(document, "mouseup");
 
             const inputElement = component.find("input").first().getDOMNode();
-            const instance = component.instance();
-            expect(onValueChangeSpy.calledOnceWithExactly(1, "1", inputElement, instance)).to.be.true;
+            expect(onValueChangeSpy.calledOnceWithExactly(1, "1", inputElement)).to.be.true;
         });
 
         it("fires onButtonClick with the number value and the string value when either button is pressed", () => {
@@ -628,8 +627,7 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                const instance = component.instance();
-                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement, instance)).to.be.true;
+                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
             });
 
             it("does not fire onValueChange if nextProps.min < value", () => {
@@ -703,8 +701,7 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                const instance = component.instance();
-                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement, instance)).to.be.true;
+                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
             });
 
             it("does not fire onValueChange if nextProps.max > value", () => {
@@ -735,8 +732,7 @@ describe("<NumericInput>", () => {
                 expect(component.state().value).to.equal("2");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                const instance = component.instance();
-                expect(onValueChangeSpy.calledOnceWithExactly(2, "2", inputElement, instance)).to.be.true;
+                expect(onValueChangeSpy.calledOnceWithExactly(2, "2", inputElement)).to.be.true;
             });
         });
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -202,7 +202,8 @@ describe("<NumericInput>", () => {
             dispatchMouseEvent(document, "mouseup");
 
             const inputElement = component.find("input").first().getDOMNode();
-            expect(onValueChangeSpy.calledOnceWithExactly(1, "1", inputElement)).to.be.true;
+            const instance = component.instance();
+            expect(onValueChangeSpy.calledOnceWithExactly(1, "1", inputElement, instance)).to.be.true;
         });
 
         it("fires onButtonClick with the number value and the string value when either button is pressed", () => {
@@ -627,7 +628,8 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
+                const instance = component.instance();
+                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement, instance)).to.be.true;
             });
 
             it("does not fire onValueChange if nextProps.min < value", () => {
@@ -701,7 +703,8 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
+                const instance = component.instance();
+                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement, instance)).to.be.true;
             });
 
             it("does not fire onValueChange if nextProps.max > value", () => {
@@ -732,7 +735,8 @@ describe("<NumericInput>", () => {
                 expect(component.state().value).to.equal("2");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                expect(onValueChangeSpy.calledOnceWithExactly(2, "2", inputElement)).to.be.true;
+                const instance = component.instance();
+                expect(onValueChangeSpy.calledOnceWithExactly(2, "2", inputElement, instance)).to.be.true;
             });
         });
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -27,7 +27,7 @@ import { spy } from "sinon";
 import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test-commons";
 
 import {
-    Button,
+    AnchorButton,
     ButtonGroup,
     ControlGroup,
     HTMLInputProps,
@@ -87,7 +87,7 @@ describe("<NumericInput>", () => {
         it("increments the value from 0 if the field is empty", () => {
             const component = mount(<NumericInput />);
 
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
             incrementButton.simulate("mousedown");
 
             const value = component.state().value;
@@ -197,7 +197,7 @@ describe("<NumericInput>", () => {
             const onValueChangeSpy = spy();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
 
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
             incrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
@@ -210,8 +210,8 @@ describe("<NumericInput>", () => {
             const onButtonClickSpy = spy();
             const component = mount(<NumericInput onButtonClick={onButtonClickSpy} />);
 
-            const incrementButton = component.find(Button).first();
-            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(AnchorButton).first();
+            const decrementButton = component.find(AnchorButton).last();
 
             // incrementing from 0
             incrementButton.simulate("mousedown");
@@ -476,12 +476,12 @@ describe("<NumericInput>", () => {
     // Enable these tests once we have a solution for testing Button onKeyUp callbacks (see PR #561)
     describe("Keyboard interactions on buttons (with Space key)", () => {
         const simulateIncrement = (component: ReactWrapper<any>, mockEvent: IMockEvent = {}) => {
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
             incrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.SPACE));
         };
 
         const simulateDecrement = (component: ReactWrapper<any>, mockEvent: IMockEvent = {}) => {
-            const decrementButton = component.find(Button).last();
+            const decrementButton = component.find(AnchorButton).last();
             decrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.SPACE));
         };
 
@@ -490,12 +490,12 @@ describe("<NumericInput>", () => {
 
     describe("Keyboard interactions on buttons (with Enter key)", () => {
         const simulateIncrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
             incrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.ENTER));
         };
 
         const simulateDecrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const decrementButton = component.find(Button).last();
+            const decrementButton = component.find(AnchorButton).last();
             decrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.ENTER));
         };
 
@@ -504,12 +504,12 @@ describe("<NumericInput>", () => {
 
     describe("Mouse interactions", () => {
         const simulateIncrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
             incrementButton.simulate("mousedown", mockEvent);
         };
 
         const simulateDecrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const decrementButton = component.find(Button).last();
+            const decrementButton = component.find(AnchorButton).last();
             decrementButton.simulate("mousedown", mockEvent);
         };
 
@@ -521,7 +521,7 @@ describe("<NumericInput>", () => {
             it("enforces no minimum bound", () => {
                 const component = mount(<NumericInput />);
 
-                const decrementButton = component.find(Button).last();
+                const decrementButton = component.find(AnchorButton).last();
                 decrementButton.simulate("mousedown", { shiftKey: true });
                 decrementButton.simulate("mousedown", { shiftKey: true });
 
@@ -532,7 +532,7 @@ describe("<NumericInput>", () => {
             it("enforces no maximum bound", () => {
                 const component = mount(<NumericInput />);
 
-                const incrementButton = component.find(Button).first();
+                const incrementButton = component.find(AnchorButton).first();
                 incrementButton.simulate("mousedown", { shiftKey: true });
                 incrementButton.simulate("mousedown", { shiftKey: true });
 
@@ -575,7 +575,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 1
-                const decrementButton = component.find(Button).last();
+                const decrementButton = component.find(AnchorButton).last();
                 decrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -587,7 +587,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 1
-                const decrementButton = component.find(Button).last();
+                const decrementButton = component.find(AnchorButton).last();
                 decrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -599,7 +599,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 0.1
-                const decrementButton = component.find(Button).last();
+                const decrementButton = component.find(AnchorButton).last();
                 decrementButton.simulate("mousedown", { altKey: true });
 
                 const newValue = component.state().value;
@@ -611,7 +611,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 10
-                const decrementButton = component.find(Button).last();
+                const decrementButton = component.find(AnchorButton).last();
                 decrementButton.simulate("mousedown", { shiftKey: true });
 
                 const newValue = component.state().value;
@@ -650,7 +650,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment by 1
-                const incrementButton = component.find(Button).first();
+                const incrementButton = component.find(AnchorButton).first();
                 incrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -662,7 +662,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment in by 1
-                const incrementButton = component.find(Button).first();
+                const incrementButton = component.find(AnchorButton).first();
                 incrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -674,7 +674,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment by 0.1
-                const incrementButton = component.find(Button).first();
+                const incrementButton = component.find(AnchorButton).first();
                 incrementButton.simulate("mousedown", { altKey: true });
 
                 const newValue = component.state().value;
@@ -686,7 +686,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment by 10
-                const incrementButton = component.find(Button).first();
+                const incrementButton = component.find(AnchorButton).first();
                 incrementButton.simulate("mousedown", { shiftKey: true });
 
                 const newValue = component.state().value;
@@ -725,7 +725,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={2} max={2} onValueChange={onValueChangeSpy} />);
                 // repeated interactions, no change in state
                 component
-                    .find(Button)
+                    .find(AnchorButton)
                     .first()
                     .simulate("mousedown")
                     .simulate("mousedown")
@@ -839,7 +839,7 @@ describe("<NumericInput>", () => {
             const value = component.state().value;
             expect(value).to.equal("<invalid>");
 
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
             incrementButton.simulate("mousedown");
 
             const newValue = component.state().value;
@@ -852,7 +852,7 @@ describe("<NumericInput>", () => {
             const value = component.state().value;
             expect(value).to.equal("<invalid>");
 
-            const decrementButton = component.find(Button).last();
+            const decrementButton = component.find(AnchorButton).last();
             decrementButton.simulate("mousedown");
 
             const newValue = component.state().value;
@@ -873,8 +873,8 @@ describe("<NumericInput>", () => {
         it("disables the increment button when the value is greater than or equal to max", () => {
             const component = mount(<NumericInput value={100} max={100} />);
 
-            const decrementButton = component.find(Button).last();
-            const incrementButton = component.find(Button).first();
+            const decrementButton = component.find(AnchorButton).last();
+            const incrementButton = component.find(AnchorButton).first();
 
             expect(decrementButton.props().disabled).to.be.false;
             expect(incrementButton.props().disabled).to.be.true;
@@ -883,8 +883,8 @@ describe("<NumericInput>", () => {
         it("disables the decrement button when the value is less than or equal to min", () => {
             const component = mount(<NumericInput value={-10} min={-10} />);
 
-            const decrementButton = component.find(Button).last();
-            const incrementButton = component.find(Button).first();
+            const decrementButton = component.find(AnchorButton).last();
+            const incrementButton = component.find(AnchorButton).first();
 
             expect(decrementButton.props().disabled).to.be.true;
             expect(incrementButton.props().disabled).to.be.false;
@@ -894,8 +894,8 @@ describe("<NumericInput>", () => {
             const component = mount(<NumericInput disabled={true} />);
 
             const inputGroup = component.find(InputGroup);
-            const decrementButton = component.find(Button).last();
-            const incrementButton = component.find(Button).first();
+            const decrementButton = component.find(AnchorButton).last();
+            const incrementButton = component.find(AnchorButton).first();
 
             expect(inputGroup.props().disabled).to.be.true;
             expect(decrementButton.props().disabled).to.be.true;
@@ -906,8 +906,8 @@ describe("<NumericInput>", () => {
             const component = mount(<NumericInput readOnly={true} />);
 
             const inputGroup = component.find(InputGroup);
-            const decrementButton = component.find(Button).last();
-            const incrementButton = component.find(Button).first();
+            const decrementButton = component.find(AnchorButton).last();
+            const incrementButton = component.find(AnchorButton).first();
 
             expect(inputGroup.props().readOnly).to.be.true;
             expect(decrementButton.props().disabled).to.be.true;
@@ -930,8 +930,8 @@ describe("<NumericInput>", () => {
         });
 
         it("shows right element if provided", () => {
-            const component = mount(<NumericInput rightElement={<Button />} />);
-            expect(component.find(InputGroup).find(Button)).to.exist;
+            const component = mount(<NumericInput rightElement={<AnchorButton />} />);
+            expect(component.find(InputGroup).find(AnchorButton)).to.exist;
         });
 
         it("passed decimal value should be rounded by stepSize", () => {
@@ -946,7 +946,7 @@ describe("<NumericInput>", () => {
 
         it("changes max precision of displayed value to that of the smallest step size defined", () => {
             const component = mount(<NumericInput majorStepSize={1} stepSize={0.1} minorStepSize={0.001} />);
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
 
             incrementButton.simulate("mousedown");
             expect(component.find("input").prop("value")).to.equal("0.1");
@@ -965,7 +965,7 @@ describe("<NumericInput>", () => {
 
         it("changes max precision appropriately when the [*]stepSize props change", () => {
             const component = mount(<NumericInput majorStepSize={1} stepSize={0.1} minorStepSize={0.001} />);
-            const incrementButton = component.find(Button).first();
+            const incrementButton = component.find(AnchorButton).first();
 
             // excess digits should truncate to max precision
             component.setState({ value: "0.0001" });


### PR DESCRIPTION
#### Fixes #4200

#### Checklist

- [X] Includes tests
- [X] Update documentation (No changes to docs)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- ~~Add a check to each iteration of handleContinuousChange, since mouseup event won't fire if the mouse is released on the disabled element (after it reached min/max limit) current behaviour keeps running it indefinitely when using min/max props and releasing the mouseup after described event.~~ Fixed using AnchorButton

- ~~Allow accessing class instance during onValueChange callback, this is necessary as if doing any conditional logic to allow a value, one needs to update the internal value to keep it in sync with given value prop (see [my comment on this issue for more details](https://github.com/palantir/blueprint/pull/4131#issuecomment-651435032))~~ Removed, another PR improves controlled mode

- Add ~~componentDidUpdate~~ getDerivedStateFromProps to AbstractButton, related to the 1st issue, its handleKeyUp is never fired if the button is disabled, so internal state is still "active" while the button is disabled (which is not correct) displaying inconsistent UI to the user when using along other components (For example NumericInput)

#### Reviewers should focus on:

Mentioned changes

#### Screenshot

N/A
