### PR TITLE
Temporarily uncontrol InputGroup during IME composition

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -90,7 +90,6 @@ export interface IInputGroupState {
     leftElementWidth?: number;
     rightElementWidth?: number;
     isComposing: boolean;
-    lastOnChangeEvent?: React.FormEvent<HTMLInputElement>;
 }
 
 @polyfill
@@ -132,9 +131,6 @@ export class InputGroup extends AbstractPureComponent2<IInputGroupProps & HTMLIn
 
         const htmlProps = {
             ...removeNonHTMLProps(this.props),
-            // Intercept onChange with our own handler so we can block change events while composing.
-            onChange: this.handleOnChange,
-
             // Add handlers to track when IME composition is occuring.
             onCompositionEnd: this.handleCompositionEnd,
             onCompositionStart: this.handleCompositionStart,
@@ -221,26 +217,11 @@ export class InputGroup extends AbstractPureComponent2<IInputGroupProps & HTMLIn
         }
     }
 
-    private handleOnChange = (e: React.FormEvent<HTMLInputElement>) => {
-        if (this.state.isComposing) {
-            // Don't propagate onChange events while IME is composing.
-            e.persist();
-            this.setState({ lastOnChangeEvent: e });
-            return;
-        }
-
-        this.props?.onChange?.(e);
-    };
-
     private handleCompositionStart = () => {
         this.setState({ isComposing: true });
     };
 
     private handleCompositionEnd = () => {
-        if (this.state.lastOnChangeEvent) {
-            // The last onChange event before composing is finished will contain the composed text.
-            this.props.onChange?.(this.state.lastOnChangeEvent);
-        }
-        this.setState({ isComposing: false, lastOnChangeEvent: undefined });
+        this.setState({ isComposing: false });
     };
 }


### PR DESCRIPTION
Read https://github.com/facebook/react/issues/3926 for full context on the issue.
Basically, while composing text using an IME, onChange events still fire for every keystroke.
From my testing, it seems that IF the InputGroup is controlled AND the `setState` call in the parent component occurs asynchronously, then the IME composition gets interrupted when the props change.

You can reproduce this behaviour by replacing this line: https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx#L58
with
```typescript
private handleFilterChange = handleStringChange(filterValue => window.setTimeout(this.setState({ filterValue }), 0));
```
to force an asynchronous update.

I'm not sure this is the right fix, but it's certainly simple.  The proposal is that we temporarily stop controlling the input component while IME composition is occurring.
We purposefully continue sending onChange events during this time, since this matches what the behaviour would be in the uncontrolled case, and ensures that once we re-take control when composition ends, the parent component's state should be in-sync with whatever was in the input box as a result of composition.

I have tested in Chrome and Safari on MacOS, and both exhibit correct behaviour after this fix, even with the above hack to force asynchronous state changes.

That said, any behaviour like this has the potential to be fragile, so would appreciate any input from the team.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Temporarily relinquish control of input component during IME composition.

#### Reviewers should focus on:

How fragile this is likely to be.  Are there any edge cases?

#### Screenshot

No visible changes.
