### PR TITLE
[core] refactor(Popover): improve popover captureDismiss mechanism

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -208,6 +208,7 @@ export const PANEL_STACK_VIEW = `${PANEL_STACK}-view`;
 export const POPOVER = `${NS}-popover`;
 export const POPOVER_ARROW = `${POPOVER}-arrow`;
 export const POPOVER_BACKDROP = `${POPOVER}-backdrop`;
+export const POPOVER_CAPTURING_DISMISS = `${POPOVER}-capturing-dismiss`;
 export const POPOVER_CONTENT = `${POPOVER}-content`;
 export const POPOVER_CONTENT_SIZING = `${POPOVER_CONTENT}-sizing`;
 export const POPOVER_DISMISS = `${POPOVER}-dismiss`;

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -95,3 +95,10 @@ export function isElementOfType<P = {}>(
         element.type.displayName === ComponentType.displayName
     );
 }
+
+/**
+ * Returns React.createRef if it's available, or a ref-like object if not.
+ */
+export function createReactRef<T>() {
+    return typeof React.createRef !== "undefined" ? React.createRef<T>() : { current: null };
+}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -103,7 +103,7 @@ export interface IPopoverState {
 @polyfill
 export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
-    private popoverRef = React.createRef<HTMLDivElement>();
+    private popoverRef = Utils.createReactRef<HTMLDivElement>();
 
     public static defaultProps: IPopoverProps = {
         boundary: "scrollParent",
@@ -313,8 +313,8 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             {
                 [Classes.DARK]: this.props.inheritDarkTheme && this.state.hasDarkParent,
                 [Classes.MINIMAL]: this.props.minimal,
+                [Classes.POPOVER_CAPTURING_DISMISS]: this.props.captureDismiss,
             },
-            this.props.captureDismiss ? Classes.POPOVER_CAPTURING_DISMISS : "",
             this.props.popoverClassName,
         );
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -103,6 +103,7 @@ export interface IPopoverState {
 @polyfill
 export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
+    private popoverRef = React.createRef<HTMLDivElement>();
 
     public static defaultProps: IPopoverProps = {
         boundary: "scrollParent",
@@ -313,13 +314,19 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 [Classes.DARK]: this.props.inheritDarkTheme && this.state.hasDarkParent,
                 [Classes.MINIMAL]: this.props.minimal,
             },
+            this.props.captureDismiss ? Classes.POPOVER_CAPTURING_DISMISS : "",
             this.props.popoverClassName,
         );
 
         return (
             <div className={Classes.TRANSITION_CONTAINER} ref={popperProps.ref} style={popperProps.style}>
                 <ResizeSensor onResize={this.reposition}>
-                    <div className={popoverClasses} style={{ transformOrigin }} {...popoverHandlers}>
+                    <div
+                        className={popoverClasses}
+                        style={{ transformOrigin }}
+                        ref={this.popoverRef}
+                        {...popoverHandlers}
+                    >
                         {this.isArrowEnabled() && (
                             <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
                         )}
@@ -495,15 +502,15 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
 
     private handlePopoverClick = (e: React.MouseEvent<HTMLElement>) => {
         const eventTarget = e.target as HTMLElement;
+        const eventPopover = eventTarget.closest(`.${Classes.POPOVER}`);
+        const isEventFromSelf = eventPopover === this.popoverRef.current;
+        const isEventPopoverCapturing = eventPopover.classList.contains(Classes.POPOVER_CAPTURING_DISMISS);
         // an OVERRIDE inside a DISMISS does not dismiss, and a DISMISS inside an OVERRIDE will dismiss.
         const dismissElement = eventTarget.closest(`.${Classes.POPOVER_DISMISS}, .${Classes.POPOVER_DISMISS_OVERRIDE}`);
         const shouldDismiss = dismissElement != null && dismissElement.classList.contains(Classes.POPOVER_DISMISS);
         const isDisabled = eventTarget.closest(`:disabled, .${Classes.DISABLED}`) != null;
-        if (shouldDismiss && !isDisabled && !e.isDefaultPrevented()) {
+        if (shouldDismiss && !isDisabled && (!isEventPopoverCapturing || isEventFromSelf)) {
             this.setOpenState(false, e);
-            if (this.props.captureDismiss) {
-                e.preventDefault();
-            }
         }
     };
 

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -42,10 +42,9 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     boundary?: PopperBoundary;
 
     /**
-     * When enabled, `preventDefault()` is invoked on `click` events that close
-     * this popover, which will prevent those clicks from closing outer
-     * popovers. When disabled, clicking inside a `Classes.POPOVER_DISMISS`
-     * element will close the parent popover.
+     * When enabled, clicking inside a `Classes.POPOVER_DISMISS`
+     * will only close the parent popover and not outer popovers.
+     * When disabled, both parent outer popovers will be closed.
      *
      * See http://blueprintjs.com/docs/#core/components/popover.closing-on-click
      * @default false


### PR DESCRIPTION
#### Fixes #2820

#### Checklist

- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Add a new popover class that will be used to determine when a popover is using ```captureDismiss```
- Add a new popover private property to hold the popover ref
- Remove dependency of ```preventDefault```/```defaultPrevented``` and instead use a more self contained approach to determine whether the popover should close in the presence of ```captureDismiss```  
