### PR TITLE
chore: fix lint script in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,17 @@ jobs:
           root: "."
           paths: [packages/*/lib, packages/*/src/generated]
 
+  format-check:
+    docker: *docker-node-lts
+    environment:
+      JUNIT_REPORT_PATH: reports
+      NODE_ENV: test
+    steps:
+      - checkout
+      - restore_cache: *restore-node-modules-cache
+      - attach_workspace: { at: "." }
+      - run: yarn format-check
+
   lint:
     docker: *docker-node-lts
     resource_class: large
@@ -80,22 +91,10 @@ jobs:
       - restore_cache: *restore-node-modules-cache
       - attach_workspace: { at: "." }
       - run: mkdir -p ./reports/eslint ./reports/stylelint
-      # we need to compile the lint rules for blueprint
-      - run: yarn compile --scope "@blueprintjs/{eslint,stylelint}-plugin"
+      # types and lint rules should already be compiled since this job depends on the 'compile' job
       - run: yarn lint
       - store_test_results: { path: ./reports }
       - store_artifacts: { path: ./reports }
-
-  format-check:
-    docker: *docker-node-lts
-    environment:
-      JUNIT_REPORT_PATH: reports
-      NODE_ENV: test
-    steps:
-      - checkout
-      - restore_cache: *restore-node-modules-cache
-      - attach_workspace: { at: "." }
-      - run: yarn format-check
 
   dist:
     docker: *docker-node-lts
@@ -214,10 +213,10 @@ workflows:
           requires: [checkout-code]
       - compile:
           requires: [checkout-code]
-      - lint:
-          requires: [checkout-code]
       - format-check:
           requires: [checkout-code]
+      - lint:
+          requires: [compile]
       - dist:
           requires: [compile]
       - test-react-15:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - attach_workspace: { at: "." }
       - run: mkdir -p ./reports/eslint ./reports/stylelint
       # we need to compile the lint rules for blueprint
-      - run: yarn compile --scope "@blueprintjs/eslint-plugin"
+      - run: yarn compile --scope "@blueprintjs/{eslint,stylelint}-plugin"
       - run: yarn lint
       - store_test_results: { path: ./reports }
       - store_artifacts: { path: ./reports }

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 
 import { AnchorButton, Classes, HotkeysProvider, Tag } from "@blueprintjs/core";
 import { IDocsCompleteData } from "@blueprintjs/docs-data";
-import { Banner, Documentation, IDocumentationProps, INavMenuItemProps, NavMenuItem } from "@blueprintjs/docs-theme";
+import { Banner, Documentation, IDocumentationProps, NavMenuItemProps, NavMenuItem } from "@blueprintjs/docs-theme";
 
 import { NavHeader } from "./navHeader";
 import { NavIcon } from "./navIcons";
@@ -104,7 +104,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
         );
     }
 
-    private renderNavMenuItem = (props: INavMenuItemProps) => {
+    private renderNavMenuItem = (props: NavMenuItemProps) => {
         const { route, title } = props.section;
         if (isNavSection(props.section)) {
             // non-interactive header that expands its menu

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -4,6 +4,7 @@
     "description": "ESLint rules for use with @blueprintjs packages",
     "main": "lib/index.js",
     "scripts": {
+        "clean": "rm -rf lib/*",
         "compile": "tsc -p src/",
         "lint": "run-p lint:es",
         "lint:es": "es-lint",

--- a/packages/node-build-scripts/es-lint.js
+++ b/packages/node-build-scripts/es-lint.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /**
  * @license Copyright 2019 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Runs ESLint, with support for generating JUnit report
@@ -8,11 +7,12 @@
 // @ts-check
 "use strict";
 
-const path = require("path");
-const fs = require("fs");
-const { junitReportPath } = require("./utils");
 const { spawn } = require("cross-spawn");
+const fs = require("fs");
 const glob = require("glob");
+const path = require("path");
+
+const { junitReportPath } = require("./utils");
 
 let format = "codeframe";
 let out;

--- a/packages/node-build-scripts/sass-lint.js
+++ b/packages/node-build-scripts/sass-lint.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /**
  * @license Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  * @fileoverview Runs stylelint, with support for generating JUnit report
@@ -9,6 +8,7 @@
 const fs = require("fs");
 const path = require("path");
 const stylelint = require("stylelint");
+
 const { junitReportPath } = require("./utils");
 
 const emitReport = process.env.JUNIT_REPORT_PATH != null;
@@ -21,16 +21,23 @@ const options = {
     fix: process.argv.indexOf("--fix") > 0,
 };
 
-stylelint.lint(options).then(resultObject => {
-    if (emitReport) {
-        // emit JUnit XML report to <cwd>/<reports>/<pkg>/stylelint.xml when this env variable is set
-        const reportPath = junitReportPath("stylelint");
-        console.info(`Stylelint report will appear in ${reportPath}`);
-        fs.writeFileSync(reportPath, resultObject.output);
-    } else {
-        console.info(resultObject.output);
-    }
-    if (resultObject.errored) {
+stylelint
+    .lint(options)
+    .then(resultObject => {
+        if (emitReport) {
+            // emit JUnit XML report to <cwd>/<reports>/<pkg>/stylelint.xml when this env variable is set
+            const reportPath = junitReportPath("stylelint");
+            console.info(`Stylelint report will appear in ${reportPath}`);
+            fs.writeFileSync(reportPath, resultObject.output);
+        } else {
+            console.info(resultObject.output);
+        }
+        if (resultObject.errored) {
+            process.exitCode = 2;
+        }
+    })
+    .catch(error => {
+        console.error("[node-build-scripts] sass-lint failed with error:");
+        console.error(error);
         process.exitCode = 2;
-    }
-});
+    });

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -4,6 +4,7 @@
     "description": "Stylelint rules for use with @blueprintjs packages",
     "main": "lib/index.js",
     "scripts": {
+        "clean": "rm -rf lib/*",
         "compile": "tsc -p src/",
         "lint": "run-p lint:es",
         "lint:es": "es-lint",

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -26,7 +26,7 @@ import {
     H4,
     H6,
     HTMLSelect,
-    IButtonProps,
+    ButtonProps,
     Intent,
     Menu,
     MenuDivider,
@@ -741,7 +741,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         );
     }
 
-    private renderButton(label: string, props: IButtonProps) {
+    private renderButton(label: string, props: ButtonProps) {
         return <Button fill={true} intent={Intent.PRIMARY} text={label} {...props} />;
     }
 


### PR DESCRIPTION
#### Fixes #4710


#### Changes proposed in this pull request:

- Fix sass-lint script so that it exits correctly with an error code when it fails
- Make 'compile' job a dependency of the 'lint' job in CI (we need it for lint rules which rely on type information like `deprecation/deprecation` and for custom rules in our repo)
- Fix lint errors existing in repo

