### PR TITLE
[v4] refactor Toaster types, fix remaining 'I' interface names in docs

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -44,7 +44,7 @@ export class BreadcrumbsExample extends React.Component {
 
 The `Breadcrumb` component renders an `a.@ns-breadcrumb` if given an `href` or
 `onClick` and a `span.@ns-breadcrumb` otherwise. Typically you will supply an
-array of `IBreadcrumbProps` to the `<Breadcrumbs items>` prop and only render
+array of `BreadcrumbProps` to the `<Breadcrumbs items>` prop and only render
 this component directly when defining a custom `breadcrumbRenderer`.
 
 @interface BreadcrumbProps

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -79,6 +79,7 @@ export * from "./tabs/tab";
 export * from "./tabs/tabs";
 export * from "./tag/tag";
 export * from "./tag-input/tagInput";
+export * from "./toast/overlayToaster";
 export * from "./toast/toast";
 export * from "./toast/toaster";
 export { TooltipProps, Tooltip } from "./tooltip/tooltip";

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,40 +25,13 @@ import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isNodeEnv } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { ToastProps, Toast } from "./toast";
-
-export type ToastOptions = ToastProps & { key: string };
-export type ToasterPosition =
-    | typeof Position.TOP
-    | typeof Position.TOP_LEFT
-    | typeof Position.TOP_RIGHT
-    | typeof Position.BOTTOM
-    | typeof Position.BOTTOM_LEFT
-    | typeof Position.BOTTOM_RIGHT;
-
-/** Instance methods available on a `<Toaster>` component instance. */
-export interface ToasterInstance {
-    /**
-     * Shows a new toast to the user, or updates an existing toast corresponding to the provided key (optional).
-     *
-     * Returns the unique key of the toast.
-     */
-    show(props: ToastProps, key?: string): string;
-
-    /** Dismiss the given toast instantly. */
-    dismiss(key: string): void;
-
-    /** Dismiss all toasts instantly. */
-    clear(): void;
-
-    /** Returns the props for all current toasts. */
-    getToasts(): ToastOptions[];
-}
+import { Toaster, ToastOptions, ToasterPosition } from "./toaster";
 
 /**
  * Props supported by the `<Toaster>` component.
  * These props can be passed as an argument to the static `Toaster.create(props?, container?)` method.
  */
-export interface ToasterProps extends Props {
+export interface OverlayToasterProps extends Props {
     /**
      * Whether a toast should acquire application focus when it first opens.
      * This is disabled by default so that toasts do not interrupt the user's flow.
@@ -103,14 +76,14 @@ export interface ToasterProps extends Props {
     maxToasts?: number;
 }
 
-export interface ToasterState {
+export interface OverlayToasterState {
     toasts: ToastOptions[];
 }
 
-export class Toaster extends AbstractPureComponent<ToasterProps, ToasterState> implements ToasterInstance {
-    public static displayName = `${DISPLAYNAME_PREFIX}.Toaster`;
+export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, OverlayToasterState> implements Toaster {
+    public static displayName = `${DISPLAYNAME_PREFIX}.OverlayToaster`;
 
-    public static defaultProps: ToasterProps = {
+    public static defaultProps: OverlayToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,
         position: Position.TOP,
@@ -121,23 +94,23 @@ export class Toaster extends AbstractPureComponent<ToasterProps, ToasterState> i
      * Create a new `Toaster` instance that can be shared around your application.
      * The `Toaster` will be rendered into a new element appended to the given container.
      */
-    public static create(props?: ToasterProps, container = document.body): ToasterInstance {
+    public static create(props?: OverlayToasterProps, container = document.body): Toaster {
         if (props != null && props.usePortal != null && !isNodeEnv("production")) {
             console.warn(TOASTER_WARN_INLINE);
         }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
-        const toaster = ReactDOM.render<ToasterProps>(
-            <Toaster {...props} usePortal={false} />,
+        const toaster = ReactDOM.render<OverlayToasterProps>(
+            <OverlayToaster {...props} usePortal={false} />,
             containerElement,
-        ) as Toaster;
+        ) as OverlayToaster;
         if (toaster == null) {
             throw new Error(TOASTER_CREATE_NULL);
         }
         return toaster;
     }
 
-    public state: ToasterState = {
+    public state: OverlayToasterState = {
         toasts: [],
     };
 
@@ -206,7 +179,7 @@ export class Toaster extends AbstractPureComponent<ToasterProps, ToasterState> i
         );
     }
 
-    protected validateProps({ maxToasts }: ToasterProps) {
+    protected validateProps({ maxToasts }: OverlayToasterProps) {
         // maximum number of toasts should not be a number less than 1
         if (maxToasts !== undefined && maxToasts < 1) {
             throw new Error(TOASTER_MAX_TOASTS_INVALID);

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -21,18 +21,18 @@ You can also apply the same visual intent styles to `Toast`s that you can to [`B
 
 @interface ToastProps
 
-@### Toaster
+@### OverlayToaster
 
-The `Toaster` React component is a stateful container for a single list of toasts. Internally, it
+The `OverlayToaster` React component is a stateful container for a single list of toasts. Internally, it
 uses [`Overlay`](#core/components/overlay) to manage children and transitions. It can be vertically
 aligned along the top or bottom edge of its container (new toasts will slide in from that edge) and
 horizontally aligned along the left edge, center, or right edge of its container.
 
-There are three ways to use the `Toaster` component:
+There are three ways to use the `OverlayToaster` component:
 
-1. `Toaster.create(props)` static method returns a new `IToaster` instance. Use the instance method `toaster.show()` to manipulate this instance. __(recommended)__
-1. `<Toaster><Toast />...</Toaster>`: Render a `<Toaster>` element with React `children`.
-1. `<Toaster ref={ref => ref.show({ ...toast })} />`: Render a `<Toaster>` element and use the `ref` prop to access its instance methods.
+1. `OverlayToaster.create(props)` static method returns a new `Toaster`. Use the instance method `toaster.show()` to manipulate this instance. __(recommended)__
+1. `<OverlayToaster><Toast />...</OverlayToaster>`: Render a `<OverlayToaster>` element with React `children`.
+1. `<OverlayToaster ref={toaster => toaster.show({ ...toast })} />`: Render a `<OverlayToaster>` element and use the `ref` prop to access its instance methods.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">Working with multiple toasters</h4>
@@ -45,40 +45,35 @@ You can have multiple toasters in a single application, but you must ensure that
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">Toaster focus</h4>
 
-`Toaster` always disables `Overlay`'s `enforceFocus` behavior (meaning that you're not blocked
+`OverlayToaster` always disables `Overlay`'s `enforceFocus` behavior (meaning that you're not blocked
 from accessing other parts of the application while a toast is active), and by default also
 disables `autoFocus` (meaning that focus will not switch to a toast when it appears). You can
-enable `autoFocus` for an individual `Toaster` via a prop, if desired.
+enable `autoFocus` for an individual `OverlayToaster` via a prop, if desired.
 
 </div>
 
 
-@interface ToasterProps
+@interface OverlayToasterProps
 
 @## Static usage
 
-The `Toaster` component provides the static `create` method that returns a new `Toaster` instance, rendered into an
+The `OverlayToaster` component provides the static `create` method that returns a new `Toaster` instance, rendered into an
 element attached to `<body>`. A `Toaster` instance
 has a collection of methods to show and hide toasts in its given container.
 
 ```ts
-Toaster.create(props?: ToasterProps, container = document.body): Toaster
+OverlayToaster.create(props?: ToasterProps, container = document.body): Toaster
 ```
 
-The `Toaster` will be rendered into a new element appended to the given `container`.
+The `OverlayToaster` will be rendered into a new element appended to the given `container`.
 The `container` determines which element toasts are positioned relative to; the default value of `<body>` allows them to use the entire viewport.
 
-Note that the return type is `IToaster`, which is a minimal interface that exposes only the instance
-methods detailed below. It can be thought of as `Toaster` minus the `React.Component` methods,
-because the `Toaster` should not be treated as a normal React component.
+Note that the return type is `Toaster`, which is a minimal interface that exposes only the instance
+methods detailed below. It can be thought of as `OverlayToaster` minus the `React.Component` methods,
+because the `OverlayToaster` should not be treated as a normal React component.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">React 16 usage</h4>
-
-`Toaster.create()` will throw an error if invoked inside a component lifecycle method in React 16, as `ReactDOM.render()` will return
-`null` resulting in an inaccessible toaster instance. See the second bullet point on the [React 16 release notes](https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes) for more information.
-
-</div>
+Note that `OverlayToaster.create()` will throw an error if invoked inside a component lifecycle method, as
+`ReactDOM.render()` will return `null` resulting in an inaccessible toaster instance.
 
 @interface Toaster
 
@@ -90,10 +85,10 @@ The following code samples demonstrate our preferred pattern for intergrating a 
 
 #### `toaster.ts`
 ```tsx
-import { Position, Toaster } from "@blueprintjs/core";
+import { Position, OverlayToaster } from "@blueprintjs/core";
 
 /** Singleton toaster instance. Create separate instances for different options. */
-export const AppToaster = Toaster.create({
+export const AppToaster = OverlayToaster.create({
     className: "recipe-toaster",
     position: Position.TOP,
 });
@@ -120,14 +115,14 @@ export class App extends React.PureComponent {
 
 @## React component usage
 
-Render the `<Toaster>` component like any other element and supply `<Toast>` elements as `children`. You can
+Render the `<OverlayToaster>` component like any other element and supply `<Toast>` elements as `children`. You can
 optionally attach a `ref` handler to access the instance methods, but we strongly recommend using the
-[`Toaster.create` static method](#core/components/toast.static-usage) documented above instead. Note that
+[`OverlayToaster.create` static method](#core/components/toast.static-usage) documented above instead. Note that
 `children` and `ref` can be used together, but `children` will always appear _after_ toasts created with
 `ref.show()`.
 
 ```tsx
-import { Button, Position, Toast, Toaster } from "@blueprintjs/core";
+import { Button, Position, Toast, OverlayToaster, Toaster } from "@blueprintjs/core";
 import React from "react";
 
 class MyComponent extends React.PureComponent {
@@ -142,10 +137,10 @@ class MyComponent extends React.PureComponent {
         return (
             <div>
                 <Button onClick={this.addToast} text="Procure toast" />
-                <Toaster position={Position.TOP_RIGHT} ref={this.refHandlers.toaster}>
+                <OverlayToaster position={Position.TOP_RIGHT} ref={this.refHandlers.toaster}>
                     {/* "Toasted!" will appear here after clicking button. */}
                     {this.state.toasts.map(toast => <Toast {...toast} />)}
-                </Toaster>
+                </OverlayToaster>
             </div>
         )
     }

--- a/packages/core/src/components/toast/toaster.ts
+++ b/packages/core/src/components/toast/toaster.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Position } from "../../common";
+import { ToastProps } from "./toast";
+
+export type ToastOptions = ToastProps & { key: string };
+export type ToasterPosition =
+    | typeof Position.TOP
+    | typeof Position.TOP_LEFT
+    | typeof Position.TOP_RIGHT
+    | typeof Position.BOTTOM
+    | typeof Position.BOTTOM_LEFT
+    | typeof Position.BOTTOM_RIGHT;
+
+/** Instance methods available on a toaster component instance. */
+export interface Toaster {
+    /**
+     * Shows a new toast to the user, or updates an existing toast corresponding to the provided key (optional).
+     *
+     * Returns the unique key of the toast.
+     */
+    show(props: ToastProps, key?: string): string;
+
+    /** Dismiss the given toast instantly. */
+    dismiss(key: string): void;
+
+    /** Dismiss all toasts instantly. */
+    clear(): void;
+
+    /** Returns the props for all current toasts. */
+    getToasts(): ToastOptions[];
+}

--- a/packages/core/src/components/tree/tree.md
+++ b/packages/core/src/components/tree/tree.md
@@ -7,7 +7,7 @@ Trees display hierarchical data.
 @## Props
 
 `Tree` is a stateless component. Its contents are dictated by the `contents` prop, which is an array
-of `ITreeNode`s (see [below](#components/tree.tree-node)). The tree is multi-rooted if
+of `TreeNode`s (see [below](#components/tree.tree-node)). The tree is multi-rooted if
 `contents` contains more than one top-level object.
 
 A variety of interaction callbacks are also exposed as props. All interaction callbacks supply a
@@ -25,7 +25,7 @@ example, `[2, 0]` represents the first child (`0`) of the third top-level node (
 
 @### Tree node
 
-`ITreeNode` objects determine the contents, appearance, and state of each node in the tree.
+`TreeNode` objects determine the contents, appearance, and state of each node in the tree.
 
 For example, `icon` controls the icon displayed for the node, and `isExpanded` determines
 whether the node's children are shown.

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -63,7 +63,7 @@ import "./tabs/tabsTests";
 import "./tag-input/tagInputTests";
 import "./tag/tagTests";
 import "./text/textTests";
-import "./toast/toasterTests";
+import "./toast/overlayToasterTests";
 import "./toast/toastTests";
 import "./tooltip/tooltipTests";
 import "./tree/treeTests";

--- a/packages/core/test/isotest.js
+++ b/packages/core/test/isotest.js
@@ -92,7 +92,7 @@ describe("Core isomorphic rendering", () => {
             props: { content: React.createElement("h1", {}, "content") },
             children: requiredChild,
         },
-        Toaster: {
+        OverlayToaster: {
             props: { usePortal: false },
             children: React.createElement(Core.Toast, { message: "Toast" }),
         },

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -22,17 +22,17 @@ import { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
-import { Classes, Toaster, ToasterInstance } from "../../src";
+import { Classes, OverlayToaster, Toaster } from "../../src";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
 
 describe("Toaster", () => {
     let testsContainerElement: HTMLElement;
-    let toaster: ToasterInstance;
+    let toaster: Toaster;
 
     before(() => {
         testsContainerElement = document.createElement("div");
         document.documentElement.appendChild(testsContainerElement);
-        toaster = Toaster.create({}, testsContainerElement);
+        toaster = OverlayToaster.create({}, testsContainerElement);
     });
 
     afterEach(() => {
@@ -139,7 +139,7 @@ describe("Toaster", () => {
     });
 
     it("does not exceed the maximum toast limit set", () => {
-        toaster = Toaster.create({ maxToasts: 3 });
+        toaster = OverlayToaster.create({ maxToasts: 3 });
         toaster.show({ message: "one" });
         toaster.show({ message: "two" });
         toaster.show({ message: "three" });
@@ -149,7 +149,7 @@ describe("Toaster", () => {
 
     describe("validation", () => {
         it("throws an error when max toast is set to a number less than 1", () => {
-            expectPropValidationError(Toaster, { maxToasts: 0 }, TOASTER_MAX_TOASTS_INVALID);
+            expectPropValidationError(OverlayToaster, { maxToasts: 0 }, TOASTER_MAX_TOASTS_INVALID);
         });
     });
 
@@ -157,7 +157,7 @@ describe("Toaster", () => {
         before(() => {
             testsContainerElement = document.createElement("div");
             document.documentElement.appendChild(testsContainerElement);
-            toaster = Toaster.create({ autoFocus: true }, testsContainerElement);
+            toaster = OverlayToaster.create({ autoFocus: true }, testsContainerElement);
         });
 
         it("focuses on newly created toast", done => {
@@ -178,7 +178,7 @@ describe("Toaster", () => {
 
             public componentDidMount() {
                 try {
-                    Toaster.create();
+                    OverlayToaster.create();
                 } catch (err) {
                     assert.equal(err.message, TOASTER_CREATE_NULL);
                 }

--- a/packages/datetime/src/datepicker.md
+++ b/packages/datetime/src/datepicker.md
@@ -24,7 +24,7 @@ in the [**react-day-picker** documentation](http://www.gpbl.org/react-day-picker
 The menu on the left of the calendars provides "shortcuts" that allow users to
 quickly select common dates. The items in this menu are controlled through
 the `shortcuts` prop: `true` to show presets, `false` to hide (default), or an
-array of `IDatePickerShortcut` objects to define custom shortcuts.
+array of `DatePickerShortcut` objects to define custom shortcuts.
 
 The **preset shortcuts** can be seen in the example above. They are as follows:
 

--- a/packages/datetime/src/daterangepicker.md
+++ b/packages/datetime/src/daterangepicker.md
@@ -20,7 +20,7 @@ Semantically:
 The menu on the left of the calendars provides "shortcuts" that allow users to
 quickly select common date ranges. The items in this menu are controlled through
 the `shortcuts` prop: `true` to show presets (default), `false` to hide, or an
-array of `IDateRangeShortcut` objects to define custom shortcuts.
+array of `DateRangeShortcut` objects to define custom shortcuts.
 
 The **preset shortcuts** can be seen in the example above. They are as follows:
 

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 
-import { Alert, Button, H5, Intent, Switch, Toaster, ToasterInstance } from "@blueprintjs/core";
+import { Alert, Button, H5, Intent, OverlayToaster, Switch, Toaster } from "@blueprintjs/core";
 import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { BlueprintExampleData } from "../../tags/types";
@@ -40,7 +40,7 @@ export class AlertExample extends React.PureComponent<ExampleProps<BlueprintExam
         willLoad: false,
     };
 
-    private toaster: ToasterInstance;
+    private toaster: Toaster;
 
     private handleEscapeKeyChange = handleBooleanChange(canEscapeKeyCancel => this.setState({ canEscapeKeyCancel }));
 
@@ -106,7 +106,7 @@ export class AlertExample extends React.PureComponent<ExampleProps<BlueprintExam
                     </p>
                 </Alert>
 
-                <Toaster ref={ref => (this.toaster = ref)} />
+                <OverlayToaster ref={ref => (this.toaster = ref)} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -23,10 +23,11 @@ import {
     H5,
     HTMLSelect,
     Intent,
-    ToasterProps,
+    OverlayToasterProps,
     ToastProps,
     Label,
     NumericInput,
+    OverlayToaster,
     Position,
     ProgressBar,
     Switch,
@@ -48,8 +49,8 @@ const POSITIONS = [
     Position.BOTTOM_RIGHT,
 ];
 
-export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExampleData>, ToasterProps> {
-    public state: ToasterProps = {
+export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExampleData>, OverlayToasterProps> {
+    public state: OverlayToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,
         position: Position.TOP,
@@ -131,7 +132,7 @@ export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExam
             <Example options={this.renderOptions()} {...this.props}>
                 {this.TOAST_BUILDERS.map(this.renderToastDemo, this)}
                 <Button onClick={this.handleProgressToast} text="Upload file" />
-                <Toaster {...this.state} ref={this.refHandlers.toaster} />
+                <OverlayToaster {...this.state} ref={this.refHandlers.toaster} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -16,7 +16,17 @@
 
 import React from "react";
 
-import { Button, H5, HotkeysTarget, KeyComboTag, MenuItem, Position, Switch, Toaster } from "@blueprintjs/core";
+import {
+    Button,
+    H5,
+    HotkeysTarget,
+    KeyComboTag,
+    MenuItem,
+    OverlayToaster,
+    Position,
+    Switch,
+    Toaster,
+} from "@blueprintjs/core";
 import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { Omnibar } from "@blueprintjs/select";
 
@@ -83,7 +93,7 @@ export class OmnibarExample extends React.PureComponent<ExampleProps, OmnibarExa
                         onItemSelect={this.handleItemSelect}
                         onClose={this.handleClose}
                     />
-                    <Toaster position={Position.TOP} ref={this.refHandlers.toaster} />
+                    <OverlayToaster position={Position.TOP} ref={this.refHandlers.toaster} />
                 </Example>
             </HotkeysTarget>
         );

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -104,7 +104,7 @@ will invoke `onItemSelect` with the item returned from `createNewItemFromQuery`.
 <div class="@ns-callout @ns-intent-warning @ns-icon-info-sign">
     <h4 class="@ns-heading">Avoiding type conflicts</h4>
 
-The "Create Item" option is represented by the reserved type `ICreateNewItem`
+The "Create Item" option is represented by the reserved type `CreateNewItem`
 exported from this package. It is exceedingly unlikely but technically possible
 for your custom type `<T>` to conflict with this type. If your type conflicts,
 you may see unexpected behavior; to resolve, consider changing the schema for

--- a/packages/table/src/docs/table-api.md
+++ b/packages/table/src/docs/table-api.md
@@ -22,7 +22,7 @@ number of rows (`numRows` prop) as well as a set of `Column` children.
 @method Table.resizeRowsByApproximateHeight
 
 
-`ICellMapper` is just a function that takes a cell-coordinate and returns a generic type:
+`CellMapper` is just a function that takes a cell-coordinate and returns a generic type:
 
 
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Fix interface name references in docs (`.md` files) which used the old "I" prefixed names (missed in #4580)
- Refactor toaster types into `Toaster` instance interface and `OverlayToaster` class (which is a specific kind of toaster, the only one available right now / so far)

