### PR TITLE
Feature request - tooltip minimal prop and flexibility over arrow

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -76,14 +76,6 @@ export interface IPopoverProps extends IPopoverSharedProps {
     hasBackdrop?: boolean;
 
     /**
-     * Whether to apply minimal styles to this popover, which includes removing
-     * the arrow and adding `Classes.MINIMAL` to minimize and accelerate the
-     * transitions.
-     * @default false
-     */
-    minimal?: boolean;
-
-    /**
      * Ref supplied to the `Classes.POPOVER` element.
      */
     popoverRef?: (ref: HTMLElement | null) => void;

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -96,6 +96,14 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     isOpen?: boolean;
 
     /**
+     * Whether to apply minimal styles to this tooltip, which includes removing
+     * the arrow and adding `Classes.MINIMAL` to minimize and accelerate the
+     * transitions.
+     * @default false
+     */
+    minimal?: boolean;
+
+    /**
      * Popper modifier options, passed directly to internal Popper instance. See
      * https://popper.js.org/docs/modifiers/ for complete
      * details.

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -96,9 +96,8 @@ export interface IPopoverSharedProps extends IOverlayableProps, IProps {
     isOpen?: boolean;
 
     /**
-     * Whether to apply minimal styles to this tooltip, which includes removing
-     * the arrow and adding `Classes.MINIMAL` to minimize and accelerate the
-     * transitions.
+     * Whether to apply minimal styling to this popover or tooltip. Minimal popovers
+     * do not have an arrow pointing to their target and use a subtler animation.
      * @default false
      */
     minimal?: boolean;

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -86,7 +86,7 @@ export class Tooltip extends AbstractPureComponent2<ITooltipProps> {
 
     public render() {
         const { children, intent, popoverClassName, ...restProps } = this.props;
-        const classes = classNames(Classes.TOOLTIP, this.props.minimal ?? Classes.MINIMAL, Classes.intentClass(intent), popoverClassName);
+        const classes = classNames(Classes.TOOLTIP, { [Classes.MINIMAL]: this.props.minimal }, Classes.intentClass(intent), popoverClassName);
 
         return (
             <Popover

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -61,6 +61,14 @@ export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
      * @default 100
      */
     transitionDuration?: number;
+
+    /**
+     * Whether to apply minimal styles to this tooltip, which includes removing
+     * the arrow and adding `Classes.MINIMAL` to minimize and accelerate the
+     * transitions.
+     * @default false
+     */
+    minimal?: boolean;
 }
 
 @polyfill
@@ -71,17 +79,19 @@ export class Tooltip extends AbstractPureComponent2<ITooltipProps> {
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
         transitionDuration: 100,
+        minimal: false,
     };
 
     private popover: Popover | null = null;
 
     public render() {
         const { children, intent, popoverClassName, ...restProps } = this.props;
-        const classes = classNames(Classes.TOOLTIP, Classes.intentClass(intent), popoverClassName);
+        const classes = classNames(Classes.TOOLTIP, this.props.minimal ?? Classes.MINIMAL, Classes.intentClass(intent), popoverClassName);
 
         return (
             <Popover
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
+                modifiers={{arrowOffset: {enabled: !this.props.minimal}}}
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -61,14 +61,6 @@ export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
      * @default 100
      */
     transitionDuration?: number;
-
-    /**
-     * Whether to apply minimal styles to this tooltip, which includes removing
-     * the arrow and adding `Classes.MINIMAL` to minimize and accelerate the
-     * transitions.
-     * @default false
-     */
-    minimal?: boolean;
 }
 
 @polyfill

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -96,7 +96,7 @@ export class Tooltip extends AbstractPureComponent2<ITooltipProps> {
         return (
             <Popover
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
-                modifiers={{ arrowOffset: { enabled: !this.props.minimal } }}
+                modifiers={{ arrow: { enabled: !this.props.minimal } }}
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -86,12 +86,17 @@ export class Tooltip extends AbstractPureComponent2<ITooltipProps> {
 
     public render() {
         const { children, intent, popoverClassName, ...restProps } = this.props;
-        const classes = classNames(Classes.TOOLTIP, { [Classes.MINIMAL]: this.props.minimal }, Classes.intentClass(intent), popoverClassName);
+        const classes = classNames(
+            Classes.TOOLTIP,
+            { [Classes.MINIMAL]: this.props.minimal },
+            Classes.intentClass(intent),
+            popoverClassName,
+        );
 
         return (
             <Popover
                 interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
-                modifiers={{arrowOffset: {enabled: !this.props.minimal}}}
+                modifiers={{ arrowOffset: { enabled: !this.props.minimal } }}
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -78,8 +78,8 @@ export class Tooltip extends AbstractPureComponent2<ITooltipProps> {
     public static defaultProps: Partial<ITooltipProps> = {
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
-        transitionDuration: 100,
         minimal: false,
+        transitionDuration: 100,
     };
 
     private popover: Popover | null = null;

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -51,6 +51,12 @@ describe("<Tooltip>", () => {
         assert.isTrue(onOpening.calledOnce);
     });
 
+    it("applies minimal class & hides arrow when minimal is true", () => {
+        const tooltip = renderTooltip({minimal: true});
+        assert.isTrue(tooltip.find(Popover).hasClass(Classes.MINIMAL));
+        assert.isFalse(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
+    })
+
     describe("in uncontrolled mode", () => {
         it("defaultIsOpen determines initial open state", () => {
             assert.lengthOf(renderTooltip({ defaultIsOpen: true }).find(TOOLTIP_SELECTOR), 1);

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -52,13 +52,13 @@ describe("<Tooltip>", () => {
     });
 
     it("applies minimal class & hides arrow when minimal is true", () => {
-        const tooltip = renderTooltip({ minimal: true });
+        const tooltip = renderTooltip({  isOpen: true, minimal: true });
         assert.isTrue(tooltip.find(TOOLTIP_SELECTOR).hasClass(Classes.MINIMAL));
         assert.isFalse(tooltip.find(Popover).props().modifiers!.arrow!.enabled);
     });
 
     it("does not apply minimal class & shows arrow when minimal is false", () => {
-        const tooltip = renderTooltip();
+        const tooltip = renderTooltip({ isOpen: true });
         // Minimal should be false by default.
         assert.isFalse(tooltip.props().minimal);
         assert.isFalse(tooltip.find(TOOLTIP_SELECTOR).hasClass(Classes.MINIMAL));

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -52,7 +52,7 @@ describe("<Tooltip>", () => {
     });
 
     it("applies minimal class & hides arrow when minimal is true", () => {
-        const tooltip = renderTooltip({  isOpen: true, minimal: true });
+        const tooltip = renderTooltip({ isOpen: true, minimal: true });
         assert.isTrue(tooltip.find(TOOLTIP_SELECTOR).hasClass(Classes.MINIMAL));
         assert.isFalse(tooltip.find(Popover).props().modifiers!.arrow!.enabled);
     });

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -53,16 +53,16 @@ describe("<Tooltip>", () => {
 
     it("applies minimal class & hides arrow when minimal is true", () => {
         const tooltip = renderTooltip({ minimal: true });
-        assert.isTrue(tooltip.find(TARGET_SELECTOR).hasClass(Classes.MINIMAL));
-        assert.isFalse(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
+        assert.isTrue(tooltip.find(TOOLTIP_SELECTOR).hasClass(Classes.MINIMAL));
+        assert.isFalse(tooltip.find(Popover).props().modifiers!.arrow!.enabled);
     });
 
     it("does not apply minimal class & shows arrow when minimal is false", () => {
-        // Minimal should be false by default.
         const tooltip = renderTooltip();
+        // Minimal should be false by default.
         assert.isFalse(tooltip.props().minimal);
-        assert.isFalse(tooltip.find(TARGET_SELECTOR).hasClass(Classes.MINIMAL));
-        assert.isTrue(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
+        assert.isFalse(tooltip.find(TOOLTIP_SELECTOR).hasClass(Classes.MINIMAL));
+        assert.isTrue(tooltip.find(Popover).props().modifiers!.arrow!.enabled);
     });
 
     describe("in uncontrolled mode", () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -53,7 +53,7 @@ describe("<Tooltip>", () => {
 
     it("applies minimal class & hides arrow when minimal is true", () => {
         const tooltip = renderTooltip({ minimal: true });
-        assert.isTrue(tooltip.find(Popover).hasClass(Classes.MINIMAL));
+        assert.isTrue(tooltip.find(TARGET_SELECTOR).hasClass(Classes.MINIMAL));
         assert.isFalse(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
     });
 
@@ -61,7 +61,7 @@ describe("<Tooltip>", () => {
         // Minimal should be false by default.
         const tooltip = renderTooltip();
         assert.isFalse(tooltip.props().minimal);
-        assert.isFalse(tooltip.find(Popover).hasClass(Classes.MINIMAL));
+        assert.isFalse(tooltip.find(TARGET_SELECTOR).hasClass(Classes.MINIMAL));
         assert.isTrue(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
     });
 

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -52,10 +52,10 @@ describe("<Tooltip>", () => {
     });
 
     it("applies minimal class & hides arrow when minimal is true", () => {
-        const tooltip = renderTooltip({minimal: true});
+        const tooltip = renderTooltip({ minimal: true });
         assert.isTrue(tooltip.find(Popover).hasClass(Classes.MINIMAL));
         assert.isFalse(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
-    })
+    });
 
     it("does not apply minimal class & shows arrow when minimal is false", () => {
         // Minimal should be false by default.
@@ -63,7 +63,7 @@ describe("<Tooltip>", () => {
         assert.isFalse(tooltip.props().minimal);
         assert.isFalse(tooltip.find(Popover).hasClass(Classes.MINIMAL));
         assert.isTrue(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
-    })
+    });
 
     describe("in uncontrolled mode", () => {
         it("defaultIsOpen determines initial open state", () => {

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -57,6 +57,14 @@ describe("<Tooltip>", () => {
         assert.isFalse(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
     })
 
+    it("does not apply minimal class & shows arrow when minimal is false", () => {
+        // Minimal should be false by default.
+        const tooltip = renderTooltip();
+        assert.isFalse(tooltip.props().minimal);
+        assert.isFalse(tooltip.find(Popover).hasClass(Classes.MINIMAL));
+        assert.isTrue(tooltip.find(Popover).props().modifiers!.arrowOffset!.enabled);
+    })
+
     describe("in uncontrolled mode", () => {
         it("defaultIsOpen determines initial open state", () => {
             assert.lengthOf(renderTooltip({ defaultIsOpen: true }).find(TOOLTIP_SELECTOR), 1);

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -59,6 +59,16 @@ export class TooltipExample extends React.PureComponent<IExampleProps, { isOpen:
                     This line's tooltip{" "}
                     <Tooltip
                         className={Classes.TOOLTIP_INDICATOR}
+                        content={<span>This tooltip has the minimal style applied!</span>}
+                        minimal={true}
+                    >
+                        is minimal.
+                    </Tooltip>
+                </div>
+                <div>
+                    This line's tooltip{" "}
+                    <Tooltip
+                        className={Classes.TOOLTIP_INDICATOR}
                         content={<span>BRRAAAIINS</span>}
                         isOpen={this.state.isOpen}
                     >


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation (auto-generated)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Flexibility over rendering the arrow was a use case required for our own project - however, I also noticed that Popover's minimal prop exhibited this same behaviour so I thought I'd keep it consistent. 

If `minimal` isn't quite right, I'd be happy to change this PR to just be a prop that controls the rendering of the arrow, as that was of importance to us in our use case. 

#### Reviewers should focus on:

Whether `minimal` is necessary for tooltip given one can pass in Classes.MINIMAL via popoverProps. If not, propose prop solely controls rendering of the arrow.

#### Screenshot

![image](https://user-images.githubusercontent.com/13777223/96454588-cc182d00-1267-11eb-98f4-a24d544f2b33.png)

Thank you for the consideration! Big fan of BlueprintJS
