### PR TITLE
ensure null values do not cause numeric input to throw

### DIFF
--- a/packages/core/src/components/forms/numericInputUtils.ts
+++ b/packages/core/src/components/forms/numericInputUtils.ts
@@ -25,7 +25,7 @@ export function clampValue(value: number, min?: number, max?: number) {
 }
 
 export function getValueOrEmptyValue(value: number | string = "") {
-    return value.toString();
+    return value === null ? "" : value.toString();
 }
 
 /** Returns `true` if the string represents a valid numeric value, like "1e6". */

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -183,6 +183,12 @@ describe("<NumericInput>", () => {
             expect(value).to.equal("10");
         });
 
+        it("accepts a null value", () => {
+            const component = mount(<NumericInput value={null} />);
+            const value = component.state().value;
+            expect(value).to.equal("");
+        });
+
         it("in controlled mode, accepts successive value changes containing non-numeric characters", () => {
             const component = mount(<NumericInput />);
             component.setProps({ value: "1" });


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Currently if null is passed in as a value to the Numeric input, an `null is not an object (evaluating 'value.toString')` error occurs. 
This is due to the `getValueOrEmptyValue` utility function treating null as a string.

Although null isn't an acceptable value for the numeric input (according to the types) it should probably not throw an error when a null is passed in.

I think the current behaviour is unintentional, probably due to the ambiguity of whether a null value would default to an empty string in the `string = ""` argument. Unfortunately is does not. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters

#### Reviewers should focus on:

I have purposely not updated any types, I'm not too sure if that was the correct approach?

#### Screenshot

Current error: 
<img width="970" alt="Screenshot 2020-07-03 at 12 04 41" src="https://user-images.githubusercontent.com/5757086/86463452-6e49ee80-bd25-11ea-9ce7-7e0d733af314.png">

