### PR TITLE
[v4] [core] fix(Portal): use new React context API

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -69,8 +69,6 @@ export const POPOVER_WARN_PLACEMENT_AND_POSITION_MUTEX =
     ns + ` <Popover> supports either placement or position prop, not both.`;
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 
-export const PORTAL_CONTEXT_CLASS_NAME_STRING = ns + ` <Portal> context blueprintPortalClassName must be string`;
-
 export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
     ns + ` <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;
 

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -71,7 +71,7 @@ export {
     PopperPlacements,
     StrictModifierNames,
 } from "./popover/popoverSharedProps";
-export * from "./portal/portal";
+export { Portal, PortalProps } from "./portal/portal";
 export * from "./progress-bar/progressBar";
 export * from "./resize-sensor/resizeSensor";
 export * from "./resize-sensor/resizeObserverTypes";

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -5,28 +5,29 @@ hierarchy. It is an essential piece of [`Overlay`](#core/components/overlay), re
 the overlay contents cover the application below. In most cases you do not need to use a `Portal`
 directly; this documentation is provided simply for reference.
 
-@## React 15
+@## Portal context options
 
-In a **React 15** environment, `Portal` will use `ReactDOM.unstable_renderSubtreeIntoContainer` to achieve the teleportation effect, which has a few caveats:
+`Portal` supports some customization through [React context](https://reactjs.org/docs/context.html).
+Using this API can be helpful if you need to apply some custom styling or logic to _all_ Blueprint
+components which use portals (popovers, tooltips, dialogs, etc.). You can do so by rendering a
+`<PortalProvider>` in your React tree (usually, this should be done near the root of your application).
 
-1. `Portal` `children` are wrapped in an extra `<div>` inside the portal container element.
-1. Test harnesses such as `enzyme` cannot trivially find elements "through" Portals as they're not in the same React tree.
-1. React `context` _is_ preserved (this one's a good thing).
+```tsx
+import { Button, Popover, PortalProvider } from "@blueprintjs/core";
+import React from "react";
+import ReactDOM from "react-dom";
 
-In a **React 16+** environment, the `Portal` component will use [`ReactDOM.createPortal`](https://reactjs.org/docs/portals.html) which preserves the React tree perfectly and does not require any of the above caveats.
+ReactDOM.render(
+    <PortalProvider portalClassName="my-custom-class">
+        <Popover content="My portal has a custom class">
+            <Button text="Example" />
+        </Popover>
+    </PortalProvider>
+    document.querySelector("#app"),
+);
+```
 
-@## React context
-
-`Portal` supports the following options on its [React context](https://facebook.github.io/react/docs/context.html).
-To use them, supply a child context to a subtree that contains the Portals you want to customize.
-
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-
-Blueprint uses the React 15-compatible `getChildContext()` API instead of the newer React 16.3 `React.createContext()` API.
-
-</div>
-
-@interface PortalContext
+@interface PortalProviderProps
 
 @## Props
 

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -19,7 +19,7 @@ import ReactDOM from "react-dom";
 
 import * as Classes from "../../common/classes";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
-import { PortalContext, PortalContextState } from "../../context";
+import { PortalContext, PortalContextState } from "../../context/portal/portalProvider";
 
 export interface PortalProps extends Props {
     /**

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -18,9 +18,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import * as Classes from "../../common/classes";
-import { ValidationMap } from "../../common/context";
-import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
+import { PortalContext, PortalContextState } from "../../context";
 
 export interface PortalProps extends Props {
     /**
@@ -40,20 +39,6 @@ export interface PortalState {
     hasMounted: boolean;
 }
 
-export interface PortalContext {
-    /** Additional CSS classes to add to all `Portal` elements in this React context. */
-    blueprintPortalClassName?: string;
-}
-
-const REACT_CONTEXT_TYPES: ValidationMap<PortalContext> = {
-    blueprintPortalClassName: (obj: PortalContext, key: keyof PortalContext) => {
-        if (obj[key] != null && typeof obj[key] !== "string") {
-            return new Error(Errors.PORTAL_CONTEXT_CLASS_NAME_STRING);
-        }
-        return undefined;
-    },
-};
-
 /**
  * This component detaches its contents and re-attaches them to document.body.
  * Use it when you need to circumvent DOM z-stacking (for dialogs, popovers, etc.).
@@ -62,13 +47,11 @@ const REACT_CONTEXT_TYPES: ValidationMap<PortalContext> = {
 export class Portal extends React.Component<PortalProps, PortalState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Portal`;
 
-    public static contextTypes = REACT_CONTEXT_TYPES;
-
     public static defaultProps: PortalProps = {
         container: typeof document !== "undefined" ? document.body : undefined,
     };
 
-    public context: PortalContext = {};
+    public static contextType = PortalContext;
 
     public state: PortalState = { hasMounted: false };
 
@@ -86,10 +69,10 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
 
     public componentDidMount() {
-        if (!this.props.container) {
+        if (this.props.container == null) {
             return;
         }
-        this.portalElement = this.createContainerElement();
+        this.portalElement = this.createPortalElement();
         this.props.container.appendChild(this.portalElement);
         /* eslint-disable-next-line react/no-did-mount-set-state */
         this.setState({ hasMounted: true }, this.props.onChildrenMount);
@@ -106,18 +89,14 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
 
     public componentWillUnmount() {
-        if (this.portalElement != null) {
-            this.portalElement.remove();
-        }
+        this.portalElement?.remove();
     }
 
-    private createContainerElement() {
+    private createPortalElement() {
         const container = document.createElement("div");
         container.classList.add(Classes.PORTAL);
         maybeAddClass(container.classList, this.props.className);
-        if (this.context != null) {
-            maybeAddClass(container.classList, this.context.blueprintPortalClassName);
-        }
+        maybeAddClass(container.classList, (this.context as PortalContextState)?.portalClassName);
         return container;
     }
 }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { HotkeysContext, HotkeysProvider, HotkeysProviderProps } from "./hotkeys/hotkeysProvider";
+export { PortalContext, PortalContextState, PortalProvider, PortalProviderProps } from "./portal/portalProvider";

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { createContext } from "react";
+
+import { DISPLAYNAME_PREFIX } from "../../common";
+
+export interface PortalContextState {
+    /**
+     * Additional CSS classes to add to _each_ `Portal` in this context.
+     */
+    portalClassName?: string;
+}
+
+const initialPortalContextState: PortalContextState = {};
+
+export const PortalContext = createContext<PortalContextState>(initialPortalContextState);
+PortalContext.displayName = `${DISPLAYNAME_PREFIX}.PortalContext`;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PortalProviderProps extends PortalContextState {
+    // empty
+}
+
+export const PortalProvider: React.FC<PortalProviderProps> = ({ portalClassName, children }) => {
+    return <PortalContext.Provider value={{ portalClassName }}>{children}</PortalContext.Provider>;
+};

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -18,7 +18,7 @@ import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import React from "react";
 
-import { Classes, PortalProps, Portal } from "../../src";
+import { Classes, PortalProps, Portal, PortalProvider } from "../../src";
 
 describe("<Portal>", () => {
     let portal: ReactWrapper<PortalProps>;
@@ -73,13 +73,14 @@ describe("<Portal>", () => {
         assert.exists(portal.find(".class-two"));
     });
 
-    it("respects blueprintPortalClassName on context", () => {
+    it("respects portalClassName on <PortalProvider> context", () => {
         const CLASS_TO_TEST = "bp-test-klass bp-other-class";
         portal = mount(
-            <Portal>
-                <p>test</p>
-            </Portal>,
-            { context: { blueprintPortalClassName: CLASS_TO_TEST } },
+            <PortalProvider portalClassName={CLASS_TO_TEST}>
+                <Portal>
+                    <p>test</p>
+                </Portal>
+            </PortalProvider>,
         );
 
         const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Remove usage of [legacy context API](https://reactjs.org/docs/legacy-context.html), switch to [stable context API](https://reactjs.org/docs/context.html)
- Expose new `<PortalProvider>` component which supports the `portalClassName` prop (previously, this was `blueprintPortalClassName` on `this.getChildContext()`)

#### Reviewers should focus on:

No regressions.

Note that I considered moving the portal container element customization API into `<PortalProvider>`, but this turned out to be needlessly complicated (at least for now) and out of scope for this PR.

