### PR TITLE
chore: deprecate icon class APIs

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -279,7 +279,9 @@ export const TREE_NODE_SELECTED = `${TREE_NODE}-selected`;
 export const TREE_ROOT = `${NS}-tree-root`;
 
 export const ICON = `${NS}-icon`;
+/** @deprecated use <Icon> components and iconName prop APIs instead */
 export const ICON_STANDARD = `${ICON}-standard`;
+/** @deprecated use <Icon> components and iconName prop APIs instead */
 export const ICON_LARGE = `${ICON}-large`;
 
 /**
@@ -310,7 +312,14 @@ export function elevationClass(elevation: Elevation | undefined) {
     return `${NS}-elevation-${elevation}`;
 }
 
-/** Returns CSS class for icon name. */
+/**
+ * Returns CSS class for icon name.
+ *
+ * @deprecated These CSS classes rely on Blueprint's icon fonts, which are a legacy feature and will be
+ * removed the next major version (4.x). Use the `<Icon>` React component and `iconName` string enum prop
+ * APIs instead – they render SVGs, which do not suffer from the blurriness of icon fonts and have
+ * equivalent browser support.
+ */
 export function iconClass(iconName: string): string;
 export function iconClass(iconName: string | undefined) {
     if (iconName == null) {

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -114,6 +114,7 @@ export class Icon extends AbstractPureComponent2<IIconProps & React.DOMAttribute
         // render path elements, or nothing if icon name is unknown.
         const paths = this.renderSvgPaths(pixelGridSize, icon);
 
+        // eslint-disable-next-line deprecation/deprecation
         const classes = classNames(Classes.ICON, Classes.iconClass(icon), Classes.intentClass(intent), className);
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
 

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -55,6 +55,7 @@ describe("<Icon>", () => {
     });
 
     it("prefixed icon renders blank icon", () => {
+        // eslint-disable-next-line deprecation/deprecation
         assert.lengthOf(shallow(<Icon icon={Classes.iconClass("airplane") as any} />).find("path"), 0);
     });
 


### PR DESCRIPTION
Matches what's in the docs here https://blueprintjs.com/docs/#core/components/icon.css