### PR TITLE
Fix no-prefix-literal autofixer

### DIFF
--- a/packages/stylelint-plugin/test/fixtures/contains-double-bp-selector.scss
+++ b/packages/stylelint-plugin/test/fixtures/contains-double-bp-selector.scss
@@ -1,0 +1,3 @@
+.bp-a.bp-b {
+  z-index: 1;
+}

--- a/packages/stylelint-plugin/test/no-prefix-literal.test.js
+++ b/packages/stylelint-plugin/test/no-prefix-literal.test.js
@@ -155,4 +155,14 @@ describe("no-prefix-literal", () => {
         });
         expect(result.results[0].invalidOptionWarnings.length).to.be.eq(2);
     });
+
+    it("Works for a double bp selector", async () => {
+        const result = await stylelint.lint({
+            files: "test/fixtures/contains-double-bp-selector.scss",
+            config,
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(2);
+    });
 });


### PR DESCRIPTION
Autofixing selectors of form `.bp-a.bp-b` was spitting out garbage, which made me realize that the autofixing logic was broken.