### PR TITLE
[v4] feat(ContextMenu): new children render prop allows omitting wrapper element

### DIFF
--- a/packages/core/src/components/context-menu/context-menu.md
+++ b/packages/core/src/components/context-menu/context-menu.md
@@ -35,6 +35,43 @@ export default function ContextMenuExample() {
 Both `content` and `children` props support the [render prop](https://reactjs.org/docs/render-props.html)
 pattern, so you may use information about the context menu's state to in your render code.
 
+### Advanced usage
+
+By default, `<ContextMenu>` will render a container `<div>` element around its children, to contain the
+generated Popover and attach an event handler. If this container breaks your HTML and/or CSS layout in some
+way and you wish to omit it, you may do so by utilizing ContextMenu's advanced rendering API, which
+uses a `children` render function. If you use this approach, you must take care to properly use the
+render props supplied to `children()`:
+
+```tsx
+import classNames from "classnames";
+import { ContextMenu, ContextMenuChildrenProps, Menu, MenuItem } from "@blueprintjs/core";
+
+export default function AdvancedContextMenuExample() {
+    return (
+        <ContextMenu
+            content={
+                <Menu>
+                    <MenuItem text="Save" />
+                    <MenuItem text="Save as..." />
+                    <MenuItem text="Delete..." intent="danger" />
+                </Menu>
+            }
+        >
+            {(props: ContextMenuChildrenProps) => (
+                <div
+                    className={classNames("my-context-menu-target", props.className)}
+                    onContextMenu={props.onContextMenu}
+                    ref={props.ref}
+                >
+                    Right click me!
+                </div>
+            )}
+        </ContextMenu>
+    )
+}
+```
+
 @## Props
 
 To enable/disable the context menu popover, use the `disabled` prop. Note that it is inadvisable to change

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -24,7 +24,12 @@ export * from "./button/buttonGroup";
 export * from "./callout/callout";
 export * from "./card/card";
 export * from "./collapse/collapse";
-export { ContextMenu, ContextMenuProps, ContextMenuRenderProps } from "./context-menu/contextMenu";
+export {
+    ContextMenu,
+    ContextMenuProps,
+    ContextMenuChildrenProps,
+    ContextMenuContentProps,
+} from "./context-menu/contextMenu";
 export * from "./dialog/dialog";
 export * from "./dialog/multistepDialog";
 export * from "./dialog/dialogStep";

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -15,10 +15,11 @@
  */
 
 import { assert } from "chai";
+import classNames from "classnames";
 import { mount, ReactWrapper } from "enzyme";
 import React from "react";
 
-import { ContextMenu, ContextMenuProps, Menu, MenuItem, Popover } from "../../src";
+import { ContextMenu, ContextMenuChildrenProps, ContextMenuProps, Menu, MenuItem, Popover } from "../../src";
 
 const MENU_ITEMS = [
     <MenuItem key="left" icon="align-left" text="Align Left" />,
@@ -29,25 +30,55 @@ const MENU = <Menu>{MENU_ITEMS}</Menu>;
 const TARGET_CLASSNAME = "test-target";
 
 describe("ContextMenu", () => {
-    it("renders children and Popover", () => {
-        const ctxMenu = mountTestMenu();
-        assert.isTrue(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists());
-        assert.isTrue(ctxMenu.find(Popover).exists());
+    describe("basic usage", () => {
+        it("renders children and Popover", () => {
+            const ctxMenu = mountTestMenu();
+            assert.isTrue(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists());
+            assert.isTrue(ctxMenu.find(Popover).exists());
+        });
+
+        it("opens popover on right click", () => {
+            const ctxMenu = mountTestMenu();
+            openCtxMenu(ctxMenu);
+            assert.isTrue(ctxMenu.find(Popover).prop("isOpen"));
+        });
+
+        function mountTestMenu(props: Partial<ContextMenuProps> = {}) {
+            return mount(
+                <ContextMenu content={MENU} transitionDuration={0} {...props}>
+                    <div className={TARGET_CLASSNAME} />
+                </ContextMenu>,
+            );
+        }
     });
 
-    it("opens popover on right click", () => {
-        const ctxMenu = mountTestMenu();
-        openCtxMenu(ctxMenu);
-        assert.isTrue(ctxMenu.find(Popover).prop("isOpen"));
-    });
+    describe("advanced usage", () => {
+        it("renders children and Popover", () => {
+            const ctxMenu = mountTestMenu();
+            assert.isTrue(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists());
+            assert.isTrue(ctxMenu.find(Popover).exists());
+        });
 
-    function mountTestMenu(props: Partial<ContextMenuProps> = {}) {
-        return mount(
-            <ContextMenu content={MENU} transitionDuration={0} {...props}>
-                <div className={TARGET_CLASSNAME} />
-            </ContextMenu>,
-        );
-    }
+        it("opens popover on right click", () => {
+            const ctxMenu = mountTestMenu();
+            openCtxMenu(ctxMenu);
+            assert.isTrue(ctxMenu.find(Popover).prop("isOpen"));
+        });
+
+        function mountTestMenu() {
+            return mount(
+                <ContextMenu content={MENU} transitionDuration={0}>
+                    {(props: ContextMenuChildrenProps) => (
+                        <div
+                            className={classNames(props.className, TARGET_CLASSNAME)}
+                            onContextMenu={props.onContextMenu}
+                            ref={props.ref}
+                        />
+                    )}
+                </ContextMenu>,
+            );
+        }
+    });
 
     function openCtxMenu(ctxMenu: ReactWrapper) {
         ctxMenu

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -73,7 +73,9 @@ describe("ContextMenu", () => {
                             className={classNames(props.className, TARGET_CLASSNAME)}
                             onContextMenu={props.onContextMenu}
                             ref={props.ref}
-                        />
+                        >
+                            {props.popover}
+                        </div>
                     )}
                 </ContextMenu>,
             );

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -28,6 +28,9 @@ export interface ClickToCopyProps extends Props, HTMLDivProps {
      */
     copiedClassName?: string;
 
+    /** TODO(adahiya) */
+    forwardedRef?: React.Ref<any>;
+
     /** Value to copy when clicked */
     value: string;
 }
@@ -63,7 +66,7 @@ export class ClickToCopy extends React.PureComponent<ClickToCopyProps, ClickToCo
     };
 
     public render() {
-        const { className, children, copiedClassName, value } = this.props;
+        const { className, children, copiedClassName, forwardedRef, value } = this.props;
         return (
             <div
                 {...removeNonHTMLProps(this.props, ["copiedClassName", "value"], true)}
@@ -72,6 +75,7 @@ export class ClickToCopy extends React.PureComponent<ClickToCopyProps, ClickToCo
                 })}
                 onClick={this.handleClick}
                 onMouseLeave={this.handleMouseLeave}
+                ref={forwardedRef}
             >
                 <input
                     onBlur={this.handleInputBlur}

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -15,12 +15,12 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import React, { forwardRef, useCallback, useRef, useState } from "react";
 
 import { HTMLDivProps, Props, Keys, removeNonHTMLProps } from "@blueprintjs/core";
 import { createKeyEventHandler } from "@blueprintjs/docs-theme";
 
-export interface ClickToCopyProps extends Props, HTMLDivProps {
+export interface ClickToCopyProps extends Props, React.RefAttributes<any>, HTMLDivProps {
     /**
      * Additional class names to apply after value has been copied
      *
@@ -28,15 +28,8 @@ export interface ClickToCopyProps extends Props, HTMLDivProps {
      */
     copiedClassName?: string;
 
-    /** TODO(adahiya) */
-    forwardedRef?: React.Ref<any>;
-
     /** Value to copy when clicked */
     value: string;
-}
-
-export interface ClickToCopyState {
-    hasCopied?: boolean;
 }
 
 /**
@@ -49,73 +42,66 @@ export interface ClickToCopyState {
  *  - `[data-copied-message="<message>"]` will be shown when the element has been copied.
  * The message is reset to default when the user mouses off the element after copying it.
  */
-export class ClickToCopy extends React.PureComponent<ClickToCopyProps, ClickToCopyState> {
-    public static defaultProps: ClickToCopyProps = {
-        copiedClassName: "docs-clipboard-copied",
-        value: "",
-    };
+export const ClickToCopy: React.FC<ClickToCopyProps> = forwardRef<any, ClickToCopyProps>((props, ref) => {
+    const { className, children, copiedClassName, value } = props;
+    const [hasCopied, setHasCopied] = useState(false);
+    const inputRef = useRef<HTMLInputElement>();
 
-    public state: ClickToCopyState = {
-        hasCopied: false,
-    };
-
-    private inputElement: HTMLInputElement;
-
-    private refHandlers = {
-        input: (input: HTMLInputElement) => (this.inputElement = input),
-    };
-
-    public render() {
-        const { className, children, copiedClassName, forwardedRef, value } = this.props;
-        return (
-            <div
-                {...removeNonHTMLProps(this.props, ["copiedClassName", "value"], true)}
-                className={classNames("docs-clipboard", className, {
-                    [copiedClassName!]: this.state.hasCopied,
-                })}
-                onClick={this.handleClick}
-                onMouseLeave={this.handleMouseLeave}
-                ref={forwardedRef}
-            >
-                <input
-                    onBlur={this.handleInputBlur}
-                    onKeyDown={this.handleKeyDown}
-                    readOnly={true}
-                    ref={this.refHandlers.input}
-                    value={value}
-                />
-                {children}
-            </div>
-        );
-    }
-
-    private copy = () => {
-        this.inputElement.select();
+    const copy = useCallback(() => {
+        inputRef.current?.select();
         document.execCommand("copy");
-        this.setState({ hasCopied: true });
-    };
+        setHasCopied(true);
+    }, [inputRef]);
 
-    private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-        this.copy();
-        this.props.onClick?.(e);
-    };
-
-    private handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
-        this.setState({ hasCopied: false });
-        this.props.onMouseLeave?.(e);
-    };
-
-    private handleInputBlur = () => {
-        this.setState({ hasCopied: false });
-    };
-
-    // eslint-disable-line @typescript-eslint/member-ordering
-    private handleKeyDown = createKeyEventHandler(
-        {
-            all: this.props.onKeyDown,
-            [Keys.SPACE]: this.copy,
-            [Keys.ENTER]: this.copy,
+    const handleClick = useCallback(
+        (e: React.MouseEvent<HTMLDivElement>) => {
+            copy();
+            props.onClick?.(e);
         },
-        true,
+        [copy, props.onClick],
     );
-}
+
+    const handleMouseLeave = useCallback(
+        (e: React.MouseEvent<HTMLDivElement>) => {
+            setHasCopied(false);
+            props.onMouseLeave?.(e);
+        },
+        [props.onMouseLeave],
+    );
+
+    const handleInputBlur = useCallback(() => {
+        setHasCopied(false);
+    }, []);
+
+    const handleKeyDown = useCallback(
+        createKeyEventHandler(
+            {
+                all: props.onKeyDown,
+                [Keys.SPACE]: copy,
+                [Keys.ENTER]: copy,
+            },
+            true,
+        ),
+        [copy, props.onKeyDown],
+    );
+
+    return (
+        <div
+            {...removeNonHTMLProps(props, ["copiedClassName", "value"], true)}
+            className={classNames("docs-clipboard", className, {
+                [copiedClassName!]: hasCopied,
+            })}
+            onClick={handleClick}
+            onMouseLeave={handleMouseLeave}
+            ref={ref}
+        >
+            <input onBlur={handleInputBlur} onKeyDown={handleKeyDown} readOnly={true} ref={inputRef} value={value} />
+            {children}
+        </div>
+    );
+});
+ClickToCopy.displayName = "ClickToCopy";
+ClickToCopy.defaultProps = {
+    copiedClassName: "docs-clipboard-copied",
+    value: "",
+};

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -57,10 +57,10 @@ export class DocsIcon extends React.PureComponent<DocsIconProps> {
             >
                 {(props: ContextMenuChildrenProps) => (
                     <ClickToCopy
-                        className="docs-icon"
+                        className={classNames("docs-icon", props.className)}
                         data-tags={tags}
-                        forwardedRef={props.ref}
                         onContextMenu={props.onContextMenu}
+                        ref={props.ref}
                         value={iconName}
                     >
                         {props.popover}

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import download from "downloadjs";
 import React from "react";
 
-import { Classes, ContextMenu, Icon, IconName, Menu, MenuItem } from "@blueprintjs/core";
+import { Classes, ContextMenu, ContextMenuChildrenProps, Icon, IconName, Menu, MenuItem } from "@blueprintjs/core";
 
 import { ClickToCopy } from "./clickToCopy";
 
@@ -55,18 +55,27 @@ export class DocsIcon extends React.PureComponent<DocsIconProps> {
                     </Menu>
                 }
             >
-                <ClickToCopy className="docs-icon" data-tags={tags} value={iconName}>
-                    <Icon icon={iconName} size={Icon.SIZE_LARGE} />
-                    <div className="docs-icon-name">{displayName}</div>
-                    <div className="docs-icon-detail">
-                        <p className="docs-code">{iconName}</p>
-                        <div className={Classes.TEXT_MUTED}>Right-click to download</div>
-                        <div
-                            className={classNames("docs-clipboard-message", Classes.TEXT_MUTED)}
-                            data-hover-message="Click to copy name"
-                        />
-                    </div>
-                </ClickToCopy>
+                {(props: ContextMenuChildrenProps) => (
+                    <ClickToCopy
+                        className="docs-icon"
+                        data-tags={tags}
+                        forwardedRef={props.ref}
+                        onContextMenu={props.onContextMenu}
+                        value={iconName}
+                    >
+                        {props.popover}
+                        <Icon icon={iconName} size={Icon.SIZE_LARGE} />
+                        <div className="docs-icon-name">{displayName}</div>
+                        <div className="docs-icon-detail">
+                            <p className="docs-code">{iconName}</p>
+                            <div className={Classes.TEXT_MUTED}>Right-click to download</div>
+                            <div
+                                className={classNames("docs-clipboard-message", Classes.TEXT_MUTED)}
+                                data-hover-message="Click to copy name"
+                            />
+                        </div>
+                    </ClickToCopy>
+                )}
             </ContextMenu>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
@@ -17,12 +17,12 @@
 import classNames from "classnames";
 import React, { useCallback } from "react";
 
-import { Classes, ContextMenu, ContextMenuRenderProps, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { Classes, ContextMenu, ContextMenuContentProps, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export const ContextMenuExample: React.FC<ExampleProps> = props => {
     const renderContent = useCallback(
-        ({ targetOffset }: ContextMenuRenderProps) => (
+        ({ targetOffset }: ContextMenuContentProps) => (
             <Menu>
                 <MenuItem icon="select" text="Select all" />
                 <MenuItem icon="insert" text="Insert...">

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import React from "react";
 
-import { AbstractComponent, ContextMenu, ContextMenuRenderProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent, ContextMenu, ContextMenuContentProps, Utils as CoreUtils } from "@blueprintjs/core";
 
 import { CellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
@@ -133,7 +133,7 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
         );
     }
 
-    private renderContextMenu = ({ mouseEvent }: ContextMenuRenderProps) => {
+    private renderContextMenu = ({ mouseEvent }: ContextMenuContentProps) => {
         const { grid, bodyContextMenuRenderer, selectedRegions } = this.props;
         const { numRows, numCols } = grid;
 


### PR DESCRIPTION
#### Fixes #4619

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Rename `ContextMenuRenderProps` -> `ContextMenuContentProps` to be more explicit and specific
- Introduce a new children rendering API for `<ContextMenu>` which allows users to omit the generated container element if they wish, and attach the necessary ref & event handler themselves to some element they render.
  - N.B. in the future, we could probably just expose this as a `useContextMenu` API, which may be a little more intuitive. But that's ok to add as an incremental (non-breaking) change.
- Use this new API in the icons list components in the docs to fix the layout issues that existed before this change due to styles which expected the old ContextMenu DOM layout.

#### Reviewers should focus on:

N/A

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://user-images.githubusercontent.com/723999/114589818-07fbe000-9c56-11eb-8baa-6bd963946719.png)
