### PR TITLE
[core] fix(InputGroup): adjust classes for leftElement span

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -264,7 +264,10 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
 
         if (leftElement != null) {
             return (
-                <span className={Classes.INPUT_LEFT_CONTAINER} ref={this.refHandlers.leftElement}>
+                <span
+                    className={classNames(Classes.INPUT_LEFT_CONTAINER, Classes.INPUT_ACTION)}
+                    ref={this.refHandlers.leftElement}
+                >
                     {leftElement}
                 </span>
             );


### PR DESCRIPTION
#### Fixes #4535

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Reuse existing logic provided for `Classes.INPUT_ACTION`, which correctly handles `z-index` for `rightElement` when inside a `ControlGroup` (due to higher specificity), without affecting `Classes.INPUT_LEFT_CONTAINER` when not inside a `ControlGroup` element.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
