### PR TITLE
[popover2] fix(ContextMenu2): allow content to be undefined

### DIFF
--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -78,8 +78,9 @@ export interface ContextMenu2Props
     /**
      * Menu content. This will usually be a Blueprint `<Menu>` component.
      * This optionally functions as a render prop so you can use component state to render content.
+     * This should only be `undefined` if `disabled` is also set to `true`.
      */
-    content: JSX.Element | ((props: ContextMenu2ContentProps) => JSX.Element);
+    content: JSX.Element | ((props: ContextMenu2ContentProps) => JSX.Element) | undefined;
 
     /**
      * The context menu target. This may optionally be a render function so you can use


### PR DESCRIPTION

#### Changes proposed in this pull request:

`content` prop should be allowed to be `undefined`; this makes the migration from `ContextMenuTarget` easier. This was already being handled in the rendering code path, but just for safety, it's probably best for consumers to also set `disabled={true}` if `content={undefined}`.

