### PR TITLE
[core] fix(NumericInput): revert to Button, improve handleContinuousChange

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -36,7 +36,7 @@ import {
 import * as Errors from "../../common/errors";
 
 import { ButtonGroup } from "../button/buttonGroup";
-import { AnchorButton } from "../button/buttons";
+import { Button } from "../button/buttons";
 import { ControlGroup } from "./controlGroup";
 import { InputGroup } from "./inputGroup";
 import {
@@ -353,13 +353,13 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         const disabled = this.props.disabled || this.props.readOnly;
         return (
             <ButtonGroup className={Classes.FIXED} key="button-group" vertical={true}>
-                <AnchorButton
+                <Button
                     disabled={disabled || (value !== "" && +value >= max)}
                     icon="chevron-up"
                     intent={intent}
                     {...this.incrementButtonHandlers}
                 />
-                <AnchorButton
+                <Button
                     disabled={disabled || (value !== "" && +value <= min)}
                     icon="chevron-down"
                     intent={intent}
@@ -445,6 +445,17 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
     };
 
     private handleContinuousChange = () => {
+        // If either min or max prop is set, when reaching the limit
+        // the button will be disabled and stopContinuousChange will be never fired,
+        // hence the need to check on each iteration to properly clear the timeout
+        if (this.props.min !== undefined || this.props.max !== undefined) {
+            const min = this.props.min ?? -Infinity;
+            const max = this.props.max ?? Infinity;
+            if (Number(this.state.value) <= min || Number(this.state.value) >= max) {
+                this.stopContinuousChange();
+                return;
+            }
+        }
         const nextValue = this.incrementValue(this.delta);
         this.props.onButtonClick?.(+nextValue, nextValue);
     };

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -27,7 +27,7 @@ import { spy } from "sinon";
 import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test-commons";
 
 import {
-    AnchorButton,
+    Button,
     ButtonGroup,
     ControlGroup,
     HTMLInputProps,
@@ -87,7 +87,7 @@ describe("<NumericInput>", () => {
         it("increments the value from 0 if the field is empty", () => {
             const component = mount(<NumericInput />);
 
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown");
 
             const value = component.state().value;
@@ -192,7 +192,7 @@ describe("<NumericInput>", () => {
             const onValueChangeSpy = spy();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
 
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
@@ -204,8 +204,8 @@ describe("<NumericInput>", () => {
             const onButtonClickSpy = spy();
             const component = mount(<NumericInput onButtonClick={onButtonClickSpy} />);
 
-            const incrementButton = component.find(AnchorButton).first();
-            const decrementButton = component.find(AnchorButton).last();
+            const incrementButton = component.find(Button).first();
+            const decrementButton = component.find(Button).last();
 
             // incrementing from 0
             incrementButton.simulate("mousedown");
@@ -470,12 +470,12 @@ describe("<NumericInput>", () => {
     // Enable these tests once we have a solution for testing Button onKeyUp callbacks (see PR #561)
     describe("Keyboard interactions on buttons (with Space key)", () => {
         const simulateIncrement = (component: ReactWrapper<any>, mockEvent: IMockEvent = {}) => {
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.SPACE));
         };
 
         const simulateDecrement = (component: ReactWrapper<any>, mockEvent: IMockEvent = {}) => {
-            const decrementButton = component.find(AnchorButton).last();
+            const decrementButton = component.find(Button).last();
             decrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.SPACE));
         };
 
@@ -484,12 +484,12 @@ describe("<NumericInput>", () => {
 
     describe("Keyboard interactions on buttons (with Enter key)", () => {
         const simulateIncrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.ENTER));
         };
 
         const simulateDecrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const decrementButton = component.find(AnchorButton).last();
+            const decrementButton = component.find(Button).last();
             decrementButton.simulate("keydown", addKeyCode(mockEvent, Keys.ENTER));
         };
 
@@ -498,12 +498,12 @@ describe("<NumericInput>", () => {
 
     describe("Mouse interactions", () => {
         const simulateIncrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", mockEvent);
         };
 
         const simulateDecrement = (component: ReactWrapper<any>, mockEvent?: IMockEvent) => {
-            const decrementButton = component.find(AnchorButton).last();
+            const decrementButton = component.find(Button).last();
             decrementButton.simulate("mousedown", mockEvent);
         };
 
@@ -515,7 +515,7 @@ describe("<NumericInput>", () => {
             it("enforces no minimum bound", () => {
                 const component = mount(<NumericInput />);
 
-                const decrementButton = component.find(AnchorButton).last();
+                const decrementButton = component.find(Button).last();
                 decrementButton.simulate("mousedown", { shiftKey: true });
                 decrementButton.simulate("mousedown", { shiftKey: true });
 
@@ -526,7 +526,7 @@ describe("<NumericInput>", () => {
             it("enforces no maximum bound", () => {
                 const component = mount(<NumericInput />);
 
-                const incrementButton = component.find(AnchorButton).first();
+                const incrementButton = component.find(Button).first();
                 incrementButton.simulate("mousedown", { shiftKey: true });
                 incrementButton.simulate("mousedown", { shiftKey: true });
 
@@ -569,7 +569,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 1
-                const decrementButton = component.find(AnchorButton).last();
+                const decrementButton = component.find(Button).last();
                 decrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -581,7 +581,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 1
-                const decrementButton = component.find(AnchorButton).last();
+                const decrementButton = component.find(Button).last();
                 decrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -593,7 +593,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 0.1
-                const decrementButton = component.find(AnchorButton).last();
+                const decrementButton = component.find(Button).last();
                 decrementButton.simulate("mousedown", { altKey: true });
 
                 const newValue = component.state().value;
@@ -605,7 +605,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={MIN_VALUE} />);
 
                 // try to decrement by 10
-                const decrementButton = component.find(AnchorButton).last();
+                const decrementButton = component.find(Button).last();
                 decrementButton.simulate("mousedown", { shiftKey: true });
 
                 const newValue = component.state().value;
@@ -643,7 +643,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment by 1
-                const incrementButton = component.find(AnchorButton).first();
+                const incrementButton = component.find(Button).first();
                 incrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -655,7 +655,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment in by 1
-                const incrementButton = component.find(AnchorButton).first();
+                const incrementButton = component.find(Button).first();
                 incrementButton.simulate("mousedown");
 
                 const newValue = component.state().value;
@@ -667,7 +667,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment by 0.1
-                const incrementButton = component.find(AnchorButton).first();
+                const incrementButton = component.find(Button).first();
                 incrementButton.simulate("mousedown", { altKey: true });
 
                 const newValue = component.state().value;
@@ -679,7 +679,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput max={MAX_VALUE} />);
 
                 // try to increment by 10
-                const incrementButton = component.find(AnchorButton).first();
+                const incrementButton = component.find(Button).first();
                 incrementButton.simulate("mousedown", { shiftKey: true });
 
                 const newValue = component.state().value;
@@ -717,7 +717,7 @@ describe("<NumericInput>", () => {
                 const component = mount(<NumericInput min={2} max={2} onValueChange={onValueChangeSpy} />);
                 // repeated interactions, no change in state
                 component
-                    .find(AnchorButton)
+                    .find(Button)
                     .first()
                     .simulate("mousedown")
                     .simulate("mousedown")
@@ -830,7 +830,7 @@ describe("<NumericInput>", () => {
             const value = component.find(NumericInput).state().value;
             expect(value).to.equal("<invalid>");
 
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown");
 
             const newValue = component.state().value;
@@ -843,7 +843,7 @@ describe("<NumericInput>", () => {
             const value = component.find(NumericInput).state().value;
             expect(value).to.equal("<invalid>");
 
-            const decrementButton = component.find(AnchorButton).last();
+            const decrementButton = component.find(Button).last();
             decrementButton.simulate("mousedown");
 
             const newValue = component.state().value;
@@ -864,7 +864,7 @@ describe("<NumericInput>", () => {
             const onValueChangeSpy = spy();
             const component = mount(<NumericInput value={initialValue} onValueChange={onValueChangeSpy} />);
 
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
@@ -893,8 +893,8 @@ describe("<NumericInput>", () => {
         it("disables the increment button when the value is greater than or equal to max", () => {
             const component = mount(<NumericInput value={100} max={100} />);
 
-            const decrementButton = component.find(AnchorButton).last();
-            const incrementButton = component.find(AnchorButton).first();
+            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(Button).first();
 
             expect(decrementButton.props().disabled).to.be.false;
             expect(incrementButton.props().disabled).to.be.true;
@@ -903,8 +903,8 @@ describe("<NumericInput>", () => {
         it("disables the decrement button when the value is less than or equal to min", () => {
             const component = mount(<NumericInput value={-10} min={-10} />);
 
-            const decrementButton = component.find(AnchorButton).last();
-            const incrementButton = component.find(AnchorButton).first();
+            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(Button).first();
 
             expect(decrementButton.props().disabled).to.be.true;
             expect(incrementButton.props().disabled).to.be.false;
@@ -914,8 +914,8 @@ describe("<NumericInput>", () => {
             const component = mount(<NumericInput disabled={true} />);
 
             const inputGroup = component.find(InputGroup);
-            const decrementButton = component.find(AnchorButton).last();
-            const incrementButton = component.find(AnchorButton).first();
+            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(Button).first();
 
             expect(inputGroup.props().disabled).to.be.true;
             expect(decrementButton.props().disabled).to.be.true;
@@ -926,8 +926,8 @@ describe("<NumericInput>", () => {
             const component = mount(<NumericInput readOnly={true} />);
 
             const inputGroup = component.find(InputGroup);
-            const decrementButton = component.find(AnchorButton).last();
-            const incrementButton = component.find(AnchorButton).first();
+            const decrementButton = component.find(Button).last();
+            const incrementButton = component.find(Button).first();
 
             expect(inputGroup.props().readOnly).to.be.true;
             expect(decrementButton.props().disabled).to.be.true;
@@ -950,8 +950,8 @@ describe("<NumericInput>", () => {
         });
 
         it("shows right element if provided", () => {
-            const component = mount(<NumericInput rightElement={<AnchorButton />} />);
-            expect(component.find(InputGroup).find(AnchorButton)).to.exist;
+            const component = mount(<NumericInput rightElement={<Button />} />);
+            expect(component.find(InputGroup).find(Button)).to.exist;
         });
 
         it("passed decimal value should be rounded by stepSize", () => {
@@ -966,7 +966,7 @@ describe("<NumericInput>", () => {
 
         it("changes max precision of displayed value to that of the smallest step size defined", () => {
             const component = mount(<NumericInput majorStepSize={1} stepSize={0.1} minorStepSize={0.001} />);
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
 
             incrementButton.simulate("mousedown");
             expect(component.find("input").prop("value")).to.equal("0.1");
@@ -996,21 +996,21 @@ describe("<NumericInput>", () => {
             );
 
             // excess digits should truncate to max precision
-            let incrementButton = component.find(AnchorButton).first();
+            let incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", { altKey: true });
             expect(onValueChangeSpy.calledOnceWith(0.001, "0.001"));
             onValueChangeSpy.resetHistory();
 
             // now try a smaller step size, and expect no truncation
             component.setProps({ minorStepSize: 0.0001 });
-            incrementButton = component.find(AnchorButton).first();
+            incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", { altKey: true });
             expect(onValueChangeSpy.calledOnceWith(0.0002, "0.0002"));
             onValueChangeSpy.resetHistory();
 
             // now try a larger step size, and expect more truncation than before
             component.setProps({ minorStepSize: 0.1 });
-            incrementButton = component.find(AnchorButton).first();
+            incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", { altKey: true });
             expect(onValueChangeSpy.calledOnceWith(0.01, "0.01"));
             onValueChangeSpy.resetHistory();
@@ -1021,7 +1021,7 @@ describe("<NumericInput>", () => {
 
             const component = mount(<NumericInput disabled={true} />);
 
-            const incrementButton = component.find(AnchorButton).first();
+            const incrementButton = component.find(Button).first();
             const handleButtonClickSpy = spy(component.instance(), "handleButtonClick" as any);
 
             incrementButton.simulate("mousedown");
@@ -1029,7 +1029,7 @@ describe("<NumericInput>", () => {
             incrementButton.simulate("keyDown", SPACE_KEYSTROKE);
             incrementButton.simulate("keyDown", { ...SPACE_KEYSTROKE, altKey: true });
 
-            const decrementButton = component.find(AnchorButton).last();
+            const decrementButton = component.find(Button).last();
             decrementButton.simulate("mousedown");
             decrementButton.simulate("mousedown", { altKey: true });
             decrementButton.simulate("keyDown", SPACE_KEYSTROKE);


### PR DESCRIPTION
#### Fixes #4270

#### Changes proposed in this pull request:

Revert AnchorButton to Button and apply an improvement to handleContinuousChange as originally in #4201
