### PR TITLE
add loading state to alerts

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -74,6 +74,15 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
      */
     isOpen: boolean;
 
+
+    /**
+     * If set to `true`, the confirm button will be set to its loading state. The cancel button, if
+     * visible, will be disabled.
+     *
+     * @default false
+     */
+    loading?: boolean;
+
     /**
      * CSS styles to apply to the alert.
      */
@@ -129,6 +138,7 @@ export class Alert extends AbstractPureComponent2<IAlertProps> {
         canOutsideClickCancel: false,
         confirmButtonText: "OK",
         isOpen: false,
+        loading: false,
     };
 
     public static displayName = `${DISPLAYNAME_PREFIX}.Alert`;
@@ -141,6 +151,7 @@ export class Alert extends AbstractPureComponent2<IAlertProps> {
             className,
             icon,
             intent,
+            loading,
             cancelButtonText,
             confirmButtonText,
             onClose,
@@ -160,8 +171,8 @@ export class Alert extends AbstractPureComponent2<IAlertProps> {
                     <div className={Classes.ALERT_CONTENTS}>{children}</div>
                 </div>
                 <div className={Classes.ALERT_FOOTER}>
-                    <Button intent={intent} text={confirmButtonText} onClick={this.handleConfirm} />
-                    {cancelButtonText && <Button text={cancelButtonText} onClick={this.handleCancel} />}
+                    <Button loading={loading} intent={intent} text={confirmButtonText} onClick={this.handleConfirm} />
+                    {cancelButtonText && <Button text={cancelButtonText} disabled={loading} onClick={this.handleCancel} />}
                 </div>
             </Dialog>
         );

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -24,16 +24,20 @@ import { IBlueprintExampleData } from "../../tags/types";
 export interface IAlertExampleState {
     canEscapeKeyCancel: boolean;
     canOutsideClickCancel: boolean;
+    isLoading: boolean;
     isOpen: boolean;
     isOpenError: boolean;
+    willLoad: boolean;
 }
 
 export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IAlertExampleState> {
     public state: IAlertExampleState = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,
+        isLoading: false,
         isOpen: false,
         isOpenError: false,
+        willLoad: false,
     };
 
     private toaster: IToaster;
@@ -42,8 +46,10 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
 
     private handleOutsideClickChange = handleBooleanChange(click => this.setState({ canOutsideClickCancel: click }));
 
+    private handleWillLoadChange = handleBooleanChange(click => this.setState({ willLoad: click }));
+
     public render() {
-        const { isOpen, isOpenError, ...alertProps } = this.state;
+        const { isLoading, isOpen, isOpenError, ...alertProps } = this.state;
         const options = (
             <>
                 <H5>Props</H5>
@@ -57,6 +63,11 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
                     label="Can outside click cancel"
                     onChange={this.handleOutsideClickChange}
                 />
+                <Switch
+                    checked={this.state.willLoad}
+                    label="Does alert use loading state"
+                    onChange={this.handleWillLoadChange}
+                />
             </>
         );
         return (
@@ -67,6 +78,7 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
                     className={this.props.data.themeName}
                     confirmButtonText="Okay"
                     isOpen={isOpenError}
+                    loading={isLoading}
                     onClose={this.handleErrorClose}
                 >
                     <p>
@@ -84,6 +96,7 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
                     icon="trash"
                     intent={Intent.DANGER}
                     isOpen={isOpen}
+                    loading={isLoading}
                     onCancel={this.handleMoveCancel}
                     onConfirm={this.handleMoveConfirm}
                 >
@@ -100,13 +113,29 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
 
     private handleErrorOpen = () => this.setState({ isOpenError: true });
 
-    private handleErrorClose = () => this.setState({ isOpenError: false });
+    private handleErrorClose = () => {
+        const close = () => this.setState({ isLoading: false, isOpenError: false });
+        if (this.state.willLoad) {
+            this.setState({ isLoading: true });
+            setTimeout(close, 2000);
+        } else {
+            close();
+        }
+    };
 
     private handleMoveOpen = () => this.setState({ isOpen: true });
 
     private handleMoveConfirm = () => {
-        this.setState({ isOpen: false });
-        this.toaster.show({ className: this.props.data.themeName, message: TOAST_MESSAGE });
+        const close = () => {
+            this.setState({ isLoading: false, isOpen: false });
+            this.toaster.show({ className: this.props.data.themeName, message: TOAST_MESSAGE });
+        }
+        if (this.state.willLoad) {
+            this.setState({ isLoading: true });
+            setTimeout(close, 2000);
+        } else {
+            close();
+        }
     };
 
     private handleMoveCancel = () => this.setState({ isOpen: false });


### PR DESCRIPTION
I ran into a situation where I wanted to make an alert that had a clear load state (specifically the one supplied by `<Button>`). Because `<Alert>` doesn't give allow much control over the buttons, I wound up implementing that solution using a dialog and styling it to look like an alert. I think it would be nice for `<Alert>` to have this functionality.

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add a loading state to `<Alert>`.

#### Reviewers should focus on:

I'm not familiar with the testing library, so I haven't yet added tests. I can dig into that if maintainers find this to be an acceptable suggestion.

#### Screenshot

![alert loading state](https://user-images.githubusercontent.com/2432205/104496399-cc397780-558d-11eb-827a-79da3072acde.gif)