### PR TITLE
feat(NumericInput): support ref object along ref callback

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -27,6 +27,7 @@ import {
     IIntentProps,
     Intent,
     IProps,
+    IRef,
     Keys,
     MaybeElement,
     Position,
@@ -99,7 +100,7 @@ export interface INumericInputProps extends IIntentProps, IProps {
     /**
      * Ref handler that receives HTML `<input>` element backing this component.
      */
-    inputRef?: (ref: HTMLInputElement | null) => any;
+    inputRef?: IRef<HTMLInputElement>;
 
     /**
      * If set to `true`, the input will display with larger styling.
@@ -441,7 +442,11 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
 
     private inputRef = (input: HTMLInputElement | null) => {
         this.inputElement = input;
-        this.props.inputRef?.(input);
+        if (typeof this.props.inputRef === "function") {
+            this.props.inputRef(input);
+        } else if (typeof this.props.inputRef === "object" && this.props.inputRef !== null) {
+            this.props.inputRef.current = input;
+        }
     };
 
     // Callbacks - Buttons

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -39,6 +39,7 @@ import {
     Position,
 } from "../../src";
 import * as Errors from "../../src/common/errors";
+import { createReactRef } from "../../src/common/utils";
 
 /**
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26979#issuecomment-465304376
@@ -214,6 +215,17 @@ describe("<NumericInput>", () => {
             decrementButton.simulate("mousedown");
             expect(onButtonClickSpy.calledOnce).to.be.true;
             expect(onButtonClickSpy.firstCall.args).to.deep.equal([0, "0"]);
+        });
+
+        it("supports ref", () => {
+            let inputRefFn: HTMLInputElement | null = null;
+            // tslint:disable-next-line:jsx-no-lambda
+            mount(<NumericInput inputRef={ref => (inputRefFn = ref)} />);
+            assert.instanceOf(inputRefFn, HTMLInputElement);
+
+            const inputRefObj = createReactRef<HTMLInputElement>();
+            mount(<NumericInput inputRef={inputRefObj} />);
+            assert.instanceOf(inputRefObj.current, HTMLInputElement);
         });
     });
 


### PR DESCRIPTION
## Checklist

- [X] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Improve ```NumericInput``` to support the same ```inputRef``` as ```InputGroup```