### PR TITLE
[datetime] fix(DatePicker): prevent iOS crash selecting month/year

### DIFF
--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -132,6 +132,10 @@ export class DatePickerCaption extends AbstractPureComponent2<IDatePickerCaption
     private dateChangeHandler(updater: (date: Date, value: number) => void, handler?: (value: number) => void) {
         return (e: React.FormEvent<HTMLSelectElement>) => {
             const value = parseInt((e.target as HTMLSelectElement).value, 10);
+            // ignore change events with invalid values to prevent crash on iOS Safari (#4178)
+            if (isNaN(value)) {
+                return;
+            }
             const newDate = clone(this.props.date);
             updater(newDate, value);
             Utils.safeInvoke(this.props.onDateChange, newDate);


### PR DESCRIPTION
#### Fixes #4178 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

- Ignore invalid values passed to the month/year select change handler to prevent a crash on Safari on iOS.

#### Reviewers should focus on:

- Whether the referenced bug has been fixed.
- Whether silently rejecting invalid values is acceptable or if it could make debugging harder in the future.

#### Screenshot

Before | After
---- | ----
![HCSF6027 (1)](https://user-images.githubusercontent.com/1751363/88423611-fd2ec000-ce26-11ea-81d0-335788c101f8.gif) | ![ETUX2092](https://user-images.githubusercontent.com/1751363/88423603-f99b3900-ce26-11ea-83c6-2df9451302b9.gif)



