### PR TITLE
[popover2] close popovers/tooltips on ContextMenu2 opening

### DIFF
--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -17,9 +17,9 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { Classes, Menu, MenuDivider, MenuItem, Tooltip, Tag, ContextMenuTarget } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps } from "@blueprintjs/popover2";
+import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps, Tooltip2 } from "@blueprintjs/popover2";
 
 export const ContextMenu2Example: React.FC<IExampleProps> = props => {
     const renderContent = React.useCallback(
@@ -51,14 +51,108 @@ export const ContextMenu2Example: React.FC<IExampleProps> = props => {
     );
 
     return (
-        <ContextMenu2 content={renderContent}>
-            <Example className="docs-context-menu-example" options={false} {...props}>
-                <GraphNode />
-                <span className={Classes.TEXT_MUTED}>Right-click on node or background.</span>
-            </Example>
-        </ContextMenu2>
+        <Example className="docs-context-menu-example" options={false} {...props}>
+            <Popover2Example />
+            <LegacyContextMenuExample />
+        </Example>
     );
+    // return (
+    //     <ContextMenu2 content={renderContent}>
+    //         <Example className="docs-context-menu-example" options={false} {...props}>
+    //             <GraphNode />
+    //             <span className={Classes.TEXT_MUTED}>Right-click on node or background.</span>
+    //         </Example>
+    //     </ContextMenu2>
+    // );
 };
+
+function Popover2Example() {
+    return (
+        <div style={{ margin: 20 }}>
+            <Tooltip2 content="hello">
+                <div>
+                    <ContextMenu2
+                        content={
+                            <Menu>
+                                <MenuItem text="First" />
+                                <MenuItem text="Second" />
+                            </Menu>
+                        }
+                    >
+                        <Tag interactive={true}>Tooltip2 + ContextMenu2 (hover and right click me)</Tag>
+                    </ContextMenu2>
+                </div>
+            </Tooltip2>
+            <br />
+            <br />
+            <Tooltip content="hello">
+                <div>
+                    <ContextMenu2
+                        content={
+                            <Menu>
+                                <MenuItem text="First" />
+                                <MenuItem text="Second" />
+                            </Menu>
+                        }
+                    >
+                        <Tag interactive={true}>Tooltip + ContextMenu2 (hover and right click me)</Tag>
+                    </ContextMenu2>
+                </div>
+            </Tooltip>
+        </div>
+    );
+}
+
+function LegacyContextMenuExample() {
+    return (
+        <div style={{ margin: 20 }}>
+            <Tooltip2 content="hello">
+                <div>
+                    <ContextMenu
+                        content={
+                            <Menu>
+                                <MenuItem text="First" />
+                                <MenuItem text="Second" />
+                            </Menu>
+                        }
+                    >
+                        <Tag interactive={true}>Tooltip2 + @ContextMenuTarget (hover and right click me)</Tag>
+                    </ContextMenu>
+                </div>
+            </Tooltip2>
+            <br />
+            <br />
+            <Tooltip content="hello">
+                <div>
+                    <ContextMenu
+                        content={
+                            <Menu>
+                                <MenuItem text="First" />
+                                <MenuItem text="Second" />
+                            </Menu>
+                        }
+                    >
+                        <Tag interactive={true}>Tooltip + @ContextMenuTarget (hover and right click me)</Tag>
+                    </ContextMenu>
+                </div>
+            </Tooltip>
+        </div>
+    );
+}
+
+@ContextMenuTarget
+class ContextMenu extends React.Component<{
+    children: React.ReactElement;
+    content: React.ReactElement;
+}> {
+    public render() {
+        return this.props.children;
+    }
+
+    public renderContextMenu() {
+        return this.props.content;
+    }
+}
 
 const GraphNode: React.FC = () => {
     const children = React.useCallback(

--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -17,9 +17,9 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Menu, MenuDivider, MenuItem, Tooltip, Tag, ContextMenuTarget } from "@blueprintjs/core";
+import { Classes, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps, Tooltip2 } from "@blueprintjs/popover2";
+import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps } from "@blueprintjs/popover2";
 
 export const ContextMenu2Example: React.FC<IExampleProps> = props => {
     const renderContent = React.useCallback(
@@ -51,108 +51,14 @@ export const ContextMenu2Example: React.FC<IExampleProps> = props => {
     );
 
     return (
-        <Example className="docs-context-menu-example" options={false} {...props}>
-            <Popover2Example />
-            <LegacyContextMenuExample />
-        </Example>
+        <ContextMenu2 content={renderContent}>
+            <Example className="docs-context-menu-example" options={false} {...props}>
+                <GraphNode />
+                <span className={Classes.TEXT_MUTED}>Right-click on node or background.</span>
+            </Example>
+        </ContextMenu2>
     );
-    // return (
-    //     <ContextMenu2 content={renderContent}>
-    //         <Example className="docs-context-menu-example" options={false} {...props}>
-    //             <GraphNode />
-    //             <span className={Classes.TEXT_MUTED}>Right-click on node or background.</span>
-    //         </Example>
-    //     </ContextMenu2>
-    // );
 };
-
-function Popover2Example() {
-    return (
-        <div style={{ margin: 20 }}>
-            <Tooltip2 content="hello">
-                <div>
-                    <ContextMenu2
-                        content={
-                            <Menu>
-                                <MenuItem text="First" />
-                                <MenuItem text="Second" />
-                            </Menu>
-                        }
-                    >
-                        <Tag interactive={true}>Tooltip2 + ContextMenu2 (hover and right click me)</Tag>
-                    </ContextMenu2>
-                </div>
-            </Tooltip2>
-            <br />
-            <br />
-            <Tooltip content="hello">
-                <div>
-                    <ContextMenu2
-                        content={
-                            <Menu>
-                                <MenuItem text="First" />
-                                <MenuItem text="Second" />
-                            </Menu>
-                        }
-                    >
-                        <Tag interactive={true}>Tooltip + ContextMenu2 (hover and right click me)</Tag>
-                    </ContextMenu2>
-                </div>
-            </Tooltip>
-        </div>
-    );
-}
-
-function LegacyContextMenuExample() {
-    return (
-        <div style={{ margin: 20 }}>
-            <Tooltip2 content="hello">
-                <div>
-                    <ContextMenu
-                        content={
-                            <Menu>
-                                <MenuItem text="First" />
-                                <MenuItem text="Second" />
-                            </Menu>
-                        }
-                    >
-                        <Tag interactive={true}>Tooltip2 + @ContextMenuTarget (hover and right click me)</Tag>
-                    </ContextMenu>
-                </div>
-            </Tooltip2>
-            <br />
-            <br />
-            <Tooltip content="hello">
-                <div>
-                    <ContextMenu
-                        content={
-                            <Menu>
-                                <MenuItem text="First" />
-                                <MenuItem text="Second" />
-                            </Menu>
-                        }
-                    >
-                        <Tag interactive={true}>Tooltip + @ContextMenuTarget (hover and right click me)</Tag>
-                    </ContextMenu>
-                </div>
-            </Tooltip>
-        </div>
-    );
-}
-
-@ContextMenuTarget
-class ContextMenu extends React.Component<{
-    children: React.ReactElement;
-    content: React.ReactElement;
-}> {
-    public render() {
-        return this.props.children;
-    }
-
-    public renderContextMenu() {
-        return this.props.content;
-    }
-}
 
 const GraphNode: React.FC = () => {
     const children = React.useCallback(

--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { Classes, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps } from "@blueprintjs/popover2";
+import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps, Tooltip2 } from "@blueprintjs/popover2";
 
 export const ContextMenu2Example: React.FC<IExampleProps> = props => {
     const renderContent = React.useCallback(
@@ -53,7 +53,15 @@ export const ContextMenu2Example: React.FC<IExampleProps> = props => {
     return (
         <ContextMenu2 content={renderContent}>
             <Example className="docs-context-menu-example" options={false} {...props}>
-                <GraphNode />
+                <Tooltip2
+                    content={
+                        <div style={{ maxWidth: 230, textAlign: "center" }}>
+                            This tooltip will close when you open the node's context menu
+                        </div>
+                    }
+                >
+                    <GraphNode />
+                </Tooltip2>
                 <span className={Classes.TEXT_MUTED}>Right-click on node or background.</span>
             </Example>
         </ContextMenu2>

--- a/packages/docs-app/src/tsconfig.json
+++ b/packages/docs-app/src/tsconfig.json
@@ -5,6 +5,8 @@
         "lib": ["dom", "es5", "es6"],
         "outDir": "../dist",
         "sourceMap": false,
-        "strictNullChecks": false
+        "strictNullChecks": false,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false
     }
 }

--- a/packages/docs-app/src/tsconfig.json
+++ b/packages/docs-app/src/tsconfig.json
@@ -5,8 +5,6 @@
         "lib": ["dom", "es5", "es6"],
         "outDir": "../dist",
         "sourceMap": false,
-        "strictNullChecks": false,
-        "noUnusedLocals": false,
-        "noUnusedParameters": false
+        "strictNullChecks": false
     }
 }

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -20,6 +20,7 @@ const NS = Classes.getClassNamespace();
 
 export const CONTEXT_MENU2 = `${NS}-context-menu2`;
 export const CONTEXT_MENU2_POPOVER2_TARGET = `${CONTEXT_MENU2}-popover2-target`;
+export const CONTEXT_MENU2_POPOVER2 = `${CONTEXT_MENU2}-popover2`;
 
 export const POPOVER2 = `${NS}-popover2`;
 export const POPOVER2_ARROW = `${POPOVER2}-arrow`;

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -174,6 +174,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
         menu === undefined ? undefined : (
             <Popover2
                 {...popoverProps}
+                autoFocus={false}
                 content={
                     // this prevents right-clicking inside our context menu
                     <div onContextMenu={cancelContextMenu}>{menu}</div>
@@ -186,7 +187,9 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
                 isOpen={isOpen}
                 minimal={true}
                 onInteraction={handlePopoverInteraction}
-                popoverClassName={classNames(popoverProps?.popoverClassName, { [CoreClasses.DARK]: isDarkTheme })}
+                popoverClassName={classNames(Classes.CONTEXT_MENU2_POPOVER2, popoverProps?.popoverClassName, {
+                    [CoreClasses.DARK]: isDarkTheme,
+                })}
                 placement="right-start"
                 positioningStrategy="fixed"
                 rootBoundary="viewport"

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -513,10 +513,12 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
     };
 
     private handleTargetContextMenu = (e: React.MouseEvent<HTMLElement>) => {
-        if (!e.defaultPrevented) {
-            // if a right-click was successfully triggered on the target, we should consider the mouse to have
-            // left the target, since a context menu is being shown
-            this.isMouseInTargetOrPopover = false;
+        // we assume that when someone prevents the default interaction on this event (a browser native context menu),
+        // they are showing a custom context menu (as ContextMenu2 does)
+        if (e.defaultPrevented) {
+            // if custom context menu is being shown, we should consider the mouse to have left the target
+            // this.handleMouseLeave(e);
+            this.setOpenState(false, e, this.props.hoverCloseDelay);
         }
     };
 

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -514,18 +514,15 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
 
     private handleTargetContextMenu = (e: React.MouseEvent<HTMLElement>) => {
         // we assume that when someone prevents the default interaction on this event (a browser native context menu),
-        // they are showing a custom context menu (as ContextMenu2 does)
+        // they are showing a custom context menu (as ContextMenu2 does); in this case, we should close this popover/tooltip
         if (e.defaultPrevented) {
-            // if custom context menu is being shown, we should consider the mouse to have left the target
-            // this.handleMouseLeave(e);
-            this.setOpenState(false, e, this.props.hoverCloseDelay);
+            this.setOpenState(false, e);
         }
     };
 
     private handleMouseEnter = (e: React.MouseEvent<HTMLElement>) => {
         this.isMouseInTargetOrPopover = true;
 
-        console.log("triggered mouse enter...", this.targetElement);
         // if we're entering the popover, and the mode is set to be HOVER_TARGET_ONLY, we want to manually
         // trigger the mouse leave event, as hovering over the popover shouldn't count.
         if (
@@ -544,7 +541,6 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
     private handleMouseLeave = (e: React.MouseEvent<HTMLElement>) => {
         this.isMouseInTargetOrPopover = false;
 
-        console.log("triggered mouse leave!!", this.targetElement);
         // wait until the event queue is flushed, because we want to leave the
         // popover open if the mouse entered the popover immediately after
         // leaving the target (or vice versa).

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -293,6 +293,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
             ? {
                   // HOVER handlers
                   onBlur: this.handleTargetBlur,
+                  onContextMenu: this.handleTargetContextMenu,
                   onFocus: this.handleTargetFocus,
                   onMouseEnter: this.handleMouseEnter,
                   onMouseLeave: this.handleMouseLeave,
@@ -511,9 +512,18 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         this.lostFocusOnSamePage = e.relatedTarget != null;
     };
 
+    private handleTargetContextMenu = (e: React.MouseEvent<HTMLElement>) => {
+        if (!e.defaultPrevented) {
+            // if a right-click was successfully triggered on the target, we should consider the mouse to have
+            // left the target, since a context menu is being shown
+            this.isMouseInTargetOrPopover = false;
+        }
+    };
+
     private handleMouseEnter = (e: React.MouseEvent<HTMLElement>) => {
         this.isMouseInTargetOrPopover = true;
 
+        console.log("triggered mouse enter...", this.targetElement);
         // if we're entering the popover, and the mode is set to be HOVER_TARGET_ONLY, we want to manually
         // trigger the mouse leave event, as hovering over the popover shouldn't count.
         if (
@@ -532,6 +542,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
     private handleMouseLeave = (e: React.MouseEvent<HTMLElement>) => {
         this.isMouseInTargetOrPopover = false;
 
+        console.log("triggered mouse leave!!", this.targetElement);
         // wait until the event queue is flushed, because we want to leave the
         // popover open if the mouse entered the popover immediately after
         // leaving the target (or vice versa).

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 
-import { Classes, ContextMenu2, ContextMenu2ContentProps, ContextMenu2Props, Popover2 } from "../src";
+import { Classes, ContextMenu2, ContextMenu2ContentProps, ContextMenu2Props, Popover2, Tooltip2 } from "../src";
 
 const MENU_ITEMS = [
     <MenuItem key="left" icon="align-left" text="Align Left" />,
@@ -114,6 +114,48 @@ describe("ContextMenu2", () => {
                     )}
                 </ContextMenu2>,
             );
+        }
+    });
+
+    describe("interacting with other components", () => {
+        it("closes parent Tooltip2", () => {
+            const wrappedCtxMenu = mount(
+                <Tooltip2 content="hello">
+                    <ContextMenu2 content={MENU} popoverProps={{ transitionDuration: 0 }}>
+                        <div className={TARGET_CLASSNAME} />
+                    </ContextMenu2>
+                </Tooltip2>,
+            );
+
+            openTooltip(wrappedCtxMenu);
+            openCtxMenu(wrappedCtxMenu);
+            assert.isTrue(
+                wrappedCtxMenu.find(ContextMenu2).find(Popover2).prop("isOpen"),
+                "ContextMenu2 popover should be open",
+            );
+            assert.lengthOf(wrappedCtxMenu.find(Classes.TOOLTIP2), 0, "Tooltip2 should be closed");
+        });
+
+        it("closes child Tooltip2", () => {
+            const ctxMenu = mount(
+                <ContextMenu2 content={MENU} popoverProps={{ transitionDuration: 0 }}>
+                    <Tooltip2 content="hello">
+                        <div className={TARGET_CLASSNAME} />
+                    </Tooltip2>
+                </ContextMenu2>,
+            );
+
+            openTooltip(ctxMenu);
+            openCtxMenu(ctxMenu);
+            assert.isTrue(
+                ctxMenu.find(ContextMenu2).find(Popover2).first().prop("isOpen"),
+                "ContextMenu2 popover should be open",
+            );
+            assert.lengthOf(ctxMenu.find(Classes.TOOLTIP2), 0, "Tooltip2 should be closed");
+        });
+
+        function openTooltip(wrapper: ReactWrapper) {
+            wrapper.find(`.${TARGET_CLASSNAME}`).simulate("mouseenter");
         }
     });
 


### PR DESCRIPTION
#### Fixes #4719

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add special event handling to Popover2 so that parent and child popovers/tooltips of a ContextMenu2 will get dismissed when the custom context menu is opened.

#### Reviewers should focus on:

No regressions

#### Screenshot

![2021-05-26 19 04 48](https://user-images.githubusercontent.com/723999/119742209-455aac80-be55-11eb-9580-40d2b8c80697.gif)
