### PR TITLE
[table-dev-app] fix: render mode changes correctly

### DIFF
--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -113,10 +113,7 @@ const TRUNCATED_POPOVER_MODES: TruncatedPopoverMode[] = [
     TruncatedPopoverMode.WHEN_TRUNCATED_APPROX,
 ];
 
-const FOCUS_STYLES: FocusStyle[] = [
-    FocusStyle.TAB,
-    FocusStyle.TAB_OR_CLICK,
-];
+const FOCUS_STYLES: FocusStyle[] = [FocusStyle.TAB, FocusStyle.TAB_OR_CLICK];
 
 const TRUNCATION_LENGTHS: number[] = [20, 80, 100, 1000];
 const TRUNCATION_LENGTH_DEFAULT_INDEX = 1;

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -113,6 +113,11 @@ const TRUNCATED_POPOVER_MODES: TruncatedPopoverMode[] = [
     TruncatedPopoverMode.WHEN_TRUNCATED_APPROX,
 ];
 
+const FOCUS_STYLES: FocusStyle[] = [
+    FocusStyle.TAB,
+    FocusStyle.TAB_OR_CLICK,
+];
+
 const TRUNCATION_LENGTHS: number[] = [20, 80, 100, 1000];
 const TRUNCATION_LENGTH_DEFAULT_INDEX = 1;
 
@@ -646,6 +651,14 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             true,
         );
 
+        const renderFocusStyleSelectMenu = this.renderSelectMenu(
+            "Focus outlines",
+            "selectedFocusStyle",
+            FOCUS_STYLES,
+            this.toFocusStyleLabel,
+            this.handleStringStateChange,
+        );
+
         return (
             <div className={classNames("sidebar", Classes.ELEVATION_0)}>
                 <H4>Table</H4>
@@ -713,7 +726,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
 
                 <H4>Page</H4>
                 <H6>Display</H6>
-                {this.renderFocusStyleSelectMenu()}
+                {renderFocusStyleSelectMenu}
                 <H6>Perf</H6>
                 {this.renderSwitch("Slow layout", "enableSlowLayout")}
                 {this.renderSwitch("Isolate layout boundary", "enableLayoutBoundary")}
@@ -739,7 +752,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             "scrollToRegionType",
             REGION_CARDINALITIES,
             this.getRegionCardinalityLabel,
-            this.handleRegionCardinalityChange,
+            this.handleStringStateChange,
         );
         const scrollToRowSelectMenu = this.renderSelectMenu(
             "Row",
@@ -812,19 +825,6 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         } else {
             return child;
         }
-    }
-
-    private renderFocusStyleSelectMenu() {
-        const { selectedFocusStyle } = this.state;
-        return (
-            <label className={classNames(Classes.LABEL, Classes.INLINE, "tbl-select-label")}>
-                Focus outlines
-                <HTMLSelect onChange={this.updateFocusStyleState()} value={selectedFocusStyle}>
-                    <option value="tab">On tab</option>
-                    <option value="tabOrClick">On tab or click</option>
-                </HTMLSelect>
-            </label>
-        );
     }
 
     private renderNumberSelectMenu(label: string, stateKey: keyof IMutableTableState, values: number[]) {
@@ -942,6 +942,15 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                 return "Truncated approx";
             default:
                 return "";
+        }
+    }
+
+    private toFocusStyleLabel(focusStyle: FocusStyle) {
+        switch (focusStyle) {
+            case FocusStyle.TAB:
+                return "On tab";
+            default:
+                return "On tab or click";
         }
     }
 
@@ -1100,19 +1109,8 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         return handleNumberChange(value => this.setState({ [stateKey]: value }));
     };
 
-    private handleRegionCardinalityChange = (stateKey: keyof IMutableTableState) => {
-        return handleNumberChange(value => this.setState({ [stateKey]: value }));
-    };
-
     private handleStringStateChange = (stateKey: keyof IMutableTableState) => {
         return handleStringChange(value => this.setState({ [stateKey]: value }));
-    };
-
-    private updateFocusStyleState = () => {
-        return handleStringChange((value: string) => {
-            const selectedFocusStyle = value === "tab" ? FocusStyle.TAB : FocusStyle.TAB_OR_CLICK;
-            this.setState({ selectedFocusStyle });
-        });
     };
 
     private renderBodyContextMenu = () => {

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -611,28 +611,28 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             "renderMode",
             RENDER_MODES,
             this.toRenderModeLabel,
-            this.handleNumberStateChange,
+            this.handleStringStateChange,
         );
         const selectedRegionTransformPresetMenu = this.renderSelectMenu(
             "Selection",
             "selectedRegionTransformPreset",
             SELECTION_MODES,
             this.toSelectedRegionTransformPresetLabel,
-            this.handleSelectedRegionTransformPresetChange,
+            this.handleStringStateChange,
         );
         const cellContentMenu = this.renderSelectMenu(
             "Cell content",
             "cellContent",
             CELL_CONTENTS,
             this.toCellContentLabel,
-            this.handleNumberStateChange,
+            this.handleStringStateChange,
         );
         const truncatedPopoverModeMenu = this.renderSelectMenu(
             "Popover",
             "cellTruncatedPopoverMode",
             TRUNCATED_POPOVER_MODES,
             this.toTruncatedPopoverModeLabel,
-            this.handleNumberStateChange,
+            this.handleStringStateChange,
             "enableCellTruncation",
             true,
         );
@@ -1104,7 +1104,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         return handleNumberChange(value => this.setState({ [stateKey]: value }));
     };
 
-    private handleSelectedRegionTransformPresetChange = (stateKey: keyof IMutableTableState) => {
+    private handleStringStateChange = (stateKey: keyof IMutableTableState) => {
         return handleStringChange(value => this.setState({ [stateKey]: value }));
     };
 


### PR DESCRIPTION
#### Fixes #4408

#### Checklist

- [ ] Includes tests
- [ ] Update documentation


#### Reviewers should focus on:

renderMode/cellContent/cellTruncatedPopoverMode are `string` instead of `number`

