### PR TITLE
feat: allow React 17 peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,8 +59,8 @@
         "tslib": "~1.13.0"
     },
     "peerDependencies": {
-        "react": "^15.3.0 || 16",
-        "react-dom": "^15.3.0 || 16"
+        "react": "^15.3.0 || 16 || 17",
+        "react-dom": "^15.3.0 || 16 || 17"
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^1.0.3",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -42,8 +42,8 @@
         "tslib": "~1.13.0"
     },
     "peerDependencies": {
-        "react": "^15.3.0 || 16",
-        "react-dom": "^15.3.0 || 16"
+        "react": "^15.3.0 || 16 || 17",
+        "react-dom": "^15.3.0 || 16 || 17"
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^1.0.3",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -38,8 +38,8 @@
         "tslib": "~1.13.0"
     },
     "peerDependencies": {
-        "react": "^15.3.0 || 16",
-        "react-dom": "^15.3.0 || 16"
+        "react": "^15.3.0 || 16 || 17",
+        "react-dom": "^15.3.0 || 16 || 17"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^1.4.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -40,8 +40,8 @@
         "tslib": "~1.13.0"
     },
     "peerDependencies": {
-        "react": "^15.3.0 || 16",
-        "react-dom": "^15.3.0 || 16"
+        "react": "^15.3.0 || 16 || 17",
+        "react-dom": "^15.3.0 || 16 || 17"
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^1.0.3",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -42,8 +42,8 @@
         "tslib": "~1.13.0"
     },
     "peerDependencies": {
-        "react": "^15.3.0 || 16",
-        "react-dom": "^15.3.0 || 16"
+        "react": "^15.3.0 || 16 || 17",
+        "react-dom": "^15.3.0 || 16 || 17"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^1.4.0",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -44,8 +44,8 @@
         "tslib": "~1.13.0"
     },
     "peerDependencies": {
-        "react": "^15.3.0 || 16",
-        "react-dom": "^15.3.0 || 16"
+        "react": "^15.3.0 || 16 || 17",
+        "react-dom": "^15.3.0 || 16 || 17"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^1.4.0",


### PR DESCRIPTION
#### Fixes #4391

#### Changes proposed in this pull request:

Allow React 17 as an NPM peer dependency for all packages.

#### Reviewers should focus on:

Despite Blueprint's usage of some legacy APIs (https://github.com/palantir/blueprint/issues/4149, https://github.com/palantir/blueprint/issues/3979, etc), React 17's [breaking changes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#other-breaking-changes) don't seem to affect our components, so I think it's ok to expand the allowed version ranges.

This PR does not change the repo to build with React 17 or test it out in CI workflows. If there are issues with React 17 compatibility in the future, we can flag those issues and work on resolving them incrementally.

#### Screenshot

Tested it out locally with a Yarn resolution set to `17.0.1`:

![image](https://user-images.githubusercontent.com/723999/98588685-16566200-229a-11eb-8459-6e434124bdc9.png)

