### PR TITLE
[popover2] feat(ContextMenu2): support click handlers on wrapper

### DIFF
--- a/packages/popover2/src/context-menu2.md
+++ b/packages/popover2/src/context-menu2.md
@@ -47,16 +47,18 @@ export default function ContextMenuExample() {
 }
 ```
 
-Both `content` and `children` props support the [render prop](https://reactjs.org/docs/render-props.html)
-pattern, so you may use information about the context menu's state to in your render code.
+`<ContextMenu2>` will render a `<div>` wrapper element which you may customize in a few ways:
+
+- Change the HTML tag with the `tagName` prop
+- Attach common mouse event handlers: `onClick`, `onDoubleClick`, `onMouseDown`, `onMouseUp`
 
 ### Advanced usage
 
-By default, `<ContextMenu2>` will render a container `<div>` element around its children, to contain the
-generated Popover and attach an event handler. If this container breaks your HTML and/or CSS layout in some
-way and you wish to omit it, you may do so by utilizing ContextMenu2's advanced rendering API, which
-uses a `children` render function. If you use this approach, you must take care to properly use the
-render props supplied to `children()`:
+By default, `<ContextMenu2>` will render a wrapper element around its children to contain the
+generated popover, attach an event handler, and get a DOM ref for layout measurement. If this
+container breaks your HTML and/or CSS layout in some way and you wish to omit it, you may do so by
+utilizing ContextMenu2's advanced rendering API, which uses a `children` render function. If you
+use this approach, you must take care to properly use the render props supplied to `children()`:
 
 ```tsx
 import classNames from "classnames";
@@ -74,12 +76,13 @@ export default function AdvancedContextMenu2Example() {
                 </Menu>
             }
         >
-            {(props: ContextMenu2ChildrenProps) => (
+            {(ctxMenuProps: ContextMenu2ChildrenProps) => (
                 <div
-                    className={classNames("my-context-menu-target", props.className)}
-                    onContextMenu={props.onContextMenu}
-                    ref={props.ref}
+                    className={classNames("my-context-menu-target", ctxMenuProps.className)}
+                    onContextMenu={ctxMenuProps.onContextMenu}
+                    ref={ctxMenuProps.ref}
                 >
+                    {ctxMenuProps.popover}
                     Right click me!
                 </div>
             )}
@@ -87,6 +90,10 @@ export default function AdvancedContextMenu2Example() {
     )
 }
 ```
+
+Both `content` and `children` props support the [render prop](https://reactjs.org/docs/render-props.html)
+pattern, so you may use information about the context menu's state (such as `isOpen: boolean`) in your
+render code.
 
 @## Props
 

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -74,6 +74,7 @@ export interface ContextMenu2ChildrenProps {
 export interface ContextMenu2Props
     extends IOverlayLifecycleProps,
         Pick<Popover2Props, "popoverClassName" | "transitionDuration">,
+        Pick<React.DOMAttributes<HTMLElement>, "onClick" | "onDoubleClick" | "onMouseDown" | "onMouseUp">,
         Props {
     /**
      * Menu content. This will usually be a Blueprint `<Menu>` component.
@@ -119,6 +120,10 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
     disabled = false,
     transitionDuration = 100,
     onContextMenu,
+    onClick,
+    onDoubleClick,
+    onMouseDown,
+    onMouseUp,
     popoverClassName,
     tagName = "div",
     ...restProps
@@ -224,7 +229,11 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
             tagName,
             {
                 className: containerClassName,
+                onClick,
                 onContextMenu: handleContextMenu,
+                onDoubleClick,
+                onMouseDown,
+                onMouseUp,
                 ref: containerRef,
             },
             maybePopover,


### PR DESCRIPTION

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

I'm commonly seeing that the only custom thing which context menu consumers need on the wrapper element is a simple `onClick` handler. So, to avoid forcing them into the child render function pattern, we can expose these common click handlers as props on ContextMenu2 directly.

