### PR TITLE
[v4] chore: remove references to React 15 in tests

### DIFF
--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -4,8 +4,6 @@
 
 const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
 
-const REACT = process.env.REACT || "16";
-
 module.exports = function (config) {
     const coverageExcludes = [
         // not worth full coverage
@@ -25,12 +23,6 @@ module.exports = function (config) {
         "src/components/hotkeys/hotkeysTarget.tsx",
         "src/context/hotkeys/hotkeysProvider.tsx",
     ];
-
-    if (REACT === "15") {
-        console.info("Excluding features which require React 16 from coverage requiremenst...");
-        // features require React 16.8+
-        coverageExcludes.push("src/context/**/*.ts*", "src/hooks/**/*.ts*", "src/components/panel-stack2/*");
-    }
 
     const baseConfig = createKarmaConfig({
         dirname: __dirname,

--- a/packages/webpack-build-scripts/webpack.config.karma.js
+++ b/packages/webpack-build-scripts/webpack.config.karma.js
@@ -6,8 +6,6 @@ const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const path = require("path");
 const webpack = require("webpack");
 
-const REACT = process.env.REACT || "16";
-
 /**
  * This differs significantly from the base webpack config, so we don't even end up extending from it.
  */
@@ -18,21 +16,6 @@ module.exports = {
     mode: "development",
 
     resolve: {
-        // swap versions of React packages when this env variable is set
-        alias:
-            REACT === "15"
-                ? {
-                      // swap enzyme adapter
-                      "enzyme-adapter-react-16": "enzyme-adapter-react-15",
-                      // use path.resolve for directory (require.resolve returns main file)
-                      react: path.resolve(__dirname, "../test-react15/node_modules/react"),
-                      "react-dom": path.resolve(__dirname, "../test-react15/node_modules/react-dom"),
-                      "react-test-renderer": path.resolve(
-                          __dirname,
-                          "../test-react15/node_modules/react-test-renderer",
-                      ),
-                  }
-                : {},
         extensions: [".css", ".js", ".ts", ".tsx"],
         fallback: {
             assert: require.resolve("assert/"),


### PR DESCRIPTION
I tried adding a React 17 test suite, but Enzyme doesn't have an adapter for it yet (https://github.com/enzymejs/enzyme/issues/2429) and the unofficial adapter [`@wojtekmaj/enzyme-adapter-react-17
`](https://www.npmjs.com/package/@wojtekmaj/enzyme-adapter-react-17) didn't work out of the box with the way we're doing webpack aliasing, so I am deferring that until the official Enzyme adapter arrives.