### PR TITLE
[timezone] fix: pass query and onQueryChange props to override Select's own behavior

### DIFF
--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -163,6 +163,7 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
                 inputProps={finalInputProps}
                 disabled={disabled}
                 onQueryChange={this.handleQueryChange}
+                query={this.props.inputProps.value}
             >
                 {children != null ? children : this.renderButton()}
             </TypedSelect>
@@ -224,5 +225,10 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
 
     private handleItemSelect = (timezone: ITimezoneItem) => this.props.onChange?.(timezone.timezone);
 
-    private handleQueryChange = (query: string) => this.setState({ query });
+    private handleQueryChange = (query: string, event: React.ChangeEvent<HTMLInputElement>) => {
+        if (this.props.inputProps.onChange) {
+            this.props.inputProps.onChange(event);
+        }
+        this.setState({ query });
+    };
 }


### PR DESCRIPTION
#### Fixes #4353

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

As mentioned in the documentation of Select component, query and onQueryChanges props should be used instead of inputProps.value and inputProps.onChange to control the InputGroup in Select component:
> **inputProps**
> Props to spread to the query InputGroup. Use query and onQueryChange instead of inputProps.value and inputProps.onChange to control this input.

Because current implementation is directly passing inputProps to Select component, Select component doesn't use these props for controlling the InputGroup. Instead it uses the QueryList's internal query state. What I have done with this commit is that now TimezonePicker passes inputProps.value as query to Select component and calls inputProps.onChange when ChangeEvent is fired from Select component.

#### Reviewers should focus on:

As I mentioned in #4362, actually Select component has a bug as well. Currently it doesn't respect the query prop and I opened another PR for that issue as well: #4363. After #4362 is resolved, this implementation of TimezonePicker will be working fine. However, if this PR is merged before #4362 is resolved, only inputProps.onChange will be working and inputProps.value will continue to be ignored.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
