### PR TITLE
[datetime] fix(DatePicker, TimePicker): allow value prop to be null

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -84,7 +84,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
     /**
      * The default date to be used in the component when uncontrolled.
      */
-    defaultValue?: Date;
+    defaultValue?: Date | null;
 
     /**
      * Whether the component should take up the full width of its container.

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -84,7 +84,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
     /**
      * The default date to be used in the component when uncontrolled.
      */
-    defaultValue?: Date | null;
+    defaultValue?: Date;
 
     /**
      * Whether the component should take up the full width of its container.

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -56,7 +56,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
      * Initial day the calendar will display as selected.
      * This should not be set if `value` is set.
      */
-    defaultValue?: Date;
+    defaultValue?: Date | null;
 
     /**
      * Whether the current day should be highlighted in the calendar.
@@ -113,7 +113,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     /**
      * The currently selected day. If this prop is provided, the component acts in a controlled manner.
      */
-    value?: Date;
+    value?: Date | null;
 }
 
 export interface IDatePickerState {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -56,7 +56,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
      * Initial day the calendar will display as selected.
      * This should not be set if `value` is set.
      */
-    defaultValue?: Date | null;
+    defaultValue?: Date;
 
     /**
      * Whether the current day should be highlighted in the calendar.

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -31,7 +31,7 @@ export interface IDateTimePickerProps extends IProps {
      * This will be ignored if `value` is set.
      * @default Date.now()
      */
-    defaultValue?: Date;
+    defaultValue?: Date | null;
 
     /**
      * Any props to be passed on to the `DatePicker` other than the `value` and `onChange` props as they come directly
@@ -53,7 +53,7 @@ export interface IDateTimePickerProps extends IProps {
     /**
      * The currently set date and time. If this prop is provided, the component acts in a controlled manner.
      */
-    value?: Date;
+    value?: Date | null;
 
     /**
      * Allows the user to clear the selection by clicking the currently selected day.

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -31,7 +31,7 @@ export interface IDateTimePickerProps extends IProps {
      * This will be ignored if `value` is set.
      * @default Date.now()
      */
-    defaultValue?: Date | null;
+    defaultValue?: Date;
 
     /**
      * Any props to be passed on to the `DatePicker` other than the `value` and `onChange` props as they come directly

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -59,7 +59,7 @@ export interface ITimePickerProps extends IProps {
      * Initial time the `TimePicker` will display.
      * This should not be set if `value` is set.
      */
-    defaultValue?: Date | null;
+    defaultValue?: Date;
 
     /**
      * Whether the time picker is non-interactive.

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -59,7 +59,7 @@ export interface ITimePickerProps extends IProps {
      * Initial time the `TimePicker` will display.
      * This should not be set if `value` is set.
      */
-    defaultValue?: Date;
+    defaultValue?: Date | null;
 
     /**
      * Whether the time picker is non-interactive.
@@ -138,7 +138,7 @@ export interface ITimePickerProps extends IProps {
      * The currently set time.
      * If this prop is provided, the component acts in a controlled manner.
      */
-    value?: Date;
+    value?: Date | null;
 }
 
 export interface ITimePickerState {


### PR DESCRIPTION
#### Changes proposed in this pull request:

Adds null typings to datetime interfaces to match clear/empty value
