### PR TITLE
[docs-theme] add non-prefixed type aliases for some interfaces

### DIFF
--- a/packages/docs-theme/src/components/banner.tsx
+++ b/packages/docs-theme/src/components/banner.tsx
@@ -17,9 +17,9 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Intent, IProps } from "@blueprintjs/core";
+import { Classes, Intent, Props } from "@blueprintjs/core";
 
-export interface IBannerProps extends IProps {
+export interface IBannerProps extends Props {
     /** Link URL. */
     href: string;
 

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -20,13 +20,13 @@ import * as React from "react";
 
 import { Classes, Code, H3 } from "@blueprintjs/core";
 
-import { ITagRendererMap } from "../tags";
+import { TagRendererMap } from "../tags";
 
 export function renderBlock(
     /** the block to render */
     block: IBlock | undefined,
     /** known tag renderers */
-    tagRenderers: ITagRendererMap,
+    tagRenderers: TagRendererMap,
     /** class names to apply to element wrapping string content. */
     textClassName?: string,
 ): JSX.Element | null {

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -18,21 +18,21 @@ import { IHeadingNode, IPageData, IPageNode, isPageNode, ITsDocBase, linkify } f
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Drawer, FocusStyleManager, HotkeysTarget2, IProps, Utils } from "@blueprintjs/core";
+import { Classes, Drawer, FocusStyleManager, HotkeysTarget2, Props, Utils } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, hasTypescriptData, IDocsData, IDocumentationContext } from "../common/context";
 import { eachLayoutNode } from "../common/utils";
-import { ITagRendererMap, TypescriptExample } from "../tags";
+import { TagRendererMap, TypescriptExample } from "../tags";
 import { renderBlock } from "./block";
 import { NavButton } from "./navButton";
 import { Navigator } from "./navigator";
 import { NavMenu } from "./navMenu";
-import { INavMenuItemProps } from "./navMenuItem";
+import { NavMenuItemProps } from "./navMenuItem";
 import { Page } from "./page";
 import { addScrollbarStyle } from "./scrollbar";
 import { ApiLink } from "./typescript/apiLink";
 
-export interface IDocumentationProps extends IProps {
+export interface IDocumentationProps extends Props {
     /**
      * An element to place above the documentation, along the top of the viewport.
      * For best results, use a `Banner` from this package.
@@ -89,7 +89,7 @@ export interface IDocumentationProps extends IProps {
      * Callback invoked to render the clickable nav menu items. (Nested menu structure is handled by the library.)
      * The default implementation renders a `NavMenuItem` element, which is exported from this package.
      */
-    renderNavMenuItem?: (props: INavMenuItemProps) => JSX.Element;
+    renderNavMenuItem?: (props: NavMenuItemProps) => JSX.Element;
 
     /**
      * Callback invoked to render actions for a documentation page.
@@ -105,7 +105,7 @@ export interface IDocumentationProps extends IProps {
     scrollParent?: HTMLElement;
 
     /** Tag renderer functions. Unknown tags will log console errors. */
-    tagRenderers: ITagRendererMap;
+    tagRenderers: TagRendererMap;
 }
 
 export interface IDocumentationState {

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -17,10 +17,10 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface IExampleProps<T = {}> extends IProps {
+export interface IExampleProps<T = {}> extends Props {
     /**
      * Identifier of this example.
      * This will appear as the `data-example-id` attribute on the DOM element.

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -30,7 +30,7 @@ export interface IModifierTableProps {
     descriptionTitle?: string;
 }
 
-export const ModifierTable: React.FunctionComponent<IModifierTableProps> = ({
+export const ModifierTable: React.FC<IModifierTableProps> = ({
     children,
     descriptionTitle = "Description",
     emptyMessage,

--- a/packages/docs-theme/src/components/navButton.tsx
+++ b/packages/docs-theme/src/components/navButton.tsx
@@ -26,7 +26,7 @@ export interface INavButtonProps {
     onClick: () => void;
 }
 
-export const NavButton: React.FunctionComponent<INavButtonProps> = props => (
+export const NavButton: React.FC<INavButtonProps> = props => (
     <div className={classNames("docs-nav-button", Classes.TEXT_MUTED)} onClick={props.onClick}>
         <Icon icon={props.icon} />
         <span className={Classes.FILL}>{props.text}</span>

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -18,20 +18,20 @@ import { IHeadingNode, IPageNode, isPageNode } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, IProps } from "@blueprintjs/core";
+import { Classes, Props } from "@blueprintjs/core";
 
-import { INavMenuItemProps, NavMenuItem } from "./navMenuItem";
+import { NavMenuItemProps, NavMenuItem } from "./navMenuItem";
 
-export interface INavMenuProps extends IProps {
+export interface INavMenuProps extends Props {
     activePageId: string;
     activeSectionId: string;
     level: number;
     onItemClick: (reference: string) => void;
     items: Array<IPageNode | IHeadingNode>;
-    renderNavMenuItem?: (props: INavMenuItemProps) => JSX.Element;
+    renderNavMenuItem?: (props: NavMenuItemProps) => JSX.Element;
 }
 
-export const NavMenu: React.FunctionComponent<INavMenuProps> = props => {
+export const NavMenu: React.FC<INavMenuProps> = props => {
     const { renderNavMenuItem = NavMenuItem } = props;
     const menu = props.items.map(section => {
         const isActive = props.activeSectionId === section.route;

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -20,6 +20,9 @@ import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 
+// eslint-disable-next-line deprecation/deprecation
+export type NavMenuItemProps = INavMenuItemProps;
+/** @deprecated use NavMenuItemProps */
 export interface INavMenuItemProps {
     /** CSS classes to apply to the root element, for proper appearance in the tree. */
     className: string;
@@ -40,7 +43,7 @@ export interface INavMenuItemProps {
     section: IPageNode | IHeadingNode;
 }
 
-export const NavMenuItem: React.FunctionComponent<INavMenuItemProps> = props => {
+export const NavMenuItem: React.FC<NavMenuItemProps> = props => {
     const { className, isActive, isExpanded, section, ...htmlProps } = props;
     return (
         <a className={classNames(Classes.MENU_ITEM, className)} {...htmlProps}>

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -18,7 +18,7 @@ import { IHeadingNode, IPageNode } from "@documentalist/client";
 import { filter } from "fuzzaldrin-plus";
 import * as React from "react";
 
-import { Classes, Icon, IInputGroupProps2, MenuItem } from "@blueprintjs/core";
+import { Classes, Icon, InputGroupProps2, MenuItem } from "@blueprintjs/core";
 import { ItemListPredicate, ItemRenderer, Omnibar } from "@blueprintjs/select";
 
 import { eachLayoutNode } from "../common/utils";
@@ -47,7 +47,7 @@ export interface INavigationSection {
 }
 
 const NavOmnibar = Omnibar.ofType<INavigationSection>();
-const INPUT_PROPS: IInputGroupProps2 = { placeholder: "Fuzzy search headings..." };
+const INPUT_PROPS: InputGroupProps2 = { placeholder: "Fuzzy search headings..." };
 
 export class Navigator extends React.PureComponent<INavigatorProps> {
     private sections: INavigationSection[];

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -19,16 +19,16 @@ import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 
-import { ITagRendererMap } from "../tags";
+import { TagRendererMap } from "../tags";
 import { renderBlock } from "./block";
 
 export interface IPageProps {
     page: IPageData;
     renderActions: (page: IPageData) => React.ReactNode;
-    tagRenderers: ITagRendererMap;
+    tagRenderers: TagRendererMap;
 }
 
-export const Page: React.FunctionComponent<IPageProps> = ({ page, renderActions, tagRenderers }) => {
+export const Page: React.FC<IPageProps> = ({ page, renderActions, tagRenderers }) => {
     // apply running text styles to blocks in pages (but not on blocks in examples)
     const pageContents = renderBlock(page, tagRenderers, Classes.TEXT_LARGE);
     return (

--- a/packages/docs-theme/src/components/typescript/apiLink.tsx
+++ b/packages/docs-theme/src/components/typescript/apiLink.tsx
@@ -16,11 +16,11 @@
 
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";
 
-export interface IApiLinkProps extends IProps {
+export interface IApiLinkProps extends Props {
     children?: never;
     name: string;
 }

--- a/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
+++ b/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
@@ -18,9 +18,7 @@ import * as React from "react";
 
 import { Intent, Tag } from "@blueprintjs/core";
 
-export const DeprecatedTag: React.FunctionComponent<{ isDeprecated: boolean | string | undefined }> = ({
-    isDeprecated,
-}) => {
+export const DeprecatedTag: React.FC<{ isDeprecated: boolean | string | undefined }> = ({ isDeprecated }) => {
     if (isDeprecated === true || typeof isDeprecated === "string") {
         return (
             <Tag intent={Intent.DANGER} minimal={true}>

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -18,7 +18,7 @@ import { ITsEnum, ITsEnumMember } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";
 import { ModifierTable } from "../modifierTable";
@@ -27,7 +27,7 @@ import { DeprecatedTag } from "./deprecatedTag";
 
 export type Renderer<T> = (props: T) => React.ReactNode;
 
-export interface IEnumTableProps extends IProps {
+export interface IEnumTableProps extends Props {
     data: ITsEnum;
 }
 

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -26,7 +26,7 @@ import {
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Intent, IProps, Tag } from "@blueprintjs/core";
+import { Classes, Intent, Props, Tag } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";
 import { ModifierTable } from "../modifierTable";
@@ -35,7 +35,7 @@ import { DeprecatedTag } from "./deprecatedTag";
 
 export type Renderer<T> = (props: T) => React.ReactNode;
 
-export interface IInterfaceTableProps extends IProps {
+export interface IInterfaceTableProps extends Props {
     data: ITsClass | ITsInterface;
     title: string;
 }

--- a/packages/docs-theme/src/components/typescript/methodTable.tsx
+++ b/packages/docs-theme/src/components/typescript/methodTable.tsx
@@ -18,7 +18,7 @@ import { isTag, ITsMethod, ITsParameter, ITsSignature } from "@documentalist/cli
 import classNames from "classnames";
 import * as React from "react";
 
-import { Code, Intent, IProps, Tag } from "@blueprintjs/core";
+import { Code, Intent, Props, Tag } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";
 import { ModifierTable } from "../modifierTable";
@@ -27,7 +27,7 @@ import { DeprecatedTag } from "./deprecatedTag";
 
 export type Renderer<T> = (props: T) => React.ReactNode;
 
-export interface IMethodTableProps extends IProps {
+export interface IMethodTableProps extends Props {
     data: ITsMethod;
 }
 

--- a/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
+++ b/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
@@ -18,12 +18,12 @@ import { ITsTypeAlias } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../../common/context";
 import { ApiHeader } from "./apiHeader";
 
-export interface ITypeAliasTableProps extends IProps {
+export interface ITypeAliasTableProps extends Props {
     data: ITsTypeAlias;
 }
 

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 
 import { Classes, Icon } from "@blueprintjs/core";
 
-export const Heading: React.FunctionComponent<IHeadingTag> = ({ level, route, value }) =>
+export const Heading: React.FC<IHeadingTag> = ({ level, route, value }) =>
     // use createElement so we can dynamically choose tag based on depth
     React.createElement(
         `h${level}`,

--- a/packages/docs-theme/src/tags/index.ts
+++ b/packages/docs-theme/src/tags/index.ts
@@ -16,6 +16,9 @@
 
 import { ITag } from "@documentalist/client";
 
+// eslint-disable-next-line deprecation/deprecation
+export type TagRendererMap = ITagRendererMap;
+/** @deprecated use TagRendererMap */
 export interface ITagRendererMap {
     [tagName: string]: React.ComponentType<ITag> | undefined;
 }

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -17,15 +17,12 @@
 import { isTsClass, isTsMethod, ITag, ITsClass, ITypescriptPluginData } from "@documentalist/client";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
 import { MethodTable } from "../components/typescript/methodTable";
 
-export const Method: React.FunctionComponent<ITag & IProps> = (
-    { className, value },
-    { getDocsData }: IDocumentationContext,
-) => {
+export const Method: React.FC<ITag & Props> = ({ className, value }, { getDocsData }: IDocumentationContext) => {
     const { typescript } = getDocsData() as ITypescriptPluginData;
     const member = typescript[value];
 

--- a/packages/docs-theme/src/tags/reactDocs.tsx
+++ b/packages/docs-theme/src/tags/reactDocs.tsx
@@ -29,7 +29,7 @@ export class ReactDocsTagRenderer {
      * it to an actual component class in the given map, or in the default map which contains
      * valid docs components from this package. Provide a custom map to inject your own components.
      */
-    public render: React.FunctionComponent<ITag> = ({ value: componentName }) => {
+    public render: React.FC<ITag> = ({ value: componentName }) => {
         if (componentName == null) {
             return null;
         }

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -40,7 +40,7 @@ export class ReactExampleTagRenderer {
      * it to an actual example component exported by one of the packages. Also returns
      * the URL of the source code on GitHub.
      */
-    public render: React.FunctionComponent<ITag> = ({ value: exampleName }) => {
+    public render: React.FC<ITag> = ({ value: exampleName }) => {
         if (exampleName == null) {
             return null;
         }

--- a/packages/docs-theme/src/tags/see.tsx
+++ b/packages/docs-theme/src/tags/see.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
 
-export const SeeTag: React.FunctionComponent<ITag> = ({ value }, { renderType }: IDocumentationContext) => (
+export const SeeTag: React.FC<ITag> = ({ value }, { renderType }: IDocumentationContext) => (
     <p>See: {renderType(value)}</p>
 );
 SeeTag.contextTypes = DocumentationContextTypes;

--- a/packages/docs-theme/src/tags/typescript.tsx
+++ b/packages/docs-theme/src/tags/typescript.tsx
@@ -17,14 +17,14 @@
 import { isTsClass, isTsEnum, isTsInterface, isTsTypeAlias, ITag, ITypescriptPluginData } from "@documentalist/client";
 import * as React from "react";
 
-import { IProps } from "@blueprintjs/core";
+import { Props } from "@blueprintjs/core";
 
 import { DocumentationContextTypes, IDocumentationContext } from "../common/context";
 import { EnumTable } from "../components/typescript/enumTable";
 import { InterfaceTable } from "../components/typescript/interfaceTable";
 import { TypeAliasTable } from "../components/typescript/typeAliasTable";
 
-export const TypescriptExample: React.FunctionComponent<ITag & IProps> = (
+export const TypescriptExample: React.FC<ITag & Props> = (
     { className, value },
     { getDocsData }: IDocumentationContext,
 ) => {


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Add type aliases for commonly used interfaces exported from the docs-theme package (similar to #4640), and deprecate the associated interface names
- Fix references to deprecated interface names in docs-theme (need to investigate why the lint task is not failing on these errors in CI...)

