### PR TITLE
[core] feat(MultiStepDialog): improve step styling

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -124,6 +124,7 @@ export const DIALOG_STEP = `${NS}-dialog-step`;
 export const DIALOG_STEP_CONTAINER = `${DIALOG_STEP}-container`;
 export const DIALOG_STEP_TITLE = `${DIALOG_STEP}-title`;
 export const DIALOG_STEP_ICON = `${DIALOG_STEP}-icon`;
+export const DIALOG_STEP_VIEWED = `${DIALOG_STEP}-viewed`;
 
 export const DIVIDER = `${NS}-divider`;
 

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -121,6 +121,7 @@ $step-radius: $pt-border-radius * 2 !default;
 
 .#{$ns}-dialog-step-title {
   color: $gray1;
+  flex: 1;
   padding-left: 10px;
 
   .#{$ns}-dark & {

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -129,8 +129,8 @@ $step-radius: $pt-border-radius * 2 !default;
     color: $pt-dark-text-color-disabled;
   }
 
-  // by default, step title is active only when the step is selected
-  .#{$ns}-active.#{$ns}-active.#{$ns}-dialog-step-viewed & {
+  // step title is active only when the step is selected
+  .#{$ns}-active.#{$ns}-dialog-step-viewed & {
     color: $blue4;
   }
 

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -57,7 +57,7 @@ $step-radius: $pt-border-radius * 2 !default;
     border-bottom: 1px solid $pt-dark-divider-black;
   }
 
-  &.#{$ns}-active {
+  &.#{$ns}-dialog-step-viewed {
     background-color: $white;
     .#{$ns}-dark & {
       background: $dark-gray4;
@@ -79,7 +79,7 @@ $step-radius: $pt-border-radius * 2 !default;
   }
 
   // by default, steps are inactive until they are visited
-  .#{$ns}-active & {
+  .#{$ns}-dialog-step-viewed & {
     background-color: $white;
     cursor: pointer;
 
@@ -111,11 +111,11 @@ $step-radius: $pt-border-radius * 2 !default;
     background-color: $pt-dark-icon-color-disabled;
   }
 
-  &.#{$ns}-active {
+  .#{$ns}-active.#{$ns}-dialog-step-viewed & {
     background-color: $blue4;
   }
 
-  &.#{$ns}-dialog-step-viewed {
+  .#{$ns}-dialog-step-viewed & {
     background-color: $gray3;
   }
 }
@@ -130,7 +130,7 @@ $step-radius: $pt-border-radius * 2 !default;
   }
 
   // by default, step title is active only when the step is selected
-  &.#{$ns}-active {
+  .#{$ns}-active & {
     color: $blue4;
   }
 }

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -99,7 +99,7 @@ $step-radius: $pt-border-radius * 2 !default;
 
 .#{$ns}-dialog-step-icon {
   align-items: center;
-  background-color: $light-gray1;
+  background-color: $pt-text-color-disabled;
   border-radius: 50%;
   color: $white;
   display: flex;
@@ -121,7 +121,7 @@ $step-radius: $pt-border-radius * 2 !default;
 }
 
 .#{$ns}-dialog-step-title {
-  color: $gray1;
+  color: $pt-text-color-disabled;
   flex: 1;
   padding-left: 10px;
 
@@ -130,7 +130,15 @@ $step-radius: $pt-border-radius * 2 !default;
   }
 
   // by default, step title is active only when the step is selected
-  .#{$ns}-active & {
+  .#{$ns}-active.#{$ns}-active.#{$ns}-dialog-step-viewed & {
     color: $blue4;
+  }
+
+  .#{$ns}-dialog-step-viewed & {
+    color: $pt-text-color;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-text-color;
+    }
   }
 }

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -27,7 +27,7 @@ $step-radius: $pt-border-radius * 2 !default;
   background-color: $light-gray5;
   border-left: 1px solid $pt-divider-black;
   border-radius: 0 0 $dialog-border-radius 0;
-  flex: 2;
+  flex: 3;
 
   .#{$ns}-dark & {
     background-color: $dark-gray3;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -28,6 +28,7 @@ $step-radius: $pt-border-radius * 2 !default;
   border-left: 1px solid $pt-divider-black;
   border-radius: 0 0 $dialog-border-radius 0;
   flex: 3;
+  min-width: 0;
 
   .#{$ns}-dark & {
     background-color: $dark-gray3;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -110,8 +110,12 @@ $step-radius: $pt-border-radius * 2 !default;
     background-color: $pt-dark-icon-color-disabled;
   }
 
-  .#{$ns}-active & {
+  &.#{$ns}-active {
     background-color: $blue4;
+  }
+
+  &.#{$ns}-dialog-step-viewed {
+    background-color: $gray3;
   }
 }
 

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -121,19 +121,16 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
         const hasBeenViewed = this.state.lastViewedIndex >= index;
         const currentlySelected = this.state.selectedIndex === index;
         return (
-            <div className={classNames(Classes.DIALOG_STEP_CONTAINER, { [Classes.ACTIVE]: hasBeenViewed })} key={index}>
+            <div
+                className={classNames(Classes.DIALOG_STEP_CONTAINER, {
+                    [Classes.ACTIVE]: currentlySelected,
+                    [Classes.DIALOG_STEP_VIEWED]: hasBeenViewed,
+                })}
+                key={index}
+            >
                 <div className={Classes.DIALOG_STEP} onClick={this.handleClickDialogStep(index)}>
-                    <div
-                        className={classNames(Classes.DIALOG_STEP_ICON, {
-                            [Classes.ACTIVE]: currentlySelected,
-                            [Classes.DIALOG_STEP_VIEWED]: hasBeenViewed && !currentlySelected,
-                        })}
-                    >
-                        {stepNumber}
-                    </div>
-                    <div className={classNames(Classes.DIALOG_STEP_TITLE, { [Classes.ACTIVE]: currentlySelected })}>
-                        {step.props.title}
-                    </div>
+                    <div className={Classes.DIALOG_STEP_ICON}>{stepNumber}</div>
+                    <div className={Classes.DIALOG_STEP_TITLE}>{step.props.title}</div>
                 </div>
             </div>
         );

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -123,7 +123,14 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
         return (
             <div className={classNames(Classes.DIALOG_STEP_CONTAINER, { [Classes.ACTIVE]: hasBeenViewed })} key={index}>
                 <div className={Classes.DIALOG_STEP} onClick={this.handleClickDialogStep(index)}>
-                    <div className={Classes.DIALOG_STEP_ICON}>{stepNumber}</div>
+                    <div
+                        className={classNames(Classes.DIALOG_STEP_ICON, {
+                            [Classes.ACTIVE]: currentlySelected,
+                            [Classes.DIALOG_STEP_VIEWED]: hasBeenViewed && !currentlySelected,
+                        })}
+                    >
+                        {stepNumber}
+                    </div>
                     <div className={classNames(Classes.DIALOG_STEP_TITLE, { [Classes.ACTIVE]: currentlySelected })}>
                         {step.props.title}
                     </div>

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -57,7 +57,7 @@ describe("<MultistepDialog>", () => {
         );
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
-        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 2);
+        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 3);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 0);
         dialog.unmount();
     });
@@ -73,7 +73,7 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
-        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 2);
+        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 3);
         dialog.unmount();
     });
 
@@ -89,12 +89,12 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
-        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 2);
+        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 3);
 
         dialog.find(BACK_BUTTON).simulate("click");
         const newSteps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(dialog.state("selectedIndex"), 0);
-        assert.strictEqual(newSteps.at(0).find(`.${Classes.ACTIVE}`).length, 2);
+        assert.strictEqual(newSteps.at(0).find(`.${Classes.ACTIVE}`).length, 3);
         assert.strictEqual(newSteps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
         dialog.unmount();
     });
@@ -157,7 +157,7 @@ describe("<MultistepDialog>", () => {
         step.at(0).simulate("click");
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(dialog.state("selectedIndex"), 0);
-        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 2);
+        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 3);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
         dialog.unmount();
     });

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -57,7 +57,7 @@ describe("<MultistepDialog>", () => {
         );
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
-        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 3);
+        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 0);
         dialog.unmount();
     });
@@ -72,8 +72,8 @@ describe("<MultistepDialog>", () => {
         dialog.find(NEXT_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
-        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
-        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 3);
+        assert.strictEqual(steps.at(0).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
+        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
         dialog.unmount();
     });
 
@@ -88,14 +88,14 @@ describe("<MultistepDialog>", () => {
         dialog.find(NEXT_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
-        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
-        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 3);
+        assert.strictEqual(steps.at(0).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
+        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
 
         dialog.find(BACK_BUTTON).simulate("click");
         const newSteps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(dialog.state("selectedIndex"), 0);
-        assert.strictEqual(newSteps.at(0).find(`.${Classes.ACTIVE}`).length, 3);
-        assert.strictEqual(newSteps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
+        assert.strictEqual(newSteps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
+        assert.strictEqual(newSteps.at(1).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
         dialog.unmount();
     });
 
@@ -157,8 +157,8 @@ describe("<MultistepDialog>", () => {
         step.at(0).simulate("click");
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(dialog.state("selectedIndex"), 0);
-        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 3);
-        assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
+        assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
+        assert.strictEqual(steps.at(1).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
         dialog.unmount();
     });
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Only make currently active step blue.
- Adjust right to left panel ratios to match original mocks.
- Set min-width on right panel to prevent overflow
- Make step title flex: 1 to allow clients to provide a title + right-aligned icon for a step.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

Before this PR:
![image](https://user-images.githubusercontent.com/7877370/114410922-bf6ef480-9b79-11eb-9d5d-a51ab789e628.png)

After this PR:
![image](https://user-images.githubusercontent.com/7877370/114720548-1acded80-9d06-11eb-954b-5c674931fd66.png)
