### PR TITLE
[popover2] feat(ContextMenu2): support ref prop

### DIFF
--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -76,6 +76,7 @@ export interface ContextMenu2ChildrenProps {
 
 export interface ContextMenu2Props
     extends Omit<React.HTMLAttributes<HTMLElement>, "children" | "className" | "onContextMenu">,
+        React.RefAttributes<any>,
         Props {
     /**
      * Menu content. This will usually be a Blueprint `<Menu>` component.
@@ -118,16 +119,17 @@ export interface ContextMenu2Props
     tagName?: keyof JSX.IntrinsicElements;
 }
 
-export const ContextMenu2: React.FC<ContextMenu2Props> = ({
-    className,
-    children,
-    content,
-    disabled = false,
-    onContextMenu,
-    popoverProps,
-    tagName = "div",
-    ...restProps
-}) => {
+export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, ContextMenu2Props>((props, userRef) => {
+    const {
+        className,
+        children,
+        content,
+        disabled = false,
+        onContextMenu,
+        popoverProps,
+        tagName = "div",
+        ...restProps
+    } = props;
     const [targetOffset, setTargetOffset] = React.useState<Offset | undefined>(undefined);
     const [mouseEvent, setMouseEvent] = React.useState<React.MouseEvent<HTMLElement>>();
     const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -227,7 +229,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
             contentProps,
             onContextMenu: handleContextMenu,
             popover: maybePopover,
-            ref: containerRef,
+            ref: mergeRefs(containerRef, userRef),
         });
     } else {
         return React.createElement(
@@ -235,14 +237,14 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = ({
             {
                 className: containerClassName,
                 onContextMenu: handleContextMenu,
-                ref: containerRef,
+                ref: mergeRefs(containerRef, userRef),
                 ...restProps,
             },
             maybePopover,
             children,
         );
     }
-};
+});
 ContextMenu2.displayName = "Blueprint.ContextMenu2";
 
 function getContainingBlockOffset(targetElement: HTMLElement | null | undefined): { left: number; top: number } {

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -229,7 +229,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
             contentProps,
             onContextMenu: handleContextMenu,
             popover: maybePopover,
-            ref: mergeRefs(containerRef, userRef),
+            ref: containerRef,
         });
     } else {
         return React.createElement(

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -50,6 +50,13 @@ describe("ContextMenu2", () => {
             assert.isTrue(ctxMenu.find(`span.${Classes.CONTEXT_MENU2}`).exists());
         });
 
+        it("supports custom refs", () => {
+            const ref = React.createRef<HTMLElement>();
+            mountTestMenu({ className: "test-container", ref });
+            assert.isDefined(ref.current);
+            assert.isTrue(ref.current?.classList.contains("test-container"));
+        });
+
         function mountTestMenu(props: Partial<ContextMenu2Props> = {}) {
             return mount(
                 <ContextMenu2 content={MENU} popoverProps={{ transitionDuration: 0 }} {...props}>


### PR DESCRIPTION

#### Changes proposed in this pull request:

Use `React.forwardRef` to forward refs to the context menu container element
