### PR TITLE
[core] fix(TagInput): restore type signature of onRemove prop

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -139,7 +139,7 @@ export interface ITagInputProps extends IIntentProps, IProps {
      * Callback invoked when the user clicks the X button on a tag.
      * Receives value and index of removed tag.
      */
-    onRemove?: (value: React.ReactNode, index: number) => void;
+    onRemove?: (valueAsString: string, index: number, value: React.ReactNode) => void;
 
     /**
      * Input placeholder text which will not appear if `values` contains any items
@@ -466,7 +466,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     /** Remove the item at the given index by invoking `onRemove` and `onChange` accordingly. */
     private removeIndexFromValues(index: number) {
         const { onChange, onRemove, values } = this.props;
-        onRemove?.(values[index], index);
+        onRemove?.(values[index]?.toString() ?? "", index, values[index]);
         if (Utils.isFunction(onChange)) {
             onChange(values.filter((_, i) => i !== index));
         }

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -116,7 +116,7 @@ describe("<TagInput>", () => {
         const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
         wrapper.find("button").at(1).simulate("click");
         assert.isTrue(onRemove.calledOnce);
-        assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
+        assert.sameMembers(onRemove.args[0], [VALUES[1], 1, VALUES[1]]);
     });
 
     describe("onAdd", () => {
@@ -294,7 +294,7 @@ describe("<TagInput>", () => {
             assert.equal(wrapper.state("activeIndex"), VALUES.length - 2);
             assert.isTrue(onRemove.calledOnce);
             const lastIndex = VALUES.length - 1;
-            assert.sameMembers(onRemove.args[0], [VALUES[lastIndex], lastIndex]);
+            assert.sameMembers(onRemove.args[0], [VALUES[lastIndex], lastIndex, VALUES[lastIndex]]);
         });
 
         it("pressing left arrow key navigates active item and backspace removes it", () => {
@@ -309,7 +309,7 @@ describe("<TagInput>", () => {
 
             assert.equal(wrapper.state("activeIndex"), 0);
             assert.isTrue(onRemove.calledOnce);
-            assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
+            assert.sameMembers(onRemove.args[0], [VALUES[1], 1, VALUES[1]]);
         });
 
         it("pressing left arrow key navigates active item and delete removes it", () => {
@@ -326,7 +326,7 @@ describe("<TagInput>", () => {
             // we rather "take the place" of the item we just removed
             assert.equal(wrapper.state("activeIndex"), 1);
             assert.isTrue(onRemove.calledOnce);
-            assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
+            assert.sameMembers(onRemove.args[0], [VALUES[1], 1, VALUES[1]]);
         });
 
         it("pressing delete with no selection does nothing", () => {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/palantir/blueprint/pull/4291, released in core 3.32.0-3.32.1

I discovered this when enabling stricter compilation options. `(value: string, index, number) => void` is not assignable to `onRemove: (value: React.ReactNode, index: number) => void`, so we can't just change the type of the first param.

Longer-term, I think `<TagInput>` should be generically typed based on its `values`... or maybe just stick to `string`?