### PR TITLE
[core] deprecate Icon, Drawer, Spinner size constant static members

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -27,7 +27,7 @@ import {
     MaybeElement,
     Utils,
 } from "../../common";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -186,7 +186,7 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
     protected renderChildren(): React.ReactNode {
         const { children, icon, loading, rightIcon, text } = this.props;
         return [
-            loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={Icon.SIZE_LARGE} />,
+            loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={IconSize.LARGE} />,
             <Icon key="leftIcon" icon={icon} />,
             (!Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children)) && (
                 <span key="text" className={Classes.BUTTON_TEXT}>

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -29,7 +29,7 @@ import {
     MaybeElement,
 } from "../../common";
 import { H4 } from "../html/html";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 
 // eslint-disable-next-line deprecation/deprecation
 export type CalloutProps = ICalloutProps;
@@ -78,7 +78,7 @@ export class Callout extends AbstractPureComponent2<CalloutProps> {
 
         return (
             <div className={classes} {...htmlProps}>
-                {iconName && <Icon icon={iconName} iconSize={Icon.SIZE_LARGE} />}
+                {iconName && <Icon icon={iconName} iconSize={IconSize.LARGE} />}
                 {title && <H4>{title}</H4>}
                 {children}
             </div>

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -23,7 +23,7 @@ import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { Button } from "../button/buttons";
 import { H4 } from "../html/html";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 import { IBackdropProps, OverlayableProps, Overlay } from "../overlay/overlay";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -119,7 +119,7 @@ export class Dialog extends AbstractPureComponent2<DialogProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<Icon icon="small-cross" iconSize={Icon.SIZE_LARGE} />}
+                    icon={<Icon icon="small-cross" iconSize={IconSize.LARGE} />}
                     minimal={true}
                     onClick={this.props.onClose}
                 />
@@ -136,7 +136,7 @@ export class Dialog extends AbstractPureComponent2<DialogProps> {
         }
         return (
             <div className={Classes.DIALOG_HEADER}>
-                <Icon icon={icon} iconSize={Icon.SIZE_LARGE} />
+                <Icon icon={icon} iconSize={IconSize.LARGE} />
                 <H4>{title}</H4>
                 {this.maybeRenderCloseButton()}
             </div>

--- a/packages/core/src/components/drawer/drawer.md
+++ b/packages/core/src/components/drawer/drawer.md
@@ -10,8 +10,8 @@ Drawers overlay content over existing parts of the UI and are anchored to the ed
 
 Use the `size` prop to set the size of the `Drawer`. This prop sets CSS `width` if `vertical={false}` (default) and `height` otherwise. Constants are available for common sizes:
 
-- `Drawer.SIZE_SMALL = 360px`
-- `Drawer.SIZE_STANDARD = 50%` (default)
-- `Drawer.SIZE_LARGE = 90%`
+- `DrawerSize.SMALL = 360px`
+- `DrawerSize.STANDARD = 50%` (default)
+- `DrawerSize.LARGE = 90%`
 
 @interface IDrawerProps

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -24,8 +24,14 @@ import { getPositionIgnoreAngles, isPositionHorizontal, Position } from "../../c
 import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { Button } from "../button/buttons";
 import { H4 } from "../html/html";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 import { IBackdropProps, OverlayableProps, Overlay } from "../overlay/overlay";
+
+export enum DrawerSize {
+    SMALL = "360px",
+    STANDARD = "50%",
+    LARGE = "90%",
+}
 
 // eslint-disable-next-line deprecation/deprecation
 export type DrawerProps = IDrawerProps;
@@ -73,11 +79,11 @@ export interface IDrawerProps extends OverlayableProps, IBackdropProps, Props {
      * and `height` otherwise.
      *
      * Constants are available for common sizes:
-     * - `Drawer.SIZE_SMALL = 360px`
-     * - `Drawer.SIZE_STANDARD = 50%`
-     * - `Drawer.SIZE_LARGE = 90%`
+     * - `DrawerSize.SMALL = 360px`
+     * - `DrawerSize.STANDARD = 50%`
+     * - `DrawerSize.LARGE = 90%`
      *
-     * @default Drawer.SIZE_STANDARD = "50%"
+     * @default DrawerSize.STANDARD = "50%"
      */
     size?: number | string;
 
@@ -122,10 +128,13 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
         vertical: false,
     };
 
+    /** @deprecated use DrawerSize.SMALL */
     public static readonly SIZE_SMALL = "360px";
 
+    /** @deprecated use DrawerSize.STANDARD */
     public static readonly SIZE_STANDARD = "50%";
 
+    /** @deprecated use DrawerSize.LARGE */
     public static readonly SIZE_LARGE = "90%";
 
     private lastActiveElementBeforeOpened: Element | null | undefined;
@@ -194,7 +203,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<Icon icon="small-cross" iconSize={Icon.SIZE_LARGE} />}
+                    icon={<Icon icon="small-cross" iconSize={IconSize.LARGE} />}
                     minimal={true}
                     onClick={this.props.onClose}
                 />
@@ -211,7 +220,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
         }
         return (
             <div className={Classes.DRAWER_HEADER}>
-                <Icon icon={icon} iconSize={Icon.SIZE_LARGE} />
+                <Icon icon={icon} iconSize={IconSize.LARGE} />
                 <H4>{title}</H4>
                 {this.maybeRenderCloseButton()}
             </div>

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -129,13 +129,13 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
     };
 
     /** @deprecated use DrawerSize.SMALL */
-    public static readonly SIZE_SMALL = "360px";
+    public static readonly SIZE_SMALL = DrawerSize.SMALL;
 
     /** @deprecated use DrawerSize.STANDARD */
-    public static readonly SIZE_STANDARD = "50%";
+    public static readonly SIZE_STANDARD = DrawerSize.STANDARD;
 
     /** @deprecated use DrawerSize.LARGE */
-    public static readonly SIZE_LARGE = "90%";
+    public static readonly SIZE_LARGE = DrawerSize.LARGE;
 
     private lastActiveElementBeforeOpened: Element | null | undefined;
 

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -41,7 +41,7 @@ which SVG is rendered and `iconSize` determines which pixel grid is used:
 grid.
 
 ```tsx
-import { Icon, Intent } from "@blueprintjs/core";
+import { Icon, IconSize, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 
 // string literals are supported through IconName union type
@@ -49,7 +49,7 @@ import { IconNames } from "@blueprintjs/icons";
 <Icon icon="globe" iconSize={20} />
 
 // constants are provided for name and size
-<Icon icon={IconNames.GRAPH} iconSize={Icon.SIZE_LARGE} intent={Intent.PRIMARY} />
+<Icon icon={IconNames.GRAPH} iconSize={IconSize.LARGE} intent={Intent.PRIMARY} />
 
 // can pass all valid HTML props
 <Icon icon="add" onClick={this.handleAdd} onKeyDown={this.handleAddKeys} />

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -24,6 +24,11 @@ import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IntentProps, Props
 
 export { IconName };
 
+export enum IconSize {
+    STANDARD = 16,
+    LARGE = 20,
+}
+
 // eslint-disable-next-line deprecation/deprecation
 export type IconProps = IIconProps;
 /** @deprecated use IconProps */
@@ -66,7 +71,7 @@ export interface IIconProps extends IntentProps, Props {
      * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
      * images, and chooses the appropriate resolution based on this prop.
      *
-     * @default Icon.SIZE_STANDARD = 16
+     * @default IconSize.STANDARD = 16
      */
     iconSize?: number;
 
@@ -93,9 +98,11 @@ export interface IIconProps extends IntentProps, Props {
 export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttributes<HTMLElement>, "title">> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Icon`;
 
-    public static readonly SIZE_STANDARD = 16;
+    /** @deprecated use IconSize.STANDARD */
+    public static readonly SIZE_STANDARD = IconSize.STANDARD;
 
-    public static readonly SIZE_LARGE = 20;
+    /** @deprecated use IconSize.LARGE */
+    public static readonly SIZE_LARGE = IconSize.LARGE;
 
     public render(): JSX.Element | null {
         const { icon } = this.props;
@@ -109,7 +116,7 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
             className,
             color,
             htmlTitle,
-            iconSize = Icon.SIZE_STANDARD,
+            iconSize = IconSize.STANDARD,
             intent,
             title = icon,
             tagName = "span",
@@ -117,7 +124,7 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
         } = this.props;
 
         // choose which pixel grid is most appropriate for given icon size
-        const pixelGridSize = iconSize >= Icon.SIZE_LARGE ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD;
+        const pixelGridSize = iconSize >= IconSize.LARGE ? IconSize.LARGE : IconSize.STANDARD;
         // render path elements, or nothing if icon name is unknown.
         const paths = this.renderSvgPaths(pixelGridSize, icon);
 
@@ -141,7 +148,7 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
 
     /** Render `<path>` elements for the given icon name. Returns `null` if name is unknown. */
     private renderSvgPaths(pathsSize: number, iconName: IconName): JSX.Element[] | null {
-        const svgPathsRecord = pathsSize === Icon.SIZE_STANDARD ? IconSvgPaths16 : IconSvgPaths20;
+        const svgPathsRecord = pathsSize === IconSize.STANDARD ? IconSvgPaths16 : IconSvgPaths20;
         const pathStrings = svgPathsRecord[iconName];
         if (pathStrings == null) {
             return null;

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -23,7 +23,7 @@ import * as Classes from "../../common/classes";
 import { DISPLAYNAME_PREFIX, Props, MaybeElement } from "../../common/props";
 import { ensureElement } from "../../common/utils";
 import { H4 } from "../html/html";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 
 // eslint-disable-next-line deprecation/deprecation
 export type NonIdealStateProps = INonIdealStateProps;
@@ -75,7 +75,7 @@ export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
         } else {
             return (
                 <div className={Classes.NON_IDEAL_STATE_VISUAL}>
-                    <Icon icon={icon} iconSize={Icon.SIZE_LARGE * 3} />
+                    <Icon icon={icon} iconSize={IconSize.LARGE * 3} />
                 </div>
             );
         }

--- a/packages/core/src/components/spinner/spinner.md
+++ b/packages/core/src/components/spinner/spinner.md
@@ -16,8 +16,8 @@ changes. Omitting `value` will result in an "indeterminate" spinner where the
 head spins indefinitely (this is the default appearance).
 
 The `size` prop determines the pixel width/height of the spinner. Size constants
-are provided as static properties: `Spinner.SIZE_SMALL`,
-`Spinner.SIZE_STANDARD`, `Spinner.SIZE_LARGE`. Small and large sizes can be set
+are provided as an enum: `SpinnerSize.SMALL`,
+`SpinnerSize.STANDARD`, `SpinnerSize.LARGE`. Small and large sizes can be set
 by including `Classes.SMALL` or `Classes.LARGE` in `className` instead of the
 `size` prop (this prevents an API break when upgrading to 3.x).
 

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -23,6 +23,12 @@ import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 
+export enum SpinnerSize {
+    SMALL = 20,
+    STANDARD = 50,
+    LARGE = 100,
+}
+
 // see http://stackoverflow.com/a/18473154/3124288 for calculating arc path
 const R = 45;
 const SPINNER_TRACK = `M 50,50 m 0,-${R} a ${R},${R} 0 1 1 0,${R * 2} a ${R},${R} 0 1 1 0,-${R * 2}`;
@@ -45,11 +51,11 @@ export interface ISpinnerProps extends Props, IntentProps {
      * 10px.
      *
      * Constants are available for common sizes:
-     * - `Spinner.SIZE_SMALL = 20px`
-     * - `Spinner.SIZE_STANDARD = 50px`
-     * - `Spinner.SIZE_LARGE = 100px`
+     * - `SpinnerSize.SMALL = 20px`
+     * - `SpinnerSize.STANDARD = 50px`
+     * - `SpinnerSize.LARGE = 100px`
      *
-     * @default Spinner.SIZE_STANDARD = 50
+     * @default SpinnerSize.STANDARD = 50
      */
     size?: number;
 
@@ -73,11 +79,14 @@ export interface ISpinnerProps extends Props, IntentProps {
 export class Spinner extends AbstractPureComponent2<SpinnerProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Spinner`;
 
-    public static readonly SIZE_SMALL = 20;
+    /** @deprecated use SpinnerSize.SMALL */
+    public static readonly SIZE_SMALL = SpinnerSize.SMALL;
 
-    public static readonly SIZE_STANDARD = 50;
+    /** @deprecated use SpinnerSize.STANDARD */
+    public static readonly SIZE_STANDARD = SpinnerSize.STANDARD;
 
-    public static readonly SIZE_LARGE = 100;
+    /** @deprecated use SpinnerSize.LARGE */
+    public static readonly SIZE_LARGE = SpinnerSize.LARGE;
 
     public componentDidUpdate(prevProps: SpinnerProps) {
         if (prevProps.value !== this.props.value) {
@@ -98,7 +107,7 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
         );
 
         // keep spinner track width consistent at all sizes (down to about 10px).
-        const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * Spinner.SIZE_LARGE) / size);
+        const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / size);
         const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
 
         // multiple DOM elements around SVG are necessary to properly isolate animation:
@@ -144,11 +153,11 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
         if (size == null) {
             // allow Classes constants to determine default size.
             if (className.indexOf(Classes.SMALL) >= 0) {
-                return Spinner.SIZE_SMALL;
+                return SpinnerSize.SMALL;
             } else if (className.indexOf(Classes.LARGE) >= 0) {
-                return Spinner.SIZE_LARGE;
+                return SpinnerSize.LARGE;
             }
-            return Spinner.SIZE_STANDARD;
+            return SpinnerSize.STANDARD;
         }
         return Math.max(MIN_SIZE, size);
     }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -20,7 +20,7 @@ import { polyfill } from "react-lifecycles-compat";
 
 import { AbstractPureComponent2, Classes, IRef, Keys, refHandler, setRef, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IntentProps, Props, MaybeElement } from "../../common/props";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 import { TagProps, Tag } from "../tag/tag";
 
 /**
@@ -255,7 +255,7 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
                 <Icon
                     className={Classes.TAG_INPUT_ICON}
                     icon={leftIcon}
-                    iconSize={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD}
+                    iconSize={isLarge ? IconSize.LARGE : IconSize.STANDARD}
                 />
                 <div className={Classes.TAG_INPUT_VALUES}>
                     {values.map(this.maybeRenderTag)}

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -29,7 +29,7 @@ import {
     Utils,
 } from "../../common";
 import { isReactNodeEmpty } from "../../common/utils";
-import { Icon, IconName } from "../icon/icon";
+import { Icon, IconName, IconSize } from "../icon/icon";
 import { Text } from "../text/text";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -166,7 +166,7 @@ export class Tag extends AbstractPureComponent2<TagProps> {
                 onClick={this.onRemoveClick}
                 tabIndex={interactive ? tabIndex : undefined}
             >
-                <Icon icon="small-cross" iconSize={isLarge ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD} />
+                <Icon icon="small-cross" iconSize={isLarge ? IconSize.LARGE : IconSize.LARGE} />
             </button>
         ) : null;
 

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -19,7 +19,7 @@ import { mount } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { Button, Classes, Dialog, H4, Icon } from "../../src";
+import { Button, Classes, Dialog, H4, Icon, IconSize } from "../../src";
 import * as Keys from "../../src/common/keys";
 
 describe("<Dialog>", () => {
@@ -151,7 +151,7 @@ describe("<Dialog>", () => {
     function createDialogContents(): JSX.Element[] {
         return [
             <div className={Classes.DIALOG_HEADER} key={0}>
-                <Icon icon="inbox" iconSize={Icon.SIZE_LARGE} />
+                <Icon icon="inbox" iconSize={IconSize.LARGE} />
                 <H4>Dialog header</H4>
             </div>,
             <div className={Classes.DIALOG_BODY} key={1}>

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 
 import { IconName } from "@blueprintjs/icons";
 
-import { Classes, Icon, IIconProps, Intent } from "../../src";
+import { Classes, Icon, IconSize, IIconProps, Intent } from "../../src";
 
 describe("<Icon>", () => {
     it("tagName dictates HTML tag", () => {
@@ -30,10 +30,10 @@ describe("<Icon>", () => {
     });
 
     it("iconSize=16 renders standard size", () =>
-        assertIconSize(<Icon icon="graph" iconSize={Icon.SIZE_STANDARD} />, Icon.SIZE_STANDARD));
+        assertIconSize(<Icon icon="graph" iconSize={IconSize.STANDARD} />, IconSize.STANDARD));
 
     it("iconSize=20 renders large size", () =>
-        assertIconSize(<Icon icon="graph" iconSize={Icon.SIZE_LARGE} />, Icon.SIZE_LARGE));
+        assertIconSize(<Icon icon="graph" iconSize={IconSize.LARGE} />, IconSize.LARGE));
 
     it("renders intent class", () =>
         assert.isTrue(shallow(<Icon icon="add" intent={Intent.DANGER} />).hasClass(Classes.INTENT_DANGER)));

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -19,7 +19,7 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import { stub } from "sinon";
 
-import { Classes, Spinner } from "../../src";
+import { Classes, Spinner, SpinnerSize } from "../../src";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../src/common/errors";
 
 describe("Spinner", () => {
@@ -38,10 +38,10 @@ describe("Spinner", () => {
 
     it("Classes.LARGE/SMALL determine default size", () => {
         const root = mount(<Spinner className={Classes.SMALL} />);
-        assert.equal(root.find("svg").prop("height"), Spinner.SIZE_SMALL, "small");
+        assert.equal(root.find("svg").prop("height"), SpinnerSize.SMALL, "small");
 
         root.setProps({ className: Classes.LARGE });
-        assert.equal(root.find("svg").prop("height"), Spinner.SIZE_LARGE, "large");
+        assert.equal(root.find("svg").prop("height"), SpinnerSize.LARGE, "large");
     });
 
     it("size overrides Classes.LARGE/SMALL", () => {
@@ -74,7 +74,7 @@ describe("Spinner", () => {
                 .find("svg")
                 .prop("viewBox");
         }
-        assert.notEqual(viewBox(Spinner.SIZE_SMALL), viewBox(Spinner.SIZE_LARGE), "expected different viewBoxes");
+        assert.notEqual(viewBox(SpinnerSize.SMALL), viewBox(SpinnerSize.LARGE), "expected different viewBoxes");
     });
 
     function assertStrokePercent(wrapper: ReactWrapper<any>, percent: number) {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 import { CaptionElementProps } from "react-day-picker";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Divider, HTMLSelect, Icon, OptionProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, Divider, HTMLSelect, Icon, IconSize, OptionProps } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import { clone } from "./common/dateUtils";
@@ -128,7 +128,7 @@ export class DatePickerCaption extends AbstractPureComponent2<IDatePickerCaption
         );
         const monthSelectWidth =
             this.containerElement == null ? 0 : this.containerElement.firstElementChild.clientWidth;
-        const rightOffset = Math.max(2, monthSelectWidth - monthTextWidth - Icon.SIZE_STANDARD - 2);
+        const rightOffset = Math.max(2, monthSelectWidth - monthTextWidth - IconSize.STANDARD - 2);
         this.setState({ monthRightOffset: rightOffset });
     }
 

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 import { CaptionElementProps } from "react-day-picker";
 import { polyfill } from "react-lifecycles-compat";
 
-import { AbstractPureComponent2, Divider, HTMLSelect, Icon, IconSize, OptionProps } from "@blueprintjs/core";
+import { AbstractPureComponent2, Divider, HTMLSelect, IconSize, OptionProps } from "@blueprintjs/core";
 
 import * as Classes from "./common/classes";
 import { clone } from "./common/dateUtils";

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import download from "downloadjs";
 import * as React from "react";
 
-import { Classes, ContextMenuTarget, Icon, IconName, Menu, MenuItem } from "@blueprintjs/core";
+import { Classes, ContextMenuTarget, Icon, IconSize, IconName, Menu, MenuItem } from "@blueprintjs/core";
 
 import { ClickToCopy } from "./clickToCopy";
 
@@ -42,7 +42,7 @@ export class DocsIcon extends React.PureComponent<IDocsIconProps> {
         const { iconName, displayName, tags } = this.props;
         return (
             <ClickToCopy className="docs-icon" data-tags={tags} value={iconName}>
-                <Icon icon={iconName} iconSize={Icon.SIZE_LARGE} />
+                <Icon icon={iconName} iconSize={IconSize.LARGE} />
                 <div className="docs-icon-name">{displayName}</div>
                 <div className="docs-icon-detail">
                     <p className="docs-code">{iconName}</p>
@@ -61,12 +61,12 @@ export class DocsIcon extends React.PureComponent<IDocsIconProps> {
         return (
             <Menu>
                 <MenuItem
-                    icon={<Icon icon={iconName} iconSize={Icon.SIZE_STANDARD} />}
+                    icon={<Icon icon={iconName} iconSize={IconSize.STANDARD} />}
                     text="Download 16px SVG"
                     onClick={this.handleClick16}
                 />
                 <MenuItem
-                    icon={<Icon icon={iconName} iconSize={Icon.SIZE_LARGE} />}
+                    icon={<Icon icon={iconName} iconSize={IconSize.LARGE} />}
                     text="Download 20px SVG"
                     onClick={this.handleClick20}
                 />

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -22,6 +22,7 @@ import {
     Code,
     Divider,
     Drawer,
+    DrawerSize,
     H5,
     HTMLSelect,
     OptionProps,
@@ -167,9 +168,9 @@ export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintE
 
 const SIZES: Array<string | OptionProps> = [
     { label: "Default", value: undefined },
-    { label: "Small", value: Drawer.SIZE_SMALL },
-    { label: "Standard", value: Drawer.SIZE_STANDARD },
-    { label: "Large", value: Drawer.SIZE_LARGE },
+    { label: "Small", value: DrawerSize.SMALL },
+    { label: "Standard", value: DrawerSize.STANDARD },
+    { label: "Large", value: DrawerSize.LARGE },
     "72%",
     "560px",
 ];

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { H5, Icon, Intent, Label, Slider } from "@blueprintjs/core";
+import { H5, Icon, IconSize, Intent, Label, Slider } from "@blueprintjs/core";
 import { Example, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 
@@ -32,7 +32,7 @@ export interface IIconExampleState {
 export class IconExample extends React.PureComponent<IExampleProps, IIconExampleState> {
     public state: IIconExampleState = {
         icon: "calendar",
-        iconSize: Icon.SIZE_STANDARD,
+        iconSize: IconSize.STANDARD,
         intent: Intent.NONE,
     };
 

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -16,7 +16,19 @@
 
 import * as React from "react";
 
-import { Button, H5, Icon, InputGroup, Intent, Menu, MenuItem, Spinner, Switch, Tag } from "@blueprintjs/core";
+import {
+    Button,
+    H5,
+    Icon,
+    IconSize,
+    InputGroup,
+    Intent,
+    Menu,
+    MenuItem,
+    Spinner,
+    Switch,
+    Tag,
+} from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
@@ -54,7 +66,7 @@ export class InputGroupExample extends React.PureComponent<IExampleProps, IInput
     public render() {
         const { disabled, filterValue, large, small, showPassword, tagValue } = this.state;
 
-        const maybeSpinner = filterValue ? <Spinner size={Icon.SIZE_STANDARD} /> : undefined;
+        const maybeSpinner = filterValue ? <Spinner size={IconSize.STANDARD} /> : undefined;
 
         const lockButton = (
             <Tooltip2 content={`${showPassword ? "Hide" : "Show"} Password`} disabled={disabled}>

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { H5, Intent, Label, Slider, Spinner, Switch } from "@blueprintjs/core";
+import { H5, Intent, Label, Slider, Spinner, SpinnerSize, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -31,7 +31,7 @@ export interface ISpinnerExampleState {
 export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerExampleState> {
     public state: ISpinnerExampleState = {
         hasValue: false,
-        size: Spinner.SIZE_STANDARD,
+        size: SpinnerSize.STANDARD,
         value: 0.7,
     };
 
@@ -58,7 +58,7 @@ export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerE
                 <Slider
                     labelStepSize={50}
                     min={0}
-                    max={Spinner.SIZE_LARGE * 2}
+                    max={SpinnerSize.LARGE * 2}
                     showTrackFill={false}
                     stepSize={5}
                     value={size}

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { Icon } from "@blueprintjs/core";
+import { IconSize } from "@blueprintjs/core";
 
 // used to exclude icons from column header measure
 export const CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT = "bp-table-text-no-measure";
 // supposed width of the icons placeholder
-const EXCLUDED_ICON_PLACEHOLDER_WIDTH = Icon.SIZE_STANDARD;
+const EXCLUDED_ICON_PLACEHOLDER_WIDTH = IconSize.STANDARD;
 
 /**
  * Since Firefox doesn't provide a computed "font" property, we manually


### PR DESCRIPTION
#### Fixes #0000

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

In conjunction with upcoming changes in v4.0 where class components are being refactored into function components (like https://github.com/palantir/blueprint/pull/4681), we must remove support for static members and provide those constants as new symbols in the public API.

Deprecated:

- `Icon.SIZE_STANDARD`
- `Icon.SIZE_LARGE`
- `Drawer.SIZE_SMALL`
- `Drawer.SIZE_STANDARD`
- `Drawer.SIZE_LARGE`
- `Spinner.SIZE_SMALL`
- `Spinner.SIZE_STANDARD`
- `Spinner.SIZE_LARGE`

Added: 

- `IconSize`
- `DrawerSize`
- `SpinnerSize`

Not addressed in this PR:

- `OverflowList.ofType()`, `Select.ofType()`, etc...