### PR TITLE
[core] fix(EditableText): add small width buffer to prevent crash

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -128,7 +128,7 @@ export interface IEditableTextState {
     value?: string;
 }
 
-const BUFFER_WIDTH_EDGE = 5;
+const BUFFER_WIDTH_DEFAULT = 5;
 const BUFFER_WIDTH_IE = 30;
 
 @polyfill
@@ -258,6 +258,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         if (this.props.disabled || (this.props.disabled == null && prevProps.disabled)) {
             state.isEditing = false;
         }
+
         this.setState(state);
 
         if (this.state.isEditing && !prevState.isEditing) {
@@ -383,12 +384,10 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
             // Chrome's input caret height misaligns text so the line-height must be larger than font-size.
             // The computed scrollHeight must also account for a larger inherited line-height from the parent.
             scrollHeight = Math.max(scrollHeight, getFontSize(this.valueElement) + 1, getLineHeight(parentElement));
-            // IE11 & Edge needs a small buffer so text does not shift prior to resizing
-            if (Browser.isEdge()) {
-                scrollWidth += BUFFER_WIDTH_EDGE;
-            } else if (Browser.isInternetExplorer()) {
-                scrollWidth += BUFFER_WIDTH_IE;
-            }
+            // Need to add a small buffer so text does not shift prior to resizing, causing an infinite loop.
+            // IE needs a larger buffer than other browsers.
+            scrollWidth += Browser.isInternetExplorer() ? BUFFER_WIDTH_IE : BUFFER_WIDTH_DEFAULT;
+
             this.setState({
                 inputHeight: scrollHeight,
                 inputWidth: Math.max(scrollWidth, minWidth),


### PR DESCRIPTION
#### Fixes #4267

I've tested this PR against the application where we originally noticed the crash, and confirmed it does fix the problem.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Add a small buffer to scrollWidth in EditableText to prevent the infinite loop described in #4267 
Before this PR we only added the buffer for IE and Edge.  This PR makes it so we add the buffer for all browsers.

#### Reviewers should focus on:

Is this really the "right" fix?  Or is this just a patch over a deeper issue?
