### PR TITLE
[menu] - @extend menu-item:hover not working on dart-css

### DIFF
--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -17,6 +17,7 @@
       // keep a trail of hovered items as submenus are opened
       /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
       @extend .#{$ns}-menu-item;
+      color: inherit;
     }
   }
 

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -16,7 +16,7 @@
     &.#{$ns}-popover-open > .#{$ns}-menu-item {
       // keep a trail of hovered items as submenus are opened
       /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
-      @extend .#{$ns}-menu-item:hover;
+      @extend .#{$ns}-menu-item;
     }
   }
 


### PR DESCRIPTION
Hey,
I'm not sure if what i did is correct, but if you could direct to me to right solution here ? i want to use `menu.scss` and it breaks me because of us using dart-css :)

I tested it and seems good:
![image](https://user-images.githubusercontent.com/71490191/99639062-d177bb80-2a4f-11eb-8f83-e6c888cf75d4.png)

Also seems all CI passes - related to https://github.com/palantir/blueprint/issues/4032