### PR TITLE
[core] fix: add IAnchorButtonProps; export setRef util

### DIFF
--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -49,11 +49,13 @@ export function getRef<T = HTMLElement>(ref: T | IRefObject<T> | null) {
 /**
  * Assign the given ref to a target, either a React ref object or a callback which takes the ref as its first argument.
  */
-export function setRef<T extends HTMLElement>(refTarget: IRef<T>, ref: T | null) {
+export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined, ref: T | null) {
+    if (refTarget === undefined) {
+        return;
+    }
     if (isRefObject<T>(refTarget)) {
         refTarget.current = ref;
-    }
-    if (isRefCallback(refTarget)) {
+    } else if (isRefCallback(refTarget)) {
         refTarget(ref);
     }
 }

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -21,11 +21,6 @@ export * from "./jsUtils";
 export * from "./reactUtils";
 export * from "./safeInvokeMember";
 
-/**
- * Utils.getRef() was added to the public API in @blueprintjs/core@3.27.0,
- * but ref utils were refactored in the next version. We keep this additional
- * export around for backwards compatibility.
- *
- * @see https://github.com/palantir/blueprint/pull/4140
- */
-export { getRef } from "../refs";
+// ref utils used to live in this folder, but got refactored and moved elsewhere.
+// we keep this export here for backwards compatibility
+export { setRef, getRef } from "../refs";

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -88,6 +88,8 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     type?: "submit" | "reset" | "button";
 }
 
+export type IAnchorButtonProps = IButtonProps<HTMLAnchorElement>;
+
 export interface IButtonState {
     isActive: boolean;
 }

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -21,9 +21,9 @@ import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { IRef, IRefObject, refHandler } from "../../common/refs";
-import { AbstractButton, IButtonProps } from "./abstractButton";
+import { AbstractButton, IButtonProps, IAnchorButtonProps } from "./abstractButton";
 
-export { IButtonProps };
+export { IAnchorButtonProps, IButtonProps };
 
 export class Button extends AbstractButton<HTMLButtonElement> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Button`;


### PR DESCRIPTION
#### Changes proposed in this pull request:

A few minor changes which helps consumers deal with minor breaks introduced in v3.38.0

- `Utils.setRef` is newly exported
- `IAnchorButtonProps` is a newly exported shorthand for `IButtonProps<HTMLAnchorElement>`, helps with the now stricter prop types

