### PR TITLE
[core] fix(Overlay): handle document click/focus in Shadow DOM

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -443,11 +443,12 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
     };
 
     private handleDocumentFocus = (e: FocusEvent) => {
+        const eventTarget = e.composed ? e.composedPath()[0] : e.target
         if (
             this.props.enforceFocus &&
             this.containerElement != null &&
-            e.target instanceof Node &&
-            !this.containerElement.contains(e.target as HTMLElement)
+            eventTarget instanceof Node &&
+            !this.containerElement.contains(eventTarget as HTMLElement)
         ) {
             // prevent default focus behavior (sometimes auto-scrolls the page)
             e.preventDefault();

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -425,6 +425,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
 
     private handleDocumentClick = (e: MouseEvent) => {
         const { canOutsideClickClose, isOpen, onClose } = this.props;
+        // get the actually target even if we are in an open mode Shadow DOM
         const eventTarget = (e.composed ? e.composedPath()[0] : e.target) as HTMLElement;
 
         const stackIndex = Overlay.openStack.indexOf(this);
@@ -443,6 +444,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
     };
 
     private handleDocumentFocus = (e: FocusEvent) => {
+        // get the actually target even if we are in an open mode Shadow DOM
         const eventTarget = e.composed ? e.composedPath()[0] : e.target;
         if (
             this.props.enforceFocus &&

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -425,7 +425,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
 
     private handleDocumentClick = (e: MouseEvent) => {
         const { canOutsideClickClose, isOpen, onClose } = this.props;
-        const eventTarget = e.target as HTMLElement;
+        const eventTarget = (e.composed ? e.composedPath()[0] : e.target) as HTMLElement;
 
         const stackIndex = Overlay.openStack.indexOf(this);
         const isClickInThisOverlayOrDescendant = Overlay.openStack

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -443,7 +443,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
     };
 
     private handleDocumentFocus = (e: FocusEvent) => {
-        const eventTarget = e.composed ? e.composedPath()[0] : e.target
+        const eventTarget = e.composed ? e.composedPath()[0] : e.target;
         if (
             this.props.enforceFocus &&
             this.containerElement != null &&


### PR DESCRIPTION
#### Fixes #4220
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

I use blueprint in Shadow DOM, and the Overlay component is closed even if I click inside it. This PR fix this problem.

I searched the place where `event.target` was used in the entire code base, it seems that only Overlay component used `event.target` in the event registered in the `document`.

#### Reviewers should focus on:

#### Screenshot
