### PR TITLE
[core] deprecate various APIs in prep for v4.0

### DIFF
--- a/packages/core/src/common/constructor.ts
+++ b/packages/core/src/common/constructor.ts
@@ -17,5 +17,7 @@
 /**
  * Generic interface defining constructor types, such as classes. This is used to type the class
  * itself in meta-programming situations such as decorators.
+ *
+ * @deprecated will be removed in Blueprint v4.0
  */
 export type IConstructor<T> = new (...args: any[]) => T;

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -83,9 +83,9 @@ export interface ILinkProps {
 }
 
 /**
- * @deprecated use IControlledProps2.
- *
  * Interface for a controlled input.
+ *
+ * @deprecated use IControlledProps2.
  */
 export interface IControlledProps {
     /** Initial value of the input, for uncontrolled usage. */
@@ -106,10 +106,14 @@ export interface IControlledProps2 {
     value?: string;
 }
 
+/**
+ * @deprecated will be removed in Blueprint v4.0, where components will use `ref` prop instead
+ */
 export interface IElementRefProps<E extends HTMLElement> {
     /** A ref handler or a ref object that receives the native HTML element rendered by this component. */
     elementRef?: IRef<E>;
 }
+
 /**
  * An interface for an option in a list, such as in a `<select>` or `RadioGroup`.
  * These props can be spread directly to an `<option>` or `<Radio>` element.

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -64,7 +64,7 @@ export function ensureElement(child: React.ReactNode | undefined, tagName: keyof
     }
 }
 
-export function isReactElement<T = any>(child: React.ReactNode): child is React.ReactElement<T> {
+function isReactElement<T = any>(child: React.ReactNode): child is React.ReactElement<T> {
     return (
         typeof child === "object" &&
         typeof (child as any).type !== "undefined" &&
@@ -75,10 +75,13 @@ export function isReactElement<T = any>(child: React.ReactNode): child is React.
 /**
  * Represents anything that has a `name` property such as Functions.
  */
-export interface INamed {
+interface INamed {
     name?: string;
 }
 
+/**
+ * @deprecated will be removed in 4.0
+ */
 export function getDisplayName(ComponentClass: React.ComponentType | INamed) {
     return (ComponentClass as React.ComponentType).displayName || (ComponentClass as INamed).name || "Unknown";
 }
@@ -108,6 +111,8 @@ export function isElementOfType<P = {}>(
 
 /**
  * Returns React.createRef if it's available, or a ref-like object if not.
+ *
+ * @deprecated use React.createRef or React.useRef
  */
 export function createReactRef<T>() {
     return typeof React.createRef !== "undefined" ? React.createRef<T>() : { current: null };
@@ -117,5 +122,7 @@ export function createReactRef<T>() {
  * Replacement type for { polyfill } from "react-lifecycles-compat" useful in some places where
  * the correct type is not inferred automatically. This should be removed once Blueprint depends on React >= 16.
  * HACKHACK part of https://github.com/palantir/blueprint/issues/4342
+ *
+ * @deprecated use React 16
  */
 export type LifecycleCompatPolyfill<P, T extends React.ComponentClass<P>> = (Comp: T) => T & { [K in keyof T]: T[K] };

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -32,6 +32,7 @@ import { Spinner } from "../spinner/spinner";
 
 export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = HTMLButtonElement>
     extends IActionProps,
+        // eslint-disable-next-line deprecation/deprecation
         IElementRefProps<E> {
     /**
      * If set to `true`, the button will display in an active state.

--- a/packages/core/src/components/context-menu/contextMenuTarget.tsx
+++ b/packages/core/src/components/context-menu/contextMenuTarget.tsx
@@ -32,6 +32,8 @@ export interface IContextMenuTargetComponent extends React.Component {
     onContextMenuClose?: () => void;
 }
 
+/* eslint-disable deprecation/deprecation */
+
 /** @deprecated use ContextMenu2 */
 export function ContextMenuTarget<T extends IConstructor<IContextMenuTargetComponent>>(WrappedComponent: T) {
     if (!isFunction(WrappedComponent.prototype.renderContextMenu)) {

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -33,6 +33,8 @@ export interface IHotkeysTargetComponent extends React.Component {
     renderHotkeys: () => React.ReactElement<IHotkeysProps>;
 }
 
+/* eslint-disable deprecation/deprecation */
+
 /** @deprecated use `useHotkeys` hook or `<HotkeysTarget2>` component */
 export function HotkeysTarget<T extends IConstructor<IHotkeysTargetComponent>>(WrappedComponent: T) {
     if (!isFunction(WrappedComponent.prototype.renderHotkeys)) {

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -24,6 +24,7 @@ import { IElementRefProps, IOptionProps } from "../../common/props";
 import { Icon, IIconProps } from "../icon/icon";
 
 export interface IHTMLSelectProps
+    // eslint-disable-next-line deprecation/deprecation
     extends IElementRefProps<HTMLSelectElement>,
         React.SelectHTMLAttributes<HTMLSelectElement> {
     /** Whether this element is non-interactive. */

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -22,6 +22,7 @@ import { AbstractPureComponent2, Classes, IElementRefProps } from "../../common"
 
 export interface IHTMLTableProps
     extends React.TableHTMLAttributes<HTMLTableElement>,
+        // eslint-disable-next-line deprecation/deprecation
         IElementRefProps<HTMLTableElement> {
     /** Enables borders between rows and cells. */
     bordered?: boolean;

--- a/packages/core/src/components/html/html.tsx
+++ b/packages/core/src/components/html/html.tsx
@@ -23,6 +23,7 @@ import { BLOCKQUOTE, CODE, CODE_BLOCK, HEADING, LABEL, LIST } from "../../common
 function htmlElement<E extends HTMLElement>(
     tagName: keyof JSX.IntrinsicElements,
     tagClassName: string,
+    // eslint-disable-next-line deprecation/deprecation
 ): React.FunctionComponent<React.HTMLProps<E> & IElementRefProps<E>> {
     /* eslint-disable-next-line react/display-name */
     return props => {

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -184,6 +184,7 @@ export interface IOverlayState {
 }
 
 // HACKHACK: https://github.com/palantir/blueprint/issues/4342
+// eslint-disable-next-line deprecation/deprecation
 @(polyfill as LifecycleCompatPolyfill<IOverlayProps, any>)
 export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Overlay`;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -100,6 +100,7 @@ export interface IPopoverState {
 export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
+    // eslint-disable-next-line deprecation/deprecation
     private popoverRef = Utils.createReactRef<HTMLDivElement>();
 
     public static defaultProps: IPopoverProps = {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -96,6 +96,7 @@ export interface ITabsState {
 }
 
 // HACKHACK: https://github.com/palantir/blueprint/issues/4342
+// eslint-disable-next-line deprecation/deprecation
 @(polyfill as Utils.LifecycleCompatPolyfill<ITabsProps, any>)
 export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
     /** Insert a `Tabs.Expander` between any two children to right-align all subsequent children. */

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -35,6 +35,7 @@ import { Text } from "../text/text";
 export interface ITagProps
     extends IProps,
         IIntentProps,
+        // eslint-disable-next-line deprecation/deprecation
         IElementRefProps<HTMLSpanElement>,
         React.HTMLAttributes<HTMLSpanElement> {
     /**


### PR DESCRIPTION

#### Changes proposed in this pull request:

Deprecate various APIs which we intend to remove in v4.0:

- `IConstructor`
- `IElementRefProps`
- `createReactRef`
- `getDisplayName`
- `LifecycleCompatPolyfill`

