### PR TITLE
[core] feat(Slider): labelRenderer option to allow different output in handle tooltip

### DIFF
--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -97,9 +97,12 @@ export interface ISliderBaseProps extends IProps, IIntentProps {
      * If `true`, labels will use number value formatted to `labelPrecision` decimal places.
      * If `false`, labels will not be shown.
      *
+     * The callback is provided a numeric value and optional rendering options, which include:
+     * - isHandleTooltip: whether this label is being rendered within a handle tooltip
+     *
      * @default true
      */
-    labelRenderer?: boolean | ((value: number, isHandle?: boolean) => string | JSX.Element);
+    labelRenderer?: boolean | ((value: number, opts?: { isHandleTooltip: boolean }) => string | JSX.Element);
 
     /**
      * Whether to show the slider in a vertical orientation.
@@ -230,12 +233,12 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         }
     }
 
-    private formatLabel(value: number, isHandle: boolean = false) {
+    private formatLabel(value: number, isHandleTooltip: boolean = false) {
         const { labelRenderer } = this.props;
         if (labelRenderer === false) {
             return undefined;
         } else if (Utils.isFunction(labelRenderer)) {
-            return labelRenderer(value, isHandle);
+            return labelRenderer(value, { isHandleTooltip });
         } else {
             return value.toFixed(this.state.labelPrecision);
         }

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -99,7 +99,7 @@ export interface ISliderBaseProps extends IProps, IIntentProps {
      *
      * @default true
      */
-    labelRenderer?: boolean | ((value: number) => string | JSX.Element);
+    labelRenderer?: boolean | ((value: number, isHandle?: boolean) => string | JSX.Element);
 
     /**
      * Whether to show the slider in a vertical orientation.
@@ -230,12 +230,12 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         }
     }
 
-    private formatLabel(value: number) {
+    private formatLabel(value: number, isHandle: boolean = false) {
         const { labelRenderer } = this.props;
         if (labelRenderer === false) {
             return undefined;
         } else if (Utils.isFunction(labelRenderer)) {
-            return labelRenderer(value);
+            return labelRenderer(value, isHandle);
         } else {
             return value.toFixed(this.state.labelPrecision);
         }
@@ -312,7 +312,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
                 })}
                 disabled={disabled}
                 key={`${index}-${handleProps.length}`}
-                label={this.formatLabel(value)}
+                label={this.formatLabel(value, true)}
                 max={max!}
                 min={min!}
                 onChange={this.getHandlerForIndex(index, this.handleChange)}

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -54,7 +54,8 @@ describe("<Slider>", () => {
     });
 
     it("renders result of labelRenderer() in each label and differently in handle", () => {
-        const labelRenderer = (val: number, isHandle?: boolean) => (isHandle ? val + "!" : val + "#");
+        const labelRenderer = (val: number, opts?: { isHandleTooltip: boolean }) =>
+            val + (opts?.isHandleTooltip ? "!" : "#");
         const wrapper = renderSlider(
             <Slider min={0} max={50} value={10} labelStepSize={10} labelRenderer={labelRenderer} />,
         );

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -54,8 +54,10 @@ describe("<Slider>", () => {
     });
 
     it("renders result of labelRenderer() in each label and differently in handle", () => {
-        const labelRenderer = (val: number, isHandle?: boolean) => isHandle ? val + "!" : val + "#";
-        const wrapper = renderSlider(<Slider min={0} max={50} value={10} labelStepSize={10} labelRenderer={labelRenderer} />);
+        const labelRenderer = (val: number, isHandle?: boolean) => (isHandle ? val + "!" : val + "#");
+        const wrapper = renderSlider(
+            <Slider min={0} max={50} value={10} labelStepSize={10} labelRenderer={labelRenderer} />,
+        );
         assert.strictEqual(wrapper.find(`.${Classes.SLIDER}-axis`).text(), "0#10#20#30#40#50#");
         assert.strictEqual(wrapper.find(`.${Classes.SLIDER_HANDLE}`).find(`.${Classes.SLIDER_LABEL}`).text(), "10!");
     });

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -53,10 +53,11 @@ describe("<Slider>", () => {
         assert.equal(tracks.getDOMNode().getBoundingClientRect().width, STEP_SIZE * 3);
     });
 
-    it("renders result of labelRenderer() in each label", () => {
-        const labelRenderer = (val: number) => val + "#";
-        const wrapper = renderSlider(<Slider min={0} max={50} labelStepSize={10} labelRenderer={labelRenderer} />);
+    it("renders result of labelRenderer() in each label and differently in handle", () => {
+        const labelRenderer = (val: number, isHandle?: boolean) => isHandle ? val + "!" : val + "#";
+        const wrapper = renderSlider(<Slider min={0} max={50} value={10} labelStepSize={10} labelRenderer={labelRenderer} />);
         assert.strictEqual(wrapper.find(`.${Classes.SLIDER}-axis`).text(), "0#10#20#30#40#50#");
+        assert.strictEqual(wrapper.find(`.${Classes.SLIDER_HANDLE}`).find(`.${Classes.SLIDER_LABEL}`).text(), "10!");
     });
 
     it("moving mouse calls onChange with nearest value", () => {


### PR DESCRIPTION
#### Fixes #3578

#### Checklist

- [x] Includes tests
- [x] Update documentation
can update docs if it looks like this PR will be accepted.

#### Changes proposed in this pull request:

add a boolean (always true) to formatLabel callback, that indicates the value should be formatted for the handle, not the axis.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

![image](https://user-images.githubusercontent.com/80646/103603794-4b5ee980-4ec4-11eb-9f0c-076d59aa6056.png)

Here on this Date range selector, we would like to add the DAY of the month to the handle, but not to the axis.
