### PR TITLE
[datetime] fix(DateInput): don't close when clicking time arrows

### DIFF
--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -243,8 +243,9 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         }
         const classes = classNames(Classes.TIMEPICKER_ARROW_BUTTON, getTimeUnitClassName(timeUnit));
         const onClick = () => (isDirectionUp ? this.incrementTime : this.decrementTime)(timeUnit);
+        // set tabIndex=-1 to ensure a valid FocusEvent relatedTarget when focused
         return (
-            <span className={classes} onClick={onClick}>
+            <span tabIndex={-1} className={classes} onClick={onClick}>
                 <Icon icon={isDirectionUp ? "chevron-up" : "chevron-down"} />
             </span>
         );

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -15,10 +15,10 @@
  */
 
 import {
-    Button,
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
     HTMLSelect,
+    Icon,
     Intent,
     IProps,
     Keys,
@@ -244,13 +244,9 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         const classes = classNames(Classes.TIMEPICKER_ARROW_BUTTON, getTimeUnitClassName(timeUnit));
         const onClick = () => (isDirectionUp ? this.incrementTime : this.decrementTime)(timeUnit);
         return (
-            <Button
-                icon={isDirectionUp ? "chevron-up" : "chevron-down"}
-                className={classes}
-                minimal={true}
-                onClick={onClick}
-                tabIndex={-1}
-            />
+            <span className={classes} onClick={onClick}>
+                <Icon icon={isDirectionUp ? "chevron-up" : "chevron-down"} />
+            </span>
         );
     }
 

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -15,10 +15,10 @@
  */
 
 import {
+    Button,
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
     HTMLSelect,
-    Icon,
     Intent,
     IProps,
     Keys,
@@ -244,9 +244,13 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         const classes = classNames(Classes.TIMEPICKER_ARROW_BUTTON, getTimeUnitClassName(timeUnit));
         const onClick = () => (isDirectionUp ? this.incrementTime : this.decrementTime)(timeUnit);
         return (
-            <span className={classes} onClick={onClick}>
-                <Icon icon={isDirectionUp ? "chevron-up" : "chevron-down"} />
-            </span>
+            <Button
+                icon={isDirectionUp ? "chevron-up" : "chevron-down"}
+                className={classes}
+                minimal={true}
+                onClick={onClick}
+                tabIndex={-1}
+            />
         );
     }
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -136,6 +136,38 @@ describe("<DateInput>", () => {
         assert.isTrue(root.find(Popover).prop("isOpen"));
     });
 
+    it("Popover should not close when time picker arrows are clicked after selecting a month", () => {
+        const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
+        const { root, changeSelect } = wrap(
+            <DateInput
+                {...DATE_FORMAT}
+                defaultValue={defaultValue}
+                timePrecision={TimePrecision.MINUTE}
+                timePickerProps={{ showArrowButtons: true }}
+            />,
+        );
+        root.setState({ isOpen: true }).update();
+        changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.MARCH);
+        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
+        assert.isTrue(root.find(Popover).prop("isOpen"));
+    });
+
+    it("Popover should not close when time picker arrows are clicked after selecting a year", () => {
+        const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
+        const { root, changeSelect } = wrap(
+            <DateInput
+                {...DATE_FORMAT}
+                defaultValue={defaultValue}
+                timePrecision={TimePrecision.MINUTE}
+                timePickerProps={{ showArrowButtons: true }}
+            />,
+        );
+        root.setState({ isOpen: true }).update();
+        changeSelect(Classes.DATEPICKER_YEAR_SELECT, 2019);
+        root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
+        assert.isTrue(root.find(Popover).prop("isOpen"));
+    });
+
     it("setting timePrecision renders a TimePicker", () => {
         const wrapper = mount(<DateInput {...DATE_FORMAT} timePrecision={TimePrecision.SECOND} />)
             .setState({


### PR DESCRIPTION
#### Fixes #3474

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

- Set tabIndex=-1 on the timepicker arrow span element to ensure e.relatedTarget on the FocusEvent passed to handlePopoverBlur in dateInput is valid, preventing inappropriate closing of the popover.

Added tests and checked in latest Chrome, Firefox and Safari.

#### Reviewers should focus on:

- Whether the referenced bug has been fixed
- Whether setting tabIndex=-1 has any other side effects

#### Screenshot

Before | After
---- | ----
![dpbefore](https://user-images.githubusercontent.com/1751363/88255363-28b08e00-ccf3-11ea-8769-0e3cca6a2453.gif) | ![dpfixed](https://user-images.githubusercontent.com/1751363/88254864-91970680-ccf1-11ea-85a7-f4e85f333d10.gif)
