### PR TITLE
[popover2] fix(ContextMenu2): render popover as wrapper sibling

### DIFF
--- a/packages/popover2/src/context-menu2.md
+++ b/packages/popover2/src/context-menu2.md
@@ -50,16 +50,16 @@ export default function ContextMenuExample() {
 `<ContextMenu2>` will render a `<div>` wrapper element around its children. You can treat this
 component as a `<div>`, since extra props will be forwarded down to the DOM element. For example,
 you can add an `onClick` handler. You may also customize the tag name of the generated wrapper
-element using the `tagName` prop.
+element using the `tagName` prop. Note that the generated popover will be rendered as a _sibling_
+of this wrapper element.
 
 ### Advanced usage
 
-By default, `<ContextMenu2>` will render a wrapper element around its children to contain the
-generated popover, attach an event handler, and get a DOM ref for layout measurement. If this
-wrapper element breaks your HTML and/or CSS layout in some way and you wish to omit it, you may
-do so by utilizing ContextMenu2's advanced rendering API which uses a `children` render function.
-If you use this approach, you must take care to properly use all the render props supplied to
-the `children()` function:
+By default, `<ContextMenu2>` will render a wrapper element around its children to attach an event handler
+and get a DOM ref for theme detection. If this wrapper element breaks your HTML and/or CSS layout in
+some way and you wish to omit it, you may do so by utilizing ContextMenu2's advanced rendering API
+which uses a `children` render function. If you use this approach, you must take care to properly use
+all the render props supplied to the `children()` function:
 
 ```tsx
 import classNames from "classnames";

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -237,25 +237,29 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
 
     const containerClassName = classNames(className, Classes.CONTEXT_MENU2);
 
-    const child = CoreUtils.isFunction(children)
-        ? children({
-              className: containerClassName,
-              contentProps,
-              onContextMenu: handleContextMenu,
-              popover: maybePopover,
-              ref: childRef,
-          })
-        : React.createElement<React.HTMLAttributes<any>>(
-              tagName,
-              {
-                  className: containerClassName,
-                  onContextMenu: handleContextMenu,
-                  ref: mergeRefs(childRef, userRef),
-                  ...restProps,
-              },
-              maybePopover,
-              children,
-          );
+    const child = CoreUtils.isFunction(children) ? (
+        children({
+            className: containerClassName,
+            contentProps,
+            onContextMenu: handleContextMenu,
+            popover: maybePopover,
+            ref: childRef,
+        })
+    ) : (
+        <>
+            {maybePopover}
+            {React.createElement<React.HTMLAttributes<any>>(
+                tagName,
+                {
+                    className: containerClassName,
+                    onContextMenu: handleContextMenu,
+                    ref: mergeRefs(childRef, userRef),
+                    ...restProps,
+                },
+                children,
+            )}
+        </>
+    );
 
     // force descendant Tooltip2s to be disabled when this context menu is open
     return <Tooltip2Provider forceDisable={isOpen}>{child}</Tooltip2Provider>;

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -18,6 +18,7 @@ import { assert } from "chai";
 import classNames from "classnames";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
+import { spy } from "sinon";
 
 import { Classes as CoreClasses, Menu, MenuItem, Keys } from "@blueprintjs/core";
 
@@ -46,7 +47,7 @@ const COMMON_TOOLTIP_PROPS: Partial<Tooltip2Props> = {
     usePortal: false,
 };
 
-describe("ContextMenu2", () => {
+describe.only("ContextMenu2", () => {
     describe("basic usage", () => {
         it("renders children and Popover2", () => {
             const ctxMenu = mountTestMenu();
@@ -83,6 +84,23 @@ describe("ContextMenu2", () => {
                     which: Keys.ESCAPE,
                 });
             assert.isFalse(ctxMenu.find(Popover2).prop("isOpen"));
+        });
+
+        it("clicks inside popover don't propagate to context menu wrapper", () => {
+            const itemClickSpy = spy();
+            const wrapperClickSpy = spy();
+            const ctxMenu = mountTestMenu({
+                content: (
+                    <Menu>
+                        <MenuItem data-testid="item" text="item" onClick={itemClickSpy} />
+                    </Menu>
+                ),
+                onClick: wrapperClickSpy,
+            });
+            openCtxMenu(ctxMenu);
+            ctxMenu.find("[data-testid='item']").hostNodes().simulate("click");
+            assert.isTrue(itemClickSpy.calledOnce, "menu item click handler should be called once");
+            assert.isFalse(wrapperClickSpy.called, "ctx menu wrapper click handler should not be called");
         });
 
         function mountTestMenu(props: Partial<ContextMenu2Props> = {}) {

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -47,7 +47,7 @@ const COMMON_TOOLTIP_PROPS: Partial<Tooltip2Props> = {
     usePortal: false,
 };
 
-describe.only("ContextMenu2", () => {
+describe("ContextMenu2", () => {
     describe("basic usage", () => {
         it("renders children and Popover2", () => {
             const ctxMenu = mountTestMenu();


### PR DESCRIPTION
#### Fixes #4777

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Render the popover as a sibling of ContextMenu2's wrapper element instead of as a child.

#### Reviewers should focus on:

No regressions, and the new unit test passes

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
