### PR TITLE
[popover2] Popover2 and ContextMenu2 fixes & enhancements

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -77,6 +77,10 @@ export const LIST = `${NS}-list`;
 export const LIST_UNSTYLED = `${NS}-list-unstyled`;
 export const RTL = `${NS}-rtl`;
 
+// layout utilities
+/** @see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block */
+export const FIXED_POSITIONING_CONTAINING_BLOCK = `${NS}-fixed-positioning-containing-block`;
+
 // components
 export const ALERT = `${NS}-alert`;
 export const ALERT_BODY = `${ALERT}-body`;

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -182,6 +182,9 @@ export class Collapse extends AbstractPureComponent2<ICollapseProps, ICollapseSt
             transition: isAutoHeight ? "none" : undefined,
         };
 
+        // in order to give hints to child elements which rely on CSS fixed positioning, we need to apply a class
+        // to the element which creates a new containing block with a non-empty `transform` property
+        // see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
         const contentsStyle = {
             // only use heightWhenOpen while closing
             transform: displayWithTransform ? "translateY(0)" : `translateY(-${this.state.heightWhenOpen}px)`,
@@ -196,7 +199,7 @@ export class Collapse extends AbstractPureComponent2<ICollapseProps, ICollapseSt
                 style: containerStyle,
             },
             <div
-                className={Classes.COLLAPSE_BODY}
+                className={classNames(Classes.COLLAPSE_BODY, Classes.FIXED_POSITIONING_CONTAINING_BLOCK)}
                 ref={this.contentsRefHandler}
                 style={contentsStyle}
                 aria-hidden={!isContentVisible && this.props.keepChildrenMounted}

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -54,6 +54,12 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
       }
     }
   }
+
+  &.#{$ns}-fixed-positioning-containing-block {
+    // use the same transform as the Collapse component, to mimic the behavior of creating a new
+    // containing block for children which are position: fixed (like ContextMenu2 targets)
+    transform: translateY(0);
+  }
 }
 
 .#{$ns}-tree-node-list {

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -94,7 +94,7 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>> {
 
     public render() {
         return (
-            <div className={classNames(Classes.TREE, this.props.className)}>
+            <div className={classNames(Classes.TREE, Classes.FIXED_POSITIONING_CONTAINING_BLOCK, this.props.className)}>
                 {this.renderNodes(this.props.contents, [], Classes.TREE_ROOT)}
             </div>
         );

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -37,17 +37,17 @@ describe("<Tree>", () => {
 
     it("renders its contents", () => {
         const tree = renderTree({ contents: [{ id: 0, label: "Node" }] });
-        assert.lengthOf(tree.find({ className: Classes.TREE }), 1);
+        assert.lengthOf(tree.find(`.${Classes.TREE}`), 1);
     });
 
     it("handles undefined input well", () => {
         const tree = renderTree({ contents: undefined });
-        assert.lengthOf(tree.find({ className: Classes.TREE }), 1);
+        assert.lengthOf(tree.find(`.${Classes.TREE}`), 1);
     });
 
     it("handles empty input well", () => {
         const tree = renderTree({ contents: [] });
-        assert.lengthOf(tree.find({ className: Classes.TREE }), 1);
+        assert.lengthOf(tree.find(`.${Classes.TREE}`), 1);
     });
 
     it("hasCaret forces a caret to be/not be displayed", () => {

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -31,6 +31,7 @@
         "classnames": "^2.2",
         "dom4": "^2.1.5",
         "downloadjs": "^1.4.7",
+        "lodash-es": "^4.17.15",
         "moment": "^2.29.1",
         "normalize.css": "^8.0.1",
         "popper.js": "^1.16.1",

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -14,65 +14,94 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { cloneDeep } from "lodash-es";
+import React, { useCallback, useReducer } from "react";
 
 import { Classes, Icon, Intent, ITreeNode, Tree } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { Tooltip2 } from "@blueprintjs/popover2";
+import { Classes as Popover2Classes, ContextMenu2, Tooltip2 } from "@blueprintjs/popover2";
 
-export interface ITreeExampleState {
-    nodes: ITreeNode[];
-}
+type NodePath = number[];
 
-// use Component so it re-renders everytime: `nodes` are not a primitive type
-// and therefore aren't included in shallow prop comparison
-export class TreeExample extends React.Component<IExampleProps, ITreeExampleState> {
-    public state: ITreeExampleState = { nodes: INITIAL_STATE };
+type TreeAction =
+    | { type: "SET_IS_EXPANDED"; payload: { path: NodePath; isExpanded: boolean } }
+    | { type: "DESELECT_ALL" }
+    | { type: "SET_IS_SELECTED"; payload: { path: NodePath; isSelected: boolean } };
 
-    public render() {
-        return (
-            <Example options={false} {...this.props}>
-                <Tree
-                    contents={this.state.nodes}
-                    onNodeClick={this.handleNodeClick}
-                    onNodeCollapse={this.handleNodeCollapse}
-                    onNodeExpand={this.handleNodeExpand}
-                    className={Classes.ELEVATION_0}
-                />
-            </Example>
-        );
+function forEachNode(nodes: ITreeNode[] | undefined, callback: (node: ITreeNode) => void) {
+    if (nodes === undefined) {
+        return;
     }
 
-    private handleNodeClick = (nodeData: ITreeNode, _nodePath: number[], e: React.MouseEvent<HTMLElement>) => {
-        const originallySelected = nodeData.isSelected;
+    for (const node of nodes) {
+        callback(node);
+        forEachNode(node.childNodes, callback);
+    }
+}
+
+function forNodeAtPath(nodes: ITreeNode[], path: NodePath, callback: (node: ITreeNode) => void) {
+    callback(Tree.nodeFromPath(path, nodes));
+}
+
+function treeExampleReducer(state: ITreeNode[], action: TreeAction) {
+    switch (action.type) {
+        case "DESELECT_ALL":
+            const newState1 = cloneDeep(state);
+            forEachNode(newState1, node => (node.isSelected = false));
+            return newState1;
+        case "SET_IS_EXPANDED":
+            const newState2 = cloneDeep(state);
+            forNodeAtPath(newState2, action.payload.path, node => (node.isExpanded = action.payload.isExpanded));
+            return newState2;
+        case "SET_IS_SELECTED":
+            const newState3 = cloneDeep(state);
+            forNodeAtPath(newState3, action.payload.path, node => (node.isSelected = action.payload.isSelected));
+            return newState3;
+        default:
+            return state;
+    }
+}
+
+export const TreeExample: React.FC<IExampleProps> = props => {
+    const [nodes, dispatch] = useReducer(treeExampleReducer, INITIAL_STATE);
+
+    const handleNodeClick = useCallback((node: ITreeNode, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
+        const originallySelected = node.isSelected;
         if (!e.shiftKey) {
-            this.forEachNode(this.state.nodes, n => (n.isSelected = false));
+            dispatch({ type: "DESELECT_ALL" });
         }
-        nodeData.isSelected = originallySelected == null ? true : !originallySelected;
-        this.setState(this.state);
-    };
+        dispatch({
+            payload: { path: nodePath, isSelected: originallySelected == null ? true : !originallySelected },
+            type: "SET_IS_SELECTED",
+        });
+    }, []);
 
-    private handleNodeCollapse = (nodeData: ITreeNode) => {
-        nodeData.isExpanded = false;
-        this.setState(this.state);
-    };
+    const handleNodeCollapse = useCallback((_node: ITreeNode, nodePath: NodePath) => {
+        dispatch({
+            payload: { path: nodePath, isExpanded: false },
+            type: "SET_IS_EXPANDED",
+        });
+    }, []);
 
-    private handleNodeExpand = (nodeData: ITreeNode) => {
-        nodeData.isExpanded = true;
-        this.setState(this.state);
-    };
+    const handleNodeExpand = useCallback((_node: ITreeNode, nodePath: NodePath) => {
+        dispatch({
+            payload: { path: nodePath, isExpanded: true },
+            type: "SET_IS_EXPANDED",
+        });
+    }, []);
 
-    private forEachNode(nodes: ITreeNode[], callback: (node: ITreeNode) => void) {
-        if (nodes == null) {
-            return;
-        }
-
-        for (const node of nodes) {
-            callback(node);
-            this.forEachNode(node.childNodes, callback);
-        }
-    }
-}
+    return (
+        <Example options={false} {...props}>
+            <Tree
+                contents={nodes}
+                onNodeClick={handleNodeClick}
+                onNodeCollapse={handleNodeCollapse}
+                onNodeExpand={handleNodeExpand}
+                className={Classes.ELEVATION_0}
+            />
+        </Example>
+    );
+};
 
 /* tslint:disable:object-literal-sort-keys so childNodes can come last */
 const INITIAL_STATE: ITreeNode[] = [
@@ -80,16 +109,22 @@ const INITIAL_STATE: ITreeNode[] = [
         id: 0,
         hasCaret: true,
         icon: "folder-close",
-        label: "Folder 0",
+        label: (
+            <ContextMenu2 popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING} content={<div>Hello there!</div>}>
+                Folder 0
+            </ContextMenu2>
+        ),
     },
     {
         id: 1,
         icon: "folder-close",
         isExpanded: true,
         label: (
-            <Tooltip2 content="I'm a folder <3" placement="right">
-                Folder 1
-            </Tooltip2>
+            <ContextMenu2 popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING} content={<div>Hello there!</div>}>
+                <Tooltip2 content="I'm a folder <3" placement="right">
+                    Folder 1
+                </Tooltip2>
+            </ContextMenu2>
         ),
         childNodes: [
             {
@@ -112,9 +147,14 @@ const INITIAL_STATE: ITreeNode[] = [
                 hasCaret: true,
                 icon: "folder-close",
                 label: (
-                    <Tooltip2 content="foo" placement="right">
-                        Folder 2
-                    </Tooltip2>
+                    <ContextMenu2
+                        popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING}
+                        content={<div>Hello there!</div>}
+                    >
+                        <Tooltip2 content="foo" placement="right">
+                            Folder 2
+                        </Tooltip2>
+                    </ContextMenu2>
                 ),
                 childNodes: [
                     { id: 5, label: "No-Icon Item" },
@@ -123,7 +163,14 @@ const INITIAL_STATE: ITreeNode[] = [
                         id: 7,
                         hasCaret: true,
                         icon: "folder-close",
-                        label: "Folder 3",
+                        label: (
+                            <ContextMenu2
+                                popoverClassName={Popover2Classes.POPOVER2_CONTENT_SIZING}
+                                content={<div>Hello there!</div>}
+                            >
+                                Folder 3
+                            </ContextMenu2>
+                        ),
                         childNodes: [
                             { id: 8, icon: "document", label: "Item 0" },
                             { id: 9, icon: "tag", label: "Item 1" },

--- a/packages/popover2/src/blueprint-popover2.scss
+++ b/packages/popover2/src/blueprint-popover2.scss
@@ -5,6 +5,7 @@ Licensed under the Apache License, Version 2.0.
 
 */
 
+@import "context-menu2";
 @import "popover2";
 @import "popover2-in-button-group";
 @import "popover2-in-control-group";

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -18,8 +18,8 @@ import { Classes } from "@blueprintjs/core";
 
 const NS = Classes.getClassNamespace();
 
-export const CONTEXT_MENU2 = `${NS}-context-menu`;
-export const CONTEXT_MENU2_POPOVER_TARGET = `${CONTEXT_MENU2}-popover-target`;
+export const CONTEXT_MENU2 = `${NS}-context-menu2`;
+export const CONTEXT_MENU2_POPOVER2_TARGET = `${CONTEXT_MENU2}-popover2-target`;
 
 export const POPOVER2 = `${NS}-popover2`;
 export const POPOVER2_ARROW = `${POPOVER2}-arrow`;

--- a/packages/popover2/src/context-menu2.md
+++ b/packages/popover2/src/context-menu2.md
@@ -52,4 +52,8 @@ pattern, so you may use information about the context menu's state to in your re
 
 @## Props
 
+To enable/disable the context menu popover, use the `disabled` prop. Note that it is inadvisable to change
+the value of this prop inside the `onContextMenu` callback for this component; doing so can lead to unpredictable
+behavior.
+
 @interface ContextMenu2Props

--- a/packages/popover2/src/context-menu2.scss
+++ b/packages/popover2/src/context-menu2.scss
@@ -1,0 +1,12 @@
+// Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "./common";
+
+.#{$ns}-context-menu2 .#{$ns}-popover2-target {
+  display: block;
+}
+
+.#{$ns}-context-menu2-popover2-target {
+  position: fixed;
+}

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -15,9 +15,15 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Classes as CoreClasses, IOverlayLifecycleProps, Utils as CoreUtils, mergeRefs } from "@blueprintjs/core";
+import {
+    Classes as CoreClasses,
+    IOverlayLifecycleProps,
+    IProps,
+    Utils as CoreUtils,
+    mergeRefs,
+} from "@blueprintjs/core";
 
 import * as Classes from "./classes";
 import { IPopover2Props, Popover2 } from "./popover2";
@@ -29,11 +35,20 @@ type Offset = {
 };
 
 export interface ContextMenu2RenderProps {
+    /** Whether the context menu is currently open */
     isOpen: boolean;
+
+    /** The computed target offset (x, y) coordinates for the context menu click event */
     targetOffset: Offset;
+
+    /** The context menu click event. If isOpen is false, this will be undefined. */
+    mouseEvent: React.MouseEvent<HTMLDivElement> | undefined;
 }
 
-export interface ContextMenu2Props extends IOverlayLifecycleProps, Pick<IPopover2Props, "transitionDuration"> {
+export interface ContextMenu2Props
+    extends IOverlayLifecycleProps,
+        Pick<IPopover2Props, "popoverClassName" | "transitionDuration">,
+        IProps {
     /**
      * Menu content. This will usually be a Blueprint `<Menu>` component.
      * This optionally functions as a render prop so you can use component state to render content.
@@ -45,79 +60,137 @@ export interface ContextMenu2Props extends IOverlayLifecycleProps, Pick<IPopover
      * component state to render the target.
      */
     children: React.ReactNode | ((props: ContextMenu2RenderProps) => React.ReactNode);
+
+    /**
+     * Whether the context menu is disabled.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * An optional context menu event handler. This can be useful if you want to do something with the
+     * mouse event unrelated to rendering the context menu itself, especially if that involves setting
+     * React state (which is an error to do in the render code path of this component).
+     */
+    onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
 }
 
 export const ContextMenu2: React.FC<ContextMenu2Props> = ({
-    content,
+    className,
     children,
+    content,
+    disabled = false,
     transitionDuration = 100,
+    onContextMenu,
+    popoverClassName,
     ...restProps
 }) => {
-    const [targetOffset, setTargetOffset] = React.useState<Offset>({ left: 0, top: 0 });
-    const [isOpen, setIsOpen] = React.useState<boolean>(false);
+    const [targetOffset, setTargetOffset] = useState<Offset>({ left: 0, top: 0 });
+    const [mouseEvent, setMouseEvent] = useState<React.MouseEvent<HTMLDivElement>>();
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const containerRef = useRef<HTMLDivElement>(null);
 
-    const handleContextMenu = React.useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-        // support nested menus (inner menu target would have called preventDefault())
-        if (e.defaultPrevented) {
-            return;
-        }
+    // If disabled prop is changed, we don't want our old context menu to stick around.
+    // If it has just been enabled (disabled = false), then the menu ought to be opened by
+    // a new mouse event. Users should not be updating this prop in the onContextMenu callback
+    // for this component (that will lead to unpredictable behavior).
+    useEffect(() => {
+        setIsOpen(false);
+    }, [disabled]);
 
-        e.preventDefault();
-        const newTargetOffset = { left: e.clientX, top: e.clientY };
-        setTargetOffset(newTargetOffset);
-        setIsOpen(true);
-    }, []);
+    const cancelContextMenu = useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
 
-    const cancelContextMenu = React.useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
-
-    const handlePopoverInteraction = React.useCallback((nextOpenState: boolean) => {
+    const handlePopoverInteraction = useCallback((nextOpenState: boolean) => {
         if (!nextOpenState) {
             setIsOpen(false);
+            setMouseEvent(undefined);
         }
     }, []);
 
-    const targetRef = React.useRef<HTMLDivElement>();
-    const renderTarget = React.useCallback(
+    const targetRef = useRef<HTMLDivElement>(null);
+    const renderTarget = useCallback(
         ({ ref }: IPopover2TargetProps) => (
             <div
-                className={Classes.CONTEXT_MENU2_POPOVER_TARGET}
+                className={Classes.CONTEXT_MENU2_POPOVER2_TARGET}
                 style={targetOffset}
                 ref={mergeRefs(ref, targetRef)}
             />
         ),
         [targetOffset],
     );
-    const isDarkTheme = React.useMemo(() => CoreUtils.isDarkTheme(targetRef?.current), [targetRef.current]);
+    const isDarkTheme = useMemo(() => CoreUtils.isDarkTheme(targetRef.current), [targetRef.current]);
 
-    // Generate key based on offset so a new Popover instance is created
-    // when offset changes, to force recomputing position.
-    const key = `${targetOffset.left}x${targetOffset.top}`;
-    const renderProps: ContextMenu2RenderProps = { isOpen, targetOffset };
+    const renderProps: ContextMenu2RenderProps = { isOpen, mouseEvent, targetOffset };
 
-    return (
-        <div className={Classes.CONTEXT_MENU2} onContextMenu={handleContextMenu}>
+    // only render the popover if there is content in the context menu;
+    // this avoid doing unnecessary rendering & computation
+    const menu = disabled ? undefined : CoreUtils.isFunction(content) ? content(renderProps) : content;
+    const maybePopover =
+        menu === undefined ? undefined : (
             <Popover2
                 {...restProps}
                 content={
-                    // prevent right-clicking inside our context menu
-                    <div onContextMenu={cancelContextMenu}>
-                        {CoreUtils.isFunction(content) ? content(renderProps) : content}
-                    </div>
+                    // this prevents right-clicking inside our context menu
+                    <div onContextMenu={cancelContextMenu}>{menu}</div>
                 }
                 enforceFocus={false}
-                key={key}
+                // Generate key based on offset so a new Popover instance is created
+                // when offset changes, to force recomputing position.
+                key={`${targetOffset.left}x${targetOffset.top}`}
                 hasBackdrop={true}
                 isOpen={isOpen}
                 minimal={true}
                 onInteraction={handlePopoverInteraction}
-                popoverClassName={classNames({ [CoreClasses.DARK]: isDarkTheme })}
+                popoverClassName={classNames(popoverClassName, { [CoreClasses.DARK]: isDarkTheme })}
                 placement="right-start"
+                positioningStrategy="fixed"
                 rootBoundary="viewport"
                 renderTarget={renderTarget}
                 transitionDuration={transitionDuration}
             />
+        );
+
+    const handleContextMenu = useCallback(
+        (e: React.MouseEvent<HTMLDivElement>) => {
+            // support nested menus (inner menu target would have called preventDefault())
+            if (e.defaultPrevented) {
+                return;
+            }
+
+            if (!disabled) {
+                e.preventDefault();
+                e.persist();
+                setMouseEvent(e);
+                const { left, top } = getContainingBlockOffset(containerRef.current);
+                setTargetOffset({ left: e.clientX - left, top: e.clientY - top });
+                setIsOpen(true);
+            }
+
+            onContextMenu?.(e);
+        },
+        [containerRef.current, onContextMenu, disabled],
+    );
+
+    return (
+        <div
+            className={classNames(className, Classes.CONTEXT_MENU2)}
+            ref={containerRef}
+            onContextMenu={handleContextMenu}
+        >
+            {maybePopover}
             {CoreUtils.isFunction(children) ? children(renderProps) : children}
         </div>
     );
 };
 ContextMenu2.displayName = "Blueprint.ContextMenu2";
+
+function getContainingBlockOffset(targetElement: HTMLElement | null | undefined): { left: number; top: number } {
+    if (targetElement != null) {
+        const containingBlock = targetElement.closest(`.${CoreClasses.FIXED_POSITIONING_CONTAINING_BLOCK}`);
+        if (containingBlock != null) {
+            return containingBlock.getBoundingClientRect();
+        }
+    }
+    return { left: 0, top: 0 };
+}

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { State as PopperState } from "@popperjs/core";
+import { State as PopperState, PositioningStrategy } from "@popperjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps, StrictModifier } from "react-popper";
@@ -86,6 +86,14 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends I
      * Ref supplied to the `Classes.POPOVER` element.
      */
     popoverRef?: (ref: HTMLElement | null) => void;
+
+    /**
+     * Popper.js positioning strategy.
+     *
+     * @see https://popper.js.org/docs/v2/constructors/#strategy
+     * @default "absolute"
+     */
+    positioningStrategy?: PositioningStrategy;
 }
 
 export interface IPopover2State {
@@ -115,6 +123,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
         minimal: false,
         openOnTargetFocus: true,
         placement: "auto",
+        positioningStrategy: "absolute",
         renderTarget: undefined as any,
         targetTagName: "span",
         transitionDuration: 300,
@@ -199,7 +208,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
                 <Popper
                     innerRef={this.refHandlers.popover}
                     placement={this.props.placement}
-                    strategy="absolute"
+                    strategy={this.props.positioningStrategy}
                     modifiers={this.computePopperModifiers()}
                 >
                     {this.renderPopover}

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -52,6 +52,9 @@ describe("ContextMenu2", () => {
     }
 
     function openCtxMenu(ctxMenu: ReactWrapper) {
-        ctxMenu.find(`.${TARGET_CLASSNAME}`).simulate("contextmenu").update();
+        ctxMenu
+            .find(`.${TARGET_CLASSNAME}`)
+            .simulate("contextmenu", { defaultPrevented: false, clientX: 10, clientY: 10 })
+            .update();
     }
 });


### PR DESCRIPTION
Ported changes on `v4` branch from https://github.com/palantir/blueprint/pull/4588 and https://github.com/palantir/blueprint/pull/4595 onto `develop`.

#### Fixes #4537

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Refactor Tree example as a function component with cleaner state handling logic (using a React reducer hook)
- Add a repro case for #4537 in the refactored Tree example
- Add `positioningStrategy` prop for Popover2
- Add `popoverClassName` prop for ContextMenu2
- Fix `ContextMenu2`'s styles to use their own classes instead of `ContextMenu`'s, add the relevant Sass stylesheet
- Create a new utility class `.bp3-fixed-positioning-containing-block` which is used to give hints to child / ancestor elements which use `position: fixed` and need to know about their containing block for proper layout calculations. [See MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block). Use this new utility class in `Collapse` and `ContextMenu2` to fix #4537.
- Update `ContextMenu2RenderProps` to include the mouse event like `ContextMenuTarget` did, to improve compatibility with existing use cases in the wild (like I encountered in the table package in #4595)
- Add `className`, `disabled`, and `onContextMenu` props for ContextMenu2

#### Reviewers should focus on:

Already reviewed
