### PR TITLE
[popover2] fix(Popover2): use more specific overlay backdrop selector

### DIFF
--- a/packages/popover2/src/_popover2.scss
+++ b/packages/popover2/src/_popover2.scss
@@ -82,7 +82,8 @@ $popover2-width: $pt-grid-size * 35 !default;
   transform: rotate(45deg);
 }
 
-.#{$ns}-popover2-backdrop {
+// use a more specific selector to ensure that we override core's _overlay.scss styles
+.#{$ns}-overlay-backdrop.#{$ns}-popover2-backdrop {
   background: rgba($white, 0);
 }
 


### PR DESCRIPTION


<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Make Popover2's backdrop style CSS selector more specific so that it is guaranteed to override the styles in `_overlay.scss` in core. Before this change, we encountered some rare situations where this was not the case, and the default overlay backdrop gray color was visible.

#### Reviewers should focus on:

No regressions

#### Screenshot

