### PR TITLE
added prop validation for multiSlider and rangeSlider to prevent out of bounds values

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -86,7 +86,9 @@ export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
 export const SLIDER_ZERO_STEP = ns + ` <Slider> stepSize must be greater than zero.`;
 export const SLIDER_ZERO_LABEL_STEP = ns + ` <Slider> labelStepSize must be greater than zero.`;
 export const RANGESLIDER_NULL_VALUE = ns + ` <RangeSlider> value prop must be an array of two non-null numbers.`;
+export const RANGESLIDER_OUT_OF_BOUNDS = ns + ` <RangeSlider> value prop must be within range of min, max props`;
 export const MULTISLIDER_INVALID_CHILD = ns + ` <MultiSlider> children must be <SliderHandle>s or <SliderTrackStop>s`;
+export const MULTISLIDER_OUT_OF_BOUNDS = ns + ` <MultiSlider> value prop must be within range of min, max props`;
 
 export const SPINNER_WARN_CLASSES_SIZE = ns + ` <Spinner> Classes.SMALL/LARGE are ignored if size prop is set.`;
 

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -88,7 +88,8 @@ export const SLIDER_ZERO_LABEL_STEP = ns + ` <Slider> labelStepSize must be grea
 export const RANGESLIDER_NULL_VALUE = ns + ` <RangeSlider> value prop must be an array of two non-null numbers.`;
 export const RANGESLIDER_OUT_OF_BOUNDS = ns + ` <RangeSlider> value prop must be within range of min, max props`;
 export const MULTISLIDER_INVALID_CHILD = ns + ` <MultiSlider> children must be <SliderHandle>s or <SliderTrackStop>s`;
-export const MULTISLIDER_OUT_OF_BOUNDS = ns + ` <MultiSlider> value prop must be within range of min, max props`;
+export const MULTISLIDER_OUT_OF_BOUNDS =
+    ns + ` <MultiSlider> children's value props must be within range of min, max props`;
 
 export const SPINNER_WARN_CLASSES_SIZE = ns + ` <Spinner> Classes.SMALL/LARGE are ignored if size prop is set.`;
 

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -210,6 +210,20 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         if (anyInvalidChildren) {
             throw new Error(Errors.MULTISLIDER_INVALID_CHILD);
         }
+
+        // don't allow supplied values to be outside of min/max range
+        let anyOutOfBoundsChildren = false;
+        React.Children.forEach(props.children, (child: Handle) => {
+            const { value, min, max } = child.props;
+
+            // make sure this child's values are within parent range and individual range
+            if (value < min || value > max || value < props.min || value > props.max) {
+                anyOutOfBoundsChildren = true;
+            }
+        });
+        if (anyOutOfBoundsChildren) {
+            throw new Error(Errors.MULTISLIDER_OUT_OF_BOUNDS);
+        }
     }
 
     private formatLabel(value: number): React.ReactChild {

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -63,9 +63,19 @@ export class RangeSlider extends AbstractPureComponent2<IRangeSliderProps> {
     }
 
     protected validateProps(props: IRangeSliderProps) {
-        const { value } = props;
+        const { value, min, max } = props;
         if (value == null || value[RangeIndex.START] == null || value[RangeIndex.END] == null) {
             throw new Error(Errors.RANGESLIDER_NULL_VALUE);
+        }
+
+        // don't allow supplied value to be outside of min/max range
+        if (
+            value[RangeIndex.START] < min ||
+            value[RangeIndex.END] > max ||
+            value[RangeIndex.START] > max ||
+            value[RangeIndex.END] < min
+        ) {
+            throw new Error(Errors.RANGESLIDER_OUT_OF_BOUNDS);
         }
     }
 }

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -24,6 +24,7 @@ import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { Classes, IMultiSliderProps, MultiSlider } from "../../src";
 import { Handle } from "../../src/components/slider/handle";
 import { mouseUpHorizontal, simulateMovement } from "./sliderTestUtils";
+import * as Errors from "../../src/common/errors";
 
 const STEP_SIZE = 20;
 
@@ -156,17 +157,6 @@ describe("<MultiSlider>", () => {
             assert.equal(onChange.callCount, 1, "higher handle invokes onChange");
             assert.deepEqual(onChange.firstCall.args[0], [5, 5, 9], "higher handle moves");
         });
-
-        it("values outside of bounds are clamped", () => {
-            const slider = renderSlider({ values: [-1, 5, 12] });
-            slider.find(`.${Classes.SLIDER_PROGRESS}`).forEach(progress => {
-                const { left, right } = progress.prop("style");
-                // CSS properties are percentage strings, but parsing will ignore trailing "%".
-                // percentages should be in 0-100% range.
-                assert.isAtLeast(parseFloat(left.toString()), 0);
-                assert.isAtMost(parseFloat(right.toString()), 100);
-            });
-        });
     });
 
     describe("labels", () => {
@@ -178,7 +168,7 @@ describe("<MultiSlider>", () => {
 
         it("renders all labels even when floating point approx would cause the last one to be skipped", () => {
             // [0  0.14  0.28  0.42  0.56  0.70]
-            const wrapper = renderSlider({ min: 0, max: 0.7, labelStepSize: 0.14 });
+            const wrapper = renderSlider({ values: [0, 0.14, 0.28], min: 0, max: 0.7, labelStepSize: 0.14 });
             assertLabelCount(wrapper, 6);
         });
 
@@ -303,6 +293,16 @@ describe("<MultiSlider>", () => {
             [0, -10].forEach(labelStepSize => {
                 expectPropValidationError(MultiSlider, { labelStepSize }, "greater than zero");
             });
+        });
+
+        it("throws error if values are outside of bounds", () => {
+            expectPropValidationError(
+                MultiSlider,
+                {
+                    children: <MultiSlider.Handle value={11} />,
+                },
+                Errors.MULTISLIDER_OUT_OF_BOUNDS,
+            );
         });
     });
 

--- a/packages/core/test/slider/rangeSliderTests.tsx
+++ b/packages/core/test/slider/rangeSliderTests.tsx
@@ -24,6 +24,7 @@ import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { Classes, RangeSlider } from "../../src";
 import { ARROW_DOWN } from "../../src/common/keys";
 import { Handle } from "../../src/components/slider/handle";
+import * as Errors from "../../src/common/errors";
 
 const STEP_SIZE = 20;
 
@@ -64,6 +65,16 @@ describe("<RangeSlider>", () => {
         handles.first().simulate("keydown", { which: ARROW_DOWN });
         handles.last().simulate("keydown", { which: ARROW_DOWN });
         assert.isTrue(changeSpy.notCalled, "onChange was called when disabled");
+    });
+
+    it("throws error if values are outside of bounds", () => {
+        expectPropValidationError(
+            RangeSlider,
+            {
+                value: [-1, 11],
+            },
+            Errors.RANGESLIDER_OUT_OF_BOUNDS,
+        );
     });
 
     function renderSlider(slider: JSX.Element) {


### PR DESCRIPTION
#### Fixes #4285 

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

As referenced in issue #4285 , a user can supply out-of-bounds value and put the `MultiSlider` and `RangeSlider` components into bad states. I proposed a logical guard, and created a new validation check in `validateProps`, following as the other components had done.

#### Reviewers should focus on:

That props are validated, and you cannot supply values that lie outside of the `min, max` range.

#### Screenshot

N/A
