### PR TITLE
[core] fix(Toaster): use absolute positioning when inline

### DIFF
--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -165,11 +165,18 @@ $toast-margin: $pt-grid-size * 2 !default;
   // container will not block clicks on elements behind it
   pointer-events: none;
 
-  position: fixed;
   right: 0;
 
   // #975 ensure toasts are on top of everything (esp dialogs)
   z-index: $pt-z-index-overlay * 2;
+
+  &.#{ns}-toast-container-in-portal {
+    position: fixed;
+  }
+
+  &.#{$ns}-toast-container-inline {
+    position: absolute;
+  }
 
   &.#{$ns}-toast-container-top {
     top: 0;

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -186,7 +186,6 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
     }
 
     public render() {
-        // $pt-transition-duration * 3 + $pt-transition-duration / 2
         const classes = classNames(Classes.TOAST_CONTAINER, this.getPositionClasses(), this.props.className);
         return (
             <Overlay
@@ -198,6 +197,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
                 hasBackdrop={false}
                 isOpen={this.state.toasts.length > 0 || this.props.children != null}
                 onClose={this.handleClose}
+                // $pt-transition-duration * 3 + $pt-transition-duration / 2
                 transitionDuration={350}
                 transitionName={Classes.TOAST}
                 usePortal={this.props.usePortal}
@@ -238,7 +238,10 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
     private getPositionClasses() {
         const positions = this.props.position!.split("-");
         // NOTE that there is no -center class because that's the default style
-        return positions.map(p => `${Classes.TOAST_CONTAINER}-${p.toLowerCase()}`);
+        return [
+            ...positions.map(p => `${Classes.TOAST_CONTAINER}-${p.toLowerCase()}`),
+            `${Classes.TOAST_CONTAINER}-${this.props.usePortal ? "in-portal" : "inline"}`,
+        ];
     }
 
     private getDismissHandler = (toast: IToastOptions) => (timeoutExpired: boolean) => {

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -53,6 +53,7 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
         autoFocus: false,
         canEscapeKeyClear: true,
         position: Position.TOP,
+        usePortal: true,
     };
 
     private TOAST_BUILDERS: IToastDemo[] = [
@@ -123,6 +124,8 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
 
     private toggleEscapeKey = handleBooleanChange(canEscapeKeyClear => this.setState({ canEscapeKeyClear }));
 
+    private toggleUsePortal = handleBooleanChange(usePortal => this.setState({ usePortal }));
+
     public render() {
         return (
             <Example options={this.renderOptions()} {...this.props}>
@@ -134,7 +137,7 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
     }
 
     protected renderOptions() {
-        const { autoFocus, canEscapeKeyClear, position, maxToasts } = this.state;
+        const { autoFocus, canEscapeKeyClear, position, maxToasts, usePortal } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -154,6 +157,7 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
                 </Label>
                 <Switch label="Auto focus" checked={autoFocus} onChange={this.toggleAutoFocus} />
                 <Switch label="Can escape key clear" checked={canEscapeKeyClear} onChange={this.toggleEscapeKey} />
+                <Switch label="Use portal" checked={usePortal} onChange={this.toggleUsePortal} />
             </>
         );
     }

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -499,6 +499,13 @@
   }
 }
 
+#{example("ToastExample")} {
+  .docs-example {
+    // necessary for inline Toaster (usePortal={false})
+    position: relative;
+  }
+}
+
 //
 // DATETIME
 //


### PR DESCRIPTION
#### Fixes #4538

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Update toaster container to use `position: absolute` when `usePortal={false}`. This seems like the proper layout approach. This is a slight breaking change but also a bugfix, so in practice it should be ok for users of this option...

#### Reviewers should focus on:

No regressions for `usePortal={true}`

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://user-images.githubusercontent.com/723999/109718421-4e4d2200-7b75-11eb-9b84-df49a143fae5.png)
