### PR TITLE
[core] fix(Icon): accept standard HTML attributes

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -87,7 +87,9 @@ export interface IIconProps extends IIntentProps, IProps {
 }
 
 @polyfill
-export class Icon extends AbstractPureComponent2<IIconProps & React.DOMAttributes<HTMLElement>> {
+export class Icon extends AbstractPureComponent2<
+    IIconProps & Omit<React.HTMLAttributes<HTMLElement>, "title"> & React.DOMAttributes<HTMLElement>
+> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Icon`;
 
     public static readonly SIZE_STANDARD = 16;

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -87,9 +87,7 @@ export interface IIconProps extends IIntentProps, IProps {
 }
 
 @polyfill
-export class Icon extends AbstractPureComponent2<
-    IIconProps & Omit<React.HTMLAttributes<HTMLElement>, "title"> & React.DOMAttributes<HTMLElement>
-> {
+export class Icon extends AbstractPureComponent2<IIconProps & Omit<React.HTMLAttributes<HTMLElement>, "title">> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Icon`;
 
     public static readonly SIZE_STANDARD = 16;


### PR DESCRIPTION
#### Fixes #4500

#### Checklist

- [X] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

This PR adds standard default HTML attributes to the core Icon component. The motivation was the inability to set a role for icons and with the proposed solution in the linked issue this is now possible.

#### Reviewers should focus on:

Unfortunately the `IIconProps` type already declares a `title` property which collides with the definition in `HTMLAttributes` due to deviating types. In order to prevent issue in the `HTMLSelect` component I decided to omit the latter. This fix is open for dicussion.
