### PR TITLE
[core] fix(Tabs): don't animate tab indicator on first render

### DIFF
--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -164,7 +164,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
     }
 
     public componentDidMount() {
-        this.moveSelectionIndicator();
+        this.moveSelectionIndicator(true);
     }
 
     public componentDidUpdate(prevProps: ITabsProps, prevState: ITabsState) {
@@ -266,7 +266,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
      * Calculate the new height, width, and position of the tab indicator.
      * Store the CSS values so the transition animation can start.
      */
-    private moveSelectionIndicator() {
+    private moveSelectionIndicator(skipTransition?: boolean) {
         if (this.tablistElement == null || !this.props.animate) {
             return;
         }
@@ -281,6 +281,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
                 height: clientHeight,
                 transform: `translateX(${Math.floor(offsetLeft)}px) translateY(${Math.floor(offsetTop)}px)`,
                 width: clientWidth,
+                ...(skipTransition ? { transitionDuration: "0s" } : {}),
             };
         }
         this.setState({ indicatorWrapperStyle });

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -164,7 +164,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
     }
 
     public componentDidMount() {
-        this.moveSelectionIndicator(true);
+        this.moveSelectionIndicator(false);
     }
 
     public componentDidUpdate(prevProps: ITabsProps, prevState: ITabsState) {
@@ -266,7 +266,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
      * Calculate the new height, width, and position of the tab indicator.
      * Store the CSS values so the transition animation can start.
      */
-    private moveSelectionIndicator(skipTransition?: boolean) {
+    private moveSelectionIndicator(animate = true) {
         if (this.tablistElement == null || !this.props.animate) {
             return;
         }
@@ -281,8 +281,11 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
                 height: clientHeight,
                 transform: `translateX(${Math.floor(offsetLeft)}px) translateY(${Math.floor(offsetTop)}px)`,
                 width: clientWidth,
-                ...(skipTransition ? { transitionDuration: "0s" } : {}),
             };
+
+            if (!animate) {
+                indicatorWrapperStyle.transition = "none";
+            }
         }
         this.setState({ indicatorWrapperStyle });
     }


### PR DESCRIPTION
#### Changes proposed in this pull request:

Skips animation transition during first render, as when working on controlled mode the selected tab may not be the first one, and there's a transition to the selected tab which shouldn't appear.

Here's a [sandbox](https://codesandbox.io/s/charming-margulis-n6s6r?file=/src/App.tsx), either click codesanbox refresh or the refresh button to see the issue.