### PR TITLE
[core] fix(ControlGroup): InputGroup leftElement visibility

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -175,6 +175,7 @@ Styleguide control-group
   // input group contents appear above input always
   .#{$ns}-input-group > .#{$ns}-icon,
   .#{$ns}-input-group > .#{$ns}-button,
+  .#{$ns}-input-group > .#{$ns}-input-left-container,
   .#{$ns}-input-group > .#{$ns}-input-action {
     z-index: index($control-group-stack, "input-group-children");
   }


### PR DESCRIPTION
#### Fixes #4535

#### Changes proposed in this pull request:

Add styling to control group to fix the z-index of `leftElement` content inside ControlGroup > InputGroup

#### Screenshot

![image](https://user-images.githubusercontent.com/723999/122975112-02f79300-d361-11eb-8d4c-35edd3d591fa.png)
