### PR TITLE
[select] fix(Omnibar): handle initialContent undefined value correctly

### DIFF
--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -70,7 +70,9 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { initialContent = null, isOpen, inputProps, overlayProps, ...restProps } = this.props;
+        const { isOpen, inputProps, overlayProps, ...restProps } = this.props;
+        const initialContent = 'initialContent' in this.props ? this.props.initialContent : null;
+
         return <this.TypedQueryList {...restProps} initialContent={initialContent} renderer={this.renderQueryList} />;
     }
 

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -71,7 +71,7 @@ export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
     public render() {
         // omit props specific to this component, spread the rest.
         const { isOpen, inputProps, overlayProps, ...restProps } = this.props;
-        const initialContent = 'initialContent' in this.props ? this.props.initialContent : null;
+        const initialContent = "initialContent" in this.props ? this.props.initialContent : null;
 
         return <this.TypedQueryList {...restProps} initialContent={initialContent} renderer={this.renderQueryList} />;
     }


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes a bug where Omnibar is unable to render all items when `initialContent` is  explicitly set to `undefined`.

Related to #3174

#### Reviewers should focus on:

The documentation for Omnibar's `initialContent` states:

> If omitted, **all items will be rendered** (or result of `itemListPredicate` with empty query).
> If explicit `null`, **nothing will be rendered** when query is empty.

Under the hood, QueryList is only checking `undefined`:

https://github.com/palantir/blueprint/blob/9bce0cd89980ab2cb66284f18f3f43127a8cc764/packages/select/src/common/itemListRenderer.ts#L84-L86

It's probably a larger breaking change to remove the default `null` value, but this at least solves the problem in the near term, ie:

```jsx

<Omnibar
  // render all the items when no query is present
  initialContent={undefined}
  isOpen={...}
  items={[...]}
  itemRenderer={...}
  onItemSelect={...}
  />
```
