### PR TITLE
[v4] [docs-theme] fix: switch to new React context API

### DIFF
--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -22,8 +22,7 @@ import {
     ITsDocBase,
     ITypescriptPluginData,
 } from "@documentalist/client";
-
-import { Utils } from "@blueprintjs/core";
+import React, { createContext } from "react";
 
 /* eslint-disable @typescript-eslint/ban-types */
 /** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
@@ -46,12 +45,10 @@ export function hasKssData(docs: DocsData): docs is IMarkdownPluginData & IKssPl
 }
 
 /**
- * Use React context to transparently provide helpful functions to children.
- * This is basically the pauper's Redux store connector: some central state from the root
- * `Documentation` component is exposed to its children so those in the know can speak
- * directly to their parent.
+ * Use React context to provide data and rendering functions from the root `Documentation`
+ * component to other ancestor components defined by the docs-theme package.
  */
-export interface DocumentationContext {
+export interface DocumentationContextApi {
     /**
      * Get the Documentalist data.
      * Use the `hasTypescriptData` and `hasKssData` typeguards before accessing those plugins' data.
@@ -71,34 +68,10 @@ export interface DocumentationContext {
     showApiDocs: (name: string) => void;
 }
 
-/**
- * To enable context access in a React component, assign `static contextTypes` and declare `context` type:
- *
- * ```tsx
- * export class ContextComponent extends React.PureComponent<ApiLinkProps> {
- *     public static contextTypes = DocumentationContextTypes;
- *     public context: DocumentationContext;
- *
- *     public render() {
- *         return this.context.renderBlock(this.props.block);
- *     }
- * }
- * ```
- *
- * NOTE: This does not reference prop-types to avoid copious "cannot be named" errors.
- */
-export const DocumentationContextTypes = {
-    getDocsData: assertFunctionProp,
-    renderBlock: assertFunctionProp,
-    renderType: assertFunctionProp,
-    renderViewSourceLinkText: assertFunctionProp,
-    showApiDocs: assertFunctionProp,
-};
-
-// simple alternative to prop-types dependency
-function assertFunctionProp<T>(obj: T, key: keyof T) {
-    if (obj[key] != null && Utils.isFunction(obj[key])) {
-        return null;
-    }
-    return new Error(`[Blueprint] Documentation context ${key} must be function.`);
-}
+export const DocumentationContext = createContext<DocumentationContextApi>({
+    getDocsData: () => ({} as DocsData),
+    renderBlock: (_block: IBlock) => undefined,
+    renderType: (type: string) => type,
+    renderViewSourceLinkText: (entry: ITsDocBase) => entry.sourceUrl,
+    showApiDocs: () => void 0,
+});

--- a/packages/docs-theme/src/components/typescript/apiHeader.tsx
+++ b/packages/docs-theme/src/components/typescript/apiHeader.tsx
@@ -15,43 +15,36 @@
  */
 
 import { isTsClass, isTsInterface, ITsDocBase } from "@documentalist/client";
-import React from "react";
+import React, { useContext } from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
-import { DocumentationContextTypes, DocumentationContext } from "../../common/context";
+import { DocumentationContext } from "../../common/context";
 
-export class ApiHeader extends React.PureComponent<ITsDocBase> {
-    public static contextTypes = DocumentationContextTypes;
+export const ApiHeader: React.FC<ITsDocBase> = props => {
+    const { renderType, renderViewSourceLinkText } = useContext(DocumentationContext);
+    let inheritance: React.ReactNode = "";
 
-    public static displayName = `${COMPONENT_DISPLAY_NAMESPACE}.ApiHeader`;
+    if (isTsClass(props) || isTsInterface(props)) {
+        const extendsTypes = maybeJoinArray("extends", props.extends);
+        const implementsTypes = maybeJoinArray("implements", props.implements);
+        inheritance = renderType(`${extendsTypes} ${implementsTypes}`);
+    }
 
-    public context: DocumentationContext;
-
-    public render() {
-        return (
-            <div className="docs-interface-header">
-                <div className="docs-interface-name">
-                    <small>{this.props.kind}</small> {this.props.name} <small>{this.renderInheritance()}</small>
-                </div>
-                <small className="docs-package-name">
-                    <a href={this.props.sourceUrl} target="_blank">
-                        {this.context.renderViewSourceLinkText(this.props)}
-                    </a>
-                </small>
-                {this.props.children}
+    return (
+        <div className="docs-interface-header">
+            <div className="docs-interface-name">
+                <small>{props.kind}</small> {props.name} <small>{inheritance}</small>
             </div>
-        );
-    }
-
-    private renderInheritance() {
-        if (isTsClass(this.props) || isTsInterface(this.props)) {
-            const extendsTypes = maybeJoinArray("extends", this.props.extends);
-            const implementsTypes = maybeJoinArray("implements", this.props.implements);
-            return this.context.renderType(`${extendsTypes} ${implementsTypes}`);
-        }
-        return "";
-    }
-}
+            <small className="docs-package-name">
+                <a href={props.sourceUrl} target="_blank">
+                    {renderViewSourceLinkText(props)}
+                </a>
+            </small>
+            {props.children}
+        </div>
+    );
+};
+ApiHeader.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.ApiHeader`;
 
 function maybeJoinArray(title: string, array: string[] | undefined): string {
     if (array == null || array.length === 0) {

--- a/packages/docs-theme/src/components/typescript/apiLink.tsx
+++ b/packages/docs-theme/src/components/typescript/apiLink.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useCallback, useContext } from "react";
 
 import { Props } from "@blueprintjs/core";
 
-import { DocumentationContextTypes, DocumentationContext } from "../../common/context";
+import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
+import { DocumentationContext } from "../../common/context";
 
 export interface ApiLinkProps extends Props {
     children?: never;
@@ -28,22 +29,17 @@ export interface ApiLinkProps extends Props {
 /**
  * Renders a link to open a symbol in the API Browser.
  */
-export class ApiLink extends React.PureComponent<ApiLinkProps> {
-    public static contextTypes = DocumentationContextTypes;
-
-    public context: DocumentationContext;
-
-    public render() {
-        const { className, name } = this.props;
-        return (
-            <a className={className} href={`#api/${name}`} onClick={this.handleClick}>
-                {name}
-            </a>
-        );
-    }
-
-    private handleClick = (evt: React.MouseEvent<HTMLAnchorElement>) => {
+export const ApiLink: React.FC<ApiLinkProps> = ({ className, name }) => {
+    const { showApiDocs } = useContext(DocumentationContext);
+    const handleClick = useCallback((evt: React.MouseEvent<HTMLAnchorElement>) => {
         evt.preventDefault();
-        this.context.showApiDocs(this.props.name);
-    };
-}
+        showApiDocs(name);
+    }, []);
+
+    return (
+        <a className={className} href={`#api/${name}`} onClick={handleClick}>
+            {name}
+        </a>
+    );
+};
+ApiLink.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.ApiLink`;

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -16,12 +16,12 @@
 
 import { ITsEnum, ITsEnumMember } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import React, { useCallback, useContext } from "react";
 
 import { Props } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
-import { DocumentationContextTypes, DocumentationContext } from "../../common/context";
+import { DocumentationContext } from "../../common/context";
 import { ModifierTable } from "../modifierTable";
 import { ApiHeader } from "./apiHeader";
 import { DeprecatedTag } from "./deprecatedTag";
@@ -32,61 +32,51 @@ export interface EnumTableProps extends Props {
     data: ITsEnum;
 }
 
-export class EnumTable extends React.PureComponent<EnumTableProps> {
-    public static contextTypes = DocumentationContextTypes;
+export const EnumTable: React.FC<EnumTableProps> = props => {
+    const { renderBlock } = useContext(DocumentationContext);
 
-    public static displayName = `${COMPONENT_DISPLAY_NAMESPACE}.EnumTable`;
+    const renderPropRow = useCallback(
+        (entry: ITsEnumMember) => {
+            const {
+                flags: { isDeprecated, isExternal },
+                name,
+            } = entry;
 
-    public context: DocumentationContext;
+            const classes = classNames("docs-prop-name", {
+                "docs-prop-is-deprecated": !!isDeprecated,
+                "docs-prop-is-internal": !isExternal,
+            });
 
-    public render() {
-        const { data } = this.props;
-        const { renderBlock } = this.context;
-        return (
-            <div className={classNames("docs-modifiers", this.props.className)}>
-                <ApiHeader {...data} />
-                {renderBlock(data.documentation)}
-                <ModifierTable emptyMessage="This enum is empty." title="Members">
-                    {data.members.map(this.renderPropRow)}
-                </ModifierTable>
-            </div>
-        );
-    }
+            // this is inside RUNNING_TEXT
+            /* eslint-disable @blueprintjs/html-components */
+            return (
+                <tr key={name}>
+                    <td className={classes}>
+                        <code>{name}</code>
+                    </td>
+                    <td className="docs-prop-details">
+                        <code className="docs-prop-type">
+                            <strong>{entry.defaultValue}</strong>
+                        </code>
+                        <div className="docs-prop-description">{renderBlock(entry.documentation)}</div>
+                        <div className="docs-prop-tags">
+                            <DeprecatedTag isDeprecated={isDeprecated} />
+                        </div>
+                    </td>
+                </tr>
+            );
+        },
+        [renderBlock],
+    );
 
-    private renderPropRow = (entry: ITsEnumMember) => {
-        // this is inside RUNNING_TEXT
-        /* eslint-disable @blueprintjs/html-components */
-        const { renderBlock } = this.context;
-        const {
-            flags: { isDeprecated, isExternal },
-            name,
-        } = entry;
-
-        const classes = classNames("docs-prop-name", {
-            "docs-prop-is-deprecated": !!isDeprecated,
-            "docs-prop-is-internal": !isExternal,
-        });
-
-        return (
-            <tr key={name}>
-                <td className={classes}>
-                    <code>{name}</code>
-                </td>
-                <td className="docs-prop-details">
-                    <code className="docs-prop-type">
-                        <strong>{entry.defaultValue}</strong>
-                    </code>
-                    <div className="docs-prop-description">{renderBlock(entry.documentation)}</div>
-                    <div className="docs-prop-tags">{this.renderTags(entry)}</div>
-                </td>
-            </tr>
-        );
-    };
-
-    private renderTags(entry: ITsEnumMember) {
-        const {
-            flags: { isDeprecated },
-        } = entry;
-        return <DeprecatedTag isDeprecated={isDeprecated} />;
-    }
-}
+    return (
+        <div className={classNames("docs-modifiers", props.className)}>
+            <ApiHeader {...props.data} />
+            {renderBlock(props.data.documentation)}
+            <ModifierTable emptyMessage="This enum is empty." title="Members">
+                {props.data.members.map(renderPropRow)}
+            </ModifierTable>
+        </div>
+    );
+};
+EnumTable.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.EnumTable`;

--- a/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
+++ b/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
@@ -16,39 +16,31 @@
 
 import { ITsTypeAlias } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import React, { useContext } from "react";
 
 import { Props } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
-import { DocumentationContextTypes, DocumentationContext } from "../../common/context";
+import { DocumentationContext } from "../../common/context";
 import { ApiHeader } from "./apiHeader";
 
 export interface TypeAliasTableProps extends Props {
     data: ITsTypeAlias;
 }
 
-export class TypeAliasTable extends React.PureComponent<TypeAliasTableProps> {
-    public static contextTypes = DocumentationContextTypes;
-
-    public static displayName = `${COMPONENT_DISPLAY_NAMESPACE}.TypeAliasTable`;
-
-    public context: DocumentationContext;
-
-    public render() {
-        const { data } = this.props;
-        const { renderBlock, renderType } = this.context;
-        const aliases = data.type.split(" | ").map((type, i) => (
-            <div key={i}>
-                {i === 0 ? "=" : "|"} {renderType(type)}
-            </div>
-        ));
-        return (
-            <div className={classNames("docs-modifiers", this.props.className)}>
-                <ApiHeader {...data} />
-                {renderBlock(data.documentation)}
-                <div className="docs-type-alias docs-code">{aliases}</div>
-            </div>
-        );
-    }
-}
+export const TypeAliasTable: React.FC<TypeAliasTableProps> = ({ className, data }) => {
+    const { renderBlock, renderType } = useContext(DocumentationContext);
+    const aliases = data.type.split(" | ").map((type, i) => (
+        <div key={i}>
+            {i === 0 ? "=" : "|"} {renderType(type)}
+        </div>
+    ));
+    return (
+        <div className={classNames("docs-modifiers", className)}>
+            <ApiHeader {...data} />
+            {renderBlock(data.documentation)}
+            <div className="docs-type-alias docs-code">{aliases}</div>
+        </div>
+    );
+};
+TypeAliasTable.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.TypeAliasTable`;

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -16,84 +16,73 @@
 
 import { IKssPluginData, ITag } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import React, { useCallback, useContext, useState } from "react";
 
 import { Checkbox, Classes, Code } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
-import { DocumentationContextTypes, DocumentationContext } from "../common/context";
+import { DocumentationContext } from "../common/context";
 import { Example } from "../components/example";
-
-export interface CssExampleState {
-    modifiers: Set<string>;
-}
-
-export class CssExample extends React.PureComponent<ITag> {
-    public static contextTypes = DocumentationContextTypes;
-
-    public static displayName = `${COMPONENT_DISPLAY_NAMESPACE}.CssExample`;
-
-    public context: DocumentationContext | undefined;
-
-    public state: CssExampleState = { modifiers: new Set<string>() };
-
-    public render() {
-        const { value } = this.props;
-        const { css } = this.context?.getDocsData() as IKssPluginData;
-        if (css == null || css[value] == null) {
-            return null;
-        }
-        const { markup, markupHtml, modifiers, reference } = css[value];
-        const options = modifiers.map(modifier => (
-            <Checkbox
-                key={modifier.name}
-                checked={this.state.modifiers.has(modifier.name)}
-                onChange={this.getModifierToggleHandler(modifier.name)}
-            >
-                <Code data-modifier={modifier.name}>{modifier.name}</Code>
-                <div className="docs-prop-description" dangerouslySetInnerHTML={{ __html: modifier.documentation }} />
-            </Checkbox>
-        ));
-        return (
-            <>
-                <Example
-                    id={reference}
-                    options={options.length > 0 ? options : false}
-                    html={this.renderExample(markup)}
-                />
-                <div
-                    className={classNames("docs-example-markup", Classes.RUNNING_TEXT)}
-                    dangerouslySetInnerHTML={{ __html: markupHtml }}
-                />
-            </>
-        );
-    }
-
-    private getModifierToggleHandler(modifier: string) {
-        return () => {
-            const modifiers = new Set(this.state.modifiers);
-            if (modifiers.has(modifier)) {
-                modifiers.delete(modifier);
-            } else {
-                modifiers.add(modifier);
-            }
-            this.setState({ modifiers });
-        };
-    }
-
-    private renderExample(markup: string) {
-        const classes = this.getModifiers(".");
-        const attrs = this.getModifiers(":");
-        return markup.replace(MODIFIER_ATTR_REGEXP, attrs).replace(MODIFIER_CLASS_REGEXP, classes);
-    }
-
-    private getModifiers(prefix: "." | ":") {
-        return Array.from(this.state.modifiers.keys())
-            .filter(mod => mod.charAt(0) === prefix)
-            .map(mod => mod.slice(1))
-            .join(" ");
-    }
-}
 
 const MODIFIER_ATTR_REGEXP = /\{\{:modifier}}/g;
 const MODIFIER_CLASS_REGEXP = /\{\{\.modifier}}/g;
+
+export const CssExample: React.FC<ITag> = ({ value }) => {
+    const { getDocsData } = useContext(DocumentationContext);
+    const [activeModifiers, setActiveModifiers] = useState<Set<string>>(new Set());
+
+    const getModifierToggleHandler = (modifier: string) => {
+        return () => {
+            const newModifiers = new Set(activeModifiers);
+            if (newModifiers.has(modifier)) {
+                newModifiers.delete(modifier);
+            } else {
+                newModifiers.add(modifier);
+            }
+            setActiveModifiers(newModifiers);
+        };
+    };
+
+    const { css } = getDocsData() as IKssPluginData;
+    if (css == null || css[value] == null) {
+        return null;
+    }
+
+    const { markup, markupHtml, modifiers, reference } = css[value];
+    const options = modifiers.map(modifier => (
+        <Checkbox
+            key={modifier.name}
+            checked={activeModifiers.has(modifier.name)}
+            onChange={getModifierToggleHandler(modifier.name)}
+        >
+            <Code data-modifier={modifier.name}>{modifier.name}</Code>
+            <div className="docs-prop-description" dangerouslySetInnerHTML={{ __html: modifier.documentation }} />
+        </Checkbox>
+    ));
+
+    const getModifiers = useCallback(
+        (prefix: "." | ":") => {
+            return Array.from(activeModifiers.keys())
+                .filter(mod => mod.charAt(0) === prefix)
+                .map(mod => mod.slice(1))
+                .join(" ");
+        },
+        [activeModifiers],
+    );
+    const classModifiers = getModifiers(".");
+    const attrModifiers = getModifiers(":");
+    const exampleHtml = markup
+        .replace(MODIFIER_ATTR_REGEXP, attrModifiers)
+        .replace(MODIFIER_CLASS_REGEXP, classModifiers);
+
+    return (
+        <>
+            <Example id={reference} options={options.length > 0 ? options : false} html={exampleHtml} />
+            <div
+                className={classNames("docs-example-markup", Classes.RUNNING_TEXT)}
+                dangerouslySetInnerHTML={{ __html: markupHtml }}
+            />
+        </>
+    );
+};
+CssExample.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.CssExample`;

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -15,18 +15,16 @@
  */
 
 import { isTsClass, isTsMethod, ITag, ITsClass, ITypescriptPluginData } from "@documentalist/client";
-import React from "react";
+import React, { useContext } from "react";
 
 import { Props } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
-import { DocumentationContextTypes, DocumentationContext } from "../common/context";
+import { DocumentationContext } from "../common/context";
 import { MethodTable } from "../components/typescript/methodTable";
 
-export const Method: React.FunctionComponent<ITag & Props> = (
-    { className, value },
-    { getDocsData }: DocumentationContext,
-) => {
+export const Method: React.FC<ITag & Props> = ({ className, value }) => {
+    const { getDocsData } = useContext(DocumentationContext);
     const { typescript } = getDocsData() as ITypescriptPluginData;
     const member = typescript[value];
 
@@ -47,5 +45,4 @@ export const Method: React.FunctionComponent<ITag & Props> = (
         throw new Error(`"@method ${value}": unknown member kind "${(member as any).kind}"`);
     }
 };
-Method.contextTypes = DocumentationContextTypes;
 Method.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.Method`;

--- a/packages/docs-theme/src/tags/see.tsx
+++ b/packages/docs-theme/src/tags/see.tsx
@@ -15,12 +15,13 @@
  */
 
 import { ITag } from "@documentalist/client";
-import React from "react";
+import React, { useContext } from "react";
 
-import { DocumentationContextTypes, DocumentationContext } from "../common/context";
+import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
+import { DocumentationContext } from "../common/context";
 
-export const SeeTag: React.FunctionComponent<ITag> = ({ value }, { renderType }: DocumentationContext) => (
-    <p>See: {renderType(value)}</p>
-);
-SeeTag.contextTypes = DocumentationContextTypes;
-SeeTag.displayName = "Docs.SeeTag";
+export const SeeTag: React.FC<ITag> = ({ value }) => {
+    const { renderType } = useContext(DocumentationContext);
+    return <p>See: {renderType(value)}</p>;
+};
+SeeTag.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.SeeTag`;

--- a/packages/docs-theme/src/tags/typescript.tsx
+++ b/packages/docs-theme/src/tags/typescript.tsx
@@ -15,20 +15,18 @@
  */
 
 import { isTsClass, isTsEnum, isTsInterface, isTsTypeAlias, ITag, ITypescriptPluginData } from "@documentalist/client";
-import React from "react";
+import React, { useContext } from "react";
 
 import { Props } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
-import { DocumentationContextTypes, DocumentationContext } from "../common/context";
+import { DocumentationContext } from "../common/context";
 import { EnumTable } from "../components/typescript/enumTable";
 import { InterfaceTable } from "../components/typescript/interfaceTable";
 import { TypeAliasTable } from "../components/typescript/typeAliasTable";
 
-export const TypescriptExample: React.FunctionComponent<ITag & Props> = (
-    { className, value },
-    { getDocsData }: DocumentationContext,
-) => {
+export const TypescriptExample: React.FC<ITag & Props> = ({ className, value }) => {
+    const { getDocsData } = useContext(DocumentationContext);
     const { typescript } = getDocsData() as ITypescriptPluginData;
     if (typescript == null || typescript[value] == null) {
         return null;
@@ -46,5 +44,4 @@ export const TypescriptExample: React.FunctionComponent<ITag & Props> = (
         throw new Error(`"@interface ${value}": unknown member kind "${(member as any).kind}"`);
     }
 };
-TypescriptExample.contextTypes = DocumentationContextTypes;
 TypescriptExample.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.TypescriptExample`;


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Remove usage of [legacy context API](https://reactjs.org/docs/legacy-context.html), switch to [stable context API](https://reactjs.org/docs/context.html)
- Refactor many docs-theme components into FCs to use context more easily

#### Reviewers should focus on:

No regressions

