### PR TITLE
chore: revert all React imports to namespace import syntax

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeysDialog2.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "../../common";
 import { HotkeyConfig } from "../../hooks";

--- a/packages/core/src/components/hotkeys/hotkeysTarget2.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from "react";
+import * as React from "react";
 
 import * as Errors from "../../common/errors";
 import { isNodeEnv } from "../../common/utils";
@@ -48,7 +48,7 @@ export const HotkeysTarget2 = ({ children, hotkeys, options }: HotkeysTarget2Pro
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys, options);
 
     // run props validation
-    useEffect(() => {
+    React.useEffect(() => {
         if (!isNodeEnv("production")) {
             if (typeof children !== "function" && hotkeys.some(h => !h.global)) {
                 console.error(Errors.HOTKEYS_TARGET2_CHILDREN_LOCAL_HOTKEYS);

--- a/packages/core/src/components/panel-stack2/panelStack2.tsx
+++ b/packages/core/src/components/panel-stack2/panelStack2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { useCallback, useState } from "react";
+import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
@@ -73,16 +73,16 @@ interface PanelStack2Component {
 
 export const PanelStack2: PanelStack2Component = <T,>(props: PanelStack2Props<T>) => {
     const { renderActivePanelOnly = true, showPanelHeader = true } = props;
-    const [direction, setDirection] = useState("push");
+    const [direction, setDirection] = React.useState("push");
 
-    const [localStack, setLocalStack] = useState(props.initialPanel !== undefined ? [props.initialPanel] : []);
+    const [localStack, setLocalStack] = React.useState(props.initialPanel !== undefined ? [props.initialPanel] : []);
     const stack = props.stack != null ? props.stack.slice().reverse() : localStack;
 
     if (stack.length === 0) {
         return null;
     }
 
-    const handlePanelOpen = useCallback(
+    const handlePanelOpen = React.useCallback(
         (panel: Panel<T>) => {
             props.onOpen?.(panel);
             if (props.stack == null) {
@@ -92,7 +92,7 @@ export const PanelStack2: PanelStack2Component = <T,>(props: PanelStack2Props<T>
         },
         [props.onOpen],
     );
-    const handlePanelClose = useCallback(
+    const handlePanelClose = React.useCallback(
         (panel: Panel<T>) => {
             // only remove this panel if it is at the top and not the only one.
             if (stack[0] !== panel || stack.length <= 1) {

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Button } from "../button/buttons";
@@ -50,7 +50,7 @@ interface PanelView2Component {
 }
 
 export const PanelView2: PanelView2Component = <T,>(props: PanelView2Props<T>) => {
-    const handleClose = useCallback(() => props.onClose(props.panel), [props.onClose, props.panel]);
+    const handleClose = React.useCallback(() => props.onClose(props.panel), [props.onClose, props.panel]);
 
     const maybeBackButton =
         props.previousPanel === undefined ? null : (

--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { createContext, useReducer, Dispatch, useCallback } from "react";
+import * as React from "react";
 
 import { HotkeysDialog2, HotkeysDialog2Props } from "../../components/hotkeys/hotkeysDialog2";
 import { HotkeyConfig } from "../../hooks";
@@ -32,10 +32,10 @@ type HotkeysAction =
     | { type: "CLOSE_DIALOG" | "OPEN_DIALOG" };
 
 const initialHotkeysState: HotkeysContextState = { hotkeys: [], isDialogOpen: false };
-const noOpDispatch: Dispatch<HotkeysAction> = () => null;
+const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
 
 // we can remove this guard once Blueprint depends on React 16
-export const HotkeysContext = createContext?.<[HotkeysContextState, Dispatch<HotkeysAction>]>([
+export const HotkeysContext = React.createContext?.<[HotkeysContextState, React.Dispatch<HotkeysAction>]>([
     initialHotkeysState,
     noOpDispatch,
 ]);
@@ -76,8 +76,8 @@ export interface HotkeysProviderProps {
  * Hotkeys context provider, necessary for the `useHotkeys` hook.
  */
 export const HotkeysProvider = ({ children, dialogProps, renderDialog }: HotkeysProviderProps) => {
-    const [state, dispatch] = useReducer(hotkeysReducer, initialHotkeysState);
-    const handleDialogClose = useCallback(() => dispatch({ type: "CLOSE_DIALOG" }), []);
+    const [state, dispatch] = React.useReducer(hotkeysReducer, initialHotkeysState);
+    const handleDialogClose = React.useCallback(() => dispatch({ type: "CLOSE_DIALOG" }), []);
 
     const dialog = renderDialog?.(state, { handleDialogClose }) ?? (
         <HotkeysDialog2

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import React, { useMemo } from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { InputGroup } from "@blueprintjs/core";
@@ -37,7 +37,7 @@ interface TestComponentContainerProps {
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputReadOnly, onKeyA, onKeyB }) => {
-    const hotkeys = useMemo(() => {
+    const hotkeys = React.useMemo(() => {
         const keys = [
             {
                 combo: "A",

--- a/packages/core/test/panel-stack2/panelStack2Tests.tsx
+++ b/packages/core/test/panel-stack2/panelStack2Tests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes, Panel, PanelProps, PanelStack2Props, PanelStack2 } from "../../src";

--- a/packages/docs-app/src/components/navIcons.tsx
+++ b/packages/docs-app/src/components/navIcons.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export const NavIcon: React.FunctionComponent<{ route: string }> = ({ route }) => {
     return (

--- a/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
+++ b/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { useEffect, useState } from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -31,10 +31,10 @@ interface IPianoKeyProps {
 }
 
 export const PianoKey: React.FC<IPianoKeyProps> = ({ context, hotkey, note, pressed }) => {
-    const [envelope, setEnvelope] = useState<Envelope>();
+    const [envelope, setEnvelope] = React.useState<Envelope>();
 
     // only create oscillator and envelop once on mount
-    useEffect(() => {
+    React.useEffect(() => {
         if (context !== undefined) {
             const oscillator = new Oscillator(context, Scale[note]);
             const newEnvelope = new Envelope(context);
@@ -45,7 +45,7 @@ export const PianoKey: React.FC<IPianoKeyProps> = ({ context, hotkey, note, pres
     }, [context]);
 
     // start/stop envelope when this key is pressed down/up
-    useEffect(() => {
+    React.useEffect(() => {
         if (pressed) {
             envelope?.on();
         } else {

--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/hotkeysTarget2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeysTarget2Example.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { HotkeysTarget2, IHotkeyProps } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useState } from "react";
+import * as React from "react";
 
 import { Button, H5, Intent, Panel, PanelProps, NumericInput, PanelStack2, Switch, UL } from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
@@ -24,8 +24,8 @@ interface PanelExampleInfo {
 }
 
 const PanelExample: React.FC<PanelProps<PanelExampleInfo>> = props => {
-    const [counter, setCounter] = useState(0);
-    const openNewPanel = useCallback(() => {
+    const [counter, setCounter] = React.useState(0);
+    const openNewPanel = React.useCallback(() => {
         const panelNumber = props.panelNumber + 1;
         props.openPanel({
             props: { panelNumber },
@@ -52,17 +52,17 @@ const initialPanel: Panel<PanelExampleInfo> = {
 };
 
 export const PanelStack2Example: React.FC<IExampleProps> = props => {
-    const [activePanelOnly, setActivePanelOnly] = useState(true);
-    const [showHeader, setShowHeader] = useState(true);
-    const [currentPanelStack, setCurrentPanelStack] = useState([initialPanel]);
+    const [activePanelOnly, setActivePanelOnly] = React.useState(true);
+    const [showHeader, setShowHeader] = React.useState(true);
+    const [currentPanelStack, setCurrentPanelStack] = React.useState([initialPanel]);
 
-    const toggleActiveOnly = useCallback(handleBooleanChange(setActivePanelOnly), []);
-    const toggleShowHeader = useCallback(handleBooleanChange(setShowHeader), []);
-    const addToPanelStack = useCallback(
+    const toggleActiveOnly = React.useCallback(handleBooleanChange(setActivePanelOnly), []);
+    const toggleShowHeader = React.useCallback(handleBooleanChange(setShowHeader), []);
+    const addToPanelStack = React.useCallback(
         (newPanel: Panel<PanelExampleInfo>) => setCurrentPanelStack(stack => [newPanel, ...stack]),
         [],
     );
-    const removeFromPanelStack = useCallback(() => setCurrentPanelStack(stack => stack.slice(1)), []);
+    const removeFromPanelStack = React.useCallback(() => setCurrentPanelStack(stack => stack.slice(1)), []);
 
     const stackList = (
         <>

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from "react";
+import * as React from "react";
 
 import { useHotkeys } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
@@ -40,7 +40,7 @@ export const UseHotkeysExample: React.FC<IExampleProps> = props => {
             setPressed,
         }));
 
-    const hotkeys = useMemo(
+    const hotkeys = React.useMemo(
         () => [
             {
                 combo: "shift + P",

--- a/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Colors, Icon, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes as CoreClasses, IOverlayLifecycleProps, Utils as CoreUtils, mergeRefs } from "@blueprintjs/core";
 

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { IItemListRendererProps, renderFilteredItems } from "../src";

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { IFocusedCellCoordinates } from "../src/common/cell";


### PR DESCRIPTION
#### Fixes #4563

Following up on the simple revert of one commit in f515648bc0c5dd95de282b8d2332829263735bfb, which was incomplete because there were features added to develop using the new import syntax.

#### Changes proposed in this pull request:

Replace all instances of synthetic default imports of `"react"` with namespace imports, i.e. `import * as React from "react"'`

