### PR TITLE
[stylelint-plugin] fix: don't lint the "bp-" prefix

### DIFF
--- a/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
@@ -27,7 +27,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
     expected: (unfixed: string, fixed: string) => `Use the \`${fixed}\` variable instead of the \`${unfixed}\` literal`,
 });
 
-const bannedPrefixes = ["bp", "bp3", "bp4"];
+const bannedPrefixes = ["bp3", "bp4"];
 
 interface Options {
     disableFix?: boolean;


### PR DESCRIPTION
`bp` is not actually a blueprint prefix.