### PR TITLE
[core] feat(Drawer): add shouldReturnFocusOnClose prop

### DIFF
--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -63,7 +63,7 @@ export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps 
      *
      * @default true
      */
-    returnFocusOnClose?: boolean;
+    shouldReturnFocusOnClose?: boolean;
 
     /**
      * CSS size of the drawer. This sets `width` if `vertical={false}` (default)
@@ -114,7 +114,7 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
     public static defaultProps: IDrawerProps = {
         canOutsideClickClose: true,
         isOpen: false,
-        returnFocusOnClose: true,
+        shouldReturnFocusOnClose: true,
         style: {},
         vertical: false,
     };
@@ -221,7 +221,7 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
     };
 
     private handleClosed = (node: HTMLElement) => {
-        if (this.props.returnFocusOnClose && this.lastActiveElementBeforeOpened instanceof HTMLElement) {
+        if (this.props.shouldReturnFocusOnClose && this.lastActiveElementBeforeOpened instanceof HTMLElement) {
             this.lastActiveElementBeforeOpened.focus();
         }
         this.props.onClosed?.(node);

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -58,6 +58,14 @@ export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps 
     position?: Position;
 
     /**
+     * Whether the application should return focus to the last active element in the
+     * document after this drawer closes.
+     *
+     * @default true
+     */
+    returnFocusOnClose?: boolean;
+
+    /**
      * CSS size of the drawer. This sets `width` if `vertical={false}` (default)
      * and `height` otherwise.
      *
@@ -106,6 +114,7 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
     public static defaultProps: IDrawerProps = {
         canOutsideClickClose: true,
         isOpen: false,
+        returnFocusOnClose: true,
         style: {},
         vertical: false,
     };
@@ -212,7 +221,7 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
     };
 
     private handleClosed = (node: HTMLElement) => {
-        if (this.lastActiveElementBeforeOpened instanceof HTMLElement) {
+        if (this.props.returnFocusOnClose && this.lastActiveElementBeforeOpened instanceof HTMLElement) {
             this.lastActiveElementBeforeOpened.focus();
         }
         this.props.onClosed?.(node);


### PR DESCRIPTION

#### Changes proposed in this pull request:

This new prop provides a way to disable Drawer's default behavior of returning focus to the previous active element (introduced in https://github.com/palantir/blueprint/pull/4422)

