### PR TITLE
Fix unsafe ref usage

### DIFF
--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -42,6 +42,11 @@ export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined | n
     }
 }
 
+/** @deprecated use mergeRefs() instead */
+export function combineRefs<T extends HTMLElement>(ref1: IRefCallback<T>, ref2: IRefCallback<T>) {
+    return mergeRefs(ref1, ref2);
+}
+
 /**
  * Utility for merging refs into one singular callback ref.
  * If using in a functional component, would recomend using `useMemo` to preserve function identity.

--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -22,51 +22,44 @@ export interface IRefObject<T extends HTMLElement = HTMLElement> {
 }
 
 export function isRefObject<T extends HTMLElement>(value: IRef<T> | undefined | null): value is IRefObject<T> {
-    return value != null && typeof (value as IRefObject<T>).current !== "undefined";
+    return value != null && typeof value !== "function";
 }
 
-export type IRefCallback<T = HTMLElement> = (ref: T | null) => any;
+export type IRefCallback<T extends HTMLElement = HTMLElement> = (ref: T | null) => any;
 
 export function isRefCallback<T extends HTMLElement>(value: IRef<T> | undefined | null): value is IRefCallback<T> {
     return typeof value === "function";
 }
 
-export function combineRefs<T extends HTMLElement>(ref1: IRefCallback<T>, ref2: IRefCallback<T>) {
-    return mergeRefs(ref1, ref2);
-}
-
-export function mergeRefs<T extends HTMLElement>(...refs: Array<IRef<T> | null>): IRefCallback<T> {
-    return value => {
-        refs.forEach(ref => {
-            if (isRefCallback(ref)) {
-                ref(value);
-            } else if (isRefObject(ref)) {
-                ref.current = value;
-            }
-        });
-    };
-}
-
-export function getRef<T extends HTMLElement>(ref: T | IRefObject<T> | null) {
-    if (ref === null) {
-        return null;
-    }
-
-    return (ref as IRefObject<T>).current ?? (ref as T);
-}
-
 /**
  * Assign the given ref to a target, either a React ref object or a callback which takes the ref as its first argument.
  */
-export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined, ref: T | null) {
-    if (refTarget === undefined) {
-        return;
-    }
+export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined | null, ref: T | null): void {
     if (isRefObject<T>(refTarget)) {
         refTarget.current = ref;
     } else if (isRefCallback(refTarget)) {
         refTarget(ref);
     }
+}
+
+/**
+ * Utility for merging refs into one singular callback ref.
+ * If using in a functional component, would recomend using `useMemo` to preserve function identity.
+ */
+export function mergeRefs<T extends HTMLElement>(...refs: Array<IRef<T> | null>): IRefCallback<T> {
+    return value => {
+        refs.forEach(ref => {
+            setRef(ref, value);
+        });
+    };
+}
+
+export function getRef<T extends HTMLElement>(ref: T | IRefObject<T> | null): T | null {
+    if (ref === null) {
+        return null;
+    }
+
+    return (ref as IRefObject<T>).current ?? (ref as T);
 }
 
 /**
@@ -78,25 +71,10 @@ export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined, re
 export function refHandler<T extends HTMLElement, K extends string>(
     refTargetParent: { [k in K]: T | null },
     refTargetKey: K,
-): IRefCallback<T>;
-export function refHandler<T extends HTMLElement, K extends string>(
-    refTargetParent: { [k in K]: T | IRefObject<T> | null },
-    refTargetKey: K,
-    refProp: IRef<T> | undefined | null,
-): IRef<T>;
-export function refHandler<T extends HTMLElement, K extends string>(
-    refTargetParent: { [k in K]: T | IRefObject<T> | null },
-    refTargetKey: K,
     refProp?: IRef<T> | undefined | null,
-) {
-    if (isRefObject<T>(refProp)) {
-        refTargetParent[refTargetKey] = refProp;
-        return refProp;
-    }
+): IRefCallback<T> {
     return (ref: T | null) => {
         refTargetParent[refTargetKey] = ref;
-        if (isRefCallback(refProp)) {
-            refProp(ref);
-        }
+        setRef(refProp, ref);
     };
 }

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -21,10 +21,8 @@ import {
     AbstractPureComponent2,
     Alignment,
     Classes,
-    getRef,
     IActionProps,
     IElementRefProps,
-    IRefObject,
     Keys,
     MaybeElement,
     Utils,
@@ -105,7 +103,7 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         isActive: false,
     };
 
-    protected abstract buttonRef: HTMLElement | IRefObject<HTMLElement> | null;
+    protected abstract buttonRef: HTMLElement | null;
 
     private currentKeyDown?: number;
 
@@ -165,7 +163,7 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         /* eslint-disable deprecation/deprecation */
         if (Keys.isKeyboardClick(e.which)) {
             this.setState({ isActive: false });
-            getRef(this.buttonRef)?.click();
+            this.buttonRef?.click();
         }
         this.currentKeyDown = undefined;
         this.props.onKeyUp?.(e);

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -20,7 +20,7 @@
 import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
-import { IRef, IRefObject, refHandler } from "../../common/refs";
+import { IRef, refHandler, setRef } from "../../common/refs";
 import { AbstractButton, IButtonProps, IAnchorButtonProps } from "./abstractButton";
 
 export { IAnchorButtonProps, IButtonProps };
@@ -29,7 +29,7 @@ export class Button extends AbstractButton<HTMLButtonElement> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Button`;
 
     // need to keep this ref so that we can access it in AbstractButton#handleKeyUp
-    public buttonRef: HTMLButtonElement | IRefObject<HTMLButtonElement> | null = null;
+    public buttonRef: HTMLButtonElement | null = null;
 
     protected handleRef: IRef<HTMLButtonElement> = refHandler(this, "buttonRef", this.props.elementRef);
 
@@ -45,13 +45,21 @@ export class Button extends AbstractButton<HTMLButtonElement> {
             </button>
         );
     }
+
+    public componentDidUpdate(prevProps: IButtonProps) {
+        if (prevProps.elementRef !== this.props.elementRef) {
+            setRef(prevProps.elementRef, null);
+            this.handleRef = refHandler(this, "buttonRef", this.props.elementRef);
+            setRef(this.props.elementRef, this.buttonRef);
+        }
+    }
 }
 
 export class AnchorButton extends AbstractButton<HTMLAnchorElement> {
     public static displayName = `${DISPLAYNAME_PREFIX}.AnchorButton`;
 
     // need to keep this ref so that we can access it in AbstractButton#handleKeyUp
-    public buttonRef: HTMLAnchorElement | IRefObject<HTMLAnchorElement> | null = null;
+    public buttonRef: HTMLAnchorElement | null = null;
 
     protected handleRef: IRef<HTMLAnchorElement> = refHandler(this, "buttonRef", this.props.elementRef);
 
@@ -71,5 +79,13 @@ export class AnchorButton extends AbstractButton<HTMLAnchorElement> {
                 {this.renderChildren()}
             </a>
         );
+    }
+
+    public componentDidUpdate(prevProps: IAnchorButtonProps) {
+        if (prevProps.elementRef !== this.props.elementRef) {
+            setRef(prevProps.elementRef, null);
+            this.handleRef = refHandler(this, "buttonRef", this.props.elementRef);
+            setRef(this.props.elementRef, this.buttonRef);
+        }
     }
 }

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -22,7 +22,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Alignment, Classes, IRef, refHandler } from "../../common";
+import { AbstractPureComponent2, Alignment, Classes, IRef, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
 
 export interface IControlProps extends IProps, HTMLInputProps {
@@ -266,8 +266,13 @@ export class Checkbox extends AbstractPureComponent2<ICheckboxProps, ICheckboxSt
         this.updateIndeterminate();
     }
 
-    public componentDidUpdate() {
+    public componentDidUpdate(prevProps: ICheckboxProps) {
         this.updateIndeterminate();
+        if (prevProps.inputRef !== this.props.inputRef) {
+            setRef(prevProps.inputRef, null);
+            this.handleInputRef = refHandler(this, "input", this.props.inputRef);
+            setRef(this.props.inputRef, this.input);
+        }
     }
 
     private updateIndeterminate() {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -34,6 +34,7 @@ import {
     Position,
     refHandler,
     removeNonHTMLProps,
+    setRef,
     Utils,
 } from "../../common";
 import * as Errors from "../../common/errors";
@@ -342,6 +343,12 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
 
     public componentDidUpdate(prevProps: INumericInputProps, prevState: INumericInputState) {
         super.componentDidUpdate(prevProps, prevState);
+
+        if (prevProps.inputRef !== this.props.inputRef) {
+            setRef(prevProps.inputRef, null);
+            this.inputRef = refHandler(this, "inputElement", this.props.inputRef);
+            setRef(this.props.inputRef, this.inputElement);
+        }
 
         if (this.state.shouldSelectAfterUpdate) {
             this.inputElement?.setSelectionRange(0, this.state.value.length);

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -18,16 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import {
-    AbstractPureComponent2,
-    Classes,
-    getRef,
-    IRef,
-    IRefObject,
-    isRefCallback,
-    isRefObject,
-    refHandler,
-} from "../../common";
+import { AbstractPureComponent2, Classes, IRef, IRefCallback, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 
 export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -70,29 +61,25 @@ export class TextArea extends AbstractPureComponent2<ITextAreaProps, ITextAreaSt
     public state: ITextAreaState = {};
 
     // used to measure and set the height of the component on first mount
-    public textareaElement: HTMLTextAreaElement | IRefObject<HTMLTextAreaElement> | null = null;
+    public textareaElement: HTMLTextAreaElement | null = null;
 
-    private handleRef: IRef<HTMLTextAreaElement> = refHandler(this, "textareaElement", this.props.inputRef);
+    private handleRef: IRefCallback<HTMLTextAreaElement> = refHandler(this, "textareaElement", this.props.inputRef);
 
     public componentDidMount() {
         if (this.props.growVertically && this.textareaElement !== null) {
             // HACKHACK: this should probably be done in getSnapshotBeforeUpdate
             /* eslint-disable-next-line react/no-did-mount-set-state */
             this.setState({
-                height: getRef(this.textareaElement)!.scrollHeight,
+                height: this.textareaElement?.scrollHeight,
             });
         }
     }
 
     public componentDidUpdate(prevProps: ITextAreaProps) {
-        const { inputRef } = this.props;
-        if (prevProps.inputRef !== inputRef) {
-            if (isRefObject<HTMLTextAreaElement>(inputRef)) {
-                inputRef.current = (this.textareaElement as IRefObject<HTMLTextAreaElement>).current;
-                this.textareaElement = inputRef;
-            } else if (isRefCallback<HTMLTextAreaElement>(inputRef)) {
-                inputRef(this.textareaElement as HTMLTextAreaElement | null);
-            }
+        if (prevProps.inputRef !== this.props.inputRef) {
+            setRef(prevProps.inputRef, null);
+            this.handleRef = refHandler(this, "textareaElement", this.props.inputRef);
+            setRef(this.props.inputRef, this.textareaElement);
         }
     }
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from "react-popper";
 
-import { AbstractPureComponent2, Classes, IRef, refHandler } from "../../common";
+import { AbstractPureComponent2, Classes, IRef, refHandler, setRef } from "../../common";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, HTMLDivProps } from "../../common/props";
 import * as Utils from "../../common/utils";
@@ -221,8 +221,15 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         this.updateDarkParent();
     }
 
-    public componentDidUpdate(props: IPopoverProps, state: IPopoverState) {
-        super.componentDidUpdate(props, state);
+    public componentDidUpdate(prevProps: IPopoverProps, prevState: IPopoverState) {
+        super.componentDidUpdate(prevProps, prevState);
+
+        if (prevProps.popoverRef !== this.props.popoverRef) {
+            setRef(prevProps.popoverRef, null);
+            this.handlePopoverRef = refHandler(this, "popoverElement", this.props.popoverRef);
+            setRef(this.props.popoverRef, this.popoverElement);
+        }
+
         this.updateDarkParent();
 
         const nextIsOpen = this.getIsOpen(this.props);
@@ -570,7 +577,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
     }
 
     private isElementInPopover(element: Element) {
-        return this.popoverElement != null && this.popoverElement.contains(element);
+        return this.popoverElement?.contains(element);
     }
 
     private isHoverInteractionKind() {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Classes, getRef, IRef, IRefObject, Keys, refHandler, Utils } from "../../common";
+import { AbstractPureComponent2, Classes, IRef, Keys, refHandler, setRef, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IIntentProps, IProps, MaybeElement } from "../../common/props";
 import { Icon, IconName } from "../icon/icon";
 import { ITagProps, Tag } from "../tag/tag";
@@ -222,7 +222,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
         isInputFocused: false,
     };
 
-    public inputElement: HTMLInputElement | IRefObject<HTMLInputElement> | null = null;
+    public inputElement: HTMLInputElement | null = null;
 
     private handleRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputRef);
 
@@ -274,6 +274,14 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
                 {this.props.rightElement}
             </div>
         );
+    }
+
+    public componentDidUpdate(prevProps: ITagInputProps) {
+        if (prevProps.inputRef !== this.props.inputRef) {
+            setRef(prevProps.inputRef, null);
+            this.handleRef = refHandler(this, "inputElement", this.props.inputRef);
+            setRef(this.props.inputRef, this.inputElement);
+        }
     }
 
     private addTags = (value: string, method: TagInputAddMethod = "default") => {
@@ -347,7 +355,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     }
 
     private handleContainerClick = () => {
-        getRef(this.inputElement)?.focus();
+        this.inputElement?.focus();
     };
 
     private handleContainerBlur = ({ currentTarget }: React.FocusEvent<HTMLDivElement>) => {

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -109,13 +109,13 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
         });
 
         if (typeof React.createRef !== "undefined") {
-            it("matches buttonRef with elementRef using createRef", done => {
+            it("matches buttonRef with elementRef.current using createRef", done => {
                 const elementRef = React.createRef<HTMLButtonElement>();
                 const wrapper = button({ elementRef }, true);
 
                 // wait for the whole lifecycle to run
                 setTimeout(() => {
-                    assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef.current);
+                    assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef);
                     done();
                 }, 0);
             });
@@ -137,8 +137,37 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             }, 0);
         });
 
+        it("updates on ref change", () => {
+            const Component = component;
+            let elementRef: HTMLElement | null = null;
+            let elementRefNew: HTMLElement | null = null;
+            let callCount = 0;
+            let newCallCount = 0;
+
+            const buttonRefCallback = (ref: HTMLElement | null) => {
+                callCount += 1;
+                elementRef = ref;
+            };
+            const buttonNewRefCallback = (ref: HTMLElement | null) => {
+                newCallCount += 1;
+                elementRefNew = ref;
+            };
+
+            const wrapper = mount(<Component elementRef={buttonRefCallback} />);
+
+            assert.instanceOf(elementRef, HTMLElement);
+            assert.strictEqual(callCount, 1);
+
+            wrapper.setProps({ elementRef: buttonNewRefCallback });
+            wrapper.update();
+            assert.strictEqual(callCount, 2);
+            assert.isNull(elementRef);
+            assert.strictEqual(newCallCount, 1);
+            assert.instanceOf(elementRefNew, HTMLElement);
+        });
+
         if (typeof React.useRef !== "undefined") {
-            it("matches buttonRef with elementRef using useRef", done => {
+            it("matches buttonRef with elementRef.current using useRef", done => {
                 let elementRef: React.RefObject<HTMLElement>;
                 const Component = component;
 
@@ -152,7 +181,7 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
 
                 // wait for the whole lifecycle to run
                 setTimeout(() => {
-                    assert.equal(elementRef.current, (wrapper.find(Component).instance() as any).buttonRef.current);
+                    assert.equal(elementRef.current, (wrapper.find(Component).instance() as any).buttonRef);
                     done();
                 }, 0);
             });

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -70,13 +70,26 @@ describe("<TextArea>", () => {
     it("updates on ref change", () => {
         let textArea: HTMLTextAreaElement | null = null;
         let textAreaNew: HTMLTextAreaElement | null = null;
-        const textAreaRefCallback = (ref: HTMLTextAreaElement | null) => (textArea = ref);
-        const textAreaNewRefCallback = (ref: HTMLTextAreaElement | null) => (textAreaNew = ref);
+        let callCount = 0;
+        let newCallCount = 0;
+        const textAreaRefCallback = (ref: HTMLTextAreaElement | null) => {
+            callCount += 1;
+            textArea = ref;
+        };
+        const textAreaNewRefCallback = (ref: HTMLTextAreaElement | null) => {
+            newCallCount += 1;
+            textAreaNew = ref;
+        };
 
         const textAreawrapper = mount(<TextArea id="textarea" inputRef={textAreaRefCallback} />);
         assert.instanceOf(textArea, HTMLTextAreaElement);
+        assert.strictEqual(callCount, 1);
 
         textAreawrapper.setProps({ inputRef: textAreaNewRefCallback });
+        textAreawrapper.update();
+        assert.strictEqual(callCount, 2);
+        assert.isNull(textArea);
+        assert.strictEqual(newCallCount, 1);
         assert.instanceOf(textAreaNew, HTMLTextAreaElement);
     });
 
@@ -89,6 +102,7 @@ describe("<TextArea>", () => {
             assert.instanceOf(textAreaRef.current, HTMLTextAreaElement);
 
             textAreawrapper.setProps({ inputRef: textAreaNewRef });
+            assert.isNull(textAreaRef.current);
             assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
         });
     }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -22,17 +22,16 @@ import { polyfill } from "react-lifecycles-compat";
 import {
     AbstractPureComponent2,
     DISPLAYNAME_PREFIX,
-    getRef,
     IInputGroupProps2,
     InputGroup,
     Intent,
     IPopoverProps,
     IProps,
-    IRefCallback,
-    IRefObject,
+    IRef,
     Keys,
     Popover,
     refHandler,
+    setRef,
 } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
@@ -86,7 +85,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
     /**
      * Props to pass to the [input group](#core/components/text-inputs.input-group).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
-     * `type` is fixed to "text" and `ref` is not supported; use `inputRef` instead.
+     * `type` is fixed to "text".
      */
     inputProps?: IInputGroupProps2;
 
@@ -180,7 +179,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         valueString: null,
     };
 
-    public inputElement: HTMLInputElement | IRefObject<HTMLInputElement> | null = null;
+    public inputElement: HTMLInputElement | null = null;
 
     public popoverContentElement: HTMLDivElement | null = null;
 
@@ -194,7 +193,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         this.props.inputProps?.inputRef,
     );
 
-    private handlePopoverContentRef: IRefCallback<HTMLDivElement> = refHandler(this, "popoverContentElement");
+    private handlePopoverContentRef: IRef<HTMLDivElement> = refHandler(this, "popoverContentElement");
 
     public componentWillUnmount() {
         this.unregisterPopoverBlurHandler();
@@ -212,7 +211,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
                 if (
                     e.key === "Tab" &&
                     !e.shiftKey &&
-                    this.lastTabbableElement.classList.contains(Classes.DATEPICKER_DAY)
+                    this.lastTabbableElement?.classList.contains(Classes.DATEPICKER_DAY)
                 ) {
                     this.setState({ isOpen: false });
                 }
@@ -279,6 +278,13 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
 
     public componentDidUpdate(prevProps: IDateInputProps, prevState: IDateInputState) {
         super.componentDidUpdate(prevProps, prevState);
+
+        if (prevProps.inputProps?.inputRef !== this.props.inputProps?.inputRef) {
+            setRef(prevProps.inputProps?.inputRef, null);
+            this.handleInputRef = refHandler(this, "inputElement", this.props.inputProps?.inputRef);
+            setRef(this.props.inputProps?.inputRef, this.inputElement);
+        }
+
         if (prevProps.value !== this.props.value) {
             this.setState({ value: this.props.value });
         }
@@ -414,7 +420,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
             this.setState({ isOpen: false });
         } else if (e.which === Keys.ESCAPE) {
             this.setState({ isOpen: false });
-            getRef(this.inputElement).blur();
+            this.inputElement?.blur();
         }
         this.safeInvokeInputProp("onKeyDown", e);
     };

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -24,17 +24,16 @@ import {
     Boundary,
     Classes,
     DISPLAYNAME_PREFIX,
-    getRef,
     IInputGroupProps2,
     InputGroup,
     Intent,
     IPopoverProps,
     IProps,
-    IRefObject,
     Keys,
     Popover,
     Position,
     refHandler,
+    setRef,
 } from "@blueprintjs/core";
 
 import { DateRange } from "./common/dateRange";
@@ -235,20 +234,20 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
 
     public static displayName = `${DISPLAYNAME_PREFIX}.DateRangeInput`;
 
-    public startInputElement: HTMLInputElement | IRefObject<HTMLInputElement> | null = null;
+    public startInputElement: HTMLInputElement | null = null;
 
-    public endInputElement: HTMLInputElement | IRefObject<HTMLInputElement> | null = null;
+    public endInputElement: HTMLInputElement | null = null;
 
     private handleStartInputRef = refHandler<HTMLInputElement, "startInputElement">(
         this,
         "startInputElement",
-        this.props.startInputProps.inputRef,
+        this.props.startInputProps?.inputRef,
     );
 
     private handleEndInputRef = refHandler<HTMLInputElement, "endInputElement">(
         this,
         "endInputElement",
-        this.props.endInputProps.inputRef,
+        this.props.endInputProps?.inputRef,
     );
 
     public constructor(props: IDateRangeInputProps, context?: any) {
@@ -275,22 +274,30 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         super.componentDidUpdate(prevProps, prevState);
         const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
 
-        const startInputRef = getRef(this.startInputElement);
-        const endInputRef = getRef(this.endInputElement);
+        if (prevProps.startInputProps?.inputRef !== this.props.startInputProps?.inputRef) {
+            setRef(prevProps.startInputProps?.inputRef, null);
+            this.handleStartInputRef = refHandler(this, "startInputElement", this.props.startInputProps?.inputRef);
+            setRef(this.props.startInputProps?.inputRef, this.startInputElement);
+        }
+        if (prevProps.endInputProps?.inputRef !== this.props.endInputProps?.inputRef) {
+            setRef(prevProps.endInputProps?.inputRef, null);
+            this.handleEndInputRef = refHandler(this, "endInputElement", this.props.endInputProps?.inputRef);
+            setRef(this.props.endInputProps?.inputRef, this.endInputElement);
+        }
 
-        const shouldFocusStartInput = this.shouldFocusInputRef(isStartInputFocused, startInputRef);
-        const shouldFocusEndInput = this.shouldFocusInputRef(isEndInputFocused, endInputRef);
+        const shouldFocusStartInput = this.shouldFocusInputRef(isStartInputFocused, this.startInputElement);
+        const shouldFocusEndInput = this.shouldFocusInputRef(isEndInputFocused, this.endInputElement);
 
         if (shouldFocusStartInput) {
-            startInputRef.focus();
+            this.startInputElement?.focus();
         } else if (shouldFocusEndInput) {
-            endInputRef.focus();
+            this.endInputElement?.focus();
         }
 
         if (isStartInputFocused && shouldSelectAfterUpdate) {
-            startInputRef.select();
+            this.startInputElement?.select();
         } else if (isEndInputFocused && shouldSelectAfterUpdate) {
-            endInputRef.select();
+            this.endInputElement?.select();
         }
 
         let nextState: IDateRangeInputState = {};

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -22,10 +22,10 @@ import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps
 import {
     AbstractPureComponent2,
     Classes as CoreClasses,
-    combineRefs,
     DISPLAYNAME_PREFIX,
     HTMLDivProps,
     isRefCallback,
+    mergeRefs,
     Overlay,
     ResizeSensor,
     Utils,
@@ -288,7 +288,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
         }
 
         if (isRefCallback(ref)) {
-            ref = combineRefs(ref, this.refHandlers.target);
+            ref = mergeRefs(ref, this.refHandlers.target);
         }
 
         const targetEventHandlers = isHoverInteractionKind

--- a/packages/popover2/src/tooltip2.md
+++ b/packages/popover2/src/tooltip2.md
@@ -29,7 +29,7 @@ required because the tooltip needs information from popover disable itself when 
 popover is open is open, thus preventing both elements from appearing at the same time.
 
 ```tsx
-import { Button, combineRefs } from "@blueprintjs/core";
+import { Button, mergeRefs } from "@blueprintjs/core";
 import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
 <Popover2
@@ -43,7 +43,7 @@ import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
                     {...popoverProps}
                     {...tooltipProps}
                     active={isPopoverOpen}
-                    elementRef={combineRefs(ref1, ref2)}
+                    elementRef={mergeRefs(ref1, ref2)}
                     text="Hover and click me"
                 />
             )}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -21,16 +21,15 @@ import {
     AbstractPureComponent2,
     Button,
     DISPLAYNAME_PREFIX,
-    getRef,
     IInputGroupProps2,
     InputGroup,
     IPopoverProps,
     IRef,
-    IRefObject,
     Keys,
     Popover,
     Position,
     refHandler,
+    setRef,
 } from "@blueprintjs/core";
 
 import { Classes, IListItemsProps } from "../../common";
@@ -89,7 +88,7 @@ export class Select<T> extends AbstractPureComponent2<ISelectProps<T>, ISelectSt
 
     private TypedQueryList = QueryList.ofType<T>();
 
-    public inputElement: HTMLInputElement | IRefObject<HTMLInputElement> | null = null;
+    public inputElement: HTMLInputElement | null = null;
 
     private queryList: QueryList<T> | null = null;
 
@@ -113,7 +112,13 @@ export class Select<T> extends AbstractPureComponent2<ISelectProps<T>, ISelectSt
         );
     }
 
-    public componentDidUpdate(_prevProps: ISelectProps<T>, prevState: ISelectState) {
+    public componentDidUpdate(prevProps: ISelectProps<T>, prevState: ISelectState) {
+        if (prevProps.inputProps?.inputRef !== this.props.inputProps?.inputRef) {
+            setRef(prevProps.inputProps?.inputRef, null);
+            this.handleInputRef = refHandler(this, "inputElement", this.props.inputProps?.inputRef);
+            setRef(this.props.inputProps?.inputRef, this.inputElement);
+        }
+
         if (this.state.isOpen && !prevState.isOpen && this.queryList != null) {
             this.queryList.scrollActiveItemIntoView();
         }
@@ -212,7 +217,7 @@ export class Select<T> extends AbstractPureComponent2<ISelectProps<T>, ISelectSt
             const { inputProps = {} } = this.props;
             // autofocus is enabled by default
             if (inputProps.autoFocus !== false) {
-                getRef(this.inputElement)?.focus();
+                this.inputElement?.focus();
             }
         });
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/4611

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

This changes a couple aspects of ref usage. 
* Makes it so that `refHandler` always creates a ref callback and always assigns an element to the local target.
  * This makes `refHandler` (more) type safe to use
  * This also prevents components from incorrectly accessing the local target element.
* Updates the local ref handler when a new ref callback is passed.
  * Previously, when passing a new ref callback it would only get called once, while the old ref callback would continue getting called.
* Properly set the previously passed ref to `null`, according to https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs

#### Reviewers should focus on:

Changes to the ref utility functions and component lifecycle methods.
