### PR TITLE
Use React.ReactNode for the label prop on HotKey and RadioGroup

### DIFF
--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -35,7 +35,7 @@ export interface IRadioGroupProps extends IProps {
     inline?: boolean;
 
     /** Optional label text to display above the radio buttons. */
-    label?: string;
+    label?: React.ReactNode;
 
     /**
      * Name of the group, used to link radio buttons together in HTML.

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -41,7 +41,7 @@ export interface IHotkeyProps extends IProps {
     /**
      * Human-friendly label for the hotkey.
      */
-    label: string;
+    label: React.ReactNode;
 
     /**
      * If `false`, the hotkey is active only when the target is focused. If


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Both of these components `label` props (`HotKey` and `RadioGroup`) don't need to be just strings, they can also be React components
- This PR simply updates prop types