### PR TITLE
#4300 Fix escape-key press

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -462,7 +462,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
         const { canEscapeKeyClose, onClose } = this.props;
         // HACKHACK: https://github.com/palantir/blueprint/issues/4165
         /* eslint-disable-next-line deprecation/deprecation */
-        if (e.which === Keys.ESCAPE && canEscapeKeyClose) {
+        if (e.key === "Escape" && canEscapeKeyClose) {
             onClose?.(e);
             // prevent browser-specific escape key behavior (Safari exits fullscreen)
             e.preventDefault();


### PR DESCRIPTION
#### Fixes #4300 
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Switch to .key instead of .which as keyCode is becoming deprecated.

#### Reviewers should focus on:
Testing components using the Overlay-component.
