### PR TITLE
[core] fix(TextArea): inputRef ref hook usage

### DIFF
--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -18,7 +18,7 @@ export type IRef<T = HTMLElement> = IRefObject<T> | IRefCallback<T>;
 
 // compatible with React.Ref type in @types/react@^16
 export interface IRefObject<T = HTMLElement> {
-    readonly current: T | null;
+    current: T | null;
 }
 
 export function isRefObject<T extends HTMLElement>(value: IRef<T> | undefined | null): value is IRefObject<T> {

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
-import { AbstractPureComponent2, Classes } from "../../common";
+import { AbstractPureComponent2, Classes, IRef, isRefCallback, isRefObject } from "../../common";
 import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 
 export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -44,7 +44,7 @@ export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTML
     /**
      * Ref handler that receives HTML `<textarea>` element backing this component.
      */
-    inputRef?: (ref: HTMLTextAreaElement | null) => any;
+    inputRef?: IRef<HTMLTextAreaElement>;
 }
 
 export interface ITextAreaState {
@@ -68,7 +68,7 @@ export class TextArea extends AbstractPureComponent2<ITextAreaProps, ITextAreaSt
     }
     public componentDidUpdate(prevProps: ITextAreaProps) {
         if (this.props.inputRef && prevProps.inputRef !== this.props.inputRef) {
-            this.props.inputRef(this.internalTextAreaRef);
+            this.handleInternalRef(this.internalTextAreaRef);
         }
     }
     public render() {
@@ -122,8 +122,13 @@ export class TextArea extends AbstractPureComponent2<ITextAreaProps, ITextAreaSt
     // hold an internal ref for growVertically
     private handleInternalRef = (ref: HTMLTextAreaElement | null) => {
         this.internalTextAreaRef = ref;
-        if (this.props.inputRef != null) {
+
+        if (isRefCallback(this.props.inputRef)) {
             this.props.inputRef(ref);
+        }
+
+        if (isRefObject(this.props.inputRef)) {
+            this.props.inputRef.current = ref;
         }
     };
 }

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -77,4 +77,16 @@ describe("<TextArea>", () => {
         textAreawrapper.setProps({ inputRef: textAreaNewRefCallback });
         assert.instanceOf(textAreaNew, HTMLTextAreaElement);
     });
+    if (typeof React.createRef !== "undefined") {
+        it("accepts RefObject and updates on change", () => {
+            const textAreaRef = React.createRef<HTMLTextAreaElement>();
+            const textAreaNewRef = React.createRef<HTMLTextAreaElement>();
+
+            const textAreawrapper = mount(<TextArea id="textarea" inputRef={textAreaRef} />);
+            assert.instanceOf(textAreaRef.current, HTMLTextAreaElement);
+
+            textAreawrapper.setProps({ inputRef: textAreaNewRef });
+            assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
+        });
+    }
 });


### PR DESCRIPTION
#### Fixes #4294

#### Checklist

- [x] Includes tests
- [NA] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Allow TextArea to receive an IRefObject for the InputRef. Change IRefObject.current to not be readonly.

#### Reviewers should focus on:

Never used Typescript, so I may be doing weird things...

