### PR TITLE
[core] fix(Button): always exit active state if blurred

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -141,6 +141,7 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         return {
             className,
             disabled,
+            onBlur: this.handleBlur,
             onClick: disabled ? undefined : this.props.onClick,
             onKeyDown: this.handleKeyDown,
             onKeyUp: this.handleKeyUp,
@@ -174,6 +175,11 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
         }
         this.currentKeyDown = null;
         this.props.onKeyUp?.(e);
+    };
+
+    protected handleBlur = (e: React.FocusEvent<any>) => {
+        if (this.state.isActive) this.setState({ isActive: false });
+        this.props.onBlur?.(e);
     };
 
     protected renderChildren(): React.ReactNode {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -178,7 +178,9 @@ export abstract class AbstractButton<H extends React.HTMLAttributes<HTMLElement>
     };
 
     protected handleBlur = (e: React.FocusEvent<any>) => {
-        if (this.state.isActive) this.setState({ isActive: false });
+        if (this.state.isActive) {
+            this.setState({ isActive: false });
+        }
         this.props.onBlur?.(e);
     };
 


### PR DESCRIPTION
#### Fixes #3977

#### Changes proposed in this pull request:

Add an onBlur handler passed to the button component that unsets the local component `isActive` state on DOM blur events if necessaary.

