### PR TITLE
[popover2] various fixes and improvements

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -336,7 +336,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
             typeof child === "object" ? (
                 React.cloneElement(child as React.ReactElement, {
                     className: classNames((child as React.ReactElement).props.className, Classes.OVERLAY_CONTENT),
-                    tabIndex: 0,
+                    tabIndex: this.props.enforceFocus || this.props.autoFocus ? 0 : undefined,
                 })
             ) : (
                 <span className={Classes.OVERLAY_CONTENT}>{child}</span>

--- a/packages/docs-app/src/examples/popover2-examples/tooltip2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/tooltip2Example.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, H1, Switch } from "@blueprintjs/core";
+import { Button, ButtonGroup, H1, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Classes, Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
@@ -140,6 +140,19 @@ export class Tooltip2Example extends React.PureComponent<IExampleProps, ITooltip
                         <Button intent="success" text="Hover and click me" />
                     </Tooltip2>
                 </Popover2>
+                <br />
+
+                <ButtonGroup>
+                    <Tooltip2 content="Each" placement="bottom">
+                        <Button intent="primary" text="Group" />
+                    </Tooltip2>
+                    <Tooltip2 content="has" placement="bottom">
+                        <Button intent="primary" text="of" />
+                    </Tooltip2>
+                    <Tooltip2 content="a tooltip" placement="bottom">
+                        <Button intent="primary" text="buttons" />
+                    </Tooltip2>
+                </ButtonGroup>
             </Example>
         );
     }

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -541,13 +541,23 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
         const eventPopover = eventTarget.closest(`.${Classes.POPOVER2}`);
         const isEventFromSelf = eventPopover === this.popoverRef.current;
         const isEventPopoverCapturing = eventPopover?.classList.contains(Classes.POPOVER2_CAPTURING_DISMISS);
+
         // an OVERRIDE inside a DISMISS does not dismiss, and a DISMISS inside an OVERRIDE will dismiss.
         const dismissElement = eventTarget.closest(
             `.${Classes.POPOVER2_DISMISS}, .${Classes.POPOVER2_DISMISS_OVERRIDE}`,
         );
-        const shouldDismiss = dismissElement != null && dismissElement.classList.contains(Classes.POPOVER2_DISMISS);
+        const shouldDismiss = dismissElement?.classList.contains(Classes.POPOVER2_DISMISS);
+
+        // dismiss selectors from the "V1" version of Popover in the core pacakge
+        // we expect these to be rendered by MenuItem, which at this point has no knowledge of Popover2
+        // this can be removed once Popover2 is merged into core in v4.0
+        const dismissElementV1 = eventTarget.closest(
+            `.${CoreClasses.POPOVER_DISMISS}, .${CoreClasses.POPOVER_DISMISS_OVERRIDE}`,
+        );
+        const shouldDismissV1 = dismissElementV1?.classList.contains(CoreClasses.POPOVER_DISMISS);
+
         const isDisabled = eventTarget.closest(`:disabled, .${CoreClasses.DISABLED}`) != null;
-        if (shouldDismiss && !isDisabled && (!isEventPopoverCapturing || isEventFromSelf)) {
+        if ((shouldDismiss || shouldDismissV1) && !isDisabled && (!isEventPopoverCapturing || isEventFromSelf)) {
             this.setOpenState(false, e);
         }
     };

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -459,6 +459,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 ...modifiers?.flip,
                 options: {
                     boundary: this.props.boundary,
+                    rootBoundary: this.props.rootBoundary,
                     ...modifiers?.flip?.options,
                 },
             },
@@ -467,6 +468,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 ...modifiers?.preventOverflow,
                 options: {
                     boundary: this.props.boundary,
+                    rootBoundary: this.props.rootBoundary,
                     ...modifiers?.preventOverflow?.options,
                 },
             },

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -393,7 +393,6 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 backdropProps={this.props.backdropProps}
                 canEscapeKeyClose={this.props.canEscapeKeyClose}
                 canOutsideClickClose={this.props.interactionKind === Popover2InteractionKind.CLICK}
-                className={this.props.portalClassName}
                 enforceFocus={this.props.enforceFocus}
                 hasBackdrop={this.props.hasBackdrop}
                 isOpen={isOpen}
@@ -405,6 +404,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 transitionDuration={this.props.transitionDuration}
                 transitionName={Classes.POPOVER2}
                 usePortal={this.props.usePortal}
+                portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
             >
                 <div className={Classes.POPOVER2_TRANSITION_CONTAINER} ref={popperProps.ref} style={popperProps.style}>

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -316,15 +316,16 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 isOpen,
             });
         } else {
-            const rawTarget = Utils.ensureElement(React.Children.toArray(children)[0])!;
+            const childTarget = Utils.ensureElement(React.Children.toArray(children)[0])!;
 
-            if (rawTarget === undefined) {
+            if (childTarget === undefined) {
                 return null;
             }
 
-            const rawTabIndex = rawTarget.props.tabIndex;
-            if (rawTabIndex != null) {
-                targetProps.tabIndex = rawTabIndex;
+            // if there is a tabIndex set on the child target, we are going to promote it to the wrapper element
+            const childTargetTabIndex = childTarget.props.tabIndex;
+            if (childTargetTabIndex != null) {
+                targetProps.tabIndex = childTargetTabIndex;
             }
 
             const targetModifierClasses = {
@@ -334,10 +335,12 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 // similarly, this class is mainly useful for targets like <Button>, <InputGroup>, etc.
                 [CoreClasses.FILL]: fill,
             };
-            const clonedTarget: JSX.Element = React.cloneElement(rawTarget, {
-                className: classNames(rawTarget.props.className, targetModifierClasses),
+            const clonedTarget: JSX.Element = React.cloneElement(childTarget, {
+                className: classNames(childTarget.props.className, targetModifierClasses),
                 // force disable single Tooltip2 child when popover is open
-                disabled: isOpen && Utils.isElementOfType(rawTarget, Tooltip2) ? true : rawTarget.props.disabled,
+                disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip2) ? true : childTarget.props.disabled,
+                // avoid having two nested elements which are focussable via keyboard navigation
+                tabIndex: targetProps.tabIndex !== undefined ? -1 : undefined,
             });
             const wrappedTarget = React.createElement(targetTagName!, targetProps, clonedTarget);
             target = wrappedTarget;

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Boundary, Placement, placements, StrictModifiers } from "@popperjs/core";
+import { Boundary, Placement, placements, RootBoundary, StrictModifiers } from "@popperjs/core";
 import { StrictModifier } from "react-popper";
 
 import { IOverlayableProps, IProps } from "@blueprintjs/core";
@@ -43,6 +43,8 @@ export interface IPopover2SharedProps<TProps> extends IOverlayableProps, IProps 
     /**
      * A boundary element supplied to the "flip" and "preventOverflow" modifiers.
      * This is a shorthand for overriding Popper.js modifier options with the `modifiers` prop.
+     *
+     * @see https://popper.js.org/docs/v2/utils/detect-overflow/#boundary
      */
     boundary?: Boundary;
 
@@ -150,6 +152,14 @@ export interface IPopover2SharedProps<TProps> extends IOverlayableProps, IProps 
      * Mutually exclusive with children, targetClassName, and targetTagName.
      */
     renderTarget?: (props: IPopover2TargetProps & TProps) => JSX.Element;
+
+    /**
+     * A root boundary element supplied to the "flip" and "preventOverflow" modifiers.
+     * This is a shorthand for overriding Popper.js modifier options with the `modifiers` prop.
+     *
+     * @see https://popper.js.org/docs/v2/utils/detect-overflow/#rootboundary
+     */
+    rootBoundary?: RootBoundary;
 
     /**
      * A space-delimited string of class names applied to the popover element.

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -216,19 +216,31 @@ describe("<Popover2>", () => {
     describe("openOnTargetFocus", () => {
         describe("if true (default)", () => {
             it('adds tabindex="0" to target\'s child node when interactionKind is HOVER', () => {
-                assertPopoverTargetTabIndex("hover", true, true);
+                assertPopoverTargetTabIndex(true, {
+                    interactionKind: "hover",
+                    openOnTargetFocus: true,
+                });
             });
 
             it('adds tabindex="0" to target\'s child node when interactionKind is HOVER_TARGET_ONLY', () => {
-                assertPopoverTargetTabIndex("hover-target", true, true);
+                assertPopoverTargetTabIndex(true, {
+                    interactionKind: "hover-target",
+                    openOnTargetFocus: true,
+                });
             });
 
             it("does not add tabindex to target's child node when interactionKind is CLICK", () => {
-                assertPopoverTargetTabIndex("click", false, true);
+                assertPopoverTargetTabIndex(false, {
+                    interactionKind: "click",
+                    openOnTargetFocus: true,
+                });
             });
 
             it("does not add tabindex to target's child node when interactionKind is CLICK_TARGET_ONLY", () => {
-                assertPopoverTargetTabIndex("click-target", false, true);
+                assertPopoverTargetTabIndex(false, {
+                    interactionKind: "click-target",
+                    openOnTargetFocus: true,
+                });
             });
 
             it("opens popover on target focus when interactionKind is HOVER", () => {
@@ -268,19 +280,31 @@ describe("<Popover2>", () => {
 
         describe("if false", () => {
             it("does not add tabindex to target's child node when interactionKind is HOVER", () => {
-                assertPopoverTargetTabIndex("hover", false, false);
+                assertPopoverTargetTabIndex(false, {
+                    interactionKind: "hover",
+                    openOnTargetFocus: false,
+                });
             });
 
             it("does not add tabindex to target's child node when interactionKind is HOVER_TARGET_ONLY", () => {
-                assertPopoverTargetTabIndex("hover-target", false, false);
+                assertPopoverTargetTabIndex(false, {
+                    interactionKind: "hover-target",
+                    openOnTargetFocus: false,
+                });
             });
 
             it("does not add tabindex to target's child node when interactionKind is CLICK", () => {
-                assertPopoverTargetTabIndex("click", false, false);
+                assertPopoverTargetTabIndex(false, {
+                    interactionKind: "click",
+                    openOnTargetFocus: false,
+                });
             });
 
             it("does not add tabindex to target's child node when interactionKind is CLICK_TARGET_ONLY", () => {
-                assertPopoverTargetTabIndex("click-target", false, false);
+                assertPopoverTargetTabIndex(false, {
+                    interactionKind: "click-target",
+                    openOnTargetFocus: false,
+                });
             });
 
             it("does not open popover on target focus when interactionKind is HOVER", () => {
@@ -326,12 +350,8 @@ describe("<Popover2>", () => {
             assert.equal(wrapper.state("isOpen"), isOpen);
         }
 
-        function assertPopoverTargetTabIndex(
-            interactionKind: Popover2InteractionKind,
-            shouldTabIndexExist: boolean,
-            openOnTargetFocus?: boolean,
-        ) {
-            wrapper = renderPopover({ interactionKind, openOnTargetFocus, usePortal: true });
+        function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<IPopover2Props>) {
+            wrapper = renderPopover({ ...popoverProps, usePortal: true });
             const targetElement = wrapper.findClass(Classes.POPOVER2_TARGET).getDOMNode();
 
             if (shouldTabIndexExist) {

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -748,7 +748,7 @@ describe("<Popover2>", () => {
     });
 
     // these tests can be removed once Popover2 is merged into core in v4.0
-    describe.only("compatibility", () => {
+    describe("compatibility", () => {
         it("MenuItem from core package is able to dismiss open Popover2", () => {
             wrapper = renderPopover(
                 { defaultIsOpen: true, usePortal: false },
@@ -756,7 +756,7 @@ describe("<Popover2>", () => {
                     <MenuItem text="Close" />
                 </Menu>,
             );
-            wrapper.find(MenuItem).simulate("click");
+            wrapper.find(`.${CoreClasses.MENU_ITEM}`).simulate("click");
             wrapper.assertIsOpen(false);
         });
     });

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -19,7 +19,7 @@ import { mount, ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
-import { Classes as CoreClasses, Keys, Overlay, Portal } from "@blueprintjs/core";
+import { Classes as CoreClasses, Keys, Menu, MenuItem, Overlay, Portal } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 
 import { Errors, Classes } from "../src";
@@ -744,6 +744,20 @@ describe("<Popover2>", () => {
 
                 setOpenStateSpy.restore();
             }, done);
+        });
+    });
+
+    // these tests can be removed once Popover2 is merged into core in v4.0
+    describe.only("compatibility", () => {
+        it("MenuItem from core package is able to dismiss open Popover2", () => {
+            wrapper = renderPopover(
+                { defaultIsOpen: true, usePortal: false },
+                <Menu>
+                    <MenuItem text="Close" />
+                </Menu>,
+            );
+            wrapper.find(MenuItem).simulate("click");
+            wrapper.assertIsOpen(false);
         });
     });
 


### PR DESCRIPTION
#### Fixes #4502, fixes #4503, fixes #4511

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- [popover2] feat: add `rootBoundary` prop
- [core] fix(Overlay): don't make container focussable unless relevant props are enabled (fixes #4503)
- [popover2] fix: don't apply duplicate tabIndex to target container (fixes #4502)
- [popover2] fix: add support for `MenuItem` dismissal
- [popover2] fix: apply `portalClassName` correctly to the Portal container, not its child Overlay (fixes #4511)

#### Screenshot

showing fix #4503 first, then #4502:

![2021-02-01 14 41 48](https://user-images.githubusercontent.com/723999/106509497-b556b880-649b-11eb-8f5e-069b096f128d.gif)
