### PR TITLE
[popover2] feat(ContextMenu2): allow specifying custom wrapper tag

### DIFF
--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -220,11 +220,16 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
             ref: containerRef,
         });
     } else {
-        return React.createElement(tagName, {
-            className: containerClassName,
-            ref: containerRef,
-            onContextMenu: handleContextMenu,
-        }, maybePopover, children);
+        return React.createElement(
+            tagName,
+            {
+                className: containerClassName,
+                onContextMenu: handleContextMenu,
+                ref: containerRef,
+            },
+            maybePopover,
+            children,
+        );
     }
 };
 ContextMenu2.displayName = "Blueprint.ContextMenu2";

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -101,6 +101,15 @@ export interface ContextMenu2Props
      * React state (which is an error to do in the render code path of this component).
      */
     onContextMenu?: React.MouseEventHandler<HTMLElement>;
+
+    /**
+     * HTML tag to use for container element. Only used if this component's children are specified as
+     * React node(s), not when it is a render function (in that case, you get to render whatever tag
+     * you wish).
+     *
+     * @default "div"
+     */
+    tagName?: keyof JSX.IntrinsicElements;
 }
 
 export const ContextMenu2: React.FC<ContextMenu2Props> = ({
@@ -111,6 +120,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
     transitionDuration = 100,
     onContextMenu,
     popoverClassName,
+    tagName = "div",
     ...restProps
 }) => {
     const [targetOffset, setTargetOffset] = React.useState<Offset>({ left: 0, top: 0 });
@@ -210,12 +220,11 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
             ref: containerRef,
         });
     } else {
-        return (
-            <div className={containerClassName} ref={containerRef} onContextMenu={handleContextMenu}>
-                {maybePopover}
-                {children}
-            </div>
-        );
+        return React.createElement(tagName, {
+            className: containerClassName,
+            ref: containerRef,
+            onContextMenu: handleContextMenu,
+        }, maybePopover, children);
     }
 };
 ContextMenu2.displayName = "Blueprint.ContextMenu2";

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 
-import { ContextMenu2, ContextMenu2Props, Popover2 } from "../src";
+import { Classes, ContextMenu2, ContextMenu2Props, Popover2 } from "../src";
 
 const MENU_ITEMS = [
     <MenuItem key="left" icon="align-left" text="Align Left" />,
@@ -43,6 +43,11 @@ describe("ContextMenu2", () => {
             const ctxMenu = mountTestMenu();
             openCtxMenu(ctxMenu);
             assert.isTrue(ctxMenu.find(Popover2).prop("isOpen"));
+        });
+
+        it("renders custom HTML tag if specified", () => {
+            const ctxMenu = mountTestMenu({ tagName: "span" });
+            assert.isTrue(ctxMenu.find(`span.${Classes.CONTEXT_MENU2}`).exists());
         });
 
         function mountTestMenu(props: Partial<ContextMenu2Props> = {}) {


### PR DESCRIPTION

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `tagName` prop to `<ContextMenu2>`, which makes dealing with the generated wrapper element a little easier in some cases

