### PR TITLE
[core] feat(MultistepDialog): allow custom next/back button props per step

### DIFF
--- a/packages/core/src/components/dialog/dialogStep.tsx
+++ b/packages/core/src/components/dialog/dialogStep.tsx
@@ -20,8 +20,10 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { IButtonProps } from "../button/buttons";
 
 export type DialogStepId = string | number;
+export type DialogStepButtonProps = Partial<Pick<IButtonProps, "disabled" | "text">>;
 
 export interface IDialogStepProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
@@ -43,6 +45,16 @@ export interface IDialogStepProps extends IProps, Omit<HTMLDivProps, "id" | "tit
      * Content of step title element, rendered in a list left of the active panel.
      */
     title?: React.ReactNode;
+
+    /**
+     * Props for the back button.
+     */
+    backButtonProps?: DialogStepButtonProps;
+
+    /**
+     * Props for the next button.
+     */
+    nextButtonProps?: DialogStepButtonProps;
 }
 
 @polyfill

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -168,7 +168,7 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
         const buttons = [];
 
         if (this.state.selectedIndex > 0) {
-            const backButtonProps = steps[selectedIndex].props.backButtonProps || this.props.backButtonProps;
+            const backButtonProps = steps[selectedIndex].props.backButtonProps ?? this.props.backButtonProps;
 
             buttons.push(
                 <Button
@@ -183,7 +183,7 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
         if (selectedIndex === this.getDialogStepChildren().length - 1) {
             buttons.push(<Button intent="primary" key="final" text="Submit" {...this.props.finalButtonProps} />);
         } else {
-            const nextButtonProps = steps[selectedIndex].props.nextButtonProps || this.props.nextButtonProps;
+            const nextButtonProps = steps[selectedIndex].props.nextButtonProps ?? this.props.nextButtonProps;
 
             buttons.push(
                 <Button

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -20,19 +20,17 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { isFunction } from "../../common/utils";
 import { Button, IButtonProps } from "../button/buttons";
 import { Dialog, IDialogProps } from "./dialog";
-import { DialogStep, DialogStepId, IDialogStepProps } from "./dialogStep";
+import { DialogStep, DialogStepId, IDialogStepProps, DialogStepButtonProps } from "./dialogStep";
 
 type DialogStepElement = React.ReactElement<IDialogStepProps & { children: React.ReactNode }>;
-type AllowedButtonProps = Pick<IButtonProps, "disabled" | "text">;
 
 export interface IMultistepDialogProps extends IDialogProps {
     /**
      * Props for the back button.
      */
-    backButtonProps?: Partial<AllowedButtonProps> | ((step: DialogStepId) => Partial<AllowedButtonProps>);
+    backButtonProps?: DialogStepButtonProps;
 
     /**
      * Props for the button to display on the final step.
@@ -42,7 +40,7 @@ export interface IMultistepDialogProps extends IDialogProps {
     /**
      * Props for the next button.
      */
-    nextButtonProps?: Partial<AllowedButtonProps> | ((step: DialogStepId) => Partial<AllowedButtonProps>);
+    nextButtonProps?: DialogStepButtonProps;
 
     /**
      * A callback that is invoked when the user selects a different step by clicking on back, next, or a step itself.
@@ -167,13 +165,10 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
     private renderButtons() {
         const { selectedIndex } = this.state;
         const steps = this.getDialogStepChildren();
-        const stepId = steps[selectedIndex].props.id;
         const buttons = [];
 
         if (this.state.selectedIndex > 0) {
-            const backButtonProps = isFunction(this.props.backButtonProps)
-                ? this.props.backButtonProps(stepId)
-                : this.props.backButtonProps;
+            const backButtonProps = steps[selectedIndex].props.backButtonProps || this.props.backButtonProps;
 
             buttons.push(
                 <Button
@@ -188,9 +183,7 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
         if (selectedIndex === this.getDialogStepChildren().length - 1) {
             buttons.push(<Button intent="primary" key="final" text="Submit" {...this.props.finalButtonProps} />);
         } else {
-            const nextButtonProps = isFunction(this.props.nextButtonProps)
-                ? this.props.nextButtonProps(stepId)
-                : this.props.nextButtonProps;
+            const nextButtonProps = steps[selectedIndex].props.nextButtonProps || this.props.nextButtonProps;
 
             buttons.push(
                 <Button

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -18,7 +18,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { Classes, MultistepDialog, DialogStep } from "../../src";
+import { Classes, MultistepDialog, DialogStep, DialogStepId } from "../../src";
 
 const NEXT_BUTTON = "[text='Next']";
 const BACK_BUTTON = "[text='Back']";
@@ -198,6 +198,31 @@ describe("<MultistepDialog>", () => {
             </MultistepDialog>,
         );
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
+        dialog.unmount();
+    });
+
+    it("disables next for second step when disabled on nextButtonProps is set to true", () => {
+        const getNextButtonProps = (stepId: DialogStepId) => {
+            if (stepId === "two") return { disabled: true };
+
+            return {};
+        };
+
+        const dialog = mount(
+            <MultistepDialog nextButtonProps={getNextButtonProps} isOpen={true} usePortal={false}>
+                <DialogStep id="one" title="Step 1" panel={<Panel />} />
+                <DialogStep id="two" title="Step 2" panel={<Panel />} />
+                <DialogStep id="three" title="Step 3" panel={<Panel />} />
+            </MultistepDialog>,
+        );
+
+        assert.strictEqual(dialog.state("selectedIndex"), 0);
+        assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), undefined);
+        dialog.find(NEXT_BUTTON).simulate("click");
+        assert.strictEqual(dialog.state("selectedIndex"), 1);
+        assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
+        dialog.find(NEXT_BUTTON).simulate("click");
+        assert.strictEqual(dialog.state("selectedIndex"), 1);
         dialog.unmount();
     });
 });

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -18,7 +18,7 @@ import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
-import { Classes, MultistepDialog, DialogStep, DialogStepId } from "../../src";
+import { Classes, MultistepDialog, DialogStep } from "../../src";
 
 const NEXT_BUTTON = "[text='Next']";
 const BACK_BUTTON = "[text='Back']";
@@ -202,16 +202,10 @@ describe("<MultistepDialog>", () => {
     });
 
     it("disables next for second step when disabled on nextButtonProps is set to true", () => {
-        const getNextButtonProps = (stepId: DialogStepId) => {
-            if (stepId === "two") return { disabled: true };
-
-            return {};
-        };
-
         const dialog = mount(
-            <MultistepDialog nextButtonProps={getNextButtonProps} isOpen={true} usePortal={false}>
+            <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
-                <DialogStep id="two" title="Step 2" panel={<Panel />} />
+                <DialogStep id="two" title="Step 2" panel={<Panel />} nextButtonProps={{ disabled: true }} />
                 <DialogStep id="three" title="Step 3" panel={<Panel />} />
             </MultistepDialog>,
         );
@@ -222,6 +216,24 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
         dialog.find(NEXT_BUTTON).simulate("click");
+        assert.strictEqual(dialog.state("selectedIndex"), 1);
+        dialog.unmount();
+    });
+
+    it("disables back for second step when disabled on backButtonProps is set to true", () => {
+        const dialog = mount(
+            <MultistepDialog isOpen={true} usePortal={false}>
+                <DialogStep id="one" title="Step 1" panel={<Panel />} />
+                <DialogStep id="two" title="Step 2" panel={<Panel />} backButtonProps={{ disabled: true }} />
+                <DialogStep id="three" title="Step 3" panel={<Panel />} />
+            </MultistepDialog>,
+        );
+
+        assert.strictEqual(dialog.state("selectedIndex"), 0);
+        dialog.find(NEXT_BUTTON).simulate("click");
+        assert.strictEqual(dialog.state("selectedIndex"), 1);
+        assert.strictEqual(dialog.find(BACK_BUTTON).prop("disabled"), true);
+        dialog.find(BACK_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         dialog.unmount();
     });


### PR DESCRIPTION
#### Fixes #4579 

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Provide a way to pass a callback to `backButtonProps` and `nextButtonProps`
