### PR TITLE
[table] remove duplicate elements in quadrants

### DIFF
--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -652,8 +652,8 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     private emitRefs() {
         this.props.quadrantRef?.(this.quadrantRefs[QuadrantType.MAIN].quadrant);
-        this.props.rowHeaderRef?.(this.quadrantRefs[QuadrantType.MAIN].rowHeader);
-        this.props.columnHeaderRef?.(this.quadrantRefs[QuadrantType.MAIN].columnHeader);
+        this.props.rowHeaderRef?.(this.quadrantRefs[QuadrantType.LEFT].rowHeader);
+        this.props.columnHeaderRef?.(this.quadrantRefs[QuadrantType.TOP].columnHeader);
         this.props.scrollContainerRef?.(this.quadrantRefs[QuadrantType.MAIN].scrollContainer);
     }
 
@@ -716,11 +716,11 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         this.maybeSetQuadrantMenuElementSizes(rowHeaderWidth, adjustedColumnHeaderHeight);
         this.maybeSetQuadrantSizes(leftQuadrantWidth, adjustedTopQuadrantHeight);
 
-        // Quadrant-offset syncing
-        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "paddingLeft", rowHeaderWidth);
-        this.maybeSetQuadrantPositionOffset(QuadrantType.TOP, "left", rowHeaderWidth);
-        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "paddingTop", columnHeaderHeight);
-        this.maybeSetQuadrantPositionOffset(QuadrantType.LEFT, "top", columnHeaderHeight);
+        // Scroll container padding syncing
+        this.maybeSetQuadrantScrollContainerPadding(QuadrantType.MAIN, "paddingLeft", rowHeaderWidth);
+        this.maybeSetQuadrantScrollContainerPadding(QuadrantType.TOP, "paddingLeft", rowHeaderWidth);
+        this.maybeSetQuadrantScrollContainerPadding(QuadrantType.MAIN, "paddingTop", columnHeaderHeight);
+        this.maybeSetQuadrantScrollContainerPadding(QuadrantType.LEFT, "paddingTop", columnHeaderHeight);
 
         // Scrollbar clearance: tweak the quadrant bottom/right offsets to
         // reveal the MAIN-quadrant scrollbars if they're visible.
@@ -747,14 +747,21 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         }
     };
 
-    private maybeSetQuadrantPositionOffset = (
-        quadrantType: QuadrantType,
-        side: "top" | "right" | "bottom" | "left" | "paddingTop" | "paddingLeft",
-        value: number,
-    ) => {
+    private maybeSetQuadrantPositionOffset = (quadrantType: QuadrantType, side: "right" | "bottom", value: number) => {
         const { quadrant } = this.quadrantRefs[quadrantType];
         if (quadrant != null) {
             quadrant.style[side] = `${value}px`;
+        }
+    };
+
+    private maybeSetQuadrantScrollContainerPadding = (
+        quadrantType: QuadrantType,
+        side: "paddingTop" | "paddingLeft",
+        value: number,
+    ) => {
+        const { scrollContainer } = this.quadrantRefs[quadrantType];
+        if (scrollContainer != null) {
+            scrollContainer.style[side] = `${value}px`;
         }
     };
 
@@ -845,17 +852,15 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
      * contents.
      */
     private measureDesiredRowHeaderWidth() {
-        // the MAIN row header serves as the source of truth
-        const mainRowHeader = this.quadrantRefs[QuadrantType.LEFT].rowHeader;
+        const leftRowHeader = this.quadrantRefs[QuadrantType.LEFT].rowHeader;
 
-        if (mainRowHeader == null) {
+        if (leftRowHeader == null) {
             return 0;
         } else {
             // (alas, we must force a reflow to measure the row header's "desired" width)
-            mainRowHeader.style.width = "auto";
+            leftRowHeader.style.width = "auto";
 
-            const desiredRowHeaderWidth = mainRowHeader.clientWidth;
-            return desiredRowHeaderWidth;
+            return leftRowHeader.clientWidth;
         }
     }
 
@@ -867,8 +872,8 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         // unlike the row headers, the column headers are in a display-flex
         // layout and are not actually bound by any fixed `height` that we set,
         // so they'll grow freely to their necessary size. makes measuring easy!
-        const mainColumnHeader = this.quadrantRefs[QuadrantType.TOP].columnHeader;
-        return mainColumnHeader == null ? 0 : mainColumnHeader.clientHeight;
+        const topColumnHeader = this.quadrantRefs[QuadrantType.TOP].columnHeader;
+        return topColumnHeader == null ? 0 : topColumnHeader.clientHeight;
     }
 
     private shouldRenderLeftQuadrants(props: ITableQuadrantStackProps = this.props) {

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -717,9 +717,9 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         this.maybeSetQuadrantSizes(leftQuadrantWidth, adjustedTopQuadrantHeight);
 
         // Quadrant-offset syncing
-        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "left", rowHeaderWidth);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "paddingLeft", rowHeaderWidth);
         this.maybeSetQuadrantPositionOffset(QuadrantType.TOP, "left", rowHeaderWidth);
-        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "top", columnHeaderHeight);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "paddingTop", columnHeaderHeight);
         this.maybeSetQuadrantPositionOffset(QuadrantType.LEFT, "top", columnHeaderHeight);
 
         // Scrollbar clearance: tweak the quadrant bottom/right offsets to
@@ -749,7 +749,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     private maybeSetQuadrantPositionOffset = (
         quadrantType: QuadrantType,
-        side: "top" | "right" | "bottom" | "left",
+        side: "top" | "right" | "bottom" | "left" | "paddingTop" | "paddingLeft",
         value: number,
     ) => {
         const { quadrant } = this.quadrantRefs[quadrantType];

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -383,8 +383,6 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
                 {...baseProps}
                 quadrantRef={this.quadrantRefHandlers[QuadrantType.LEFT].quadrant}
                 quadrantType={QuadrantType.LEFT}
-                columnHeaderCellRenderer={this.renderLeftQuadrantColumnHeader}
-                menuRenderer={this.renderLeftQuadrantMenu}
                 rowHeaderCellRenderer={this.renderLeftQuadrantRowHeader}
                 scrollContainerRef={this.quadrantRefHandlers[QuadrantType.LEFT].scrollContainer}
             />
@@ -409,9 +407,6 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
                     onScroll={onMainQuadrantScroll}
                     quadrantRef={this.quadrantRefHandlers[QuadrantType.MAIN].quadrant}
                     quadrantType={QuadrantType.MAIN}
-                    columnHeaderCellRenderer={this.renderMainQuadrantColumnHeader}
-                    menuRenderer={this.renderMainQuadrantMenu}
-                    rowHeaderCellRenderer={this.renderMainQuadrantRowHeader}
                     scrollContainerRef={this.quadrantRefHandlers[QuadrantType.MAIN].scrollContainer}
                 />
                 <TableQuadrant
@@ -419,8 +414,6 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
                     quadrantRef={this.quadrantRefHandlers[QuadrantType.TOP].quadrant}
                     quadrantType={QuadrantType.TOP}
                     columnHeaderCellRenderer={this.renderTopQuadrantColumnHeader}
-                    menuRenderer={this.renderTopQuadrantMenu}
-                    rowHeaderCellRenderer={this.renderTopQuadrantRowHeader}
                     scrollContainerRef={this.quadrantRefHandlers[QuadrantType.TOP].scrollContainer}
                 />
                 {maybeLeftQuadrant}
@@ -452,51 +445,15 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     // Menu
 
-    private renderMainQuadrantMenu = () => {
-        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.MAIN].menu);
-    };
-
-    private renderTopQuadrantMenu = () => {
-        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.TOP].menu);
-    };
-
-    private renderLeftQuadrantMenu = () => {
-        return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.LEFT].menu);
-    };
-
     private renderTopLeftQuadrantMenu = () => {
         return this.props.menuRenderer?.(this.quadrantRefHandlers[QuadrantType.TOP_LEFT].menu);
     };
 
     // Column header
 
-    private renderMainQuadrantColumnHeader = (showFrozenColumnsOnly: boolean) => {
-        const refHandler = this.quadrantRefHandlers[QuadrantType.MAIN].columnHeader;
-        const resizeHandler = this.handleColumnResizeGuideMain;
-        const reorderingHandler = this.handleColumnsReordering;
-        return this.props.columnHeaderCellRenderer?.(
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenColumnsOnly,
-        );
-    };
-
     private renderTopQuadrantColumnHeader = (showFrozenColumnsOnly: boolean) => {
         const refHandler = this.quadrantRefHandlers[QuadrantType.TOP].columnHeader;
         const resizeHandler = this.handleColumnResizeGuideTop;
-        const reorderingHandler = this.handleColumnsReordering;
-        return this.props.columnHeaderCellRenderer?.(
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenColumnsOnly,
-        );
-    };
-
-    private renderLeftQuadrantColumnHeader = (showFrozenColumnsOnly: boolean) => {
-        const refHandler = this.quadrantRefHandlers[QuadrantType.LEFT].columnHeader;
-        const resizeHandler = this.handleColumnResizeGuideLeft;
         const reorderingHandler = this.handleColumnsReordering;
         return this.props.columnHeaderCellRenderer?.(
             refHandler,
@@ -519,20 +476,6 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
     };
 
     // Row header
-
-    private renderMainQuadrantRowHeader = (showFrozenRowsOnly: boolean) => {
-        const refHandler = this.quadrantRefHandlers[QuadrantType.MAIN].rowHeader;
-        const resizeHandler = this.handleRowResizeGuideMain;
-        const reorderingHandler = this.handleRowsReordering;
-        return this.props.rowHeaderCellRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenRowsOnly);
-    };
-
-    private renderTopQuadrantRowHeader = (showFrozenRowsOnly: boolean) => {
-        const refHandler = this.quadrantRefHandlers[QuadrantType.TOP].rowHeader;
-        const resizeHandler = this.handleRowResizeGuideTop;
-        const reorderingHandler = this.handleRowsReordering;
-        return this.props.rowHeaderCellRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenRowsOnly);
-    };
 
     private renderLeftQuadrantRowHeader = (showFrozenRowsOnly: boolean) => {
         const refHandler = this.quadrantRefHandlers[QuadrantType.LEFT].rowHeader;
@@ -653,16 +596,8 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     // Columns
 
-    private handleColumnResizeGuideMain = (verticalGuides: number[]) => {
-        this.invokeColumnResizeHandler(verticalGuides, QuadrantType.MAIN);
-    };
-
     private handleColumnResizeGuideTop = (verticalGuides: number[]) => {
         this.invokeColumnResizeHandler(verticalGuides, QuadrantType.TOP);
-    };
-
-    private handleColumnResizeGuideLeft = (verticalGuides: number[]) => {
-        this.invokeColumnResizeHandler(verticalGuides, QuadrantType.LEFT);
     };
 
     private handleColumnResizeGuideTopLeft = (verticalGuides: number[]) => {
@@ -675,14 +610,6 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
     };
 
     // Rows
-
-    private handleRowResizeGuideMain = (horizontalGuides: number[]) => {
-        this.invokeRowResizeHandler(horizontalGuides, QuadrantType.MAIN);
-    };
-
-    private handleRowResizeGuideTop = (horizontalGuides: number[]) => {
-        this.invokeRowResizeHandler(horizontalGuides, QuadrantType.TOP);
-    };
 
     private handleRowResizeGuideLeft = (horizontalGuides: number[]) => {
         this.invokeRowResizeHandler(horizontalGuides, QuadrantType.LEFT);
@@ -783,11 +710,17 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         // Writes (batched to avoid DOM thrashing)
         //
 
-        // Quadrant-size sync'ing: make the quadrants precisely as big as they
+        // Quadrant-size syncing: make the quadrants precisely as big as they
         // need to be to fit their variable-sized headers and/or frozen areas.
         this.maybesSetQuadrantRowHeaderSizes(rowHeaderWidth);
         this.maybeSetQuadrantMenuElementSizes(rowHeaderWidth, adjustedColumnHeaderHeight);
         this.maybeSetQuadrantSizes(leftQuadrantWidth, adjustedTopQuadrantHeight);
+
+        // Quadrant-offset syncing
+        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "left", rowHeaderWidth);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.TOP, "left", rowHeaderWidth);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.MAIN, "top", columnHeaderHeight);
+        this.maybeSetQuadrantPositionOffset(QuadrantType.LEFT, "top", columnHeaderHeight);
 
         // Scrollbar clearance: tweak the quadrant bottom/right offsets to
         // reveal the MAIN-quadrant scrollbars if they're visible.
@@ -814,7 +747,11 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         }
     };
 
-    private maybeSetQuadrantPositionOffset = (quadrantType: QuadrantType, side: "right" | "bottom", value: number) => {
+    private maybeSetQuadrantPositionOffset = (
+        quadrantType: QuadrantType,
+        side: "top" | "right" | "bottom" | "left",
+        value: number,
+    ) => {
         const { quadrant } = this.quadrantRefs[quadrantType];
         if (quadrant != null) {
             quadrant.style[side] = `${value}px`;
@@ -909,7 +846,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
      */
     private measureDesiredRowHeaderWidth() {
         // the MAIN row header serves as the source of truth
-        const mainRowHeader = this.quadrantRefs[QuadrantType.MAIN].rowHeader;
+        const mainRowHeader = this.quadrantRefs[QuadrantType.LEFT].rowHeader;
 
         if (mainRowHeader == null) {
             return 0;
@@ -930,7 +867,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
         // unlike the row headers, the column headers are in a display-flex
         // layout and are not actually bound by any fixed `height` that we set,
         // so they'll grow freely to their necessary size. makes measuring easy!
-        const mainColumnHeader = this.quadrantRefs[QuadrantType.MAIN].columnHeader;
+        const mainColumnHeader = this.quadrantRefs[QuadrantType.TOP].columnHeader;
         return mainColumnHeader == null ? 0 : mainColumnHeader.clientHeight;
     }
 

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -41,7 +41,7 @@ describe("Column", () => {
                 <Column />
             </Table>,
         );
-        const selector = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_NAME_TEXT}`;
+        const selector = `.${Classes.TABLE_QUADRANT_TOP} .${Classes.TABLE_COLUMN_NAME_TEXT}`;
         expect(table.find(selector, 0).element).to.exist;
         expect(table.find(selector, 1).element).to.exist;
         expect(table.find(selector, 2).element).to.exist;
@@ -57,7 +57,7 @@ describe("Column", () => {
             </Table>,
         );
 
-        const selector = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_NAME_TEXT}`;
+        const selector = `.${Classes.TABLE_QUADRANT_TOP} .${Classes.TABLE_COLUMN_NAME_TEXT}`;
 
         expect(table.find(selector, 0).text()).to.equal("Zero"); // custom
         expect(table.find(selector, 1).text()).to.equal("One"); // custom

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -90,8 +90,6 @@ describe("TableQuadrantStack", () => {
         };
 
         expect(isMainQuadrantChild(quadrantRef)).to.be.true;
-        expect(isMainQuadrantChild(rowHeaderRef)).to.be.true;
-        expect(isMainQuadrantChild(columnHeaderRef)).to.be.true;
         expect(isMainQuadrantChild(scrollContainerRef)).to.be.true;
     });
 
@@ -200,7 +198,7 @@ describe("TableQuadrantStack", () => {
             const bodyRenderer = sinon.spy();
             const menuRenderer = sinon.spy();
             mount(<TableQuadrantStack grid={grid} bodyRenderer={bodyRenderer} menuRenderer={menuRenderer} />);
-            expect(menuRenderer.callCount).to.equal(4);
+            expect(menuRenderer.callCount).to.equal(1);
         });
 
         it("invokes columnHeaderCellRenderer once for each quadrant on mount", () => {
@@ -213,7 +211,7 @@ describe("TableQuadrantStack", () => {
                     columnHeaderCellRenderer={columnHeaderCellRenderer}
                 />,
             );
-            expect(columnHeaderCellRenderer.callCount).to.equal(4);
+            expect(columnHeaderCellRenderer.callCount).to.equal(2);
         });
 
         it("invokes rowHeaderCellRenderer once for each quadrant on mount", () => {
@@ -226,7 +224,7 @@ describe("TableQuadrantStack", () => {
                     rowHeaderCellRenderer={rowHeaderCellRenderer}
                 />,
             );
-            expect(rowHeaderCellRenderer.callCount).to.equal(4);
+            expect(rowHeaderCellRenderer.callCount).to.equal(2);
         });
 
         it("does not render LEFT/TOP_LEFT quadrants if row header not shown and no frozen columns", () => {

--- a/packages/table/test/selectionTests.tsx
+++ b/packages/table/test/selectionTests.tsx
@@ -26,8 +26,8 @@ import { createTableOfSize } from "./mocks/table";
 
 describe("Selection", () => {
     const harness = new ReactHarness();
-    const COLUMN_TH_SELECTOR = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
-    const ROW_TH_SELECTOR = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`;
+    const COLUMN_TH_SELECTOR = `.${Classes.TABLE_QUADRANT_TOP} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
+    const ROW_TH_SELECTOR = `.${Classes.TABLE_QUADRANT_LEFT} .${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`;
     const CELL_SELECTOR = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.rowCellIndexClass(
         2,
     )}.${Classes.columnCellIndexClass(0)}`;

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -813,7 +813,7 @@ describe("<Table>", function (this) {
             // and expect a non-zero height.
             table.scrollToRegion(Regions.column(columnWidths.length - 1));
 
-            const quadrantSelector = `.${Classes.TABLE_QUADRANT_TOP}`;
+            const quadrantSelector = `.${Classes.TABLE_QUADRANT_TOP_LEFT}`;
             const columnHeaderSelector = `${quadrantSelector} .${Classes.TABLE_COLUMN_HEADERS}`;
             const resizeHandleSelector = `${columnHeaderSelector} .${Classes.TABLE_RESIZE_HANDLE_TARGET}`;
 
@@ -856,7 +856,7 @@ describe("<Table>", function (this) {
         }
 
         function getRowHeadersWrapper(table: ElementHarness) {
-            return table.find(`.${Classes.TABLE_ROW_HEADERS}`);
+            return table.find(`.${Classes.TABLE_QUADRANT_LEFT} .${Classes.TABLE_ROW_HEADERS}`);
         }
 
         function getResizeHandle(header: ElementHarness, index: number) {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -1827,20 +1827,18 @@ describe("<Table>", function (this) {
             component.simulate("mousedown").simulate("mouseup");
         }
 
-        function find(selector: string) {
-            return table.find(`.${Classes.TABLE_QUADRANT_MAIN} ${selector}`);
-        }
-
         function clickRowHeaderCell() {
-            click(find(`.${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`).at(CELL_INDEX));
+            const selector = `.${Classes.TABLE_QUADRANT_LEFT} .${Classes.TABLE_ROW_HEADERS} .${Classes.TABLE_HEADER}`;
+            click(table.find(selector).at(CELL_INDEX));
         }
 
         function clickColumnHeaderCell() {
-            click(find(`.${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`).at(CELL_INDEX));
+            const selector = `.${Classes.TABLE_QUADRANT_TOP} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
+            click(table.find(selector).at(CELL_INDEX));
         }
 
         function clickTableMenu() {
-            click(find(`.${Classes.TABLE_MENU}`));
+            click(table.find(`.${Classes.TABLE_QUADRANT_TOP_LEFT} .${Classes.TABLE_MENU}`));
         }
 
         function expectNoSelectedRegions() {

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -47,7 +47,7 @@ describe("<Table>", function (this) {
     // allow retrying failed tests here to reduce flakes.
     this.retries(2);
 
-    const COLUMN_HEADER_SELECTOR = `.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
+    const COLUMN_HEADER_SELECTOR = `.${Classes.TABLE_QUADRANT_TOP} .${Classes.TABLE_COLUMN_HEADERS} .${Classes.TABLE_HEADER}`;
 
     const harness = new ReactHarness();
 
@@ -541,7 +541,7 @@ describe("<Table>", function (this) {
         }
 
         function selectFullTable(table: ReactWrapper<any>, ...mouseEventArgs: any[]) {
-            const menu = table.find(`.${Classes.TABLE_QUADRANT_MAIN} .${Classes.TABLE_MENU}`);
+            const menu = table.find(`.${Classes.TABLE_QUADRANT_TOP_LEFT} .${Classes.TABLE_MENU}`);
             menu.simulate("mousedown", ...mouseEventArgs).simulate("mouseup", ...mouseEventArgs);
         }
     });
@@ -813,7 +813,7 @@ describe("<Table>", function (this) {
             // and expect a non-zero height.
             table.scrollToRegion(Regions.column(columnWidths.length - 1));
 
-            const quadrantSelector = `.${Classes.TABLE_QUADRANT_LEFT}`;
+            const quadrantSelector = `.${Classes.TABLE_QUADRANT_TOP}`;
             const columnHeaderSelector = `${quadrantSelector} .${Classes.TABLE_COLUMN_HEADERS}`;
             const resizeHandleSelector = `${columnHeaderSelector} .${Classes.TABLE_RESIZE_HANDLE_TARGET}`;
 


### PR DESCRIPTION
Remove duplicate menu / row header / column header in quadrants.

#### Fixes #4420 

#### Reviewers should focus on:

Is there any side effects if we remove these duplicate elements. 

