### PR TITLE
[v4] migrate non-core packages from Popover to Popover2

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@blueprintjs/core": "^3.41.0",
         "@blueprintjs/icons": "^3.24.0",
+        "@blueprintjs/popover2": "^0.3.3",
         "classnames": "^2.2",
         "react-day-picker": "7.4.8",
         "react-lifecycles-compat": "^3.0.4",

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -25,14 +25,13 @@ import {
     InputGroupProps,
     InputGroup,
     Intent,
-    PopoverProps,
     Props,
     RefCallback,
     RefObject,
     Keys,
-    Popover,
     refHandler,
 } from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import * as Classes from "./common/classes";
 import { isDateValid, isDayInRange } from "./common/dateUtils";
@@ -105,11 +104,11 @@ export interface DateInputProps extends DatePickerBaseProps, DateFormatProps, Pr
     onError?: (errorDate: Date) => void;
 
     /**
-     * Props to pass to the `Popover`.
+     * Props to pass to the `Popover2`.
      * Note that `content`, `autoFocus`, and `enforceFocus` cannot be changed.
      */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    popoverProps?: Partial<PopoverProps> & object;
+    popoverProps?: Partial<Popover2Props> & object;
 
     /**
      * Element to render on right side of input.
@@ -242,8 +241,7 @@ export class DateInput extends AbstractPureComponent<DateInputProps, DateInputSt
         const { inputProps = {}, popoverProps = {} } = this.props;
         const isErrorState = value != null && (!isDateValid(value) || !this.isDateInRange(value));
         return (
-            /* eslint-disable-next-line deprecation/deprecation */
-            <Popover
+            <Popover2
                 isOpen={this.state.isOpen && !this.props.disabled}
                 fill={this.props.fill}
                 {...popoverProps}
@@ -270,8 +268,7 @@ export class DateInput extends AbstractPureComponent<DateInputProps, DateInputSt
                     onKeyDown={this.handleInputKeyDown}
                     value={dateString}
                 />
-                {/* eslint-disable-next-line deprecation/deprecation */}
-            </Popover>
+            </Popover2>
         );
     }
 

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -27,14 +27,12 @@ import {
     InputGroupProps,
     InputGroup,
     Intent,
-    PopoverProps,
     Props,
     RefObject,
     Keys,
-    Popover,
-    Position,
     refHandler,
 } from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { DateRange } from "./common/dateRange";
 import { areSameTime, isDateValid, isDayInRange } from "./common/dateUtils";
@@ -125,7 +123,7 @@ export interface DateRangeInputProps extends DatePickerBaseProps, DateFormatProp
      * The props to pass to the popover.
      * `autoFocus`, `content`, and `enforceFocus` will be ignored to avoid compromising usability.
      */
-    popoverProps?: Partial<PopoverProps>;
+    popoverProps?: Partial<Popover2Props>;
 
     /**
      * Whether the entire text field should be selected on focus.
@@ -332,10 +330,9 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
         // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
-            /* eslint-disable-next-line deprecation/deprecation */
-            <Popover
+            <Popover2
                 isOpen={this.state.isOpen}
-                position={Position.BOTTOM_LEFT}
+                placement="bottom-start"
                 {...this.props.popoverProps}
                 autoFocus={false}
                 className={popoverClassName}
@@ -347,8 +344,7 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
                     {this.renderInputGroup(Boundary.START)}
                     {this.renderInputGroup(Boundary.END)}
                 </div>
-                {/* eslint-disable-next-line deprecation/deprecation */}
-            </Popover>
+            </Popover2>
         );
     }
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -19,7 +19,8 @@ import { mount } from "enzyme";
 import React from "react";
 import sinon from "sinon";
 
-import { Classes as CoreClasses, InputGroup, Intent, Keys, Popover, Position } from "@blueprintjs/core";
+import { InputGroup, Intent, Keys } from "@blueprintjs/core";
+import { Classes as Popover2Classes, Popover2 } from "@blueprintjs/popover2";
 
 import { Classes, DateInput, DatePicker, DateInputProps, TimePicker, TimePrecision } from "../src";
 import { Months } from "../src/common/months";
@@ -48,7 +49,7 @@ describe("<DateInput>", () => {
         );
         wrapper.setState({ isOpen: true });
 
-        const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_WRAPPER}`).hostNodes();
+        const popoverTarget = wrapper.find(`.${Popover2Classes.POPOVER2_TARGET}`).hostNodes();
         assert.isTrue(popoverTarget.hasClass(CLASS_1));
         assert.isTrue(popoverTarget.hasClass(CLASS_2));
     });
@@ -71,25 +72,21 @@ describe("<DateInput>", () => {
     it("Popover opens on input focus", () => {
         const wrapper = mount(<DateInput {...DATE_FORMAT} />);
         wrapper.find("input").simulate("focus");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+        assert.isTrue(wrapper.find(Popover2).prop("isOpen"));
     });
 
     it("Popover doesn't open if disabled=true", () => {
         const wrapper = mount(<DateInput {...DATE_FORMAT} disabled={true} />);
         wrapper.find("input").simulate("focus");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isFalse(wrapper.find(Popover).prop("isOpen"));
+        assert.isFalse(wrapper.find(Popover2).prop("isOpen"));
     });
 
     it("Popover closes when ESC key pressed", () => {
         const wrapper = mount(<DateInput {...DATE_FORMAT} />);
         wrapper.setState({ isOpen: true });
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+        assert.isTrue(wrapper.find(Popover2).prop("isOpen"));
         wrapper.find("input").simulate("keydown", { which: Keys.ESCAPE });
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isFalse(wrapper.find(Popover).prop("isOpen"));
+        assert.isFalse(wrapper.find(Popover2).prop("isOpen"));
     });
 
     it("Popover closes when tabbing on first day of the month", () => {
@@ -97,34 +94,29 @@ describe("<DateInput>", () => {
         const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
         wrapper.find("input").simulate("focus").simulate("blur");
         // First day of month is the only .DayPicker-Day with tabIndex == 0
-        /* eslint-disable-next-line deprecation/deprecation */
-        const tabbables = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 });
+        const tabbables = wrapper.find(Popover2).find(".DayPicker-Day").filter({ tabIndex: 0 });
         tabbables.simulate("keydown", { key: "Tab" });
         // manually updating wrapper is required with enzyme 3
         // ref: https://github.com/airbnb/enzyme/blob/master/docs/guides/migration-from-2-to-3.md#for-mount-updates-are-sometimes-required-when-they-werent-before
         wrapper.update();
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isFalse(wrapper.find(Popover).prop("isOpen"));
+        assert.isFalse(wrapper.find(Popover2).prop("isOpen"));
     });
 
     it("Popover should not close if focus moves to previous day", () => {
         const defaultValue = new Date(2018, Months.FEBRUARY, 6, 15, 0, 0, 0);
         const wrapper = mount(<DateInput {...DATE_FORMAT} defaultValue={defaultValue} />);
         wrapper.find("input").simulate("focus").simulate("blur");
-        /* eslint-disable-next-line deprecation/deprecation */
-        const tabbables = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 });
+        const tabbables = wrapper.find(Popover2).find(".DayPicker-Day").filter({ tabIndex: 0 });
         const firstDay = tabbables.getDOMNode() as HTMLElement;
         const lastDayOfPrevMonth = wrapper
-            /* eslint-disable-next-line deprecation/deprecation */
-            .find(Popover)
+            .find(Popover2)
             .find(".DayPicker-Body > .DayPicker-Week .DayPicker-Day--outside")
             .last();
         const relatedTarget = lastDayOfPrevMonth.getDOMNode();
         const event = createFocusEvent("blur", relatedTarget);
         firstDay.dispatchEvent(event);
         wrapper.update();
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+        assert.isTrue(wrapper.find(Popover2).prop("isOpen"));
     });
 
     it("Popover should not close if focus moves to month select", () => {
@@ -133,8 +125,7 @@ describe("<DateInput>", () => {
         root.setState({ isOpen: true });
         root.find("input").simulate("focus").simulate("blur");
         changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(root.find(Popover).prop("isOpen"));
+        assert.isTrue(root.find(Popover2).prop("isOpen"));
     });
 
     it("Popover should not close if focus moves to year select", () => {
@@ -143,8 +134,7 @@ describe("<DateInput>", () => {
         root.setState({ isOpen: true });
         root.find("input").simulate("focus").simulate("blur");
         changeSelect(Classes.DATEPICKER_YEAR_SELECT, 2016);
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(root.find(Popover).prop("isOpen"));
+        assert.isTrue(root.find(Popover2).prop("isOpen"));
     });
 
     it("Popover should not close when time picker arrows are clicked after selecting a month", () => {
@@ -160,8 +150,7 @@ describe("<DateInput>", () => {
         root.setState({ isOpen: true }).update();
         changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.MARCH);
         root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(root.find(Popover).prop("isOpen"));
+        assert.isTrue(root.find(Popover2).prop("isOpen"));
     });
 
     it("Popover should not close when time picker arrows are clicked after selecting a year", () => {
@@ -177,8 +166,7 @@ describe("<DateInput>", () => {
         root.setState({ isOpen: true }).update();
         changeSelect(Classes.DATEPICKER_YEAR_SELECT, 2019);
         root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(root.find(Popover).prop("isOpen"));
+        assert.isTrue(root.find(Popover2).prop("isOpen"));
     });
 
     it("setting timePrecision renders a TimePicker", () => {
@@ -303,19 +291,18 @@ describe("<DateInput>", () => {
                     content: "fail",
                     fill: true,
                     onOpening,
-                    position: Position.TOP,
+                    placement: "top",
                     usePortal: false,
                 }}
             />,
         );
         wrapper.find("input").simulate("focus");
 
-        /* eslint-disable-next-line deprecation/deprecation */
-        const popover = wrapper.find(Popover);
+        const popover = wrapper.find(Popover2);
         assert.strictEqual(popover.prop("autoFocus"), false, "autoFocus cannot be changed");
         assert.notStrictEqual(popover.prop("content"), "fail", "content cannot be changed");
         assert.strictEqual(popover.prop("fill"), true);
-        assert.strictEqual(popover.prop("position"), Position.TOP);
+        assert.strictEqual(popover.prop("placement"), "top");
         assert.strictEqual(popover.prop("usePortal"), false);
         assert.isTrue(onOpening.calledOnce);
     });
@@ -408,8 +395,7 @@ describe("<DateInput>", () => {
                 />,
             );
             changeSelect(Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
-            /* eslint-disable-next-line deprecation/deprecation */
-            assert.isTrue(root.find(Popover).prop("isOpen"));
+            assert.isTrue(root.find(Popover2).prop("isOpen"));
         });
 
         it("Popover doesn't close when time changes", () => {
@@ -422,13 +408,11 @@ describe("<DateInput>", () => {
 
             // try typing a new time
             wrapper.find(`.${Classes.TIMEPICKER_MILLISECOND}`).simulate("change", { target: { value: "1" } });
-            /* eslint-disable-next-line deprecation/deprecation */
-            assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+            assert.isTrue(wrapper.find(Popover2).prop("isOpen"));
 
             // try keyboard-incrementing to a new time
             wrapper.find(`.${Classes.TIMEPICKER_MILLISECOND}`).simulate("keydown", { which: Keys.ARROW_UP });
-            /* eslint-disable-next-line deprecation/deprecation */
-            assert.isTrue(wrapper.find(Popover).prop("isOpen"));
+            assert.isTrue(wrapper.find(Popover2).prop("isOpen"));
         });
 
         it("Clicking a date in a different month sets input value but keeps popover open", () => {

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -21,18 +21,8 @@ import ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
-import {
-    Boundary,
-    Classes as CoreClasses,
-    HTMLDivProps,
-    HTMLInputProps,
-    InputGroupProps,
-    InputGroup,
-    PopoverProps,
-    Keys,
-    Popover,
-    Position,
-} from "@blueprintjs/core";
+import { Boundary, HTMLDivProps, HTMLInputProps, InputGroupProps, InputGroup, Keys } from "@blueprintjs/core";
+import { Classes as Popover2Classes, Popover2, Popover2Props } from "@blueprintjs/popover2";
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
 import { Classes as DateClasses, DateRange, DateRangeInput, DateRangePicker, TimePrecision } from "../src";
@@ -121,7 +111,7 @@ describe("<DateRangeInput>", () => {
         );
         wrapper.setState({ isOpen: true });
 
-        const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_WRAPPER}`).hostNodes();
+        const popoverTarget = wrapper.find(`.${Popover2Classes.POPOVER2_TARGET}`).hostNodes();
         expect(popoverTarget.hasClass(CLASS_1)).to.be.true;
         expect(popoverTarget.hasClass(CLASS_2)).to.be.true;
     });
@@ -155,8 +145,7 @@ describe("<DateRangeInput>", () => {
             );
 
             root.setState({ isOpen: true });
-            /* eslint-disable-next-line deprecation/deprecation */
-            expect(root.find(Popover).prop("isOpen")).to.be.true;
+            expect(root.find(Popover2).prop("isOpen")).to.be.true;
 
             keyDownOnInput(DateClasses.TIMEPICKER_HOUR, Keys.ARROW_UP);
             expect(isStartInputFocused(root), "start input focus to be false").to.be.false;
@@ -180,8 +169,7 @@ describe("<DateRangeInput>", () => {
 
             keyDownOnInput(DateClasses.TIMEPICKER_HOUR, Keys.ARROW_UP);
             root.update();
-            /* eslint-disable-next-line deprecation/deprecation */
-            expect(root.find(Popover).prop("isOpen")).to.be.true;
+            expect(root.find(Popover2).prop("isOpen")).to.be.true;
         });
 
         it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
@@ -195,8 +183,7 @@ describe("<DateRangeInput>", () => {
             root.update();
             keyDownOnInput(DateClasses.TIMEPICKER_HOUR, Keys.ARROW_UP, 1);
             root.update();
-            /* eslint-disable-next-line deprecation/deprecation */
-            expect(root.find(Popover).prop("isOpen")).to.be.true;
+            expect(root.find(Popover2).prop("isOpen")).to.be.true;
         });
 
         afterEach(() => {
@@ -222,8 +209,7 @@ describe("<DateRangeInput>", () => {
             const startInput = getStartInput(root);
 
             startInput.simulate("click");
-            /* eslint-disable-next-line deprecation/deprecation */
-            expect(root.find(Popover).prop("isOpen")).to.be.false;
+            expect(root.find(Popover2).prop("isOpen")).to.be.false;
             expect(startInput.prop("disabled")).to.be.true;
         });
 
@@ -238,8 +224,7 @@ describe("<DateRangeInput>", () => {
             const endInput = getEndInput(root);
 
             endInput.simulate("click");
-            /* eslint-disable-next-line deprecation/deprecation */
-            expect(root.find(Popover).prop("isOpen")).to.be.false;
+            expect(root.find(Popover2).prop("isOpen")).to.be.false;
             expect(endInput.prop("disabled")).to.be.true;
         });
 
@@ -364,8 +349,7 @@ describe("<DateRangeInput>", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} disabled={true} />);
         const startInput = getStartInput(root);
         startInput.simulate("click");
-        /* eslint-disable-next-line deprecation/deprecation */
-        expect(root.find(Popover).prop("isOpen")).to.be.false;
+        expect(root.find(Popover2).prop("isOpen")).to.be.false;
         expect(startInput.prop("disabled")).to.be.true;
         expect(getEndInput(root).prop("disabled")).to.be.true;
     });
@@ -523,16 +507,14 @@ describe("<DateRangeInput>", () => {
 
     describe("popoverProps", () => {
         it("accepts custom popoverProps", () => {
-            const popoverProps: Partial<PopoverProps> = {
+            const popoverProps: Partial<Popover2Props> = {
                 backdropProps: {},
-                position: Position.TOP_LEFT,
+                placement: "top-start",
                 usePortal: false,
             };
-            /* eslint-disable-next-line deprecation/deprecation */
-            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover2);
             expect(popover.prop("backdropProps")).to.equal(popoverProps.backdropProps);
-            /* eslint-disable-next-line deprecation/deprecation */
-            expect(popover.prop("position")).to.equal(popoverProps.position);
+            expect(popover.prop("placement")).to.equal(popoverProps.placement);
         });
 
         it("ignores autoFocus, enforceFocus, and content in custom popoverProps", () => {
@@ -543,8 +525,7 @@ describe("<DateRangeInput>", () => {
                 enforceFocus: true,
                 usePortal: false,
             };
-            /* eslint-disable-next-line deprecation/deprecation */
-            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover2);
             // this test assumes the following values will be the defaults internally
             expect(popover.prop("autoFocus")).to.be.false;
             expect(popover.prop("enforceFocus")).to.be.false;

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 
-import { H5, Position, Switch } from "@blueprintjs/core";
+import { H5, Switch } from "@blueprintjs/core";
 import { DateInput, DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 
@@ -76,7 +76,7 @@ export class DateInputExample extends React.PureComponent<ExampleProps, DateInpu
                     {...format}
                     defaultValue={new Date()}
                     onChange={this.handleDateChange}
-                    popoverProps={{ position: Position.BOTTOM }}
+                    popoverProps={{ placement: "bottom" }}
                     timePickerProps={
                         timePrecision === undefined
                             ? undefined

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 
-import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import { H5, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { TimezoneDisplayFormat, TimezonePicker } from "@blueprintjs/timezone";
 
@@ -78,7 +78,7 @@ export class TimezonePickerExample extends React.PureComponent<ExampleProps, Tim
                     value={timezone}
                     onChange={this.handleTimezoneChange}
                     valueDisplayFormat={targetDisplayFormat}
-                    popoverProps={{ position: Position.BOTTOM }}
+                    popoverProps={{ placement: "bottom" }}
                     showLocalTimezone={showLocalTimezone}
                     disabled={disabled}
                 >

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -299,6 +299,8 @@ export class Popover2<T> extends AbstractPureComponent<Popover2Props<T>, Popover
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
               };
+        // Ensure target is focusable if relevant prop enabled
+        const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const targetProps = {
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
@@ -309,9 +311,6 @@ export class Popover2<T> extends AbstractPureComponent<Popover2Props<T>, Popover
                 [CoreClasses.ACTIVE]: !isControlled && isOpen && !isHoverInteractionKind,
             }),
             ref,
-            // Ensure target is focusable if relevant prop enabled. When renderTarget is undefined, we apply
-            // tabIndex to the wrapper because that's the element which has event handlers.
-            tabIndex: openOnTargetFocus && isHoverInteractionKind ? 0 : undefined,
             ...((targetEventHandlers as unknown) as T),
         };
 
@@ -323,18 +322,13 @@ export class Popover2<T> extends AbstractPureComponent<Popover2Props<T>, Popover
                 // if the consumer renders a tooltip target, it's their responsibility to disable that tooltip
                 // when *this* popover is open
                 isOpen,
+                tabIndex: targetTabIndex,
             });
         } else {
             const childTarget = Utils.ensureElement(React.Children.toArray(children)[0])!;
 
             if (childTarget === undefined) {
                 return null;
-            }
-
-            // if there is a tabIndex set on the child target, we are going to promote it to the wrapper element
-            const childTargetTabIndex = childTarget.props.tabIndex;
-            if (childTargetTabIndex != null) {
-                targetProps.tabIndex = childTargetTabIndex;
             }
 
             const targetModifierClasses = {
@@ -348,8 +342,7 @@ export class Popover2<T> extends AbstractPureComponent<Popover2Props<T>, Popover
                 className: classNames(childTarget.props.className, targetModifierClasses),
                 // force disable single Tooltip2 child when popover is open
                 disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip2) ? true : childTarget.props.disabled,
-                // avoid having two nested elements which are focussable via keyboard navigation
-                tabIndex: targetProps.tabIndex !== undefined ? -1 : undefined,
+                tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
             });
             const wrappedTarget = React.createElement(targetTagName!, targetProps, clonedTarget);
             target = wrappedTarget;

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -352,7 +352,7 @@ describe("<Popover2>", () => {
 
         function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<Popover2Props>) {
             wrapper = renderPopover({ ...popoverProps, usePortal: true });
-            const targetElement = wrapper.findClass(Classes.POPOVER2_TARGET).getDOMNode();
+            const targetElement = wrapper.find("[data-testid='target-button']").getDOMNode();
 
             if (shouldTabIndexExist) {
                 assert.equal(targetElement.getAttribute("tabindex"), "0");
@@ -782,7 +782,7 @@ describe("<Popover2>", () => {
                 hoverOpenDelay={0}
                 content={<div>Text {content}</div>}
             >
-                <button>Target</button>
+                <button data-testid="target-button">Target</button>
             </Popover2>,
             { attachTo: testsContainerElement },
         ) as Popover2Wrapper;

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@blueprintjs/core": "^3.41.0",
         "@blueprintjs/icons": "^3.24.0",
+        "@blueprintjs/popover2": "^0.3.3",
         "classnames": "^2.2",
         "tslib": "~1.13.0"
     },

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -7,7 +7,7 @@ $select-popover-max-height: $pt-grid-size * 30 !default;
 $select-popover-max-width: $pt-grid-size * 40 !default;
 
 .#{$ns}-select-popover {
-  .#{$ns}-popover-content {
+  .#{$ns}-popover2-content {
     // use padding on container rather than margin on input group
     // because top margin leaves some empty space with no background color.
     padding: $pt-grid-size / 2;
@@ -24,7 +24,7 @@ $select-popover-max-width: $pt-grid-size * 40 !default;
     padding: 0;
 
     &:not(:first-child) {
-      // adjust padding to account for that on .#{$ns}-popover-content above
+      // adjust padding to account for that on .#{$ns}-popover2-content above
       padding-top: $pt-grid-size / 2;
     }
   }

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -164,6 +164,11 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                 placement="bottom-start"
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
+                content={
+                    <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+                        {listProps.itemList}
+                    </div>
+                }
                 interactionKind="click"
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
@@ -186,9 +191,6 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                         onRemove={this.handleTagRemove}
                         values={selectedItems.map(this.props.tagRenderer)}
                     />
-                </div>
-                <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
-                    {listProps.itemList}
                 </div>
             </Popover2>
         );

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -20,15 +20,12 @@ import {
     AbstractPureComponent,
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
-    PopoverProps,
     TagInputProps,
     Keys,
-    Popover,
-    PopoverInteractionKind,
-    Position,
     TagInput,
     TagInputAddMethod,
 } from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps } from "../../common";
 import { QueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -75,7 +72,7 @@ export interface MultiSelectProps<T> extends ListItemsProps<T> {
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    popoverProps?: Partial<PopoverProps> & object;
+    popoverProps?: Partial<Popover2Props> & object;
 
     /** Controlled selected values. */
     selectedItems?: T[];
@@ -159,16 +156,15 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
         };
 
         return (
-            /* eslint-disable-next-line deprecation/deprecation */
-            <Popover
+            <Popover2
                 autoFocus={false}
                 canEscapeKeyClose={true}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
-                position={Position.BOTTOM_LEFT}
+                placement="bottom-start"
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
-                interactionKind={PopoverInteractionKind.CLICK}
+                interactionKind="click"
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpened={this.handlePopoverOpened}
@@ -194,8 +190,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                 <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                     {listProps.itemList}
                 </div>
-                {/* eslint-disable-next-line deprecation/deprecation */}
-            </Popover>
+            </Popover2>
         );
     };
 

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -144,6 +144,12 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                 placement="bottom-start"
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
+                content={
+                    <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+                        {filterable ? input : undefined}
+                        {listProps.itemList}
+                    </div>
+                }
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 onOpening={this.handlePopoverOpening}
@@ -155,10 +161,6 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                 >
                     {this.props.children}
-                </div>
-                <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
-                    {filterable ? input : undefined}
-                    {listProps.itemList}
                 </div>
             </Popover2>
         );

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -24,15 +24,13 @@ import {
     getRef,
     InputGroupProps,
     InputGroup,
-    PopoverProps,
     Ref,
     RefObject,
     Keys,
-    Popover,
-    Position,
     refHandler,
 } from "@blueprintjs/core";
 import { Cross, Search } from "@blueprintjs/icons";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps } from "../../common";
 import { QueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -64,7 +62,7 @@ export interface SelectProps<T> extends ListItemsProps<T> {
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    popoverProps?: Partial<PopoverProps> & object;
+    popoverProps?: Partial<Popover2Props> & object;
 
     /**
      * Whether the active item should be reset to the first matching item _when
@@ -138,13 +136,12 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
         const { handleKeyDown, handleKeyUp } = listProps;
         return (
-            /* eslint-disable-next-line deprecation/deprecation */
-            <Popover
+            <Popover2
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
                 disabled={disabled}
-                position={Position.BOTTOM_LEFT}
+                placement="bottom-start"
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
@@ -163,8 +160,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                     {filterable ? input : undefined}
                     {listProps.itemList}
                 </div>
-                {/* eslint-disable-next-line deprecation/deprecation */}
-            </Popover>
+            </Popover2>
         );
     };
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -23,15 +23,13 @@ import {
     getRef,
     InputGroupProps,
     InputGroup,
-    PopoverProps,
     Ref,
     RefObject,
     Keys,
-    Popover,
     PopoverInteractionKind,
-    Position,
     refHandler,
 } from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps } from "../../common";
 import { QueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -89,7 +87,7 @@ export interface SuggestProps<T> extends ListItemsProps<T> {
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    popoverProps?: Partial<PopoverProps> & object;
+    popoverProps?: Partial<Popover2Props> & object;
 
     /**
      * Whether the active item should be reset to the first matching item _when
@@ -157,8 +155,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
         if (this.state.isOpen === false && prevState.isOpen === true) {
             // just closed, likely by keyboard interaction
             // wait until the transition ends so there isn't a flash of content in the popover
-            /* eslint-disable-next-line deprecation/deprecation */
-            const timeout = this.props.popoverProps?.transitionDuration ?? Popover.defaultProps.transitionDuration;
+            const timeout = this.props.popoverProps?.transitionDuration ?? Popover2.defaultProps.transitionDuration;
             setTimeout(() => this.maybeResetActiveItemToSelectedItem(), timeout);
         }
 
@@ -188,12 +185,11 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
         }
 
         return (
-            /* eslint-disable-next-line deprecation/deprecation */
-            <Popover
+            <Popover2
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={isOpen}
-                position={Position.BOTTOM_LEFT}
+                placement="bottom-start"
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 interactionKind={PopoverInteractionKind.CLICK}
@@ -217,8 +213,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
                 <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                     {listProps.itemList}
                 </div>
-                {/* eslint-disable-next-line deprecation/deprecation */}
-            </Popover>
+            </Popover2>
         );
     };
 

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -192,6 +192,11 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
                 placement="bottom-start"
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
+                content={
+                    <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+                        {listProps.itemList}
+                    </div>
+                }
                 interactionKind={PopoverInteractionKind.CLICK}
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
@@ -210,9 +215,6 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
                     placeholder={inputPlaceholder}
                     value={inputValue}
                 />
-                <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
-                    {listProps.itemList}
-                </div>
             </Popover2>
         );
     };

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -19,7 +19,8 @@ import { mount } from "enzyme";
 import React from "react";
 import sinon from "sinon";
 
-import { InputGroup, Popover } from "@blueprintjs/core";
+import { InputGroup } from "@blueprintjs/core";
+import { Popover2 } from "@blueprintjs/popover2";
 
 import { Film, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import { ItemRendererProps, SelectProps, SelectState, Select } from "../src";
@@ -53,21 +54,18 @@ describe("<Select>", () => {
     it("renders a Popover around children that contains InputGroup and items", () => {
         const wrapper = select();
         assert.lengthOf(wrapper.find(InputGroup), 1, "should render InputGroup");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.lengthOf(wrapper.find(Popover), 1, "should render Popover");
+        assert.lengthOf(wrapper.find(Popover2), 1, "should render Popover");
     });
 
     it("filterable=false hides InputGroup", () => {
         const wrapper = select({ filterable: false });
         assert.lengthOf(wrapper.find(InputGroup), 0, "should not render InputGroup");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.lengthOf(wrapper.find(Popover), 1, "should render Popover");
+        assert.lengthOf(wrapper.find(Popover2), 1, "should render Popover");
     });
 
     it("disabled=true disables Popover", () => {
         const wrapper = select({ disabled: true });
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.strictEqual(wrapper.find(Popover).prop("disabled"), true);
+        assert.strictEqual(wrapper.find(Popover2).prop("disabled"), true);
     });
 
     it("disabled=true doesn't call itemRenderer", () => {
@@ -93,12 +91,11 @@ describe("<Select>", () => {
         const modifiers = {}; // our own instance
         const wrapper = select({ popoverProps: { onOpening, modifiers } });
         wrapper.find("article").simulate("click");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.strictEqual(wrapper.find(Popover).prop("modifiers"), modifiers);
+        assert.strictEqual(wrapper.find(Popover2).prop("modifiers"), modifiers);
         assert.isTrue(onOpening.calledOnce);
     });
 
-    it("returns focus to focusable target after popover closed");
+    it.skip("returns focus to focusable target after popover closed");
 
     function select(props: Partial<SelectProps<Film>> = {}, query?: string) {
         const wrapper = mount(

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -19,7 +19,8 @@ import { mount, ReactWrapper } from "enzyme";
 import React from "react";
 import sinon from "sinon";
 
-import { InputGroup, PopoverProps, Keys, MenuItem, Popover } from "@blueprintjs/core";
+import { InputGroup, Keys, MenuItem } from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { Film, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
 import { ItemRendererProps, QueryList } from "../src";
@@ -62,8 +63,7 @@ describe("Suggest", () => {
     describe("Basic behavior", () => {
         it("renders an input that triggers a popover containing items", () => {
             const wrapper = suggest();
-            /* eslint-disable-next-line deprecation/deprecation */
-            const popover = wrapper.find(Popover);
+            const popover = wrapper.find(Popover2);
             assert.lengthOf(wrapper.find(InputGroup), 1, "should render InputGroup");
             assert.lengthOf(popover, 1, "should render Popover");
             assert.lengthOf(popover.find(MenuItem), 100, "should render 100 items in popover");
@@ -241,12 +241,11 @@ describe("Suggest", () => {
             const modifiers = {}; // our own instance
             const wrapper = suggest({ popoverProps: getPopoverProps(false, modifiers) });
             wrapper.setProps({ popoverProps: getPopoverProps(true, modifiers) }).update();
-            /* eslint-disable-next-line deprecation/deprecation */
-            assert.strictEqual(wrapper.find(Popover).prop("modifiers"), modifiers);
+            assert.strictEqual(wrapper.find(Popover2).prop("modifiers"), modifiers);
             assert.isTrue(onOpening.calledOnce);
         });
 
-        function getPopoverProps(isOpen: boolean, modifiers: any): Partial<PopoverProps> {
+        function getPopoverProps(isOpen: boolean, modifiers: any): Partial<Popover2Props> {
             return {
                 ...defaultProps.popoverProps,
                 isOpen,

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -36,6 +36,7 @@
     },
     "dependencies": {
         "@blueprintjs/core": "^3.41.0",
+        "@blueprintjs/popover2": "^0.3.3",
         "classnames": "^2.2",
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.4",

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -17,8 +17,9 @@
 import classNames from "classnames";
 import React from "react";
 
-import { DISPLAYNAME_PREFIX, Props, Popover, Position } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, Props } from "@blueprintjs/core";
 import { More } from "@blueprintjs/icons";
+import { Popover2 } from "@blueprintjs/popover2";
 
 import * as Classes from "../../common/classes";
 import { Utils } from "../../common/utils";
@@ -214,7 +215,7 @@ export class TruncatedFormat extends React.PureComponent<TruncatedFormatProps, T
     private renderPopover() {
         const { children, preformatted } = this.props;
 
-        // `<Popover>` will always check the content's position on update
+        // `<Popover2>` will always check the content's position on update
         // regardless if it is open or not. This negatively affects perf due to
         // layout thrashing. So instead we manage the popover state ourselves
         // and mimic its popover target
@@ -225,22 +226,19 @@ export class TruncatedFormat extends React.PureComponent<TruncatedFormatProps, T
             );
             const popoverContent = <div className={popoverClasses}>{children}</div>;
             return (
-                /* eslint-disable-next-line deprecation/deprecation */
-                <Popover
+                <Popover2
                     className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
-                    modifiers={{ preventOverflow: { boundariesElement: "window" } }}
                     content={popoverContent}
-                    position={Position.BOTTOM}
+                    placement="bottom"
                     isOpen={true}
                     onClose={this.handlePopoverClose}
                 >
                     <More />
-                    {/* eslint-disable-next-line deprecation/deprecation */}
-                </Popover>
+                </Popover2>
             );
         } else {
-            // NOTE: This structure matches what `<Popover>` does internally. If
-            // `<Popover>` changes, this must be updated.
+            // NOTE: This structure matches what `<Popover2>` does internally. If
+            // `<Popover2>` changes, this must be updated.
             return (
                 <span className={Classes.TABLE_TRUNCATED_POPOVER_TARGET} onClick={this.handlePopoverOpen}>
                     <More />

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -17,7 +17,8 @@
 import classNames from "classnames";
 import React from "react";
 
-import { AbstractPureComponent, Icon, IconName, Props, Popover, Position, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractPureComponent, Icon, IconName, Props, Utils as CoreUtils } from "@blueprintjs/core";
+import { Popover2 } from "@blueprintjs/popover2";
 
 import * as Classes from "../common/classes";
 import { columnInteractionBarContextTypes, ColumnInteractionBarContextTypes } from "../common/context";
@@ -194,18 +195,15 @@ export class ColumnHeaderCell extends AbstractPureComponent<ColumnHeaderCellProp
         return (
             <div className={classes}>
                 <div className={Classes.TABLE_TH_MENU_CONTAINER_BACKGROUND} />
-                {/* eslint-disable-next-line deprecation/deprecation */}
-                <Popover
+                <Popover2
                     content={menuRenderer(index)}
-                    position={Position.BOTTOM}
+                    placement="bottom"
                     className={Classes.TABLE_TH_MENU}
-                    modifiers={{ preventOverflow: { boundariesElement: "window" } }}
                     onOpened={this.handlePopoverOpened}
                     onClosing={this.handlePopoverClosing}
                 >
                     <Icon icon={menuIcon} />
-                    {/* eslint-disable-next-line deprecation/deprecation */}
-                </Popover>
+                </Popover2>
             </div>
         );
     }

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -19,7 +19,7 @@ import { shallow } from "enzyme";
 import React from "react";
 import sinon from "sinon";
 
-import { Classes as CoreClasses, H4, Menu, MenuItem } from "@blueprintjs/core";
+import { H4, Menu, MenuItem } from "@blueprintjs/core";
 
 import { ColumnHeaderCell, ColumnHeaderCellProps } from "../src";
 import * as Classes from "../src/common/classes";
@@ -84,7 +84,7 @@ describe("<ColumnHeaderCell>", () => {
 
         it("renders custom menu items", () => {
             const menuClickSpy = sinon.spy();
-            const menu = getMenuComponent(menuClickSpy);
+            const menu = renderMenu(menuClickSpy);
             const renderMenuFn = () => menu;
 
             const columnHeaderCellRenderer = (columnIndex: number) => {
@@ -96,7 +96,7 @@ describe("<ColumnHeaderCell>", () => {
 
         it("renders custom menu items with a menuRenderer callback", () => {
             const menuClickSpy = sinon.spy();
-            const menu = getMenuComponent(menuClickSpy);
+            const menu = renderMenu(menuClickSpy);
             const menuRenderer = sinon.stub().returns(menu);
 
             const columnHeaderCellRenderer = (columnIndex: number) => (
@@ -117,7 +117,7 @@ describe("<ColumnHeaderCell>", () => {
             );
         });
 
-        function getMenuComponent(menuClickSpy: sinon.SinonSpy) {
+        function renderMenu(menuClickSpy: sinon.SinonSpy) {
             return (
                 <Menu>
                     <MenuItem className="export-item" icon="export" onClick={menuClickSpy} text="Teleport" />
@@ -129,7 +129,8 @@ describe("<ColumnHeaderCell>", () => {
 
         function expectMenuToOpen(table: ElementHarness, menuClickSpy: sinon.SinonSpy) {
             table.find(`.${Classes.TABLE_COLUMN_HEADERS}`).mouse("mousemove");
-            table.find(`.${Classes.TABLE_TH_MENU} .${CoreClasses.POPOVER_TARGET}`).mouse("click");
+            // menu element is the popover target
+            table.find(`.${Classes.TABLE_TH_MENU}`).mouse("click");
             ElementHarness.document().find(".export-item").mouse("click");
             expect(menuClickSpy.called).to.be.true;
         }

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@blueprintjs/core": "^3.41.0",
         "@blueprintjs/icons": "^3.24.0",
+        "@blueprintjs/popover2": "^0.3.3",
         "@blueprintjs/select": "^3.15.8",
         "classnames": "^2.2",
         "moment": "^2.29.0",

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -24,11 +24,11 @@ import {
     DISPLAYNAME_PREFIX,
     ButtonProps,
     InputGroupProps,
-    PopoverProps,
     Props,
     MenuItem,
 } from "@blueprintjs/core";
 import { CaretDown } from "@blueprintjs/icons";
+import { Popover2Props } from "@blueprintjs/popover2";
 import { ItemListPredicate, ItemRenderer, Select } from "@blueprintjs/select";
 
 import * as Classes from "../../common/classes";
@@ -103,8 +103,8 @@ export interface TimezonePickerProps extends Props {
      */
     inputProps?: InputGroupProps;
 
-    /** Props to spread to `Popover`. Note that `content` cannot be changed. */
-    popoverProps?: Partial<PopoverProps>;
+    /** Props to spread to `Popover2`. Note that `content` cannot be changed. */
+    popoverProps?: Partial<Popover2Props>;
 }
 
 export interface TimezonePickerState {
@@ -148,7 +148,7 @@ export class TimezonePicker extends AbstractPureComponent<TimezonePickerProps, T
             placeholder: "Search for timezones...",
             ...inputProps,
         };
-        const finalPopoverProps: Partial<PopoverProps> = {
+        const finalPopoverProps: Partial<Popover2Props> = {
             ...popoverProps,
             popoverClassName: classNames(Classes.TIMEZONE_PICKER_POPOVER, popoverProps.popoverClassName),
         };
@@ -185,7 +185,7 @@ export class TimezonePicker extends AbstractPureComponent<TimezonePickerProps, T
         }
     }
 
-    protected validateProps(props: PopoverProps & { children?: React.ReactNode }) {
+    protected validateProps(props: TimezonePickerProps & { children?: React.ReactNode }) {
         const childrenCount = React.Children.count(props.children);
         if (childrenCount > 1) {
             console.warn(Errors.TIMEZONE_PICKER_WARN_TOO_MANY_CHILDREN);

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -168,7 +168,7 @@ export class TimezonePicker extends AbstractPureComponent<TimezonePickerProps, T
                 disabled={disabled}
                 onQueryChange={this.handleQueryChange}
             >
-                {children != null ? children : this.renderButton()}
+                {children ?? this.renderButton()}
             </TypedSelect>
         );
     }
@@ -226,7 +226,11 @@ export class TimezonePicker extends AbstractPureComponent<TimezonePickerProps, T
         );
     };
 
-    private handleItemSelect = (timezone: TimezoneItem) => this.props.onChange?.(timezone.timezone);
+    private handleItemSelect = (timezone: TimezoneItem) => {
+        this.props.onChange?.(timezone.timezone);
+    };
 
-    private handleQueryChange = (query: string) => this.setState({ query });
+    private handleQueryChange = (query: string) => {
+        this.setState({ query });
+    };
 }

--- a/packages/timezone/test/timezonePickerTests.tsx
+++ b/packages/timezone/test/timezonePickerTests.tsx
@@ -20,16 +20,8 @@ import moment from "moment-timezone";
 import React from "react";
 import sinon from "sinon";
 
-import {
-    Button,
-    ButtonProps,
-    InputGroupProps,
-    InputGroup,
-    PopoverProps,
-    MenuItem,
-    Popover,
-    Position,
-} from "@blueprintjs/core";
+import { Button, ButtonProps, InputGroupProps, InputGroup, MenuItem } from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 import { QueryList, Select } from "@blueprintjs/select";
 
 import { TimezonePickerProps, TimezonePickerState, TimezoneDisplayFormat, TimezonePicker } from "../src";
@@ -70,8 +62,7 @@ describe("<TimezonePicker>", () => {
         // remove isOpen from popoverProps so it's
         const timezonePicker = mount(<TimezonePicker {...DEFAULT_PROPS} popoverProps={{ usePortal: false }} />);
         timezonePicker.find(Button).simulate("click");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isTrue(timezonePicker.find(Popover).prop("isOpen"));
+        assert.isTrue(timezonePicker.find(Popover2).prop("isOpen"));
     });
 
     it("if disabled=true, clicking on button target does not open popover", () => {
@@ -79,8 +70,7 @@ describe("<TimezonePicker>", () => {
             <TimezonePicker {...DEFAULT_PROPS} disabled={true} popoverProps={{ usePortal: false }} />,
         );
         timezonePicker.find(Button).simulate("click");
-        /* eslint-disable-next-line deprecation/deprecation */
-        assert.isFalse(timezonePicker.find(Popover).prop("isOpen"));
+        assert.isFalse(timezonePicker.find(Popover2).prop("isOpen"));
     });
 
     it("if query is empty, shows initial items", () => {
@@ -187,15 +177,15 @@ describe("<TimezonePicker>", () => {
     });
 
     it("popover can be controlled with popover props", () => {
-        const popoverProps: PopoverProps = {
+        const popoverProps: Popover2Props = {
             isOpen: true,
-            position: Position.RIGHT,
+            placement: "right",
             usePortal: false,
         };
         const timezonePicker = shallow(<TimezonePicker {...DEFAULT_PROPS} popoverProps={popoverProps} />);
         const popover = findPopover(timezonePicker);
         for (const key of Object.keys(popoverProps)) {
-            assert.deepEqual(popover.prop(key), popoverProps[key as keyof PopoverProps]);
+            assert.deepEqual(popover.prop(key), popoverProps[key as keyof Popover2Props]);
         }
     });
 
@@ -245,8 +235,7 @@ describe("<TimezonePicker>", () => {
     }
 
     function findPopover(timezonePicker: TimezonePickerShallowWrapper) {
-        /* eslint-disable-next-line deprecation/deprecation */
-        return findQueryList(timezonePicker).shallow().find(Popover);
+        return findQueryList(timezonePicker).shallow().find(Popover2);
     }
 
     function findInputGroup(timezonePicker: TimezonePickerShallowWrapper) {

--- a/packages/timezone/test/timezonePickerTests.tsx
+++ b/packages/timezone/test/timezonePickerTests.tsx
@@ -20,9 +20,9 @@ import moment from "moment-timezone";
 import React from "react";
 import sinon from "sinon";
 
-import { Button, ButtonProps, InputGroupProps, InputGroup, MenuItem } from "@blueprintjs/core";
+import { Classes, Button, ButtonProps, InputGroupProps, InputGroup } from "@blueprintjs/core";
 import { Popover2, Popover2Props } from "@blueprintjs/popover2";
-import { QueryList, Select } from "@blueprintjs/select";
+import { Select } from "@blueprintjs/select";
 
 import { TimezonePickerProps, TimezonePickerState, TimezoneDisplayFormat, TimezonePicker } from "../src";
 import {
@@ -162,16 +162,21 @@ describe("<TimezonePicker>", () => {
 
     it("invokes the on change prop when a timezone is selected", () => {
         const timezonePicker = mount(<TimezonePicker {...DEFAULT_PROPS} />);
-        clickSecondMenuItem(timezonePicker);
+        timezonePicker.find(`.${Classes.MENU_ITEM}`).at(1).simulate("click");
         assert.isTrue(onChange.calledOnce);
     });
 
     it("if value is non-empty, the selected timezone will stay in sync with that value", () => {
         const value = "Europe/Bratislava";
         const timezonePicker = mount(
-            <TimezonePicker value={value} onChange={onChange} valueDisplayFormat={TimezoneDisplayFormat.NAME} />,
+            <TimezonePicker
+                {...DEFAULT_PROPS}
+                value={value}
+                onChange={onChange}
+                valueDisplayFormat={TimezoneDisplayFormat.NAME}
+            />,
         );
-        clickSecondMenuItem(timezonePicker);
+        timezonePicker.find(`.${Classes.MENU_ITEM}`).at(1).simulate("click");
         assert.isTrue(onChange.calledOnce);
         assert.strictEqual(timezonePicker.find(Button).prop("text"), value);
     });
@@ -236,10 +241,5 @@ describe("<TimezonePicker>", () => {
 
     function findInputGroup(timezonePicker: TimezonePickerWrapper) {
         return timezonePicker.find(InputGroup);
-    }
-
-    // first menu item may be the current timezone
-    function clickSecondMenuItem(timezonePicker: TimezonePickerWrapper): void {
-        timezonePicker.find(MenuItem).at(1).simulate("click");
     }
 });


### PR DESCRIPTION
Includes a bugfix for https://github.com/palantir/blueprint/issues/4521, which I will extract into a separate PR for the 3.x `develop` branch.

Comparison screenshots of tab focus indicator:

Before:

![2021-03-16 15 22 24](https://user-images.githubusercontent.com/723999/111368586-7441ee80-866c-11eb-94e8-a7e8b2547382.gif)

After:

![2021-03-16 15 22 43](https://user-images.githubusercontent.com/723999/111368602-773cdf00-866c-11eb-86d7-5841ea524f9c.gif)
