### PR TITLE
Remove inner shadow on focused inputs

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -102,7 +102,7 @@ $control-group-stack: (
 
   &:focus,
   &.#{$ns}-active {
-    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+    box-shadow: input-transition-shadow($input-shadow-color-focus, true);
   }
 
   &[type="search"],


### PR DESCRIPTION
#### Checklist

- ~~[ ] Includes tests~~
- ~~[ ] Update documentation~~

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Remove inner shadow when an input is focused

The rational here is that the inner shadow is mostly useful to:
- Identify the component as an input
- Have it stand out
But in the case when the field has been focused by a user or is auto-focused, it seems unnecessary / redundant given we already have a strong visual indication with the blue shadow.
We can find the same behaviour on Github for example

![Screenshot 2021-03-19 at 13 01 57](https://user-images.githubusercontent.com/6755553/111784597-7ea1f980-88b3-11eb-9bb2-d8e2e14abdd9.png)
![Screenshot 2021-03-19 at 13 01 59](https://user-images.githubusercontent.com/6755553/111784603-7fd32680-88b3-11eb-9065-e987e108c00d.png)


#### Reviewers should focus on:

- Make sure the change is not affecting other components that should not be

#### Screenshot

![Screenshot 2021-03-19 at 11 59 15](https://user-images.githubusercontent.com/6755553/111778906-4eeff300-88ad-11eb-9030-b5110c6089ef.png)

