### PR TITLE
refactor: allow popover to close even if event is defaultPrevented

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -113,6 +113,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         hasBackdrop: false,
         hoverCloseDelay: 300,
         hoverOpenDelay: 150,
+        ignoreDefaultPreventedOnDismiss: false,
         inheritDarkTheme: true,
         interactionKind: PopoverInteractionKind.CLICK,
         minimal: false,
@@ -499,7 +500,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         const dismissElement = eventTarget.closest(`.${Classes.POPOVER_DISMISS}, .${Classes.POPOVER_DISMISS_OVERRIDE}`);
         const shouldDismiss = dismissElement != null && dismissElement.classList.contains(Classes.POPOVER_DISMISS);
         const isDisabled = eventTarget.closest(`:disabled, .${Classes.DISABLED}`) != null;
-        if (shouldDismiss && !isDisabled && !e.isDefaultPrevented()) {
+        if (shouldDismiss && !isDisabled && (this.props.ignoreDefaultPreventedOnDismiss || !e.isDefaultPrevented())) {
             this.setOpenState(false, e);
             if (this.props.captureDismiss) {
                 e.preventDefault();

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -85,6 +85,7 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
      * `ClassesClasses.POPOVER_DISMISS` even if the event has defaultPrevented
      * set to true (useful for allowing popover to close when clicking on a
      * <Link /> react-router-dom component and similars)
+     * @default false
      */
     ignoreDefaultPreventedOnDismiss?: boolean;
 

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -81,6 +81,14 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     hoverOpenDelay?: number;
 
     /**
+     * When enabled, popover will close after clicking on an element with
+     * `ClassesClasses.POPOVER_DISMISS` even if the event has defaultPrevented
+     * set to true (useful for allowing popover to close when clicking on a
+     * <Link /> react-router-dom component and similars)
+     */
+    ignoreDefaultPreventedOnDismiss?: boolean;
+
+    /**
      * Whether a popover that uses a `Portal` should automatically inherit the
      * dark theme from its parent.
      * @default true

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -688,6 +688,35 @@ describe("<Popover>", () => {
                 true,
             ));
 
+        it("Classes.POPOVER_DISMISS does not close if event is defaultPrevented", () => {
+            const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+                e.preventDefault();
+            };
+            return assertClickToClose(
+                <a href="#" onClick={handleClick}>
+                    <button className={Classes.POPOVER_DISMISS} id="btn">
+                        Dismiss
+                    </button>
+                </a>,
+                true,
+            );
+        });
+
+        it("Classes.POPOVER_DISMISS closes if ignoreDefaultPreventedOnDismiss is set even if event is defaultPrevented", () => {
+            const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+                e.preventDefault();
+            };
+            return assertClickToClose(
+                <a href="#" onClick={handleClick}>
+                    <button className={Classes.POPOVER_DISMISS} id="btn">
+                        Dismiss
+                    </button>
+                </a>,
+                false,
+                { ignoreDefaultPreventedOnDismiss: true },
+            );
+        });
+
         it(":disabled does not close", () =>
             assertClickToClose(
                 <button className={Classes.POPOVER_DISMISS} disabled={true} id="btn">
@@ -729,8 +758,12 @@ describe("<Popover>", () => {
                 false,
             ));
 
-        function assertClickToClose(children: React.ReactNode, expectedIsOpen: boolean) {
-            wrapper = renderPopover({ defaultIsOpen: true }, children);
+        function assertClickToClose(
+            children: React.ReactNode,
+            expectedIsOpen: boolean,
+            popoverProps?: Partial<IPopoverProps>,
+        ) {
+            wrapper = renderPopover({ defaultIsOpen: true, ...popoverProps }, children);
             wrapper.find("#btn").simulate("click");
             wrapper.assertIsOpen(expectedIsOpen);
         }


### PR DESCRIPTION
#### Fixes #2820

#### Checklist

- [X] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Including an opt-in prop to allow the popover to close even if the event is defaultPrevented, useful for cases like ```<Link />``` component
