### PR TITLE
[core] fix(Tag): remove button has tabIndex if interactive

### DIFF
--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -137,7 +137,12 @@ export class Tag extends AbstractPureComponent2<ITagProps> {
         );
         const isLarge = large || tagClasses.indexOf(Classes.LARGE) >= 0;
         const removeButton = isRemovable ? (
-            <button type="button" className={Classes.TAG_REMOVE} onClick={this.onRemoveClick} tabIndex={interactive ? tabIndex : undefined} >
+            <button
+                type="button"
+                className={Classes.TAG_REMOVE}
+                onClick={this.onRemoveClick}
+                tabIndex={interactive ? tabIndex : undefined}
+            >
                 <Icon icon="small-cross" iconSize={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD} />
             </button>
         ) : null;

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -137,7 +137,7 @@ export class Tag extends AbstractPureComponent2<ITagProps> {
         );
         const isLarge = large || tagClasses.indexOf(Classes.LARGE) >= 0;
         const removeButton = isRemovable ? (
-            <button type="button" className={Classes.TAG_REMOVE} onClick={this.onRemoveClick}>
+            <button type="button" className={Classes.TAG_REMOVE} onClick={this.onRemoveClick} tabIndex={interactive ? tabIndex : undefined} >
                 <Icon icon="small-cross" iconSize={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD} />
             </button>
         ) : null;


### PR DESCRIPTION
multi-select tag remove button now tabs only when tabbing for tag implemented

#### Fixes #4247 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Tabbing of the remove button is aligned with the tag itself.

#### Reviewers should focus on:

Just a quick fix that makes all elements of the tag 'tabbable' or not depending upon whether` interactive = true` and a `tabIndex `has been set.

