### PR TITLE
chore: make css side effects work

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/blueprint.css",
     "unpkg": "dist/core.bundle.js",
     "sideEffects": [
-        "*.css",
+        "**/*.css",
         "lib/esm/components/index.js",
         "lib/esm/common/configureDom4.js",
         "lib/esnext/components/index.js",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/blueprint-datetime.css",
     "unpkg": "dist/datetime.bundle.js",
     "sideEffects": [
-        "*.css"
+        "**/*.css"
     ],
     "scripts": {
         "clean": "rm -rf dist/* && rm -rf lib/*",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/docs-theme.css",
     "unpkg": "dist/docs-theme.bundle.js",
     "sideEffects": [
-        "*.css"
+        "**/*.css"
     ],
     "scripts": {
         "clean": "rm -rf dist/* && rm -rf lib/*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/blueprint-icons.css",
     "unpkg": "dist/icons.bundle.js",
     "sideEffects": [
-        "*.css"
+        "**/*.css"
     ],
     "scripts": {
         "clean": "rm -rf dist/* && rm -rf lib/* && rm -rf src/generated/*",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/blueprint-select.css",
     "unpkg": "dist/select.bundle.js",
     "sideEffects": [
-        "*.css"
+        "**/*.css"
     ],
     "scripts": {
         "clean": "rm -rf dist/* && rm -rf lib/*",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/table.css",
     "unpkg": "dist/table.bundle.js",
     "sideEffects": [
-        "*.css"
+        "**/*.css"
     ],
     "scripts": {
         "clean": "rm -rf dist/* && rm -rf lib/*",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -9,7 +9,7 @@
     "style": "lib/css/blueprint-timezone.css",
     "unpkg": "dist/timezone.bundle.js",
     "sideEffects": [
-        "*.css"
+        "**/*.css"
     ],
     "scripts": {
         "clean": "rm -rf dist/* && rm -rf lib/*",


### PR DESCRIPTION
The CSS files shipped in the NPM package have a deep path, for example `@blueprintjs/core/lib/css/blueprint.css`. This PR changes `*.css` to `**/*.css` to make it work correctly