### PR TITLE
fix: remove css rule that causes DateRangePicker prev button to misalign

### DIFF
--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -9,11 +9,6 @@
   display: flex;
   white-space: nowrap;
 
-  // indent first navbar a bit
-  .DayPicker:first-of-type .#{$ns}-datepicker-navbar {
-    left: $datepicker-padding;
-  }
-
   .DayPicker-NavButton--interactionDisabled {
     display: none;
   }


### PR DESCRIPTION
#### Fixes #4082

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Remove css rule that causes DateRangePicker prev button to misalign.

#### Reviewers should focus on:

This change only affects the DateRangePicker component. There was a 5px shift on left side of the navbar for only DateRangePicker. It is mentioned that this is a bug for DateRangePicker at the discussion of #4082.

#### Screenshot

The old version is:
![image](https://user-images.githubusercontent.com/26118454/88103841-373f5e00-cbaa-11ea-8ac6-5cd586d26357.png)

The new version is:
![image](https://user-images.githubusercontent.com/26118454/88103775-268ee800-cbaa-11ea-8b46-470de90bc556.png)

