### PR TITLE
[core] fix(NumericInput): disabled prop prevents button interactions

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -229,6 +229,9 @@ Styleguide control-group
 
   Styleguide control-group-fill
   */
+  &.#{$ns}-fill {
+    width: 100%;
+  }
 
   > .#{$ns}-fill {
     flex: 1 1 auto;

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -229,9 +229,6 @@ Styleguide control-group
 
   Styleguide control-group-fill
   */
-  &.#{$ns}-fill {
-    width: 100%;
-  }
 
   > .#{$ns}-fill {
     flex: 1 1 auto;

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -405,15 +405,15 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         return {
             // keydown is fired repeatedly when held so it's implicitly continuous
             onKeyDown: evt => {
-                if (Keys.isKeyboardClick(evt.keyCode)) {
-                    if (this.props.disabled) return;
+                if (!this.props.disabled && Keys.isKeyboardClick(evt.keyCode)) {
                     this.handleButtonClick(evt, direction);
                 }
             },
             onMouseDown: evt => {
-                if (this.props.disabled) return;
-                this.handleButtonClick(evt, direction);
-                this.startContinuousChange();
+                if (!this.props.disabled) {
+                    this.handleButtonClick(evt, direction);
+                    this.startContinuousChange();
+                }
             },
         };
     }

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -406,10 +406,12 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
             // keydown is fired repeatedly when held so it's implicitly continuous
             onKeyDown: evt => {
                 if (Keys.isKeyboardClick(evt.keyCode)) {
+                    if (this.props.disabled) return;
                     this.handleButtonClick(evt, direction);
                 }
             },
             onMouseDown: evt => {
+                if (this.props.disabled) return;
                 this.handleButtonClick(evt, direction);
                 this.startContinuousChange();
             },

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -29,6 +29,7 @@ import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test
 import {
     AnchorButton,
     ButtonGroup,
+    Classes,
     ControlGroup,
     HTMLInputProps,
     Icon,
@@ -1019,10 +1020,11 @@ describe("<NumericInput>", () => {
         it("must not call handleButtonClick if component is disabled", () => {
             const SPACE_KEYSTROKE = { keyCode: Keys.SPACE, which: Keys.SPACE };
 
-            const onValueChangeSpy = spy();
-            const component = mount(<NumericInput onValueChange={onValueChangeSpy} disabled={true} />);
+            const component = mount(<NumericInput disabled={true} />);
 
             const incrementButton = component.find(AnchorButton).first();
+            const handleButtonClickSpy = spy(component.instance(), "handleButtonClick" as any);
+
             incrementButton.simulate("mousedown");
             incrementButton.simulate("mousedown", { altKey: true });
             incrementButton.simulate("keyDown", SPACE_KEYSTROKE);
@@ -1034,7 +1036,13 @@ describe("<NumericInput>", () => {
             decrementButton.simulate("keyDown", SPACE_KEYSTROKE);
             decrementButton.simulate("keyDown", { ...SPACE_KEYSTROKE, altKey: true });
 
-            expect(onValueChangeSpy.notCalled).to.be.true;
+            expect(handleButtonClickSpy.notCalled).to.be.true;
+        });
+
+        it("must set fill class on controlGroup element when fill is enabled", () => {
+            const component = mount(<NumericInput fill={true} />);
+            const controlGroupNode = component.find(ControlGroup).first().getDOMNode();
+            expect(controlGroupNode.classList.contains(Classes.FILL)).to.be.true;
         });
     });
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -29,7 +29,6 @@ import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test
 import {
     AnchorButton,
     ButtonGroup,
-    Classes,
     ControlGroup,
     HTMLInputProps,
     Icon,
@@ -1037,12 +1036,6 @@ describe("<NumericInput>", () => {
             decrementButton.simulate("keyDown", { ...SPACE_KEYSTROKE, altKey: true });
 
             expect(handleButtonClickSpy.notCalled).to.be.true;
-        });
-
-        it("must set fill class on controlGroup element when fill is enabled", () => {
-            const component = mount(<NumericInput fill={true} />);
-            const controlGroupNode = component.find(ControlGroup).first().getDOMNode();
-            expect(controlGroupNode.classList.contains(Classes.FILL)).to.be.true;
         });
     });
 

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -1015,6 +1015,27 @@ describe("<NumericInput>", () => {
             expect(onValueChangeSpy.calledOnceWith(0.01, "0.01"));
             onValueChangeSpy.resetHistory();
         });
+
+        it("must not call handleButtonClick if component is disabled", () => {
+            const SPACE_KEYSTROKE = { keyCode: Keys.SPACE, which: Keys.SPACE };
+
+            const onValueChangeSpy = spy();
+            const component = mount(<NumericInput onValueChange={onValueChangeSpy} disabled={true} />);
+
+            const incrementButton = component.find(AnchorButton).first();
+            incrementButton.simulate("mousedown");
+            incrementButton.simulate("mousedown", { altKey: true });
+            incrementButton.simulate("keyDown", SPACE_KEYSTROKE);
+            incrementButton.simulate("keyDown", { ...SPACE_KEYSTROKE, altKey: true });
+
+            const decrementButton = component.find(AnchorButton).last();
+            decrementButton.simulate("mousedown");
+            decrementButton.simulate("mousedown", { altKey: true });
+            decrementButton.simulate("keyDown", SPACE_KEYSTROKE);
+            decrementButton.simulate("keyDown", { ...SPACE_KEYSTROKE, altKey: true });
+
+            expect(onValueChangeSpy.notCalled).to.be.true;
+        });
     });
 
     interface IMockEvent {


### PR DESCRIPTION
#### Fixes #4213

Also fixes a bug where disabled element allowed interacting with the buttonHandlers (due to now using AnchorButton)

#### Checklist

- [X] Includes tests
- [X] Update documentation

#### Changes proposed in this pull request:

- Add missing class to sass to handle control-group fill
- Don't execute handleButtonClick if component is disabled

#### Reviewers should focus on:

#### Screenshot

