### PR TITLE
[datetime] docs: improve dateRangePicker example

### DIFF
--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -61,8 +61,12 @@ const MIN_DATE_OPTIONS: IDateOption[] = [
 const MAX_DATE_OPTIONS: IDateOption[] = [
     { label: "None", value: undefined },
     {
-        label: "1 month ago",
-        value: moment().add(-1, "months").toDate(),
+        label: "4 months from now",
+        value: moment().add(4, "months").toDate(),
+    },
+    {
+        label: "1 year from now",
+        value: moment().add(1, "years").toDate(),
     },
 ];
 


### PR DESCRIPTION
#### Issue:

Go to https://blueprintjs.com/docs/#datetime/daterangepicker, select maximum date "1 month ago", notice how the datePicker is not usable anymore using the change month arrows.

#### Changes proposed in this pull request:

Normalize it with minDate so users can visualize both ranges correctly. Also, even if the change month arrows may require a separate fix when current calendar is ahead of maxDate or before minDate, the default maxDate used in the example is not appropiate.
