### PR TITLE
[v4] fix: remove usage of findDOMNode

### DIFF
--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -105,10 +105,3 @@ export function isElementOfType<P = {}>(
         element.type.displayName === ComponentType.displayName
     );
 }
-
-/**
- * Returns React.createRef if it's available, or a ref-like object if not.
- */
-export function createReactRef<T>() {
-    return typeof React.createRef !== "undefined" ? React.createRef<T>() : { current: null };
-}

--- a/packages/core/src/components/html/html.tsx
+++ b/packages/core/src/components/html/html.tsx
@@ -15,24 +15,23 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import React, { forwardRef } from "react";
 
-import { ElementRefProps } from "../../common";
 import { BLOCKQUOTE, CODE, CODE_BLOCK, HEADING, LABEL, LIST } from "../../common/classes";
 
 function htmlElement<E extends HTMLElement>(
     tagName: keyof JSX.IntrinsicElements,
     tagClassName: string,
-): React.FunctionComponent<React.HTMLProps<E> & ElementRefProps<E>> {
+): React.FC<React.HTMLAttributes<E> & React.RefAttributes<E>> {
     /* eslint-disable-next-line react/display-name */
-    return props => {
-        const { className, elementRef, ...htmlProps } = props;
+    return forwardRef<E, React.HTMLAttributes<E>>((props, ref) => {
+        const { className, ...htmlProps } = props;
         return React.createElement(tagName, {
             ...htmlProps,
             className: classNames(tagClassName, className),
-            ref: elementRef,
+            ref,
         });
-    };
+    });
 }
 
 // the following components are linted by blueprint-html-components because

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -284,7 +284,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
     public bringFocusInsideOverlay() {
         // always delay focus manipulation to just before repaint to prevent scroll jumping
         return this.requestAnimationFrame(() => {
-            // content element ref may be undefined between component mounting and Portal rendering
+            // container element may be undefined between component mounting and Portal rendering
             // activeElement may be undefined in some rare cases in IE
             if (this.containerElement.current == null || document.activeElement == null || !this.props.isOpen) {
                 return;
@@ -349,6 +349,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
         const {
             backdropClassName,
             backdropProps,
+            canOutsideClickClose,
             hasBackdrop,
             isOpen,
             transitionDuration,
@@ -367,7 +368,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
                         {...backdropProps}
                         className={classNames(Classes.OVERLAY_BACKDROP, backdropClassName, backdropProps?.className)}
                         onMouseDown={this.handleBackdropMouseDown}
-                        tabIndex={this.props.canOutsideClickClose ? 0 : undefined}
+                        tabIndex={canOutsideClickClose ? 0 : undefined}
                     />
                 </CSSTransition>
             );
@@ -443,7 +444,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
         const isClickInThisOverlayOrDescendant = Overlay.openStack
             .slice(stackIndex)
             .some(({ containerElement: elem }) => {
-                // `elem` is the container of backdrop & content, so clicking on that container
+                // `elem` is the container of backdrop & content, so clicking directly on that container
                 // should not count as being "inside" the overlay.
                 return elem.current?.contains(eventTarget) && !elem.current.isSameNode(eventTarget);
             });

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -570,8 +570,9 @@ export class Popover<T> extends AbstractPureComponent<PopoverProps<T>, PopoverSt
         }
 
         const eventTarget = e.target as HTMLElement;
-        // if click was in target, target event listener will handle things, so don't close
-        if (!Utils.elementIsOrContains(this.targetElement, eventTarget) || e.nativeEvent instanceof KeyboardEvent) {
+        const isClickInsideTarget = Utils.elementIsOrContains(this.targetElement, eventTarget);
+        // if click was in target, target event listener will handle things, so don't close here
+        if (!isClickInsideTarget || e.nativeEvent instanceof KeyboardEvent) {
             this.setOpenState(false, e);
         }
     };

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -21,10 +21,6 @@ import * as Classes from "../../common/classes";
 import { ValidationMap } from "../../common/context";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
-import { isFunction } from "../../common/utils";
-
-/** Detect if `React.createPortal()` API method does not exist. */
-const cannotCreatePortal = !isFunction(ReactDOM.createPortal);
 
 export interface PortalProps extends Props {
     /**
@@ -82,12 +78,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         // Only render `children` once this component has mounted in a browser environment, so they are
         // immediately attached to the DOM tree and can do DOM things like measuring or `autoFocus`.
         // See long comment on componentDidMount in https://reactjs.org/docs/portals.html#event-bubbling-through-portals
-        if (
-            cannotCreatePortal ||
-            typeof document === "undefined" ||
-            !this.state.hasMounted ||
-            this.portalElement === null
-        ) {
+        if (typeof document === "undefined" || !this.state.hasMounted || this.portalElement === null) {
             return null;
         } else {
             return ReactDOM.createPortal(this.props.children, this.portalElement);
@@ -102,9 +93,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         this.props.container.appendChild(this.portalElement);
         /* eslint-disable-next-line react/no-did-mount-set-state */
         this.setState({ hasMounted: true }, this.props.onChildrenMount);
-        if (cannotCreatePortal) {
-            this.unstableRenderNoPortal();
-        }
     }
 
     public componentDidUpdate(prevProps: PortalProps) {
@@ -115,17 +103,10 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             }
             maybeAddClass(this.portalElement.classList, this.props.className);
         }
-
-        if (cannotCreatePortal) {
-            this.unstableRenderNoPortal();
-        }
     }
 
     public componentWillUnmount() {
         if (this.portalElement != null) {
-            if (cannotCreatePortal) {
-                ReactDOM.unmountComponentAtNode(this.portalElement);
-            }
             this.portalElement.remove();
         }
     }
@@ -138,17 +119,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             maybeAddClass(container.classList, this.context.blueprintPortalClassName);
         }
         return container;
-    }
-
-    private unstableRenderNoPortal() {
-        if (this.portalElement === null) {
-            return;
-        }
-        ReactDOM.unstable_renderSubtreeIntoContainer(
-            /* parentComponent */ this,
-            <div>{this.props.children}</div>,
-            this.portalElement,
-        );
     }
 }
 

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -18,6 +18,15 @@ function handleResize(entries: ResizeEntry[]) {
 </ResizeSensor>
 ```
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h4 class="@ns-heading">DOM ref required</h4>
+
+ResizeSensor's implementation relies on a React ref being attached to a DOM element,
+so the child of this component _must be a native DOM element_ or utilize
+[`React.forwardRef()`](https://reactjs.org/docs/forwarding-refs.html).
+
+</div>
+
 @## Props
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -6,6 +6,16 @@ DOM element child. It is a thin wrapper around
 
 [resizeobserver]: https://developers.google.com/web/updates/2016/10/resizeobserver
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h4 class="@ns-heading">DOM ref required</h4>
+
+ResizeSensor's implementation relies on a React ref being attached to a DOM element,
+so the child of this component _must be a native DOM element_ or utilize
+[`React.forwardRef()`](https://reactjs.org/docs/forwarding-refs.html) to forward any
+injected ref to the underlying DOM element.
+
+</div>
+
 ```tsx
 import { ResizeEntry, ResizeSensor } from "@blueprintjs/core";
 
@@ -18,14 +28,16 @@ function handleResize(entries: ResizeEntry[]) {
 </ResizeSensor>
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">DOM ref required</h4>
+If you attach a `ref` to the child yourself, you must pass the same value to `ResizeSensor`
+with the `targetRef` prop (otherwise, the component won't be able to attach one itself).
 
-ResizeSensor's implementation relies on a React ref being attached to a DOM element,
-so the child of this component _must be a native DOM element_ or utilize
-[`React.forwardRef()`](https://reactjs.org/docs/forwarding-refs.html).
+```tsx
+const myRef = React.createRef();
 
-</div>
+<ResizeSensor targetRef={myRef} onResize={handleResize}>
+    <div ref={myRef} style={{ width: this.props.width }} />
+</ResizeSensor>
+```
 
 @## Props
 

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import React from "react";
-import { findDOMNode } from "react-dom";
+import React, { cloneElement, useEffect, useMemo, useRef } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 
-import { AbstractPureComponent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { ResizeEntry } from "./resizeObserverTypes";
 
 /** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 export interface ResizeSensorProps {
+    /**
+     * Single child, must be an element and not a string or fragment.
+     */
+    children: JSX.Element;
+
     /**
      * Callback invoked when the wrapped element resizes.
      *
@@ -50,76 +53,41 @@ export interface ResizeSensorProps {
     observeParents?: boolean;
 }
 
-export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
+export const ResizeSensor: React.FC<ResizeSensorProps> = props => {
+    const observer = useMemo(
+        () =>
+            new ResizeObserver(entries => {
+                props.onResize?.(entries);
+            }),
+        [props.children, props.onResize],
+    );
+    const elementRef = useRef<HTMLElement>();
 
-    private element: Element | null = null;
-
-    private observer = new ResizeObserver(entries => this.props.onResize?.(entries));
-
-    public render() {
-        // pass-through render of single child
-        return React.Children.only(this.props.children);
-    }
-
-    public componentDidMount() {
-        this.observeElement();
-    }
-
-    public componentDidUpdate(prevProps: ResizeSensorProps) {
-        this.observeElement(this.props.observeParents !== prevProps.observeParents);
-    }
-
-    public componentWillUnmount() {
-        this.observer.disconnect();
-    }
-
-    /**
-     * Observe the DOM element, if defined and different from the currently
-     * observed element. Pass `force` argument to skip element checks and always
-     * re-observe.
-     */
-    private observeElement(force = false) {
-        const element = this.getElement();
-        if (!(element instanceof Element)) {
-            // stop everything if not defined
-            this.observer.disconnect();
-            return;
+    // effect to observe this element
+    useEffect(() => {
+        if (elementRef.current instanceof Element) {
+            // N.B. observer callback is invoked immediately when observing new elements
+            observer.observe(elementRef.current);
         }
 
-        if (element === this.element && !force) {
-            // quit if given same element -- nothing to update (unless forced)
-            return;
-        } else {
-            // clear observer list if new element
-            this.observer.disconnect();
-            // remember element reference for next time
-            this.element = element;
-        }
+        return () => observer.disconnect();
+    }, [observer, elementRef.current]);
 
-        // observer callback is invoked immediately when observing new elements
-        this.observer.observe(element);
-
-        if (this.props.observeParents) {
-            let parent = element.parentElement;
+    // effect to observe parents
+    useEffect(() => {
+        if (props.observeParents && elementRef.current instanceof Element) {
+            let parent = elementRef.current.parentElement;
             while (parent != null) {
-                this.observer.observe(parent);
+                observer.observe(parent);
                 parent = parent.parentElement;
             }
         }
-    }
 
-    private getElement() {
-        try {
-            // using findDOMNode for two reasons:
-            // 1. cloning to insert a ref is unwieldy and not performant.
-            // 2. ensure that we resolve to an actual DOM node (instead of any JSX ref instance).
-            // HACKHACK: see https://github.com/palantir/blueprint/issues/3979
-            /* eslint-disable-next-line react/no-find-dom-node */
-            return findDOMNode(this);
-        } catch {
-            // swallow error if findDOMNode is run on unmounted component.
-            return null;
-        }
-    }
-}
+        // this is probably redundant with the first effect defined above, but do it anyway just in case
+        return () => observer.disconnect();
+    }, [observer, props.observeParents]);
+
+    const onlyChild = React.Children.only(props.children);
+    return cloneElement(onlyChild, { ref: elementRef });
+};
+ResizeSensor.displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -52,6 +52,12 @@ export interface ResizeSensorProps {
      * @default false
      */
     observeParents?: boolean;
+
+    /**
+     * If you attach a `ref` to the child yourself when rendering it, you must pass the
+     * same value here (otherwise, ResizeSensor won't be able to attach its own).
+     */
+    targetRef?: React.Ref<any>;
 }
 
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
@@ -65,6 +71,12 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     public render() {
         const onlyChild = React.Children.only(this.props.children);
+
+        // if we're provided a ref to the child already, we don't need to attach one ourselves
+        if (this.props.targetRef !== undefined) {
+            return onlyChild;
+        }
+
         return cloneElement(onlyChild, { ref: this.elementRef });
     }
 

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -38,7 +38,6 @@ describe("<ResizeSensor>", () => {
         const onResize = spy();
         mountResizeSensor(onResize);
         await resize({ width: 200 });
-        await resize({ width: 200 }); // this one is ignored
         await resize({ height: 100 });
         await resize({ width: 55 });
         assert.equal(onResize.callCount, 3);
@@ -98,9 +97,9 @@ interface SizeProps {
     height?: number;
 }
 
-type ResizeTesterProps = ResizeSensorProps & SizeProps;
-const ResizeTester: React.FunctionComponent<ResizeTesterProps> = ({ id, width, height, ...resizeProps }) => (
-    <ResizeSensor {...resizeProps}>
+type ResizeTesterProps = Omit<ResizeSensorProps, "children"> & SizeProps;
+const ResizeTester: React.FC<ResizeTesterProps> = ({ id, width, height, ...sensorProps }) => (
+    <ResizeSensor {...sensorProps}>
         <div key={id} style={{ width, height }} />
     </ResizeSensor>
 );

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -44,6 +44,15 @@ describe("<ResizeSensor>", () => {
         assertResizeArgs(onResize, ["200x0", "200x100", "55x100"]);
     });
 
+    it("onResize is NOT called redundantly when size is unchanged", async () => {
+        const onResize = spy();
+        mountResizeSensor(onResize);
+        await resize({ width: 200 });
+        await resize({ width: 200 }); // this one should be ignored
+        assert.equal(onResize.callCount, 1);
+        assertResizeArgs(onResize, ["200x0"]);
+    });
+
     it("onResize is called when element changes", async () => {
         const onResize = spy();
         mountResizeSensor(onResize);
@@ -63,13 +72,13 @@ describe("<ResizeSensor>", () => {
         await resize({ height: 100, id: 2 });
         await resize({ width: 55, id: 3 });
 
-        assert.equal(onResize1.callCount, 1);
-        assert.equal(onResize2.callCount, 2);
+        assert.equal(onResize1.callCount, 1, "first callback should have been called exactly once");
+        assert.equal(onResize2.callCount, 2, "second callback should have been called exactly twice");
     });
 
     function mountResizeSensor(onResize: ResizeSensorProps["onResize"]) {
         return (wrapper = mount<ResizeTesterProps>(
-            <ResizeTester onResize={onResize} />,
+            <ResizeTester id={0} onResize={onResize} />,
             // must be in the DOM for measurement
             { attachTo: testsContainerElement },
         ));

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -77,10 +77,9 @@ export class PopoverPortalExample extends React.PureComponent<ExampleProps, Popo
                             content="I am in a Portal (default)."
                             isOpen={this.state.isOpen}
                             usePortal={true}
+                            // strip out `isOpen` so that it is not rendered to HTML element
                             // tslint:disable-next-line jsx-no-lambda
-                            renderTarget={({ isOpen, ref, ...p }) => (
-                                <Code {...p} elementRef={ref}>{`usePortal={true}`}</Code>
-                            )}
+                            renderTarget={({ isOpen, ...p }) => <Code {...p}>{`usePortal={true}`}</Code>}
                         />
                     </div>
                 </div>
@@ -98,10 +97,9 @@ export class PopoverPortalExample extends React.PureComponent<ExampleProps, Popo
                             modifiers={{
                                 preventOverflow: { enabled: false },
                             }}
+                            // strip out `isOpen` so that it is not rendered to HTML element
                             // tslint:disable-next-line jsx-no-lambda
-                            renderTarget={({ isOpen, ref, ...p }) => (
-                                <Code {...p} elementRef={ref}>{`usePortal={false}`}</Code>
-                            )}
+                            renderTarget={({ isOpen, ...p }) => <Code {...p}>{`usePortal={false}`}</Code>}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
#### Fixes #3979

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Remove usage of `React.findDOMNode` in `<Overlay>` by using the new `nodeRef` prop on `<CSSTransition>` instead (we only expect one overlay child, so just one ref on a single transition child should be sufficient).
- Remove usage of `React.findDOMNode` in `<ResizeSensor>` by ~refactoring its implementation into a function component and~ using the `React.cloneElement` approach described in https://github.com/palantir/blueprint/issues/3979#issue-571047705.
- Remove defensive code in `<Portal>` which guarded against `React.createPortal` not being available (since we don't support React 15 anymore)

#### Reviewers should focus on:

No regressions

#### Screenshot

