### PR TITLE
chore: enable ESLint rule "unbound-method"

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -28,8 +28,8 @@ import * as ContextMenu from "./contextMenu";
 
 export interface IContextMenuTargetComponent extends React.Component {
     render(): React.ReactElement<any> | null | undefined;
-    renderContextMenu(e: React.MouseEvent<HTMLElement>): JSX.Element | undefined;
-    onContextMenuClose?(): void;
+    renderContextMenu: (e: React.MouseEvent<HTMLElement>) => JSX.Element | undefined;
+    onContextMenuClose?: () => void;
 }
 
 export function ContextMenuTarget<T extends IConstructor<IContextMenuTargetComponent>>(WrappedComponent: T) {

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -30,7 +30,7 @@ export interface IHotkeysTargetComponent extends React.Component {
      * Components decorated with the `@HotkeysTarget` decorator must implement
      * this method, and it must return a `Hotkeys` React element.
      */
-    renderHotkeys(): React.ReactElement<IHotkeysProps>;
+    renderHotkeys: () => React.ReactElement<IHotkeysProps>;
 }
 
 export function HotkeysTarget<T extends IConstructor<IHotkeysTargetComponent>>(WrappedComponent: T) {

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -220,9 +220,9 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
         }
     }
 
-    private renderToast(toast: IToastOptions) {
+    private renderToast = (toast: IToastOptions) => {
         return <Toast {...toast} onDismiss={this.getDismissHandler(toast)} />;
-    }
+    };
 
     private createToastOptions(props: IToastProps, key = `toast-${this.toastId++}`) {
         // clone the object before adding the key prop to avoid leaking the mutation

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -789,7 +789,12 @@ describe("<Popover>", () => {
         wrapper.popoverElement = (wrapper.instance() as Popover).popoverElement!;
         wrapper.targetElement = (wrapper.instance() as Popover).targetElement!;
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {
-            (expected ? assert.isTrue : assert.isFalse)(wrapper!.findClass(className).exists(), msg);
+            const actual = wrapper!.findClass(className);
+            if (expected) {
+                assert.isTrue(actual.exists(), msg);
+            } else {
+                assert.isFalse(actual.exists(), msg);
+            }
             return wrapper!;
         };
         wrapper.assertIsOpen = (isOpen = true, index = 0) => {

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -115,7 +115,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
         return <NavMenuItem {...props} />;
     };
 
-    private renderPageActions(page: IPageData) {
+    private renderPageActions = (page: IPageData) => {
         return (
             <AnchorButton
                 href={`${GITHUB_SOURCE_URL}/${page.sourcePath}`}
@@ -125,7 +125,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
                 text="Edit this page"
             />
         );
-    }
+    };
 
     private maybeRenderPageTag(reference: string) {
         const tag = this.props.docs.pages[reference].metadata.tag;
@@ -139,9 +139,9 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
         );
     }
 
-    private renderViewSourceLinkText(entry: ITsDocBase) {
+    private renderViewSourceLinkText = (entry: ITsDocBase) => {
         return `@blueprintjs/${entry.fileName.split("/", 2)[1]}`;
-    }
+    };
 
     private maybeRenderPackageLink(packageName: string) {
         const pkg = this.getNpmPackage(packageName);

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -67,7 +67,7 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
         );
     }
 
-    private maybeRenderIconGroup(groupName: string, index: number) {
+    private maybeRenderIconGroup = (groupName: string, index: number) => {
         const { iconRenderer } = this.props;
         const iconElements = this.getFilteredIcons(groupName).map(iconRenderer);
         if (iconElements.length === 0) {
@@ -84,7 +84,7 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
                 {iconElements}
             </div>
         );
-    }
+    };
 
     private renderZeroState() {
         return <NonIdealState className={Classes.TEXT_MUTED} icon="zoom-out" description="No icons found" />;

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -108,9 +108,9 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
         );
     }
 
-    private renderLabel(value: number) {
+    private renderLabel = (value: number) => {
         return `${value}%`;
-    }
+    };
 
     private handleChangeWidth = (width: number) => this.setState({ width });
     private handleChangeRenderCurrentAsInput = () =>

--- a/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
@@ -91,13 +91,13 @@ export class CollapsibleListExample extends React.PureComponent<IExampleProps, I
         /* eslint-enable deprecation/deprecation */
     }
 
-    private renderBreadcrumb(props: IMenuItemProps) {
+    private renderBreadcrumb = (props: IMenuItemProps) => {
         if (props.href != null) {
             return <a className={Classes.BREADCRUMB}>{props.text}</a>;
         } else {
             return <span className={classNames(Classes.BREADCRUMB, Classes.BREADCRUMB_CURRENT)}>{props.text}</span>;
         }
-    }
+    };
 
     private handleChangeCount = (visibleItemCount: number) => this.setState({ visibleItemCount });
 }

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -85,11 +85,11 @@ export class SliderExample extends React.PureComponent<IExampleProps, ISliderExa
         return (value: number) => this.setState({ [key]: value });
     }
 
-    private renderLabel2(val: number) {
+    private renderLabel2 = (val: number) => {
         return `${Math.round(val * 100)}%`;
-    }
+    };
 
-    private renderLabel3(val: number) {
+    private renderLabel3 = (val: number) => {
         return val === 0 ? `£${val}` : `£${val},000`;
-    }
+    };
 }

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -153,10 +153,10 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
         );
     }
 
-    private renderToastDemo(toast: IToastDemo, index: number) {
+    private renderToastDemo = (toast: IToastDemo, index: number) => {
         // tslint:disable-next-line:jsx-no-lambda
         return <Button intent={toast.intent} key={index} text={toast.button} onClick={() => this.addToast(toast)} />;
-    }
+    };
 
     private renderProgress(amount: number): IToastProps {
         return {

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -166,20 +166,20 @@ class RecordSortableColumn extends AbstractSortableColumn {
         }
     }
 
-    private toWins(a: any) {
+    private toWins = (a: any) => {
         const match = RecordSortableColumn.WIN_LOSS_PATTERN.exec(a);
         return match == null ? -1 : parseInt(match[1], 10);
-    }
+    };
 
-    private toTies(a: any) {
+    private toTies = (a: any) => {
         const match = RecordSortableColumn.WIN_LOSS_PATTERN.exec(a);
         return match == null || match[3] == null ? -1 : parseInt(match[3], 10);
-    }
+    };
 
-    private toLosses(a: any) {
+    private toLosses = (a: any) => {
         const match = RecordSortableColumn.WIN_LOSS_PATTERN.exec(a);
         return match == null ? -1 : parseInt(match[5], 10);
-    }
+    };
 }
 
 export class TableSortableExample extends React.PureComponent<IExampleProps> {

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -55,19 +55,19 @@ export interface IDocumentationContext {
      * Get the Documentalist data.
      * Use the `hasTypescriptData` and `hasKssData` typeguards before accessing those plugins' data.
      */
-    getDocsData(): IDocsData;
+    getDocsData: () => IDocsData;
 
     /** Render a block of Documentalist documentation to a React node. */
-    renderBlock(block: IBlock): React.ReactNode;
+    renderBlock: (block: IBlock) => React.ReactNode;
 
     /** Render a Documentalist Typescript type string to a React node. */
-    renderType(type: string): React.ReactNode;
+    renderType: (type: string) => React.ReactNode;
 
     /** Render the text of a "View source" link. */
-    renderViewSourceLinkText(entry: ITsDocBase): React.ReactNode;
+    renderViewSourceLinkText: (entry: ITsDocBase) => React.ReactNode;
 
     /** Open the API browser to the given member name. */
-    showApiDocs(name: string): void;
+    showApiDocs: (name: string) => void;
 }
 
 /**

--- a/packages/eslint-config/typescript-eslint-rules.json
+++ b/packages/eslint-config/typescript-eslint-rules.json
@@ -46,5 +46,11 @@
             "lib": "always"
         }
     ],
+    "@typescript-eslint/unbound-method": [
+        "error",
+        {
+            "ignoreStatic": true
+        }
+    ],
     "@typescript-eslint/unified-signatures": "error"
 }

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -134,6 +134,7 @@ const LARGE_JSON_PROP_COUNT = 3;
 const LARGE_JSON_OBJECT_DEPTH = 2;
 
 const CELL_CONTENT_GENERATORS: { [name: string]: (ri: number, ci: number) => string | Record<string, unknown> } = {
+    /* eslint-disable-next-line @typescript-eslint/unbound-method */
     [CellContent.CELL_NAMES]: Utils.toBase26CellName,
     [CellContent.EMPTY]: () => "",
     [CellContent.LONG_TEXT]: () => {
@@ -612,28 +613,28 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             "Render mode",
             "renderMode",
             RENDER_MODES,
-            this.toRenderModeLabel,
+            toRenderModeLabel,
             this.handleStringStateChange,
         );
         const selectedRegionTransformPresetMenu = this.renderSelectMenu(
             "Selection",
             "selectedRegionTransformPreset",
             SELECTION_MODES,
-            this.toSelectedRegionTransformPresetLabel,
+            toSelectedRegionTransformPresetLabel,
             this.handleStringStateChange,
         );
         const cellContentMenu = this.renderSelectMenu(
             "Cell content",
             "cellContent",
             CELL_CONTENTS,
-            this.toCellContentLabel,
+            toCellContentLabel,
             this.handleStringStateChange,
         );
         const truncatedPopoverModeMenu = this.renderSelectMenu(
             "Popover",
             "cellTruncatedPopoverMode",
             TRUNCATED_POPOVER_MODES,
-            this.toTruncatedPopoverModeLabel,
+            toTruncatedPopoverModeLabel,
             this.handleStringStateChange,
             "enableCellTruncation",
             true,
@@ -642,7 +643,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             "Length",
             "cellTruncationLength",
             TRUNCATION_LENGTHS,
-            this.toValueLabel,
+            toValueLabel,
             this.handleNumberStateChange,
             "enableCellTruncationFixed",
             true,
@@ -652,7 +653,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             "Focus outlines",
             "selectedFocusStyle",
             FOCUS_STYLES,
-            this.toFocusStyleLabel,
+            toFocusStyleLabel,
             this.handleStringStateChange,
         );
 
@@ -748,7 +749,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
             "Region type",
             "scrollToRegionType",
             REGION_CARDINALITIES,
-            this.getRegionCardinalityLabel,
+            getRegionCardinalityLabel,
             this.handleStringStateChange,
         );
         const scrollToRowSelectMenu = this.renderSelectMenu(
@@ -784,21 +785,6 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         );
     }
 
-    private getRegionCardinalityLabel(cardinality: RegionCardinality) {
-        switch (cardinality) {
-            case RegionCardinality.CELLS:
-                return "Cell";
-            case RegionCardinality.FULL_ROWS:
-                return "Row";
-            case RegionCardinality.FULL_COLUMNS:
-                return "Column";
-            case RegionCardinality.FULL_TABLE:
-                return "Full table";
-            default:
-                return "";
-        }
-    }
-
     private renderSwitch(
         label: string,
         stateKey: keyof IMutableTableState,
@@ -825,7 +811,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
     }
 
     private renderNumberSelectMenu(label: string, stateKey: keyof IMutableTableState, values: number[]) {
-        return this.renderSelectMenu(label, stateKey, values, this.toValueLabel, this.handleNumberStateChange);
+        return this.renderSelectMenu(label, stateKey, values, toValueLabel, this.handleNumberStateChange);
     }
 
     private renderSelectMenu<T>(
@@ -883,76 +869,6 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
     ) {
         // Blueprint Tooltip affects the layout, so just show a native title on hover
         return <div title={`Requires ${prereqStateKey}=${prereqStateKeyValue}`}>{element}</div>;
-    }
-
-    // Select menu - label generators
-    // ==============================
-
-    private toRenderModeLabel(renderMode: RenderMode) {
-        switch (renderMode) {
-            case RenderMode.BATCH:
-                return "Batch";
-            case RenderMode.BATCH_ON_UPDATE:
-                return "Batch on update";
-            default:
-                return "None";
-        }
-    }
-
-    private toSelectedRegionTransformPresetLabel(selectedRegionTransformPreset: SelectedRegionTransformPreset) {
-        switch (selectedRegionTransformPreset) {
-            case SelectedRegionTransformPreset.CELL:
-                return "Unconstrained";
-            case SelectedRegionTransformPreset.ROW:
-                return "Whole rows only";
-            case SelectedRegionTransformPreset.COLUMN:
-                return "Whole columns only";
-            default:
-                return "None";
-        }
-    }
-
-    private toCellContentLabel(cellContent: CellContent) {
-        switch (cellContent) {
-            case CellContent.CELL_NAMES:
-                return "Cell names";
-            case CellContent.EMPTY:
-                return "Empty";
-            case CellContent.LONG_TEXT:
-                return "Long text";
-            case CellContent.LARGE_JSON:
-                return "Large JSON (~5KB)";
-            default:
-                return "";
-        }
-    }
-
-    private toTruncatedPopoverModeLabel(truncatedPopoverMode: TruncatedPopoverMode) {
-        switch (truncatedPopoverMode) {
-            case TruncatedPopoverMode.ALWAYS:
-                return "Always";
-            case TruncatedPopoverMode.NEVER:
-                return "Never";
-            case TruncatedPopoverMode.WHEN_TRUNCATED:
-                return "When truncated";
-            case TruncatedPopoverMode.WHEN_TRUNCATED_APPROX:
-                return "Truncated approx";
-            default:
-                return "";
-        }
-    }
-
-    private toFocusStyleLabel(focusStyle: FocusStyle) {
-        switch (focusStyle) {
-            case FocusStyle.TAB:
-                return "On tab";
-            default:
-                return "On tab or click";
-        }
-    }
-
-    private toValueLabel(value: any) {
-        return value.toString();
     }
 
     // Callbacks
@@ -1190,4 +1106,89 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                   },
               ] as IStyledRegionGroup[]);
     }
+}
+
+// Select menu - label generators
+// ==============================
+
+function toRenderModeLabel(renderMode: RenderMode) {
+    switch (renderMode) {
+        case RenderMode.BATCH:
+            return "Batch";
+        case RenderMode.BATCH_ON_UPDATE:
+            return "Batch on update";
+        default:
+            return "None";
+    }
+}
+
+function toSelectedRegionTransformPresetLabel(selectedRegionTransformPreset: SelectedRegionTransformPreset) {
+    switch (selectedRegionTransformPreset) {
+        case SelectedRegionTransformPreset.CELL:
+            return "Unconstrained";
+        case SelectedRegionTransformPreset.ROW:
+            return "Whole rows only";
+        case SelectedRegionTransformPreset.COLUMN:
+            return "Whole columns only";
+        default:
+            return "None";
+    }
+}
+
+function toCellContentLabel(cellContent: CellContent) {
+    switch (cellContent) {
+        case CellContent.CELL_NAMES:
+            return "Cell names";
+        case CellContent.EMPTY:
+            return "Empty";
+        case CellContent.LONG_TEXT:
+            return "Long text";
+        case CellContent.LARGE_JSON:
+            return "Large JSON (~5KB)";
+        default:
+            return "";
+    }
+}
+
+function toTruncatedPopoverModeLabel(truncatedPopoverMode: TruncatedPopoverMode) {
+    switch (truncatedPopoverMode) {
+        case TruncatedPopoverMode.ALWAYS:
+            return "Always";
+        case TruncatedPopoverMode.NEVER:
+            return "Never";
+        case TruncatedPopoverMode.WHEN_TRUNCATED:
+            return "When truncated";
+        case TruncatedPopoverMode.WHEN_TRUNCATED_APPROX:
+            return "Truncated approx";
+        default:
+            return "";
+    }
+}
+
+function toFocusStyleLabel(focusStyle: FocusStyle) {
+    switch (focusStyle) {
+        case FocusStyle.TAB:
+            return "On tab";
+        default:
+            return "On tab or click";
+    }
+}
+
+function getRegionCardinalityLabel(cardinality: RegionCardinality) {
+    switch (cardinality) {
+        case RegionCardinality.CELLS:
+            return "Cell";
+        case RegionCardinality.FULL_ROWS:
+            return "Row";
+        case RegionCardinality.FULL_COLUMNS:
+            return "Column";
+        case RegionCardinality.FULL_TABLE:
+            return "Full table";
+        default:
+            return "";
+    }
+}
+
+function toValueLabel(value: any) {
+    return value.toString();
 }

--- a/packages/table-dev-app/src/nav.tsx
+++ b/packages/table-dev-app/src/nav.tsx
@@ -42,7 +42,7 @@ export class Nav extends React.PureComponent<INavProps> {
         );
     }
 
-    private handleToggleDarkTheme() {
+    private handleToggleDarkTheme = () => {
         document.body.classList.toggle(Classes.DARK);
-    }
+    };
 }

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -78,7 +78,7 @@ export const Utils = {
      * Note that this isn't technically mathematically equivalent to base 26 since
      * there is no zero element.
      */
-    toBase26Alpha(num: number): string {
+    toBase26Alpha: (num: number) => {
         let str = "";
         while (true) {
             const letter = num % 26;
@@ -96,7 +96,7 @@ export const Utils = {
      * Returns traditional spreadsheet-style cell names
      * e.g. (A1, B2, ..., Z44, AA1) with rows 1-indexed.
      */
-    toBase26CellName(rowIndex: number, columnIndex: number): string {
+    toBase26CellName: (rowIndex: number, columnIndex: number) => {
         return `${Utils.toBase26Alpha(columnIndex)}${rowIndex + 1}`;
     },
 


### PR DESCRIPTION
Note that this was never enabled with TSLint because `no-unbound-method` requires type information, and we did not prioritize those rules in the Blueprint config.