### PR TITLE
[datetime] fix(DRI): check time boundaries for same day overlap

### DIFF
--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -938,10 +938,10 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         }
 
         if (boundary === Boundary.START) {
-            const isAfter = DayPicker.DateUtils.isDayAfter(date, otherBoundaryDate);
+            const isAfter = date > otherBoundaryDate;
             return isAfter || (!allowSingleDayRange && DayPicker.DateUtils.isSameDay(date, otherBoundaryDate));
         } else {
-            const isBefore = DayPicker.DateUtils.isDayBefore(date, otherBoundaryDate);
+            const isBefore = date < otherBoundaryDate;
             return isBefore || (!allowSingleDayRange && DayPicker.DateUtils.isSameDay(date, otherBoundaryDate));
         }
     };

--- a/packages/datetime/test/common/dateFormat.ts
+++ b/packages/datetime/test/common/dateFormat.ts
@@ -21,3 +21,14 @@ export const DATE_FORMAT: IDateFormatProps = {
     parseDate: str => new Date(str),
     placeholder: "M/D/YYYY",
 };
+
+export const DATETIME_FORMAT: IDateFormatProps = {
+    formatDate: date => {
+        const hour = `${date.getHours()}`.padStart(2, "0");
+        const minute = `${date.getMinutes()}`.padStart(2, "0");
+        const dateString = [date.getMonth() + 1, date.getDate(), date.getFullYear()].join("/");
+        return `${dateString} ${hour}:${minute}`;
+    },
+    parseDate: str => new Date(str),
+    placeholder: "M/D/YYYY HH:mm",
+};

--- a/packages/datetime/test/common/dateTestUtils.ts
+++ b/packages/datetime/test/common/dateTestUtils.ts
@@ -29,6 +29,13 @@ export function toDateString(date: Date) {
     return [month, day, year].join("/");
 }
 
+export function toDateHourMinuteString(date: Date) {
+    const hour = `${date.getHours()}`.padStart(2, "0");
+    const minute = `${date.getMinutes()}`.padStart(2, "0");
+    const dateString = toDateString(date);
+    return `${dateString} ${hour}:${minute}`;
+}
+
 /**
  * Creates a date object with time only.
  */


### PR DESCRIPTION
#### Fixes #4155

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes a bug that allowed the start time to be later than the end time in the DateRangeInput when single day range was enabled.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
