### PR TITLE
[select] feat: pass create item renderer to item list renderer

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -62,9 +62,9 @@ export interface IItemListRendererProps<T> {
     renderItem: (item: T, index: number) => JSX.Element | null;
 
     /**
-     * The rendered createIem.
+     * Call this function to render the "create new item" view component.
      */
-    createItemView: JSX.Element | null;
+    renderCreateItem: () => JSX.Element | null;
 }
 
 /** Type alias for a function that renders the list of items. */

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -63,8 +63,9 @@ export interface IItemListRendererProps<T> {
 
     /**
      * Call this function to render the "create new item" view component.
+     * @returns null when creating a new item is not available, and undefined if the createNewItemRenderer returns undefined
      */
-    renderCreateItem: () => JSX.Element | null;
+    renderCreateItem: () => JSX.Element | null | undefined;
 }
 
 /** Type alias for a function that renders the list of items. */

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -60,6 +60,11 @@ export interface IItemListRendererProps<T> {
      * to the owner component's `itemRenderer` prop.
      */
     renderItem: (item: T, index: number) => JSX.Element | null;
+
+    /**
+     * The rendered createIem.
+     */
+    createItemView: JSX.Element | null;
 }
 
 /** Type alias for a function that renders the list of items. */

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -202,6 +202,9 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     public render() {
         const { className, items, renderer, itemListRenderer = this.renderItemList } = this.props;
         const { createNewItem, ...spreadableState } = this.state;
+        const createItemView = this.isCreateItemRendered()
+            ? this.renderCreateItemMenuItem(this.state.query.trim())
+            : null;
         return renderer({
             ...spreadableState,
             className,
@@ -215,6 +218,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                 items,
                 itemsParentRef: this.refHandlers.itemsParent,
                 renderItem: this.renderItem,
+                createItemView,
             }),
         });
     }
@@ -334,18 +338,15 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         const { initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
-        const maybeNoResults = this.isCreateItemRendered() ? null : noResults;
+        const maybeNoResults = listProps.createItemView == null ? null : noResults;
         const menuContent = renderFilteredItems(listProps, maybeNoResults, initialContent);
-        const createItemView = this.isCreateItemRendered()
-            ? this.renderCreateItemMenuItem(this.state.query.trim())
-            : null;
-        if (menuContent == null && createItemView == null) {
+        if (menuContent == null && listProps.createItemView == null) {
             return null;
         }
         return (
             <Menu ulRef={listProps.itemsParentRef}>
                 {menuContent}
-                {createItemView}
+                {listProps.createItemView}
             </Menu>
         );
     };

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -202,9 +202,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     public render() {
         const { className, items, renderer, itemListRenderer = this.renderItemList } = this.props;
         const { createNewItem, ...spreadableState } = this.state;
-        const createItemView = this.isCreateItemRendered()
-            ? this.renderCreateItemMenuItem(this.state.query.trim())
-            : null;
+        const renderCreateItem: () => this.isCreateItemRendered() ? this.renderCreateItemMenuItem(this.state.query.trim()) : null;
         return renderer({
             ...spreadableState,
             className,
@@ -218,7 +216,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                 items,
                 itemsParentRef: this.refHandlers.itemsParent,
                 renderItem: this.renderItem,
-                createItemView,
+                renderCreateItem,
             }),
         });
     }
@@ -338,15 +336,16 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         const { initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
-        const maybeNoResults = listProps.createItemView != null ? null : noResults;
+        const createItemView = listProps.renderCreateItem();
+        const maybeNoResults = createItemView != null ? null : noResults;
         const menuContent = renderFilteredItems(listProps, maybeNoResults, initialContent);
-        if (menuContent == null && listProps.createItemView == null) {
+        if (menuContent == null && createItemView == null) {
             return null;
         }
         return (
             <Menu ulRef={listProps.itemsParentRef}>
                 {menuContent}
-                {listProps.createItemView}
+                {createItemView}
             </Menu>
         );
     };

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -202,7 +202,6 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     public render() {
         const { className, items, renderer, itemListRenderer = this.renderItemList } = this.props;
         const { createNewItem, ...spreadableState } = this.state;
-        const renderCreateItem: () => this.isCreateItemRendered() ? this.renderCreateItemMenuItem(this.state.query.trim()) : null;
         return renderer({
             ...spreadableState,
             className,
@@ -215,8 +214,8 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
                 ...spreadableState,
                 items,
                 itemsParentRef: this.refHandlers.itemsParent,
+                renderCreateItem: this.renderCreateItemMenuItem,
                 renderItem: this.renderItem,
-                renderCreateItem,
             }),
         });
     }
@@ -371,13 +370,17 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         return null;
     };
 
-    private renderCreateItemMenuItem = (query: string) => {
-        const { activeItem } = this.state;
-        const handleClick: React.MouseEventHandler<HTMLElement> = evt => {
-            this.handleItemCreate(query, evt);
-        };
-        const isActive = isCreateNewItem(activeItem);
-        return this.props.createNewItemRenderer?.(query, isActive, handleClick);
+    private renderCreateItemMenuItem = () => {
+        if (this.isCreateItemRendered()) {
+            const { activeItem, query } = this.state;
+            const handleClick: React.MouseEventHandler<HTMLElement> = evt => {
+                this.handleItemCreate(query.trim(), evt);
+            };
+            const isActive = isCreateNewItem(activeItem);
+            return this.props.createNewItemRenderer!(query, isActive, handleClick);
+        }
+
+        return null;
     };
 
     private getActiveElement() {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -338,7 +338,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         const { initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
-        const maybeNoResults = listProps.createItemView == null ? null : noResults;
+        const maybeNoResults = listProps.createItemView != null ? null : noResults;
         const menuContent = renderFilteredItems(listProps, maybeNoResults, initialContent);
         if (menuContent == null && listProps.createItemView == null) {
             return null;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -373,11 +373,12 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     private renderCreateItemMenuItem = () => {
         if (this.isCreateItemRendered()) {
             const { activeItem, query } = this.state;
+            const trimmedQuery = query.trim();
             const handleClick: React.MouseEventHandler<HTMLElement> = evt => {
-                this.handleItemCreate(query.trim(), evt);
+                this.handleItemCreate(trimmedQuery, evt);
             };
             const isActive = isCreateNewItem(activeItem);
-            return this.props.createNewItemRenderer!(query, isActive, handleClick);
+            return this.props.createNewItemRenderer!(trimmedQuery, isActive, handleClick);
         }
 
         return null;

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -26,6 +26,7 @@ describe("renderFilteredItems()", () => {
         items: ["one", "two", "three"],
         itemsParentRef: sinon.stub(),
         query: "x",
+        renderCreateItem: () => undefined,
         renderItem: () => <div />,
     };
     const noResults = <strong />;


### PR DESCRIPTION
#### Fixes #4302, fixes #4031 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- pass in `renderCreateItem` to the itemListRenderer which will render the custom item using the passed in props

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
