### PR TITLE
Fix dialog automatically closing when clicking on scrollbar by adding…

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -68,6 +68,8 @@ $dialog-padding: $pt-grid-size * 2 !default;
   display: flex;
   flex-direction: column;
   margin: $dialog-margin;
+  max-height: 80vh;
+  overflow: auto;
   padding-bottom: $pt-grid-size * 2;
   pointer-events: all;
   user-select: text;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -68,8 +68,6 @@ $dialog-padding: $pt-grid-size * 2 !default;
   display: flex;
   flex-direction: column;
   margin: $dialog-margin;
-  max-height: 80vh;
-  overflow: auto;
   padding-bottom: $pt-grid-size * 2;
   pointer-events: all;
   user-select: text;
@@ -131,6 +129,8 @@ $dialog-padding: $pt-grid-size * 2 !default;
   flex: 1 1 auto;
   line-height: $pt-grid-size * 1.8;
   margin: $dialog-padding;
+  max-height: 70vh;
+  overflow: auto;
 }
 
 .#{$ns}-dialog-footer {


### PR DESCRIPTION
… scrollbars to the dialog when max-height is greater than 80vh.


#### Fixes #3930 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

When the dialog is opened and the window resized so that scrollbars appear on the dialog, the dialog should remain open when a user clicks on the scrollbar. 
#### Reviewers should focus on:

Resizing the dialog until scrollbars appear and making sure that the dialog does not close when the scrollbar is clicked on. 

<!-- Fill this out. -->

#### Screenshot

![Screen Shot 2020-07-28 at 3 35 41 PM](https://user-images.githubusercontent.com/68716114/88616348-11edab00-d0e8-11ea-9bf5-4211daf914e9.png)

