### PR TITLE
[core] fix(EditableText): optimize updateInputDimensions

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -283,7 +283,9 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
             this.props.maxLines !== prevProps.maxLines ||
             this.props.minLines !== prevProps.minLines ||
             this.props.minWidth !== prevProps.minWidth ||
-            this.props.multiline !== prevProps.multiline
+            this.props.multiline !== prevProps.multiline ||
+            this.state.value !== prevState.value ||
+            this.props.alwaysRenderInput !== prevProps.alwaysRenderInput
         ) {
             this.updateInputDimensions();
         }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -280,12 +280,12 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         // updateInputDimensions is an expensive method. Call it only when the props
         // it depends on change
         if (
+            this.props.alwaysRenderInput !== prevProps.alwaysRenderInput ||
             this.props.maxLines !== prevProps.maxLines ||
             this.props.minLines !== prevProps.minLines ||
             this.props.minWidth !== prevProps.minWidth ||
             this.props.multiline !== prevProps.multiline ||
-            this.state.value !== prevState.value ||
-            this.props.alwaysRenderInput !== prevProps.alwaysRenderInput
+            this.state.value !== prevState.value
         ) {
             this.updateInputDimensions();
         }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -280,12 +280,12 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         // updateInputDimensions is an expensive method. Call it only when the props
         // it depends on change
         if (
+            this.state.value !== prevState.value ||
             this.props.alwaysRenderInput !== prevProps.alwaysRenderInput ||
             this.props.maxLines !== prevProps.maxLines ||
             this.props.minLines !== prevProps.minLines ||
             this.props.minWidth !== prevProps.minWidth ||
-            this.props.multiline !== prevProps.multiline ||
-            this.state.value !== prevState.value
+            this.props.multiline !== prevProps.multiline
         ) {
             this.updateInputDimensions();
         }

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -277,7 +277,16 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         if (this.state.isEditing && !prevState.isEditing) {
             this.props.onEdit?.(this.state.value);
         }
-        this.updateInputDimensions();
+        // updateInputDimensions is an expensive method. Call it only when the props
+        // it depends on change
+        if (
+            this.props.maxLines !== prevProps.maxLines ||
+            this.props.minLines !== prevProps.minLines ||
+            this.props.minWidth !== prevProps.minWidth ||
+            this.props.multiline !== prevProps.multiline
+        ) {
+            this.updateInputDimensions();
+        }
     }
 
     public cancelEditing = () => {


### PR DESCRIPTION

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
`componentDidUpdate` of Editable text calls `updateInputDimensions` on every rerender, this triggers the layout calculations.
This PR addresses that issue by only calling `updateInputDimensions`  only when the props it depends on change

ref: https://github.com/palantir/blueprint/pull/4639#issuecomment-820503242

#### Reviewers should focus on:

Confirm if calling `updateInputDimensions` conditionally is a safe change

