### PR TITLE
[select] feat: createNewItemPosition prop

### DIFF
--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -34,6 +34,7 @@ const FilmSelect = Select.ofType<IFilm>();
 
 export interface ISelectExampleState {
     allowCreate: boolean;
+    createFirst: boolean;
     createdItems: IFilm[];
     film: IFilm;
     filterable: boolean;
@@ -50,6 +51,7 @@ export interface ISelectExampleState {
 export class SelectExample extends React.PureComponent<IExampleProps, ISelectExampleState> {
     public state: ISelectExampleState = {
         allowCreate: false,
+        createFirst: false,
         createdItems: [],
         disableItems: false,
         disabled: false,
@@ -64,6 +66,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
     };
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
+    private handleCreateFirstChange = this.handleSwitchChange("createFirst");
     private handleDisabledChange = this.handleSwitchChange("disabled");
     private handleFilterableChange = this.handleSwitchChange("filterable");
     private handleInitialContentChange = this.handleSwitchChange("hasInitialContent");
@@ -89,6 +92,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     {...flags}
                     createNewItemFromQuery={maybeCreateNewItemFromQuery}
                     createNewItemRenderer={maybeCreateNewItemRenderer}
+                    createNewItemPosition={this.state.createFirst ? "first" : "last"}
                     disabled={disabled}
                     itemDisabled={this.isItemDisabled}
                     itemsEqual={areFilmsEqual}
@@ -146,6 +150,12 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     label="Allow creating new items"
                     checked={this.state.allowCreate}
                     onChange={this.handleAllowCreateChange}
+                />
+                <Switch
+                    label="Create new position: first"
+                    disabled={!this.state.allowCreate}
+                    checked={this.state.createFirst}
+                    onChange={this.handleCreateFirstChange}
                 />
                 <H5>Popover props</H5>
                 <Switch

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -181,6 +181,13 @@ export interface IListItemsProps<T> extends IProps {
     ) => JSX.Element | undefined;
 
     /**
+     * Determines the position of the `createNewItem` within the list: first or
+     * last. Only relevant when `createNewItemRenderer` is defined.
+     * @default 'last'
+     */
+    createNewItemPosition?: "first" | "last";
+
+    /**
      * Whether the active item should be reset to the first matching item _every
      * time the query changes_ (via prop or by user input).
      * @default true

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -395,7 +395,8 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         const { activeItem } = this.state;
         if (this.itemsParentRef != null) {
             if (isCreateNewItem(activeItem)) {
-                return this.itemsParentRef.children.item(this.state.filteredItems.length) as HTMLElement;
+                const index = this.props.createNewItemPosition === "first" ? 0 : this.state.filteredItems.length;
+                return this.itemsParentRef.children.item(index) as HTMLElement;
             } else {
                 const activeIndex = this.getActiveIndex();
                 return this.itemsParentRef.children.item(activeIndex) as HTMLElement;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -312,7 +312,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
 
         if (shouldUpdateActiveItem) {
             // if the `createNewItem` is at the top, that should be the first active item.
-            if (this.isCreateItemRendered() && this.props.createNewItemPosition === "first") {
+            if (this.isCreateItemRendered() && this.isCreateItemFirst()) {
                 this.setActiveItem(getCreateNewItem());
             } else {
                 this.setActiveItem(getFirstEnabledItem(filteredItems, props.itemDisabled));
@@ -337,7 +337,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
 
     /** default `itemListRenderer` implementation */
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
-        const { createNewItemPosition, initialContent, noResults } = this.props;
+        const { initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
         const createItemView = listProps.renderCreateItem();
@@ -346,7 +346,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         if (menuContent == null && createItemView == null) {
             return null;
         }
-        const createFirst = createNewItemPosition === "first";
+        const createFirst = this.isCreateItemFirst();
         return (
             <Menu ulRef={listProps.itemsParentRef}>
                 {createFirst && createItemView}
@@ -395,7 +395,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         const { activeItem } = this.state;
         if (this.itemsParentRef != null) {
             if (isCreateNewItem(activeItem)) {
-                const index = this.props.createNewItemPosition === "first" ? 0 : this.state.filteredItems.length;
+                const index = this.isCreateItemFirst() ? 0 : this.state.filteredItems.length;
                 return this.itemsParentRef.children.item(index) as HTMLElement;
             } else {
                 const activeIndex = this.getActiveIndex();
@@ -556,6 +556,10 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             // existing item is much clearer.
             !this.wouldCreatedItemMatchSomeExistingItem()
         );
+    }
+
+    private isCreateItemFirst(): boolean {
+        return this.props.createNewItemPosition === "first";
     }
 
     private canCreateItems(): boolean {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -311,7 +311,12 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             isItemDisabled(getActiveItem(this.state.activeItem), activeIndex, props.itemDisabled);
 
         if (shouldUpdateActiveItem) {
-            this.setActiveItem(getFirstEnabledItem(filteredItems, props.itemDisabled));
+            // if the `createNewItem` is at the top, that should be the first active item.
+            if (this.isCreateItemRendered() && this.props.createNewItemPosition === "first") {
+                this.setActiveItem(getCreateNewItem());
+            } else {
+                this.setActiveItem(getFirstEnabledItem(filteredItems, props.itemDisabled));
+            }
         }
     }
 
@@ -332,7 +337,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
 
     /** default `itemListRenderer` implementation */
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
-        const { initialContent, noResults } = this.props;
+        const { createNewItemPosition, initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
         const createItemView = listProps.renderCreateItem();
@@ -341,10 +346,12 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         if (menuContent == null && createItemView == null) {
             return null;
         }
+        const createFirst = createNewItemPosition === "first";
         return (
             <Menu ulRef={listProps.itemsParentRef}>
+                {createFirst && createItemView}
                 {menuContent}
-                {createItemView}
+                {!createFirst && createItemView}
             </Menu>
         );
     };

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -311,7 +311,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
             isItemDisabled(getActiveItem(this.state.activeItem), activeIndex, props.itemDisabled);
 
         if (shouldUpdateActiveItem) {
-            // if the `createNewItem` is at the top, that should be the first active item.
+            // if the `createNewItem` is first, that should be the first active item.
             if (this.isCreateItemRendered() && this.isCreateItemFirst()) {
                 this.setActiveItem(getCreateNewItem());
             } else {

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -29,6 +29,7 @@ import {
 } from "../src";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
+import { Menu } from "@blueprintjs/core";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 
 type FilmQueryListWrapper = ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>>;
@@ -193,6 +194,20 @@ describe("<QueryList>", () => {
             };
             const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
             assert(filmQueryList.state().activeItem === null);
+        });
+
+        it("createNewItemPosition affects position of create new item", () => {
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                createNewItemFromQuery: sinon.spy(),
+                createNewItemRenderer: () => <article />,
+                items: TOP_100_FILMS.slice(0, 4),
+                query: "the",
+            };
+            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            assert(filmQueryList.find(Menu).children().children().last().is("article"));
+            filmQueryList.setProps({ createNewItemPosition: "first" });
+            assert(filmQueryList.find(Menu).children().children().first().is("article"));
         });
     });
 

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Menu } from "@blueprintjs/core";
 import { IQueryListProps } from "@blueprintjs/select";
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
@@ -29,7 +30,6 @@ import {
 } from "../src";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
-import { Menu } from "@blueprintjs/core";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 
 type FilmQueryListWrapper = ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>>;


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- new `createNewItemPosition?: "first" | "last"` prop on QueryList (defaults to "last" - current behavior)
- add test and switch in example

#### Reviewers should focus on:

👋 hey buddy, hope you're well! this was fun to put together, and to revisit the project. i may have another `select` PR or two coming your way soon...

- this allows the user to hit enter immediately to create a new item instead of having to find it at the bottom or hope for the query to exclude all existing items.


#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
<img width="815" alt="Blueprint_–_Documentation" src="https://user-images.githubusercontent.com/464822/98408886-c1f77c00-2026-11eb-9c13-1005bb2ac3ae.png">
