### PR TITLE
EditableText: improve `componentDidMount` performance

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -282,7 +282,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         // Eg, a lot of developers use inline functions for callback props – like this: <EditableText onEdit={() => { ... }} />.)
         const callbackKeys = Object.keys(this.props)
             .concat(Object.keys(prevProps))
-            .filter(key => key.match(/^on[A-Z]/)) as (keyof IEditableTextProps)[];
+            .filter(key => key.match(/^on[A-Z]/)) as Array<keyof IEditableTextProps>;
         if (!shallowCompareKeys(this.props, prevProps, { exclude: callbackKeys })) {
             this.updateInputDimensions();
         }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -282,7 +282,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         // Eg, a lot of developers use inline functions for callback props – like this: <EditableText onEdit={() => { ... }} />.)
         const callbackKeys = Object.keys(this.props)
             .concat(Object.keys(prevProps))
-            .filter(key => key.match(/^on[A-Z]/));
+            .filter(key => key.match(/^on[A-Z]/)) as (keyof IEditableTextProps)[];
         if (!shallowCompareKeys(this.props, prevProps, { exclude: callbackKeys })) {
             this.updateInputDimensions();
         }


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

##### Problem

Heya! While helping a client with React performance, I’ve stumbled upon a case where `EditableText` would force expensive style recalculations:

![CleanShot 2021-04-15 at 01 09 56@2x](https://user-images.githubusercontent.com/2953267/114779819-9e7bee80-9d87-11eb-80ab-40279baaab8c.png)

It turned out that every time `EditableText` updates, its `componentDidUpdate` calls `updateInputDimensions`:

https://github.com/palantir/blueprint/blob/b9f91ee2178695ec03b053dbf6f109fb431e0e30/packages/core/src/components/editable-text/editableText.tsx#L277

`updateInputDimensions`, in turn, reads the `scrollHeight` and `scrollWidth` properties from a DOM node:

https://github.com/palantir/blueprint/blob/b9f91ee2178695ec03b053dbf6f109fb431e0e30/packages/core/src/components/editable-text/editableText.tsx#L384

And reading `scrollHeight`/`scrollWidth`, in turn, forces the browser to recalculate page styles and layout. (Here’s why: [explainer](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing), [full list of such attributes](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)).

##### Solution

This PR fixes that by ensuring `updateInputDimensions` is not called when `EditableText`’s event listeners change.

Why does this matter? `EditableText` is a `PureComponent`, so it doesn’t rerender unless any of its props change. That works great for most `EditableText` props – except for callbacks (`onCancel`, `onChange`, and etc).

In the user land, it’s common to use arrow functions for callback props:

```jsx
<EditableText
  onCancel={() => {
    console.log('Cancelled');
  }}
/>
```

Passing an arrow function this way means the function will be regenerated on every rerender. This, in turn, will change the function reference – and cause `EditableText` to rerender – every time a parent component renders. And the `EditableText`’s rerender is expensive – due to `updateInputDimensions`.

#### Reviewers should focus on:

- Confirming that skipping `on...` callbacks is a safe approach


