### PR TITLE
[v4] use synthetic default imports for React

### DIFF
--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useCallback, useState } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
@@ -85,18 +85,16 @@ interface PanelStackComponent {
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: PanelStackProps<T>) => {
     const { renderActivePanelOnly = true, showPanelHeader = true } = props;
-    const [direction, setDirection] = React.useState("push");
+    const [direction, setDirection] = useState("push");
 
-    const [localStack, setLocalStack] = React.useState<T[]>(
-        props.initialPanel !== undefined ? [props.initialPanel] : [],
-    );
+    const [localStack, setLocalStack] = useState<T[]>(props.initialPanel !== undefined ? [props.initialPanel] : []);
     const stack = props.stack != null ? props.stack.slice().reverse() : localStack;
 
     if (stack.length === 0) {
         return null;
     }
 
-    const handlePanelOpen = React.useCallback(
+    const handlePanelOpen = useCallback(
         (panel: T) => {
             props.onOpen?.(panel);
             if (props.stack == null) {

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React, { useCallback } from "react";
 
 import { ChevronLeft } from "@blueprintjs/icons";
 
@@ -55,7 +55,7 @@ interface PanelViewComponent {
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const PanelView: PanelViewComponent = <T extends Panel<object>>(props: PanelViewProps<T>) => {
-    const handleClose = React.useCallback(() => props.onClose(props.panel), [props.onClose, props.panel]);
+    const handleClose = useCallback(() => props.onClose(props.panel), [props.onClose, props.panel]);
 
     const maybeBackButton =
         props.previousPanel === undefined ? null : (

--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React, { createContext } from "react";
 
 import { HotkeysDialog, HotkeysDialogProps } from "../../components/hotkeys/hotkeysDialog";
 import { HotkeyConfig } from "../../hooks";
@@ -34,8 +34,7 @@ type HotkeysAction =
 const initialHotkeysState: HotkeysContextState = { hotkeys: [], isDialogOpen: false };
 const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
 
-// we can remove this guard once Blueprint depends on React 16
-export const HotkeysContext = React.createContext?.<[HotkeysContextState, React.Dispatch<HotkeysAction>]>([
+export const HotkeysContext = createContext<[HotkeysContextState, React.Dispatch<HotkeysAction>]>([
     initialHotkeysState,
     noOpDispatch,
 ]);

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
+import React, { useMemo } from "react";
 import { spy } from "sinon";
 
 // N.B. { fireEvent } from "@testing-library/react" does not generate "real" enough events which
@@ -37,7 +37,7 @@ interface TestComponentContainerProps {
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputReadOnly, onKeyA, onKeyB }) => {
-    const hotkeys = React.useMemo(() => {
+    const hotkeys = useMemo(() => {
         const keys = [
             {
                 combo: "A",

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import * as React from "react";
+import React from "react";
 import { spy } from "sinon";
 
 import { Classes, Panel, PanelProps, PanelStackProps, PanelStack } from "../../src";
@@ -38,11 +38,6 @@ const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
 };
 
 describe("<PanelStack>", () => {
-    if (React.version.startsWith("15")) {
-        it("skipped tests for backwards-incompatible component", () => assert(true));
-        return;
-    }
-
     let testsContainerElement: HTMLElement;
     let panelStackWrapper: PanelStackWrapper<TestPanelType>;
 

--- a/packages/docs-app/src/components/colorSchemes.tsx
+++ b/packages/docs-app/src/components/colorSchemes.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as chroma from "chroma-js";
+import chroma from "chroma-js";
 import classNames from "classnames";
 import React from "react";
 

--- a/packages/docs-app/src/components/navIcons.tsx
+++ b/packages/docs-app/src/components/navIcons.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React from "react";
 
-export const NavIcon: React.FunctionComponent<{ route: string }> = ({ route }) => {
+export const NavIcon: React.FC<{ route: string }> = ({ route }) => {
     return (
         <svg className="docs-nav-package-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
             {ICON_CONTENTS[route]}

--- a/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
+++ b/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useEffect, useState } from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -31,10 +31,10 @@ interface PianoKeyProps {
 }
 
 export const PianoKey: React.FC<PianoKeyProps> = ({ context, hotkey, note, pressed }) => {
-    const [envelope, setEnvelope] = React.useState<Envelope>();
+    const [envelope, setEnvelope] = useState<Envelope>();
 
     // only create oscillator and envelop once on mount
-    React.useEffect(() => {
+    useEffect(() => {
         if (context !== undefined) {
             const oscillator = new Oscillator(context, Scale[note]);
             const newEnvelope = new Envelope(context);
@@ -45,7 +45,7 @@ export const PianoKey: React.FC<PianoKeyProps> = ({ context, hotkey, note, press
     }, [context]);
 
     // start/stop envelope when this key is pressed down/up
-    React.useEffect(() => {
+    useEffect(() => {
         if (pressed) {
             envelope?.on();
         } else {

--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -15,14 +15,14 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useCallback } from "react";
 
 import { Classes, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { ContextMenu2, ContextMenu2RenderProps } from "@blueprintjs/popover2";
 
 export const ContextMenu2Example: React.FC<ExampleProps> = props => {
-    const renderContent = React.useCallback(
+    const renderContent = useCallback(
         ({ targetOffset }: ContextMenu2RenderProps) => (
             <Menu>
                 <MenuItem icon="select" text="Select all" />
@@ -54,7 +54,7 @@ export const ContextMenu2Example: React.FC<ExampleProps> = props => {
 };
 
 const GraphNode: React.FC = () => {
-    const children = React.useCallback(
+    const children = useCallback(
         ({ isOpen }) => <div className={classNames("docs-context-menu-node", { "docs-context-menu-open": isOpen })} />,
         [],
     );

--- a/packages/docs-app/src/examples/core-examples/hotkeysTargetExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeysTargetExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React from "react";
 
 import { HotkeysTarget, HotkeyProps } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -21,7 +21,7 @@
  * Panel1 renders either a new Panel2 or Panel3. Panel2 and Panel3 both render a new Panel1.
  */
 
-import * as React from "react";
+import React, { useCallback, useState } from "react";
 
 import { Button, H5, Intent, Panel, PanelProps, NumericInput, PanelStack, Switch, UL } from "@blueprintjs/core";
 import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
@@ -32,7 +32,7 @@ interface Panel1Info {
 }
 
 const Panel1: React.FC<PanelProps<Panel1Info>> = props => {
-    const [counter, setCounter] = React.useState(0);
+    const [counter, setCounter] = useState(0);
     const shouldOpenPanelType2 = counter % 2 === 0;
 
     const openNewPanel = () => {
@@ -113,19 +113,19 @@ const initialPanel: Panel<Panel1Info> = {
 };
 
 export const PanelStackExample: React.FC<ExampleProps> = props => {
-    const [activePanelOnly, setActivePanelOnly] = React.useState(true);
-    const [showHeader, setShowHeader] = React.useState(true);
-    const [currentPanelStack, setCurrentPanelStack] = React.useState<
-        Array<Panel<Panel1Info | Panel2Info | Panel3Info>>
-    >([initialPanel]);
+    const [activePanelOnly, setActivePanelOnly] = useState(true);
+    const [showHeader, setShowHeader] = useState(true);
+    const [currentPanelStack, setCurrentPanelStack] = useState<Array<Panel<Panel1Info | Panel2Info | Panel3Info>>>([
+        initialPanel,
+    ]);
 
-    const toggleActiveOnly = React.useCallback(handleBooleanChange(setActivePanelOnly), []);
-    const toggleShowHeader = React.useCallback(handleBooleanChange(setShowHeader), []);
-    const addToPanelStack = React.useCallback(
+    const toggleActiveOnly = useCallback(handleBooleanChange(setActivePanelOnly), []);
+    const toggleShowHeader = useCallback(handleBooleanChange(setShowHeader), []);
+    const addToPanelStack = useCallback(
         (newPanel: Panel<Panel1Info | Panel2Info | Panel3Info>) => setCurrentPanelStack(stack => [newPanel, ...stack]),
         [],
     );
-    const removeFromPanelStack = React.useCallback(() => setCurrentPanelStack(stack => stack.slice(1)), []);
+    const removeFromPanelStack = useCallback(() => setCurrentPanelStack(stack => stack.slice(1)), []);
 
     const stackList = (
         <>

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 
 import { useHotkeys } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
@@ -22,10 +22,10 @@ import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { PianoKey } from "./audio";
 
 export const UseHotkeysExample: React.FC<ExampleProps> = props => {
-    const [audioContext, setAudioContext] = React.useState<AudioContext>();
+    const [audioContext, setAudioContext] = useState<AudioContext>();
 
-    const pianoRef = React.useRef<HTMLDivElement>();
-    const focusPiano = React.useCallback(() => {
+    const pianoRef = useRef<HTMLDivElement>();
+    const focusPiano = useCallback(() => {
         pianoRef?.current.focus();
         if (typeof window.AudioContext !== "undefined" && audioContext === undefined) {
             setAudioContext(new AudioContext());
@@ -34,13 +34,13 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
 
     // create a dictionary of key states and updater functions
     const keys = Array.apply(null, Array(24))
-        .map(() => React.useState(() => false), [])
+        .map(() => useState(() => false), [])
         .map(([pressed, setPressed]) => ({
             pressed,
             setPressed,
         }));
 
-    const hotkeys = React.useMemo(
+    const hotkeys = useMemo(
         () => [
             {
                 combo: "shift + P",

--- a/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/components/customTimezoneTarget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React from "react";
 
 import { Colors, Icon, Intent } from "@blueprintjs/core";
 import { Tooltip2 } from "@blueprintjs/popover2";

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 
 import { Classes as CoreClasses, OverlayLifecycleProps, Utils as CoreUtils, mergeRefs } from "@blueprintjs/core";
 
@@ -53,10 +53,10 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
     transitionDuration = 100,
     ...restProps
 }) => {
-    const [targetOffset, setTargetOffset] = React.useState<Offset>({ left: 0, top: 0 });
-    const [isOpen, setIsOpen] = React.useState<boolean>(false);
+    const [targetOffset, setTargetOffset] = useState<Offset>({ left: 0, top: 0 });
+    const [isOpen, setIsOpen] = useState<boolean>(false);
 
-    const handleContextMenu = React.useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
         // support nested menus (inner menu target would have called preventDefault())
         if (e.defaultPrevented) {
             return;
@@ -68,16 +68,16 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
         setIsOpen(true);
     }, []);
 
-    const cancelContextMenu = React.useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
+    const cancelContextMenu = useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
 
-    const handlePopoverInteraction = React.useCallback((nextOpenState: boolean) => {
+    const handlePopoverInteraction = useCallback((nextOpenState: boolean) => {
         if (!nextOpenState) {
             setIsOpen(false);
         }
     }, []);
 
-    const targetRef = React.useRef<HTMLDivElement>();
-    const renderTarget = React.useCallback(
+    const targetRef = useRef<HTMLDivElement>();
+    const renderTarget = useCallback(
         ({ ref }: Popover2TargetProps) => (
             <div
                 className={Classes.CONTEXT_MENU2_POPOVER_TARGET}
@@ -87,7 +87,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
         ),
         [targetOffset],
     );
-    const isDarkTheme = React.useMemo(() => CoreUtils.isDarkTheme(targetRef?.current), [targetRef.current]);
+    const isDarkTheme = useMemo(() => CoreUtils.isDarkTheme(targetRef?.current), [targetRef.current]);
 
     // Generate key based on offset so a new Popover instance is created
     // when offset changes, to force recomputing position.

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import * as React from "react";
+import React from "react";
 import sinon from "sinon";
 
 import { ItemListRendererProps, renderFilteredItems } from "../src";

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
+import React from "react";
 import sinon from "sinon";
 
 import { FocusedCellCoordinates } from "../src/common/cell";

--- a/packages/test-commons/src/generateIsomorphicTests.ts
+++ b/packages/test-commons/src/generateIsomorphicTests.ts
@@ -5,7 +5,7 @@
  */
 
 import { strictEqual } from "assert";
-import * as Enzyme from "enzyme";
+import Enzyme from "enzyme";
 import React from "react";
 
 function isReactClass(Component: any): Component is React.ComponentClass<any> {


### PR DESCRIPTION
Following up on https://github.com/palantir/blueprint/pull/4544, refactoring all remaining `import * as React` import statements to `import React`...