### PR TITLE
[popover2] fix(ContextMenu2): detect dark theme correctly

### DIFF
--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -76,6 +76,7 @@ const GraphNode: React.FC = () => {
                     "docs-context-menu-open": props.contentProps.isOpen,
                 })}
                 onContextMenu={props.onContextMenu}
+                ref={props.ref}
             >
                 {props.popover}
             </div>

--- a/packages/popover2/src/_context-menu2.scss
+++ b/packages/popover2/src/_context-menu2.scss
@@ -7,6 +7,6 @@
   display: block;
 }
 
-.#{$ns}-context-menu2-popover2-target {
+.#{$ns}-context-menu2-virtual-target {
   position: fixed;
 }

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -19,7 +19,7 @@ import { Classes } from "@blueprintjs/core";
 const NS = Classes.getClassNamespace();
 
 export const CONTEXT_MENU2 = `${NS}-context-menu2`;
-export const CONTEXT_MENU2_POPOVER2_TARGET = `${CONTEXT_MENU2}-popover2-target`;
+export const CONTEXT_MENU2_VIRTUAL_TARGET = `${CONTEXT_MENU2}-popover2-target`;
 export const CONTEXT_MENU2_POPOVER2 = `${CONTEXT_MENU2}-popover2`;
 export const CONTEXT_MENU2_BACKDROP = `${CONTEXT_MENU2}-backdrop`;
 

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -19,7 +19,7 @@ import { Classes } from "@blueprintjs/core";
 const NS = Classes.getClassNamespace();
 
 export const CONTEXT_MENU2 = `${NS}-context-menu2`;
-export const CONTEXT_MENU2_VIRTUAL_TARGET = `${CONTEXT_MENU2}-popover2-target`;
+export const CONTEXT_MENU2_VIRTUAL_TARGET = `${CONTEXT_MENU2}-virtual-target`;
 export const CONTEXT_MENU2_POPOVER2 = `${CONTEXT_MENU2}-popover2`;
 export const CONTEXT_MENU2_BACKDROP = `${CONTEXT_MENU2}-backdrop`;
 

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -164,7 +164,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
         }
     }, []);
 
-    // but Popover2 should attach its ref to the virtual target we render inside a Portal
+    // Popover2 should attach its ref to the virtual target we render inside a Portal, not the "inline" child target
     const renderTarget = React.useCallback(
         ({ ref }: Popover2TargetProps) => (
             <Portal>

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -17,14 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import {
-    Classes as CoreClasses,
-    IOverlayLifecycleProps,
-    Portal,
-    Props,
-    Utils as CoreUtils,
-    mergeRefs,
-} from "@blueprintjs/core";
+import { Classes as CoreClasses, IOverlayLifecycleProps, Portal, Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "./classes";
 import { Popover2Props, Popover2 } from "./popover2";
@@ -159,20 +152,21 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
         }
     }, []);
 
+    // we need a ref on the real target to check for dark theme,
+    // but Popover2 should attach its ref to the virtual target we render inside a Portal
     const targetRef = React.useRef<HTMLDivElement>(null);
     const renderTarget = React.useCallback(
         ({ ref }: Popover2TargetProps) => (
-            <Portal>
-                <div
-                    className={Classes.CONTEXT_MENU2_POPOVER2_TARGET}
-                    style={targetOffset}
-                    ref={mergeRefs(ref, targetRef)}
-                />
-            </Portal>
+            <div ref={targetRef}>
+                <Portal>
+                    <div className={Classes.CONTEXT_MENU2_VIRTUAL_TARGET} style={targetOffset} ref={ref} />
+                </Portal>
+            </div>
         ),
         [targetOffset],
     );
-    const isDarkTheme = React.useMemo(() => CoreUtils.isDarkTheme(targetRef.current), [targetRef.current]);
+    // if the menu was just opened, we should check for dark theme (but don't do this on every render)
+    const isDarkTheme = React.useMemo(() => CoreUtils.isDarkTheme(targetRef.current), [targetRef, isOpen]);
 
     const contentProps: ContextMenu2ContentProps = { isOpen, mouseEvent, targetOffset };
 

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -17,7 +17,14 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes as CoreClasses, IOverlayLifecycleProps, Portal, Props, Utils as CoreUtils } from "@blueprintjs/core";
+import {
+    Classes as CoreClasses,
+    IOverlayLifecycleProps,
+    Portal,
+    Props,
+    Utils as CoreUtils,
+    mergeRefs,
+} from "@blueprintjs/core";
 
 import * as Classes from "./classes";
 import { Popover2Props, Popover2 } from "./popover2";
@@ -64,6 +71,9 @@ export interface ContextMenu2ChildrenProps {
 
     /** Popover element rendered by ContextMenu, used to establish a click target to position the menu */
     popover: JSX.Element | undefined;
+
+    /** DOM ref for the context menu target, used to detect dark theme */
+    ref: React.Ref<any>;
 }
 
 export interface ContextMenu2Props
@@ -132,6 +142,8 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
     // hold a reference to the click mouse event to pass to content/child render functions
     const [mouseEvent, setMouseEvent] = React.useState<React.MouseEvent<HTMLElement>>();
     const [isOpen, setIsOpen] = React.useState<boolean>(false);
+    // we need a ref on the child element (or the wrapper we generate) to check for dark theme
+    const childRef = React.useRef<HTMLDivElement>(null);
 
     // If disabled prop is changed, we don't want our old context menu to stick around.
     // If it has just been enabled (disabled = false), then the menu ought to be opened by
@@ -152,26 +164,22 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
         }
     }, []);
 
-    // we need a ref on the real target to check for dark theme,
     // but Popover2 should attach its ref to the virtual target we render inside a Portal
-    const targetRef = React.useRef<HTMLDivElement>(null);
     const renderTarget = React.useCallback(
         ({ ref }: Popover2TargetProps) => (
-            <div ref={targetRef}>
-                <Portal>
-                    <div className={Classes.CONTEXT_MENU2_VIRTUAL_TARGET} style={targetOffset} ref={ref} />
-                </Portal>
-            </div>
+            <Portal>
+                <div className={Classes.CONTEXT_MENU2_VIRTUAL_TARGET} style={targetOffset} ref={ref} />
+            </Portal>
         ),
         [targetOffset],
     );
-    // if the menu was just opened, we should check for dark theme (but don't do this on every render)
-    const isDarkTheme = React.useMemo(() => CoreUtils.isDarkTheme(targetRef.current), [targetRef, isOpen]);
 
-    const contentProps: ContextMenu2ContentProps = { isOpen, mouseEvent, targetOffset };
+    // if the menu was just opened, we should check for dark theme (but don't do this on every render)
+    const isDarkTheme = React.useMemo(() => CoreUtils.isDarkTheme(childRef.current), [childRef, isOpen]);
 
     // only render the popover if there is content in the context menu;
     // this avoid doing unnecessary rendering & computation
+    const contentProps: ContextMenu2ContentProps = { isOpen, mouseEvent, targetOffset };
     const menu = disabled ? undefined : CoreUtils.isFunction(content) ? content(contentProps) : content;
     const maybePopover =
         menu === undefined ? undefined : (
@@ -235,13 +243,14 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
               contentProps,
               onContextMenu: handleContextMenu,
               popover: maybePopover,
+              ref: childRef,
           })
-        : React.createElement(
+        : React.createElement<React.HTMLAttributes<any>>(
               tagName,
               {
                   className: containerClassName,
                   onContextMenu: handleContextMenu,
-                  ref: userRef,
+                  ref: mergeRefs(childRef, userRef),
                   ...restProps,
               },
               maybePopover,

--- a/packages/popover2/src/index.md
+++ b/packages/popover2/src/index.md
@@ -9,6 +9,8 @@ provides successors to Popover and Tooltip in `@blueprintjs/core`:
 
 -   [`Popover2`](#popover2-package/popover2)
 -   [`Tooltip2`](#popover2-package/tooltip2)
+-   [`ContextMenu2`](#popover2-package/context-menu2)
+-   [`ResizeSensor2`](#popover2-package/resize-sensor2)
 
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
 

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -144,6 +144,43 @@ describe("ContextMenu2", () => {
         }
     });
 
+    describe("theming", () => {
+        it("detects dark theme", () => {
+            const wrapper = mount(
+                <div className={CoreClasses.DARK}>
+                    <ContextMenu2 content={MENU} popoverProps={{ transitionDuration: 0 }}>
+                        <div className={TARGET_CLASSNAME} />
+                    </ContextMenu2>
+                </div>,
+            );
+
+            openCtxMenu(wrapper);
+            const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU2_POPOVER2}`).hostNodes();
+            assert.isTrue(
+                ctxMenuPopover.hasClass(CoreClasses.DARK),
+                "ContextMenu2 popover should be open WITH dark theme applied",
+            );
+        });
+
+        it("detects theme change (dark -> light)", () => {
+            const wrapper = mount(
+                <div className={CoreClasses.DARK}>
+                    <ContextMenu2 content={MENU} popoverProps={{ transitionDuration: 0 }}>
+                        <div className={TARGET_CLASSNAME} />
+                    </ContextMenu2>
+                </div>,
+            );
+
+            wrapper.setProps({ className: undefined });
+            openCtxMenu(wrapper);
+            const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU2_POPOVER2}`).hostNodes();
+            assert.isFalse(
+                ctxMenuPopover.hasClass(CoreClasses.DARK),
+                "ContextMenu2 popover should be open WITHOUT dark theme applied",
+            );
+        });
+    });
+
     describe("interacting with other components", () => {
         describe("with one level of nesting", () => {
             it("closes parent Tooltip2", () => {


### PR DESCRIPTION
#### Fixes #4743

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Fix ContextMenu2 dark theme detection by restoring an inline `<div>` rendered as the popover target, so that we can attach a ref to it and properly query for dark theme. Before this change, we were checking for dark theme on the "virtual" target we rendered inside a `<Portal>`, which will almost always be an invalid check since applications rarely add `.bp3-dark` to the `<body>` element.
- 🔥 BREAKING CHANGE: rename `Classes.CONTEXT_MENU2_POPOVER2_TARGET` to `Classes.CONTEXT_MENU2_VIRTUAL_TARGET`
- 🔥 BREAKING CHANGE: add `ref` property _back_ to `ContextMenu2ChildrenProps` after it was removed in #4740 (sorry for the API whiplash). If upgrading from popover2 `> 0.8.0 < 0.11.0` and you are using the advanced children render function API, you'll need to attach this ref to whatever you return from the children render function.

#### Reviewers should focus on:

N/A

#### Screenshot

![2021-06-11 13 18 07](https://user-images.githubusercontent.com/723999/121725620-8094e680-cab7-11eb-8d53-468367a541f3.gif)
