### PR TITLE
fix(setState usage): doesn't clobber existing keys

### DIFF
--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -125,12 +125,12 @@ export class TableEditableExample extends React.PureComponent<IExampleProps, ITa
     private setArrayState<T>(key: string, index: number, value: T) {
         const values = (this.state as any)[key].slice() as T[];
         values[index] = value;
-        this.setState({ [key]: values });
+        this.setState({ ...this.state, [key]: values });
     }
 
     private setSparseState<T>(stateKey: string, dataKey: string, value: T) {
         const stateData = (this.state as any)[stateKey] as { [key: string]: T };
         const values = { ...stateData, [dataKey]: value };
-        this.setState({ [stateKey]: values });
+        this.setState({ ...this.state, [stateKey]: values });
     }
 }


### PR DESCRIPTION
When setting state from `setArrayState` and `setSparseState`, set existing state values first, and then overwrite the intended field with `stateKey`, without clobbering over all existing state values that are not `stateKey`.

#### Fixes #4629

#### Checklist

- [x] Includes tests
- [x] Update documentation (well technically this _is_ the update to the documentation (code example))

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Fixes two bugs in EditableTable component examples in Blueprintjs docs.

#### Reviewers should focus on:
Do doc examples have associated test cases? Where are they? (My bad if I'm being blind).

#### Screenshot
n/a
