### PR TITLE
[select] fix: force Select to respect query prop

### DIFF
--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -131,7 +131,7 @@ export class Select<T> extends AbstractPureComponent2<ISelectProps<T>, ISelectSt
                 {...inputProps}
                 inputRef={this.refHandlers.input}
                 onChange={listProps.handleQueryChange}
-                value={listProps.query}
+                value={this.props.query || listProps.query}
             />
         );
 


### PR DESCRIPTION
#### Fixes #4362

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

As mentioned in the documentation of Select component, query prop can be used to control the InputGroup in Select component:

> **inputProps**
> Props to spread to the query InputGroup. Use query and onQueryChange instead of inputProps.value and inputProps.onChange to control this input.

However, as the code sandbox I provided in #4362, query prop acts like an initial value to it and doesn't control the InputGroup. This is because the one that controls the InputGroup is actually QueryList component. It initializes its internal state with the query prop that is passed to Select component. However, from that point onward, it keeps its internal query state and passes that internal state to the InputGroup.

What I have changed is that no matter what the internal query state of QueryList, the query prop of Select component is passed to the InputGroup if it is provided.
