### PR TITLE
[popover2] docs: remove "content as second child" JSDoc

### DIFF
--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -53,8 +53,7 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends I
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
     /**
-     * The content displayed inside the popover. This can instead be provided as
-     * the _second_ element in `children` (first is `target`).
+     * The content displayed inside the popover.
      */
     content?: string | JSX.Element;
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Remove `This can instead be provided as the second element in children (first is target).` from Popover2's `content` prop, since Popover2 only accepts a single child (`target`).

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
