### PR TITLE
[core] fix: don't render "asyncControl" as HTML attr

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -116,6 +116,7 @@ export interface IOptionProps extends IProps {
 const INVALID_PROPS = [
     "active",
     "alignText",
+    "asyncControl", // IInputGroupProps
     "containerRef",
     "current",
     "elementRef",

--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -16,6 +16,7 @@
 
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
+import { DISPLAYNAME_PREFIX } from "../../common/props";
 
 export interface IAsyncControllableInputProps
     extends React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> {
@@ -64,6 +65,8 @@ export class AsyncControllableInput extends React.PureComponent<
     IAsyncControllableInputProps,
     IAsyncControllableInputState
 > {
+    public static displayName = `${DISPLAYNAME_PREFIX}.AsyncControllableInput`;
+
     public state: IAsyncControllableInputState = {
         hasPendingUpdate: false,
         isComposing: false,


### PR DESCRIPTION
Fixes a minor issue introduced in #4383