### PR TITLE
[popover2] fix(ContextMenu2): allow content function to return undefined

### DIFF
--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -82,7 +82,7 @@ export interface ContextMenu2Props
      * Menu content. This will usually be a Blueprint `<Menu>` component.
      * This optionally functions as a render prop so you can use component state to render content.
      */
-    content: JSX.Element | ((props: ContextMenu2ContentProps) => JSX.Element) | undefined;
+    content: JSX.Element | ((props: ContextMenu2ContentProps) => JSX.Element | undefined) | undefined;
 
     /**
      * The context menu target. This may optionally be a render function so you can use


### PR DESCRIPTION

#### Changes proposed in this pull request:

`content` should be allowed to return `undefined` when it is a function, just like it is allowed for values
