### PR TITLE
Cb/multi slider.handle class name

### DIFF
--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -294,12 +294,12 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
             return null;
         }
 
-        return handleProps.map(({ value, type }, index) => (
+        return handleProps.map(({ value, type, className }, index) => (
             <Handle
                 className={classNames({
                     [Classes.START]: type === HandleType.START,
                     [Classes.END]: type === HandleType.END,
-                })}
+                }, className)}
                 disabled={disabled}
                 key={`${index}-${handleProps.length}`}
                 label={this.formatLabel(value)}

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -296,10 +296,13 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
         return handleProps.map(({ value, type, className }, index) => (
             <Handle
-                className={classNames({
-                    [Classes.START]: type === HandleType.START,
-                    [Classes.END]: type === HandleType.END,
-                }, className)}
+                className={classNames(
+                    {
+                        [Classes.START]: type === HandleType.START,
+                        [Classes.END]: type === HandleType.END,
+                    },
+                    className,
+                )}
                 disabled={disabled}
                 key={`${index}-${handleProps.length}`}
                 label={this.formatLabel(value)}

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -66,8 +66,8 @@ describe("<MultiSlider>", () => {
                 </MultiSlider>,
                 { attachTo: testsContainerElement },
             );
-            assert.lengthOf(slider.find('span.testClass'), 1);
-        })
+            assert.lengthOf(slider.find("span.testClass"), 1);
+        });
 
         it("moving mouse on the first handle updates the first value", () => {
             const slider = renderSlider({ onChange });

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -58,6 +58,17 @@ describe("<MultiSlider>", () => {
             assert.deepEqual(onRelease.firstCall.args[0], [0, 5, 10]);
         });
 
+        it("propagates className to the handles", () => {
+            const slider = mount(
+                <MultiSlider>
+                    <MultiSlider.Handle value={3} className="testClass" />
+                    <MultiSlider.Handle value={5} />
+                </MultiSlider>,
+                { attachTo: testsContainerElement },
+            );
+            assert.lengthOf(slider.find('span.testClass'), 1);
+        })
+
         it("moving mouse on the first handle updates the first value", () => {
             const slider = renderSlider({ onChange });
             simulateMovement(slider, { dragSize: STEP_SIZE, dragTimes: 4, handleIndex: 0 });


### PR DESCRIPTION
#### Fixes #4440

#### Checklist

- [x] Includes tests

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Passes user provided `className` on `MultiSlider.Handle` to the rendered `span` element.

#### Reviewers should focus on:

I confirmed that the `className` was being passed locally, and included a simple test.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
