### PR TITLE
Add type aliases for interfaces renamed in v4.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,9 @@ module.exports = {
                 "@typescript-eslint/no-unused-expressions": "off",
                 // HACKHACK: test dependencies are only declared at root but used in all packages.
                 "import/no-extraneous-dependencies": "off",
+                // HACKHACK: added to reduce diff in https://github.com/palantir/blueprint/pull/4644,
+                // can be removed in v4.0
+                "deprecation/deprecation": "off",
             },
         },
         {

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -49,11 +49,13 @@ export interface IProps {
     /** A space-delimited list of class names to pass along to a child element. */
     className?: string;
 }
+export type Props = IProps;
 
 export interface IIntentProps {
     /** Visual intent color to apply to element. */
     intent?: Intent;
 }
+export type IntentProps = IIntentProps;
 
 /**
  * Interface for a clickable action, such as a button or menu item.
@@ -72,6 +74,7 @@ export interface IActionProps extends IIntentProps, IProps {
     /** Action text. Can be any single React renderable. */
     text?: React.ReactNode;
 }
+export type ActionProps = IActionProps;
 
 /** Interface for a link, with support for customizing target window. */
 export interface ILinkProps {
@@ -81,6 +84,7 @@ export interface ILinkProps {
     /** Link target attribute. Use `"_blank"` to open in a new window. */
     target?: string;
 }
+export type LinkProps = ILinkProps;
 
 /**
  * Interface for a controlled input.
@@ -105,6 +109,7 @@ export interface IControlledProps2 {
     /** Form value of the input, for controlled usage. */
     value?: string;
 }
+export type ControlledProps2 = IControlledProps2;
 
 /**
  * @deprecated will be removed in Blueprint v4.0, where components will use `ref` prop instead
@@ -128,6 +133,7 @@ export interface IOptionProps extends IProps {
     /** Value of this option. */
     value: string | number;
 }
+export type OptionProps = IOptionProps;
 
 /** A collection of curated prop keys used across our Components which are not valid HTMLElement props. */
 const INVALID_PROPS = [

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -44,24 +44,31 @@ export type MaybeElement = JSX.Element | false | null | undefined;
 
 /**
  * A shared base interface for all Blueprint component props.
+ *
+ * @deprecated use Props
  */
 export interface IProps {
     /** A space-delimited list of class names to pass along to a child element. */
     className?: string;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type Props = IProps;
 
+/** @deprecated use IntentProps */
 export interface IIntentProps {
     /** Visual intent color to apply to element. */
     intent?: Intent;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type IntentProps = IIntentProps;
 
 /**
  * Interface for a clickable action, such as a button or menu item.
  * These props can be spready directly to a `<Button>` or `<MenuItem>` element.
+ *
+ * @deprecated use ActionProps
  */
-export interface IActionProps extends IIntentProps, IProps {
+export interface IActionProps extends IntentProps, Props {
     /** Whether this action is non-interactive. */
     disabled?: boolean;
 
@@ -74,9 +81,14 @@ export interface IActionProps extends IIntentProps, IProps {
     /** Action text. Can be any single React renderable. */
     text?: React.ReactNode;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type ActionProps = IActionProps;
 
-/** Interface for a link, with support for customizing target window. */
+/**
+ * Interface for a link, with support for customizing target window.
+ *
+ * @deprecated use LinkProps
+ */
 export interface ILinkProps {
     /** Link URL. */
     href?: string;
@@ -84,6 +96,7 @@ export interface ILinkProps {
     /** Link target attribute. Use `"_blank"` to open in a new window. */
     target?: string;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type LinkProps = ILinkProps;
 
 /**
@@ -122,8 +135,10 @@ export interface IElementRefProps<E extends HTMLElement> {
 /**
  * An interface for an option in a list, such as in a `<select>` or `RadioGroup`.
  * These props can be spread directly to an `<option>` or `<Radio>` element.
+ *
+ * @deprecated use OptionProps
  */
-export interface IOptionProps extends IProps {
+export interface IOptionProps extends Props {
     /** Whether this option is non-interactive. */
     disabled?: boolean;
 
@@ -133,6 +148,7 @@ export interface IOptionProps extends IProps {
     /** Value of this option. */
     value: string | number;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type OptionProps = IOptionProps;
 
 /** A collection of curated prop keys used across our Components which are not valid HTMLElement props. */

--- a/packages/core/src/common/utils/compareUtils.ts
+++ b/packages/core/src/common/utils/compareUtils.ts
@@ -25,10 +25,12 @@ export type IKeyBlacklist<T> = IKeyDenylist<T>;
 export interface IKeyAllowlist<T> {
     include: Array<keyof T>;
 }
+export type KeyAllowlist<T> = IKeyAllowlist<T>;
 
 export interface IKeyDenylist<T> {
     exclude: Array<keyof T>;
 }
+export type KeyDenylist<T> = IKeyDenylist<T>;
 
 /**
  * Returns true if the arrays are equal. Elements will be shallowly compared by

--- a/packages/core/src/common/utils/compareUtils.ts
+++ b/packages/core/src/common/utils/compareUtils.ts
@@ -14,23 +14,29 @@
  * limitations under the License.
  */
 
+// we use the empty object {} a lot in this public API
+/* eslint-disable @typescript-eslint/ban-types */
+
+/* eslint-disable deprecation/deprecation */
+
 /** @deprecated use IKeyAllowlist */
 export type IKeyWhitelist<T> = IKeyAllowlist<T>;
 /** @deprecated use IKeyDenylist */
 export type IKeyBlacklist<T> = IKeyDenylist<T>;
 
-// we use the empty object {} a lot in this public API
-/* eslint-disable @typescript-eslint/ban-types */
-
+/** @deprecated use KeyAllowlist */
 export interface IKeyAllowlist<T> {
     include: Array<keyof T>;
 }
 export type KeyAllowlist<T> = IKeyAllowlist<T>;
 
+/** @deprecated use KeyDenylist */
 export interface IKeyDenylist<T> {
     exclude: Array<keyof T>;
 }
 export type KeyDenylist<T> = IKeyDenylist<T>;
+
+/* eslint-enable deprecation/deprecation */
 
 /**
  * Returns true if the arrays are equal. Elements will be shallowly compared by
@@ -54,7 +60,7 @@ export function arraysEqual(arrA: any[], arrB: any[], compare = (a: any, b: any)
  *
  * @returns true if items are equal.
  */
-export function shallowCompareKeys<T extends {}>(objA: T, objB: T, keys?: IKeyDenylist<T> | IKeyAllowlist<T>) {
+export function shallowCompareKeys<T extends {}>(objA: T, objB: T, keys?: KeyDenylist<T> | KeyAllowlist<T>) {
     // treat `null` and `undefined` as the same
     if (objA == null && objB == null) {
         return true;
@@ -131,7 +137,7 @@ export function getDeepUnequalKeyValues<T extends {}>(
 /**
  * Partial shallow comparison between objects using the given list of keys.
  */
-function shallowCompareKeysImpl<T extends object>(objA: T, objB: T, keys: IKeyDenylist<T> | IKeyAllowlist<T>) {
+function shallowCompareKeysImpl<T extends object>(objA: T, objB: T, keys: KeyDenylist<T> | KeyAllowlist<T>) {
     return filterKeys(objA, objB, keys).every(key => {
         return objA.hasOwnProperty(key) === objB.hasOwnProperty(key) && objA[key] === objB[key];
     });
@@ -150,7 +156,7 @@ function isSimplePrimitiveType(value: any) {
     return typeof value === "number" || typeof value === "string" || typeof value === "boolean";
 }
 
-function filterKeys<T>(objA: T, objB: T, keys: IKeyDenylist<T> | IKeyAllowlist<T>) {
+function filterKeys<T>(objA: T, objB: T, keys: KeyDenylist<T> | KeyAllowlist<T>) {
     if (isAllowlist(keys)) {
         return keys.include;
     } else if (isDenylist(keys)) {
@@ -170,12 +176,12 @@ function filterKeys<T>(objA: T, objB: T, keys: IKeyDenylist<T> | IKeyAllowlist<T
     return [];
 }
 
-function isAllowlist<T>(keys: any): keys is IKeyAllowlist<T> {
-    return keys != null && (keys as IKeyAllowlist<T>).include != null;
+function isAllowlist<T>(keys: any): keys is KeyAllowlist<T> {
+    return keys != null && (keys as KeyAllowlist<T>).include != null;
 }
 
-function isDenylist<T>(keys: any): keys is IKeyDenylist<T> {
-    return keys != null && (keys as IKeyDenylist<T>).exclude != null;
+function isDenylist<T>(keys: any): keys is KeyDenylist<T> {
+    return keys != null && (keys as KeyDenylist<T>).exclude != null;
 }
 
 function arrayToObject(arr: any[]) {

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -29,6 +29,7 @@ import { Dialog } from "../dialog/dialog";
 import { Icon, IconName } from "../icon/icon";
 import { IOverlayLifecycleProps } from "../overlay/overlay";
 
+export type AlertProps = IAlertProps;
 export interface IAlertProps extends IOverlayLifecycleProps, IProps {
     /**
      * Whether pressing <kbd>escape</kbd> when focused on the Alert should cancel the alert.

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, Intent, IProps, MaybeElement } from "../../common";
+import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, Intent, Props, MaybeElement } from "../../common";
 import {
     ALERT_WARN_CANCEL_ESCAPE_KEY,
     ALERT_WARN_CANCEL_OUTSIDE_CLICK,
@@ -29,8 +29,10 @@ import { Dialog } from "../dialog/dialog";
 import { Icon, IconName } from "../icon/icon";
 import { IOverlayLifecycleProps } from "../overlay/overlay";
 
+// eslint-disable-next-line deprecation/deprecation
 export type AlertProps = IAlertProps;
-export interface IAlertProps extends IOverlayLifecycleProps, IProps {
+/** @deprecated use AlertProps */
+export interface IAlertProps extends IOverlayLifecycleProps, Props {
     /**
      * Whether pressing <kbd>escape</kbd> when focused on the Alert should cancel the alert.
      * If this prop is enabled, then either `onCancel` or `onClose` must also be defined.
@@ -132,8 +134,8 @@ export interface IAlertProps extends IOverlayLifecycleProps, IProps {
 }
 
 @polyfill
-export class Alert extends AbstractPureComponent2<IAlertProps> {
-    public static defaultProps: IAlertProps = {
+export class Alert extends AbstractPureComponent2<AlertProps> {
+    public static defaultProps: AlertProps = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,
         confirmButtonText: "OK",
@@ -180,7 +182,7 @@ export class Alert extends AbstractPureComponent2<IAlertProps> {
         );
     }
 
-    protected validateProps(props: IAlertProps) {
+    protected validateProps(props: AlertProps) {
         if (props.onClose == null && (props.cancelButtonText == null) !== (props.onCancel == null)) {
             console.warn(ALERT_WARN_CANCEL_PROPS);
         }

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -18,16 +18,18 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { IActionProps, ILinkProps } from "../../common/props";
+import { ActionProps, LinkProps } from "../../common/props";
 import { Icon } from "../icon/icon";
 
+// eslint-disable-next-line deprecation/deprecation
 export type BreadcrumbProps = IBreadcrumbProps;
-export interface IBreadcrumbProps extends IActionProps, ILinkProps {
+/** @deprecated use BreadcrumbProps */
+export interface IBreadcrumbProps extends ActionProps, LinkProps {
     /** Whether this breadcrumb is the current breadcrumb. */
     current?: boolean;
 }
 
-export const Breadcrumb: React.FunctionComponent<IBreadcrumbProps> = breadcrumbProps => {
+export const Breadcrumb: React.FunctionComponent<BreadcrumbProps> = breadcrumbProps => {
     const classes = classNames(
         Classes.BREADCRUMB,
         {

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -21,6 +21,7 @@ import * as Classes from "../../common/classes";
 import { IActionProps, ILinkProps } from "../../common/props";
 import { Icon } from "../icon/icon";
 
+export type BreadcrumbProps = IBreadcrumbProps;
 export interface IBreadcrumbProps extends IActionProps, ILinkProps {
     /** Whether this breadcrumb is the current breadcrumb. */
     current?: boolean;

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -25,6 +25,7 @@ import { IOverflowListProps, OverflowList } from "../overflow-list/overflowList"
 import { IPopoverProps, Popover } from "../popover/popover";
 import { Breadcrumb, IBreadcrumbProps } from "./breadcrumb";
 
+export type BreadcrumbsProps = IBreadcrumbsProps;
 export interface IBreadcrumbsProps extends IProps {
     /**
      * Callback invoked to render visible breadcrumbs. Best practice is to

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -18,15 +18,17 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Boundary, Classes, IProps, Position, removeNonHTMLProps } from "../../common";
+import { AbstractPureComponent2, Boundary, Classes, Props, Position, removeNonHTMLProps } from "../../common";
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
-import { IOverflowListProps, OverflowList } from "../overflow-list/overflowList";
+import { OverflowListProps, OverflowList } from "../overflow-list/overflowList";
 import { IPopoverProps, Popover } from "../popover/popover";
-import { Breadcrumb, IBreadcrumbProps } from "./breadcrumb";
+import { Breadcrumb, BreadcrumbProps } from "./breadcrumb";
 
+// eslint-disable-next-line deprecation/deprecation
 export type BreadcrumbsProps = IBreadcrumbsProps;
-export interface IBreadcrumbsProps extends IProps {
+/** @deprecated use BreadcrumbsProps */
+export interface IBreadcrumbsProps extends Props {
     /**
      * Callback invoked to render visible breadcrumbs. Best practice is to
      * render a `<Breadcrumb>` element. If `currentBreadcrumbRenderer` is also
@@ -34,7 +36,7 @@ export interface IBreadcrumbsProps extends IProps {
      *
      * @default Breadcrumb
      */
-    breadcrumbRenderer?: (props: IBreadcrumbProps) => JSX.Element;
+    breadcrumbRenderer?: (props: BreadcrumbProps) => JSX.Element;
 
     /**
      * Which direction the breadcrumbs should collapse from: start or end.
@@ -50,13 +52,13 @@ export interface IBreadcrumbsProps extends IProps {
      * If this prop is omitted, `breadcrumbRenderer` will be invoked for the
      * current breadcrumb instead.
      */
-    currentBreadcrumbRenderer?: (props: IBreadcrumbProps) => JSX.Element;
+    currentBreadcrumbRenderer?: (props: BreadcrumbProps) => JSX.Element;
 
     /**
      * All breadcrumbs to display. Breadcrumbs that do not fit in the container
      * will be rendered in an overflow menu instead.
      */
-    items: IBreadcrumbProps[];
+    items: BreadcrumbProps[];
 
     /**
      * The minimum number of visible breadcrumbs that should never collapse into
@@ -70,7 +72,7 @@ export interface IBreadcrumbsProps extends IProps {
      * Props to spread to `OverflowList`. Note that `items`,
      * `overflowRenderer`, and `visibleItemRenderer` cannot be changed.
      */
-    overflowListProps?: Partial<IOverflowListProps<IBreadcrumbProps>>;
+    overflowListProps?: Partial<OverflowListProps<BreadcrumbProps>>;
 
     /**
      * Props to spread to the `Popover` showing the overflow menu.
@@ -79,8 +81,8 @@ export interface IBreadcrumbsProps extends IProps {
 }
 
 @polyfill
-export class Breadcrumbs extends AbstractPureComponent2<IBreadcrumbsProps> {
-    public static defaultProps: Partial<IBreadcrumbsProps> = {
+export class Breadcrumbs extends AbstractPureComponent2<BreadcrumbsProps> {
+    public static defaultProps: Partial<BreadcrumbsProps> = {
         collapseFrom: Boundary.START,
     };
 
@@ -100,7 +102,7 @@ export class Breadcrumbs extends AbstractPureComponent2<IBreadcrumbsProps> {
         );
     }
 
-    private renderOverflow = (items: IBreadcrumbProps[]) => {
+    private renderOverflow = (items: BreadcrumbProps[]) => {
         const { collapseFrom } = this.props;
         const position = collapseFrom === Boundary.END ? Position.BOTTOM_RIGHT : Position.BOTTOM_LEFT;
         let orderedItems = items;
@@ -124,18 +126,18 @@ export class Breadcrumbs extends AbstractPureComponent2<IBreadcrumbsProps> {
         /* eslint-enable deprecation/deprecation */
     };
 
-    private renderOverflowBreadcrumb = (props: IBreadcrumbProps, index: number) => {
+    private renderOverflowBreadcrumb = (props: BreadcrumbProps, index: number) => {
         const isClickable = props.href != null || props.onClick != null;
         const htmlProps = removeNonHTMLProps(props);
         return <MenuItem disabled={!isClickable} {...htmlProps} text={props.text} key={index} />;
     };
 
-    private renderBreadcrumbWrapper = (props: IBreadcrumbProps, index: number) => {
+    private renderBreadcrumbWrapper = (props: BreadcrumbProps, index: number) => {
         const isCurrent = this.props.items[this.props.items.length - 1] === props;
         return <li key={index}>{this.renderBreadcrumb(props, isCurrent)}</li>;
     };
 
-    private renderBreadcrumb(props: IBreadcrumbProps, isCurrent: boolean) {
+    private renderBreadcrumb(props: BreadcrumbProps, isCurrent: boolean) {
         if (isCurrent && this.props.currentBreadcrumbRenderer != null) {
             return this.props.currentBreadcrumbRenderer(props);
         } else if (this.props.breadcrumbRenderer != null) {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -30,6 +30,7 @@ import {
 import { Icon, IconName } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
 
+export type ButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = HTMLButtonElement> = IButtonProps<E>;
 export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = HTMLButtonElement>
     extends IActionProps,
         // eslint-disable-next-line deprecation/deprecation
@@ -88,6 +89,7 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
 }
 
 export type IAnchorButtonProps = IButtonProps<HTMLAnchorElement>;
+export type AnchorButtonProps = IAnchorButtonProps;
 
 export interface IButtonState {
     isActive: boolean;

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -21,7 +21,7 @@ import {
     AbstractPureComponent2,
     Alignment,
     Classes,
-    IActionProps,
+    ActionProps,
     IElementRefProps,
     Keys,
     MaybeElement,
@@ -30,9 +30,11 @@ import {
 import { Icon, IconName } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
 
+// eslint-disable-next-line deprecation/deprecation
 export type ButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = HTMLButtonElement> = IButtonProps<E>;
+/** @deprecated use ButtonProps */
 export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = HTMLButtonElement>
-    extends IActionProps,
+    extends ActionProps,
         // eslint-disable-next-line deprecation/deprecation
         IElementRefProps<E> {
     /**
@@ -88,7 +90,9 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     type?: "submit" | "reset" | "button";
 }
 
-export type IAnchorButtonProps = IButtonProps<HTMLAnchorElement>;
+/** @deprecated use AnchorButtonProps */
+export type IAnchorButtonProps = ButtonProps<HTMLAnchorElement>;
+// eslint-disable-next-line deprecation/deprecation
 export type AnchorButtonProps = IAnchorButtonProps;
 
 export interface IButtonState {
@@ -96,7 +100,7 @@ export interface IButtonState {
 }
 
 export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorElement> extends AbstractPureComponent2<
-    IButtonProps<E> &
+    ButtonProps<E> &
         (E extends HTMLButtonElement
             ? React.ButtonHTMLAttributes<HTMLButtonElement>
             : React.AnchorHTMLAttributes<HTMLAnchorElement>),

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Alignment, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type ButtonGroupProps = IButtonGroupProps;
-export interface IButtonGroupProps extends IProps, HTMLDivProps {
+/** @deprecated use ButtonGroupProps */
+export interface IButtonGroupProps extends Props, HTMLDivProps {
     /**
      * Text alignment within button. By default, icons and text will be centered
      * within the button. Passing `"left"` or `"right"` will align the button
@@ -63,7 +65,7 @@ export interface IButtonGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class ButtonGroup extends AbstractPureComponent2<IButtonGroupProps> {
+export class ButtonGroup extends AbstractPureComponent2<ButtonGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ButtonGroup`;
 
     public render() {

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
+export type ButtonGroupProps = IButtonGroupProps;
 export interface IButtonGroupProps extends IProps, HTMLDivProps {
     /**
      * Text alignment within button. By default, icons and text will be centered

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -21,9 +21,10 @@ import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { IRef, refHandler, setRef } from "../../common/refs";
-import { AbstractButton, IButtonProps, IAnchorButtonProps } from "./abstractButton";
+import { AbstractButton, IButtonProps, IAnchorButtonProps, ButtonProps, AnchorButtonProps } from "./abstractButton";
 
-export { IAnchorButtonProps, IButtonProps };
+// eslint-disable-next-line deprecation/deprecation
+export { IAnchorButtonProps, IButtonProps, ButtonProps, AnchorButtonProps };
 
 export class Button extends AbstractButton<HTMLButtonElement> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Button`;
@@ -46,7 +47,7 @@ export class Button extends AbstractButton<HTMLButtonElement> {
         );
     }
 
-    public componentDidUpdate(prevProps: IButtonProps) {
+    public componentDidUpdate(prevProps: ButtonProps) {
         if (prevProps.elementRef !== this.props.elementRef) {
             setRef(prevProps.elementRef, null);
             this.handleRef = refHandler(this, "buttonRef", this.props.elementRef);
@@ -81,7 +82,7 @@ export class AnchorButton extends AbstractButton<HTMLAnchorElement> {
         );
     }
 
-    public componentDidUpdate(prevProps: IAnchorButtonProps) {
+    public componentDidUpdate(prevProps: AnchorButtonProps) {
         if (prevProps.elementRef !== this.props.elementRef) {
             setRef(prevProps.elementRef, null);
             this.handleRef = refHandler(this, "buttonRef", this.props.elementRef);

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -31,7 +31,7 @@ import {
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
 
-/** This component also supports the full range of HTML `<div>` props. */
+export type CalloutProps = ICalloutProps;
 export interface ICalloutProps extends IIntentProps, IProps, HTMLDivProps {
     /**
      * Name of a Blueprint UI icon (or an icon element) to render on the left side.
@@ -59,6 +59,7 @@ export interface ICalloutProps extends IIntentProps, IProps, HTMLDivProps {
     title?: string;
 }
 
+/** This component supports the full range of HTML `<div>` props. */
 @polyfill
 export class Callout extends AbstractPureComponent2<ICalloutProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Callout`;

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -23,16 +23,18 @@ import {
     Classes,
     DISPLAYNAME_PREFIX,
     HTMLDivProps,
-    IIntentProps,
+    IntentProps,
     Intent,
-    IProps,
+    Props,
     MaybeElement,
 } from "../../common";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
 
+// eslint-disable-next-line deprecation/deprecation
 export type CalloutProps = ICalloutProps;
-export interface ICalloutProps extends IIntentProps, IProps, HTMLDivProps {
+/** @deprecated use CalloutProps */
+export interface ICalloutProps extends IntentProps, Props, HTMLDivProps {
     /**
      * Name of a Blueprint UI icon (or an icon element) to render on the left side.
      *
@@ -61,7 +63,7 @@ export interface ICalloutProps extends IIntentProps, IProps, HTMLDivProps {
 
 /** This component supports the full range of HTML `<div>` props. */
 @polyfill
-export class Callout extends AbstractPureComponent2<ICalloutProps> {
+export class Callout extends AbstractPureComponent2<CalloutProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Callout`;
 
     public render() {
@@ -83,7 +85,7 @@ export class Callout extends AbstractPureComponent2<ICalloutProps> {
         );
     }
 
-    private getIconName(icon?: ICalloutProps["icon"], intent?: Intent): IconName | MaybeElement {
+    private getIconName(icon?: CalloutProps["icon"], intent?: Intent): IconName | MaybeElement {
         // 1. no icon
         if (icon === null) {
             return undefined;

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, Elevation } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
+export type CardProps = ICardProps;
 export interface ICardProps extends IProps, HTMLDivProps {
     /**
      * Controls the intensity of the drop shadow beneath the card: the higher

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Elevation } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type CardProps = ICardProps;
-export interface ICardProps extends IProps, HTMLDivProps {
+/** @deprecated use CardProps */
+export interface ICardProps extends Props, HTMLDivProps {
     /**
      * Controls the intensity of the drop shadow beneath the card: the higher
      * the elevation, the higher the drop shadow. At elevation `0`, no drop
@@ -51,10 +53,10 @@ export interface ICardProps extends IProps, HTMLDivProps {
 }
 
 @polyfill
-export class Card extends AbstractPureComponent2<ICardProps> {
+export class Card extends AbstractPureComponent2<CardProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Card`;
 
-    public static defaultProps: ICardProps = {
+    public static defaultProps: CardProps = {
         elevation: Elevation.ZERO,
         interactive: false,
     };

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
+export type CollapseProps = ICollapseProps;
 export interface ICollapseProps extends IProps {
     /**
      * Component to render as the root element.

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type CollapseProps = ICollapseProps;
-export interface ICollapseProps extends IProps {
+/** @deprecated use CollapseProps */
+export interface ICollapseProps extends Props {
     /**
      * Component to render as the root element.
      * Useful when rendering a `Collapse` inside a `<table>`, for instance.
@@ -116,17 +118,17 @@ export enum AnimationStates {
 }
 
 @polyfill
-export class Collapse extends AbstractPureComponent2<ICollapseProps, ICollapseState> {
+export class Collapse extends AbstractPureComponent2<CollapseProps, ICollapseState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Collapse`;
 
-    public static defaultProps: ICollapseProps = {
+    public static defaultProps: CollapseProps = {
         component: "div",
         isOpen: false,
         keepChildrenMounted: false,
         transitionDuration: 200,
     };
 
-    public static getDerivedStateFromProps(props: ICollapseProps, state: ICollapseState) {
+    public static getDerivedStateFromProps(props: CollapseProps, state: ICollapseState) {
         const { isOpen } = props;
         const { animationState } = state;
 

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -21,16 +21,18 @@ import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { Position } from "../../common/position";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isElementOfType } from "../../common/utils";
 import { Menu } from "../menu/menu";
-import { IMenuItemProps, MenuItem } from "../menu/menuItem";
+import { MenuItemProps, MenuItem } from "../menu/menuItem";
 import { IPopoverProps, Popover } from "../popover/popover";
 
-type CollapsibleItem = React.ReactElement<IMenuItemProps>;
+type CollapsibleItem = React.ReactElement<MenuItemProps>;
 
+// eslint-disable-next-line deprecation/deprecation
 export type CollapsibleListProps = ICollapsibleListProps;
-export interface ICollapsibleListProps extends IProps {
+/** @deprecated use CollapsibleListProps */
+export interface ICollapsibleListProps extends Props {
     /**
      * Element to render as dropdown target with `CLICK` interaction to show collapsed menu.
      */
@@ -45,7 +47,7 @@ export interface ICollapsibleListProps extends IProps {
      * Callback invoked to render each visible item. The item will be wrapped in an `li` with
      * the optional `visibleItemClassName` prop.
      */
-    visibleItemRenderer: (props: IMenuItemProps, index: number) => JSX.Element;
+    visibleItemRenderer: (props: MenuItemProps, index: number) => JSX.Element;
 
     /**
      * Which direction the items should collapse from: start or end of the children.
@@ -68,10 +70,10 @@ export interface ICollapsibleListProps extends IProps {
 }
 
 /** @deprecated use `<OverflowList>` for automatic overflow based on available space. */
-export class CollapsibleList extends React.Component<ICollapsibleListProps> {
+export class CollapsibleList extends React.Component<CollapsibleListProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.CollapsibleList`;
 
-    public static defaultProps: Partial<ICollapsibleListProps> = {
+    public static defaultProps: Partial<CollapsibleListProps> = {
         collapseFrom: Boundary.START,
         visibleItemCount: 3,
     };

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -29,6 +29,7 @@ import { IPopoverProps, Popover } from "../popover/popover";
 
 type CollapsibleItem = React.ReactElement<IMenuItemProps>;
 
+export type CollapsibleListProps = ICollapsibleListProps;
 export interface ICollapsibleListProps extends IProps {
     /**
      * Element to render as dropdown target with `CLICK` interaction to show collapsed menu.

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -20,14 +20,16 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
-import { DISPLAYNAME_PREFIX, IProps, MaybeElement } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { Button } from "../button/buttons";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
-import { IBackdropProps, IOverlayableProps, Overlay } from "../overlay/overlay";
+import { IBackdropProps, OverlayableProps, Overlay } from "../overlay/overlay";
 
+// eslint-disable-next-line deprecation/deprecation
 export type DialogProps = IDialogProps;
-export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps {
+/** @deprecated use DialogProps */
+export interface IDialogProps extends OverlayableProps, IBackdropProps, Props {
     /**
      * Toggles the visibility of the overlay and its children.
      * This prop is required because the component is controlled.
@@ -77,8 +79,8 @@ export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps 
 }
 
 @polyfill
-export class Dialog extends AbstractPureComponent2<IDialogProps> {
-    public static defaultProps: IDialogProps = {
+export class Dialog extends AbstractPureComponent2<DialogProps> {
+    public static defaultProps: DialogProps = {
         canOutsideClickClose: true,
         isOpen: false,
     };
@@ -98,7 +100,7 @@ export class Dialog extends AbstractPureComponent2<IDialogProps> {
         );
     }
 
-    protected validateProps(props: IDialogProps) {
+    protected validateProps(props: DialogProps) {
         if (props.title == null) {
             if (props.icon != null) {
                 console.warn(Errors.DIALOG_WARN_NO_HEADER_ICON);

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -26,6 +26,7 @@ import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
 import { IBackdropProps, IOverlayableProps, Overlay } from "../overlay/overlay";
 
+export type DialogProps = IDialogProps;
 export interface IDialogProps extends IOverlayableProps, IBackdropProps, IProps {
     /**
      * Toggles the visibility of the overlay and its children.

--- a/packages/core/src/components/dialog/dialogStep.tsx
+++ b/packages/core/src/components/dialog/dialogStep.tsx
@@ -25,6 +25,7 @@ import { IButtonProps } from "../button/buttons";
 export type DialogStepId = string | number;
 export type DialogStepButtonProps = Partial<Pick<IButtonProps, "disabled" | "text">>;
 
+export type DialogStepProps = IDialogStepProps;
 export interface IDialogStepProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
      * Unique identifier used to identify which step is selected.

--- a/packages/core/src/components/dialog/dialogStep.tsx
+++ b/packages/core/src/components/dialog/dialogStep.tsx
@@ -19,14 +19,16 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
-import { IButtonProps } from "../button/buttons";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
+import { ButtonProps } from "../button/buttons";
 
 export type DialogStepId = string | number;
-export type DialogStepButtonProps = Partial<Pick<IButtonProps, "disabled" | "text">>;
+export type DialogStepButtonProps = Partial<Pick<ButtonProps, "disabled" | "text">>;
 
+// eslint-disable-next-line deprecation/deprecation
 export type DialogStepProps = IDialogStepProps;
-export interface IDialogStepProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
+/** @deprecated use DialogStepProps */
+export interface IDialogStepProps extends Props, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
      * Unique identifier used to identify which step is selected.
      */
@@ -59,7 +61,7 @@ export interface IDialogStepProps extends IProps, Omit<HTMLDivProps, "id" | "tit
 }
 
 @polyfill
-export class DialogStep extends AbstractPureComponent2<IDialogStepProps> {
+export class DialogStep extends AbstractPureComponent2<DialogStepProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.DialogStep`;
 
     // this component is never rendered directly; see MultistepDialog#renderDialogStepPanel()

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -20,14 +20,16 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { Button, IButtonProps } from "../button/buttons";
-import { Dialog, IDialogProps } from "./dialog";
-import { DialogStep, DialogStepId, IDialogStepProps, DialogStepButtonProps } from "./dialogStep";
+import { Button, ButtonProps } from "../button/buttons";
+import { Dialog, DialogProps } from "./dialog";
+import { DialogStep, DialogStepId, DialogStepProps, DialogStepButtonProps } from "./dialogStep";
 
-type DialogStepElement = React.ReactElement<IDialogStepProps & { children: React.ReactNode }>;
+type DialogStepElement = React.ReactElement<DialogStepProps & { children: React.ReactNode }>;
 
+// eslint-disable-next-line deprecation/deprecation
 export type MultistepDialogProps = IMultistepDialogProps;
-export interface IMultistepDialogProps extends IDialogProps {
+/** @deprecated use MultistepDialogProps */
+export interface IMultistepDialogProps extends DialogProps {
     /**
      * Props for the back button.
      */
@@ -36,7 +38,7 @@ export interface IMultistepDialogProps extends IDialogProps {
     /**
      * Props for the button to display on the final step.
      */
-    finalButtonProps?: Partial<IButtonProps>;
+    finalButtonProps?: Partial<ButtonProps>;
 
     /**
      * Props for the next button.
@@ -74,10 +76,10 @@ const INITIAL_STATE = {
 };
 
 @polyfill
-export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProps, IMultistepDialogState> {
+export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps, IMultistepDialogState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MultistepDialog`;
 
-    public static defaultProps: Partial<IMultistepDialogProps> = {
+    public static defaultProps: Partial<MultistepDialogProps> = {
         canOutsideClickClose: true,
         isOpen: false,
     };
@@ -95,7 +97,7 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
         );
     }
 
-    public componentDidUpdate(prevProps: IMultistepDialogProps) {
+    public componentDidUpdate(prevProps: MultistepDialogProps) {
         if (
             (prevProps.resetOnClose === undefined || prevProps.resetOnClose) &&
             !prevProps.isOpen &&
@@ -220,7 +222,7 @@ export class MultistepDialog extends AbstractPureComponent2<IMultistepDialogProp
     }
 
     /** Filters children to only `<DialogStep>`s */
-    private getDialogStepChildren(props: IMultistepDialogProps & { children?: React.ReactNode } = this.props) {
+    private getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode } = this.props) {
         return React.Children.toArray(props.children).filter(isDialogStepElement);
     }
 }

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -26,6 +26,7 @@ import { DialogStep, DialogStepId, IDialogStepProps, DialogStepButtonProps } fro
 
 type DialogStepElement = React.ReactElement<IDialogStepProps & { children: React.ReactNode }>;
 
+export type MultistepDialogProps = IMultistepDialogProps;
 export interface IMultistepDialogProps extends IDialogProps {
     /**
      * Props for the back button.

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -20,9 +20,9 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2 } from "../../common";
 import { DIVIDER } from "../../common/classes";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 
-export interface IDividerProps extends IProps, React.HTMLAttributes<HTMLElement> {
+export interface IDividerProps extends Props, React.HTMLAttributes<HTMLElement> {
     /**
      * HTML tag to use for element.
      *

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -21,14 +21,16 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
 import { getPositionIgnoreAngles, isPositionHorizontal, Position } from "../../common/position";
-import { DISPLAYNAME_PREFIX, IProps, MaybeElement } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { Button } from "../button/buttons";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
-import { IBackdropProps, IOverlayableProps, Overlay } from "../overlay/overlay";
+import { IBackdropProps, OverlayableProps, Overlay } from "../overlay/overlay";
 
+// eslint-disable-next-line deprecation/deprecation
 export type DrawerProps = IDrawerProps;
-export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps {
+/** @deprecated use DrawerProps */
+export interface IDrawerProps extends OverlayableProps, IBackdropProps, Props {
     /**
      * Name of a Blueprint UI icon (or an icon element) to render in the
      * drawer's header. Note that the header will only be rendered if `title` is
@@ -109,10 +111,10 @@ export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps 
 }
 
 @polyfill
-export class Drawer extends AbstractPureComponent2<IDrawerProps> {
+export class Drawer extends AbstractPureComponent2<DrawerProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Drawer`;
 
-    public static defaultProps: IDrawerProps = {
+    public static defaultProps: DrawerProps = {
         canOutsideClickClose: true,
         isOpen: false,
         shouldReturnFocusOnClose: true,
@@ -164,7 +166,7 @@ export class Drawer extends AbstractPureComponent2<IDrawerProps> {
         );
     }
 
-    protected validateProps(props: IDrawerProps) {
+    protected validateProps(props: DrawerProps) {
         if (props.title == null) {
             if (props.icon != null) {
                 console.warn(Errors.DIALOG_WARN_NO_HEADER_ICON);

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -27,6 +27,7 @@ import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
 import { IBackdropProps, IOverlayableProps, Overlay } from "../overlay/overlay";
 
+export type DrawerProps = IDrawerProps;
 export interface IDrawerProps extends IOverlayableProps, IBackdropProps, IProps {
     /**
      * Name of a Blueprint UI icon (or an icon element) to render in the

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -23,6 +23,7 @@ import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 import { Browser } from "../../compatibility";
 
+export type EditableTextProps = IEditableTextProps;
 export interface IEditableTextProps extends IIntentProps, IProps {
     /**
      * EXPERIMENTAL FEATURE.

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -19,12 +19,14 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
-import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 import { Browser } from "../../compatibility";
 
+// eslint-disable-next-line deprecation/deprecation
 export type EditableTextProps = IEditableTextProps;
-export interface IEditableTextProps extends IIntentProps, IProps {
+/** @deprecated use EditableTextProps */
+export interface IEditableTextProps extends IntentProps, Props {
     /**
      * EXPERIMENTAL FEATURE.
      *
@@ -141,10 +143,10 @@ const BUFFER_WIDTH_DEFAULT = 5;
 const BUFFER_WIDTH_IE = 30;
 
 @polyfill
-export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEditableTextState> {
+export class EditableText extends AbstractPureComponent2<EditableTextProps, IEditableTextState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.EditableText`;
 
-    public static defaultProps: IEditableTextProps = {
+    public static defaultProps: EditableTextProps = {
         alwaysRenderInput: false,
         confirmOnEnterKey: false,
         defaultValue: "",
@@ -188,7 +190,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         },
     };
 
-    public constructor(props: IEditableTextProps, context?: any) {
+    public constructor(props: EditableTextProps, context?: any) {
         super(props, context);
 
         const value = props.value == null ? props.defaultValue : props.value;
@@ -257,7 +259,7 @@ export class EditableText extends AbstractPureComponent2<IEditableTextProps, IEd
         this.updateInputDimensions();
     }
 
-    public componentDidUpdate(prevProps: IEditableTextProps, prevState: IEditableTextState) {
+    public componentDidUpdate(prevProps: EditableTextProps, prevState: IEditableTextState) {
         const newState: IEditableTextState = {};
         // allow setting the value to undefined/null in controlled mode
         if (this.props.value !== prevProps.value && (prevProps.value != null || this.props.value != null)) {

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type ControlGroupProps = IControlGroupProps;
-export interface IControlGroupProps extends IProps, HTMLDivProps {
+/** @deprecated use ControlGroupProps */
+export interface IControlGroupProps extends Props, HTMLDivProps {
     /**
      * Whether the control group should take up the full width of its container.
      *
@@ -41,7 +43,7 @@ export interface IControlGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class ControlGroup extends AbstractPureComponent2<IControlGroupProps> {
+export class ControlGroup extends AbstractPureComponent2<ControlGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ControlGroup`;
 
     public render() {

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
+export type ControlGroupProps = IControlGroupProps;
 export interface IControlGroupProps extends IProps, HTMLDivProps {
     /**
      * Whether the control group should take up the full width of its container.

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -23,10 +23,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Alignment, Classes, IRef, refHandler, setRef } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLInputProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type ControlProps = IControlProps;
-export interface IControlProps extends IProps, HTMLInputProps {
+/** @deprecated use ControlProps */
+export interface IControlProps extends Props, HTMLInputProps {
     // NOTE: HTML props are duplicated here to provide control-specific documentation
 
     /**
@@ -90,7 +92,7 @@ export interface IControlProps extends IProps, HTMLInputProps {
 }
 
 /** Internal props for Checkbox/Radio/Switch to render correctly. */
-interface IControlInternalProps extends IControlProps {
+interface IControlInternalProps extends ControlProps {
     type: "checkbox" | "radio";
     typeClassName: string;
     indicatorChildren?: React.ReactNode;
@@ -143,8 +145,10 @@ const Control: React.FunctionComponent<IControlInternalProps> = ({
 // Switch
 //
 
+// eslint-disable-next-line deprecation/deprecation
 export type SwitchProps = ISwitchProps;
-export interface ISwitchProps extends IControlProps {
+/** @deprecated use SwitchProps */
+export interface ISwitchProps extends ControlProps {
     /**
      * Text to display inside the switch indicator when checked.
      * If `innerLabel` is provided and this prop is omitted, then `innerLabel`
@@ -161,7 +165,7 @@ export interface ISwitchProps extends IControlProps {
 }
 
 @polyfill
-export class Switch extends AbstractPureComponent2<ISwitchProps> {
+export class Switch extends AbstractPureComponent2<SwitchProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Switch`;
 
     public render() {
@@ -194,11 +198,13 @@ export class Switch extends AbstractPureComponent2<ISwitchProps> {
 // Radio
 //
 
-export type IRadioProps = IControlProps;
+/** @deprecated use RadioProps */
+export type IRadioProps = ControlProps;
+// eslint-disable-next-line deprecation/deprecation
 export type RadioProps = IRadioProps;
 
 @polyfill
-export class Radio extends AbstractPureComponent2<IRadioProps> {
+export class Radio extends AbstractPureComponent2<RadioProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Radio`;
 
     public render() {
@@ -210,8 +216,10 @@ export class Radio extends AbstractPureComponent2<IRadioProps> {
 // Checkbox
 //
 
+// eslint-disable-next-line deprecation/deprecation
 export type CheckboxProps = ICheckboxProps;
-export interface ICheckboxProps extends IControlProps {
+/** @deprecated use CheckboxProps */
+export interface ICheckboxProps extends ControlProps {
     /** Whether this checkbox is initially indeterminate (uncontrolled mode). */
     defaultIndeterminate?: boolean;
 
@@ -232,10 +240,10 @@ export interface ICheckboxState {
 }
 
 @polyfill
-export class Checkbox extends AbstractPureComponent2<ICheckboxProps, ICheckboxState> {
+export class Checkbox extends AbstractPureComponent2<CheckboxProps, ICheckboxState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Checkbox`;
 
-    public static getDerivedStateFromProps({ indeterminate }: ICheckboxProps): ICheckboxState | null {
+    public static getDerivedStateFromProps({ indeterminate }: CheckboxProps): ICheckboxState | null {
         // put props into state if controlled by props
         if (indeterminate != null) {
             return { indeterminate };
@@ -270,7 +278,7 @@ export class Checkbox extends AbstractPureComponent2<ICheckboxProps, ICheckboxSt
         this.updateIndeterminate();
     }
 
-    public componentDidUpdate(prevProps: ICheckboxProps) {
+    public componentDidUpdate(prevProps: CheckboxProps) {
         this.updateIndeterminate();
         if (prevProps.inputRef !== this.props.inputRef) {
             setRef(prevProps.inputRef, null);

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -25,6 +25,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Alignment, Classes, IRef, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IProps } from "../../common/props";
 
+export type ControlProps = IControlProps;
 export interface IControlProps extends IProps, HTMLInputProps {
     // NOTE: HTML props are duplicated here to provide control-specific documentation
 
@@ -142,6 +143,7 @@ const Control: React.FunctionComponent<IControlInternalProps> = ({
 // Switch
 //
 
+export type SwitchProps = ISwitchProps;
 export interface ISwitchProps extends IControlProps {
     /**
      * Text to display inside the switch indicator when checked.
@@ -193,6 +195,7 @@ export class Switch extends AbstractPureComponent2<ISwitchProps> {
 //
 
 export type IRadioProps = IControlProps;
+export type RadioProps = IRadioProps;
 
 @polyfill
 export class Radio extends AbstractPureComponent2<IRadioProps> {
@@ -207,6 +210,7 @@ export class Radio extends AbstractPureComponent2<IRadioProps> {
 // Checkbox
 //
 
+export type CheckboxProps = ICheckboxProps;
 export interface ICheckboxProps extends IControlProps {
     /** Whether this checkbox is initially indeterminate (uncontrolled mode). */
     defaultIndeterminate?: boolean;

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
+export type FileInputProps = IFileInputProps;
 export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, IProps {
     /**
      * Whether the file input is non-interactive.

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type FileInputProps = IFileInputProps;
-export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, IProps {
+/** @deprecated use FileInputProps */
+export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, Props {
     /**
      * Whether the file input is non-interactive.
      * Setting this to `true` will automatically disable the child input too.
@@ -84,10 +86,10 @@ export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElem
 // TODO: write tests (ignoring for now to get a build passing quickly)
 /* istanbul ignore next */
 @polyfill
-export class FileInput extends AbstractPureComponent2<IFileInputProps> {
+export class FileInput extends AbstractPureComponent2<FileInputProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.FileInput`;
 
-    public static defaultProps: IFileInputProps = {
+    public static defaultProps: FileInputProps = {
         hasSelection: false,
         inputProps: {},
         text: "Choose file...",

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type FormGroupProps = IFormGroupProps;
-export interface IFormGroupProps extends IIntentProps, IProps {
+/** @deprecated use FormGroupProps */
+export interface IFormGroupProps extends IntentProps, Props {
     /**
      * A space-delimited list of class names to pass along to the
      * `Classes.FORM_CONTENT` element that contains `children`.
@@ -64,7 +66,7 @@ export interface IFormGroupProps extends IIntentProps, IProps {
 }
 
 @polyfill
-export class FormGroup extends AbstractPureComponent2<IFormGroupProps> {
+export class FormGroup extends AbstractPureComponent2<FormGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.FormGroup`;
 
     public render() {

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 
+export type FormGroupProps = IFormGroupProps;
 export interface IFormGroupProps extends IIntentProps, IProps {
     /**
      * A space-delimited list of class names to pass along to the

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -24,9 +24,9 @@ import {
     DISPLAYNAME_PREFIX,
     HTMLInputProps,
     IControlledProps,
-    IControlledProps2,
-    IIntentProps,
-    IProps,
+    ControlledProps2,
+    IntentProps,
+    Props,
     MaybeElement,
     removeNonHTMLProps,
 } from "../../common/props";
@@ -45,8 +45,8 @@ export type InputGroupProps = IInputGroupProps;
 export interface IInputGroupProps
     // eslint-disable-next-line deprecation/deprecation
     extends IControlledProps,
-        IIntentProps,
-        IProps {
+        IntentProps,
+        Props {
     /**
      * Set this to `true` if you will be controlling the `value` of this input with asynchronous updates.
      * These may occur if you do not immediately call setState in a parent component with the value from
@@ -111,12 +111,14 @@ export interface IInputGroupProps
     type?: string;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type InputGroupProps2 = IInputGroupProps2;
+/** @deprecated use InputGroupProps2 */
 export interface IInputGroupProps2
-    extends Omit<HTMLInputProps, keyof IControlledProps2>,
-        IControlledProps2,
-        IIntentProps,
-        IProps {
+    extends Omit<HTMLInputProps, keyof ControlledProps2>,
+        ControlledProps2,
+        IntentProps,
+        Props {
     /**
      * Set this to `true` if you will be controlling the `value` of this input with asynchronous updates.
      * These may occur if you do not immediately call setState in a parent component with the value from
@@ -187,7 +189,7 @@ export interface IInputGroupState {
 }
 
 @polyfill
-export class InputGroup extends AbstractPureComponent2<IInputGroupProps2, IInputGroupState> {
+export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputGroupState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.InputGroup`;
 
     public state: IInputGroupState = {};
@@ -244,14 +246,14 @@ export class InputGroup extends AbstractPureComponent2<IInputGroupProps2, IInput
         this.updateInputWidth();
     }
 
-    public componentDidUpdate(prevProps: IInputGroupProps2) {
+    public componentDidUpdate(prevProps: InputGroupProps2) {
         const { leftElement, rightElement } = this.props;
         if (prevProps.leftElement !== leftElement || prevProps.rightElement !== rightElement) {
             this.updateInputWidth();
         }
     }
 
-    protected validateProps(props: IInputGroupProps2) {
+    protected validateProps(props: InputGroupProps2) {
         if (props.leftElement != null && props.leftIcon != null) {
             console.warn(Errors.INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX);
         }

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -33,13 +33,15 @@ import {
 import { Icon, IconName } from "../icon/icon";
 import { AsyncControllableInput } from "./asyncControllableInput";
 
+// eslint-disable-next-line deprecation/deprecation
+export type InputGroupProps = IInputGroupProps;
+
 /**
  * @deprecated use IInputGroupProps2.
  *
  * NOTE: This interface does not extend HTMLInputProps due to incompatiblity with `IControlledProps`.
  * Instead, we union the props in the component definition, which does work and properly disallows `string[]` values.
  */
-
 export interface IInputGroupProps
     // eslint-disable-next-line deprecation/deprecation
     extends IControlledProps,
@@ -109,6 +111,7 @@ export interface IInputGroupProps
     type?: string;
 }
 
+export type InputGroupProps2 = IInputGroupProps2;
 export interface IInputGroupProps2
     extends Omit<HTMLInputProps, keyof IControlledProps2>,
         IControlledProps2,

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -25,9 +25,9 @@ import {
     Classes,
     DISPLAYNAME_PREFIX,
     HTMLInputProps,
-    IIntentProps,
+    IntentProps,
     Intent,
-    IProps,
+    Props,
     IRef,
     Keys,
     MaybeElement,
@@ -53,8 +53,10 @@ import {
     toMaxPrecision,
 } from "./numericInputUtils";
 
+// eslint-disable-next-line deprecation/deprecation
 export type NumericInputProps = INumericInputProps;
-export interface INumericInputProps extends IIntentProps, IProps {
+/** @deprecated use NumericInputProps */
+export interface INumericInputProps extends IntentProps, Props {
     /**
      * Whether to allow only floating-point number characters in the field,
      * mimicking the native `input[type="number"]`.
@@ -210,7 +212,7 @@ enum IncrementDirection {
     UP = +1,
 }
 
-const NON_HTML_PROPS: Array<keyof INumericInputProps> = [
+const NON_HTML_PROPS: Array<keyof NumericInputProps> = [
     "allowNumericCharactersOnly",
     "buttonPosition",
     "clampValueOnBlur",
@@ -228,14 +230,14 @@ const NON_HTML_PROPS: Array<keyof INumericInputProps> = [
 type ButtonEventHandlers = Required<Pick<React.HTMLAttributes<Element>, "onKeyDown" | "onMouseDown">>;
 
 @polyfill
-export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumericInputProps, INumericInputState> {
+export class NumericInput extends AbstractPureComponent2<HTMLInputProps & NumericInputProps, INumericInputState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NumericInput`;
 
     public static VALUE_EMPTY = "";
 
     public static VALUE_ZERO = "0";
 
-    public static defaultProps: INumericInputProps = {
+    public static defaultProps: NumericInputProps = {
         allowNumericCharactersOnly: true,
         buttonPosition: Position.RIGHT,
         clampValueOnBlur: false,
@@ -248,7 +250,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         stepSize: 1,
     };
 
-    public static getDerivedStateFromProps(props: INumericInputProps, state: INumericInputState) {
+    public static getDerivedStateFromProps(props: NumericInputProps, state: INumericInputState) {
         const nextState = {
             prevMaxProp: props.max,
             prevMinProp: props.min,
@@ -282,7 +284,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
 
     // Value Helpers
     // =============
-    private static getStepMaxPrecision(props: HTMLInputProps & INumericInputProps) {
+    private static getStepMaxPrecision(props: HTMLInputProps & NumericInputProps) {
         if (props.minorStepSize != null) {
             return Utils.countDecimalPlaces(props.minorStepSize);
         } else {
@@ -342,7 +344,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         );
     }
 
-    public componentDidUpdate(prevProps: INumericInputProps, prevState: INumericInputState) {
+    public componentDidUpdate(prevProps: NumericInputProps, prevState: INumericInputState) {
         super.componentDidUpdate(prevProps, prevState);
 
         if (prevProps.inputRef !== this.props.inputRef) {
@@ -371,7 +373,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & INumer
         }
     }
 
-    protected validateProps(nextProps: HTMLInputProps & INumericInputProps) {
+    protected validateProps(nextProps: HTMLInputProps & NumericInputProps) {
         const { majorStepSize, max, min, minorStepSize, stepSize, value } = nextProps;
         if (min != null && max != null && min > max) {
             console.error(Errors.NUMERIC_INPUT_MIN_MAX);

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -53,6 +53,7 @@ import {
     toMaxPrecision,
 } from "./numericInputUtils";
 
+export type NumericInputProps = INumericInputProps;
 export interface INumericInputProps extends IIntentProps, IProps {
     /**
      * Whether to allow only floating-point number characters in the field,

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -19,12 +19,14 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
-import { DISPLAYNAME_PREFIX, IOptionProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, OptionProps, Props } from "../../common/props";
 import { isElementOfType } from "../../common/utils";
-import { IRadioProps, Radio } from "./controls";
+import { RadioProps, Radio } from "./controls";
 
+// eslint-disable-next-line deprecation/deprecation
 export type RadioGroupProps = IRadioGroupProps;
-export interface IRadioGroupProps extends IProps {
+/** @deprecated use RadioGroupProps */
+export interface IRadioGroupProps extends Props {
     /**
      * Whether the group and _all_ its radios are disabled.
      * Individual radios can be disabled using their `disabled` prop.
@@ -54,10 +56,10 @@ export interface IRadioGroupProps extends IProps {
 
     /**
      * Array of options to render in the group. This prop is mutually exclusive
-     * with `children`: either provide an array of `IOptionProps` objects or
+     * with `children`: either provide an array of `OptionProps` objects or
      * provide `<Radio>` children elements.
      */
-    options?: IOptionProps[];
+    options?: OptionProps[];
 
     /** Value of the selected radio. The child with this value will be `:checked`. */
     selectedValue?: string | number;
@@ -69,7 +71,7 @@ function nextName() {
 }
 
 @polyfill
-export class RadioGroup extends AbstractPureComponent2<IRadioGroupProps> {
+export class RadioGroup extends AbstractPureComponent2<RadioGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.RadioGroup`;
 
     // a unique name for this group, which can be overridden by `name` prop.
@@ -94,7 +96,7 @@ export class RadioGroup extends AbstractPureComponent2<IRadioGroupProps> {
     private renderChildren() {
         return React.Children.map(this.props.children, child => {
             if (isElementOfType(child, Radio)) {
-                return React.cloneElement(child, this.getRadioProps(child.props as IOptionProps));
+                return React.cloneElement(child, this.getRadioProps(child.props as OptionProps));
             } else {
                 return child;
             }
@@ -107,7 +109,7 @@ export class RadioGroup extends AbstractPureComponent2<IRadioGroupProps> {
         ));
     }
 
-    private getRadioProps(optionProps: IOptionProps): IRadioProps {
+    private getRadioProps(optionProps: OptionProps): RadioProps {
         const { name } = this.props;
         const { className, disabled, value } = optionProps;
         return {

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -23,6 +23,7 @@ import { DISPLAYNAME_PREFIX, IOptionProps, IProps } from "../../common/props";
 import { isElementOfType } from "../../common/utils";
 import { IRadioProps, Radio } from "./controls";
 
+export type RadioGroupProps = IRadioGroupProps;
 export interface IRadioGroupProps extends IProps {
     /**
      * Whether the group and _all_ its radios are disabled.

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, IRef, IRefCallback, refHandler, setRef } from "../../common";
-import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TextAreaProps = ITextAreaProps;
-export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+/** @deprecated use TextAreaProps */
+export interface ITextAreaProps extends IntentProps, Props, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     /**
      * Whether the text area should take up the full width of its container.
      */
@@ -56,7 +58,7 @@ export interface ITextAreaState {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class TextArea extends AbstractPureComponent2<ITextAreaProps, ITextAreaState> {
+export class TextArea extends AbstractPureComponent2<TextAreaProps, ITextAreaState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TextArea`;
 
     public state: ITextAreaState = {};
@@ -76,7 +78,7 @@ export class TextArea extends AbstractPureComponent2<ITextAreaProps, ITextAreaSt
         }
     }
 
-    public componentDidUpdate(prevProps: ITextAreaProps) {
+    public componentDidUpdate(prevProps: TextAreaProps) {
         if (prevProps.inputRef !== this.props.inputRef) {
             setRef(prevProps.inputRef, null);
             this.handleRef = refHandler(this, "textareaElement", this.props.inputRef);

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, IRef, IRefCallback, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 
+export type TextAreaProps = ITextAreaProps;
 export interface ITextAreaProps extends IIntentProps, IProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     /**
      * Whether the text area should take up the full width of its container.

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -18,11 +18,11 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
+import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { HotkeyConfig } from "../../hooks";
 import { KeyCombo } from "./keyCombo";
 
-export type IHotkeyProps = IProps & HotkeyConfig;
+export type IHotkeyProps = Props & HotkeyConfig;
 
 @polyfill
 export class Hotkey extends AbstractPureComponent2<IHotkeyProps> {

--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -19,11 +19,11 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { Classes } from "../../common";
-import { Dialog, IDialogProps } from "../../components";
+import { Dialog, DialogProps } from "../../components";
 import { Hotkey, IHotkeyProps } from "./hotkey";
 import { Hotkeys } from "./hotkeys";
 
-export interface IHotkeysDialogProps extends IDialogProps {
+export interface IHotkeysDialogProps extends DialogProps {
     /**
      * This string displayed as the group name in the hotkeys dialog for all
      * global hotkeys.

--- a/packages/core/src/components/hotkeys/hotkeysDialog2.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog2.tsx
@@ -19,11 +19,11 @@ import * as React from "react";
 
 import { Classes } from "../../common";
 import { HotkeyConfig } from "../../hooks";
-import { Dialog, IDialogProps } from "../dialog/dialog";
+import { Dialog, DialogProps } from "../dialog/dialog";
 import { Hotkey } from "./hotkey";
 import { Hotkeys } from "./hotkeys";
 
-export interface HotkeysDialog2Props extends IDialogProps {
+export interface HotkeysDialog2Props extends DialogProps {
     /**
      * This string displayed as the group name in the hotkeys dialog for all
      * global hotkeys.

--- a/packages/core/src/components/hotkeys/hotkeysTypes.ts
+++ b/packages/core/src/components/hotkeys/hotkeysTypes.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { IProps } from "../../common";
+import { Props } from "../../common";
 
-export interface IHotkeysProps extends IProps {
+export interface IHotkeysProps extends Props {
     /**
      * In order to make local hotkeys work on elements that are not normally
      * focusable, such as `<div>`s or `<span>`s, we add a `tabIndex` attribute

--- a/packages/core/src/components/hotkeys/index.ts
+++ b/packages/core/src/components/hotkeys/index.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+/* eslint-disable deprecation/deprecation */
+
 export * from "./hotkeysTypes";
 export * from "./hotkeys";
 export { Hotkey, IHotkeyProps } from "./hotkey";
-export { KeyCombo, IKeyComboProps } from "./keyCombo";
-// eslint-disable-next-line import/no-cycle, deprecation/deprecation
+export { KeyCombo, KeyComboTagProps, IKeyComboProps } from "./keyCombo";
+// eslint-disable-next-line import/no-cycle
 export { HotkeysTarget, IHotkeysTargetComponent } from "./hotkeysTarget";
 export { IKeyCombo, comboMatches, getKeyCombo, getKeyComboString, parseKeyCombo } from "./hotkeyParser";
 // eslint-disable-next-line import/no-cycle

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -36,6 +36,7 @@ const KeyIcons: { [key: string]: IconName } = {
     up: "arrow-up",
 };
 
+export type KeyComboTagProps = IKeyComboProps;
 export interface IKeyComboProps extends IProps {
     /** The key combo to display, such as `"cmd + s"`. */
     combo: string;

--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
+import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { Icon, IconName } from "../icon/icon";
 import { normalizeKeyCombo } from "./hotkeyParser";
 
@@ -36,8 +36,10 @@ const KeyIcons: { [key: string]: IconName } = {
     up: "arrow-up",
 };
 
+// eslint-disable-next-line deprecation/deprecation
 export type KeyComboTagProps = IKeyComboProps;
-export interface IKeyComboProps extends IProps {
+/** @deprecated use KeyComboTagProps */
+export interface IKeyComboProps extends Props {
     /** The key combo to display, such as `"cmd + s"`. */
     combo: string;
 
@@ -52,7 +54,7 @@ export interface IKeyComboProps extends IProps {
 }
 
 @polyfill
-export class KeyCombo extends AbstractPureComponent2<IKeyComboProps> {
+export class KeyCombo extends AbstractPureComponent2<KeyComboTagProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.KeyCombo`;
 
     public render() {

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -20,10 +20,12 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2 } from "../../common";
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
-import { IElementRefProps, IOptionProps } from "../../common/props";
-import { Icon, IIconProps } from "../icon/icon";
+import { IElementRefProps, OptionProps } from "../../common/props";
+import { Icon, IconProps } from "../icon/icon";
 
+// eslint-disable-next-line deprecation/deprecation
 export type HTMLSelectProps = IHTMLSelectProps;
+/** @deprecated use HTMLSelectPRops */
 export interface IHTMLSelectProps
     // eslint-disable-next-line deprecation/deprecation
     extends IElementRefProps<HTMLSelectElement>,
@@ -35,7 +37,7 @@ export interface IHTMLSelectProps
     fill?: boolean;
 
     /** Props to spread to the `<Icon>` element. */
-    iconProps?: Partial<IIconProps>;
+    iconProps?: Partial<IconProps>;
 
     /** Whether to use large styles. */
     large?: boolean;
@@ -54,7 +56,7 @@ export interface IHTMLSelectProps
      * `{ label?, value }` objects. If no `label` is supplied, `value`
      * will be used as the label.
      */
-    options?: Array<string | number | IOptionProps>;
+    options?: Array<string | number | OptionProps>;
 
     /** Controlled value of this component. */
     value?: string | number;
@@ -63,7 +65,7 @@ export interface IHTMLSelectProps
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class HTMLSelect extends AbstractPureComponent2<IHTMLSelectProps> {
+export class HTMLSelect extends AbstractPureComponent2<HTMLSelectProps> {
     public render() {
         const {
             className,
@@ -88,7 +90,7 @@ export class HTMLSelect extends AbstractPureComponent2<IHTMLSelectProps> {
         );
 
         const optionChildren = options.map(option => {
-            const props: IOptionProps = typeof option === "object" ? option : { value: option };
+            const props: OptionProps = typeof option === "object" ? option : { value: option };
             return <option {...props} key={props.value} children={props.label || props.value} />;
         });
 

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -23,6 +23,7 @@ import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classe
 import { IElementRefProps, IOptionProps } from "../../common/props";
 import { Icon, IIconProps } from "../icon/icon";
 
+export type HTMLSelectProps = IHTMLSelectProps;
 export interface IHTMLSelectProps
     // eslint-disable-next-line deprecation/deprecation
     extends IElementRefProps<HTMLSelectElement>,

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -20,7 +20,9 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, IElementRefProps } from "../../common";
 
+// eslint-disable-next-line deprecation/deprecation
 export type HTMLTableProps = IHTMLTableProps;
+/** @deprecated use HTMLTableProps */
 export interface IHTMLTableProps
     extends React.TableHTMLAttributes<HTMLTableElement>,
         // eslint-disable-next-line deprecation/deprecation
@@ -48,7 +50,7 @@ export interface IHTMLTableProps
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class HTMLTable extends AbstractPureComponent2<IHTMLTableProps> {
+export class HTMLTable extends AbstractPureComponent2<HTMLTableProps> {
     public render() {
         // eslint-disable-next-line deprecation/deprecation
         const { bordered, className, condensed, elementRef, interactive, small, striped, ...htmlProps } = this.props;

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -20,6 +20,7 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, IElementRefProps } from "../../common";
 
+export type HTMLTableProps = IHTMLTableProps;
 export interface IHTMLTableProps
     extends React.TableHTMLAttributes<HTMLTableElement>,
         // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -20,12 +20,14 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { IconName, IconSvgPaths16, IconSvgPaths20 } from "@blueprintjs/icons";
 
-import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IIntentProps, IProps, MaybeElement } from "../../common";
+import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IntentProps, Props, MaybeElement } from "../../common";
 
 export { IconName };
 
+// eslint-disable-next-line deprecation/deprecation
 export type IconProps = IIconProps;
-export interface IIconProps extends IIntentProps, IProps {
+/** @deprecated use IconProps */
+export interface IIconProps extends IntentProps, Props {
     /** This component does not support custom children. Use the `icon` prop. */
     children?: never;
 
@@ -88,7 +90,7 @@ export interface IIconProps extends IIntentProps, IProps {
 }
 
 @polyfill
-export class Icon extends AbstractPureComponent2<IIconProps & Omit<React.HTMLAttributes<HTMLElement>, "title">> {
+export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttributes<HTMLElement>, "title">> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Icon`;
 
     public static readonly SIZE_STANDARD = 16;

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -24,6 +24,7 @@ import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IIntentProps, IPro
 
 export { IconName };
 
+export type IconProps = IIconProps;
 export interface IIconProps extends IIntentProps, IProps {
     /** This component does not support custom children. Use the `icon` prop. */
     children?: never;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -19,14 +19,16 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, IRef } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { MenuDivider } from "./menuDivider";
 // this cyclic import can be removed in v4.0 (https://github.com/palantir/blueprint/issues/3829)
 // eslint-disable-next-line import/no-cycle
 import { MenuItem } from "./menuItem";
 
+// eslint-disable-next-line deprecation/deprecation
 export type MenuProps = IMenuProps;
-export interface IMenuProps extends IProps, React.HTMLAttributes<HTMLUListElement> {
+/** @deprecated use MenuProps */
+export interface IMenuProps extends Props, React.HTMLAttributes<HTMLUListElement> {
     /** Whether the menu items in this menu should use a large appearance. */
     large?: boolean;
 
@@ -35,7 +37,7 @@ export interface IMenuProps extends IProps, React.HTMLAttributes<HTMLUListElemen
 }
 
 @polyfill
-export class Menu extends AbstractPureComponent2<IMenuProps> {
+export class Menu extends AbstractPureComponent2<MenuProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Menu`;
 
     /** @deprecated use MenuDivider */

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -25,6 +25,7 @@ import { MenuDivider } from "./menuDivider";
 // eslint-disable-next-line import/no-cycle
 import { MenuItem } from "./menuItem";
 
+export type MenuProps = IMenuProps;
 export interface IMenuProps extends IProps, React.HTMLAttributes<HTMLUListElement> {
     /** Whether the menu items in this menu should use a large appearance. */
     large?: boolean;

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -18,11 +18,13 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { H6 } from "../html/html";
 
+// eslint-disable-next-line deprecation/deprecation
 export type MenuDividerProps = IMenuDividerProps;
-export interface IMenuDividerProps extends IProps {
+/** @deprecated use MenuDividerProps */
+export interface IMenuDividerProps extends Props {
     /** This component does not support children. */
     children?: never;
 
@@ -30,7 +32,7 @@ export interface IMenuDividerProps extends IProps {
     title?: React.ReactNode;
 }
 
-export class MenuDivider extends React.Component<IMenuDividerProps> {
+export class MenuDivider extends React.Component<MenuDividerProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MenuDivider`;
 
     public render() {

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -21,6 +21,7 @@ import * as Classes from "../../common/classes";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { H6 } from "../html/html";
 
+export type MenuDividerProps = IMenuDividerProps;
 export interface IMenuDividerProps extends IProps {
     /** This component does not support children. */
     children?: never;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Position } from "../../common";
-import { DISPLAYNAME_PREFIX, IActionProps, ILinkProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, ActionProps, LinkProps } from "../../common/props";
 import { Icon } from "../icon/icon";
 import { IPopoverProps, Popover, PopoverInteractionKind } from "../popover/popover";
 import { Text } from "../text/text";
@@ -28,8 +28,10 @@ import { Text } from "../text/text";
 // eslint-disable-next-line import/no-cycle
 import { Menu } from "./menu";
 
+// eslint-disable-next-line deprecation/deprecation
 export type MenuItemProps = IMenuItemProps;
-export interface IMenuItemProps extends IActionProps, ILinkProps {
+/** @deprecated use MenuItemProps */
+export interface IMenuItemProps extends ActionProps, LinkProps {
     // override from IActionProps to make it required
     /** Item text, required for usability. */
     text: React.ReactNode;
@@ -110,8 +112,8 @@ export interface IMenuItemProps extends IActionProps, ILinkProps {
 }
 
 @polyfill
-export class MenuItem extends AbstractPureComponent2<IMenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {
-    public static defaultProps: IMenuItemProps = {
+export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {
+    public static defaultProps: MenuItemProps = {
         disabled: false,
         multiline: false,
         popoverProps: {},

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -28,6 +28,7 @@ import { Text } from "../text/text";
 // eslint-disable-next-line import/no-cycle
 import { Menu } from "./menu";
 
+export type MenuItemProps = IMenuItemProps;
 export interface IMenuItemProps extends IActionProps, ILinkProps {
     // override from IActionProps to make it required
     /** Item text, required for usability. */

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -26,7 +26,7 @@ import { NavbarHeading } from "./navbarHeading";
 
 export { INavbarDividerProps } from "./navbarDivider";
 
-// allow the empty interface so we can label it clearly in the docs
+export type NavbarProps = INavbarProps;
 export interface INavbarProps extends IProps, HTMLDivProps {
     /**
      * Whether this navbar should be fixed to the top of the viewport (using CSS `position: fixed`).

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -19,15 +19,18 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 import { NavbarDivider } from "./navbarDivider";
 import { NavbarGroup } from "./navbarGroup";
 import { NavbarHeading } from "./navbarHeading";
 
-export { INavbarDividerProps } from "./navbarDivider";
+// eslint-disable-next-line deprecation/deprecation
+export { INavbarDividerProps, NavbarDividerProps } from "./navbarDivider";
 
+// eslint-disable-next-line deprecation/deprecation
 export type NavbarProps = INavbarProps;
-export interface INavbarProps extends IProps, HTMLDivProps {
+/** @deprecated use NavbarProps */
+export interface INavbarProps extends Props, HTMLDivProps {
     /**
      * Whether this navbar should be fixed to the top of the viewport (using CSS `position: fixed`).
      */
@@ -37,7 +40,7 @@ export interface INavbarProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class Navbar extends AbstractPureComponent2<INavbarProps> {
+export class Navbar extends AbstractPureComponent2<NavbarProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Navbar`;
 
     public static Divider = NavbarDivider;

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
+export type NavbarDividerProps = INavbarDividerProps;
 // allow the empty interface so we can label it clearly in the docs
 export interface INavbarDividerProps extends IProps, HTMLDivProps {
     // Empty

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -19,18 +19,19 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type NavbarDividerProps = INavbarDividerProps;
-// allow the empty interface so we can label it clearly in the docs
-export interface INavbarDividerProps extends IProps, HTMLDivProps {
-    // Empty
+/** @deprecated use NavbarDividerProps */
+export interface INavbarDividerProps extends Props, HTMLDivProps {
+    // allow the empty interface so we can label it clearly in the docs
 }
 
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class NavbarDivider extends AbstractPureComponent2<INavbarDividerProps> {
+export class NavbarDivider extends AbstractPureComponent2<NavbarDividerProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NavbarDivider`;
 
     public render() {

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
+export type NavbarGroupProps = INavbarGroupProps;
 export interface INavbarGroupProps extends IProps, HTMLDivProps {
     /**
      * The side of the navbar on which the group should appear.

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Alignment, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type NavbarGroupProps = INavbarGroupProps;
-export interface INavbarGroupProps extends IProps, HTMLDivProps {
+/** @deprecated use NavbarGroupProps */
+export interface INavbarGroupProps extends Props, HTMLDivProps {
     /**
      * The side of the navbar on which the group should appear.
      * The `Alignment` enum provides constants for these values.
@@ -35,10 +37,10 @@ export interface INavbarGroupProps extends IProps, HTMLDivProps {
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class NavbarGroup extends AbstractPureComponent2<INavbarGroupProps> {
+export class NavbarGroup extends AbstractPureComponent2<NavbarGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NavbarGroup`;
 
-    public static defaultProps: INavbarGroupProps = {
+    public static defaultProps: NavbarGroupProps = {
         align: Alignment.LEFT,
     };
 

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -19,18 +19,19 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type NavbarHeadingProps = INavbarHeadingProps;
-// allow the empty interface so we can label it clearly in the docs
-export interface INavbarHeadingProps extends IProps, HTMLDivProps {
-    // Empty
+/** @deprecated use NavbarHeadingProps */
+export interface INavbarHeadingProps extends Props, HTMLDivProps {
+    // allow the empty interface so we can label it clearly in the docs
 }
 
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
 @polyfill
-export class NavbarHeading extends AbstractPureComponent2<INavbarHeadingProps> {
+export class NavbarHeading extends AbstractPureComponent2<NavbarHeadingProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NavbarHeading`;
 
     public render() {

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
+export type NavbarHeadingProps = INavbarHeadingProps;
 // allow the empty interface so we can label it clearly in the docs
 export interface INavbarHeadingProps extends IProps, HTMLDivProps {
     // Empty

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -20,13 +20,15 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2 } from "../../common";
 import * as Classes from "../../common/classes";
-import { DISPLAYNAME_PREFIX, IProps, MaybeElement } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { ensureElement } from "../../common/utils";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
 
+// eslint-disable-next-line deprecation/deprecation
 export type NonIdealStateProps = INonIdealStateProps;
-export interface INonIdealStateProps extends IProps {
+/** @deprecated use NonIdealStateProps */
+export interface INonIdealStateProps extends Props {
     /** An action to resolve the non-ideal state which appears after `description`. */
     action?: JSX.Element;
 
@@ -50,7 +52,7 @@ export interface INonIdealStateProps extends IProps {
 }
 
 @polyfill
-export class NonIdealState extends AbstractPureComponent2<INonIdealStateProps> {
+export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NonIdealState`;
 
     public render() {

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -25,6 +25,7 @@ import { ensureElement } from "../../common/utils";
 import { H4 } from "../html/html";
 import { Icon, IconName } from "../icon/icon";
 
+export type NonIdealStateProps = INonIdealStateProps;
 export interface INonIdealStateProps extends IProps {
     /** An action to resolve the non-ideal state which appears after `description`. */
     action?: JSX.Element;

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -32,6 +32,7 @@ export enum OverflowDirection {
     SHRINK,
 }
 
+export type OverflowListProps<T> = IOverflowListProps<T>;
 export interface IOverflowListProps<T> extends IProps {
     /**
      * Which direction the items should collapse from: start or end of the

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -20,9 +20,9 @@ import * as React from "react";
 import { Boundary } from "../../common/boundary";
 import * as Classes from "../../common/classes";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { shallowCompareKeys } from "../../common/utils";
-import { IResizeEntry } from "../resize-sensor/resizeObserverTypes";
+import { ResizeEntry } from "../resize-sensor/resizeObserverTypes";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
 
 /** @internal - do not expose this type */
@@ -32,8 +32,10 @@ export enum OverflowDirection {
     SHRINK,
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type OverflowListProps<T> = IOverflowListProps<T>;
-export interface IOverflowListProps<T> extends IProps {
+/** @deprecated use OverflowListProps */
+export interface IOverflowListProps<T> extends Props {
     /**
      * Which direction the items should collapse from: start or end of the
      * children. This also determines whether `overflowRenderer` appears before
@@ -117,16 +119,16 @@ export interface IOverflowListState<T> {
     visible: T[];
 }
 
-export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOverflowListState<T>> {
+export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOverflowListState<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.OverflowList`;
 
-    public static defaultProps: Partial<IOverflowListProps<any>> = {
+    public static defaultProps: Partial<OverflowListProps<any>> = {
         collapseFrom: Boundary.START,
         minVisibleItems: 0,
     };
 
     public static ofType<U>() {
-        return OverflowList as new (props: IOverflowListProps<U>) => OverflowList<U>;
+        return OverflowList as new (props: OverflowListProps<U>) => OverflowList<U>;
     }
 
     public state: IOverflowListState<T> = {
@@ -145,7 +147,7 @@ export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOve
         this.repartition(false);
     }
 
-    public shouldComponentUpdate(_nextProps: IOverflowListProps<T>, nextState: IOverflowListState<T>) {
+    public shouldComponentUpdate(_nextProps: OverflowListProps<T>, nextState: IOverflowListState<T>) {
         // We want this component to always re-render, even when props haven't changed, so that
         // changes in the renderers' behavior can be reflected.
         // The following statement prevents re-rendering only in the case where the state changes
@@ -154,7 +156,7 @@ export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOve
         return !(this.state !== nextState && shallowCompareKeys(this.state, nextState));
     }
 
-    public componentDidUpdate(prevProps: IOverflowListProps<T>, prevState: IOverflowListState<T>) {
+    public componentDidUpdate(prevProps: OverflowListProps<T>, prevState: IOverflowListState<T>) {
         if (prevProps.observeParents !== this.props.observeParents) {
             console.warn(OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED);
         }
@@ -219,7 +221,7 @@ export class OverflowList<T> extends React.Component<IOverflowListProps<T>, IOve
         return this.props.overflowRenderer(overflow);
     }
 
-    private resize = (entries: IResizeEntry[]) => {
+    private resize = (entries: ResizeEntry[]) => {
         // if any parent is growing, assume we have more room than before
         const growing = entries.some(entry => {
             const previousWidth = this.previousWidths.get(entry.target) || 0;

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -23,11 +23,13 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { CSSTransitionProps } from "react-transition-group/CSSTransition";
 
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isFunction, LifecycleCompatPolyfill } from "../../common/utils";
 import { Portal } from "../portal/portal";
 
+// eslint-disable-next-line deprecation/deprecation
 export type OverlayableProps = IOverlayableProps;
+/** @deprecated use OverlayableProps */
 export interface IOverlayableProps extends IOverlayLifecycleProps {
     /**
      * Whether the overlay should acquire application focus when it first opens.
@@ -166,8 +168,10 @@ export interface IBackdropProps {
     hasBackdrop?: boolean;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type OverlayProps = IOverlayProps;
-export interface IOverlayProps extends IOverlayableProps, IBackdropProps, IProps {
+/** @deprecated use OverlayProps */
+export interface IOverlayProps extends OverlayableProps, IBackdropProps, Props {
     /**
      * Toggles the visibility of the overlay and its children.
      * This prop is required because the component is controlled.
@@ -189,11 +193,11 @@ export interface IOverlayState {
 
 // HACKHACK: https://github.com/palantir/blueprint/issues/4342
 // eslint-disable-next-line deprecation/deprecation
-@(polyfill as LifecycleCompatPolyfill<IOverlayProps, any>)
-export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState> {
+@(polyfill as LifecycleCompatPolyfill<OverlayProps, any>)
+export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Overlay`;
 
-    public static defaultProps: IOverlayProps = {
+    public static defaultProps: OverlayProps = {
         autoFocus: true,
         backdropProps: {},
         canEscapeKeyClose: true,
@@ -207,7 +211,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
         usePortal: true,
     };
 
-    public static getDerivedStateFromProps({ isOpen: hasEverOpened }: IOverlayProps) {
+    public static getDerivedStateFromProps({ isOpen: hasEverOpened }: OverlayProps) {
         if (hasEverOpened) {
             return { hasEverOpened };
         }
@@ -286,7 +290,7 @@ export class Overlay extends AbstractPureComponent2<IOverlayProps, IOverlayState
         }
     }
 
-    public componentDidUpdate(prevProps: IOverlayProps) {
+    public componentDidUpdate(prevProps: OverlayProps) {
         if (prevProps.isOpen && !this.props.isOpen) {
             this.overlayWillClose();
         } else if (!prevProps.isOpen && this.props.isOpen) {

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -27,6 +27,7 @@ import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 import { isFunction, LifecycleCompatPolyfill } from "../../common/utils";
 import { Portal } from "../portal/portal";
 
+export type OverlayableProps = IOverlayableProps;
 export interface IOverlayableProps extends IOverlayLifecycleProps {
     /**
      * Whether the overlay should acquire application focus when it first opens.
@@ -112,6 +113,7 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
     onClose?: (event: React.SyntheticEvent<HTMLElement>) => void;
 }
 
+export type OverlayLifecycleProps = IOverlayLifecycleProps;
 export interface IOverlayLifecycleProps {
     /**
      * Lifecycle method invoked just before the CSS _close_ transition begins on
@@ -140,6 +142,7 @@ export interface IOverlayLifecycleProps {
     onOpened?: (node: HTMLElement) => void;
 }
 
+export type BackdropProps = IBackdropProps;
 export interface IBackdropProps {
     /** CSS class names to apply to backdrop element. */
     backdropClassName?: string;
@@ -163,6 +166,7 @@ export interface IBackdropProps {
     hasBackdrop?: boolean;
 }
 
+export type OverlayProps = IOverlayProps;
 export interface IOverlayProps extends IOverlayableProps, IBackdropProps, IProps {
     /**
      * Toggles the visibility of the overlay and its children.

--- a/packages/core/src/components/panel-stack2/panelStack2.tsx
+++ b/packages/core/src/components/panel-stack2/panelStack2.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
-import { Classes, DISPLAYNAME_PREFIX, IProps } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { Panel } from "./panelTypes";
 import { PanelView2 } from "./panelView2";
 
@@ -26,7 +26,7 @@ import { PanelView2 } from "./panelView2";
  * @template T type union of all possible panels in this stack
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface PanelStack2Props<T extends Panel<object>> extends IProps {
+export interface PanelStack2Props<T extends Panel<object>> extends Props {
     /**
      * The initial panel to show on mount. This panel cannot be removed from the
      * stack and will appear when the stack is empty.

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -17,8 +17,8 @@
 import { Boundary as PopperBoundary, Modifiers as PopperModifiers, Placement } from "popper.js";
 
 import { Position } from "../../common/position";
-import { IProps } from "../../common/props";
-import { IOverlayableProps } from "../overlay/overlay";
+import { Props } from "../../common/props";
+import { OverlayableProps } from "../overlay/overlay";
 
 // re-export symbols for library consumers
 export { PopperBoundary, PopperModifiers };
@@ -34,7 +34,7 @@ export const PopoverPosition = {
 export type PopoverPosition = typeof PopoverPosition[keyof typeof PopoverPosition];
 
 /** Props shared between `Popover` and `Tooltip`. */
-export interface IPopoverSharedProps extends IOverlayableProps, IProps {
+export interface IPopoverSharedProps extends OverlayableProps, Props {
     /**
      * Determines the boundary element used by Popper for its `flip` and
      * `preventOverflow` modifiers. Three shorthand keywords are supported;

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -20,14 +20,14 @@ import * as ReactDOM from "react-dom";
 import * as Classes from "../../common/classes";
 import { ValidationMap } from "../../common/context";
 import * as Errors from "../../common/errors";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isFunction } from "../../common/utils";
 
 /** Detect if `React.createPortal()` API method does not exist. */
 const cannotCreatePortal = !isFunction(ReactDOM.createPortal);
 
 export type PortalProps = IPortalProps;
-export interface IPortalProps extends IProps {
+export interface IPortalProps extends Props {
     /**
      * Callback invoked when the children of this `Portal` have been added to the DOM.
      */

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -26,6 +26,7 @@ import { isFunction } from "../../common/utils";
 /** Detect if `React.createPortal()` API method does not exist. */
 const cannotCreatePortal = !isFunction(ReactDOM.createPortal);
 
+export type PortalProps = IPortalProps;
 export interface IPortalProps extends IProps {
     /**
      * Callback invoked when the children of this `Portal` have been added to the DOM.

--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -22,6 +22,7 @@ import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
 import { clamp } from "../../common/utils";
 
+export type ProgressBarProps = IProgressBarProps;
 export interface IProgressBarProps extends IProps, IIntentProps {
     /**
      * Whether the background should animate.

--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -19,11 +19,13 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 
+// eslint-disable-next-line deprecation/deprecation
 export type ProgressBarProps = IProgressBarProps;
-export interface IProgressBarProps extends IProps, IIntentProps {
+/** @deprecated use ProgressBarProps */
+export interface IProgressBarProps extends Props, IntentProps {
     /**
      * Whether the background should animate.
      *
@@ -47,7 +49,7 @@ export interface IProgressBarProps extends IProps, IIntentProps {
 }
 
 @polyfill
-export class ProgressBar extends AbstractPureComponent2<IProgressBarProps> {
+export class ProgressBar extends AbstractPureComponent2<ProgressBarProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ProgressBar`;
 
     public render() {

--- a/packages/core/src/components/resize-sensor/resizeObserverTypes.ts
+++ b/packages/core/src/components/resize-sensor/resizeObserverTypes.ts
@@ -16,6 +16,8 @@
 
 /** This file contains types duplicated from resize-observer-polyfill which are not exported in a consumer-friendly way. */
 
+export type ResizeEntry = IResizeEntry;
+
 /** Equivalent to `ResizeObserverEntry` */
 export interface IResizeEntry {
     /** Measured dimensions of the target. */
@@ -25,6 +27,7 @@ export interface IResizeEntry {
     readonly target: Element;
 }
 
+export type DOMRectReadOnly = IDOMRectReadOnly;
 interface IDOMRectReadOnly {
     readonly x: number;
     readonly y: number;

--- a/packages/core/src/components/resize-sensor/resizeObserverTypes.ts
+++ b/packages/core/src/components/resize-sensor/resizeObserverTypes.ts
@@ -16,18 +16,25 @@
 
 /** This file contains types duplicated from resize-observer-polyfill which are not exported in a consumer-friendly way. */
 
+// eslint-disable-next-line deprecation/deprecation
 export type ResizeEntry = IResizeEntry;
 
-/** Equivalent to `ResizeObserverEntry` */
+/**
+ * Equivalent to `ResizeObserverEntry`
+ *
+ * @deprecated use ResizeEntry
+ */
 export interface IResizeEntry {
     /** Measured dimensions of the target. */
-    readonly contentRect: IDOMRectReadOnly;
+    readonly contentRect: DOMRectReadOnly;
 
     /** The resized element. */
     readonly target: Element;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type DOMRectReadOnly = IDOMRectReadOnly;
+/** @deprecated use DOMRectReadOnly */
 interface IDOMRectReadOnly {
     readonly x: number;
     readonly y: number;

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -23,7 +23,7 @@ import { AbstractPureComponent2 } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { IResizeEntry } from "./resizeObserverTypes";
 
-/** `ResizeSensor` requires a single DOM element child and will error otherwise. */
+export type ResizeSensorProps = IResizeSensorProps;
 export interface IResizeSensorProps {
     /**
      * Callback invoked when the wrapped element resizes.
@@ -51,6 +51,7 @@ export interface IResizeSensorProps {
     observeParents?: boolean;
 }
 
+/** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 @polyfill
 export class ResizeSensor extends AbstractPureComponent2<IResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -21,9 +21,11 @@ import ResizeObserver from "resize-observer-polyfill";
 
 import { AbstractPureComponent2 } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { IResizeEntry } from "./resizeObserverTypes";
+import { ResizeEntry } from "./resizeObserverTypes";
 
+// eslint-disable-next-line deprecation/deprecation
 export type ResizeSensorProps = IResizeSensorProps;
+/** @deprecated use ResizeSensorProps */
 export interface IResizeSensorProps {
     /**
      * Callback invoked when the wrapped element resizes.
@@ -35,7 +37,7 @@ export interface IResizeSensorProps {
      * Note that this method is called _asynchronously_ after a resize is
      * detected and typically it will be called no more than once per frame.
      */
-    onResize: (entries: IResizeEntry[]) => void;
+    onResize: (entries: ResizeEntry[]) => void;
 
     /**
      * If `true`, all parent DOM elements of the container will also be
@@ -53,7 +55,7 @@ export interface IResizeSensorProps {
 
 /** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 @polyfill
-export class ResizeSensor extends AbstractPureComponent2<IResizeSensorProps> {
+export class ResizeSensor extends AbstractPureComponent2<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
     private element: Element | null = null;
@@ -69,7 +71,7 @@ export class ResizeSensor extends AbstractPureComponent2<IResizeSensorProps> {
         this.observeElement();
     }
 
-    public componentDidUpdate(prevProps: IResizeSensorProps) {
+    public componentDidUpdate(prevProps: ResizeSensorProps) {
         this.observeElement(this.props.observeParents !== prevProps.observeParents);
     }
 

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -21,13 +21,13 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { clamp } from "../../common/utils";
-import { IHandleProps } from "./handleProps";
+import { HandleProps } from "./handleProps";
 import { formatPercentage } from "./sliderUtils";
 
 /**
  * Props for the internal <Handle> component needs some additional info from the parent Slider.
  */
-export interface IInternalHandleProps extends IHandleProps {
+export interface IInternalHandleProps extends HandleProps {
     disabled?: boolean;
     label: JSX.Element | string | undefined;
     max: number;

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Intent, IProps } from "../../common";
+import { Intent, Props } from "../../common";
 
 export const HandleType = {
     /** A full handle appears as a small square. */
@@ -47,8 +47,10 @@ export const HandleInteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HandleInteractionKind = typeof HandleInteractionKind[keyof typeof HandleInteractionKind];
 
+// eslint-disable-next-line deprecation/deprecation
 export type HandleProps = IHandleProps;
-export interface IHandleProps extends IProps {
+/** @deprecated use HandleProps */
+export interface IHandleProps extends Props {
     /** Numeric value of this handle. */
     value: number;
 

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -47,6 +47,7 @@ export const HandleInteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HandleInteractionKind = typeof HandleInteractionKind[keyof typeof HandleInteractionKind];
 
+export type HandleProps = IHandleProps;
 export interface IHandleProps extends IProps {
     /** Numeric value of this handle. */
     value: number;

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -20,20 +20,20 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Intent } from "../../common";
 import * as Errors from "../../common/errors";
-import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 import * as Utils from "../../common/utils";
 import { Handle } from "./handle";
-import { HandleInteractionKind, HandleType, IHandleProps } from "./handleProps";
+import { HandleInteractionKind, HandleType, HandleProps } from "./handleProps";
 import { argMin, fillValues, formatPercentage } from "./sliderUtils";
 
 /**
  * SFC used to pass slider handle props to a `MultiSlider`.
  * This element is not rendered directly.
  */
-const MultiSliderHandle: React.FunctionComponent<IHandleProps> = () => null;
+const MultiSliderHandle: React.FunctionComponent<HandleProps> = () => null;
 MultiSliderHandle.displayName = `${DISPLAYNAME_PREFIX}.MultiSliderHandle`;
 
-export interface ISliderBaseProps extends IProps, IIntentProps {
+export interface ISliderBaseProps extends Props, IntentProps {
     /**
      * Whether the slider is non-interactive.
      *
@@ -112,7 +112,9 @@ export interface ISliderBaseProps extends IProps, IIntentProps {
     vertical?: boolean;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type MultiSliderProps = IMultiSliderProps;
+/** @deprecated use MultiSliderProps */
 export interface IMultiSliderProps extends ISliderBaseProps {
     /** Default intent of a track segment, used only if no handle specifies `intentBefore/After`. */
     defaultTrackIntent?: Intent;
@@ -133,7 +135,7 @@ export interface ISliderState {
 }
 
 @polyfill
-export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISliderState> {
+export class MultiSlider extends AbstractPureComponent2<MultiSliderProps, ISliderState> {
     public static defaultSliderProps: ISliderBaseProps = {
         disabled: false,
         max: 10,
@@ -143,7 +145,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         vertical: false,
     };
 
-    public static defaultProps: IMultiSliderProps = {
+    public static defaultProps: MultiSliderProps = {
         ...MultiSlider.defaultSliderProps,
         defaultTrackIntent: Intent.NONE,
     };
@@ -152,11 +154,11 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     public static Handle = MultiSliderHandle;
 
-    public static getDerivedStateFromProps(props: IMultiSliderProps) {
+    public static getDerivedStateFromProps(props: MultiSliderProps) {
         return { labelPrecision: MultiSlider.getLabelPrecision(props) };
     }
 
-    private static getLabelPrecision({ labelPrecision, stepSize }: IMultiSliderProps) {
+    private static getLabelPrecision({ labelPrecision, stepSize }: MultiSliderProps) {
         // infer default label precision from stepSize because that's how much the handle moves.
         return labelPrecision == null ? Utils.countDecimalPlaces(stepSize!) : labelPrecision;
     }
@@ -171,7 +173,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
 
     private trackElement: HTMLElement | null = null;
 
-    public getSnapshotBeforeUpdate(prevProps: IMultiSliderProps): null {
+    public getSnapshotBeforeUpdate(prevProps: MultiSliderProps): null {
         const prevHandleProps = getSortedInteractiveHandleProps(prevProps);
         const newHandleProps = getSortedInteractiveHandleProps(this.props);
         if (newHandleProps.length !== prevHandleProps.length) {
@@ -206,12 +208,12 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         this.updateTickSize();
     }
 
-    public componentDidUpdate(prevProps: IMultiSliderProps, prevState: ISliderState) {
+    public componentDidUpdate(prevProps: MultiSliderProps, prevState: ISliderState) {
         super.componentDidUpdate(prevProps, prevState);
         this.updateTickSize();
     }
 
-    protected validateProps(props: React.PropsWithChildren<IMultiSliderProps>) {
+    protected validateProps(props: React.PropsWithChildren<MultiSliderProps>) {
         if (props.stepSize! <= 0) {
             throw new Error(Errors.SLIDER_ZERO_STEP);
         }
@@ -270,7 +272,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         trackStops.push({ value: this.props.max! });
 
         // render from current to previous, then increment previous
-        let previous: IHandleProps = { value: this.props.min! };
+        let previous: HandleProps = { value: this.props.min! };
         const handles: JSX.Element[] = [];
         for (let index = 0; index < trackStops.length; index++) {
             const current = trackStops[index];
@@ -280,7 +282,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         return handles;
     }
 
-    private renderTrackFill(index: number, start: IHandleProps, end: IHandleProps) {
+    private renderTrackFill(index: number, start: HandleProps, end: HandleProps) {
         // ensure startRatio <= endRatio
         const [startRatio, endRatio] = [this.getOffsetRatio(start.value), this.getOffsetRatio(end.value)].sort(
             (left, right) => left - right,
@@ -456,7 +458,7 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
         return Utils.clamp((value - this.props.min!) * this.state.tickSizeRatio, 0, 1);
     }
 
-    private getTrackIntent(start: IHandleProps, end?: IHandleProps): Intent {
+    private getTrackIntent(start: HandleProps, end?: HandleProps): Intent {
         if (!this.props.showTrackFill) {
             return Intent.NONE;
         }
@@ -478,18 +480,18 @@ export class MultiSlider extends AbstractPureComponent2<IMultiSliderProps, ISlid
     }
 }
 
-function getLabelPrecision({ labelPrecision, stepSize = MultiSlider.defaultSliderProps.stepSize! }: IMultiSliderProps) {
+function getLabelPrecision({ labelPrecision, stepSize = MultiSlider.defaultSliderProps.stepSize! }: MultiSliderProps) {
     // infer default label precision from stepSize because that's how much the handle moves.
     return labelPrecision == null ? Utils.countDecimalPlaces(stepSize) : labelPrecision;
 }
 
-function getSortedInteractiveHandleProps(props: React.PropsWithChildren<IMultiSliderProps>): IHandleProps[] {
+function getSortedInteractiveHandleProps(props: React.PropsWithChildren<MultiSliderProps>): HandleProps[] {
     return getSortedHandleProps(props, childProps => childProps.interactionKind !== HandleInteractionKind.NONE);
 }
 
 function getSortedHandleProps(
-    { children }: React.PropsWithChildren<IMultiSliderProps>,
-    predicate: (props: IHandleProps) => boolean = () => true,
+    { children }: React.PropsWithChildren<MultiSliderProps>,
+    predicate: (props: HandleProps) => boolean = () => true,
 ) {
     const maybeHandles = React.Children.map(children, child =>
         Utils.isElementOfType(child, MultiSlider.Handle) && predicate(child.props) ? child.props : null,

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -112,6 +112,7 @@ export interface ISliderBaseProps extends IProps, IIntentProps {
     vertical?: boolean;
 }
 
+export type MultiSliderProps = IMultiSliderProps;
 export interface IMultiSliderProps extends ISliderBaseProps {
     /** Default intent of a track segment, used only if no handle specifies `intentBefore/After`. */
     defaultTrackIntent?: Intent;

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -29,7 +29,9 @@ enum RangeIndex {
     END = 1,
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type RangeSliderProps = IRangeSliderProps;
+/** @deprecated use RangeSliderProps */
 export interface IRangeSliderProps extends ISliderBaseProps {
     /**
      * Range value of slider. Handles will be rendered at each position in the range.
@@ -46,8 +48,8 @@ export interface IRangeSliderProps extends ISliderBaseProps {
 }
 
 @polyfill
-export class RangeSlider extends AbstractPureComponent2<IRangeSliderProps> {
-    public static defaultProps: IRangeSliderProps = {
+export class RangeSlider extends AbstractPureComponent2<RangeSliderProps> {
+    public static defaultProps: RangeSliderProps = {
         ...MultiSlider.defaultSliderProps,
         intent: Intent.PRIMARY,
         value: [0, 10],
@@ -65,7 +67,7 @@ export class RangeSlider extends AbstractPureComponent2<IRangeSliderProps> {
         );
     }
 
-    protected validateProps(props: IRangeSliderProps) {
+    protected validateProps(props: RangeSliderProps) {
         const { value } = props;
         if (value == null || value[RangeIndex.START] == null || value[RangeIndex.END] == null) {
             throw new Error(Errors.RANGESLIDER_NULL_VALUE);

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -29,6 +29,7 @@ enum RangeIndex {
     END = 1,
 }
 
+export type RangeSliderProps = IRangeSliderProps;
 export interface IRangeSliderProps extends ISliderBaseProps {
     /**
      * Range value of slider. Handles will be rendered at each position in the range.

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -21,7 +21,9 @@ import { AbstractPureComponent2, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { ISliderBaseProps, MultiSlider } from "./multiSlider";
 
+// eslint-disable-next-line deprecation/deprecation
 export type SliderProps = ISliderProps;
+/** @deprecated use SliderProps */
 export interface ISliderProps extends ISliderBaseProps {
     /**
      * Initial value of the slider. This determines the other end of the
@@ -46,8 +48,8 @@ export interface ISliderProps extends ISliderBaseProps {
 }
 
 @polyfill
-export class Slider extends AbstractPureComponent2<ISliderProps> {
-    public static defaultProps: ISliderProps = {
+export class Slider extends AbstractPureComponent2<SliderProps> {
+    public static defaultProps: SliderProps = {
         ...MultiSlider.defaultSliderProps,
         initialValue: 0,
         intent: Intent.PRIMARY,

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -21,6 +21,7 @@ import { AbstractPureComponent2, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { ISliderBaseProps, MultiSlider } from "./multiSlider";
 
+export type SliderProps = ISliderProps;
 export interface ISliderProps extends ISliderBaseProps {
     /**
      * Initial value of the slider. This determines the other end of the

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -20,7 +20,7 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
-import { DISPLAYNAME_PREFIX, IIntentProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 
 // see http://stackoverflow.com/a/18473154/3124288 for calculating arc path
@@ -36,8 +36,10 @@ const MIN_SIZE = 10;
 const STROKE_WIDTH = 4;
 const MIN_STROKE_WIDTH = 16;
 
+// eslint-disable-next-line deprecation/deprecation
 export type SpinnerProps = ISpinnerProps;
-export interface ISpinnerProps extends IProps, IIntentProps {
+/** @deprecated use SpinnerProps */
+export interface ISpinnerProps extends Props, IntentProps {
     /**
      * Width and height of the spinner in pixels. The size cannot be less than
      * 10px.
@@ -68,7 +70,7 @@ export interface ISpinnerProps extends IProps, IIntentProps {
 }
 
 @polyfill
-export class Spinner extends AbstractPureComponent2<ISpinnerProps> {
+export class Spinner extends AbstractPureComponent2<SpinnerProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Spinner`;
 
     public static readonly SIZE_SMALL = 20;
@@ -77,7 +79,7 @@ export class Spinner extends AbstractPureComponent2<ISpinnerProps> {
 
     public static readonly SIZE_LARGE = 100;
 
-    public componentDidUpdate(prevProps: ISpinnerProps) {
+    public componentDidUpdate(prevProps: SpinnerProps) {
         if (prevProps.value !== this.props.value) {
             // IE/Edge: re-render after changing value to force SVG update
             this.forceUpdate();
@@ -127,7 +129,7 @@ export class Spinner extends AbstractPureComponent2<ISpinnerProps> {
         );
     }
 
-    protected validateProps({ className = "", size }: ISpinnerProps) {
+    protected validateProps({ className = "", size }: SpinnerProps) {
         if (size != null && (className.indexOf(Classes.SMALL) >= 0 || className.indexOf(Classes.LARGE) >= 0)) {
             console.warn(SPINNER_WARN_CLASSES_SIZE);
         }

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -36,6 +36,7 @@ const MIN_SIZE = 10;
 const STROKE_WIDTH = 4;
 const MIN_STROKE_WIDTH = 16;
 
+export type SpinnerProps = ISpinnerProps;
 export interface ISpinnerProps extends IProps, IIntentProps {
     /**
      * Width and height of the spinner in pixels. The size cannot be less than

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -19,12 +19,14 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
 export type TabId = string | number;
 
+// eslint-disable-next-line deprecation/deprecation
 export type TabProps = ITabProps;
-export interface ITabProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
+/** @deprecated use TabProps */
+export interface ITabProps extends Props, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
      * Content of tab title, rendered in a list above the active panel.
      * Can also be set via the `title` prop.
@@ -63,8 +65,8 @@ export interface ITabProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "
 }
 
 @polyfill
-export class Tab extends AbstractPureComponent2<ITabProps> {
-    public static defaultProps: Partial<ITabProps> = {
+export class Tab extends AbstractPureComponent2<TabProps> {
+    public static defaultProps: Partial<TabProps> = {
         disabled: false,
     };
 

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -23,6 +23,7 @@ import { DISPLAYNAME_PREFIX, HTMLDivProps, IProps } from "../../common/props";
 
 export type TabId = string | number;
 
+export type TabProps = ITabProps;
 export interface ITabProps extends IProps, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
      * Content of tab title, rendered in a list above the active panel.

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -20,10 +20,12 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
-import { ITabProps, TabId } from "./tab";
+import { TabProps, TabId } from "./tab";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TabTitleProps = ITabTitleProps;
-export interface ITabTitleProps extends ITabProps {
+/** @deprecated use TabTitleProps */
+export interface ITabTitleProps extends TabProps {
     /** Handler invoked when this tab is clicked. */
     onClick: (id: TabId, event: React.MouseEvent<HTMLElement>) => void;
 
@@ -35,7 +37,7 @@ export interface ITabTitleProps extends ITabProps {
 }
 
 @polyfill
-export class TabTitle extends AbstractPureComponent2<ITabTitleProps> {
+export class TabTitle extends AbstractPureComponent2<TabTitleProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TabTitle`;
 
     public render() {

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -22,6 +22,7 @@ import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { ITabProps, TabId } from "./tab";
 
+export type TabTitleProps = ITabTitleProps;
 export interface ITabTitleProps extends ITabProps {
     /** Handler invoked when this tab is clicked. */
     onClick: (id: TabId, event: React.MouseEvent<HTMLElement>) => void;

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -19,19 +19,21 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import * as Utils from "../../common/utils";
-import { ITabProps, Tab, TabId } from "./tab";
+import { TabProps, Tab, TabId } from "./tab";
 import { generateTabPanelId, generateTabTitleId, TabTitle } from "./tabTitle";
 
 export const Expander: React.FunctionComponent = () => <div className={Classes.FLEX_EXPANDER} />;
 
-type TabElement = React.ReactElement<ITabProps & { children: React.ReactNode }>;
+type TabElement = React.ReactElement<TabProps & { children: React.ReactNode }>;
 
 const TAB_SELECTOR = `.${Classes.TAB}`;
 
+// eslint-disable-next-line deprecation/deprecation
 export type TabsProps = ITabsProps;
-export interface ITabsProps extends IProps {
+/** @deprecated use TabsProps */
+export interface ITabsProps extends Props {
     /**
      * Whether the selected tab indicator should animate its movement.
      *
@@ -99,13 +101,13 @@ export interface ITabsState {
 // HACKHACK: https://github.com/palantir/blueprint/issues/4342
 // eslint-disable-next-line deprecation/deprecation
 @(polyfill as Utils.LifecycleCompatPolyfill<ITabsProps, any>)
-export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
+export class Tabs extends AbstractPureComponent2<TabsProps, ITabsState> {
     /** Insert a `Tabs.Expander` between any two children to right-align all subsequent children. */
     public static Expander = Expander;
 
     public static Tab = Tab;
 
-    public static defaultProps: Partial<ITabsProps> = {
+    public static defaultProps: Partial<TabsProps> = {
         animate: true,
         large: false,
         renderActiveTabPanelOnly: false,
@@ -114,7 +116,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
 
     public static displayName = `${DISPLAYNAME_PREFIX}.Tabs`;
 
-    public static getDerivedStateFromProps({ selectedTabId }: ITabsProps) {
+    public static getDerivedStateFromProps({ selectedTabId }: TabsProps) {
         if (selectedTabId !== undefined) {
             // keep state in sync with controlled prop, so state is canonical source of truth
             return { selectedTabId };
@@ -128,7 +130,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
         tablist: (tabElement: HTMLDivElement) => (this.tablistElement = tabElement),
     };
 
-    constructor(props: ITabsProps) {
+    constructor(props: TabsProps) {
         super(props);
         const selectedTabId = this.getInitialSelectedTabId();
         this.state = { selectedTabId };
@@ -175,7 +177,7 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
         this.moveSelectionIndicator(false);
     }
 
-    public componentDidUpdate(prevProps: ITabsProps, prevState: ITabsState) {
+    public componentDidUpdate(prevProps: TabsProps, prevState: ITabsState) {
         if (this.state.selectedTabId !== prevState.selectedTabId) {
             this.moveSelectionIndicator();
         } else if (prevState.selectedTabId != null) {
@@ -215,12 +217,12 @@ export class Tabs extends AbstractPureComponent2<ITabsProps, ITabsState> {
         return undefined;
     }
 
-    private getTabChildrenProps(props: ITabsProps & { children?: React.ReactNode } = this.props) {
+    private getTabChildrenProps(props: TabsProps & { children?: React.ReactNode } = this.props) {
         return this.getTabChildren(props).map(child => child.props);
     }
 
     /** Filters children to only `<Tab>`s */
-    private getTabChildren(props: ITabsProps & { children?: React.ReactNode } = this.props) {
+    private getTabChildren(props: TabsProps & { children?: React.ReactNode } = this.props) {
         return React.Children.toArray(props.children).filter(isTabElement);
     }
 

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -30,6 +30,7 @@ type TabElement = React.ReactElement<ITabProps & { children: React.ReactNode }>;
 
 const TAB_SELECTOR = `.${Classes.TAB}`;
 
+export type TabsProps = ITabsProps;
 export interface ITabsProps extends IProps {
     /**
      * Whether the selected tab indicator should animate its movement.

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -33,6 +33,7 @@ import { ITagProps, Tag } from "../tag/tag";
  */
 export type TagInputAddMethod = "default" | "blur" | "paste";
 
+export type TagInputProps = ITagInputProps;
 export interface ITagInputProps extends IIntentProps, IProps {
     /**
      * If true, `onAdd` will be invoked when the input loses focus.

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -19,9 +19,9 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, IRef, Keys, refHandler, setRef, Utils } from "../../common";
-import { DISPLAYNAME_PREFIX, HTMLInputProps, IIntentProps, IProps, MaybeElement } from "../../common/props";
+import { DISPLAYNAME_PREFIX, HTMLInputProps, IntentProps, Props, MaybeElement } from "../../common/props";
 import { Icon, IconName } from "../icon/icon";
-import { ITagProps, Tag } from "../tag/tag";
+import { TagProps, Tag } from "../tag/tag";
 
 /**
  * The method in which a `TagInput` value was added.
@@ -33,8 +33,10 @@ import { ITagProps, Tag } from "../tag/tag";
  */
 export type TagInputAddMethod = "default" | "blur" | "paste";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TagInputProps = ITagInputProps;
-export interface ITagInputProps extends IIntentProps, IProps {
+/** @deprecated use TagInputProps */
+export interface ITagInputProps extends IntentProps, Props {
     /**
      * If true, `onAdd` will be invoked when the input loses focus.
      * Otherwise, `onAdd` is only invoked when `enter` is pressed.
@@ -168,7 +170,7 @@ export interface ITagInputProps extends IIntentProps, IProps {
      * If you define `onRemove` here then you will have to implement your own tag removal
      * handling as `TagInput`'s own `onRemove` handler will never be invoked.
      */
-    tagProps?: ITagProps | ((value: React.ReactNode, index: number) => ITagProps);
+    tagProps?: TagProps | ((value: React.ReactNode, index: number) => TagProps);
 
     /**
      * Controlled tag values. Each value will be rendered inside a `Tag`, which can be customized
@@ -193,10 +195,10 @@ export interface ITagInputState {
 const NONE = -1;
 
 @polyfill
-export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputState> {
+export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TagInput`;
 
-    public static defaultProps: Partial<ITagInputProps> = {
+    public static defaultProps: Partial<TagInputProps> = {
         addOnBlur: false,
         addOnPaste: true,
         inputProps: {},
@@ -205,7 +207,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
     };
 
     public static getDerivedStateFromProps(
-        props: Readonly<ITagInputProps>,
+        props: Readonly<TagInputProps>,
         state: Readonly<ITagInputState>,
     ): Partial<ITagInputState> | null {
         if (props.inputValue !== state.prevInputValueProp) {
@@ -277,7 +279,7 @@ export class TagInput extends AbstractPureComponent2<ITagInputProps, ITagInputSt
         );
     }
 
-    public componentDidUpdate(prevProps: ITagInputProps) {
+    public componentDidUpdate(prevProps: TagInputProps) {
         if (prevProps.inputRef !== this.props.inputRef) {
             setRef(prevProps.inputRef, null);
             this.handleRef = refHandler(this, "inputElement", this.props.inputRef);

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -32,6 +32,7 @@ import { isReactNodeEmpty } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { Text } from "../text/text";
 
+export type TagProps = ITagProps;
 export interface ITagProps
     extends IProps,
         IIntentProps,

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -23,8 +23,8 @@ import {
     Classes,
     DISPLAYNAME_PREFIX,
     IElementRefProps,
-    IIntentProps,
-    IProps,
+    IntentProps,
+    Props,
     MaybeElement,
     Utils,
 } from "../../common";
@@ -32,10 +32,12 @@ import { isReactNodeEmpty } from "../../common/utils";
 import { Icon, IconName } from "../icon/icon";
 import { Text } from "../text/text";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TagProps = ITagProps;
+/** @deprecated use TagProps */
 export interface ITagProps
-    extends IProps,
-        IIntentProps,
+    extends Props,
+        IntentProps,
         // eslint-disable-next-line deprecation/deprecation
         IElementRefProps<HTMLSpanElement>,
         React.HTMLAttributes<HTMLSpanElement> {
@@ -100,7 +102,7 @@ export interface ITagProps
      * Click handler for remove button.
      * The remove button will only be rendered if this prop is defined.
      */
-    onRemove?: (e: React.MouseEvent<HTMLButtonElement>, tagProps: ITagProps) => void;
+    onRemove?: (e: React.MouseEvent<HTMLButtonElement>, tagProps: TagProps) => void;
 
     /** Name of a Blueprint UI icon (or an icon element) to render after the children. */
     rightIcon?: IconName | MaybeElement;
@@ -119,7 +121,7 @@ export interface ITagProps
 }
 
 @polyfill
-export class Tag extends AbstractPureComponent2<ITagProps> {
+export class Tag extends AbstractPureComponent2<TagProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tag`;
 
     public render() {

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TextProps = ITextProps;
-export interface ITextProps extends IProps {
+/** @deprecated use TextProps */
+export interface ITextProps extends Props {
     /**
      * Indicates that this component should be truncated with an ellipsis if it overflows its container.
      * The `title` attribute will also be added when content overflows to show the full text of the children on hover.
@@ -50,10 +52,10 @@ export interface ITextState {
 }
 
 @polyfill
-export class Text extends AbstractPureComponent2<ITextProps, ITextState> {
+export class Text extends AbstractPureComponent2<TextProps, ITextState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Text`;
 
-    public static defaultProps: Partial<ITextProps> = {
+    public static defaultProps: Partial<TextProps> = {
         ellipsize: false,
         tagName: "div",
     };

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -21,6 +21,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
 
+export type TextProps = ITextProps;
 export interface ITextProps extends IProps {
     /**
      * Indicates that this component should be truncated with an ellipsis if it overflows its container.

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -19,20 +19,20 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IActionProps, IIntentProps, ILinkProps, IProps, MaybeElement } from "../../common/props";
+import { DISPLAYNAME_PREFIX, ActionProps, IntentProps, LinkProps, Props, MaybeElement } from "../../common/props";
 import { ButtonGroup } from "../button/buttonGroup";
 import { AnchorButton, Button } from "../button/buttons";
 import { Icon, IconName } from "../icon/icon";
 
 export type ToastProps = IToastProps;
-export interface IToastProps extends IProps, IIntentProps {
+export interface IToastProps extends Props, IntentProps {
     /**
      * Action rendered as a minimal `AnchorButton`. The toast is dismissed automatically when the
      * user clicks the action button. Note that the `intent` prop is ignored (the action button
      * cannot have its own intent color that might conflict with the toast's intent). Omit this
      * prop to omit the action button.
      */
-    action?: IActionProps & ILinkProps;
+    action?: ActionProps & LinkProps;
 
     /** Name of a Blueprint UI icon (or an icon element) to render before the message. */
     icon?: IconName | MaybeElement;

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -24,6 +24,7 @@ import { ButtonGroup } from "../button/buttonGroup";
 import { AnchorButton, Button } from "../button/buttons";
 import { Icon, IconName } from "../icon/icon";
 
+export type ToastProps = IToastProps;
 export interface IToastProps extends IProps, IIntentProps {
     /**
      * Action rendered as a minimal `AnchorButton`. The toast is dismissed automatically when the

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -257,3 +257,6 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
         }
     };
 }
+
+export const OverlayToaster = Toaster;
+export type OverlayToasterProps = IToasterProps;

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -22,7 +22,7 @@ import { polyfill } from "react-lifecycles-compat";
 import { AbstractPureComponent2, Classes, Position } from "../../common";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID, TOASTER_WARN_INLINE } from "../../common/errors";
 import { ESCAPE } from "../../common/keys";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isNodeEnv } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
 import { IToastProps, Toast } from "./toast";
@@ -59,7 +59,7 @@ export interface IToaster {
  * Props supported by the `<Toaster>` component.
  * These props can be passed as an argument to the static `Toaster.create(props?, container?)` method.
  */
-export interface IToasterProps extends IProps {
+export interface IToasterProps extends Props {
     /**
      * Whether a toast should acquire application focus when it first opens.
      * This is disabled by default so that toasts do not interrupt the user's flow.

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -24,6 +24,7 @@ import { DISPLAYNAME_PREFIX, IIntentProps } from "../../common/props";
 import { Popover, PopoverInteractionKind } from "../popover/popover";
 import { IPopoverSharedProps } from "../popover/popoverSharedProps";
 
+export type TooltipProps = ITooltipProps;
 export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
     /**
      * The content that will be displayed inside of the tooltip.

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,13 +19,15 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, IIntentProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, IntentProps } from "../../common/props";
 // eslint-disable-next-line import/no-cycle
 import { Popover, PopoverInteractionKind } from "../popover/popover";
 import { IPopoverSharedProps } from "../popover/popoverSharedProps";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TooltipProps = ITooltipProps;
-export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
+/** @deprecated use TooltipProps */
+export interface ITooltipProps extends IPopoverSharedProps, IntentProps {
     /**
      * The content that will be displayed inside of the tooltip.
      */
@@ -71,10 +73,10 @@ export interface ITooltipProps extends IPopoverSharedProps, IIntentProps {
 
 /** @deprecated use { Tooltip2 } from "@blueprintjs/popover2" */
 @polyfill
-export class Tooltip extends AbstractPureComponent2<ITooltipProps> {
+export class Tooltip extends AbstractPureComponent2<TooltipProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tooltip`;
 
-    public static defaultProps: Partial<ITooltipProps> = {
+    public static defaultProps: Partial<TooltipProps> = {
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
         minimal: false,

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -18,25 +18,26 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { DISPLAYNAME_PREFIX, IProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isFunction } from "../../common/utils";
-import { ITreeNode, TreeNode } from "./treeNode";
+import { TreeNodeInfo, TreeNode } from "./treeNode";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type TreeEventHandler<T = {}> = (
-    node: ITreeNode<T>,
+    node: TreeNodeInfo<T>,
     nodePath: number[],
     e: React.MouseEvent<HTMLElement>,
 ) => void;
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/ban-types, deprecation/deprecation
 export type TreeProps<T = {}> = ITreeProps<T>;
+/** @deprecated use TreeProps */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface ITreeProps<T = {}> extends IProps {
+export interface ITreeProps<T = {}> extends Props {
     /**
      * The data specifying the contents and appearance of the tree.
      */
-    contents: Array<ITreeNode<T>>;
+    contents: Array<TreeNodeInfo<T>>;
 
     /**
      * Invoked when a node is clicked anywhere other than the caret for expanding/collapsing the node.
@@ -77,14 +78,14 @@ export interface ITreeProps<T = {}> extends IProps {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export class Tree<T = {}> extends React.Component<ITreeProps<T>> {
+export class Tree<T = {}> extends React.Component<TreeProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tree`;
 
     public static ofType<U>() {
-        return Tree as new (props: ITreeProps<U>) => Tree<U>;
+        return Tree as new (props: TreeProps<U>) => Tree<U>;
     }
 
-    public static nodeFromPath<U>(path: number[], treeNodes?: Array<ITreeNode<U>>): ITreeNode<U> {
+    public static nodeFromPath<U>(path: number[], treeNodes?: Array<TreeNodeInfo<U>>): TreeNodeInfo<U> {
         if (path.length === 1) {
             return treeNodes![path[0]];
         } else {
@@ -111,7 +112,7 @@ export class Tree<T = {}> extends React.Component<ITreeProps<T>> {
         return this.nodeRefs[nodeId];
     }
 
-    private renderNodes(treeNodes: Array<ITreeNode<T>> | undefined, currentPath?: number[], className?: string) {
+    private renderNodes(treeNodes: Array<TreeNodeInfo<T>> | undefined, currentPath?: number[], className?: string) {
         if (treeNodes == null) {
             return null;
         }

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -30,6 +30,8 @@ export type TreeEventHandler<T = {}> = (
 ) => void;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
+export type TreeProps<T = {}> = ITreeProps<T>;
+// eslint-disable-next-line @typescript-eslint/ban-types
 export interface ITreeProps<T = {}> extends IProps {
     /**
      * The data specifying the contents and appearance of the tree.

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -23,6 +23,8 @@ import { Collapse } from "../collapse/collapse";
 import { Icon, IconName } from "../icon/icon";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
+export type TreeNodeInfo<T = {}> = ITreeNode<T>;
+// eslint-disable-next-line @typescript-eslint/ban-types
 export interface ITreeNode<T = {}> extends IProps {
     /**
      * Child tree nodes of this node.
@@ -80,6 +82,8 @@ export interface ITreeNode<T = {}> extends IProps {
     nodeData?: T;
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type TreeNodeProps<T = {}> = ITreeNodeProps<T>;
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
     children?: React.ReactNode;

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -18,18 +18,19 @@ import classNames from "classnames";
 import * as React from "react";
 
 import * as Classes from "../../common/classes";
-import { DISPLAYNAME_PREFIX, IProps, MaybeElement } from "../../common/props";
+import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { Collapse } from "../collapse/collapse";
 import { Icon, IconName } from "../icon/icon";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/ban-types, deprecation/deprecation
 export type TreeNodeInfo<T = {}> = ITreeNode<T>;
+/** @deprecated use TreeNodeInfo */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface ITreeNode<T = {}> extends IProps {
+export interface ITreeNode<T = {}> extends Props {
     /**
      * Child tree nodes of this node.
      */
-    childNodes?: Array<ITreeNode<T>>;
+    childNodes?: Array<TreeNodeInfo<T>>;
 
     /**
      * Whether this tree node is non-interactive. Enabling this prop will ignore
@@ -85,7 +86,7 @@ export interface ITreeNode<T = {}> extends IProps {
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type TreeNodeProps<T = {}> = ITreeNodeProps<T>;
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface ITreeNodeProps<T = {}> extends ITreeNode<T> {
+export interface ITreeNodeProps<T = {}> extends TreeNodeInfo<T> {
     children?: React.ReactNode;
     contentRef?: (node: TreeNode<T>, element: HTMLDivElement | null) => void;
     depth: number;

--- a/packages/core/test/isotest.js
+++ b/packages/core/test/isotest.js
@@ -16,8 +16,11 @@
 // @ts-check
 
 require("@blueprintjs/test-commons/bootstrap");
-const { generateIsomorphicTests } = require("@blueprintjs/test-commons");
+
 const React = require("react");
+
+const { generateIsomorphicTests } = require("@blueprintjs/test-commons");
+
 const Core = require("../lib/cjs");
 
 const requiredChild = React.createElement("button");
@@ -47,8 +50,13 @@ describe("Core isomorphic rendering", () => {
             props: { icon: "build" },
         },
         MultistepDialog: {
-            props: { isOpen: true, usePortal: false},
-            children: React.createElement(Core.DialogStep, { key: 1, id: 1, title: "Step one", panel: React.createElement('div') }),
+            props: { isOpen: true, usePortal: false },
+            children: React.createElement(Core.DialogStep, {
+                key: 1,
+                id: 1,
+                title: "Step one",
+                panel: React.createElement("div"),
+            }),
         },
         KeyCombo: {
             props: { combo: "?" },
@@ -58,6 +66,9 @@ describe("Core isomorphic rendering", () => {
         },
         Overlay: {
             props: { lazy: false, usePortal: false },
+        },
+        OverlayToaster: {
+            skip: true,
         },
         PanelStack: {
             props: {

--- a/packages/datetime/src/dateFormat.tsx
+++ b/packages/datetime/src/dateFormat.tsx
@@ -17,6 +17,7 @@
 import { isDateValid, isDayInRange } from "./common/dateUtils";
 import { IDatePickerBaseProps } from "./datePickerCore";
 
+export type DateFormatProps = IDateFormatProps;
 export interface IDateFormatProps {
     /**
      * The error message to display when the date selected is invalid.

--- a/packages/datetime/src/dateFormat.tsx
+++ b/packages/datetime/src/dateFormat.tsx
@@ -17,7 +17,9 @@
 import { isDateValid, isDayInRange } from "./common/dateUtils";
 import { IDatePickerBaseProps } from "./datePickerCore";
 
+// eslint-disable-next-line deprecation/deprecation
 export type DateFormatProps = IDateFormatProps;
+/** @deprecated use DateFormatProps */
 export interface IDateFormatProps {
     /**
      * The error message to display when the date selected is invalid.
@@ -62,7 +64,7 @@ export interface IDateFormatProps {
 
 export function getFormattedDateString(
     date: Date | false | null,
-    props: IDateFormatProps & IDatePickerBaseProps,
+    props: DateFormatProps & IDatePickerBaseProps,
     ignoreRange = false,
 ) {
     if (date == null) {

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -22,11 +22,11 @@ import { polyfill } from "react-lifecycles-compat";
 import {
     AbstractPureComponent2,
     DISPLAYNAME_PREFIX,
-    IInputGroupProps2,
+    InputGroupProps2,
     InputGroup,
     Intent,
     IPopoverProps,
-    IProps,
+    Props,
     IRef,
     Keys,
     Popover,
@@ -36,13 +36,15 @@ import {
 
 import * as Classes from "./common/classes";
 import { isDateValid, isDayInRange } from "./common/dateUtils";
-import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
+import { getFormattedDateString, DateFormatProps } from "./dateFormat";
 import { DatePicker } from "./datePicker";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
-import { IDatePickerShortcut } from "./shortcuts";
+import { DatePickerShortcut } from "./shortcuts";
 
+// eslint-disable-next-line deprecation/deprecation
 export type DateInputProps = IDateInputProps;
-export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps, IProps {
+/** @deprecated use DateInputProps */
+export interface IDateInputProps extends IDatePickerBaseProps, DateFormatProps, Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      * Passed to `DatePicker` component.
@@ -88,7 +90,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `type` is fixed to "text".
      */
-    inputProps?: IInputGroupProps2;
+    inputProps?: InputGroupProps2;
 
     /**
      * Called when the user selects a new valid date through the `DatePicker` or by typing
@@ -132,7 +134,7 @@ export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps,
      *
      * @default false
      */
-    shortcuts?: boolean | IDatePickerShortcut[];
+    shortcuts?: boolean | DatePickerShortcut[];
 
     /**
      * The currently selected day. If this prop is provided, the component acts in a controlled manner.
@@ -159,10 +161,10 @@ export interface IDateInputState {
 }
 
 @polyfill
-export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInputState> {
+export class DateInput extends AbstractPureComponent2<DateInputProps, IDateInputState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.DateInput`;
 
-    public static defaultProps: Partial<IDateInputProps> = {
+    public static defaultProps: Partial<DateInputProps> = {
         closeOnSelection: true,
         dayPickerProps: {},
         disabled: false,
@@ -277,7 +279,7 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         );
     }
 
-    public componentDidUpdate(prevProps: IDateInputProps, prevState: IDateInputState) {
+    public componentDidUpdate(prevProps: DateInputProps, prevState: IDateInputState) {
         super.componentDidUpdate(prevProps, prevState);
 
         if (prevProps.inputProps?.inputRef !== this.props.inputProps?.inputRef) {
@@ -482,12 +484,12 @@ export class DateInput extends AbstractPureComponent2<IDateInputProps, IDateInpu
         this.lastTabbableElement?.removeEventListener("blur", this.handlePopoverBlur);
     };
 
-    private handleShortcutChange = (_: IDatePickerShortcut, selectedShortcutIndex: number) => {
+    private handleShortcutChange = (_: DatePickerShortcut, selectedShortcutIndex: number) => {
         this.setState({ selectedShortcutIndex });
     };
 
     /** safe wrapper around invoking input props event handler (prop defaults to undefined) */
-    private safeInvokeInputProp(name: keyof IInputGroupProps2, e: React.SyntheticEvent<HTMLElement>) {
+    private safeInvokeInputProp(name: keyof InputGroupProps2, e: React.SyntheticEvent<HTMLElement>) {
         const { inputProps = {} } = this.props;
         inputProps[name]?.(e);
     }

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -41,6 +41,7 @@ import { DatePicker } from "./datePicker";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
 import { IDatePickerShortcut } from "./shortcuts";
 
+export type DateInputProps = IDateInputProps;
 export interface IDateInputProps extends IDatePickerBaseProps, IDateFormatProps, IProps {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, NavbarElementProps } from "react-day-picker";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Button, DISPLAYNAME_PREFIX, Divider, IProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, Button, DISPLAYNAME_PREFIX, Divider, Props } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -27,11 +27,13 @@ import * as Errors from "./common/errors";
 import { DatePickerCaption } from "./datePickerCaption";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
 import { DatePickerNavbar } from "./datePickerNavbar";
-import { IDatePickerShortcut, IDateRangeShortcut, Shortcuts } from "./shortcuts";
+import { DatePickerShortcut, DateRangeShortcut, Shortcuts } from "./shortcuts";
 import { TimePicker } from "./timePicker";
 
+// eslint-disable-next-line deprecation/deprecation
 export type DatePickerProps = IDatePickerProps;
-export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
+/** @deprecated use DatePickerProps */
+export interface IDatePickerProps extends IDatePickerBaseProps, Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      *
@@ -57,7 +59,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     /**
      * Called when the `shortcuts` props is enabled and the user changes the shortcut.
      */
-    onShortcutChange?: (shortcut: IDatePickerShortcut, index: number) => void;
+    onShortcutChange?: (shortcut: DatePickerShortcut, index: number) => void;
 
     /**
      * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
@@ -72,7 +74,7 @@ export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
      * If `false`, no shortcuts will be displayed.
      * If an array is provided, the custom shortcuts will be displayed.
      */
-    shortcuts?: boolean | IDatePickerShortcut[];
+    shortcuts?: boolean | DatePickerShortcut[];
 
     /**
      * The currently selected shortcut.
@@ -109,8 +111,8 @@ export interface IDatePickerState {
 }
 
 @polyfill
-export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePickerState> {
-    public static defaultProps: IDatePickerProps = {
+export class DatePicker extends AbstractPureComponent2<DatePickerProps, IDatePickerState> {
+    public static defaultProps: DatePickerProps = {
         canClearSelection: true,
         clearButtonText: "Clear",
         dayPickerProps: {},
@@ -128,7 +130,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
 
     private ignoreNextMonthChange = false;
 
-    public constructor(props: IDatePickerProps, context?: any) {
+    public constructor(props: DatePickerProps, context?: any) {
         super(props, context);
         const value = getInitialValue(props);
         const initialMonth = getInitialMonth(props, value);
@@ -175,7 +177,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
         );
     }
 
-    public componentDidUpdate(prevProps: IDatePickerProps, prevState: IDatePickerState) {
+    public componentDidUpdate(prevProps: DatePickerProps, prevState: IDatePickerState) {
         super.componentDidUpdate(prevProps, prevState);
         const { value } = this.props;
         if (value === prevProps.value) {
@@ -198,7 +200,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
         }
     }
 
-    protected validateProps(props: IDatePickerProps) {
+    protected validateProps(props: DatePickerProps) {
         const { defaultValue, initialMonth, maxDate, minDate, value } = props;
         if (defaultValue != null && !DateUtils.isDayInRange(defaultValue, [minDate, maxDate])) {
             console.error(Errors.DATEPICKER_DEFAULT_VALUE_INVALID);
@@ -303,7 +305,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
         const { selectedShortcutIndex } = this.state;
         const { maxDate, minDate, timePrecision } = this.props;
         // Reuse the existing date range shortcuts and only care about start date
-        const dateRangeShortcuts: IDateRangeShortcut[] | true =
+        const dateRangeShortcuts: DateRangeShortcut[] | true =
             shortcuts === true
                 ? true
                 : shortcuts.map(shortcut => ({
@@ -342,7 +344,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
         this.updateValue(newValue, true);
     };
 
-    private handleShortcutClick = (shortcut: IDateRangeShortcut, selectedShortcutIndex: number) => {
+    private handleShortcutClick = (shortcut: DateRangeShortcut, selectedShortcutIndex: number) => {
         const { onShortcutChange, selectedShortcutIndex: currentShortcutIndex } = this.props;
         const { dateRange, includeTime } = shortcut;
         const newDate = dateRange[0];
@@ -435,7 +437,7 @@ export class DatePicker extends AbstractPureComponent2<IDatePickerProps, IDatePi
     }
 }
 
-function getInitialValue(props: IDatePickerProps): Date | null {
+function getInitialValue(props: DatePickerProps): Date | null {
     // !== because `null` is a valid value (no date)
     if (props.value !== undefined) {
         return props.value;
@@ -446,7 +448,7 @@ function getInitialValue(props: IDatePickerProps): Date | null {
     return null;
 }
 
-function getInitialMonth(props: IDatePickerProps, value: Date | null): Date {
+function getInitialMonth(props: DatePickerProps, value: Date | null): Date {
     const today = new Date();
     // != because we must have a real `Date` to begin the calendar on.
     if (props.initialMonth != null) {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -30,6 +30,7 @@ import { DatePickerNavbar } from "./datePickerNavbar";
 import { IDatePickerShortcut, IDateRangeShortcut, Shortcuts } from "./shortcuts";
 import { TimePicker } from "./timePicker";
 
+export type DatePickerProps = IDatePickerProps;
 export interface IDatePickerProps extends IDatePickerBaseProps, IProps {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 import { CaptionElementProps } from "react-day-picker";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Divider, HTMLSelect, Icon, IOptionProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, Divider, HTMLSelect, Icon, OptionProps } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import { clone } from "./common/dateUtils";
@@ -61,10 +61,10 @@ export class DatePickerCaption extends AbstractPureComponent2<IDatePickerCaption
         const startMonth = displayYear === minYear ? minDate.getMonth() : 0;
         const endMonth = displayYear === maxYear ? maxDate.getMonth() + 1 : undefined;
         const monthOptionElements = months
-            .map<IOptionProps>((month, i) => ({ label: month, value: i }))
+            .map<OptionProps>((month, i) => ({ label: month, value: i }))
             .slice(startMonth, endMonth);
 
-        const years: Array<number | IOptionProps> = [minYear];
+        const years: Array<number | OptionProps> = [minYear];
         for (let year = minYear + 1; year <= maxYear; ++year) {
             years.push(year);
         }

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -17,17 +17,20 @@
 import { DayPickerProps, LocaleUtils } from "react-day-picker";
 
 import { Months } from "./common/months";
-import { ITimePickerProps, TimePrecision } from "./timePicker";
+import { TimePickerProps, TimePrecision } from "./timePicker";
 
 // DatePicker supports a simpler set of modifiers (for now).
 // also we need an interface for the dictionary without `today` and `outside` injected by r-d-p.
 /**
  * Collection of functions that determine which modifier classes get applied to which days.
  * See the [**react-day-picker** documentation](http://react-day-picker.js.org/api/ModifiersUtils) to learn more.
+ *
+ * @deprecated use DatePickerModifiers
  */
 export interface IDatePickerModifiers {
     [name: string]: (date: Date) => boolean;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type DatePickerModifiers = IDatePickerModifiers;
 
 export interface IDatePickerBaseProps {
@@ -89,7 +92,7 @@ export interface IDatePickerBaseProps {
      * Each function should accept a `Date` and return a boolean.
      * See the [**react-day-picker** documentation](http://react-day-picker.js.org/api/ModifiersUtils) to learn more.
      */
-    modifiers?: IDatePickerModifiers;
+    modifiers?: DatePickerModifiers;
 
     /**
      * If `true`, the month menu will appear to the left of the year menu.
@@ -116,7 +119,7 @@ export interface IDatePickerBaseProps {
      *
      * Passing any non-empty object to this prop will cause the `TimePicker` to appear.
      */
-    timePickerProps?: ITimePickerProps;
+    timePickerProps?: TimePickerProps;
 }
 
 export const DISABLED_MODIFIER = "disabled";
@@ -147,7 +150,7 @@ export function getDefaultMinDate() {
     return date;
 }
 
-export function combineModifiers(baseModifiers: IDatePickerModifiers, userModifiers: IDatePickerModifiers) {
+export function combineModifiers(baseModifiers: DatePickerModifiers, userModifiers: DatePickerModifiers) {
     let modifiers = baseModifiers;
     if (userModifiers != null) {
         modifiers = {};

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -28,6 +28,7 @@ import { ITimePickerProps, TimePrecision } from "./timePicker";
 export interface IDatePickerModifiers {
     [name: string]: (date: Date) => boolean;
 }
+export type DatePickerModifiers = IDatePickerModifiers;
 
 export interface IDatePickerBaseProps {
     /**

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -51,6 +51,7 @@ type InputEvent =
     | React.FocusEvent<HTMLInputElement>
     | React.ChangeEvent<HTMLInputElement>;
 
+export type DateRangeInputProps = IDateRangeInputProps;
 export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatProps, IProps {
     /**
      * Whether the start and end dates of the range can be the same day.

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -24,11 +24,11 @@ import {
     Boundary,
     Classes,
     DISPLAYNAME_PREFIX,
-    IInputGroupProps2,
+    InputGroupProps2,
     InputGroup,
     Intent,
     IPopoverProps,
-    IProps,
+    Props,
     Keys,
     Popover,
     Position,
@@ -39,10 +39,10 @@ import {
 import { DateRange } from "./common/dateRange";
 import { areSameTime, isDateValid, isDayInRange } from "./common/dateUtils";
 import * as Errors from "./common/errors";
-import { getFormattedDateString, IDateFormatProps } from "./dateFormat";
+import { getFormattedDateString, DateFormatProps } from "./dateFormat";
 import { getDefaultMaxDate, getDefaultMinDate, IDatePickerBaseProps } from "./datePickerCore";
 import { DateRangePicker } from "./dateRangePicker";
-import { IDateRangeShortcut } from "./shortcuts";
+import { DateRangeShortcut } from "./shortcuts";
 
 // we handle events in a kind of generic way in this component, so here we enumerate all the different kinds of events which we have handlers for
 type InputEvent =
@@ -51,8 +51,10 @@ type InputEvent =
     | React.FocusEvent<HTMLInputElement>
     | React.ChangeEvent<HTMLInputElement>;
 
+// eslint-disable-next-line deprecation/deprecation
 export type DateRangeInputProps = IDateRangeInputProps;
-export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatProps, IProps {
+/** @deprecated use DateRangeInputProps */
+export interface IDateRangeInputProps extends IDatePickerBaseProps, DateFormatProps, Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.
@@ -95,7 +97,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatP
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `ref` is not supported; use `inputRef` instead.
      */
-    endInputProps?: IInputGroupProps2;
+    endInputProps?: InputGroupProps2;
 
     /**
      * Called when the user selects a day.
@@ -143,7 +145,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatP
      *
      * @default true
      */
-    shortcuts?: boolean | IDateRangeShortcut[];
+    shortcuts?: boolean | DateRangeShortcut[];
 
     /**
      * Whether to show only a single month calendar.
@@ -157,7 +159,7 @@ export interface IDateRangeInputProps extends IDatePickerBaseProps, IDateFormatP
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `ref` is not supported; use `inputRef` instead.
      */
-    startInputProps?: IInputGroupProps2;
+    startInputProps?: InputGroupProps2;
 
     /**
      * The currently selected date range.
@@ -213,8 +215,8 @@ interface IStateKeysAndValuesObject {
 }
 
 @polyfill
-export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps, IDateRangeInputState> {
-    public static defaultProps: Partial<IDateRangeInputProps> = {
+export class DateRangeInput extends AbstractPureComponent2<DateRangeInputProps, IDateRangeInputState> {
+    public static defaultProps: Partial<DateRangeInputProps> = {
         allowSingleDayRange: false,
         closeOnSelection: true,
         contiguousCalendarMonths: true,
@@ -251,7 +253,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         this.props.endInputProps?.inputRef,
     );
 
-    public constructor(props: IDateRangeInputProps, context?: any) {
+    public constructor(props: DateRangeInputProps, context?: any) {
         super(props, context);
         this.reset(props);
     }
@@ -259,7 +261,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
     /**
      * Public method intended for unit testing only. Do not use in feature work!
      */
-    public reset(props: IDateRangeInputProps = this.props) {
+    public reset(props: DateRangeInputProps = this.props) {
         const [selectedStart, selectedEnd] = this.getInitialRange();
         this.state = {
             formattedMaxDateString: this.getFormattedMinMaxDateString(props, "maxDate"),
@@ -271,7 +273,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         };
     }
 
-    public componentDidUpdate(prevProps: IDateRangeInputProps, prevState: IDateRangeInputState) {
+    public componentDidUpdate(prevProps: DateRangeInputProps, prevState: IDateRangeInputState) {
         super.componentDidUpdate(prevProps, prevState);
         const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
 
@@ -362,7 +364,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         );
     }
 
-    protected validateProps(props: IDateRangeInputProps) {
+    protected validateProps(props: DateRangeInputProps) {
         if (props.value === null) {
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
         }
@@ -491,7 +493,7 @@ export class DateRangeInput extends AbstractPureComponent2<IDateRangeInputProps,
         this.props.onChange?.(selectedRange);
     };
 
-    private handleShortcutChange = (_: IDateRangeShortcut, selectedShortcutIndex: number) => {
+    private handleShortcutChange = (_: DateRangeShortcut, selectedShortcutIndex: number) => {
         this.setState({ selectedShortcutIndex });
     };
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -41,6 +41,7 @@ import { DateRangeSelectionStrategy } from "./dateRangeSelectionStrategy";
 import { IDateRangeShortcut, Shortcuts } from "./shortcuts";
 import { TimePicker } from "./timePicker";
 
+export type DateRangePickerProps = IDateRangePickerProps;
 export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     /**
      * Whether the start and end dates of the range can be the same day.

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Boundary, DISPLAYNAME_PREFIX, Divider, IProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, Boundary, DISPLAYNAME_PREFIX, Divider, Props } from "@blueprintjs/core";
 
 import * as DateClasses from "./common/classes";
 import { DateRange } from "./common/dateRange";
@@ -33,16 +33,18 @@ import {
     getDefaultMinDate,
     HOVERED_RANGE_MODIFIER,
     IDatePickerBaseProps,
-    IDatePickerModifiers,
+    DatePickerModifiers,
     SELECTED_RANGE_MODIFIER,
 } from "./datePickerCore";
 import { DatePickerNavbar } from "./datePickerNavbar";
 import { DateRangeSelectionStrategy } from "./dateRangeSelectionStrategy";
-import { IDateRangeShortcut, Shortcuts } from "./shortcuts";
+import { DateRangeShortcut, Shortcuts } from "./shortcuts";
 import { TimePicker } from "./timePicker";
 
+// eslint-disable-next-line deprecation/deprecation
 export type DateRangePickerProps = IDateRangePickerProps;
-export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
+/** @deprecated use DateRangePickerProps */
+export interface IDateRangePickerProps extends IDatePickerBaseProps, Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.
@@ -92,7 +94,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
     /**
      * Called when the `shortcuts` props is enabled and the user changes the shortcut.
      */
-    onShortcutChange?: (shortcut: IDateRangeShortcut, index: number) => void;
+    onShortcutChange?: (shortcut: DateRangeShortcut, index: number) => void;
 
     /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
@@ -102,7 +104,7 @@ export interface IDateRangePickerProps extends IDatePickerBaseProps, IProps {
      *
      * @default true
      */
-    shortcuts?: boolean | IDateRangeShortcut[];
+    shortcuts?: boolean | DateRangeShortcut[];
 
     /**
      * The currently selected shortcut.
@@ -135,8 +137,8 @@ export interface IDateRangePickerState {
 }
 
 @polyfill
-export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProps, IDateRangePickerState> {
-    public static defaultProps: IDateRangePickerProps = {
+export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps, IDateRangePickerState> {
+    public static defaultProps: DateRangePickerProps = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,
         dayPickerProps: {},
@@ -151,7 +153,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
     public static displayName = `${DISPLAYNAME_PREFIX}.DateRangePicker`;
 
     // these will get merged with the user's own
-    private modifiers: IDatePickerModifiers = {
+    private modifiers: DatePickerModifiers = {
         [SELECTED_RANGE_MODIFIER]: day => {
             const { value } = this.state;
             return value[0] != null && value[1] != null && DateUtils.isDayInRange(day, value, true);
@@ -188,7 +190,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
         },
     };
 
-    public constructor(props: IDateRangePickerProps, context?: any) {
+    public constructor(props: DateRangePickerProps, context?: any) {
         super(props, context);
         const value = getInitialValue(props);
         const time: DateRange = value;
@@ -245,7 +247,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
         );
     }
 
-    public componentDidUpdate(prevProps: IDateRangePickerProps, prevState: IDateRangePickerState) {
+    public componentDidUpdate(prevProps: DateRangePickerProps, prevState: IDateRangePickerState) {
         super.componentDidUpdate(prevProps, prevState);
 
         if (
@@ -266,7 +268,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
         }
     }
 
-    protected validateProps(props: IDateRangePickerProps) {
+    protected validateProps(props: DateRangePickerProps) {
         const { defaultValue, initialMonth, maxDate, minDate, boundaryToModify, value } = props;
         const dateRange: DateRange = [minDate, maxDate];
 
@@ -558,7 +560,7 @@ export class DateRangePicker extends AbstractPureComponent2<IDateRangePickerProp
         this.handleNextState(nextValue);
     };
 
-    private handleShortcutClick = (shortcut: IDateRangeShortcut, selectedShortcutIndex: number) => {
+    private handleShortcutClick = (shortcut: DateRangeShortcut, selectedShortcutIndex: number) => {
         const { onChange, contiguousCalendarMonths, onShortcutChange } = this.props;
         const { dateRange, includeTime } = shortcut;
         if (includeTime) {
@@ -767,7 +769,7 @@ function getStateChange(
     return {};
 }
 
-function getInitialValue(props: IDateRangePickerProps): DateRange | null {
+function getInitialValue(props: DateRangePickerProps): DateRange | null {
     if (props.value != null) {
         return props.value;
     }
@@ -777,7 +779,7 @@ function getInitialValue(props: IDateRangePickerProps): DateRange | null {
     return [null, null];
 }
 
-function getInitialMonth(props: IDateRangePickerProps, value: DateRange): Date {
+function getInitialMonth(props: DateRangePickerProps, value: DateRange): Date {
     const today = new Date();
     // != because we must have a real `Date` to begin the calendar on.
     if (props.initialMonth != null) {

--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -18,14 +18,14 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, DISPLAYNAME_PREFIX, IProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, DISPLAYNAME_PREFIX, Props } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
-import { DatePicker, IDatePickerProps } from "./datePicker";
-import { ITimePickerProps, TimePicker } from "./timePicker";
+import { DatePicker, DatePickerProps } from "./datePicker";
+import { TimePickerProps, TimePicker } from "./timePicker";
 
-export interface IDateTimePickerProps extends IProps {
+export interface IDateTimePickerProps extends Props {
     /**
      * The initial date and time value that will be set.
      * This will be ignored if `value` is set.
@@ -38,7 +38,7 @@ export interface IDateTimePickerProps extends IProps {
      * Any props to be passed on to the `DatePicker` other than the `value` and `onChange` props as they come directly
      * from the `DateTimePicker` props.
      */
-    datePickerProps?: IDatePickerProps;
+    datePickerProps?: DatePickerProps;
 
     /**
      * Callback invoked when the user changes the date or time.
@@ -49,7 +49,7 @@ export interface IDateTimePickerProps extends IProps {
      * Any props to be passed on to the `TimePicker` other than the `value` and `onChange` props as they come directly
      * from the `DateTimePicker` props.
      */
-    timePickerProps?: ITimePickerProps;
+    timePickerProps?: TimePickerProps;
 
     /**
      * The currently set date and time. If this prop is provided, the component acts in a controlled manner.
@@ -105,7 +105,7 @@ export class DateTimePicker extends AbstractPureComponent2<IDateTimePickerProps,
         );
     }
 
-    public componentDidUpdate(prevProps: IDatePickerProps) {
+    public componentDidUpdate(prevProps: DatePickerProps) {
         if (this.props.value === prevProps.value) {
             return;
         } else if (this.props.value != null) {

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -24,18 +24,22 @@ import * as DateUtils from "./common/dateUtils";
 type IDatePickerLocaleUtils = typeof LocaleUtils;
 export { DateUtils, IDatePickerLocaleUtils, IDatePickerDayModifiers };
 
+type DatePickerLocaleUtils = IDatePickerLocaleUtils;
+type DatePickerDayModifiers = IDatePickerDayModifiers;
+export { DatePickerLocaleUtils, DatePickerDayModifiers };
+
 export const Classes = classes;
 
 export { DateRange } from "./common/dateRange";
 export { Months } from "./common/months";
 export { TimeUnit } from "./common/timeUnit";
-export { IDateFormatProps } from "./dateFormat";
-export { DateInput, IDateInputProps } from "./dateInput";
-export { DatePicker, IDatePickerProps } from "./datePicker";
-export { IDatePickerModifiers } from "./datePickerCore";
+export { DateFormatProps, IDateFormatProps } from "./dateFormat";
+export { DateInput, DateInputProps, IDateInputProps } from "./dateInput";
+export { DatePicker, DatePickerProps, IDatePickerProps } from "./datePicker";
+export { DatePickerModifiers, IDatePickerModifiers } from "./datePickerCore";
 // eslint-disable-next-line deprecation/deprecation
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
-export { DateRangeInput, IDateRangeInputProps } from "./dateRangeInput";
-export { DateRangePicker, IDateRangePickerProps } from "./dateRangePicker";
-export { ITimePickerProps, TimePicker, TimePrecision } from "./timePicker";
-export { IDatePickerShortcut, IDateRangeShortcut } from "./shortcuts";
+export { DateRangeInput, DateRangeInputProps, IDateRangeInputProps } from "./dateRangeInput";
+export { DateRangePicker, DateRangePickerProps, IDateRangePickerProps } from "./dateRangePicker";
+export { ITimePickerProps, TimePicker, TimePickerProps, TimePrecision } from "./timePicker";
+export { DatePickerShortcut, DateRangeShortcut, IDatePickerShortcut, IDateRangeShortcut } from "./shortcuts";

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -19,6 +19,8 @@ import { DayModifiers as IDatePickerDayModifiers, LocaleUtils } from "react-day-
 import * as classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
 
+/* eslint-disable deprecation/deprecation */
+
 // re-exporting these symbols to preserve compatility
 
 type IDatePickerLocaleUtils = typeof LocaleUtils;
@@ -37,7 +39,6 @@ export { DateFormatProps, IDateFormatProps } from "./dateFormat";
 export { DateInput, DateInputProps, IDateInputProps } from "./dateInput";
 export { DatePicker, DatePickerProps, IDatePickerProps } from "./datePicker";
 export { DatePickerModifiers, IDatePickerModifiers } from "./datePickerCore";
-// eslint-disable-next-line deprecation/deprecation
 export { DateTimePicker, IDateTimePickerProps } from "./dateTimePicker";
 export { DateRangeInput, DateRangeInputProps, IDateRangeInputProps } from "./dateRangeInput";
 export { DateRangePicker, DateRangePickerProps, IDateRangePickerProps } from "./dateRangePicker";

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -38,7 +38,9 @@ export interface IDateShortcutBase {
     includeTime?: boolean;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type DateRangeShortcut = IDateRangeShortcut;
+/** @deprecated use DateRangeShortcut */
 export interface IDateRangeShortcut extends IDateShortcutBase {
     /**
      * Date range represented by this shortcut. Note that time components of a
@@ -47,7 +49,9 @@ export interface IDateRangeShortcut extends IDateShortcutBase {
     dateRange: DateRange;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type DatePickerShortcut = IDatePickerShortcut;
+/** @deprecated use DatePickerShortcut */
 export interface IDatePickerShortcut extends IDateShortcutBase {
     /**
      * Date represented by this shortcut. Note that time components of a
@@ -60,10 +64,10 @@ export interface IShortcutsProps {
     allowSingleDayRange: boolean;
     minDate: Date;
     maxDate: Date;
-    shortcuts: IDateRangeShortcut[] | true;
+    shortcuts: DateRangeShortcut[] | true;
     timePrecision: TimePrecision;
     selectedShortcutIndex?: number;
-    onShortcutClick: (shortcut: IDateRangeShortcut, index: number) => void;
+    onShortcutClick: (shortcut: DateRangeShortcut, index: number) => void;
     /**
      * The DatePicker component reuses this component for a single date.
      * This changes the default shortcut labels and affects which shortcuts are used.
@@ -106,7 +110,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
         );
     }
 
-    private getShorcutClickHandler = (shortcut: IDateRangeShortcut, index: number) => () => {
+    private getShorcutClickHandler = (shortcut: DateRangeShortcut, index: number) => () => {
         const { onShortcutClick } = this.props;
 
         onShortcutClick(shortcut, index);
@@ -119,7 +123,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
     };
 }
 
-function createShortcut(label: string, dateRange: DateRange): IDateRangeShortcut {
+function createShortcut(label: string, dateRange: DateRange): DateRangeShortcut {
     return { dateRange, label };
 }
 

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -38,6 +38,7 @@ export interface IDateShortcutBase {
     includeTime?: boolean;
 }
 
+export type DateRangeShortcut = IDateRangeShortcut;
 export interface IDateRangeShortcut extends IDateShortcutBase {
     /**
      * Date range represented by this shortcut. Note that time components of a
@@ -46,6 +47,7 @@ export interface IDateRangeShortcut extends IDateShortcutBase {
     dateRange: DateRange;
 }
 
+export type DatePickerShortcut = IDatePickerShortcut;
 export interface IDatePickerShortcut extends IDateShortcutBase {
     /**
      * Date represented by this shortcut. Note that time components of a

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, DISPLAYNAME_PREFIX, HTMLSelect, Icon, Intent, IProps, Keys } from "@blueprintjs/core";
+import { Classes as CoreClasses, DISPLAYNAME_PREFIX, HTMLSelect, Icon, Intent, Props, Keys } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import * as DateUtils from "./common/dateUtils";
@@ -41,8 +41,10 @@ export const TimePrecision = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type TimePrecision = typeof TimePrecision[keyof typeof TimePrecision];
 
+// eslint-disable-next-line deprecation/deprecation
 export type TimePickerProps = ITimePickerProps;
-export interface ITimePickerProps extends IProps {
+/** @deprecated use TimePickerProps */
+export interface ITimePickerProps extends Props {
     /**
      * Whether to focus the first input when it opens initially.
      *
@@ -150,8 +152,8 @@ export interface ITimePickerState {
     isPm?: boolean;
 }
 
-export class TimePicker extends React.Component<ITimePickerProps, ITimePickerState> {
-    public static defaultProps: ITimePickerProps = {
+export class TimePicker extends React.Component<TimePickerProps, ITimePickerState> {
+    public static defaultProps: TimePickerProps = {
         autoFocus: false,
         disabled: false,
         maxTime: getDefaultMaxTime(),
@@ -164,7 +166,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
 
     public static displayName = `${DISPLAYNAME_PREFIX}.TimePicker`;
 
-    public constructor(props?: ITimePickerProps, context?: any) {
+    public constructor(props?: TimePickerProps, context?: any) {
         super(props, context);
 
         let value = props.minTime;
@@ -215,7 +217,7 @@ export class TimePicker extends React.Component<ITimePickerProps, ITimePickerSta
         );
     }
 
-    public componentDidUpdate(prevProps: ITimePickerProps) {
+    public componentDidUpdate(prevProps: TimePickerProps) {
         const didMinTimeChange = prevProps.minTime !== this.props.minTime;
         const didMaxTimeChange = prevProps.maxTime !== this.props.maxTime;
         const didBoundsChange = didMinTimeChange || didMaxTimeChange;

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -41,6 +41,7 @@ export const TimePrecision = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type TimePrecision = typeof TimePrecision[keyof typeof TimePrecision];
 
+export type TimePickerProps = ITimePickerProps;
 export interface ITimePickerProps extends IProps {
     /**
      * Whether to focus the first input when it opens initially.

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -17,10 +17,10 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { HTMLDivProps, IProps, Keys, removeNonHTMLProps } from "@blueprintjs/core";
+import { HTMLDivProps, Props, Keys, removeNonHTMLProps } from "@blueprintjs/core";
 import { createKeyEventHandler } from "@blueprintjs/docs-theme";
 
-export interface IClickToCopyProps extends IProps, HTMLDivProps {
+export interface IClickToCopyProps extends Props, HTMLDivProps {
     /**
      * Additional class names to apply after value has been copied
      *

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -24,7 +24,7 @@ import {
     Card,
     Checkbox,
     H5,
-    IBreadcrumbProps,
+    BreadcrumbProps,
     InputGroup,
     Label,
     RadioGroup,
@@ -43,7 +43,7 @@ const COLLAPSE_FROM_RADIOS = [
     { label: "End", value: Boundary.END.toString() },
 ];
 
-const ITEMS: IBreadcrumbProps[] = [
+const ITEMS: BreadcrumbProps[] = [
     { icon: "folder-close", text: "All files" },
     { icon: "folder-close", text: "Users" },
     { icon: "folder-close", text: "Janet" },
@@ -117,13 +117,12 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
     private handleChangeRenderCurrentAsInput = () =>
         this.setState({ renderCurrentAsInput: !this.state.renderCurrentAsInput });
 
-    private renderBreadcrumbInput = ({ text }: IBreadcrumbProps) => {
+    private renderBreadcrumbInput = ({ text }: BreadcrumbProps) => {
         return <BreadcrumbInput defaultValue={typeof text === "string" ? text : undefined} />;
     };
 }
 
-/* eslint-disable  max-classes-per-file */
-class BreadcrumbInput extends React.PureComponent<IBreadcrumbProps & { defaultValue: string | undefined }> {
+class BreadcrumbInput extends React.PureComponent<BreadcrumbProps & { defaultValue: string | undefined }> {
     public state = {
         text: this.props.defaultValue ?? "",
     };

--- a/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
@@ -22,7 +22,7 @@ import {
     Classes,
     CollapsibleList,
     H5,
-    IMenuItemProps,
+    MenuItemProps,
     Label,
     MenuItem,
     RadioGroup,
@@ -91,7 +91,7 @@ export class CollapsibleListExample extends React.PureComponent<IExampleProps, I
         /* eslint-enable deprecation/deprecation */
     }
 
-    private renderBreadcrumb = (props: IMenuItemProps) => {
+    private renderBreadcrumb = (props: MenuItemProps) => {
         if (props.href != null) {
             return <a className={Classes.BREADCRUMB}>{props.text}</a>;
         } else {

--- a/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
@@ -16,9 +16,9 @@
 
 import * as React from "react";
 
-import { IProps, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { Props, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 
-export interface IFileMenuProps extends IProps {
+export interface IFileMenuProps extends Props {
     shouldDismissPopover?: boolean;
 }
 

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -24,7 +24,7 @@ import {
     Drawer,
     H5,
     HTMLSelect,
-    IOptionProps,
+    OptionProps,
     Label,
     Position,
     Switch,
@@ -165,7 +165,7 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
     private handleClose = () => this.setState({ isOpen: false });
 }
 
-const SIZES: Array<string | IOptionProps> = [
+const SIZES: Array<string | OptionProps> = [
     { label: "Default", value: undefined },
     { label: "Small", value: Drawer.SIZE_SMALL },
     { label: "Standard", value: Drawer.SIZE_STANDARD },

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -25,7 +25,7 @@ import {
     DialogStep,
     Switch,
     Classes,
-    IButtonProps,
+    ButtonProps,
     RadioGroup,
     Radio,
 } from "@blueprintjs/core";
@@ -67,7 +67,7 @@ export class MultistepDialogExample extends React.PureComponent<
     private handleOutsideClickChange = handleBooleanChange(val => this.setState({ canOutsideClickClose: val }));
 
     public render() {
-        const finalButtonProps: Partial<IButtonProps> = {
+        const finalButtonProps: Partial<ButtonProps> = {
             intent: "primary",
             onClick: this.handleClose,
             text: "Close",

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -19,8 +19,8 @@ import {
     H5,
     HTMLSelect,
     Intent,
-    INumericInputProps,
-    IOptionProps,
+    NumericInputProps,
+    OptionProps,
     Label,
     NumericInput,
     Position,
@@ -58,8 +58,8 @@ const BUTTON_POSITIONS = [
     { label: "Right", value: Position.RIGHT },
 ];
 
-export class NumericInputBasicExample extends React.PureComponent<IExampleProps, INumericInputProps> {
-    public state: INumericInputProps = {
+export class NumericInputBasicExample extends React.PureComponent<IExampleProps, NumericInputProps> {
+    public state: NumericInputProps = {
         allowNumericCharactersOnly: true,
         buttonPosition: "right",
         disabled: false,
@@ -82,7 +82,7 @@ export class NumericInputBasicExample extends React.PureComponent<IExampleProps,
 
     private handleIntentChange = handleValueChange((intent: Intent) => this.setState({ intent }));
 
-    private handleButtonPositionChange = handleValueChange((buttonPosition: INumericInputProps["buttonPosition"]) =>
+    private handleButtonPositionChange = handleValueChange((buttonPosition: NumericInputProps["buttonPosition"]) =>
         this.setState({ buttonPosition }),
     );
 
@@ -168,7 +168,7 @@ export class NumericInputBasicExample extends React.PureComponent<IExampleProps,
     private renderSelectMenu(
         label: string,
         value: number | string,
-        options: IOptionProps[],
+        options: OptionProps[],
         onChange: React.FormEventHandler,
     ) {
         return (

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, H5, Intent, ITagProps, Switch, TagInput } from "@blueprintjs/core";
+import { Button, H5, Intent, TagProps, Switch, TagInput } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -94,7 +94,7 @@ export class TagInputExample extends React.PureComponent<IExampleProps, ITagInpu
         // define a new function every time so switch changes will cause it to re-render
         // NOTE: avoid this pattern in your app (use this.getTagProps instead); this is only for
         // example purposes!!
-        const getTagProps = (_v: React.ReactNode, index: number): ITagProps => ({
+        const getTagProps = (_v: React.ReactNode, index: number): TagProps => ({
             intent: tagIntents ? INTENTS[index % INTENTS.length] : Intent.NONE,
             large: props.large,
             minimal: tagMinimal,

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -17,7 +17,7 @@
 import { cloneDeep } from "lodash-es";
 import * as React from "react";
 
-import { Classes, Icon, Intent, ITreeNode, Tree } from "@blueprintjs/core";
+import { Classes, Icon, Intent, TreeNodeInfo, Tree } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Classes as Popover2Classes, ContextMenu2, Tooltip2 } from "@blueprintjs/popover2";
 
@@ -28,7 +28,7 @@ type TreeAction =
     | { type: "DESELECT_ALL" }
     | { type: "SET_IS_SELECTED"; payload: { path: NodePath; isSelected: boolean } };
 
-function forEachNode(nodes: ITreeNode[] | undefined, callback: (node: ITreeNode) => void) {
+function forEachNode(nodes: TreeNodeInfo[] | undefined, callback: (node: TreeNodeInfo) => void) {
     if (nodes === undefined) {
         return;
     }
@@ -39,11 +39,11 @@ function forEachNode(nodes: ITreeNode[] | undefined, callback: (node: ITreeNode)
     }
 }
 
-function forNodeAtPath(nodes: ITreeNode[], path: NodePath, callback: (node: ITreeNode) => void) {
+function forNodeAtPath(nodes: TreeNodeInfo[], path: NodePath, callback: (node: TreeNodeInfo) => void) {
     callback(Tree.nodeFromPath(path, nodes));
 }
 
-function treeExampleReducer(state: ITreeNode[], action: TreeAction) {
+function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
     switch (action.type) {
         case "DESELECT_ALL":
             const newState1 = cloneDeep(state);
@@ -66,7 +66,7 @@ export const TreeExample: React.FC<IExampleProps> = props => {
     const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
 
     const handleNodeClick = React.useCallback(
-        (node: ITreeNode, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
+        (node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
             const originallySelected = node.isSelected;
             if (!e.shiftKey) {
                 dispatch({ type: "DESELECT_ALL" });
@@ -79,14 +79,14 @@ export const TreeExample: React.FC<IExampleProps> = props => {
         [],
     );
 
-    const handleNodeCollapse = React.useCallback((_node: ITreeNode, nodePath: NodePath) => {
+    const handleNodeCollapse = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { path: nodePath, isExpanded: false },
             type: "SET_IS_EXPANDED",
         });
     }, []);
 
-    const handleNodeExpand = React.useCallback((_node: ITreeNode, nodePath: NodePath) => {
+    const handleNodeExpand = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { path: nodePath, isExpanded: true },
             type: "SET_IS_EXPANDED",
@@ -107,7 +107,7 @@ export const TreeExample: React.FC<IExampleProps> = props => {
 };
 
 /* tslint:disable:object-literal-sort-keys so childNodes can come last */
-const INITIAL_STATE: ITreeNode[] = [
+const INITIAL_STATE: TreeNodeInfo[] = [
     {
         id: 0,
         hasCaret: true,

--- a/packages/docs-app/src/examples/datetime-examples/common/formatSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/formatSelect.tsx
@@ -18,15 +18,15 @@ import moment from "moment";
 import * as React from "react";
 
 import { Radio, RadioGroup } from "@blueprintjs/core";
-import { IDateFormatProps } from "@blueprintjs/datetime";
+import { DateFormatProps } from "@blueprintjs/datetime";
 import { handleNumberChange } from "@blueprintjs/docs-theme";
 
 export interface IFormatSelectProps {
     /** Selected formatter. */
-    format: IDateFormatProps;
+    format: DateFormatProps;
 
     /** The callback to fire when a new formatter is chosen. */
-    onChange: (format: IDateFormatProps) => void;
+    onChange: (format: DateFormatProps) => void;
 }
 
 export class FormatSelect extends React.PureComponent<IFormatSelectProps> {
@@ -44,7 +44,7 @@ export class FormatSelect extends React.PureComponent<IFormatSelectProps> {
     }
 }
 
-export const FORMATS: IDateFormatProps[] = [
+export const FORMATS: DateFormatProps[] = [
     {
         formatDate: date => (date == null ? "" : date.toLocaleDateString()),
         parseDate: str => new Date(Date.parse(str)),
@@ -55,7 +55,7 @@ export const FORMATS: IDateFormatProps[] = [
     momentFormatter("YYYY-MM-DD HH:mm:ss"),
 ];
 
-function momentFormatter(format: string): IDateFormatProps {
+function momentFormatter(format: string): DateFormatProps {
     return {
         formatDate: date => moment(date).format(format),
         parseDate: str => moment(str, format).toDate(),

--- a/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import moment from "moment";
 import * as React from "react";
 
-import { Icon, Intent, IProps, Tag } from "@blueprintjs/core";
+import { Icon, Intent, Props, Tag } from "@blueprintjs/core";
 import { DateRange } from "@blueprintjs/datetime";
 
 const FORMAT = "dddd, LL";
@@ -38,7 +38,7 @@ export const MomentDate: React.FunctionComponent<{ date: Date; format?: string; 
 };
 
 export const MomentDateRange: React.FunctionComponent<
-    { range: DateRange; format?: string; withTime?: boolean } & IProps
+    { range: DateRange; format?: string; withTime?: boolean } & Props
 > = ({ className, range: [start, end], withTime = false, format = withTime ? FORMAT_TIME : FORMAT }) => (
     <div className={classNames("docs-date-range", className)}>
         <MomentDate withTime={withTime} date={start} format={format} />

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Position, Switch } from "@blueprintjs/core";
-import { DateInput, IDateFormatProps, TimePrecision } from "@blueprintjs/datetime";
+import { DateInput, DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { FORMATS, FormatSelect } from "./common/formatSelect";
@@ -29,7 +29,7 @@ export interface IDateInputExampleState {
     date: Date | null;
     disabled: boolean;
     fill: boolean;
-    format: IDateFormatProps;
+    format: DateFormatProps;
     reverseMonthAndYearMenus: boolean;
     shortcuts: boolean;
     timePrecision: TimePrecision | undefined;
@@ -126,5 +126,5 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
 
     private handleDateChange = (date: Date | null) => this.setState({ date });
 
-    private handleFormatChange = (format: IDateFormatProps) => this.setState({ format });
+    private handleFormatChange = (format: DateFormatProps) => this.setState({ format });
 }

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Switch } from "@blueprintjs/core";
-import { DateRange, DateRangeInput, IDateFormatProps, TimePrecision } from "@blueprintjs/datetime";
+import { DateRange, DateRangeInput, DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { FORMATS, FormatSelect } from "./common/formatSelect";
@@ -29,7 +29,7 @@ export interface IDateRangeInputExampleState {
     contiguousCalendarMonths: boolean;
     disabled: boolean;
     enableTimePicker: boolean;
-    format: IDateFormatProps;
+    format: DateFormatProps;
     range: DateRange;
     reverseMonthAndYearMenus: boolean;
     selectAllOnFocus: boolean;
@@ -151,7 +151,7 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
         );
     }
 
-    private handleFormatChange = (format: IDateFormatProps) => this.setState({ format });
+    private handleFormatChange = (format: DateFormatProps) => this.setState({ format });
 
     private handleRangeChange = (range: DateRange) => this.setState({ range });
 }

--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -42,7 +42,7 @@ import {
 } from "@blueprintjs/docs-theme";
 import {
     Classes,
-    IPopover2SharedProps,
+    Popover2SharedProps,
     Placement,
     PlacementOptions,
     Popover2,
@@ -69,7 +69,7 @@ export interface IPopover2ExampleState {
     isControlled: boolean;
     isOpen?: boolean;
     minimal?: boolean;
-    modifiers?: IPopover2SharedProps<HTMLElement>["modifiers"];
+    modifiers?: Popover2SharedProps<HTMLElement>["modifiers"];
     placement?: Placement;
     sliderValue?: number;
     usePortal?: boolean;

--- a/packages/docs-app/src/examples/popover2-examples/popover2MinimalExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2MinimalExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Button, Intent } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { IPopover2Props, Popover2 } from "@blueprintjs/popover2";
+import { Popover2Props, Popover2 } from "@blueprintjs/popover2";
 
 import { FileMenu } from "../core-examples/common/fileMenu";
 
@@ -26,7 +26,7 @@ export class Popover2MinimalExample extends React.PureComponent<IExampleProps> {
     public static displayName = "Popover2MinimalExample";
 
     public render() {
-        const baseProps: Partial<IPopover2Props> = { content: <FileMenu />, placement: "bottom-end" };
+        const baseProps: Partial<Popover2Props> = { content: <FileMenu />, placement: "bottom-end" };
 
         return (
             <Example options={false} {...this.props}>

--- a/packages/docs-app/src/examples/popover2-examples/popover2PortalExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2PortalExample.tsx
@@ -18,9 +18,9 @@ import * as React from "react";
 
 import { Button, Code, H5, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { IPopover2Props, Popover2 } from "@blueprintjs/popover2";
+import { Popover2Props, Popover2 } from "@blueprintjs/popover2";
 
-const POPOVER2_PROPS: Partial<IPopover2Props> = {
+const POPOVER2_PROPS: Partial<Popover2Props> = {
     autoFocus: false,
     enforceFocus: false,
     modifiers: {

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, H5, Intent, ITagProps, MenuItem, Switch } from "@blueprintjs/core";
+import { Button, H5, Intent, TagProps, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { ItemRenderer, MultiSelect } from "@blueprintjs/select";
 
@@ -83,7 +83,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
 
     public render() {
         const { allowCreate, films, hasInitialContent, tagMinimal, popoverMinimal, ...flags } = this.state;
-        const getTagProps = (_value: React.ReactNode, index: number): ITagProps => ({
+        const getTagProps = (_value: React.ReactNode, index: number): TagProps => ({
             intent: this.state.intent ? INTENTS[index % INTENTS.length] : Intent.NONE,
             minimal: tagMinimal,
         });

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -20,14 +20,14 @@ import * as React from "react";
 import {
     Classes as CoreClasses,
     IOverlayLifecycleProps,
-    IProps,
+    Props,
     Utils as CoreUtils,
     mergeRefs,
 } from "@blueprintjs/core";
 
 import * as Classes from "./classes";
-import { IPopover2Props, Popover2 } from "./popover2";
-import { IPopover2TargetProps } from "./popover2SharedProps";
+import { Popover2Props, Popover2 } from "./popover2";
+import { Popover2TargetProps } from "./popover2SharedProps";
 
 type Offset = {
     left: number;
@@ -73,8 +73,8 @@ export interface ContextMenu2ChildrenProps {
 
 export interface ContextMenu2Props
     extends IOverlayLifecycleProps,
-        Pick<IPopover2Props, "popoverClassName" | "transitionDuration">,
-        IProps {
+        Pick<Popover2Props, "popoverClassName" | "transitionDuration">,
+        Props {
     /**
      * Menu content. This will usually be a Blueprint `<Menu>` component.
      * This optionally functions as a render prop so you can use component state to render content.
@@ -136,7 +136,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
 
     const targetRef = React.useRef<HTMLDivElement>(null);
     const renderTarget = React.useCallback(
-        ({ ref }: IPopover2TargetProps) => (
+        ({ ref }: Popover2TargetProps) => (
             <div
                 className={Classes.CONTEXT_MENU2_POPOVER2_TARGET}
                 style={targetOffset}

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable deprecation/deprecation */
+
 export * as Classes from "./classes";
 export * as Errors from "./errors";
 export {
@@ -21,7 +23,6 @@ export {
     ContextMenu2Props,
     ContextMenu2ChildrenProps,
     ContextMenu2ContentProps,
-    // eslint-disable-next-line deprecation/deprecation
     ContextMenu2RenderProps,
 } from "./contextMenu2";
 export {

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -27,10 +27,12 @@ export {
 export {
     IPopover2SharedProps,
     IPopover2TargetProps,
+    Popover2SharedProps,
+    Popover2TargetProps,
     PopperBoundary,
     Placement,
     PlacementOptions,
     StrictModifierNames,
 } from "./popover2SharedProps";
-export { IPopover2Props, Popover2, Popover2InteractionKind } from "./popover2";
-export { ITooltip2Props, Tooltip2 } from "./tooltip2";
+export { IPopover2Props, Popover2Props, Popover2, Popover2InteractionKind } from "./popover2";
+export { ITooltip2Props, Tooltip2Props, Tooltip2 } from "./tooltip2";

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -49,6 +49,7 @@ export const Popover2InteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Popover2InteractionKind = typeof Popover2InteractionKind[keyof typeof Popover2InteractionKind];
 
+export type Popover2Props<TProps = React.HTMLProps<HTMLElement>> = IPopover2Props<TProps>;
 export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends IPopover2SharedProps<TProps> {
     /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
     backdropProps?: React.HTMLProps<HTMLDivElement>;

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -35,7 +35,7 @@ import * as Classes from "./classes";
 import * as Errors from "./errors";
 import { POPOVER_ARROW_SVG_SIZE, Popover2Arrow } from "./popover2Arrow";
 import { positionToPlacement } from "./popover2PlacementUtils";
-import { IPopover2SharedProps } from "./popover2SharedProps";
+import { Popover2SharedProps } from "./popover2SharedProps";
 // eslint-disable-next-line import/no-cycle
 import { Tooltip2 } from "./tooltip2";
 import { getBasePlacement, getTransformOrigin } from "./utils";
@@ -49,8 +49,10 @@ export const Popover2InteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Popover2InteractionKind = typeof Popover2InteractionKind[keyof typeof Popover2InteractionKind];
 
+// eslint-disable-next-line deprecation/deprecation
 export type Popover2Props<TProps = React.HTMLProps<HTMLElement>> = IPopover2Props<TProps>;
-export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends IPopover2SharedProps<TProps> {
+/** @deprecated use Popover2Props */
+export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends Popover2SharedProps<TProps> {
     /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
@@ -105,12 +107,13 @@ export interface IPopover2State {
 /**
  * @template T target component props inteface
  */
-export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopover2State> {
+export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopover2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover2`;
 
+    // eslint-disable-next-line deprecation/deprecation
     private popoverRef = Utils.createReactRef<HTMLDivElement>();
 
-    public static defaultProps: IPopover2Props = {
+    public static defaultProps: Popover2Props = {
         boundary: "clippingParents",
         captureDismiss: false,
         defaultIsOpen: false,
@@ -180,7 +183,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
         );
     };
 
-    private getIsOpen(props: IPopover2Props<T>) {
+    private getIsOpen(props: Popover2Props<T>) {
         // disabled popovers should never be allowed to open.
         if (props.disabled) {
             return false;
@@ -223,7 +226,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
         this.updateDarkParent();
     }
 
-    public componentDidUpdate(props: IPopover2Props<T>, state: IPopover2State) {
+    public componentDidUpdate(props: Popover2Props<T>, state: IPopover2State) {
         super.componentDidUpdate(props, state);
         this.updateDarkParent();
 
@@ -240,7 +243,7 @@ export class Popover2<T> extends AbstractPureComponent2<IPopover2Props<T>, IPopo
         }
     }
 
-    protected validateProps(props: IPopover2Props & { children?: React.ReactNode }) {
+    protected validateProps(props: Popover2Props & { children?: React.ReactNode }) {
         if (props.isOpen == null && props.onInteraction != null) {
             console.warn(Errors.POPOVER2_WARN_UNCONTROLLED_ONINTERACTION);
         }

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -23,6 +23,7 @@ export { Boundary as PopperBoundary, Placement, placements as PlacementOptions }
 // copied from @popperjs/core, where it is not exported as public
 export type StrictModifierNames = NonNullable<StrictModifiers["name"]>;
 
+export type Popover2TargetProps = IPopover2TargetProps;
 /**
  * E: target element interface, defaults to HTMLElement in Popover2 component props interface.
  */
@@ -33,6 +34,7 @@ export interface IPopover2TargetProps {
     isOpen: boolean;
 }
 
+export type Popover2SharedProps<T> = IPopover2SharedProps<T>;
 /**
  * Props shared between `Popover2` and `Tooltip2`.
  *

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -17,15 +17,16 @@
 import { Boundary, Placement, placements, RootBoundary, StrictModifiers } from "@popperjs/core";
 import { StrictModifier } from "react-popper";
 
-import { IOverlayableProps, IProps, PopoverPosition } from "@blueprintjs/core";
+import { OverlayableProps, Props, PopoverPosition } from "@blueprintjs/core";
 
 export { Boundary as PopperBoundary, Placement, placements as PlacementOptions };
 // copied from @popperjs/core, where it is not exported as public
 export type StrictModifierNames = NonNullable<StrictModifiers["name"]>;
 
+// eslint-disable-next-line deprecation/deprecation
 export type Popover2TargetProps = IPopover2TargetProps;
 /**
- * E: target element interface, defaults to HTMLElement in Popover2 component props interface.
+ * @deprecated use Popover2TargetProps
  */
 export interface IPopover2TargetProps {
     ref: React.Ref<any>;
@@ -34,14 +35,16 @@ export interface IPopover2TargetProps {
     isOpen: boolean;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type Popover2SharedProps<T> = IPopover2SharedProps<T>;
 /**
  * Props shared between `Popover2` and `Tooltip2`.
  *
  * @template TProps HTML props interface for target element,
  *                  defaults to props for HTMLElement in IPopover2Props and ITooltip2Props
+ * @deprecated use Popover2SharedProps
  */
-export interface IPopover2SharedProps<TProps> extends IOverlayableProps, IProps {
+export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
     /**
      * A boundary element supplied to the "flip" and "preventOverflow" modifiers.
      * This is a shorthand for overriding Popper.js modifier options with the `modifiers` prop.
@@ -153,7 +156,7 @@ export interface IPopover2SharedProps<TProps> extends IOverlayableProps, IProps 
      *
      * Mutually exclusive with children, targetClassName, and targetTagName.
      */
-    renderTarget?: (props: IPopover2TargetProps & TProps) => JSX.Element;
+    renderTarget?: (props: Popover2TargetProps & TProps) => JSX.Element;
 
     /**
      * A root boundary element supplied to the "flip" and "preventOverflow" modifiers.

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -25,6 +25,7 @@ import { Popover2, Popover2InteractionKind } from "./popover2";
 import { TOOLTIP_ARROW_SVG_SIZE } from "./popover2Arrow";
 import { IPopover2SharedProps } from "./popover2SharedProps";
 
+export type Tooltip2Props<TProps = React.HTMLProps<HTMLElement>> = ITooltip2Props<TProps>;
 export interface ITooltip2Props<TProps = React.HTMLProps<HTMLElement>>
     extends IPopover2SharedProps<TProps>,
         IIntentProps {

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -17,18 +17,20 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, DISPLAYNAME_PREFIX, IIntentProps } from "@blueprintjs/core";
+import { Classes as CoreClasses, DISPLAYNAME_PREFIX, IntentProps } from "@blueprintjs/core";
 
 import * as Classes from "./classes";
 // eslint-disable-next-line import/no-cycle
 import { Popover2, Popover2InteractionKind } from "./popover2";
 import { TOOLTIP_ARROW_SVG_SIZE } from "./popover2Arrow";
-import { IPopover2SharedProps } from "./popover2SharedProps";
+import { Popover2SharedProps } from "./popover2SharedProps";
 
+// eslint-disable-next-line deprecation/deprecation
 export type Tooltip2Props<TProps = React.HTMLProps<HTMLElement>> = ITooltip2Props<TProps>;
+/** @deprecated use Tooltip2Props */
 export interface ITooltip2Props<TProps = React.HTMLProps<HTMLElement>>
-    extends IPopover2SharedProps<TProps>,
-        IIntentProps {
+    extends Popover2SharedProps<TProps>,
+        IntentProps {
     /**
      * The content that will be displayed inside of the tooltip.
      */
@@ -72,10 +74,10 @@ export interface ITooltip2Props<TProps = React.HTMLProps<HTMLElement>>
     transitionDuration?: number;
 }
 
-export class Tooltip2<T> extends React.PureComponent<ITooltip2Props<T>> {
+export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tooltip2`;
 
-    public static defaultProps: Partial<ITooltip2Props> = {
+    public static defaultProps: Partial<Tooltip2Props> = {
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
         minimal: false,

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IProps, Utils } from "@blueprintjs/core";
+import { Props, Utils } from "@blueprintjs/core";
 
 import { ItemListRenderer } from "./itemListRenderer";
 import { ItemRenderer } from "./itemRenderer";
@@ -34,7 +34,7 @@ export type ItemsEqualComparator<T> = (itemA: T, itemB: T) => boolean;
 export type ItemsEqualProp<T> = ItemsEqualComparator<T> | keyof T;
 
 /** Reusable generic props for a component that operates on a filterable, selectable list of `items`. */
-export interface IListItemsProps<T> extends IProps {
+export interface IListItemsProps<T> extends Props {
     /**
      * The currently focused item for keyboard interactions, or `null` to
      * indicate that no item is active. If omitted or `undefined`, this prop will be

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -17,19 +17,21 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { DISPLAYNAME_PREFIX, IInputGroupProps2, InputGroup, IOverlayProps, Overlay } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, InputGroupProps2, InputGroup, OverlayProps, Overlay } from "@blueprintjs/core";
 
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
+// eslint-disable-next-line deprecation/deprecation
 export type OmnibarProps<T> = IOmnibarProps<T>;
+/** @deprecated use OmnibarProps */
 export interface IOmnibarProps<T> extends IListItemsProps<T> {
     /**
      * Props to spread to the query `InputGroup`. Use `query` and
      * `onQueryChange` instead of `inputProps.value` and `inputProps.onChange`
      * to control this input.
      */
-    inputProps?: IInputGroupProps2;
+    inputProps?: InputGroupProps2;
 
     /**
      * Toggles the visibility of the omnibar.
@@ -50,14 +52,14 @@ export interface IOmnibarProps<T> extends IListItemsProps<T> {
     onClose?: (event?: React.SyntheticEvent<HTMLElement>) => void;
 
     /** Props to spread to `Overlay`. */
-    overlayProps?: Partial<IOverlayProps>;
+    overlayProps?: Partial<OverlayProps>;
 }
 
-export class Omnibar<T> extends React.PureComponent<IOmnibarProps<T>> {
+export class Omnibar<T> extends React.PureComponent<OmnibarProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Omnibar`;
 
     public static ofType<U>() {
-        return Omnibar as new (props: IOmnibarProps<U>) => Omnibar<U>;
+        return Omnibar as new (props: OmnibarProps<U>) => Omnibar<U>;
     }
 
     private TypedQueryList = QueryList.ofType<T>();

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -22,6 +22,7 @@ import { DISPLAYNAME_PREFIX, IInputGroupProps2, InputGroup, IOverlayProps, Overl
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
+export type OmnibarProps<T> = IOmnibarProps<T>;
 export interface IOmnibarProps<T> extends IListItemsProps<T> {
     /**
      * Props to spread to the query `InputGroup`. Use `query` and

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { AbstractComponent2, DISPLAYNAME_PREFIX, IProps, Keys, Menu, Utils } from "@blueprintjs/core";
+import { AbstractComponent2, DISPLAYNAME_PREFIX, Props, Keys, Menu, Utils } from "@blueprintjs/core";
 
 import {
     executeItemsEqual,
@@ -30,7 +30,9 @@ import {
     renderFilteredItems,
 } from "../../common";
 
+// eslint-disable-next-line deprecation/deprecation
 export type QueryListProps<T> = IQueryListProps<T>;
+/** @deprecated use QueryListProps */
 export interface IQueryListProps<T> extends IListItemsProps<T> {
     /**
      * Initial active item, useful if the parent component is controlling its selectedItem but
@@ -72,7 +74,7 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
  */
 export interface IQueryListRendererProps<T> // Omit `createNewItem`, because it's used strictly for internal tracking.
     extends Pick<IQueryListState<T>, "activeItem" | "filteredItems" | "query">,
-        IProps {
+        Props {
     /**
      * Selection handler that should be invoked when a new item has been chosen,
      * perhaps because the user clicked it.
@@ -138,7 +140,7 @@ export interface IQueryListState<T> {
     query: string;
 }
 
-export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryListState<T>> {
+export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryListState<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.QueryList`;
 
     public static defaultProps = {
@@ -147,7 +149,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
     };
 
     public static ofType<U>() {
-        return QueryList as new (props: IQueryListProps<U>) => QueryList<U>;
+        return QueryList as new (props: QueryListProps<U>) => QueryList<U>;
     }
 
     private itemsParentRef?: HTMLElement | null;
@@ -185,7 +187,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
      */
     private isEnterKeyPressed = false;
 
-    public constructor(props: IQueryListProps<T>, context?: any) {
+    public constructor(props: QueryListProps<T>, context?: any) {
         super(props, context);
 
         const { query = "" } = props;
@@ -224,7 +226,7 @@ export class QueryList<T> extends AbstractComponent2<IQueryListProps<T>, IQueryL
         });
     }
 
-    public componentDidUpdate(prevProps: IQueryListProps<T>) {
+    public componentDidUpdate(prevProps: QueryListProps<T>) {
         if (this.props.activeItem !== undefined && this.props.activeItem !== this.state.activeItem) {
             this.shouldCheckActiveItemInViewport = true;
             this.setState({ activeItem: this.props.activeItem });
@@ -590,7 +592,7 @@ function pxToNumber(value: string | null) {
     return value == null ? 0 : parseInt(value.slice(0, -2), 10);
 }
 
-function getMatchingItem<T>(query: string, { items, itemPredicate }: IQueryListProps<T>): T | undefined {
+function getMatchingItem<T>(query: string, { items, itemPredicate }: QueryListProps<T>): T | undefined {
     if (Utils.isFunction(itemPredicate)) {
         // .find() doesn't exist in ES5. Alternative: use a for loop instead of
         // .filter() so that we can return as soon as we find the first match.
@@ -604,7 +606,7 @@ function getMatchingItem<T>(query: string, { items, itemPredicate }: IQueryListP
     return undefined;
 }
 
-function getFilteredItems<T>(query: string, { items, itemPredicate, itemListPredicate }: IQueryListProps<T>) {
+function getFilteredItems<T>(query: string, { items, itemPredicate, itemListPredicate }: QueryListProps<T>) {
     if (Utils.isFunction(itemListPredicate)) {
         // note that implementations can reorder the items here
         return itemListPredicate(query, items);

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -30,6 +30,7 @@ import {
     renderFilteredItems,
 } from "../../common";
 
+export type QueryListProps<T> = IQueryListProps<T>;
 export interface IQueryListProps<T> extends IListItemsProps<T> {
     /**
      * Initial active item, useful if the parent component is controlling its selectedItem but

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -35,6 +35,7 @@ import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
+export type MultiSelectProps<T> = IMultiSelectProps<T>;
 export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     /**
      * Whether the component should take up the full width of its container.

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -21,7 +21,7 @@ import {
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
     IPopoverProps,
-    ITagInputProps,
+    TagInputProps,
     Keys,
     Popover,
     PopoverInteractionKind,
@@ -35,7 +35,9 @@ import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
+// eslint-disable-next-line deprecation/deprecation
 export type MultiSelectProps<T> = IMultiSelectProps<T>;
+/** @deprecated use MultiSelectProps */
 export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     /**
      * Whether the component should take up the full width of its container.
@@ -83,7 +85,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
 
     /** Props to spread to `TagInput`. Use `query` and `onQueryChange` to control the input. */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    tagInputProps?: Partial<ITagInputProps> & object;
+    tagInputProps?: Partial<TagInputProps> & object;
 
     /** Custom renderer to transform an item into tag content. */
     tagRenderer: (item: T) => React.ReactNode;
@@ -93,7 +95,7 @@ export interface IMultiSelectState {
     isOpen: boolean;
 }
 
-export class MultiSelect<T> extends AbstractPureComponent2<IMultiSelectProps<T>, IMultiSelectState> {
+export class MultiSelect<T> extends AbstractPureComponent2<MultiSelectProps<T>, IMultiSelectState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect`;
 
     public static defaultProps = {
@@ -102,7 +104,7 @@ export class MultiSelect<T> extends AbstractPureComponent2<IMultiSelectProps<T>,
     };
 
     public static ofType<U>() {
-        return MultiSelect as new (props: IMultiSelectProps<U>) => MultiSelect<U>;
+        return MultiSelect as new (props: MultiSelectProps<U>) => MultiSelect<U>;
     }
 
     public state: IMultiSelectState = {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -35,6 +35,7 @@ import {
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
+export type SelectProps<T> = ISelectProps<T>;
 export interface ISelectProps<T> extends IListItemsProps<T> {
     /**
      * Whether the dropdown list can be filtered.

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -21,7 +21,7 @@ import {
     AbstractPureComponent2,
     Button,
     DISPLAYNAME_PREFIX,
-    IInputGroupProps2,
+    InputGroupProps2,
     InputGroup,
     IPopoverProps,
     IRef,
@@ -35,7 +35,9 @@ import {
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
+// eslint-disable-next-line deprecation/deprecation
 export type SelectProps<T> = ISelectProps<T>;
+/** @deprecated use SelectProps */
 export interface ISelectProps<T> extends IListItemsProps<T> {
     /**
      * Whether the dropdown list can be filtered.
@@ -59,7 +61,7 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      * `onQueryChange` instead of `inputProps.value` and `inputProps.onChange`
      * to control this input.
      */
-    inputProps?: IInputGroupProps2;
+    inputProps?: InputGroupProps2;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     // eslint-disable-next-line @typescript-eslint/ban-types
@@ -78,11 +80,11 @@ export interface ISelectState {
     isOpen: boolean;
 }
 
-export class Select<T> extends AbstractPureComponent2<ISelectProps<T>, ISelectState> {
+export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Select`;
 
     public static ofType<U>() {
-        return Select as new (props: ISelectProps<U>) => Select<U>;
+        return Select as new (props: SelectProps<U>) => Select<U>;
     }
 
     public state: ISelectState = { isOpen: false };
@@ -113,7 +115,7 @@ export class Select<T> extends AbstractPureComponent2<ISelectProps<T>, ISelectSt
         );
     }
 
-    public componentDidUpdate(prevProps: ISelectProps<T>, prevState: ISelectState) {
+    public componentDidUpdate(prevProps: SelectProps<T>, prevState: ISelectState) {
         if (prevProps.inputProps?.inputRef !== this.props.inputProps?.inputRef) {
             setRef(prevProps.inputProps?.inputRef, null);
             this.handleInputRef = refHandler(this, "inputElement", this.props.inputProps?.inputRef);

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -35,6 +35,7 @@ import {
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
+export type SuggestProps<T> = ISuggestProps<T>;
 export interface ISuggestProps<T> extends IListItemsProps<T> {
     /**
      * Whether the popover should close after selecting an item.

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import {
     AbstractPureComponent2,
     DISPLAYNAME_PREFIX,
-    IInputGroupProps2,
+    InputGroupProps2,
     InputGroup,
     IPopoverProps,
     IRef,
@@ -35,7 +35,9 @@ import {
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
+// eslint-disable-next-line deprecation/deprecation
 export type SuggestProps<T> = ISuggestProps<T>;
+/** @deprecated use SuggestProps */
 export interface ISuggestProps<T> extends IListItemsProps<T> {
     /**
      * Whether the popover should close after selecting an item.
@@ -58,7 +60,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
      * `query` and `onQueryChange` instead of `inputProps.value` and
      * `inputProps.onChange`.
      */
-    inputProps?: IInputGroupProps2;
+    inputProps?: InputGroupProps2;
 
     /** Custom renderer to transform an item into a string for the input value. */
     inputValueRenderer: (item: T) => string;
@@ -105,10 +107,10 @@ export interface ISuggestState<T> {
     selectedItem: T | null;
 }
 
-export class Suggest<T> extends AbstractPureComponent2<ISuggestProps<T>, ISuggestState<T>> {
+export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggestState<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Suggest`;
 
-    public static defaultProps: Partial<ISuggestProps<any>> = {
+    public static defaultProps: Partial<SuggestProps<any>> = {
         closeOnSelect: true,
         fill: false,
         openOnKeyDown: false,
@@ -116,7 +118,7 @@ export class Suggest<T> extends AbstractPureComponent2<ISuggestProps<T>, ISugges
     };
 
     public static ofType<U>() {
-        return Suggest as new (props: ISuggestProps<U>) => Suggest<U>;
+        return Suggest as new (props: SuggestProps<U>) => Suggest<U>;
     }
 
     public state: ISuggestState<T> = {
@@ -148,7 +150,7 @@ export class Suggest<T> extends AbstractPureComponent2<ISuggestProps<T>, ISugges
         );
     }
 
-    public componentDidUpdate(prevProps: ISuggestProps<T>, prevState: ISuggestState<T>) {
+    public componentDidUpdate(prevProps: SuggestProps<T>, prevState: ISuggestState<T>) {
         if (prevProps.inputProps?.inputRef !== this.props.inputProps?.inputRef) {
             setRef(prevProps.inputProps?.inputRef, null);
             this.handleInputRef = refHandler(this, "inputElement", this.props.inputProps?.inputRef);

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -30,6 +30,7 @@ import { LoadableContent } from "../common/loadableContent";
 import { JSONFormat } from "./formats/jsonFormat";
 import { TruncatedFormat } from "./formats/truncatedFormat";
 
+export type CellProps = ICellProps;
 export interface ICellProps extends IIntentProps, IProps {
     key?: string;
 
@@ -111,6 +112,7 @@ export interface ICellProps extends IIntentProps, IProps {
 }
 
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
+export type CellRenderer = ICellRenderer;
 
 export const emptyCellRenderer = () => <Cell />;
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -19,8 +19,8 @@ import * as React from "react";
 import {
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
-    IIntentProps,
-    IProps,
+    IntentProps,
+    Props,
     IRef,
     Utils as CoreUtils,
 } from "@blueprintjs/core";
@@ -31,7 +31,7 @@ import { JSONFormat } from "./formats/jsonFormat";
 import { TruncatedFormat } from "./formats/truncatedFormat";
 
 export type CellProps = ICellProps;
-export interface ICellProps extends IIntentProps, IProps {
+export interface ICellProps extends IntentProps, Props {
     key?: string;
 
     style?: React.CSSProperties;

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -30,6 +30,7 @@ import * as Classes from "../common/classes";
 import { Draggable } from "../interactions/draggable";
 import { Cell, ICellProps } from "./cell";
 
+export type EditableCellProps = IEditableCellProps;
 export interface IEditableCellProps extends ICellProps {
     /**
      * Whether the given cell is the current active/focused cell.

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -22,7 +22,7 @@ import {
     Hotkey,
     Hotkeys,
     HotkeysTarget,
-    IEditableTextProps,
+    EditableTextProps,
     Utils as CoreUtils,
 } from "@blueprintjs/core";
 
@@ -71,7 +71,7 @@ export interface IEditableCellProps extends ICellProps {
     /**
      * Props that should be passed to the EditableText when it is used to edit
      */
-    editableTextProps?: IEditableTextProps;
+    editableTextProps?: EditableTextProps;
 }
 
 export interface IEditableCellState {

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -22,7 +22,7 @@ import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
 import * as Classes from "../../common/classes";
 import { ITruncatedFormatProps, TruncatedFormat, TruncatedPopoverMode } from "./truncatedFormat";
 
-/* istanbul ignore next */
+export type JSONFormatProps = IJSONFormatProps;
 export interface IJSONFormatProps extends ITruncatedFormatProps {
     children?: any;
 
@@ -42,6 +42,7 @@ export interface IJSONFormatProps extends ITruncatedFormatProps {
     stringify?: (obj: any) => string;
 }
 
+/* istanbul ignore next */
 export class JSONFormat extends React.Component<IJSONFormatProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.JSONFormat`;
 

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { DISPLAYNAME_PREFIX, Icon, IProps, Popover, Position } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, Icon, Props, Popover, Position } from "@blueprintjs/core";
 
 import * as Classes from "../../common/classes";
 import { Utils } from "../../common/utils";
@@ -76,7 +76,7 @@ export interface ITrucatedFormateMeasureByApproximateOptions {
 }
 
 export type TruncatedFormatProps = ITruncatedFormatProps;
-export interface ITruncatedFormatProps extends IProps {
+export interface ITruncatedFormatProps extends Props {
     children?: string;
 
     /**

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -75,6 +75,7 @@ export interface ITrucatedFormateMeasureByApproximateOptions {
     numBufferLines: number;
 }
 
+export type TruncatedFormatProps = ITruncatedFormatProps;
 export interface ITruncatedFormatProps extends IProps {
     children?: string;
 

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { DISPLAYNAME_PREFIX, IProps } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, Props } from "@blueprintjs/core";
 
 import { emptyCellRenderer, ICellRenderer } from "./cell/cell";
 import { IColumnHeaderRenderer } from "./headers/columnHeader";
@@ -24,7 +24,7 @@ import { IColumnNameProps } from "./headers/columnHeaderCell";
 import { ColumnLoadingOption } from "./regions";
 
 export type ColumnProps = IColumnProps;
-export interface IColumnProps extends IColumnNameProps, IProps {
+export interface IColumnProps extends IColumnNameProps, Props {
     /**
      * A unique ID, similar to React's `key`. This is used, for example, to
      * maintain the width of a column between re-ordering and rendering. If no

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -23,6 +23,7 @@ import { IColumnHeaderRenderer } from "./headers/columnHeader";
 import { IColumnNameProps } from "./headers/columnHeaderCell";
 import { ColumnLoadingOption } from "./regions";
 
+export type ColumnProps = IColumnProps;
 export interface IColumnProps extends IColumnNameProps, IProps {
     /**
      * A unique ID, similar to React's `key`. This is used, for example, to

--- a/packages/table/src/common/cell.ts
+++ b/packages/table/src/common/cell.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+export type CellCoordinates = ICellCoordinates;
 export interface ICellCoordinates {
     col: number;
     row: number;
 }
 
+export type FocusedCellCoordinates = IFocusedCellCoordinates;
 export interface IFocusedCellCoordinates extends ICellCoordinates {
     focusSelectionIndex: number;
 }

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -22,7 +22,7 @@ import {
     AbstractPureComponent2,
     Icon,
     IconName,
-    IProps,
+    Props,
     Popover,
     Position,
     Utils as CoreUtils,
@@ -53,7 +53,7 @@ export interface IColumnNameProps {
      * The callback will also receive the column index if an `index` was originally
      * provided via props.
      */
-    nameRenderer?: (name: string, index?: number) => React.ReactElement<IProps>;
+    nameRenderer?: (name: string, index?: number) => React.ReactElement<Props>;
 }
 
 export interface IColumnHeaderCellProps extends IHeaderCellProps, IColumnNameProps {

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -17,12 +17,12 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
+import { EditableText, IntentProps, Props } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 
 export type EditableNameProps = IEditableNameProps;
-export interface IEditableNameProps extends IIntentProps, IProps {
+export interface IEditableNameProps extends IntentProps, Props {
     /**
      * The name displayed in the text box. Be sure to update this value when
      * rendering this component after a confirmed change.

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -21,6 +21,7 @@ import { EditableText, IIntentProps, IProps } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 
+export type EditableNameProps = IEditableNameProps;
 export interface IEditableNameProps extends IIntentProps, IProps {
     /**
      * The name displayed in the text box. Be sure to update this value when

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -17,12 +17,12 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, ContextMenuTarget, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { Classes as CoreClasses, ContextMenuTarget, Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { ResizeHandle } from "../interactions/resizeHandle";
 
-export interface IHeaderCellProps extends IProps {
+export interface IHeaderCellProps extends Props {
     /**
      * The index of the cell in the header. If provided, this will be passed as an argument to any
      * callbacks when they are invoked.

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -27,6 +27,7 @@ import { Header, IHeaderProps } from "./header";
 import { IRowHeaderCellProps, RowHeaderCell } from "./rowHeaderCell";
 
 export type IRowHeaderRenderer = (rowIndex: number) => React.ReactElement<IRowHeaderCellProps>;
+export type RowHeaderRenderer = IRowHeaderRenderer;
 
 export interface IRowHeights {
     minRowHeight?: number;

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -23,6 +23,7 @@ import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
 import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
+export type RowHeaderCellProps = IRowHeaderCellProps;
 export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
     /**
      * Specifies if the row is reorderable.

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, IProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, Props } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
 import { HeaderCell, IHeaderCellProps } from "./headerCell";
 
 export type RowHeaderCellProps = IRowHeaderCellProps;
-export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
+export interface IRowHeaderCellProps extends IHeaderCellProps, Props {
     /**
      * Specifies if the row is reorderable.
      */
@@ -45,7 +45,7 @@ export interface IRowHeaderCellProps extends IHeaderCellProps, IProps {
      * The callback will also receive the row index if an `index` was originally
      * provided via props.
      */
-    nameRenderer?: (name: string, index?: number) => React.ReactElement<IProps>;
+    nameRenderer?: (name: string, index?: number) => React.ReactElement<Props>;
 }
 
 @polyfill

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -69,4 +69,5 @@ export {
     TableLoadingOption,
 } from "./regions";
 
+// eslint-disable-next-line deprecation/deprecation
 export { ITableProps, TableProps, Table } from "./table";

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -14,23 +14,35 @@
  * limitations under the License.
  */
 
-export { Cell, ICellProps, ICellRenderer } from "./cell/cell";
+export { Cell, CellProps, ICellProps, ICellRenderer, CellRenderer } from "./cell/cell";
 
-export { EditableCell, IEditableCellProps } from "./cell/editableCell";
+export { EditableCell, IEditableCellProps, EditableCellProps } from "./cell/editableCell";
 
-export { JSONFormat, IJSONFormatProps } from "./cell/formats/jsonFormat";
+export { JSONFormat, IJSONFormatProps, JSONFormatProps } from "./cell/formats/jsonFormat";
 
-export { TruncatedPopoverMode, TruncatedFormat, ITruncatedFormatProps } from "./cell/formats/truncatedFormat";
+export {
+    TruncatedPopoverMode,
+    TruncatedFormat,
+    TruncatedFormatProps,
+    ITruncatedFormatProps,
+} from "./cell/formats/truncatedFormat";
 
-export { Column, IColumnProps } from "./column";
+export { Column, ColumnProps, IColumnProps } from "./column";
 
 export { AnyRect, Clipboard, Grid, Rect, RenderMode, Utils } from "./common/index";
 
 export { IDraggableProps, Draggable } from "./interactions/draggable";
 
-export { IClientCoordinates, ICoordinateData, IDragHandler } from "./interactions/dragTypes";
+export {
+    IClientCoordinates,
+    ClientCoordinates,
+    ICoordinateData,
+    CoordinateData,
+    IDragHandler,
+    DragHandler,
+} from "./interactions/dragTypes";
 
-export { CopyCellsMenuItem, IContextMenuRenderer, IMenuContext } from "./interactions/menus";
+export { CopyCellsMenuItem, IContextMenuRenderer, ContextMenuRenderer, IMenuContext } from "./interactions/menus";
 
 export { ILockableLayout, IResizeHandleProps, Orientation, ResizeHandle } from "./interactions/resizeHandle";
 
@@ -42,12 +54,13 @@ export { ColumnHeaderCell, IColumnHeaderCellProps, HorizontalCellDivider } from 
 
 export { IRowHeaderCellProps, RowHeaderCell } from "./headers/rowHeaderCell";
 
-export { IEditableNameProps, EditableName } from "./headers/editableName";
+export { IEditableNameProps, EditableNameProps, EditableName } from "./headers/editableName";
 
 export {
     ColumnLoadingOption,
     ICellInterval,
     IRegion,
+    Region,
     IStyledRegionGroup,
     RegionCardinality,
     Regions,
@@ -56,4 +69,4 @@ export {
     TableLoadingOption,
 } from "./regions";
 
-export { ITableProps, Table } from "./table";
+export { ITableProps, TableProps, Table } from "./table";

--- a/packages/table/src/interactions/dragTypes.ts
+++ b/packages/table/src/interactions/dragTypes.ts
@@ -15,7 +15,9 @@
  */
 
 export type IClientCoordinates = [number, number];
+export type ClientCoordinates = IClientCoordinates;
 
+export type CoordinateData = ICoordinateData;
 /**
  * Various useful coordinate values are pre-computed for you and supplied to
  * onDragMove and onDragEnd callbacks.
@@ -47,6 +49,7 @@ export interface ICoordinateData {
     offset: IClientCoordinates;
 }
 
+export type DragHandler = IDragHandler;
 export interface IDragHandler {
     /**
      * Called when the mouse is pressed down. Drag and click operations may

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -17,12 +17,12 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import { DragEvents } from "./dragEvents";
 import { IDragHandler } from "./dragTypes";
 
-export interface IDraggableProps extends IProps, IDragHandler {}
+export interface IDraggableProps extends Props, IDragHandler {}
 
 const REATTACH_PROPS_KEYS = ["stopPropagation", "preventDefault"] as Array<keyof IDraggableProps>;
 

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -16,13 +16,13 @@
 
 import * as React from "react";
 
-import { IMenuItemProps, MenuItem } from "@blueprintjs/core";
+import { MenuItemProps, MenuItem } from "@blueprintjs/core";
 
 import { Clipboard } from "../../common/clipboard";
 import { Regions } from "../../regions";
 import { IMenuContext } from "./menuContext";
 
-export interface ICopyCellsMenuItemProps extends IMenuItemProps {
+export interface ICopyCellsMenuItemProps extends MenuItemProps {
     /**
      * The `IMenuContext` that launched the menu.
      */

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -17,6 +17,7 @@
 import { ICellCoordinate, IRegion, Regions } from "../../regions";
 
 export type IContextMenuRenderer = (context: IMenuContext) => JSX.Element;
+export type ContextMenuRenderer = IContextMenuRenderer;
 
 export interface IMenuContext {
     /**

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractPureComponent2, Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import { Utils } from "../common/index";
 import { ILockableLayout, Orientation, ResizeHandle } from "./resizeHandle";
@@ -25,7 +25,7 @@ import { ILockableLayout, Orientation, ResizeHandle } from "./resizeHandle";
 export type IIndexedResizeCallback = (index: number, size: number) => void;
 export type IndexedResizeCallback = IIndexedResizeCallback;
 
-export interface IResizableProps extends IProps, ILockableLayout {
+export interface IResizableProps extends Props, ILockableLayout {
     /**
      * Enables/disables the resize interaction for the column.
      *
@@ -88,6 +88,7 @@ export interface IResizeableState {
 }
 
 // HACKHACK: https://github.com/palantir/blueprint/issues/4342
+// eslint-disable-next-line deprecation/deprecation
 @(polyfill as CoreUtils.LifecycleCompatPolyfill<IResizableProps, any>)
 export class Resizable extends AbstractPureComponent2<IResizableProps, IResizeableState> {
     public static defaultProps = {

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -23,6 +23,7 @@ import { Utils } from "../common/index";
 import { ILockableLayout, Orientation, ResizeHandle } from "./resizeHandle";
 
 export type IIndexedResizeCallback = (index: number, size: number) => void;
+export type IndexedResizeCallback = IIndexedResizeCallback;
 
 export interface IResizableProps extends IProps, ILockableLayout {
     /**

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { Draggable } from "./draggable";
@@ -32,7 +32,7 @@ export interface ILockableLayout {
     onLayoutLock: (isLayoutLocked?: boolean) => void;
 }
 
-export interface IResizeHandleProps extends IProps, ILockableLayout {
+export interface IResizeHandleProps extends Props, ILockableLayout {
     /**
      * A callback that is called while the user is dragging the resize
      * handle.

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -32,6 +32,7 @@ export type ISelectedRegionTransform = (
     event: MouseEvent | KeyboardEvent,
     coords?: ICoordinateData,
 ) => IRegion;
+export type SelectedRegionTransform = ISelectedRegionTransform;
 
 export interface ISelectableProps {
     /**

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -17,11 +17,11 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 
-export interface IGuideLayerProps extends IProps {
+export interface IGuideLayerProps extends Props {
     /**
      *  The left-offset location of the vertical guides
      */

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { QuadrantType } from "../quadrants/tableQuadrant";
@@ -25,7 +25,7 @@ import { IRegion, Regions } from "../regions";
 
 export type IRegionStyler = (region: IRegion, quadrantType?: QuadrantType) => React.CSSProperties;
 
-export interface IRegionLayerProps extends IProps {
+export interface IRegionLayerProps extends Props {
     /**
      * The array of regions to render.
      */

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractComponent2, IProps, IRef } from "@blueprintjs/core";
+import { AbstractComponent2, Props, IRef } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import * as Errors from "../common/errors";
@@ -47,7 +47,7 @@ export enum QuadrantType {
     TOP_LEFT = "top-left",
 }
 
-export interface ITableQuadrantProps extends IProps {
+export interface ITableQuadrantProps extends Props {
     /**
      * A callback that receives a `ref` to the quadrant's body-wrapping element. Will need to be
      * provided only for the MAIN quadrant, because that quadrant contains the main table body.

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractComponent2, IProps, IRef, setRef, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent2, Props, IRef, setRef, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { Grid } from "../common/grid";
@@ -39,7 +39,7 @@ type QuadrantRefHandler = IRef<HTMLDivElement>;
 type IQuadrantRefs = IQuadrantRefMap<HTMLDivElement>;
 type IQuadrantRefHandlers = IQuadrantRefMap<QuadrantRefHandler>;
 
-export interface ITableQuadrantStackProps extends IProps {
+export interface ITableQuadrantStackProps extends Props {
     /**
      * A callback that receives a `ref` to the main quadrant's table-body element.
      */

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -79,6 +79,7 @@ export enum TableLoadingOption {
     ROW_HEADERS = "row-header",
 }
 
+export type StyledRegionGroup = IStyledRegionGroup;
 export interface IStyledRegionGroup {
     className?: string;
     regions: IRegion[];
@@ -112,6 +113,7 @@ export interface IRegion {
      */
     cols?: ICellInterval | null;
 }
+export type Region = IRegion;
 
 export class Regions {
     /**

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -97,6 +97,7 @@ interface IResizeRowsByApproximateHeightResolvedOptions {
     getNumBufferLines?: number;
 }
 
+export type TableProps = ITableProps;
 export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
     /**
      * The children of a `Table` component, which must be React elements

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -24,7 +24,7 @@ import {
     Hotkey,
     Hotkeys,
     HotkeysTarget,
-    IProps,
+    Props,
     IRef,
     Utils as CoreUtils,
 } from "@blueprintjs/core";
@@ -97,8 +97,10 @@ interface IResizeRowsByApproximateHeightResolvedOptions {
     getNumBufferLines?: number;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export type TableProps = ITableProps;
-export interface ITableProps extends IProps, IRowHeights, IColumnWidths {
+/** @deprecated use TableProps */
+export interface ITableProps extends Props, IRowHeights, IColumnWidths {
     /**
      * The children of a `Table` component, which must be React elements
      * that use `IColumnProps`.
@@ -456,10 +458,10 @@ export interface ITableSnapshot {
 // eslint-disable-next-line deprecation/deprecation
 @HotkeysTarget
 @polyfill
-export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSnapshot> {
+export class Table extends AbstractComponent2<TableProps, ITableState, ITableSnapshot> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Table`;
 
-    public static defaultProps: ITableProps = {
+    public static defaultProps: TableProps = {
         defaultColumnWidth: 150,
         defaultRowHeight: 20,
         enableFocusedCell: false,
@@ -480,7 +482,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
 
     public static childContextTypes: React.ValidationMap<IColumnInteractionBarContextTypes> = columnInteractionBarContextTypes;
 
-    public static getDerivedStateFromProps(props: ITableProps, state: ITableState) {
+    public static getDerivedStateFromProps(props: TableProps, state: ITableState) {
         const {
             children,
             defaultColumnWidth,
@@ -583,7 +585,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
 
     private static SHALLOW_COMPARE_PROP_KEYS_DENYLIST = [
         "selectedRegions", // (intentionally omitted; can be deeply compared to save on re-renders in controlled mode)
-    ] as Array<keyof ITableProps>;
+    ] as Array<keyof TableProps>;
 
     private static SHALLOW_COMPARE_STATE_KEYS_DENYLIST = [
         "selectedRegions", // (intentionally omitted; can be deeply compared to save on re-renders in uncontrolled mode)
@@ -602,7 +604,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
     }
 
     private static isSelectionModeEnabled(
-        props: ITableProps,
+        props: TableProps,
         selectionMode: RegionCardinality,
         selectionModes = props.selectionModes,
     ) {
@@ -644,7 +646,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
      */
     private didCompletelyMount = false;
 
-    public constructor(props: ITableProps, context?: any) {
+    public constructor(props: TableProps, context?: any) {
         super(props, context);
 
         const { children, columnWidths, defaultRowHeight, defaultColumnWidth, numRows, rowHeights } = this.props;
@@ -810,7 +812,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
         };
     }
 
-    public shouldComponentUpdate(nextProps: ITableProps, nextState: ITableState) {
+    public shouldComponentUpdate(nextProps: TableProps, nextState: ITableState) {
         const propKeysDenylist = { exclude: Table.SHALLOW_COMPARE_PROP_KEYS_DENYLIST };
         const stateKeysDenylist = { exclude: Table.SHALLOW_COMPARE_STATE_KEYS_DENYLIST };
 
@@ -948,7 +950,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
         return { nextScrollLeft, nextScrollTop };
     }
 
-    public componentDidUpdate(prevProps: ITableProps, prevState: ITableState, snapshot: ITableSnapshot) {
+    public componentDidUpdate(prevProps: TableProps, prevState: ITableState, snapshot: ITableSnapshot) {
         super.componentDidUpdate(prevProps, prevState, snapshot);
 
         const didChildrenChange =
@@ -984,7 +986,7 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
         }
     }
 
-    protected validateProps(props: ITableProps) {
+    protected validateProps(props: TableProps) {
         const { children, columnWidths, numFrozenColumns, numFrozenRows, numRows, rowHeights } = props;
         const numColumns = React.Children.count(children);
 
@@ -2268,13 +2270,13 @@ export class Table extends AbstractComponent2<ITableProps, ITableState, ITableSn
     }
 }
 
-function clampNumFrozenColumns(props: ITableProps) {
+function clampNumFrozenColumns(props: TableProps) {
     const { numFrozenColumns } = props;
     const numColumns = React.Children.count(props.children);
     return clampPotentiallyNullValue(numFrozenColumns, numColumns);
 }
 
-function clampNumFrozenRows(props: ITableProps) {
+function clampNumFrozenRows(props: TableProps) {
     const { numFrozenRows, numRows } = props;
     return clampPotentiallyNullValue(numFrozenRows, numRows);
 }

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent2, IProps, Utils as CoreUtils } from "@blueprintjs/core";
+import { AbstractComponent2, Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import { emptyCellRenderer, ICellRenderer } from "./cell/cell";
 import { Batcher } from "./common/batcher";
@@ -27,7 +27,7 @@ import { Grid, IColumnIndices, IRowIndices } from "./common/grid";
 import { Rect } from "./common/rect";
 import { RenderMode } from "./common/renderMode";
 
-export interface ITableBodyCellsProps extends IRowIndices, IColumnIndices, IProps {
+export interface ITableBodyCellsProps extends IRowIndices, IColumnIndices, Props {
     /**
      * A cell renderer for the cells in the body.
      */

--- a/packages/timezone/src/components/timezone-picker/timezoneItems.ts
+++ b/packages/timezone/src/components/timezone-picker/timezoneItems.ts
@@ -20,6 +20,7 @@ import { IconName } from "@blueprintjs/core";
 
 import { getTimezoneMetadata, ITimezoneMetadata } from "./timezoneMetadata";
 
+export type TimezoneItem = ITimezoneItem;
 /** Timezone-specific QueryList item */
 export interface ITimezoneItem {
     /** Key to be used as the rendered react key. */

--- a/packages/timezone/src/components/timezone-picker/timezoneItems.ts
+++ b/packages/timezone/src/components/timezone-picker/timezoneItems.ts
@@ -20,8 +20,13 @@ import { IconName } from "@blueprintjs/core";
 
 import { getTimezoneMetadata, ITimezoneMetadata } from "./timezoneMetadata";
 
+// eslint-disable-next-line deprecation/deprecation
 export type TimezoneItem = ITimezoneItem;
-/** Timezone-specific QueryList item */
+/**
+ * Timezone-specific QueryList item
+ *
+ * @deprecated use TimezoneItem
+ */
 export interface ITimezoneItem {
     /** Key to be used as the rendered react key. */
     key: string;
@@ -44,7 +49,7 @@ export interface ITimezoneItem {
  *
  * @param date the date to use when determining timezone offsets
  */
-export function getTimezoneItems(date: Date): ITimezoneItem[] {
+export function getTimezoneItems(date: Date): TimezoneItem[] {
     return moment.tz
         .names()
         .map(timezone => getTimezoneMetadata(timezone, date))
@@ -60,7 +65,7 @@ export function getTimezoneItems(date: Date): ITimezoneItem[] {
  * @param date the date to use when determining timezone offsets
  * @param includeLocalTimezone whether to include the local timezone
  */
-export function getInitialTimezoneItems(date: Date, includeLocalTimezone: boolean): ITimezoneItem[] {
+export function getInitialTimezoneItems(date: Date, includeLocalTimezone: boolean): TimezoneItem[] {
     const populous = getPopulousTimezoneItems(date);
     const local = getLocalTimezoneItem(date);
     return includeLocalTimezone && local !== undefined ? [local, ...populous] : populous;
@@ -71,7 +76,7 @@ export function getInitialTimezoneItems(date: Date, includeLocalTimezone: boolea
  *
  * @param date the date to use when determining timezone offsets
  */
-export function getLocalTimezoneItem(date: Date): ITimezoneItem | undefined {
+export function getLocalTimezoneItem(date: Date): TimezoneItem | undefined {
     const timezone = moment.tz.guess();
     if (timezone !== undefined) {
         const timestamp = date.getTime();
@@ -95,7 +100,7 @@ export function getLocalTimezoneItem(date: Date): ITimezoneItem | undefined {
  *
  * @param date the date to use when determining timezone offsets
  */
-function getPopulousTimezoneItems(date: Date): ITimezoneItem[] {
+function getPopulousTimezoneItems(date: Date): TimezoneItem[] {
     // Filter out noisy timezones. See https://github.com/moment/moment-timezone/issues/227
     const timezones = moment.tz.names().filter(timezone => /\//.test(timezone) && !/Etc\//.test(timezone));
 
@@ -124,7 +129,7 @@ function getPopulousTimezoneItems(date: Date): ITimezoneItem[] {
     );
 }
 
-function toTimezoneItem({ abbreviation, offsetAsString, timezone }: ITimezoneMetadata): ITimezoneItem {
+function toTimezoneItem({ abbreviation, offsetAsString, timezone }: ITimezoneMetadata): TimezoneItem {
     return {
         key: timezone,
         label: offsetAsString,

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -38,6 +38,7 @@ import { getInitialTimezoneItems, getTimezoneItems, ITimezoneItem } from "./time
 
 export { TimezoneDisplayFormat };
 
+export type TimezonePickerProps = ITimezonePickerProps;
 export interface ITimezonePickerProps extends IProps {
     /**
      * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -23,10 +23,10 @@ import {
     Button,
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
-    IButtonProps,
-    IInputGroupProps2,
+    ButtonProps,
+    InputGroupProps2,
     IPopoverProps,
-    IProps,
+    Props,
     MenuItem,
 } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Select } from "@blueprintjs/select";
@@ -34,12 +34,14 @@ import { ItemListPredicate, ItemRenderer, Select } from "@blueprintjs/select";
 import * as Classes from "../../common/classes";
 import * as Errors from "../../common/errors";
 import { formatTimezone, TimezoneDisplayFormat } from "./timezoneDisplayFormat";
-import { getInitialTimezoneItems, getTimezoneItems, ITimezoneItem } from "./timezoneItems";
+import { getInitialTimezoneItems, getTimezoneItems, TimezoneItem } from "./timezoneItems";
 
 export { TimezoneDisplayFormat };
 
+// eslint-disable-next-line deprecation/deprecation
 export type TimezonePickerProps = ITimezonePickerProps;
-export interface ITimezonePickerProps extends IProps {
+/** @deprecated use TimezonePickerProps */
+export interface ITimezonePickerProps extends Props {
     /**
      * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".
      * See https://www.iana.org/time-zones for more information.
@@ -94,7 +96,7 @@ export interface ITimezonePickerProps extends IProps {
      * Props to spread to the target `Button`.
      * This prop will be ignored if `children` is provided.
      */
-    buttonProps?: Partial<IButtonProps>;
+    buttonProps?: Partial<ButtonProps>;
 
     /**
      * Props to spread to the filter `InputGroup`.
@@ -102,7 +104,7 @@ export interface ITimezonePickerProps extends IProps {
      * If you want to control the filter input, you can pass `value` and `onChange` here
      * to override `Select`'s own behavior.
      */
-    inputProps?: IInputGroupProps2;
+    inputProps?: InputGroupProps2;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     popoverProps?: Partial<IPopoverProps>;
@@ -112,13 +114,13 @@ export interface ITimezonePickerState {
     query: string;
 }
 
-const TypedSelect = Select.ofType<ITimezoneItem>();
+const TypedSelect = Select.ofType<TimezoneItem>();
 
 @polyfill
-export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps, ITimezonePickerState> {
+export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, ITimezonePickerState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TimezonePicker`;
 
-    public static defaultProps: Partial<ITimezonePickerProps> = {
+    public static defaultProps: Partial<TimezonePickerProps> = {
         date: new Date(),
         disabled: false,
         inputProps: {},
@@ -128,11 +130,11 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
         valueDisplayFormat: TimezoneDisplayFormat.OFFSET,
     };
 
-    private timezoneItems: ITimezoneItem[];
+    private timezoneItems: TimezoneItem[];
 
-    private initialTimezoneItems: ITimezoneItem[];
+    private initialTimezoneItems: TimezoneItem[];
 
-    constructor(props: ITimezonePickerProps, context?: any) {
+    constructor(props: TimezonePickerProps, context?: any) {
         super(props, context);
 
         const { date = new Date(), showLocalTimezone, inputProps = {} } = props;
@@ -146,7 +148,7 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
         const { children, className, disabled, inputProps, popoverProps } = this.props;
         const { query } = this.state;
 
-        const finalInputProps: IInputGroupProps2 = {
+        const finalInputProps: InputGroupProps2 = {
             placeholder: "Search for timezones...",
             ...inputProps,
         };
@@ -175,7 +177,7 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
         );
     }
 
-    public componentDidUpdate(prevProps: ITimezonePickerProps, prevState: ITimezonePickerState) {
+    public componentDidUpdate(prevProps: TimezonePickerProps, prevState: ITimezonePickerState) {
         super.componentDidUpdate(prevProps, prevState);
         const { date: nextDate = new Date(), inputProps: nextInputProps = {} } = this.props;
 
@@ -204,14 +206,14 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
         return <Button rightIcon="caret-down" disabled={disabled} text={buttonContent} {...buttonProps} />;
     }
 
-    private filterItems: ItemListPredicate<ITimezoneItem> = (query, items) => {
+    private filterItems: ItemListPredicate<TimezoneItem> = (query, items) => {
         // using list predicate so only one RegExp instance is needed
         // escape bad regex characters, let spaces act as any separator
         const expr = new RegExp(query.replace(/([[()+*?])/g, "\\$1").replace(" ", "[ _/\\(\\)]+"), "i");
         return items.filter(item => expr.test(item.text + item.label));
     };
 
-    private renderItem: ItemRenderer<ITimezoneItem> = (item, { handleClick, modifiers }) => {
+    private renderItem: ItemRenderer<TimezoneItem> = (item, { handleClick, modifiers }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
@@ -228,7 +230,7 @@ export class TimezonePicker extends AbstractPureComponent2<ITimezonePickerProps,
         );
     };
 
-    private handleItemSelect = (timezone: ITimezoneItem) => this.props.onChange?.(timezone.timezone);
+    private handleItemSelect = (timezone: TimezoneItem) => this.props.onChange?.(timezone.timezone);
 
     private handleQueryChange = (query: string) => this.setState({ query });
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add type aliases for `I`-prefixed interfaces across the public API. This allows 3.x consumers to start using the new names now, which should make it easier to upgrade to 4.0.
  - I covered most of the interfaces, not all (I believe the ones I missed don't have any real usage outside this repo).
  - Interfaces for components which have "v2" versions (Popover, ContextMenuTarget, HotkeysTarget, PanelStack) did not get type aliases; their "v2" versions were already exporting non-prefixed names.
- Deprecate `I`-prefixed interfaces across the public API to provide TS hints / lint failures to help with the migration.

