### PR TITLE
[core] feat(MultiStepDialog): Allow skipping to a specific step in the dialog

### DIFF
--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -232,7 +232,7 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
     }
 
     private getInitialIndexFromProps(props: MultistepDialogProps) {
-        if (props.initialStepIndex) {
+        if (props.initialStepIndex !== undefined) {
             const boundedInitialIndex = Math.max(
                 0,
                 Math.min(props.initialStepIndex, this.getDialogStepChildren(props).length - 1),

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -57,6 +57,8 @@ export interface IMultistepDialogProps extends DialogProps {
     /**
      * Whether to reset the dialog state to its initial state on close.
      * By default, closing the dialog will reset its state.
+     *
+     * @default true
      */
     resetOnClose?: boolean;
 
@@ -77,11 +79,6 @@ const PADDING_BOTTOM = 0;
 
 const MIN_WIDTH = 800;
 
-const INITIAL_STATE = {
-    lastViewedIndex: 0,
-    selectedIndex: 0,
-};
-
 @polyfill
 export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps, IMultistepDialogState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MultistepDialog`;
@@ -89,15 +86,10 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
     public static defaultProps: Partial<MultistepDialogProps> = {
         canOutsideClickClose: true,
         isOpen: false,
+        resetOnClose: true,
     };
 
-    public state: IMultistepDialogState;
-
-    constructor(props: MultistepDialogProps) {
-        super(props);
-
-        this.state = this.getInitialIndexFromProps(props);
-    }
+    public state: IMultistepDialogState = this.getInitialIndexFromProps(this.props);
 
     public render() {
         return (
@@ -112,7 +104,7 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
 
     public componentDidUpdate(prevProps: MultistepDialogProps) {
         if (
-            (prevProps.resetOnClose === undefined || prevProps.resetOnClose) &&
+            (prevProps.resetOnClose || prevProps.initialStepIndex !== this.props.initialStepIndex) &&
             !prevProps.isOpen &&
             this.props.isOpen
         ) {
@@ -250,7 +242,10 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
                 selectedIndex: boundedInitialIndex,
             };
         } else {
-            return INITIAL_STATE;
+            return {
+                lastViewedIndex: 0,
+                selectedIndex: 0,
+            };
         }
     }
 }

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -59,6 +59,13 @@ export interface IMultistepDialogProps extends DialogProps {
      * By default, closing the dialog will reset its state.
      */
     resetOnClose?: boolean;
+
+    /**
+     * A 0 indexed initial step to start off on, to start in the middle of the dialog, for example.
+     * If the provided index exceeds the number of steps, it defaults to the last step.
+     * If a negative index is provided, it defaults to the first step.
+     */
+    initialStepIndex?: number;
 }
 
 interface IMultistepDialogState {
@@ -84,7 +91,13 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
         isOpen: false,
     };
 
-    public state: IMultistepDialogState = INITIAL_STATE;
+    public state: IMultistepDialogState;
+
+    constructor(props: MultistepDialogProps) {
+        super(props);
+
+        this.state = this.getInitialIndexFromProps(props);
+    }
 
     public render() {
         return (
@@ -103,7 +116,7 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
             !prevProps.isOpen &&
             this.props.isOpen
         ) {
-            this.setState(INITIAL_STATE);
+            this.setState(this.getInitialIndexFromProps(this.props));
         }
     }
 
@@ -224,6 +237,18 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
     /** Filters children to only `<DialogStep>`s */
     private getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode } = this.props) {
         return React.Children.toArray(props.children).filter(isDialogStepElement);
+    }
+
+    private getInitialIndexFromProps(props: MultistepDialogProps) {
+        if (props.initialStepIndex) {
+            const boundedInitialIndex = Math.max(0, Math.min(props.initialStepIndex, this.getDialogStepChildren(props).length - 1));
+            return {
+                lastViewedIndex: boundedInitialIndex,
+                selectedIndex: boundedInitialIndex,
+            }
+        } else {
+            return INITIAL_STATE;
+        }
     }
 }
 

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -241,11 +241,14 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
 
     private getInitialIndexFromProps(props: MultistepDialogProps) {
         if (props.initialStepIndex) {
-            const boundedInitialIndex = Math.max(0, Math.min(props.initialStepIndex, this.getDialogStepChildren(props).length - 1));
+            const boundedInitialIndex = Math.max(
+                0,
+                Math.min(props.initialStepIndex, this.getDialogStepChildren(props).length - 1),
+            );
             return {
                 lastViewedIndex: boundedInitialIndex,
                 selectedIndex: boundedInitialIndex,
-            }
+            };
         } else {
             return INITIAL_STATE;
         }

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -104,7 +104,14 @@ export class MultistepDialogExample extends React.PureComponent<
     }
 
     private renderOptions() {
-        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, usePortal, initialStepIndex } = this.state;
+        const {
+            autoFocus,
+            enforceFocus,
+            canEscapeKeyClose,
+            canOutsideClickClose,
+            usePortal,
+            initialStepIndex,
+        } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -120,7 +127,12 @@ export class MultistepDialogExample extends React.PureComponent<
                 />
                 <Switch checked={canEscapeKeyClose} label="Escape key to close" onChange={this.handleEscapeKeyChange} />
                 <Label>Initial step index (0-indexed)</Label>
-                <NumericInput value={initialStepIndex} onValueChange={this.handleInitialStepIndexChange} max={2} min={-1} />
+                <NumericInput
+                    value={initialStepIndex}
+                    onValueChange={this.handleInitialStepIndexChange}
+                    max={2}
+                    min={-1}
+                />
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -55,9 +55,9 @@ export class MultistepDialogExample extends React.PureComponent<
         canEscapeKeyClose: true,
         canOutsideClickClose: true,
         enforceFocus: true,
+        initialStepIndex: 0,
         isOpen: false,
         usePortal: true,
-        initialStepIndex: 0,
     };
 
     private handleAutoFocusChange = handleBooleanChange(autoFocus => this.setState({ autoFocus }));

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -28,6 +28,8 @@ import {
     ButtonProps,
     RadioGroup,
     Radio,
+    NumericInput,
+    Label,
 } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
 
@@ -41,6 +43,7 @@ export interface IMultistepDialogExampleState {
     isOpen: boolean;
     usePortal: boolean;
     value?: string;
+    initialStepIndex: number;
 }
 
 export class MultistepDialogExample extends React.PureComponent<
@@ -54,6 +57,7 @@ export class MultistepDialogExample extends React.PureComponent<
         enforceFocus: true,
         isOpen: false,
         usePortal: true,
+        initialStepIndex: 0,
     };
 
     private handleAutoFocusChange = handleBooleanChange(autoFocus => this.setState({ autoFocus }));
@@ -100,7 +104,7 @@ export class MultistepDialogExample extends React.PureComponent<
     }
 
     private renderOptions() {
-        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, usePortal } = this.state;
+        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, usePortal, initialStepIndex } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -115,6 +119,8 @@ export class MultistepDialogExample extends React.PureComponent<
                     onChange={this.handleOutsideClickChange}
                 />
                 <Switch checked={canEscapeKeyClose} label="Escape key to close" onChange={this.handleEscapeKeyChange} />
+                <Label>Initial step index (0-indexed)</Label>
+                <NumericInput value={initialStepIndex} onValueChange={this.handleInitialStepIndexChange} max={2} min={-1} />
             </>
         );
     }
@@ -124,6 +130,8 @@ export class MultistepDialogExample extends React.PureComponent<
     private handleClose = () => this.setState({ isOpen: false });
 
     private handleSelectionChange = handleStringChange(value => this.setState({ value }));
+
+    private handleInitialStepIndexChange = (newValue: number) => this.setState({ initialStepIndex: newValue });
 }
 
 export interface ISelectPanelProps {


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Allows for providing an optional `initialStepIndex` prop which will start the dialog off at the specified step index (0-indexed)
- If the index < 0, it will start from the first step
- If the index exceeds the number of steps, it will start from the last step

#### Reviewers should focus on:

Is there more validation I should be doing?

#### Screenshot

![dialog](https://user-images.githubusercontent.com/1143755/119062495-945b9a00-b99c-11eb-9996-09669710dc52.gif)
