### PR TITLE
[core] fix(useHotkeys): remove synthetic default import of React

### DIFF
--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useContext, useEffect, useMemo } from "react";
+import * as React from "react";
 
 import { comboMatches, getKeyCombo, IKeyCombo, parseKeyCombo } from "../../components/hotkeys/hotkeyParser";
 import { HotkeysContext } from "../../context";
@@ -42,7 +42,7 @@ export interface UseHotkeysReturnValue {
  */
 export function useHotkeys(keys: HotkeyConfig[], options: UseHotkeysOptions = {}): UseHotkeysReturnValue {
     const { showDialogKeyCombo = "?" } = options;
-    const localKeys = useMemo(
+    const localKeys = React.useMemo(
         () =>
             keys
                 .filter(k => !k.global)
@@ -52,7 +52,7 @@ export function useHotkeys(keys: HotkeyConfig[], options: UseHotkeysOptions = {}
                 })),
         [keys],
     );
-    const globalKeys = useMemo(
+    const globalKeys = React.useMemo(
         () =>
             keys
                 .filter(k => k.global)
@@ -64,8 +64,8 @@ export function useHotkeys(keys: HotkeyConfig[], options: UseHotkeysOptions = {}
     );
 
     // register keys with global context
-    const [, dispatch] = useContext(HotkeysContext);
-    useEffect(() => {
+    const [, dispatch] = React.useContext(HotkeysContext);
+    React.useEffect(() => {
         const payload = [...globalKeys.map(k => k.config), ...localKeys.map(k => k.config)];
         dispatch({ type: "ADD_HOTKEYS", payload });
         return () => dispatch({ type: "REMOVE_HOTKEYS", payload });
@@ -94,7 +94,7 @@ export function useHotkeys(keys: HotkeyConfig[], options: UseHotkeysOptions = {}
         }
     };
 
-    const handleGlobalKeyDown = useCallback(
+    const handleGlobalKeyDown = React.useCallback(
         (e: KeyboardEvent) => {
             // special case for global keydown: if '?' is pressed, open the hotkeys dialog
             const combo = getKeyCombo(e);
@@ -107,23 +107,23 @@ export function useHotkeys(keys: HotkeyConfig[], options: UseHotkeysOptions = {}
         },
         [globalKeys],
     );
-    const handleGlobalKeyUp = useCallback(
+    const handleGlobalKeyUp = React.useCallback(
         (e: KeyboardEvent) => invokeNamedCallbackIfComboRecognized(true, getKeyCombo(e), "onKeyUp", e),
         [globalKeys],
     );
 
-    const handleLocalKeyDown = useCallback(
+    const handleLocalKeyDown = React.useCallback(
         (e: React.KeyboardEvent<HTMLElement>) =>
             invokeNamedCallbackIfComboRecognized(false, getKeyCombo(e.nativeEvent), "onKeyDown", e.nativeEvent),
         [localKeys],
     );
-    const handleLocalKeyUp = useCallback(
+    const handleLocalKeyUp = React.useCallback(
         (e: React.KeyboardEvent<HTMLElement>) =>
             invokeNamedCallbackIfComboRecognized(false, getKeyCombo(e.nativeEvent), "onKeyUp", e.nativeEvent),
         [localKeys],
     );
 
-    useEffect(() => {
+    React.useEffect(() => {
         document.addEventListener("keydown", handleGlobalKeyDown);
         document.addEventListener("keyup", handleGlobalKeyUp);
         return () => {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Revert to using `import * as React` syntax for useHotkeys, else you get these errors when `allowSyntheticDefaultImports` is not enabled:

```
[error] TypeScript error node_modules/.pnpm/@blueprintjs/core@3.41.0_react-dom@16.14.0+react@16.14.0/node_modules/@blueprintjs/core/lib/esm/hooks/hotkeys/useHotkeys.d.ts:1:8 - error TS1259: Module '"/home/git/project/node_modules/.pnpm/@types/react@16.9.55/node_modules/@types/react/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
1 import React from "react";
         ~~~~~
  node_modules/.pnpm/@types/react@16.9.55/node_modules/@types/react/index.d.ts:65:1
    65 export = React;
       ~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
```

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
