### PR TITLE
[popover2] docs: fix Tooltip2 example

### DIFF
--- a/packages/popover2/src/tooltip2.md
+++ b/packages/popover2/src/tooltip2.md
@@ -29,7 +29,7 @@ required because the tooltip needs information from popover disable itself when 
 popover is open is open, thus preventing both elements from appearing at the same time.
 
 ```tsx
-import { Button, combineRefs } from "@blueprintjs/core";
+import { Button, mergeRefs } from "@blueprintjs/core";
 import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
 <Popover2
@@ -43,7 +43,7 @@ import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
                     {...popoverProps}
                     {...tooltipProps}
                     active={isPopoverOpen}
-                    elementRef={combineRefs(ref1, ref2)}
+                    elementRef={mergeRefs(ref1, ref2)}
                     text="Hover and click me"
                 />
             )}

--- a/packages/popover2/src/tooltip2.md
+++ b/packages/popover2/src/tooltip2.md
@@ -38,7 +38,7 @@ import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
         <Tooltip2
             content="I have a popover!"
             disabled={isPopoverOpen}
-            renderTarget={({ isOpen: isTooltipOpen, ref2, ...tooltipProps }) => (
+            renderTarget={({ isOpen: isTooltipOpen, ref: ref2, ...tooltipProps }) => (
                 <Button
                     {...popoverProps}
                     {...tooltipProps}


### PR DESCRIPTION
- `ref2` is not defined, and it is supposed to be `ref` renamed
- `combineRefs` only accepts `IRefCallback` arguments, but `ref1` and `ref2` are `IRef`, so need to use `mergeRefs` instead