### PR TITLE
Make contributions easier via the online automated dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+tasks:
+  - init: |
+        yarn --network-timeout 100000
+        yarn compile
+    command: yarn run dev
+
+ports:
+  - port: 9000
+    onOpen: open-preview
+  - port: 8080
+
+vscode:
+  extensions:
+    - esbenp.prettier-vscode@5.7.1:4Zx39KyQMoIz7x94PSmDmQ==

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ yarn
 yarn verify
 ```
 
+### Online one-click setup
+
+You can use Gitpod(an Online IDE which is free for Open Source) for contributing. With a single click it will launch a workspace and automatically: clone the `Blueprint` repo, install the dependencies, run `yarn compile` and `yarn dev`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Developing
 
 A typical contributor workflow looks like this:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img height="204" src="https://cloud.githubusercontent.com/assets/464822/20228152/d3f36dc2-a804-11e6-80ff-51ada2d13ea7.png">
 
-# [Blueprint](http://blueprintjs.com/) [![CircleCI](https://circleci.com/gh/palantir/blueprint/tree/develop.svg?style=svg)](https://circleci.com/gh/palantir/workflows/blueprint)
+# [Blueprint](http://blueprintjs.com/) [![CircleCI](https://circleci.com/gh/palantir/blueprint/tree/develop.svg?style=svg)](https://circleci.com/gh/palantir/workflows/blueprint) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 Blueprint is a React-based UI toolkit for the web.
 
@@ -80,6 +80,12 @@ After cloning this repo, run:
     1. Ensure `bash` is your configured script-shell by running:<br />
        `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`
 1. `yarn verify` to ensure you have all the build tooling working properly.
+
+### Online one-click setup
+
+You can use Gitpod(an Online IDE which is free for Open Source) for contributing. With a single click it will launch a workspace and automatically: clone the `Blueprint` repo, install the dependencies, run `yarn compile` and `yarn dev`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ### Incorporating upstream changes
 


### PR DESCRIPTION
#### Fixes #0000

Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `blueprint` repo.
- install the dependencies.
- run `yarn compile`.
- run `yarn dev`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/buleprint

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/97153871-fd778800-1794-11eb-9de6-4d89c0e0b8a3.png)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
