### PR TITLE
Add 'slow' prop to Spinner to animate at half speed

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -209,6 +209,7 @@ export const END = `${NS}-end`;
 
 export const SPINNER = `${NS}-spinner`;
 export const SPINNER_ANIMATION = `${SPINNER}-animation`;
+export const SPINNER_ANIMATION_SLOW = `${SPINNER}-animation-slow`;
 export const SPINNER_HEAD = `${SPINNER}-head`;
 export const SPINNER_NO_SPIN = `${NS}-no-spin`;
 export const SPINNER_TRACK = `${SPINNER}-track`;

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.#{$ns}-spinner-animation-slow {
+  animation: pt-spinner-animation ($pt-transition-duration * 10) linear infinite;
+}
+
 .#{$ns}-dark .#{$ns}-spinner {
   .#{$ns}-spinner-head {
     stroke: $dark-progress-head-color;

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -47,6 +47,11 @@ export interface ISpinnerProps extends IProps, IIntentProps {
      * Omitting this prop will result in an "indeterminate" spinner where the head spins indefinitely.
      */
     value?: number;
+
+    /**
+     * A boolean value that causes the spinner to animate at half speed.
+     */
+    slow?: boolean;
 }
 
 export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
@@ -64,7 +69,7 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
     }
 
     public render() {
-        const { className, intent, value, tagName: TagName = "div" } = this.props;
+        const { className, intent, value, tagName: TagName = "div", slow } = this.props;
         const size = this.getSize();
 
         const classes = classNames(
@@ -73,6 +78,8 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
             { [Classes.SPINNER_NO_SPIN]: value != null },
             className,
         );
+
+        const animationClasses = classNames(Classes.SPINNER_ANIMATION, { [Classes.SPINNER_ANIMATION_SLOW]: slow });
 
         // attempt to keep spinner stroke width constant at all sizes
         const strokeWidth = Math.min(MIN_STROKE_WIDTH, STROKE_WIDTH * Spinner.SIZE_LARGE / size);
@@ -84,7 +91,7 @@ export class Spinner extends AbstractPureComponent<ISpinnerProps, {}> {
         // - SPINNER_ANIMATION isolates svg from parent display and is always centered inside root element.
         return (
             <TagName className={classes}>
-                <span className={Classes.SPINNER_ANIMATION}>
+                <span className={animationClasses}>
                     <svg height={size} width={size} viewBox="0 0 100 100" strokeWidth={strokeWidth}>
                         <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
                         <path

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -15,6 +15,7 @@ export interface ISpinnerExampleState {
     intent?: Intent;
     size: number;
     value: number;
+    slow: boolean;
 }
 
 export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerExampleState> {
@@ -22,22 +23,24 @@ export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerE
         hasValue: false,
         size: Spinner.SIZE_STANDARD,
         value: 0.7,
+        slow: false,
     };
 
     private handleIndeterminateChange = handleBooleanChange(hasValue => this.setState({ hasValue }));
+    private handleSlowChange = handleBooleanChange(slow => this.setState({ slow }));
     private handleModifierChange = handleStringChange((intent: Intent) => this.setState({ intent }));
 
     public render() {
-        const { size, hasValue, intent, value } = this.state;
+        const { size, hasValue, intent, value, slow } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
-                <Spinner intent={intent} size={size} value={hasValue ? value : null} />
+                <Spinner intent={intent} size={size} value={hasValue ? value : null} slow={slow} />
             </Example>
         );
     }
 
     private renderOptions() {
-        const { size, hasValue, intent, value } = this.state;
+        const { size, hasValue, intent, value, slow } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -52,6 +55,7 @@ export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerE
                     value={size}
                     onChange={this.handleSizeChange}
                 />
+                <Switch checked={slow} label="Slow" onChange={this.handleSlowChange} />
                 <Switch checked={hasValue} label="Known value" onChange={this.handleIndeterminateChange} />
                 <Slider
                     disabled={!hasValue}


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added a 'slow' prop to Spinner to operate at half speed

#### Reviewers should focus on:

I updated the Spinner docs with an easy toggle.

#### Screenshot

Looks like the normal spinner, just at half speed. Understandable if you don't think this is valuable, but I found it helpful for indeterminate longer-running tasks. The normal spinner is a bit fast.