### PR TITLE
[v4] fix: do not show icon tooltips by default

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -116,7 +116,7 @@ export class Icon extends AbstractPureComponent<
             intent,
             tagName,
             title = icon,
-            htmlTitle = title,
+            htmlTitle,
             ...htmlProps
         } = this.props;
         const { iconComponent: Component } = this.state;
@@ -136,7 +136,7 @@ export class Icon extends AbstractPureComponent<
                     size={size}
                     tagName={tagName}
                     title={title}
-                    htmlTitle={htmlTitle as string | undefined}
+                    htmlTitle={htmlTitle}
                     {...htmlProps}
                 />
             );

--- a/packages/icons/scripts/iconComponent.tsx.hbs
+++ b/packages/icons/scripts/iconComponent.tsx.hbs
@@ -23,7 +23,7 @@ export const {{pascalCase iconName}}: React.FC<SVGIconProps> = ({
     color,
     size = ICON_SIZE_STANDARD,
     title = "{{iconName}}",
-    htmlTitle = title,
+    htmlTitle,
     tagName = "span",
     ...htmlProps
 }) => {

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -30,7 +30,7 @@ export interface SVGIconProps {
 
     /**
      * String for the `title` attribute on the rendered element, which will appear
-     * on hover as a native browser tooltip. Defaults to the title prop.
+     * on hover as a native browser tooltip.
      */
     htmlTitle?: string;
 


### PR DESCRIPTION
#### Fixes #4650

#### Changes proposed in this pull request:

By setting `htmlTitle = title` by default, this would cause a browser tooltip to appear for each icon:

![image](https://user-images.githubusercontent.com/723999/115911653-59695380-a43c-11eb-81da-6246389af060.png)

We don't want this; it's a regression from v3.x. This PR removes that default value. Only Icons with explicit `htmlTitle` will get the tooltip.

