### PR TITLE
[icons] fix: remove whitespace from icon contents

### DIFF
--- a/packages/icons/resources/icons/icons.json
+++ b/packages/icons/resources/icons/icons.json
@@ -970,28 +970,28 @@
         "iconName": "arrow-up",
         "tags": "direction, north",
         "group": "interface",
-        "content": "\\2191 "
+        "content": "\\2191"
     },
     {
         "displayName": "Arrow: down",
         "iconName": "arrow-down",
         "tags": "direction, south",
         "group": "interface",
-        "content": "\\2193 "
+        "content": "\\2193"
     },
     {
         "displayName": "Arrows: horizontal",
         "iconName": "arrows-horizontal",
         "tags": "direction, level",
         "group": "interface",
-        "content": "\\2194 "
+        "content": "\\2194"
     },
     {
         "displayName": "Arrows: vertical",
         "iconName": "arrows-vertical",
         "tags": "direction, level",
         "group": "interface",
-        "content": "\\2195 "
+        "content": "\\2195"
     },
     {
         "displayName": "Resolve",


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Removes extraneous whitespace in the unicode font content for a couple icons
