### PR TITLE
[v4] fix(ContextMenu2): position correctly inside Collapse containers

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -87,6 +87,10 @@ export const LIST = `${NS}-list`;
 export const LIST_UNSTYLED = `${NS}-list-unstyled`;
 export const RTL = `${NS}-rtl`;
 
+// layout utilities
+/** @see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block */
+export const FIXED_POSITIONING_CONTAINING_BLOCK = `${NS}-fixed-positioning-containing-block`;
+
 // components
 export const ALERT = `${NS}-alert`;
 export const ALERT_BODY = `${ALERT}-body`;

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -180,6 +180,9 @@ export class Collapse extends AbstractPureComponent<CollapseProps, CollapseState
             transition: isAutoHeight ? "none" : undefined,
         };
 
+        // in order to give hints to child elements which rely on CSS fixed positioning, we need to apply a class
+        // to the element which creates a new containing block with a non-empty `transform` property
+        // see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
         const contentsStyle = {
             // only use heightWhenOpen while closing
             transform: displayWithTransform ? "translateY(0)" : `translateY(-${this.state.heightWhenOpen}px)`,
@@ -194,7 +197,7 @@ export class Collapse extends AbstractPureComponent<CollapseProps, CollapseState
                 style: containerStyle,
             },
             <div
-                className={Classes.COLLAPSE_BODY}
+                className={classNames(Classes.COLLAPSE_BODY, Classes.FIXED_POSITIONING_CONTAINING_BLOCK)}
                 ref={this.contentsRefHandler}
                 style={contentsStyle}
                 aria-hidden={!isContentVisible && this.props.keepChildrenMounted}

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -54,6 +54,12 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
       }
     }
   }
+
+  &.#{$ns}-fixed-positioning-containing-block {
+    // use the same transform as the Collapse component, to mimic the behavior of creating a new
+    // containing block for children which are position: fixed (like ContextMenu2 targets)
+    transform: translateY(0);
+  }
 }
 
 .#{$ns}-tree-node-list {

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -87,7 +87,7 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
 
     public render() {
         return (
-            <div className={classNames(Classes.TREE, this.props.className)}>
+            <div className={classNames(Classes.TREE, Classes.FIXED_POSITIONING_CONTAINING_BLOCK, this.props.className)}>
                 {this.renderNodes(this.props.contents, [], Classes.TREE_ROOT)}
             </div>
         );

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -37,17 +37,17 @@ describe("<Tree>", () => {
 
     it("renders its contents", () => {
         const tree = renderTree({ contents: [{ id: 0, label: "Node" }] });
-        assert.lengthOf(tree.find({ className: Classes.TREE }), 1);
+        assert.lengthOf(tree.find(`.${Classes.TREE}`), 1);
     });
 
     it("handles undefined input well", () => {
         const tree = renderTree({ contents: undefined });
-        assert.lengthOf(tree.find({ className: Classes.TREE }), 1);
+        assert.lengthOf(tree.find(`.${Classes.TREE}`), 1);
     });
 
     it("handles empty input well", () => {
         const tree = renderTree({ contents: [] });
-        assert.lengthOf(tree.find({ className: Classes.TREE }), 1);
+        assert.lengthOf(tree.find(`.${Classes.TREE}`), 1);
     });
 
     it("hasCaret forces a caret to be/not be displayed", () => {

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -31,6 +31,7 @@
         "classnames": "^2.2",
         "dom4": "^2.1.5",
         "downloadjs": "^1.4.7",
+        "lodash-es": "^4.17.15",
         "moment": "^2.29.1",
         "normalize.css": "^8.0.1",
         "popper.js": "^1.16.1",

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -18,7 +18,7 @@ import React, { useCallback, useReducer } from "react";
 
 import { Classes, Icon, Intent, TreeNodeInfo, Tree } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
-import { Tooltip2 } from "@blueprintjs/popover2";
+import { Classes as Popover2Classes, ContextMenu2, Tooltip2 } from "@blueprintjs/popover2";
 
 type NodePath = number[];
 
@@ -108,16 +108,22 @@ const INITIAL_STATE: TreeNodeInfo[] = [
         id: 0,
         hasCaret: true,
         icon: "folder-close",
-        label: "Folder 0",
+        label: (
+            <ContextMenu2 popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING} content={<div>Hello there!</div>}>
+                Folder 0
+            </ContextMenu2>
+        ),
     },
     {
         id: 1,
         icon: "folder-close",
         isExpanded: true,
         label: (
-            <Tooltip2 content="I'm a folder <3" placement="right">
-                Folder 1
-            </Tooltip2>
+            <ContextMenu2 popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING} content={<div>Hello there!</div>}>
+                <Tooltip2 content="I'm a folder <3" placement="right">
+                    Folder 1
+                </Tooltip2>
+            </ContextMenu2>
         ),
         childNodes: [
             {
@@ -140,9 +146,14 @@ const INITIAL_STATE: TreeNodeInfo[] = [
                 hasCaret: true,
                 icon: "folder-close",
                 label: (
-                    <Tooltip2 content="foo" placement="right">
-                        Folder 2
-                    </Tooltip2>
+                    <ContextMenu2
+                        popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING}
+                        content={<div>Hello there!</div>}
+                    >
+                        <Tooltip2 content="foo" placement="right">
+                            Folder 2
+                        </Tooltip2>
+                    </ContextMenu2>
                 ),
                 childNodes: [
                     { id: 5, label: "No-Icon Item" },
@@ -151,7 +162,14 @@ const INITIAL_STATE: TreeNodeInfo[] = [
                         id: 7,
                         hasCaret: true,
                         icon: "folder-close",
-                        label: "Folder 3",
+                        label: (
+                            <ContextMenu2
+                                popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING}
+                                content={<div>Hello there!</div>}
+                            >
+                                Folder 3
+                            </ContextMenu2>
+                        ),
                         childNodes: [
                             { id: 8, icon: "document", label: "Item 0" },
                             { id: 9, icon: "tag", label: "Item 1" },

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { cloneDeep } from "lodash-es";
 import React, { useCallback, useReducer } from "react";
 
 import { Classes, Icon, Intent, TreeNodeInfo, Tree } from "@blueprintjs/core";
@@ -27,8 +28,8 @@ type TreeAction =
     | { type: "DESELECT_ALL" }
     | { type: "SET_IS_SELECTED"; payload: { path: NodePath; isSelected: boolean } };
 
-function forEachNode(nodes: TreeNodeInfo[], callback: (node: TreeNodeInfo) => void) {
-    if (nodes == null) {
+function forEachNode(nodes: TreeNodeInfo[] | undefined, callback: (node: TreeNodeInfo) => void) {
+    if (nodes === undefined) {
         return;
     }
 
@@ -45,15 +46,15 @@ function forNodeAtPath(nodes: TreeNodeInfo[], path: NodePath, callback: (node: T
 function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
     switch (action.type) {
         case "DESELECT_ALL":
-            const newState1 = [...state];
+            const newState1 = cloneDeep(state);
             forEachNode(newState1, node => (node.isSelected = false));
             return newState1;
         case "SET_IS_EXPANDED":
-            const newState2 = [...state];
+            const newState2 = cloneDeep(state);
             forNodeAtPath(newState2, action.payload.path, node => (node.isExpanded = action.payload.isExpanded));
             return newState2;
         case "SET_IS_SELECTED":
-            const newState3 = [...state];
+            const newState3 = cloneDeep(state);
             forNodeAtPath(newState3, action.payload.path, node => (node.isSelected = action.payload.isSelected));
             return newState3;
         default:

--- a/packages/popover2/src/_context-menu2.scss
+++ b/packages/popover2/src/_context-menu2.scss
@@ -1,0 +1,12 @@
+// Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "./common";
+
+.#{$ns}-context-menu2 .#{$ns}-popover2-target {
+  display: block;
+}
+
+.#{$ns}-context-menu2-popover2-target {
+  position: fixed;
+}

--- a/packages/popover2/src/blueprint-popover2.scss
+++ b/packages/popover2/src/blueprint-popover2.scss
@@ -5,6 +5,7 @@ Licensed under the Apache License, Version 2.0.
 
 */
 
+@import "context-menu2";
 @import "popover2";
 @import "popover2-in-button-group";
 @import "popover2-in-control-group";

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -18,8 +18,8 @@ import { Classes } from "@blueprintjs/core";
 
 const NS = Classes.getClassNamespace();
 
-export const CONTEXT_MENU2 = `${NS}-context-menu`;
-export const CONTEXT_MENU2_POPOVER_TARGET = `${CONTEXT_MENU2}-popover-target`;
+export const CONTEXT_MENU2 = `${NS}-context-menu2`;
+export const CONTEXT_MENU2_POPOVER2_TARGET = `${CONTEXT_MENU2}-popover2-target`;
 
 export const POPOVER2 = `${NS}-popover2`;
 export const POPOVER2_ARROW = `${POPOVER2}-arrow`;

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -90,7 +90,6 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
             <div
                 className={Classes.CONTEXT_MENU2_POPOVER2_TARGET}
                 style={targetOffset}
-                // style={{ transform: `translate(${targetOffset.left}px, ${targetOffset.top}px)` }}
                 ref={mergeRefs(ref, targetRef)}
             />
         ),

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { State as PopperState } from "@popperjs/core";
+import { State as PopperState, PositioningStrategy } from "@popperjs/core";
 import classNames from "classnames";
 import React from "react";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps, StrictModifier } from "react-popper";
@@ -86,6 +86,14 @@ export interface Popover2Props<TProps = React.HTMLProps<HTMLElement>> extends Po
      * Ref supplied to the `Classes.POPOVER` element.
      */
     popoverRef?: (ref: HTMLElement | null) => void;
+
+    /**
+     * Popper.js positioning strategy.
+     *
+     * @see https://popper.js.org/docs/v2/constructors/#strategy
+     * @default "absolute"
+     */
+    positioningStrategy?: PositioningStrategy;
 }
 
 export interface Popover2State {
@@ -115,6 +123,7 @@ export class Popover2<T> extends AbstractPureComponent<Popover2Props<T>, Popover
         minimal: false,
         openOnTargetFocus: true,
         placement: "auto",
+        positioningStrategy: "absolute",
         renderTarget: undefined as any,
         targetTagName: "span",
         transitionDuration: 300,
@@ -199,7 +208,7 @@ export class Popover2<T> extends AbstractPureComponent<Popover2Props<T>, Popover
                 <Popper
                     innerRef={this.refHandlers.popover}
                     placement={this.props.placement}
-                    strategy="absolute"
+                    strategy={this.props.positioningStrategy}
                     modifiers={this.computePopperModifiers()}
                 >
                     {this.renderPopover}


### PR DESCRIPTION
#### Fixes #4537

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Refactor Tree example as a function component with cleaner state handling logic (using a React reducer hook)
- Add a repro case for #4537 in the refactored Tree example
- Add `positioningStrategy` prop for Popover2
- Add `popoverClassName` prop for ContextMenu2
- Fix `ContextMenu2`'s styles to use their own classes instead of `ContextMenu`'s, add the relevant Sass stylesheet
- Create a new utility class `.bp4-fixed-positioning-containing-block` which is used to give hints to child / ancestor elements which use `position: fixed` and need to know about their containing block for proper layout calculations. [See MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block)
- Use this new utility class in `Collapse` and `ContextMenu2` to fix #4537 

#### Reviewers should focus on:

Overall design of the bugfix using the utility class

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![2021-03-15 18 11 32](https://user-images.githubusercontent.com/723999/111228023-e86f8a00-85b9-11eb-9b2b-25a061b1e15c.gif)
