### PR TITLE
[datetime] fix(DatePicker): apply min/max boundaries to time picker

### DIFF
--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -296,8 +296,8 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
         if (timePrecision == null && timePickerProps === DatePicker.defaultProps.timePickerProps) {
             return null;
         }
-        const applyMin = this.state.value && minDate && DateUtils.areSameDay(this.state.value, minDate);
-        const applyMax = this.state.value && maxDate && DateUtils.areSameDay(this.state.value, maxDate);
+        const applyMin = DateUtils.areSameDay(this.state.value, minDate);
+        const applyMax = DateUtils.areSameDay(this.state.value, maxDate);
         return (
             <div className={Classes.DATEPICKER_TIMEPICKER_WRAPPER}>
                 <TimePicker

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -292,14 +292,18 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
     }
 
     private maybeRenderTimePicker() {
-        const { timePrecision, timePickerProps } = this.props;
+        const { timePrecision, timePickerProps, minDate, maxDate } = this.props;
         if (timePrecision == null && timePickerProps === DatePicker.defaultProps.timePickerProps) {
             return null;
         }
+        const applyMin = this.state.value && minDate && DateUtils.areSameDay(this.state.value, minDate);
+        const applyMax = this.state.value && maxDate && DateUtils.areSameDay(this.state.value, maxDate);
         return (
             <div className={Classes.DATEPICKER_TIMEPICKER_WRAPPER}>
                 <TimePicker
                     precision={timePrecision}
+                    minTime={applyMin ? minDate : undefined}
+                    maxTime={applyMax ? maxDate : undefined}
                     {...timePickerProps}
                     onChange={this.handleTimeChange}
                     value={this.state.value}

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -263,6 +263,7 @@ describe("<DatePicker>", () => {
     describe("minDate/maxDate bounds", () => {
         const MIN_DATE = new Date(2015, Months.JANUARY, 7);
         const MAX_DATE = new Date(2015, Months.JANUARY, 12);
+
         it("maxDate must be later than minDate", () => {
             expectPropValidationError(
                 DatePicker,
@@ -336,6 +337,32 @@ describe("<DatePicker>", () => {
             assert.isTrue(onChange.notCalled);
             getDay(8).simulate("click");
             assert.isTrue(onChange.calledOnce);
+        });
+
+        it("constrains time picker when minDate is selected", () => {
+            const picker = mount(
+                <DatePicker
+                    maxDate={MAX_DATE}
+                    minDate={MIN_DATE}
+                    timePrecision={TimePrecision.MINUTE}
+                    value={MIN_DATE}
+                />,
+            );
+            const timePicker = picker.find(TimePicker).first();
+            assert.strictEqual(timePicker.props().minTime, MIN_DATE);
+        });
+
+        it("constrains time picker when max date is selected", () => {
+            const picker = mount(
+                <DatePicker
+                    maxDate={MAX_DATE}
+                    minDate={MIN_DATE}
+                    timePrecision={TimePrecision.MINUTE}
+                    value={MAX_DATE}
+                />,
+            );
+            const timePicker = picker.find(TimePicker).first();
+            assert.strictEqual(timePicker.props().maxTime, MAX_DATE);
         });
     });
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

When I pass `maxDate: 2 July 2020 13:00` to DatePicker with time precision, I cannot select date after 2 July, but I can select 2 July 13:05, which is actually bigger than `props.maxDate`. 
To avoid this, let's pass default `minTime/maxTime` to TimePicker. They can be overwritten  by `timePickerProps.minTime/timePickerProps.maxTime` anyways
