### PR TITLE
[core] fix(Portal): handle more className edge cases

### DIFF
--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -111,9 +111,7 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
     public componentDidUpdate(prevProps: IPortalProps) {
         // update className prop on portal DOM element
         if (this.portalElement != null && prevProps.className !== this.props.className) {
-            if (prevProps.className !== undefined) {
-                this.portalElement.classList.remove(prevProps.className);
-            }
+            maybeRemoveClass(this.portalElement.classList, prevProps.className);
             maybeAddClass(this.portalElement.classList, this.props.className);
         }
 
@@ -150,6 +148,12 @@ export class Portal extends React.Component<IPortalProps, IPortalState> {
             <div>{this.props.children}</div>,
             this.portalElement,
         );
+    }
+}
+
+function maybeRemoveClass(classList: DOMTokenList, className?: string) {
+    if (className != null && className !== "") {
+        classList.remove(...className.split(" "));
     }
 }
 

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -86,6 +86,26 @@ describe("<Portal>", () => {
         assert.isTrue(portalElement?.classList.contains(Classes.PORTAL));
     });
 
+    it("does not crash when removing multiple classes from className", () => {
+        portal = mount(
+            <Portal className="class-one class-two">
+                <p>test</p>
+            </Portal>,
+        );
+        portal.setProps({ className: undefined });
+        // no assertion necessary - will crash on incorrect code
+    });
+
+    it("does not crash when an empty string is provided for className", () => {
+        portal = mount(
+            <Portal className="">
+                <p>test</p>
+            </Portal>,
+        );
+        portal.setProps({ className: "class-one" });
+        // no assertion necessary - will crash on incorrect code
+    });
+
     it("children mount before onChildrenMount invoked", done => {
         function spy() {
             // can't use `portal` in here as `mount()` has not finished, so query DOM directly


### PR DESCRIPTION
#### Fixes #4519, #4728

#### Checklist

- [x] Includes tests
- [ ] Update documentation


#### Changes proposed in this pull request:

Updates how `Portal` removes classes so that it will not crash when 1) an empty string was previously provided or 2) when removing multiple classes at once.

#### Reviewers should focus on:

Any logic errors in removing the class names.

