### PR TITLE
[popover2] fix(ContextMenu2): simpler target positioning logic

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -78,7 +78,10 @@ export const LIST_UNSTYLED = `${NS}-list-unstyled`;
 export const RTL = `${NS}-rtl`;
 
 // layout utilities
-/** @see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block */
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
+ * @deprecated this is no longer needed for ContextMenu2, will be removed in v4.0
+ */
 export const FIXED_POSITIONING_CONTAINING_BLOCK = `${NS}-fixed-positioning-containing-block`;
 
 // components

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -185,9 +185,6 @@ export class Collapse extends AbstractPureComponent2<CollapseProps, ICollapseSta
             transition: isAutoHeight ? "none" : undefined,
         };
 
-        // in order to give hints to child elements which rely on CSS fixed positioning, we need to apply a class
-        // to the element which creates a new containing block with a non-empty `transform` property
-        // see https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
         const contentsStyle = {
             // only use heightWhenOpen while closing
             transform: displayWithTransform ? "translateY(0)" : `translateY(-${this.state.heightWhenOpen}px)`,
@@ -202,7 +199,7 @@ export class Collapse extends AbstractPureComponent2<CollapseProps, ICollapseSta
                 style: containerStyle,
             },
             <div
-                className={classNames(Classes.COLLAPSE_BODY, Classes.FIXED_POSITIONING_CONTAINING_BLOCK)}
+                className={Classes.COLLAPSE_BODY}
                 ref={this.contentsRefHandler}
                 style={contentsStyle}
                 aria-hidden={!isContentVisible && this.props.keepChildrenMounted}

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -54,12 +54,6 @@ $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) / 2 !default;
       }
     }
   }
-
-  &.#{$ns}-fixed-positioning-containing-block {
-    // use the same transform as the Collapse component, to mimic the behavior of creating a new
-    // containing block for children which are position: fixed (like ContextMenu2 targets)
-    transform: translateY(0);
-  }
 }
 
 .#{$ns}-tree-node-list {

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -97,7 +97,7 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
 
     public render() {
         return (
-            <div className={classNames(Classes.TREE, Classes.FIXED_POSITIONING_CONTAINING_BLOCK, this.props.className)}>
+            <div className={classNames(Classes.TREE, this.props.className)}>
                 {this.renderNodes(this.props.contents, [], Classes.TREE_ROOT)}
             </div>
         );

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -129,7 +129,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
         ...restProps
     } = props;
 
-    // click target offset relative to the page (e.pageX/pageY), since the target will be rendered in a Portal
+    // click target offset relative to the viewport (e.clientX/clientY), since the target will be rendered in a Portal
     const [targetOffset, setTargetOffset] = React.useState<Offset | undefined>(undefined);
     // hold a reference to the click mouse event to pass to content/child render functions
     const [mouseEvent, setMouseEvent] = React.useState<React.MouseEvent<HTMLElement>>();
@@ -216,7 +216,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
                 e.preventDefault();
                 e.persist();
                 setMouseEvent(e);
-                setTargetOffset({ left: e.pageX, top: e.pageY });
+                setTargetOffset({ left: e.clientX, top: e.clientY });
                 setIsOpen(true);
             }
 

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -104,7 +104,6 @@ describe("ContextMenu2", () => {
                         <div
                             className={classNames(ctxMenuProps.className, TARGET_CLASSNAME)}
                             onContextMenu={ctxMenuProps.onContextMenu}
-                            ref={ctxMenuProps.ref}
                         >
                             {ctxMenuProps.popover}
                             <span data-testid="content-clicked-info">
@@ -162,7 +161,7 @@ describe("ContextMenu2", () => {
     function openCtxMenu(ctxMenu: ReactWrapper) {
         ctxMenu
             .find(`.${TARGET_CLASSNAME}`)
-            .simulate("contextmenu", { defaultPrevented: false, clientX: 10, clientY: 10 })
+            .simulate("contextmenu", { defaultPrevented: false, pageX: 10, pageY: 10 })
             .update();
     }
 

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -161,7 +161,7 @@ describe("ContextMenu2", () => {
     function openCtxMenu(ctxMenu: ReactWrapper) {
         ctxMenu
             .find(`.${TARGET_CLASSNAME}`)
-            .simulate("contextmenu", { defaultPrevented: false, pageX: 10, pageY: 10 })
+            .simulate("contextmenu", { defaultPrevented: false, clientX: 10, clientY: 10 })
             .update();
     }
 


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Wrap ContextMenu2's generated popover target in a `<Portal>` to make its implementation align more closely with the legacy ContextMenuTarget API.
	- This obviates the need for attaching our own container ref and querying its containing positioning block with `Classes.FIXED_POSITIONING_CONTAINING_BLOCK`, making the API simpler for users in many use cases
	- This fixes a bug where the offset calculation was wrong in cases where the context menu child scrolled around in its container and/or the developer was not able to attach `Classes.FIXED_POSITIONING_CONTAINING_BLOCK` to the most relevant DOM element (for example, when using third-party libraries)
- Deprecate `Classes.FIXED_POSITIONING_CONTAINING_BLOCK`
- ❌ BREAKING CHANGE: Removed `ref` from `ContextMenu2ChildrenProps`

#### Reviewers should focus on:

No regressions in ContextMenu2 and Tree examples in docs

#### Screenshot

![image](https://user-images.githubusercontent.com/723999/119868347-ec3e5780-beec-11eb-932b-08b745f0b772.png)

![image](https://user-images.githubusercontent.com/723999/119868403-ffe9be00-beec-11eb-90c7-196c589da2e0.png)
