### PR TITLE
Allow ContextMenu2 to accept Popover usePortal prop

### DIFF
--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -73,7 +73,7 @@ export interface ContextMenu2ChildrenProps {
 
 export interface ContextMenu2Props
     extends IOverlayLifecycleProps,
-        Pick<Popover2Props, "popoverClassName" | "transitionDuration">,
+        Pick<Popover2Props, "popoverClassName" | "transitionDuration" | "usePortal">,
         Props {
     /**
      * Menu content. This will usually be a Blueprint `<Menu>` component.


### PR DESCRIPTION
#### Changes proposed in this pull request:

This PR will allow the next ContextMenu2 component to expose usePortal from Popover2Props.

