### PR TITLE
className prop moved to outer component element

### DIFF
--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -132,14 +132,18 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
         const { size, style, position, vertical } = this.props;
         const realPosition = position ? getPositionIgnoreAngles(position) : undefined;
 
-        const classes = classNames(
+        const drawer_classes = classNames(
             Classes.DRAWER,
             {
                 [Classes.VERTICAL]: !realPosition && vertical,
                 [Classes.positionClass(realPosition) ?? ""]: true,
             },
-            this.props.className,
         );
+
+        const overlay_classes = classNames(
+            Classes.OVERLAY_CONTAINER,
+            this.props.className,
+        )
 
         const styleProp =
             size == null
@@ -151,11 +155,11 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
         return (
             <Overlay
                 {...this.props}
-                className={Classes.OVERLAY_CONTAINER}
+                className={overlay_classes}
                 onOpening={this.handleOpening}
                 onClosed={this.handleClosed}
             >
-                <div className={classes} style={styleProp}>
+                <div className={drawer_classes} style={styleProp}>
                     {this.maybeRenderHeader()}
                     {this.props.children}
                 </div>


### PR DESCRIPTION
#### Fixes #0000

The Drawer component maps the className prop to an inner `<div>.` It seems to be common - and realized by all other blueprintjs components - that the most outer DOM element receives the className prop in its class name list.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Move the className prop to the class name list of the outer `<Overlay>` component.

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
