### PR TITLE
[datetime] fix(DateInput): Improve blur handling to avoid unexpected popover closures

### DIFF
--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -36,7 +36,7 @@ export const DATEPICKER_FOOTER = `${DATEPICKER}-footer`;
 export const DATEPICKER_MONTH_SELECT = `${DATEPICKER}-month-select`;
 export const DATEPICKER_YEAR_SELECT = `${DATEPICKER}-year-select`;
 export const DATEPICKER_NAVBAR = `${DATEPICKER}-navbar`;
-export const DATEPICKER_NAVBUTTON = `${DATEPICKER}-NavButton`;
+export const DATEPICKER_NAVBUTTON = `DayPicker-NavButton`;
 export const DATEPICKER_TIMEPICKER_WRAPPER = `${DATEPICKER}-timepicker-wrapper`;
 
 export const DATERANGEPICKER = `${NS}-daterangepicker`;

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -36,6 +36,7 @@ export const DATEPICKER_FOOTER = `${DATEPICKER}-footer`;
 export const DATEPICKER_MONTH_SELECT = `${DATEPICKER}-month-select`;
 export const DATEPICKER_YEAR_SELECT = `${DATEPICKER}-year-select`;
 export const DATEPICKER_NAVBAR = `${DATEPICKER}-navbar`;
+export const DATEPICKER_NAVBUTTON = `${DATEPICKER}-NavButton`;
 export const DATEPICKER_TIMEPICKER_WRAPPER = `${DATEPICKER}-timepicker-wrapper`;
 
 export const DATERANGEPICKER = `${NS}-daterangepicker`;

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -210,7 +210,11 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             // If the user tabs on a DayPicker Day element and the lastElementInPopover is also a DayPicker Day
             // element, the popover should be closed
             onDayKeyDown: (day, modifiers, e) => {
-                if (e.key === "Tab" && !e.shiftKey && this.lastElementInPopover.classList.contains("DayPicker-Day")) {
+                if (
+                    e.key === "Tab" &&
+                    !e.shiftKey &&
+                    this.lastElementInPopover.classList.contains(Classes.DATEPICKER_DAY)
+                ) {
                     this.setState({ isOpen: false });
                 }
                 this.props.dayPickerProps.onDayKeyDown?.(day, modifiers, e);
@@ -432,9 +436,9 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             // - On disabled change months buttons
             // - DayPicker day elements, their "blur" will be managed at its own onKeyDown
             // event listener for improving UX
-            const isChangeMonthEvt = eventTarget.classList.contains("DayPicker-NavButton");
+            const isChangeMonthEvt = eventTarget.classList.contains(Classes.DATEPICKER_NAVBUTTON);
             const isChangeMonthButtonDisabled = isChangeMonthEvt && (eventTarget as HTMLButtonElement).disabled;
-            const isDayPickerDayEvt = eventTarget.classList.contains("DayPicker-Day");
+            const isDayPickerDayEvt = eventTarget.classList.contains(Classes.DATEPICKER_DAY);
             if (!isChangeMonthButtonDisabled && !isDayPickerDayEvt) {
                 this.handleClosePopover();
             }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -207,7 +207,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         const dateValue = isDateValid(value) ? value : null;
         const dayPickerProps: DayPickerProps = {
             ...this.props.dayPickerProps,
-            // If the user tabs on a DayPicker Day element and the lastElementInPopover is also a DayPicker Day
+            // If the user presses the TAB key on a DayPicker Day element and the lastElementInPopover is also a DayPicker Day
             // element, the popover should be closed
             onDayKeyDown: (day, modifiers, e) => {
                 if (
@@ -435,7 +435,6 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             // and would close the Popover unexpectedly
             // - On disabled change months buttons
             // - DayPicker day elements, their "blur" will be managed at its own onKeyDown
-            // event listener for improving UX
             const isChangeMonthEvt = eventTarget.classList.contains(Classes.DATEPICKER_NAVBUTTON);
             const isChangeMonthButtonDisabled = isChangeMonthEvt && (eventTarget as HTMLButtonElement).disabled;
             const isDayPickerDayEvt = eventTarget.classList.contains(Classes.DATEPICKER_DAY);

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -87,14 +87,13 @@ describe("<DateInput>", () => {
         assert.isFalse(wrapper.find(Popover).prop("isOpen"));
     });
 
-    it("Popover closes when first day of the month is blurred", () => {
+    it("Popover closes when tabbing on first day of the month", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
         const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
         wrapper.find("input").simulate("focus").simulate("blur");
         // First day of month is the only .DayPicker-Day with tabIndex == 0
         const tabbables = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 });
-        const firstDay = tabbables.getDOMNode() as HTMLElement;
-        firstDay.dispatchEvent(createFocusEvent("blur"));
+        tabbables.simulate("keydown", { key: "Tab" });
         // manually updating wrapper is required with enzyme 3
         // ref: https://github.com/airbnb/enzyme/blob/master/docs/guides/migration-from-2-to-3.md#for-mount-updates-are-sometimes-required-when-they-werent-before
         wrapper.update();


### PR DESCRIPTION
#### Fixes #3603

#### Changes proposed in this pull request:

The poposed solution is to avoid the case where minDate/maxDate is set, and using the change month arrows makes the popover to close on chrome browser, upon debugging, the issue is that document.activeElement is returning "body" instead of the change month button, which makes ```handlePopoverBlur``` set up execute incorrectly and subsequently calling ```handleClosePopover``` which causes the described issue.

#### Reviewers should focus on:

While this solution works correctly for that case, it makes "Popover closes when first day of the month is blurred" test fail, and after evaluating both use cases, it seems the min/max date has more weight, and so losing that "feature" is worth it.

Here's the [sandbox](https://codesandbox.io/s/old-butterfly-spcxx) (open in chrome) and without selecting any date, move 2 months before/after and notice how the popover closes incorrectly.
