### PR TITLE
[popover2] fix(Popover2): apply tabIndex to target correctly

### DIFF
--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -290,6 +290,8 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
               };
+        // Ensure target is focusable if relevant prop enabled
+        const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const targetProps = {
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
@@ -300,9 +302,6 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 [CoreClasses.ACTIVE]: !isControlled && isOpen && !isHoverInteractionKind,
             }),
             ref,
-            // Ensure target is focusable if relevant prop enabled. When renderTarget is undefined, we apply
-            // tabIndex to the wrapper because that's the element which has event handlers.
-            tabIndex: openOnTargetFocus && isHoverInteractionKind ? 0 : undefined,
             ...((targetEventHandlers as unknown) as T),
         };
 
@@ -314,18 +313,13 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 // if the consumer renders a tooltip target, it's their responsibility to disable that tooltip
                 // when *this* popover is open
                 isOpen,
+                tabIndex: targetTabIndex,
             });
         } else {
             const childTarget = Utils.ensureElement(React.Children.toArray(children)[0])!;
 
             if (childTarget === undefined) {
                 return null;
-            }
-
-            // if there is a tabIndex set on the child target, we are going to promote it to the wrapper element
-            const childTargetTabIndex = childTarget.props.tabIndex;
-            if (childTargetTabIndex != null) {
-                targetProps.tabIndex = childTargetTabIndex;
             }
 
             const targetModifierClasses = {
@@ -339,8 +333,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 className: classNames(childTarget.props.className, targetModifierClasses),
                 // force disable single Tooltip2 child when popover is open
                 disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip2) ? true : childTarget.props.disabled,
-                // avoid having two nested elements which are focussable via keyboard navigation
-                tabIndex: targetProps.tabIndex !== undefined ? -1 : undefined,
+                tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
             });
             const wrappedTarget = React.createElement(targetTagName!, targetProps, clonedTarget);
             target = wrappedTarget;

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -352,7 +352,7 @@ describe("<Popover2>", () => {
 
         function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<IPopover2Props>) {
             wrapper = renderPopover({ ...popoverProps, usePortal: true });
-            const targetElement = wrapper.findClass(Classes.POPOVER2_TARGET).getDOMNode();
+            const targetElement = wrapper.find("[data-testid='target-button']").getDOMNode();
 
             if (shouldTabIndexExist) {
                 assert.equal(targetElement.getAttribute("tabindex"), "0");
@@ -782,7 +782,7 @@ describe("<Popover2>", () => {
                 hoverOpenDelay={0}
                 content={<div>Text {content}</div>}
             >
-                <button>Target</button>
+                <button data-testid="target-button">Target</button>
             </Popover2>,
             { attachTo: testsContainerElement },
         ) as IPopover2Wrapper;


### PR DESCRIPTION
#### Fixes #4521

#### Checklist

- [x] Includes tests

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This PR removes the overly magical logic which extracted a Popover2 child target's `tabIndex` and applied it to the generated target wrapper element. Targets now get rendered with the `tabIndex` directly specified as props.


#### Screenshot

Comparison screenshots of tab focus indicator:

Before:

![2021-03-16 15 22 24](https://user-images.githubusercontent.com/723999/111368586-7441ee80-866c-11eb-94e8-a7e8b2547382.gif)

After:

![2021-03-16 15 22 43](https://user-images.githubusercontent.com/723999/111368602-773cdf00-866c-11eb-86d7-5841ea524f9c.gif)
