### PR TITLE
[table] refactor: replace force-hardware-acceleration mixin with "will-change: transform"

### DIFF
--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -99,30 +99,8 @@ $pt-dark-intent-text-colors: (
   @return $number;
 }
 
-@mixin force-hardware-acceleration() {
-  // CSS animations are typically smoother when they run on the GPU. most browsers trigger GPU
-  // ("hardware") acceleration automatically when certain CSS rules are applied (like `transform`).
-  //
-  // the transform rule below has no visual effect, but it achieves the following:
-  //   - creates a new stacking context
-  //   - creates a new containing block for fixed-position descendants
-  //   - "tricks" the browser into using hardware acceleration
-  //
-  // `will-change: transform` does the same thing, but it suffers from a Chrome bug that could make
-  // the styled element blurry when transform'd (e.g. this happens when a Blueprint Table is in a
-  // Popover that animates open). we should move to `will-change` and delete this mixin once that
-  // bug is fixed (tracking in issue #859).
-  //
-  // see the following YouTube video and Chrome bug report for more:
-  //   - https://www.youtube.com/watch?v=iSvUlSpIbNk
-  //   - https://bugs.chromium.org/p/chromium/issues/detail?id=596382
-  //
-  // see this post for more on will-change: https://dev.opera.com/articles/css-will-change-property/
-  transform: translateZ(0);
-  // will-change: transform;
-}
+// Isolates z-indices
 
 @mixin new-render-layer() {
-  // a semantic rename of the mixin above for when you just want to isolate z-indices
-  @include force-hardware-acceleration();
+  transform: translateZ(0);
 }

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -31,7 +31,6 @@ $table-quadrant-scroll-container-overflow: 20px;
 }
 
 .#{$ns}-table-quadrant-scroll-container {
-  @include force-hardware-acceleration();
   bottom: 0;
   left: 0;
   overflow: auto;
@@ -39,6 +38,7 @@ $table-quadrant-scroll-container-overflow: 20px;
   right: 0;
   top: 0;
   user-select: none;
+  will-change: transform; // forces hardware acceleration for smoother animations
 
   // We disable x or y scrolling when we are displaying "ghost" cells that
   // overflow the body.

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -22,7 +22,6 @@ $row-z-index: $column-z-index + 1 !default;
 $menu-z-index: $row-z-index + 1 !default;
 
 .#{$ns}-table-container {
-  @include force-hardware-acceleration();
   background-color: $table-background-color;
   display: flex;
   flex-direction: column;
@@ -31,6 +30,7 @@ $menu-z-index: $row-z-index + 1 !default;
   max-width: 100%;
   min-height: $pt-grid-size * 6; // For unit tests, we make sure at least one row is visible
   overflow: hidden;
+  will-change: transform; // forces hardware acceleration for smoother animations
 
   .#{$ns}-dark & {
     background-color: $dark-table-background-color;


### PR DESCRIPTION
#### Fixes #859 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Delete force-hardware-acceleration mixin and replace the places that this mixin is used with `will-change: transform`

#### Reviewers should focus on:

In the mentioned issue, it is said that this mixin is only used in `table.scss`. However, it turned out that it is also used in `_quadrants.scss`. Changes on that file should also be reviewed.

#### Screenshot

Because it is a refactor, there isn't any screenshot.
