### PR TITLE
[v4] remove elementRef, use forwardRef everywhere

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -19,7 +19,6 @@ import React from "react";
 import { IconName } from "@blueprintjs/icons";
 
 import { Intent } from "./intent";
-import { Ref } from "./refs";
 
 export const DISPLAYNAME_PREFIX = "Blueprint3";
 
@@ -94,10 +93,6 @@ export interface ControlledProps {
     value?: string;
 }
 
-export interface ElementRefProps<E extends HTMLElement> {
-    /** A ref handler or a ref object that receives the native HTML element rendered by this component. */
-    elementRef?: Ref<E>;
-}
 /**
  * An interface for an option in a list, such as in a `<select>` or `RadioGroup`.
  * These props can be spread directly to an `<option>` or `<Radio>` element.
@@ -120,7 +115,6 @@ const INVALID_PROPS = [
     "asyncControl", // InputGroupProps
     "containerRef",
     "current",
-    "elementRef",
     "fill",
     "icon",
     "inputRef",

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -15,16 +15,15 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { DoubleCaretVertical, SVGIconProps } from "@blueprintjs/icons";
 
-import { AbstractPureComponent } from "../../common";
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
-import { ElementRefProps, OptionProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, OptionProps } from "../../common/props";
 
 export interface HTMLSelectProps
-    extends ElementRefProps<HTMLSelectElement>,
+    extends React.RefAttributes<HTMLSelectElement>,
         React.SelectHTMLAttributes<HTMLSelectElement> {
     /** Whether this element is non-interactive. */
     disabled?: boolean;
@@ -61,43 +60,32 @@ export interface HTMLSelectProps
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 
-export class HTMLSelect extends AbstractPureComponent<HTMLSelectProps> {
-    public render() {
-        const {
-            className,
-            disabled,
-            elementRef,
-            fill,
-            iconProps,
-            large,
-            minimal,
-            options = [],
-            ...htmlProps
-        } = this.props;
-        const classes = classNames(
-            HTML_SELECT,
-            {
-                [DISABLED]: disabled,
-                [FILL]: fill,
-                [LARGE]: large,
-                [MINIMAL]: minimal,
-            },
-            className,
-        );
+export const HTMLSelect: React.FC<HTMLSelectProps> = forwardRef((props, ref) => {
+    const { className, children, disabled, fill, iconProps, large, minimal, options = [], ...htmlProps } = props;
+    const classes = classNames(
+        HTML_SELECT,
+        {
+            [DISABLED]: disabled,
+            [FILL]: fill,
+            [LARGE]: large,
+            [MINIMAL]: minimal,
+        },
+        className,
+    );
 
-        const optionChildren = options.map(option => {
-            const props: OptionProps = typeof option === "object" ? option : { value: option };
-            return <option {...props} key={props.value} children={props.label || props.value} />;
-        });
+    const optionChildren = options.map(option => {
+        const optionProps: OptionProps = typeof option === "object" ? option : { value: option };
+        return <option {...optionProps} key={optionProps.value} children={optionProps.label || optionProps.value} />;
+    });
 
-        return (
-            <div className={classes}>
-                <select disabled={disabled} ref={elementRef} {...htmlProps} multiple={false}>
-                    {optionChildren}
-                    {htmlProps.children}
-                </select>
-                <DoubleCaretVertical {...iconProps} />
-            </div>
-        );
-    }
-}
+    return (
+        <div className={classes}>
+            <select disabled={disabled} ref={ref} {...htmlProps} multiple={false}>
+                {optionChildren}
+                {children}
+            </select>
+            <DoubleCaretVertical {...iconProps} />
+        </div>
+    );
+});
+HTMLSelect.displayName = `${DISPLAYNAME_PREFIX}.HTMLSelect`;

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -15,11 +15,13 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import React, { forwardRef } from "react";
 
-import { AbstractPureComponent, Classes, ElementRefProps } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 
-export interface HTMLTableProps extends React.TableHTMLAttributes<HTMLTableElement>, ElementRefProps<HTMLTableElement> {
+export interface HTMLTableProps
+    extends React.TableHTMLAttributes<HTMLTableElement>,
+        React.RefAttributes<HTMLTableElement> {
     /** Enables borders between rows and cells. */
     bordered?: boolean;
 
@@ -36,20 +38,19 @@ export interface HTMLTableProps extends React.TableHTMLAttributes<HTMLTableEleme
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 
-export class HTMLTable extends AbstractPureComponent<HTMLTableProps> {
-    public render() {
-        const { bordered, className, condensed, elementRef, interactive, striped, ...htmlProps } = this.props;
-        const classes = classNames(
-            Classes.HTML_TABLE,
-            {
-                [Classes.HTML_TABLE_BORDERED]: bordered,
-                [Classes.HTML_TABLE_CONDENSED]: condensed,
-                [Classes.HTML_TABLE_STRIPED]: striped,
-                [Classes.INTERACTIVE]: interactive,
-            },
-            className,
-        );
-        // eslint-disable-next-line @blueprintjs/html-components
-        return <table {...htmlProps} ref={elementRef} className={classes} />;
-    }
-}
+export const HTMLTable: React.FC<HTMLTableProps> = forwardRef((props, ref) => {
+    const { bordered, className, condensed, interactive, striped, ...htmlProps } = props;
+    const classes = classNames(
+        Classes.HTML_TABLE,
+        {
+            [Classes.HTML_TABLE_BORDERED]: bordered,
+            [Classes.HTML_TABLE_CONDENSED]: condensed,
+            [Classes.HTML_TABLE_STRIPED]: striped,
+            [Classes.INTERACTIVE]: interactive,
+        },
+        className,
+    );
+    // eslint-disable-next-line @blueprintjs/html-components
+    return <table {...htmlProps} ref={ref} className={classes} />;
+});
+HTMLTable.displayName = `${DISPLAYNAME_PREFIX}.HTMLTable`;

--- a/packages/core/src/components/html/html.md
+++ b/packages/core/src/components/html/html.md
@@ -25,7 +25,7 @@ The following elements should be used in this manner:
 | `HTMLTable`  | `table`      | `HTML_TABLE` - see [HTML Table](#core/components/html-table) |
 
 The React components listed above each support the full set of relevant HTML attributes **and an
-optional `elementRef` prop** to access the instance of the HTML element itself
+optional `ref` prop** (via `React.forwardRef`) to access the instance of the HTML element itself
 (not the React component).
 
 @## Nested usage

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -63,7 +63,7 @@ export interface ResizeSensorProps {
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
-    private elementRef = createRef<HTMLElement>();
+    private targetRef = createRef<HTMLElement>();
 
     private prevElement: HTMLElement | undefined = undefined;
 
@@ -77,7 +77,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
             return onlyChild;
         }
 
-        return cloneElement(onlyChild, { ref: this.elementRef });
+        return cloneElement(onlyChild, { ref: this.targetRef });
     }
 
     public componentDidMount() {
@@ -98,27 +98,27 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
      * re-observe.
      */
     private observeElement(force = false) {
-        if (!(this.elementRef.current instanceof Element)) {
+        if (!(this.targetRef.current instanceof Element)) {
             // stop everything if not defined
             this.observer.disconnect();
             return;
         }
 
-        if (this.elementRef.current === this.prevElement && !force) {
+        if (this.targetRef.current === this.prevElement && !force) {
             // quit if given same element -- nothing to update (unless forced)
             return;
         } else {
             // clear observer list if new element
             this.observer.disconnect();
             // remember element reference for next time
-            this.prevElement = this.elementRef.current;
+            this.prevElement = this.targetRef.current;
         }
 
         // observer callback is invoked immediately when observing new elements
-        this.observer.observe(this.elementRef.current);
+        this.observer.observe(this.targetRef.current);
 
         if (this.props.observeParents) {
-            let parent = this.elementRef.current.parentElement;
+            let parent = this.targetRef.current.parentElement;
             while (parent != null) {
                 this.observer.observe(parent);
                 parent = parent.parentElement;

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -15,20 +15,11 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { SmallCross } from "@blueprintjs/icons";
 
-import {
-    AbstractPureComponent,
-    Classes,
-    DISPLAYNAME_PREFIX,
-    ElementRefProps,
-    IntentProps,
-    Props,
-    MaybeElement,
-    Utils,
-} from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, IntentProps, Props, MaybeElement, Utils } from "../../common";
 import { isReactNodeEmpty } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { Text } from "../text/text";
@@ -36,7 +27,7 @@ import { Text } from "../text/text";
 export interface TagProps
     extends Props,
         IntentProps,
-        ElementRefProps<HTMLSpanElement>,
+        React.RefAttributes<HTMLSpanElement>,
         React.HTMLAttributes<HTMLSpanElement> {
     /**
      * Whether the tag should appear in an active state.
@@ -117,70 +108,65 @@ export interface TagProps
     htmlTitle?: string;
 }
 
-export class Tag extends AbstractPureComponent<TagProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.Tag`;
-
-    public render() {
-        const {
-            active,
-            children,
-            className,
-            fill,
-            icon,
-            intent,
-            interactive,
-            large,
-            minimal,
-            multiline,
-            onRemove,
-            rightIcon,
-            round,
-            tabIndex = 0,
-            htmlTitle,
-            elementRef,
-            ...htmlProps
-        } = this.props;
-        const isRemovable = Utils.isFunction(onRemove);
-        const tagClasses = classNames(
-            Classes.TAG,
-            Classes.intentClass(intent),
-            {
-                [Classes.ACTIVE]: active,
-                [Classes.FILL]: fill,
-                [Classes.INTERACTIVE]: interactive,
-                [Classes.LARGE]: large,
-                [Classes.MINIMAL]: minimal,
-                [Classes.ROUND]: round,
-            },
-            className,
-        );
-        const isLarge = large || tagClasses.indexOf(Classes.LARGE) >= 0;
-        const removeButton = isRemovable ? (
-            <button
-                type="button"
-                className={Classes.TAG_REMOVE}
-                onClick={this.onRemoveClick}
-                tabIndex={interactive ? tabIndex : undefined}
-            >
-                <SmallCross size={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD} />
-            </button>
-        ) : null;
-
-        return (
-            <span {...htmlProps} className={tagClasses} tabIndex={interactive ? tabIndex : undefined} ref={elementRef}>
-                <Icon icon={icon} />
-                {!isReactNodeEmpty(children) && (
-                    <Text className={Classes.FILL} ellipsize={!multiline} tagName="span" title={htmlTitle}>
-                        {children}
-                    </Text>
-                )}
-                <Icon icon={rightIcon} />
-                {removeButton}
-            </span>
-        );
-    }
-
-    private onRemoveClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-        this.props.onRemove?.(e, this.props);
+export const Tag: React.FC<TagProps> = forwardRef((props, ref) => {
+    const {
+        active,
+        children,
+        className,
+        fill,
+        icon,
+        intent,
+        interactive,
+        large,
+        minimal,
+        multiline,
+        onRemove,
+        rightIcon,
+        round,
+        tabIndex = 0,
+        htmlTitle,
+        ...htmlProps
+    } = props;
+    const isRemovable = Utils.isFunction(onRemove);
+    const tagClasses = classNames(
+        Classes.TAG,
+        Classes.intentClass(intent),
+        {
+            [Classes.ACTIVE]: active,
+            [Classes.FILL]: fill,
+            [Classes.INTERACTIVE]: interactive,
+            [Classes.LARGE]: large,
+            [Classes.MINIMAL]: minimal,
+            [Classes.ROUND]: round,
+        },
+        className,
+    );
+    const isLarge = large || tagClasses.indexOf(Classes.LARGE) >= 0;
+    const handleRemoveClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+        props.onRemove?.(e, props);
     };
-}
+    const removeButton = isRemovable ? (
+        <button
+            type="button"
+            className={Classes.TAG_REMOVE}
+            onClick={handleRemoveClick}
+            tabIndex={interactive ? tabIndex : undefined}
+        >
+            <SmallCross size={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD} />
+        </button>
+    ) : null;
+
+    return (
+        <span {...htmlProps} className={tagClasses} tabIndex={interactive ? tabIndex : undefined} ref={ref}>
+            <Icon icon={icon} />
+            {!isReactNodeEmpty(children) && (
+                <Text className={Classes.FILL} ellipsize={!multiline} tagName="span" title={htmlTitle}>
+                    {children}
+                </Text>
+            )}
+            <Icon icon={rightIcon} />
+            {removeButton}
+        </span>
+    );
+});
+Tag.displayName = `${DISPLAYNAME_PREFIX}.Tag`;

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -117,20 +117,20 @@ function buttonTestSuite(component: React.FC<any>, tagName: string) {
         });
 
         it("attaches ref with useRef", () => {
-            let elementRef: React.RefObject<any> | undefined;
+            let buttonRef: React.RefObject<any> | undefined;
             const Component = component;
 
             const Test = () => {
-                elementRef = React.useRef<any>(null);
+                buttonRef = React.useRef<any>(null);
 
-                return <Component ref={elementRef} />;
+                return <Component ref={buttonRef} />;
             };
 
             const wrapper = mount(<Test />);
             wrapper.update();
 
             assert.isTrue(
-                elementRef?.current instanceof (tagName === "button" ? HTMLButtonElement : HTMLAnchorElement),
+                buttonRef?.current instanceof (tagName === "button" ? HTMLButtonElement : HTMLAnchorElement),
                 `ref.current should be a(n) ${tagName} element`,
             );
         });

--- a/packages/core/test/common/propsTests.ts
+++ b/packages/core/test/common/propsTests.ts
@@ -28,7 +28,6 @@ describe("Props", () => {
                 banana: true,
                 cat: true,
                 containerRef: true,
-                elementRef: true,
                 icon: true,
                 intent: true,
                 round: true,
@@ -48,7 +47,6 @@ describe("Props", () => {
             assert.deepEqual(removeNonHTMLProps(props, ["apple", "banana"]), {
                 cat: true,
                 containerRef: true,
-                elementRef: true,
                 icon: true,
                 intent: true,
                 round: true,

--- a/packages/core/test/tag/tagTests.tsx
+++ b/packages/core/test/tag/tagTests.tsx
@@ -82,12 +82,12 @@ describe("<Tag>", () => {
 
     if (typeof React.createRef !== "undefined") {
         it("supports ref objects", done => {
-            const elementRef = React.createRef<HTMLSpanElement>();
-            const wrapper = mount(<Tag elementRef={elementRef}>Hello</Tag>);
+            const tagRef = React.createRef<HTMLSpanElement>();
+            const wrapper = mount(<Tag ref={tagRef}>Hello</Tag>);
 
             // wait for the whole lifecycle to run
             setTimeout(() => {
-                assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
+                assert.equal(tagRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
                 done();
             }, 0);
         });


### PR DESCRIPTION
#### Changes proposed in this pull request:

Remove all instances of `elementRef` prop and `ElementRefProps` type, switch to a function component + `React.forwardRef` implementation instead:

- HTMLSelect
- HTMLTable
- Tag
