### PR TITLE
Deprecate safeInvoke utility

### DIFF
--- a/packages/core/src/common/utils/functionUtils.ts
+++ b/packages/core/src/common/utils/functionUtils.ts
@@ -23,6 +23,7 @@ export function isFunction(value: any): value is Function {
 /**
  * Safely invoke the function with the given arguments, if it is indeed a
  * function, and return its value. Otherwise, return undefined.
+ * @deprecated use TypeScript 3.7+ optional call operator func?.()
  */
 export function safeInvoke<R>(func: (() => R) | undefined): R | undefined;
 export function safeInvoke<A, R>(func: ((arg1: A) => R) | undefined, arg1: A): R | undefined;
@@ -51,6 +52,7 @@ export function safeInvoke(func: Function | undefined, ...args: any[]) {
 /**
  * Safely invoke the provided entity if it is a function; otherwise, return the
  * entity itself.
+ * @deprecated use TypeScript 3.7+ optional call operator func?.()
  */
 export function safeInvokeOrValue<R>(funcOrValue: (() => R) | R | undefined): R;
 export function safeInvokeOrValue<A, R>(funcOrValue: ((arg1: A) => R) | R | undefined, arg1: A): R;

--- a/packages/core/src/common/utils/safeInvokeMember.ts
+++ b/packages/core/src/common/utils/safeInvokeMember.ts
@@ -35,6 +35,7 @@ one item.
  * Safely invoke the member function with no arguments, if the object
  * exists and the given key is indeed a function, and return its value.
  * Otherwise, return `undefined`.
+ * @deprecated use TypeScript 3.7+ optional chaining and optional call operator obj?[key]?.()
  */
 export function safeInvokeMember<T extends { [k in K]?: () => R }, K extends keyof T, R = void>(
     obj: T | undefined,
@@ -48,6 +49,7 @@ export function safeInvokeMember<T extends { [k in K]?: () => R }, K extends key
  * ```js
  * // example usage
  * safeInvokeMember(this.props.inputProps, "onChange", evt);
+ * @deprecated use TypeScript 3.7+ optional chaining and optional call operator obj?[key]?.()
  * ```
  */
 export function safeInvokeMember<T extends { [k in K]?: (a: A) => R }, K extends keyof T, A, R = void>(
@@ -59,6 +61,7 @@ export function safeInvokeMember<T extends { [k in K]?: (a: A) => R }, K extends
  * Safely invoke the member function with two arguments, if the object
  * exists and the given key is indeed a function, and return its value.
  * Otherwise, return `undefined`.
+ * @deprecated use TypeScript 3.7+ optional chaining and optional call operator obj?[key]?.()
  */
 export function safeInvokeMember<T extends { [k in K]?: (a: A, b: B) => R }, K extends keyof T, A, B, R = void>(
     obj: T | undefined,
@@ -70,6 +73,7 @@ export function safeInvokeMember<T extends { [k in K]?: (a: A, b: B) => R }, K e
  * Safely invoke the member function with three arguments, if the object
  * exists and the given key is indeed a function, and return its value.
  * Otherwise, return undefined.
+ * @deprecated use TypeScript 3.7+ optional chaining and optional call operator obj?[key]?.()
  */
 export function safeInvokeMember<
     T extends { [k in K]?: (a: A, b: B, c: C) => R },

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -24,7 +24,6 @@ import {
     ALERT_WARN_CANCEL_OUTSIDE_CLICK,
     ALERT_WARN_CANCEL_PROPS,
 } from "../../common/errors";
-import { safeInvoke } from "../../common/utils";
 import { Button } from "../button/buttons";
 import { Dialog } from "../dialog/dialog";
 import { Icon, IconName } from "../icon/icon";
@@ -182,7 +181,7 @@ export class Alert extends AbstractPureComponent2<IAlertProps> {
 
     private internalHandleCallbacks(confirmed: boolean, evt?: React.SyntheticEvent<HTMLElement>) {
         const { onCancel, onClose, onConfirm } = this.props;
-        safeInvoke(confirmed ? onConfirm : onCancel, evt);
-        safeInvoke(onClose, confirmed, evt);
+        (confirmed ? onConfirm : onCancel)?.(evt);
+        onClose?.(confirmed, evt);
     }
 }

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -19,7 +19,6 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, Position } from "../../common";
-import { safeInvoke } from "../../common/utils";
 import { IOverlayLifecycleProps } from "../overlay/overlay";
 import { Popover } from "../popover/popover";
 import { PopperModifiers } from "../popover/popoverSharedProps";
@@ -94,7 +93,7 @@ class ContextMenu extends AbstractPureComponent2<IContextMenuProps, IContextMenu
     }
 
     public hide() {
-        safeInvoke(this.state.onClose);
+        this.state.onClose?.();
         this.setState({ isOpen: false, onClose: undefined });
     }
 

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -22,7 +22,7 @@ import {
     CONTEXTMENU_WARN_DECORATOR_NEEDS_REACT_ELEMENT,
     CONTEXTMENU_WARN_DECORATOR_NO_METHOD,
 } from "../../common/errors";
-import { getDisplayName, isFunction, safeInvoke } from "../../common/utils";
+import { getDisplayName, isFunction } from "../../common/utils";
 import { isDarkTheme } from "../../common/utils/isDarkTheme";
 import * as ContextMenu from "./contextMenu";
 
@@ -68,7 +68,7 @@ export function ContextMenuTarget<T extends IConstructor<IContextMenuTargetCompo
                     }
                 }
 
-                safeInvoke(oldOnContextMenu, e);
+                oldOnContextMenu?.(e);
             };
 
             return React.cloneElement(element, { onContextMenu });

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
-import { clamp, safeInvoke } from "../../common/utils";
+import { clamp } from "../../common/utils";
 import { Browser } from "../../compatibility";
 
 export interface IEditableTextProps extends IIntentProps, IProps {
@@ -262,7 +262,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         this.setState(state);
 
         if (this.state.isEditing && !prevState.isEditing) {
-            safeInvoke(this.props.onEdit, this.state.value);
+            this.props.onEdit?.(this.state.value);
         }
         this.updateInputDimensions();
     }
@@ -271,16 +271,16 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         const { lastValue, value } = this.state;
         this.setState({ isEditing: false, value: lastValue });
         if (value !== lastValue) {
-            safeInvoke(this.props.onChange, lastValue);
+            this.props.onChange?.(lastValue);
         }
-        safeInvoke(this.props.onCancel, lastValue);
+        this.props.onCancel?.(lastValue);
     };
 
     public toggleEditing = () => {
         if (this.state.isEditing) {
             const { value } = this.state;
             this.setState({ isEditing: false, lastValue: value });
-            safeInvoke(this.props.onConfirm, value);
+            this.props.onConfirm?.(value);
         } else if (!this.props.disabled) {
             this.setState({ isEditing: true });
         }
@@ -305,7 +305,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         if (this.props.value == null) {
             this.setState({ value });
         }
-        safeInvoke(this.props.onChange, value);
+        this.props.onChange?.(value);
     };
 
     private handleKeyEvent = (event: React.KeyboardEvent<HTMLElement>) => {

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -24,7 +24,6 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
 
 export interface IControlProps extends IProps, HTMLInputProps {
     // NOTE: HTML props are duplicated here to provide control-specific documentation
@@ -280,11 +279,11 @@ export class Checkbox extends AbstractPureComponent2<ICheckboxProps, ICheckboxSt
             this.setState({ indeterminate });
         }
         // otherwise wait for props change. always invoke handler.
-        safeInvoke(this.props.onChange, evt);
+        this.props.onChange?.(evt);
     };
 
     private handleInputRef = (ref: HTMLInputElement) => {
         this.input = ref;
-        safeInvoke(this.props.inputRef, ref);
+        this.props.inputRef?.(ref);
     };
 }

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
-import { AbstractPureComponent2, Classes, Utils } from "../../common";
+import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
 export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, IProps {
@@ -131,7 +131,7 @@ export class FileInput extends AbstractPureComponent2<IFileInputProps> {
     }
 
     private handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
-        Utils.safeInvoke(this.props.onInputChange, e);
-        Utils.safeInvoke(this.props.inputProps.onChange, e);
+        this.props.onInputChange?.(e);
+        this.props.inputProps.onChange?.(e);
     };
 }

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -395,7 +395,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
 
     private inputRef = (input: HTMLInputElement | null) => {
         this.inputElement = input;
-        Utils.safeInvoke(this.props.inputRef, input);
+        this.props.inputRef?.(input);
     };
 
     // Callbacks - Buttons
@@ -452,10 +452,10 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
     // Callbacks - Input
     // =================
 
-    private handleInputFocus = (e: React.FocusEvent) => {
+    private handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
         // update this state flag to trigger update for input selection (see componentDidUpdate)
         this.setState({ shouldSelectAfterUpdate: this.props.selectAllOnFocus });
-        Utils.safeInvoke(this.props.onFocus, e);
+        this.props.onFocus?.(e);
     };
 
     private handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
@@ -467,10 +467,10 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
             this.handleNextValue(this.roundAndClampValue(value));
         }
 
-        Utils.safeInvoke(this.props.onBlur, e);
+        this.props.onBlur?.(e);
     };
 
-    private handleInputKeyDown = (e: React.KeyboardEvent) => {
+    private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (this.props.disabled || this.props.readOnly) {
             return;
         }
@@ -497,7 +497,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
             this.incrementValue(delta);
         }
 
-        Utils.safeInvoke(this.props.onKeyDown, e);
+        this.props.onKeyDown?.(e);
     };
 
     private handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
@@ -519,19 +519,19 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         }
     };
 
-    private handleInputKeyPress = (e: React.KeyboardEvent) => {
+    private handleInputKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
         // we prohibit keystrokes in onKeyPress instead of onKeyDown, because
         // e.key is not trustworthy in onKeyDown in all browsers.
         if (this.props.allowNumericCharactersOnly && !isValidNumericKeyboardEvent(e)) {
             e.preventDefault();
         }
 
-        Utils.safeInvoke(this.props.onKeyPress, e);
+        this.props.onKeyPress?.(e);
     };
 
-    private handleInputPaste = (e: React.ClipboardEvent) => {
+    private handleInputPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
         this.didPasteEventJustOccur = true;
-        Utils.safeInvoke(this.props.onPaste, e);
+        this.props.onPaste?.(e);
     };
 
     private handleInputChange = (e: React.FormEvent) => {

--- a/packages/core/src/components/hotkeys/hotkeysEvents.ts
+++ b/packages/core/src/components/hotkeys/hotkeysEvents.ts
@@ -15,7 +15,7 @@
  */
 
 import { Children, ReactElement, ReactNode } from "react";
-import { isElementOfType, safeInvoke } from "../../common/utils";
+import { isElementOfType } from "../../common/utils";
 
 import { Hotkey, IHotkeyProps } from "./hotkey";
 import { comboMatches, getKeyCombo, IKeyCombo, parseKeyCombo } from "./hotkeyParser";
@@ -102,7 +102,7 @@ export class HotkeysEvents {
                     (e as any).isPropagationStopped = true;
                     e.stopPropagation();
                 }
-                safeInvoke(action.props[callbackName], e);
+                action.props[callbackName]?.(e);
             }
         }
     }

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { IConstructor } from "../../common/constructor";
 import { HOTKEYS_WARN_DECORATOR_NEEDS_REACT_ELEMENT, HOTKEYS_WARN_DECORATOR_NO_METHOD } from "../../common/errors";
-import { getDisplayName, isFunction, safeInvoke } from "../../common/utils";
+import { getDisplayName, isFunction } from "../../common/utils";
 import { HotkeyScope, HotkeysEvents } from "./hotkeysEvents";
 import { IHotkeysProps } from "./hotkeysTypes";
 
@@ -97,12 +97,12 @@ export function HotkeysTarget<T extends IConstructor<IHotkeysTargetComponent>>(W
 
                     const handleKeyDownWrapper = (e: React.KeyboardEvent<HTMLElement>) => {
                         this.localHotkeysEvents.handleKeyDown(e.nativeEvent as KeyboardEvent);
-                        safeInvoke(existingKeyDown, e);
+                        existingKeyDown?.(e);
                     };
 
                     const handleKeyUpWrapper = (e: React.KeyboardEvent<HTMLElement>) => {
                         this.localHotkeysEvents.handleKeyUp(e.nativeEvent as KeyboardEvent);
-                        safeInvoke(existingKeyUp, e);
+                        existingKeyUp?.(e);
                     };
                     return React.cloneElement(element, {
                         onKeyDown: handleKeyDownWrapper,

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -21,8 +21,9 @@ import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { safeInvoke, shallowCompareKeys } from "../../common/utils";
-import { IResizeEntry, ResizeSensor } from "../resize-sensor/resizeSensor";
+import { shallowCompareKeys } from "../../common/utils";
+import { IResizeEntry } from "../resize-sensor/resizeObserverTypes";
+import { ResizeSensor } from "../resize-sensor/resizeSensor";
 
 /** @internal - do not expose this type */
 export enum OverflowDirection {
@@ -177,7 +178,7 @@ export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOve
             direction !== prevState.direction &&
             overflow.length !== lastOverflowCount
         ) {
-            safeInvoke(this.props.onOverflow, overflow);
+            this.props.onOverflow?.(overflow);
         }
     }
 

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -24,7 +24,6 @@ import { CSSTransitionProps } from "react-transition-group/CSSTransition";
 import { findDOMNode } from "react-dom";
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
 import { Portal } from "../portal/portal";
 
 export interface IOverlayableProps extends IOverlayLifecycleProps {
@@ -414,13 +413,13 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
     private handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
         const { backdropProps, canOutsideClickClose, enforceFocus, onClose } = this.props;
         if (canOutsideClickClose) {
-            safeInvoke(onClose, e);
+            onClose?.(e);
         }
         if (enforceFocus) {
             // make sure document.activeElement is updated before bringing the focus back
             this.bringFocusInsideOverlay();
         }
-        safeInvoke(backdropProps.onMouseDown, e);
+        backdropProps.onMouseDown?.(e);
     };
 
     private handleDocumentClick = (e: MouseEvent) => {
@@ -439,7 +438,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
 
         if (isOpen && canOutsideClickClose && !isClickInThisOverlayOrDescendant) {
             // casting to any because this is a native event
-            safeInvoke(onClose, e as any);
+            onClose?.(e as any);
         }
     };
 
@@ -464,7 +463,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
         // HACKHACK: https://github.com/palantir/blueprint/issues/4165
         /* eslint-disable-next-line deprecation/deprecation */
         if (e.which === Keys.ESCAPE && canEscapeKeyClose) {
-            safeInvoke(onClose, e);
+            onClose?.(e);
             // prevent browser-specific escape key behavior (Safari exits fullscreen)
             e.preventDefault();
         }

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -21,7 +21,6 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
 import { IProps } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
 import { IPanel } from "./panelProps";
 import { PanelView } from "./panelView";
 
@@ -168,7 +167,7 @@ export class PanelStack extends AbstractPureComponent2<IPanelStackProps, IPanelS
         if (stack[0] !== panel || stack.length <= 1) {
             return;
         }
-        safeInvoke(this.props.onClose, panel);
+        this.props.onClose?.(panel);
         if (this.props.stack == null) {
             this.setState(state => ({
                 direction: "pop",
@@ -178,7 +177,7 @@ export class PanelStack extends AbstractPureComponent2<IPanelStackProps, IPanelS
     };
 
     private handlePanelOpen = (panel: IPanel) => {
-        safeInvoke(this.props.onOpen, panel);
+        this.props.onOpen?.(panel);
         if (this.props.stack == null) {
             this.setState(state => ({
                 direction: "push",

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -85,7 +85,7 @@ export interface IPopoverProps extends IPopoverSharedProps {
     /**
      * Ref supplied to the `Classes.POPOVER` element.
      */
-    popoverRef?: (ref: HTMLDivElement | null) => void;
+    popoverRef?: (ref: HTMLElement | null) => void;
 
     /**
      * The target to which the popover content is attached. This can instead be
@@ -156,7 +156,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
     private refHandlers = {
         popover: (ref: HTMLElement) => {
             this.popoverElement = ref;
-            Utils.safeInvoke(this.props.popoverRef, ref);
+            this.props.popoverRef?.(ref);
         },
         target: (ref: HTMLElement) => (this.targetElement = ref),
     };
@@ -250,7 +250,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
      * without changing its _size_ (since `Popover` already repositions when it
      * detects a resize).
      */
-    public reposition = () => Utils.safeInvoke(this.popperScheduleUpdate);
+    public reposition = () => this.popperScheduleUpdate?.();
 
     protected validateProps(props: IPopoverProps & { children?: React.ReactNode }) {
         if (props.isOpen == null && props.onInteraction != null) {
@@ -438,9 +438,9 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 // lost focus (e.g. due to switching tabs).
                 return;
             }
-            this.handleMouseEnter(e);
+            this.handleMouseEnter((e as unknown) as React.MouseEvent<HTMLElement>);
         }
-        Utils.safeInvokeMember(this.props.targetProps, "onFocus", e);
+        this.props.targetProps?.onFocus(e);
     };
 
     private handleTargetBlur = (e: React.FocusEvent<HTMLElement>) => {
@@ -451,14 +451,14 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             // it won't be set. So, we filter those out here and assume that a click handler somewhere else will
             // close the popover if necessary.
             if (e.relatedTarget != null && !this.isElementInPopover(e.relatedTarget as HTMLElement)) {
-                this.handleMouseLeave(e);
+                this.handleMouseLeave((e as unknown) as React.MouseEvent<HTMLElement>);
             }
         }
         this.lostFocusOnSamePage = e.relatedTarget != null;
-        Utils.safeInvokeMember(this.props.targetProps, "onBlur", e);
+        this.props.targetProps?.onBlur?.(e);
     };
 
-    private handleMouseEnter = (e: React.SyntheticEvent<HTMLElement>) => {
+    private handleMouseEnter = (e: React.MouseEvent<HTMLElement>) => {
         this.isMouseInTargetOrPopover = true;
 
         // if we're entering the popover, and the mode is set to be HOVER_TARGET_ONLY, we want to manually
@@ -474,10 +474,10 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             // only begin opening popover when it is enabled
             this.setOpenState(true, e, this.props.hoverOpenDelay);
         }
-        Utils.safeInvokeMember(this.props.targetProps, "onMouseEnter", e);
+        this.props.targetProps?.onMouseEnter?.(e);
     };
 
-    private handleMouseLeave = (e: React.SyntheticEvent<HTMLElement>) => {
+    private handleMouseLeave = (e: React.MouseEvent<HTMLElement>) => {
         this.isMouseInTargetOrPopover = false;
 
         // wait until the event queue is flushed, because we want to leave the
@@ -490,7 +490,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             // user-configurable closing delay is helpful when moving mouse from target to popover
             this.setOpenState(false, e, this.props.hoverCloseDelay);
         });
-        Utils.safeInvokeMember(this.props.targetProps, "onMouseLeave", e);
+        this.props.targetProps?.onMouseLeave?.(e);
     };
 
     private handlePopoverClick = (e: React.MouseEvent<HTMLElement>) => {
@@ -524,24 +524,24 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 this.setOpenState(!this.props.isOpen, e);
             }
         }
-        Utils.safeInvokeMember(this.props.targetProps, "onClick", e);
+        this.props.targetProps?.onClick?.(e);
     };
 
     // a wrapper around setState({isOpen}) that will call props.onInteraction instead when in controlled mode.
     // starts a timeout to delay changing the state if a non-zero duration is provided.
     private setOpenState(isOpen: boolean, e?: React.SyntheticEvent<HTMLElement>, timeout?: number) {
         // cancel any existing timeout because we have new state
-        Utils.safeInvoke(this.cancelOpenTimeout);
+        this.cancelOpenTimeout?.();
         if (timeout > 0) {
             this.cancelOpenTimeout = this.setTimeout(() => this.setOpenState(isOpen, e), timeout);
         } else {
             if (this.props.isOpen == null) {
                 this.setState({ isOpen });
             } else {
-                Utils.safeInvoke(this.props.onInteraction, isOpen, e);
+                this.props.onInteraction?.(isOpen, e);
             }
             if (!isOpen) {
-                Utils.safeInvoke(this.props.onClose, e);
+                this.props.onClose?.(e);
             }
         }
     }

--- a/packages/core/src/components/resize-sensor/resizeObserverTypes.ts
+++ b/packages/core/src/components/resize-sensor/resizeObserverTypes.ts
@@ -1,0 +1,37 @@
+/* !
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** This file contains types duplicated from resize-observer-polyfill which are not exported in a consumer-friendly way. */
+
+/** Equivalent to `ResizeObserverEntry` */
+export interface IResizeEntry {
+    /** Measured dimensions of the target. */
+    readonly contentRect: IDOMRectReadOnly;
+
+    /** The resized element. */
+    readonly target: Element;
+}
+
+interface IDOMRectReadOnly {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+    readonly top: number;
+    readonly right: number;
+    readonly bottom: number;
+    readonly left: number;
+}

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -20,16 +20,7 @@ import { polyfill } from "react-lifecycles-compat";
 import ResizeObserver from "resize-observer-polyfill";
 import { AbstractPureComponent2 } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
-
-/** A parallel type to `ResizeObserverEntry` (from resize-observer-polyfill). */
-export interface IResizeEntry {
-    /** Measured dimensions of the target. */
-    contentRect: DOMRectReadOnly;
-
-    /** The resized element. */
-    target: Element;
-}
+import { IResizeEntry } from "./resizeObserverTypes";
 
 /** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 export interface IResizeSensorProps {
@@ -63,7 +54,7 @@ export class ResizeSensor extends AbstractPureComponent2<IResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
     private element: Element | null = null;
-    private observer = new ResizeObserver(entries => safeInvoke(this.props.onResize, entries));
+    private observer = new ResizeObserver(entries => this.props.onResize?.(entries));
 
     public render() {
         // pass-through render of single child

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { clamp, safeInvoke } from "../../common/utils";
+import { clamp } from "../../common/utils";
 import { IHandleProps } from "./handleProps";
 import { formatPercentage } from "./sliderUtils";
 
@@ -164,9 +164,8 @@ export class Handle extends AbstractPureComponent2<IInternalHandleProps, IHandle
         this.removeDocumentEventListeners();
         this.setState({ isMoving: false });
         // always invoke onRelease; changeValue may call onChange if value is different
-        const { onRelease } = this.props;
         const finalValue = this.changeValue(this.clientToValue(clientPixel));
-        safeInvoke(onRelease, finalValue);
+        this.props.onRelease?.(finalValue);
     };
 
     private handleHandleMovement = (event: MouseEvent) => {
@@ -202,7 +201,7 @@ export class Handle extends AbstractPureComponent2<IInternalHandleProps, IHandle
         // HACKHACK: https://github.com/palantir/blueprint/issues/4165
         /* eslint-disable-next-line deprecation/deprecation */
         if ([Keys.ARROW_UP, Keys.ARROW_DOWN, Keys.ARROW_LEFT, Keys.ARROW_RIGHT].indexOf(event.which) >= 0) {
-            safeInvoke(this.props.onRelease, this.props.value);
+            this.props.onRelease?.(this.props.value);
         }
     };
 
@@ -210,7 +209,7 @@ export class Handle extends AbstractPureComponent2<IInternalHandleProps, IHandle
     private changeValue(newValue: number, callback = this.props.onChange) {
         newValue = this.clamp(newValue);
         if (!isNaN(newValue) && this.props.value !== newValue) {
-            safeInvoke(callback, newValue);
+            callback?.(newValue);
         }
         return newValue;
     }

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -360,7 +360,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     private getHandlerForIndex = (index: number, callback?: (values: number[]) => void) => {
         return (newValue: number) => {
-            Utils.safeInvoke(callback, this.getNewHandleValues(newValue, index));
+            callback?.(this.getNewHandleValues(newValue, index));
         };
     };
 
@@ -402,10 +402,10 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         const handleProps = getSortedInteractiveHandleProps(this.props);
         const oldValues = handleProps.map(handle => handle.value);
         if (!Utils.arraysEqual(newValues, oldValues)) {
-            Utils.safeInvoke(this.props.onChange, newValues);
+            this.props.onChange?.(newValues);
             handleProps.forEach((handle, index) => {
                 if (oldValues[index] !== newValues[index]) {
-                    Utils.safeInvoke(handle.onChange, newValues[index]);
+                    handle.onChange?.(newValues[index]);
                 }
             });
         }
@@ -413,9 +413,9 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     private handleRelease = (newValues: number[]) => {
         const handleProps = getSortedInteractiveHandleProps(this.props);
-        Utils.safeInvoke(this.props.onRelease, newValues);
+        this.props.onRelease?.(newValues);
         handleProps.forEach((handle, index) => {
-            Utils.safeInvoke(handle.onRelease, newValues[index]);
+            handle.onRelease?.(newValues[index]);
         });
     };
 

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -256,7 +256,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
     };
 
     private handleTabClick = (newTabId: TabId, event: React.MouseEvent<HTMLElement>) => {
-        Utils.safeInvoke(this.props.onChange, newTabId, this.state.selectedTabId, event);
+        this.props.onChange?.(newTabId, this.state.selectedTabId, event);
         if (this.props.selectedTabId === undefined) {
             this.setState({ selectedTabId: newTabId });
         }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -139,7 +139,7 @@ export interface ITagInputProps extends IIntentProps, IProps {
      * Callback invoked when the user clicks the X button on a tag.
      * Receives value and index of removed tag.
      */
-    onRemove?: (value: string, index: number) => void;
+    onRemove?: (value: React.ReactNode, index: number) => void;
 
     /**
      * Input placeholder text which will not appear if `values` contains any items
@@ -231,7 +231,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     private refHandlers = {
         input: (ref: HTMLInputElement) => {
             this.inputElement = ref;
-            Utils.safeInvoke(this.props.inputRef, ref);
+            this.props.inputRef?.(ref);
         },
     };
 
@@ -288,7 +288,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     private addTags = (value: string, method: TagInputAddMethod = "default") => {
         const { inputValue, onAdd, onChange, values } = this.props;
         const newValues = this.getValues(value);
-        let shouldClearInput = Utils.safeInvoke(onAdd, newValues, method) !== false && inputValue === undefined;
+        let shouldClearInput = onAdd?.(newValues, method) !== false && inputValue === undefined;
         // avoid a potentially expensive computation if this prop is omitted
         if (Utils.isFunction(onChange)) {
             shouldClearInput = onChange([...values, ...newValues]) !== false && shouldClearInput;
@@ -374,15 +374,15 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
         });
     };
 
-    private handleInputFocus = (event: React.FocusEvent<HTMLElement>) => {
+    private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
         this.setState({ isInputFocused: true });
-        Utils.safeInvoke(this.props.inputProps.onFocus, event);
+        this.props.inputProps.onFocus?.(event);
     };
 
     private handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.setState({ activeIndex: NONE, inputValue: event.currentTarget.value });
-        Utils.safeInvoke(this.props.onInputChange, event);
-        Utils.safeInvoke(this.props.inputProps.onChange, event);
+        this.props.onInputChange?.(event);
+        this.props.inputProps.onChange?.(event);
     };
 
     private handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -466,7 +466,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     /** Remove the item at the given index by invoking `onRemove` and `onChange` accordingly. */
     private removeIndexFromValues(index: number) {
         const { onChange, onRemove, values } = this.props;
-        Utils.safeInvoke(onRemove, values[index], index);
+        onRemove?.(values[index], index);
         if (Utils.isFunction(onChange)) {
             onChange(values.filter((_, i) => i !== index));
         }
@@ -477,8 +477,8 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
         event: React.KeyboardEvent<HTMLInputElement>,
         activeIndex: number,
     ) {
-        Utils.safeInvoke(this.props[propCallbackName], event, activeIndex === NONE ? undefined : activeIndex);
-        Utils.safeInvoke(this.props.inputProps[propCallbackName], event);
+        this.props[propCallbackName]?.(event, activeIndex === NONE ? undefined : activeIndex);
+        this.props.inputProps[propCallbackName]?.(event);
     }
 
     /** Returns whether the given index represents a valid item in `this.props.values`. */

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -162,6 +162,6 @@ export class Tag extends AbstractPureComponent2<ITagProps> {
     }
 
     private onRemoveClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-        Utils.safeInvoke(this.props.onRemove, e, this.props);
+        this.props.onRemove?.(e, this.props);
     };
 }

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -19,7 +19,6 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IActionProps, IIntentProps, ILinkProps, IProps, MaybeElement } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
 import { ButtonGroup } from "../button/buttonGroup";
 import { AnchorButton, Button } from "../button/buttons";
 import { Icon, IconName } from "../icon/icon";
@@ -112,7 +111,7 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
     }
 
     private handleActionClick = (e: React.MouseEvent<HTMLElement>) => {
-        safeInvoke(this.props.action.onClick, e);
+        this.props.action.onClick?.(e);
         this.triggerDismiss(false);
     };
 
@@ -120,7 +119,7 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
 
     private triggerDismiss(didTimeoutExpire: boolean) {
         this.clearTimeouts();
-        safeInvoke(this.props.onDismiss, didTimeoutExpire);
+        this.props.onDismiss?.(didTimeoutExpire);
     }
 
     private startTimeout = () => {

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -22,7 +22,7 @@ import { AbstractPureComponent2, Classes, Position } from "../../common";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID, TOASTER_WARN_INLINE } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
-import { isNodeEnv, safeInvoke } from "../../common/utils";
+import { isNodeEnv } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { IToastProps, Toast } from "./toast";
 
@@ -163,7 +163,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
             toasts: toasts.filter(t => {
                 const matchesKey = t.key === key;
                 if (matchesKey) {
-                    safeInvoke(t.onDismiss, timeoutExpired);
+                    t.onDismiss?.(timeoutExpired);
                 }
                 return !matchesKey;
             }),
@@ -171,7 +171,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
     }
 
     public clear() {
-        this.state.toasts.map(t => safeInvoke(t.onDismiss, false));
+        this.state.toasts.forEach(t => t.onDismiss?.(false));
         this.setState({ toasts: [] });
     }
 

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -19,7 +19,6 @@ import * as React from "react";
 
 import * as Classes from "../../common/classes";
 import { DISPLAYNAME_PREFIX, IProps, MaybeElement } from "../../common/props";
-import { safeInvoke } from "../../common/utils";
 import { Collapse } from "../collapse/collapse";
 import { Icon, IconName } from "../icon/icon";
 
@@ -169,30 +168,30 @@ export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>> {
     private handleCaretClick = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         const { isExpanded, onCollapse, onExpand } = this.props;
-        safeInvoke(isExpanded ? onCollapse : onExpand, this, e);
+        (isExpanded ? onCollapse : onExpand)?.(this, e);
     };
 
     private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-        safeInvoke(this.props.onClick, this, e);
+        this.props.onClick?.(this, e);
     };
 
     private handleContentRef = (element: HTMLDivElement | null) => {
-        safeInvoke(this.props.contentRef, this, element);
+        this.props.contentRef?.(this, element);
     };
 
     private handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
-        safeInvoke(this.props.onContextMenu, this, e);
+        this.props.onContextMenu?.(this, e);
     };
 
     private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-        safeInvoke(this.props.onDoubleClick, this, e);
+        this.props.onDoubleClick?.(this, e);
     };
 
     private handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
-        safeInvoke(this.props.onMouseEnter, this, e);
+        this.props.onMouseEnter?.(this, e);
     };
 
     private handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
-        safeInvoke(this.props.onMouseLeave, this, e);
+        this.props.onMouseLeave?.(this, e);
     };
 }

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -40,7 +40,8 @@ describe("Utils", () => {
         assert.isFalse(Utils.isReactNodeEmpty([null, <div key="div" />]), "array");
     });
 
-    it("safeInvoke", () => {
+    /* eslint-disable deprecation/deprecation */
+    it.skip("safeInvoke", () => {
         assert.doesNotThrow(() => Utils.safeInvoke(undefined, 1, "2", true, 4));
 
         // try the max number of args (4)
@@ -49,7 +50,7 @@ describe("Utils", () => {
         assert.isTrue(callback.firstCall.calledWith(1, "2", true, 4));
     });
 
-    it("safeInvokeOrValue", () => {
+    it.skip("safeInvokeOrValue", () => {
         assert.doesNotThrow(() => Utils.safeInvokeOrValue(undefined, 1, "2", true, 4));
 
         // try the max number of args (4)
@@ -62,6 +63,7 @@ describe("Utils", () => {
         const result = Utils.safeInvokeOrValue(value);
         assert.strictEqual(result, value);
     });
+    /* eslint-enable deprecation/deprecation */
 
     it("elementIsOrContains", () => {
         const child = document.createElement("span");

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -34,7 +34,6 @@ import {
     isRefObject,
     Keys,
     Popover,
-    Utils,
 } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
@@ -213,7 +212,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             // onMonthChange is called. setTimeout is necessary to wait
             // for the updated month to be rendered
             onMonthChange: (month: Date) => {
-                Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, month);
+                this.props.dayPickerProps.onMonthChange?.(month);
                 this.setTimeout(this.registerPopoverBlurHandler);
             },
         };
@@ -279,7 +278,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
 
     private handleClosePopover = (e?: React.SyntheticEvent<HTMLElement>) => {
         const { popoverProps = {} } = this.props;
-        Utils.safeInvoke(popoverProps.onClose, e);
+        popoverProps.onClose?.(e);
         this.setState({ isOpen: false });
     };
 
@@ -307,7 +306,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         } else {
             this.setState({ isInputFocused, isOpen });
         }
-        Utils.safeInvoke(this.props.onChange, newDate, isUserChange);
+        this.props.onChange?.(newDate, isUserChange);
     };
 
     private hasMonthChanged(prevDate: Date | null, nextDate: Date | null) {
@@ -351,10 +350,10 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             } else {
                 this.setState({ valueString });
             }
-            Utils.safeInvoke(this.props.onChange, value, true);
+            this.props.onChange?.(value, true);
         } else {
             if (valueString.length === 0) {
-                Utils.safeInvoke(this.props.onChange, null, true);
+                this.props.onChange?.(null, true);
             }
             this.setState({ valueString });
         }
@@ -376,11 +375,11 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             }
 
             if (isNaN(date.valueOf())) {
-                Utils.safeInvoke(this.props.onError, new Date(undefined));
+                this.props.onError?.(new Date(undefined));
             } else if (!this.isDateInRange(date)) {
-                Utils.safeInvoke(this.props.onError, date);
+                this.props.onError?.(date);
             } else {
-                Utils.safeInvoke(this.props.onChange, date, true);
+                this.props.onChange?.(date, true);
             }
         } else {
             if (valueString.length === 0) {
@@ -469,7 +468,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
     /** safe wrapper around invoking input props event handler (prop defaults to undefined) */
     private safeInvokeInputProp(name: keyof HTMLInputProps, e: React.SyntheticEvent<HTMLElement>) {
         const { inputProps = {} } = this.props;
-        Utils.safeInvoke(inputProps[name], e);
+        inputProps[name]?.(e);
     }
 
     private parseDate(dateString: string): Date | null {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AbstractPureComponent2, Button, DISPLAYNAME_PREFIX, Divider, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent2, Button, DISPLAYNAME_PREFIX, Divider, IProps } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
@@ -347,7 +347,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
     }
 
     private handleDayClick = (day: Date, modifiers: DayModifiers, e: React.MouseEvent<HTMLDivElement>) => {
-        Utils.safeInvoke(this.props.dayPickerProps.onDayClick, day, modifiers, e);
+        this.props.dayPickerProps.onDayClick?.(day, modifiers, e);
         if (modifiers.disabled) {
             return;
         }
@@ -374,7 +374,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
         }
 
         const datePickerShortcut = { ...shortcut, date: shortcut.dateRange[0] };
-        Utils.safeInvoke(onShortcutChange, datePickerShortcut, selectedShortcutIndex);
+        onShortcutChange?.(datePickerShortcut, selectedShortcutIndex);
     };
 
     private updateDay = (day: Date) => {
@@ -421,7 +421,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
             this.updateValue(date, false, this.ignoreNextMonthChange);
             this.ignoreNextMonthChange = false;
         }
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, date);
+        this.props.dayPickerProps.onMonthChange?.(date);
     };
 
     private handleTodayClick = () => {
@@ -434,7 +434,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
     };
 
     private handleTimeChange = (time: Date) => {
-        Utils.safeInvoke(this.props.timePickerProps.onChange, time);
+        this.props.timePickerProps.onChange?.(time);
         const { value } = this.state;
         const newValue = DateUtils.getDateTime(value != null ? value : new Date(), time);
         this.updateValue(newValue, true);
@@ -445,7 +445,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
      */
     private updateValue(value: Date, isUserChange: boolean, skipOnChange = false) {
         if (!skipOnChange) {
-            Utils.safeInvoke(this.props.onChange, value, isUserChange);
+            this.props.onChange?.(value, isUserChange);
         }
         if (this.props.value === undefined) {
             this.setState({ value });

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AbstractPureComponent2, Divider, HTMLSelect, Icon, IOptionProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent2, Divider, HTMLSelect, Icon, IOptionProps } from "@blueprintjs/core";
 import * as React from "react";
 import { CaptionElementProps } from "react-day-picker";
 import { polyfill } from "react-lifecycles-compat";
@@ -138,8 +138,8 @@ export class DatePickerCaption extends AbstractPureComponent2<IDatePickerCaption
             }
             const newDate = clone(this.props.date);
             updater(newDate, value);
-            Utils.safeInvoke(this.props.onDateChange, newDate);
-            Utils.safeInvoke(handler, value);
+            this.props.onDateChange?.(newDate);
+            handler?.(value);
         };
     }
 }

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AbstractPureComponent2, Boundary, DISPLAYNAME_PREFIX, Divider, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent2, Boundary, DISPLAYNAME_PREFIX, Divider, IProps } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
@@ -491,7 +491,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
     );
 
     private handleDayMouseEnter = (day: Date, modifiers: DayModifiers, e: React.MouseEvent<HTMLDivElement>) => {
-        Utils.safeInvoke(this.props.dayPickerProps.onDayMouseEnter, day, modifiers, e);
+        this.props.dayPickerProps.onDayMouseEnter?.(day, modifiers, e);
 
         if (modifiers.disabled) {
             return;
@@ -503,20 +503,20 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
             this.props.boundaryToModify,
         );
         this.setState({ hoverValue: dateRange });
-        Utils.safeInvoke(this.props.onHoverChange, dateRange, day, boundary);
+        this.props.onHoverChange?.(dateRange, day, boundary);
     };
 
     private handleDayMouseLeave = (day: Date, modifiers: DayModifiers, e: React.MouseEvent<HTMLDivElement>) => {
-        Utils.safeInvoke(this.props.dayPickerProps.onDayMouseLeave, day, modifiers, e);
+        this.props.dayPickerProps.onDayMouseLeave?.(day, modifiers, e);
         if (modifiers.disabled) {
             return;
         }
         this.setState({ hoverValue: undefined });
-        Utils.safeInvoke(this.props.onHoverChange, undefined, day, undefined);
+        this.props.onHoverChange?.(undefined, day, undefined);
     };
 
     private handleDayClick = (day: Date, modifiers: DayModifiers, e: React.MouseEvent<HTMLDivElement>) => {
-        Utils.safeInvoke(this.props.dayPickerProps.onDayClick, day, modifiers, e);
+        this.props.dayPickerProps.onDayClick?.(day, modifiers, e);
 
         if (modifiers.disabled) {
             // rerender base component to get around bug where you can navigate past bounds by clicking days
@@ -546,7 +546,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
             const newTimeRange: DateRange = [dateRange[0], dateRange[1]];
             const nextState = getStateChange(this.state.value, dateRange, this.state, contiguousCalendarMonths);
             this.setState({ ...nextState, time: newTimeRange });
-            Utils.safeInvoke(onChange, newDateRange);
+            onChange?.(newDateRange);
         } else {
             this.handleNextState(dateRange);
         }
@@ -555,7 +555,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
             this.setState({ selectedShortcutIndex });
         }
 
-        Utils.safeInvoke(onShortcutChange, shortcut, selectedShortcutIndex);
+        onShortcutChange?.(shortcut, selectedShortcutIndex);
     };
 
     private handleNextState = (nextValue: DateRange) => {
@@ -568,30 +568,30 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
         if (this.props.value == null) {
             this.setState(nextState);
         }
-        Utils.safeInvoke(this.props.onChange, nextValue);
+        this.props.onChange?.(nextValue);
     };
 
     private handleLeftMonthChange = (newDate: Date) => {
         const leftView = MonthAndYear.fromDate(newDate);
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, leftView.getFullDate());
+        this.props.dayPickerProps.onMonthChange?.(leftView.getFullDate());
         this.updateLeftView(leftView);
     };
 
     private handleRightMonthChange = (newDate: Date) => {
         const rightView = MonthAndYear.fromDate(newDate);
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, rightView.getFullDate());
+        this.props.dayPickerProps.onMonthChange?.(rightView.getFullDate());
         this.updateRightView(rightView);
     };
 
     private handleLeftMonthSelectChange = (leftMonth: number) => {
         const leftView = new MonthAndYear(leftMonth, this.state.leftView.getYear());
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, leftView.getFullDate());
+        this.props.dayPickerProps.onMonthChange?.(leftView.getFullDate());
         this.updateLeftView(leftView);
     };
 
     private handleRightMonthSelectChange = (rightMonth: number) => {
         const rightView = new MonthAndYear(rightMonth, this.state.rightView.getYear());
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, rightView.getFullDate());
+        this.props.dayPickerProps.onMonthChange?.(rightView.getFullDate());
         this.updateRightView(rightView);
     };
 
@@ -620,7 +620,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
      */
     private handleLeftYearSelectChange = (leftDisplayYear: number) => {
         let leftView = new MonthAndYear(this.state.leftView.getMonth(), leftDisplayYear);
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, leftView.getFullDate());
+        this.props.dayPickerProps.onMonthChange?.(leftView.getFullDate());
         const { minDate, maxDate } = this.props;
         const adjustedMaxDate = DateUtils.getDatePreviousMonth(maxDate);
 
@@ -643,7 +643,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
 
     private handleRightYearSelectChange = (rightDisplayYear: number) => {
         let rightView = new MonthAndYear(this.state.rightView.getMonth(), rightDisplayYear);
-        Utils.safeInvoke(this.props.dayPickerProps.onMonthChange, rightView.getFullDate());
+        this.props.dayPickerProps.onMonthChange?.(rightView.getFullDate());
         const { minDate, maxDate } = this.props;
         const adjustedMinDate = DateUtils.getDateNextMonth(minDate);
 

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, DISPLAYNAME_PREFIX, IProps, Utils } from "@blueprintjs/core";
+import { AbstractPureComponent2, DISPLAYNAME_PREFIX, IProps } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -122,7 +122,7 @@ export class DateTimePicker extends AbstractPureComponent2<IDateTimePickerProps,
             this.setState({ dateValue });
         }
         const value = DateUtils.getDateTime(dateValue, this.state.timeValue);
-        Utils.safeInvoke(this.props.onChange, value, isUserChange);
+        this.props.onChange?.(value, isUserChange);
     };
 
     public handleTimeChange = (timeValue: Date) => {
@@ -130,6 +130,6 @@ export class DateTimePicker extends AbstractPureComponent2<IDateTimePickerProps,
             this.setState({ timeValue });
         }
         const value = DateUtils.getDateTime(this.state.dateValue, timeValue);
-        Utils.safeInvoke(this.props.onChange, value, true);
+        this.props.onChange?.(value, true);
     };
 }

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    Classes as CoreClasses,
-    DISPLAYNAME_PREFIX,
-    HTMLSelect,
-    Icon,
-    Intent,
-    IProps,
-    Keys,
-    Utils as BlueprintUtils,
-} from "@blueprintjs/core";
+import { Classes as CoreClasses, DISPLAYNAME_PREFIX, HTMLSelect, Icon, Intent, IProps, Keys } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -316,17 +307,17 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         }
     };
 
-    private getInputBlurHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
+    private getInputBlurHandler = (unit: TimeUnit) => (e: React.FocusEvent<HTMLInputElement>) => {
         const text = getStringValueFromInputEvent(e);
         this.updateTime(parseInt(text, 10), unit);
-        BlueprintUtils.safeInvoke(this.props.onBlur, e, unit);
+        this.props.onBlur?.(e, unit);
     };
 
-    private getInputFocusHandler = (unit: TimeUnit) => (e: React.SyntheticEvent<HTMLInputElement>) => {
+    private getInputFocusHandler = (unit: TimeUnit) => (e: React.FocusEvent<HTMLInputElement>) => {
         if (this.props.selectAllOnFocus) {
             e.currentTarget.select();
         }
-        BlueprintUtils.safeInvoke(this.props.onFocus, e, unit);
+        this.props.onFocus?.(e, unit);
     };
 
     private getInputKeyDownHandler = (unit: TimeUnit) => (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -337,11 +328,11 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
                 (e.currentTarget as HTMLInputElement).blur();
             },
         });
-        BlueprintUtils.safeInvoke(this.props.onKeyDown, e, unit);
+        this.props.onKeyDown?.(e, unit);
     };
 
     private getInputKeyUpHandler = (unit: TimeUnit) => (e: React.KeyboardEvent<HTMLInputElement>) => {
-        BlueprintUtils.safeInvoke(this.props.onKeyUp, e, unit);
+        this.props.onKeyUp?.(e, unit);
     };
 
     private handleAmPmChange = (e: React.SyntheticEvent<HTMLSelectElement>) => {
@@ -421,7 +412,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         }
 
         if (hasNewValue) {
-            BlueprintUtils.safeInvoke(this.props.onChange, newState.value);
+            this.props.onChange?.(newState.value);
         }
     }
 }

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { HTMLDivProps, IProps, Keys, removeNonHTMLProps, Utils } from "@blueprintjs/core";
+import { HTMLDivProps, IProps, Keys, removeNonHTMLProps } from "@blueprintjs/core";
 import { createKeyEventHandler } from "@blueprintjs/docs-theme";
 
 export interface IClickToCopyProps extends IProps, HTMLDivProps {
@@ -69,11 +69,11 @@ export class ClickToCopy extends React.PureComponent<IClickToCopyProps, IClickTo
                 className={classNames("docs-clipboard", className, {
                     [copiedClassName!]: this.state.hasCopied,
                 })}
-                onClick={this.handleClickEvent}
+                onClick={this.handleClick}
                 onMouseLeave={this.handleMouseLeave}
             >
                 <input
-                    onBlur={this.handleMouseLeave}
+                    onBlur={this.handleInputBlur}
                     onKeyDown={this.handleKeyDown}
                     readOnly={true}
                     ref={this.refHandlers.input}
@@ -84,25 +84,33 @@ export class ClickToCopy extends React.PureComponent<IClickToCopyProps, IClickTo
         );
     }
 
-    private handleClickEvent = (e: React.SyntheticEvent<HTMLElement>) => {
+    private copy = () => {
         this.inputElement.select();
         document.execCommand("copy");
         this.setState({ hasCopied: true });
-        Utils.safeInvoke(this.props.onClick, e);
+    };
+
+    private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        this.copy();
+        this.props.onClick?.(e);
+    };
+
+    private handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
+        this.setState({ hasCopied: false });
+        this.props.onMouseLeave?.(e);
+    };
+
+    private handleInputBlur = () => {
+        this.setState({ hasCopied: false });
     };
 
     // eslint-disable-line @typescript-eslint/member-ordering
     private handleKeyDown = createKeyEventHandler(
         {
             all: this.props.onKeyDown,
-            [Keys.SPACE]: this.handleClickEvent,
-            [Keys.ENTER]: this.handleClickEvent,
+            [Keys.SPACE]: this.copy,
+            [Keys.ENTER]: this.copy,
         },
         true,
     );
-
-    private handleMouseLeave = (e: React.SyntheticEvent<HTMLElement>) => {
-        this.setState({ hasCopied: false });
-        Utils.safeInvoke(this.props.onMouseLeave, e);
-    };
 }

--- a/packages/docs-theme/src/common/utils.ts
+++ b/packages/docs-theme/src/common/utils.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Utils } from "@blueprintjs/core";
 import { IHeadingNode, IPageNode, isPageNode } from "@documentalist/client";
 import * as React from "react";
 
@@ -42,16 +41,16 @@ export function smartSearch(query: string, ...content: string[]) {
     return terms.every(term => dataToSearch.some(d => d.indexOf(term) >= 0));
 }
 
-export interface IKeyEventMap {
+export interface IKeyEventMap<T = HTMLElement> {
     /** event handler invoked on all events */
-    all?: React.KeyboardEventHandler<HTMLElement>;
+    all?: React.KeyboardEventHandler<T>;
 
     /** map keycodes to specific event handlers */
-    [keyCode: number]: React.KeyboardEventHandler<HTMLElement>;
+    [keyCode: number]: React.KeyboardEventHandler<T>;
 }
 
-export function createKeyEventHandler(actions: IKeyEventMap, preventDefault = false) {
-    return (e: React.KeyboardEvent<HTMLElement>) => {
+export function createKeyEventHandler<T = HTMLElement>(actions: IKeyEventMap<T>, preventDefault = false) {
+    return (e: React.KeyboardEvent<T>) => {
         for (const k of Object.keys(actions)) {
             const key = Number(k);
             // HACKHACK: https://github.com/palantir/blueprint/issues/4165
@@ -63,7 +62,7 @@ export function createKeyEventHandler(actions: IKeyEventMap, preventDefault = fa
                 actions[key](e);
             }
         }
-        Utils.safeInvoke(actions.all, e);
+        actions.all?.(e);
     };
 }
 

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -247,7 +247,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
         // hooray! so you don't have to!
         FocusStyleManager.onlyShowFocusOnTabs();
         this.scrollToActiveSection();
-        Utils.safeInvoke(this.props.onComponentUpdate, this.state.activePageId);
+        this.props.onComponentUpdate?.(this.state.activePageId);
         // whoa handling future history...
         window.addEventListener("hashchange", this.handleHashChange);
         document.addEventListener("scroll", this.handleScroll);
@@ -268,7 +268,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
             this.maybeScrollToActivePageMenuItem();
         }
 
-        Utils.safeInvoke(this.props.onComponentUpdate, activePageId);
+        this.props.onComponentUpdate?.(activePageId);
     }
 
     private updateHash() {

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Classes, Icon, IInputGroupProps, MenuItem, Utils } from "@blueprintjs/core";
+import { Classes, Icon, IInputGroupProps, MenuItem } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Omnibar } from "@blueprintjs/select";
 
 import { IHeadingNode, IPageNode } from "@documentalist/client";
@@ -55,7 +55,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
     public componentDidMount() {
         this.sections = [];
         eachLayoutNode(this.props.items, (node, parents) => {
-            if (Utils.safeInvoke(this.props.itemExclude, node) === true) {
+            if (this.props.itemExclude?.(node) === true) {
                 // ignore excluded item
                 return;
             }

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -24,7 +24,6 @@ import {
     InputGroup,
     IOverlayProps,
     Overlay,
-    Utils,
 } from "@blueprintjs/core";
 
 import { Classes, IListItemsProps } from "../../common";
@@ -105,7 +104,7 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
     };
 
     private handleOverlayClose = (event?: React.SyntheticEvent<HTMLElement>) => {
-        Utils.safeInvokeMember(this.props.overlayProps, "onClose", event);
-        Utils.safeInvoke(this.props.onClose, event);
+        this.props.overlayProps?.onClose?.(event);
+        this.props.onClose?.(event);
     };
 }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -185,7 +185,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         super(props, context);
 
         const { query = "" } = props;
-        const createNewItem = Utils.safeInvoke(props.createNewItemFromQuery, query);
+        const createNewItem = props.createNewItemFromQuery?.(query);
         const filteredItems = getFilteredItems(query, props);
 
         this.state = {
@@ -290,7 +290,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         this.shouldCheckActiveItemInViewport = true;
         const hasQueryChanged = query !== this.state.query;
         if (hasQueryChanged) {
-            Utils.safeInvoke(props.onQueryChange, query);
+            props.onQueryChange?.(query);
         }
 
         // Leading and trailing whitespace can be confusing to display, so we remove it when passing it
@@ -323,9 +323,9 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         }
 
         if (isCreateNewItem(activeItem)) {
-            Utils.safeInvoke(this.props.onActiveItemChange, null, true);
+            this.props.onActiveItemChange?.(null, true);
         } else {
-            Utils.safeInvoke(this.props.onActiveItemChange, activeItem, false);
+            this.props.onActiveItemChange?.(activeItem, false);
         }
     }
 
@@ -377,7 +377,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             this.handleItemCreate(query, evt);
         };
         const isActive = isCreateNewItem(activeItem);
-        return Utils.safeInvoke(this.props.createNewItemRenderer, query, isActive, handleClick);
+        return this.props.createNewItemRenderer?.(query, isActive, handleClick);
     };
 
     private getActiveElement() {
@@ -419,16 +419,16 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     private handleItemCreate = (query: string, evt?: React.SyntheticEvent<HTMLElement>) => {
         // we keep a cached createNewItem in state, but might as well recompute
         // the result just to be sure it's perfectly in sync with the query.
-        const item = Utils.safeInvoke(this.props.createNewItemFromQuery, query);
+        const item = this.props.createNewItemFromQuery?.(query);
         if (item != null) {
-            Utils.safeInvoke(this.props.onItemSelect, item, evt);
+            this.props.onItemSelect?.(item, evt);
             this.maybeResetQuery();
         }
     };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         this.setActiveItem(item);
-        Utils.safeInvoke(this.props.onItemSelect, item, event);
+        this.props.onItemSelect?.(item, event);
         this.maybeResetQuery();
     };
 
@@ -450,7 +450,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                 nextActiveItem = equalItem;
                 pastedItemsToEmit.push(equalItem);
             } else if (this.canCreateItems()) {
-                const newItem = Utils.safeInvoke(createNewItemFromQuery, query);
+                const newItem = createNewItemFromQuery?.(query);
                 if (newItem !== undefined) {
                     pastedItemsToEmit.push(newItem);
                 }
@@ -470,7 +470,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             this.setActiveItem(nextActiveItem);
         }
 
-        Utils.safeInvoke(onItemsPaste, pastedItemsToEmit);
+        onItemsPaste?.(pastedItemsToEmit);
     };
 
     private handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
@@ -485,7 +485,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             this.isEnterKeyPressed = true;
         }
 
-        Utils.safeInvoke(this.props.onKeyDown, event);
+        this.props.onKeyDown?.(event);
     };
 
     private handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
@@ -506,13 +506,13 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             this.isEnterKeyPressed = false;
         }
 
-        Utils.safeInvoke(onKeyUp, event);
+        onKeyUp?.(event);
     };
 
     private handleInputQueryChange = (event?: React.ChangeEvent<HTMLInputElement>) => {
         const query = event == null ? "" : event.target.value;
         this.setQuery(query);
-        Utils.safeInvoke(this.props.onQueryChange, query, event);
+        this.props.onQueryChange?.(query, event);
     };
 
     /**

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -182,12 +182,12 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
         if (this.input != null) {
             this.input.focus();
         }
-        Utils.safeInvoke(this.props.onItemSelect, item, evt);
+        this.props.onItemSelect?.(item, evt);
     };
 
     private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {
         this.setState({ isOpen: query.length > 0 || !this.props.openOnKeyDown });
-        Utils.safeInvoke(this.props.onQueryChange, query, evt);
+        this.props.onQueryChange?.(query, evt);
     };
 
     // Popover interaction kind is CLICK, so this only handles click events.
@@ -235,7 +235,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             const isTargetingTagRemoveButton = (e.target as HTMLElement).closest(`.${CoreClasses.TAG_REMOVE}`) != null;
 
             if (this.state.isOpen && !isTargetingTagRemoveButton) {
-                Utils.safeInvoke(handleQueryListKeyDown, e);
+                handleQueryListKeyDown?.(e);
             }
         };
     };
@@ -247,7 +247,7 @@ export class MultiSelect<T> extends React.PureComponent<IMultiSelectProps<T>, IM
             // only handle events when the focus is on the actual <input> inside the TagInput, as that's
             // what QueryList is designed to do
             if (this.state.isOpen && isTargetingInput) {
-                Utils.safeInvoke(handleQueryListKeyUp, e);
+                handleQueryListKeyUp?.(e);
             }
         };
     };

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -181,7 +181,7 @@ export class Select<T> extends React.PureComponent<ISelectProps<T>, ISelectState
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isOpen: false });
-        Utils.safeInvoke(this.props.onItemSelect, item, event);
+        this.props.onItemSelect?.(item, event);
     };
 
     private handlePopoverInteraction = (isOpen: boolean) => {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -267,7 +267,7 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             this.setState({ isOpen: nextOpenState });
         }
 
-        Utils.safeInvoke(this.props.onItemSelect, item, event);
+        this.props.onItemSelect?.(item, event);
     };
 
     private getInitialSelectedItem(): T | null {
@@ -334,19 +334,19 @@ export class Suggest<T> extends React.PureComponent<ISuggestProps<T>, ISuggestSt
             }
 
             if (this.state.isOpen) {
-                Utils.safeInvoke(handleQueryListKeyDown, evt);
+                handleQueryListKeyDown?.(evt);
             }
 
-            Utils.safeInvokeMember(this.props.inputProps, "onKeyDown", evt);
+            this.props.inputProps?.onKeyDown?.(evt);
         };
     };
 
     private getTargetKeyUpHandler = (handleQueryListKeyUp: React.EventHandler<React.KeyboardEvent<HTMLElement>>) => {
         return (evt: React.KeyboardEvent<HTMLInputElement>) => {
             if (this.state.isOpen) {
-                Utils.safeInvoke(handleQueryListKeyUp, evt);
+                handleQueryListKeyUp?.(evt);
             }
-            Utils.safeInvokeMember(this.props.inputProps, "onKeyUp", evt);
+            this.props.inputProps?.onKeyUp?.(evt);
         };
     };
 

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -245,7 +245,7 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
     private invokeCallback(callback: (value: string, rowIndex?: number, columnIndex?: number) => void, value: string) {
         // pass through the row and column indices if they were provided as props by the consumer
         const { rowIndex, columnIndex } = this.props;
-        CoreUtils.safeInvoke(callback, value, rowIndex, columnIndex);
+        callback?.(value, rowIndex, columnIndex);
     }
 
     private handleCellActivate = (_event: MouseEvent) => {

--- a/packages/table/src/common/batcher.ts
+++ b/packages/table/src/common/batcher.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Utils } from "@blueprintjs/core";
 import { requestIdleCallback } from "./requestIdleCallback";
 
 export type SimpleStringifyable = string | number | null | undefined;
@@ -194,7 +193,7 @@ export class Batcher<T> {
     private handleIdleCallback = () => {
         const callback = this.callback;
         delete this.callback;
-        Utils.safeInvoke(callback);
+        callback?.();
     };
 
     private mapCurrentObjectKey = (key: string) => {

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EditableText, IIntentProps, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import * as Classes from "../common/classes";
@@ -117,6 +117,6 @@ export class EditableName extends React.PureComponent<IEditableNameProps, IEdita
 
     private invokeCallback(callback: (value: string, columnIndex?: number) => void, value: string) {
         const { index } = this.props;
-        CoreUtils.safeInvoke(callback, value, index);
+        callback?.(value, index);
     }
 }

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -337,8 +337,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
 
         const modifiedHandleSizeChanged = (size: number) => this.props.handleSizeChanged(index, size);
         const modifiedHandleResizeEnd = (size: number) => this.props.handleResizeEnd(index, size);
-        const modifiedHandleResizeHandleDoubleClick = () =>
-            CoreUtils.safeInvoke(this.props.handleResizeDoubleClick, index);
+        const modifiedHandleResizeHandleDoubleClick = () => this.props.handleResizeDoubleClick?.(index);
 
         const baseChildren = (
             <DragSelectable

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IMenuItemProps, MenuItem, Utils } from "@blueprintjs/core";
+import { IMenuItemProps, MenuItem } from "@blueprintjs/core";
 import * as React from "react";
 
 import { Clipboard } from "../../common/clipboard";
@@ -57,6 +57,6 @@ export class CopyCellsMenuItem extends React.PureComponent<ICopyCellsMenuItemPro
         const cells = context.getUniqueCells();
         const sparse = Regions.sparseMapCells(cells, getCellData);
         const success = Clipboard.copyCells(sparse);
-        Utils.safeInvoke(onCopy, success);
+        onCopy?.(success);
     };
 }

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -189,7 +189,7 @@ export class DragReorderable extends React.PureComponent<IDragReorderable> {
 
     private shouldIgnoreMouseDown(event: MouseEvent) {
         const { disabled } = this.props;
-        const isDisabled = CoreUtils.isFunction(disabled) ? CoreUtils.safeInvoke(disabled, event) : disabled;
+        const isDisabled = CoreUtils.isFunction(disabled) ? disabled?.(event) : disabled;
         return !Utils.isLeftClick(event) || isDisabled;
     }
 

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -242,7 +242,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
 
         const isLeftClick = Utils.isLeftClick(event);
         const isContextMenuTrigger = isLeftClick && event.ctrlKey && PlatformUtils.isMac();
-        const isDisabled = CoreUtils.safeInvokeOrValue(disabled, event);
+        const isDisabled = typeof disabled === "function" ? disabled(event) : disabled;
 
         return (
             !isLeftClick ||
@@ -341,7 +341,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
     // =====
 
     private finishInteraction = () => {
-        CoreUtils.safeInvoke(this.props.onSelectionEnd, this.props.selectedRegions);
+        this.props.onSelectionEnd?.(this.props.selectedRegions);
         this.didExpandSelectionOnActivate = false;
         this.lastEmittedSelectedRegions = null;
     };

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractComponent2, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent2, IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import * as Errors from "../common/errors";
@@ -142,10 +142,9 @@ export class TableQuadrant extends AbstractComponent2<ITableQuadrantProps> {
 
         const className = classNames(Classes.TABLE_QUADRANT, this.getQuadrantCssClass(), this.props.className);
 
-        const maybeMenu = enableRowHeader && CoreUtils.safeInvoke(this.props.menuRenderer);
-        const maybeRowHeader =
-            enableRowHeader && CoreUtils.safeInvoke(this.props.rowHeaderCellRenderer, showFrozenRowsOnly);
-        const maybeColumnHeader = CoreUtils.safeInvoke(this.props.columnHeaderCellRenderer, showFrozenColumnsOnly);
+        const maybeMenu = enableRowHeader && this.props.menuRenderer?.();
+        const maybeRowHeader = enableRowHeader && this.props.rowHeaderCellRenderer?.(showFrozenRowsOnly);
+        const maybeColumnHeader = this.props.columnHeaderCellRenderer?.(showFrozenColumnsOnly);
         const body =
             quadrantType != null
                 ? bodyRenderer(quadrantType, showFrozenRowsOnly, showFrozenColumnsOnly)

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -446,19 +446,19 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
     // Menu
 
     private renderMainQuadrantMenu = () => {
-        return CoreUtils.safeInvoke(this.props.menuRenderer, this.quadrantRefHandlers[QuadrantType.MAIN].menu);
+        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.MAIN].menu);
     };
 
     private renderTopQuadrantMenu = () => {
-        return CoreUtils.safeInvoke(this.props.menuRenderer, this.quadrantRefHandlers[QuadrantType.TOP].menu);
+        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.TOP].menu);
     };
 
     private renderLeftQuadrantMenu = () => {
-        return CoreUtils.safeInvoke(this.props.menuRenderer, this.quadrantRefHandlers[QuadrantType.LEFT].menu);
+        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.LEFT].menu);
     };
 
     private renderTopLeftQuadrantMenu = () => {
-        return CoreUtils.safeInvoke(this.props.menuRenderer, this.quadrantRefHandlers[QuadrantType.TOP_LEFT].menu);
+        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.TOP_LEFT].menu);
     };
 
     // Column header
@@ -467,8 +467,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const refHandler = this.quadrantRefHandlers[QuadrantType.MAIN].columnHeader;
         const resizeHandler = this.handleColumnResizeGuideMain;
         const reorderingHandler = this.handleColumnsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.columnHeaderCellRenderer,
+        return this.props.columnHeaderCellRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -480,8 +479,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const refHandler = this.quadrantRefHandlers[QuadrantType.TOP].columnHeader;
         const resizeHandler = this.handleColumnResizeGuideTop;
         const reorderingHandler = this.handleColumnsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.columnHeaderCellRenderer,
+        return this.props.columnHeaderCellRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -493,8 +491,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const refHandler = this.quadrantRefHandlers[QuadrantType.LEFT].columnHeader;
         const resizeHandler = this.handleColumnResizeGuideLeft;
         const reorderingHandler = this.handleColumnsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.columnHeaderCellRenderer,
+        return this.props.columnHeaderCellRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -506,8 +503,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const refHandler = this.quadrantRefHandlers[QuadrantType.TOP_LEFT].columnHeader;
         const resizeHandler = this.handleColumnResizeGuideTopLeft;
         const reorderingHandler = this.handleColumnsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.columnHeaderCellRenderer,
+        return this.props.columnHeaderCellRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -521,52 +517,28 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const refHandler = this.quadrantRefHandlers[QuadrantType.MAIN].rowHeader;
         const resizeHandler = this.handleRowResizeGuideMain;
         const reorderingHandler = this.handleRowsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.rowHeaderCellRenderer,
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenRowsOnly,
-        );
+        return this.props.rowHeaderCellRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenRowsOnly);
     };
 
     private renderTopQuadrantRowHeader = (showFrozenRowsOnly: boolean) => {
         const refHandler = this.quadrantRefHandlers[QuadrantType.TOP].rowHeader;
         const resizeHandler = this.handleRowResizeGuideTop;
         const reorderingHandler = this.handleRowsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.rowHeaderCellRenderer,
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenRowsOnly,
-        );
+        return this.props.rowHeaderCellRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenRowsOnly);
     };
 
     private renderLeftQuadrantRowHeader = (showFrozenRowsOnly: boolean) => {
         const refHandler = this.quadrantRefHandlers[QuadrantType.LEFT].rowHeader;
         const resizeHandler = this.handleRowResizeGuideLeft;
         const reorderingHandler = this.handleRowsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.rowHeaderCellRenderer,
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenRowsOnly,
-        );
+        return this.props.rowHeaderCellRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenRowsOnly);
     };
 
     private renderTopLeftQuadrantRowHeader = (showFrozenRowsOnly: boolean) => {
         const refHandler = this.quadrantRefHandlers[QuadrantType.TOP_LEFT].rowHeader;
         const resizeHandler = this.handleRowResizeGuideTopLeft;
         const reorderingHandler = this.handleRowsReordering;
-        return CoreUtils.safeInvoke(
-            this.props.rowHeaderCellRenderer,
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenRowsOnly,
-        );
+        return this.props.rowHeaderCellRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenRowsOnly);
     };
 
     // Event handlers
@@ -583,7 +555,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
         // invoke onScroll - which may read current scroll position - before
         // forcing a reflow with upcoming .scroll{Top,Left} setters.
-        CoreUtils.safeInvoke(this.props.onScroll, event);
+        this.props.onScroll?.(event);
 
         // batch DOM reads here. note that onScroll events don't include deltas
         // like onWheel events do, so we have to read from the DOM directly.
@@ -603,7 +575,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
     private handleWheel = (event: React.WheelEvent<HTMLElement>) => {
         // again, let the listener read the current scroll position before we
         // force a reflow by resizing or repositioning stuff.
-        CoreUtils.safeInvoke(this.props.onScroll, event);
+        this.props.onScroll?.(event);
 
         // this helper performs DOM reads, so do them together before the writes below.
         const nextScrollLeft = this.getNextScrollOffset("horizontal", event.deltaX);
@@ -692,7 +664,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     private invokeColumnResizeHandler = (verticalGuides: number[], quadrantType: QuadrantType) => {
         const adjustedGuides = this.adjustVerticalGuides(verticalGuides, quadrantType);
-        CoreUtils.safeInvoke(this.props.handleColumnResizeGuide, adjustedGuides);
+        this.props.handleColumnResizeGuide?.(adjustedGuides);
     };
 
     // Rows
@@ -715,7 +687,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     private invokeRowResizeHandler = (horizontalGuides: number[], quadrantType: QuadrantType) => {
         const adjustedGuides = this.adjustHorizontalGuides(horizontalGuides, quadrantType);
-        CoreUtils.safeInvoke(this.props.handleRowResizeGuide, adjustedGuides);
+        this.props.handleRowResizeGuide?.(adjustedGuides);
     };
 
     // Reordering
@@ -728,7 +700,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const leftOffset = this.props.grid.getCumulativeWidthBefore(guideIndex);
         const quadrantType = guideIndex <= this.props.numFrozenColumns ? QuadrantType.TOP_LEFT : QuadrantType.TOP;
         const verticalGuides = this.adjustVerticalGuides([leftOffset], quadrantType);
-        CoreUtils.safeInvoke(this.props.handleColumnsReordering, verticalGuides);
+        this.props.handleColumnsReordering?.(verticalGuides);
     };
 
     // Rows
@@ -738,17 +710,17 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         const topOffset = this.props.grid.getCumulativeHeightBefore(guideIndex);
         const quadrantType = guideIndex <= this.props.numFrozenRows ? QuadrantType.TOP_LEFT : QuadrantType.LEFT;
         const horizontalGuides = this.adjustHorizontalGuides([topOffset], quadrantType);
-        CoreUtils.safeInvoke(this.props.handleRowsReordering, horizontalGuides);
+        this.props.handleRowsReordering?.(horizontalGuides);
     };
 
     // Emitters
     // ========
 
     private emitRefs() {
-        CoreUtils.safeInvoke(this.props.quadrantRef, this.quadrantRefs[QuadrantType.MAIN].quadrant);
-        CoreUtils.safeInvoke(this.props.rowHeaderRef, this.quadrantRefs[QuadrantType.MAIN].rowHeader);
-        CoreUtils.safeInvoke(this.props.columnHeaderRef, this.quadrantRefs[QuadrantType.MAIN].columnHeader);
-        CoreUtils.safeInvoke(this.props.scrollContainerRef, this.quadrantRefs[QuadrantType.MAIN].scrollContainer);
+        this.props.quadrantRef?.(this.quadrantRefs[QuadrantType.MAIN].quadrant);
+        this.props.rowHeaderRef?.(this.quadrantRefs[QuadrantType.MAIN].rowHeader);
+        this.props.columnHeaderRef?.(this.quadrantRefs[QuadrantType.MAIN].columnHeader);
+        this.props.scrollContainerRef?.(this.quadrantRefs[QuadrantType.MAIN].scrollContainer);
     }
 
     // Size syncing

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -220,7 +220,7 @@ export class TableBodyCells extends AbstractComponent2<ITableBodyCellsProps> {
         const { onCompleteRender, renderMode } = this.props;
 
         if (renderMode === RenderMode.NONE || (renderMode === RenderMode.BATCH && this.batcher.isDone())) {
-            CoreUtils.safeInvoke(onCompleteRender);
+            onCompleteRender?.();
         }
     }
 

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -223,7 +223,7 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
         );
     };
 
-    private handleItemSelect = (timezone: ITimezoneItem) => Utils.safeInvoke(this.props.onChange, timezone.timezone);
+    private handleItemSelect = (timezone: ITimezoneItem) => this.props.onChange?.(timezone.timezone);
 
     private handleQueryChange = (query: string) => this.setState({ query });
 }

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -29,7 +29,6 @@ import {
     IPopoverProps,
     IProps,
     MenuItem,
-    Utils,
 } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Select } from "@blueprintjs/select";
 


### PR DESCRIPTION
#### Fixes #4135

#### Changes proposed in this pull request:

- Deprecate `safeInvoke`, `safeInvokeMember`, and `saveInvokeOrValue`
- Replace usages with TS 3.7+ optional calls `?.()`

