### PR TITLE
[core] fix: force EditableText to respect disabled when alwaysRenderInput is true

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -339,9 +339,10 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
     };
 
     private renderInput(value: string | undefined) {
-        const { maxLength, multiline, type, placeholder } = this.props;
+        const { disabled, maxLength, multiline, type, placeholder } = this.props;
         const props: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> = {
             className: Classes.EDITABLE_TEXT_INPUT,
+            disabled,
             maxLength,
             onBlur: this.toggleEditing,
             onChange: this.handleTextChange,


### PR DESCRIPTION
#### Fixes #4329

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

As mentioned in #4329, EditableText component doesn't respect to disabled prop when alwaysRenderInput is set to true. Normally, disabled prop is not passed to the input element. Instead a span element is displayed when disabled prop is true. However, alwaysRenderInput prop forces component to render input element no matter what. So, I pass disabled prop of EditableText to input element to disabled the input element while rendering it all the time because of alwaysRenderInput.
