### PR TITLE
[core] feat(Icon): deprecate iconSize, replace with size prop

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -169,7 +169,7 @@ export class Alert extends AbstractPureComponent2<AlertProps> {
                 portalContainer={this.props.portalContainer}
             >
                 <div className={Classes.ALERT_BODY}>
-                    <Icon icon={icon} iconSize={40} intent={intent} />
+                    <Icon icon={icon} size={40} intent={intent} />
                     <div className={Classes.ALERT_CONTENTS}>{children}</div>
                 </div>
                 <div className={Classes.ALERT_FOOTER}>

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -78,7 +78,7 @@ export class Callout extends AbstractPureComponent2<CalloutProps> {
 
         return (
             <div className={classes} {...htmlProps}>
-                {iconName && <Icon icon={iconName} iconSize={IconSize.LARGE} />}
+                {iconName && <Icon icon={iconName} size={IconSize.LARGE} />}
                 {title && <H4>{title}</H4>}
                 {children}
             </div>

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -119,7 +119,7 @@ export class Dialog extends AbstractPureComponent2<DialogProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<Icon icon="small-cross" iconSize={IconSize.LARGE} />}
+                    icon={<Icon icon="small-cross" size={IconSize.LARGE} />}
                     minimal={true}
                     onClick={this.props.onClose}
                 />
@@ -136,7 +136,7 @@ export class Dialog extends AbstractPureComponent2<DialogProps> {
         }
         return (
             <div className={Classes.DIALOG_HEADER}>
-                <Icon icon={icon} iconSize={IconSize.LARGE} />
+                <Icon icon={icon} size={IconSize.LARGE} />
                 <H4>{title}</H4>
                 {this.maybeRenderCloseButton()}
             </div>

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -203,7 +203,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<Icon icon="small-cross" iconSize={IconSize.LARGE} />}
+                    icon={<Icon icon="small-cross" size={IconSize.LARGE} />}
                     minimal={true}
                     onClick={this.props.onClose}
                 />
@@ -220,7 +220,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
         }
         return (
             <div className={Classes.DRAWER_HEADER}>
-                <Icon icon={icon} iconSize={IconSize.LARGE} />
+                <Icon icon={icon} size={IconSize.LARGE} />
                 <H4>{title}</H4>
                 {this.maybeRenderCloseButton()}
             </div>

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -19,16 +19,16 @@ the name as a string, these components render `<Icon icon="..." />` under the ho
 
 Use the `<Icon>` component to easily render __SVG icons__ in React. The `icon`
 prop is typed such that editors can offer autocomplete for known icon names. The
-optional `iconSize` prop determines the exact width and height of the icon
-image; the icon element itself can be sized separately using CSS.
+optional `size` prop (previously called `iconSize`) determines the exact width
+and height of the icon image; the icon element itself can be sized separately using CSS.
 
 The HTML element rendered by `<Icon>` can be customized with the `tagName` prop
 (defaults to `span`), and additional props are passed to this element.
 
 Data files in the __@blueprintjs/icons__ package provide SVG path information
 for Blueprint's 300+ icons for 16px and 20px grids. The `icon` prop dictates
-which SVG is rendered and `iconSize` determines which pixel grid is used:
-`iconSize >= 20` will use the 20px grid and smaller icons will use the 16px
+which SVG is rendered and `size` determines which pixel grid is used:
+`size >= 20` will use the 20px grid and smaller icons will use the 16px
 grid.
 
 ```tsx

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -36,17 +36,17 @@ import { Icon, IconSize } from "@blueprintjs/core";
 
 // string literals are supported through IconName union type
 <Icon icon="cross" />
-<Icon icon="globe" iconSize={20} />
+<Icon icon="globe" size={20} />
 
 // constants are provided for name and size
-<Icon icon="graph" iconSize={IconSize.LARGE} intent="primary" />
+<Icon icon="graph" size={IconSize.LARGE} intent="primary" />
 
 // can pass all valid HTML props
 <Icon icon="add" onClick={this.handleAdd} onKeyDown={this.handleAddKeys} />
 ```
 
 ```html
-<Icon icon="globe" iconSize={30} />
+<Icon icon="globe" size={30} />
 <!-- renders the following HTML markup: -->
 <svg class="@ns-icon" data-icon="globe" width="30" height="30" viewBox="0 0 20 20">
     <title>globe</title>

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -68,12 +68,17 @@ export interface IIconProps extends IntentProps, Props {
     icon: IconName | MaybeElement;
 
     /**
+     * @deprecated use size prop instead
+     */
+    iconSize?: number;
+
+    /**
      * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
      * images, and chooses the appropriate resolution based on this prop.
      *
      * @default IconSize.STANDARD = 16
      */
-    iconSize?: number;
+    size?: number;
 
     /** CSS style properties. */
     style?: React.CSSProperties;
@@ -116,15 +121,17 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
             className,
             color,
             htmlTitle,
-            iconSize = IconSize.STANDARD,
+            // eslint-disable-next-line deprecation/deprecation
+            iconSize,
             intent,
+            size = iconSize ?? IconSize.STANDARD,
             title = icon,
             tagName = "span",
             ...htmlprops
         } = this.props;
 
         // choose which pixel grid is most appropriate for given icon size
-        const pixelGridSize = iconSize >= IconSize.LARGE ? IconSize.LARGE : IconSize.STANDARD;
+        const pixelGridSize = size >= IconSize.LARGE ? IconSize.LARGE : IconSize.STANDARD;
         // render path elements, or nothing if icon name is unknown.
         const paths = this.renderSvgPaths(pixelGridSize, icon);
 
@@ -139,7 +146,7 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
                 className: classes,
                 title: htmlTitle,
             },
-            <svg fill={color} data-icon={icon} width={iconSize} height={iconSize} viewBox={viewBox}>
+            <svg fill={color} data-icon={icon} width={size} height={size} viewBox={viewBox}>
                 {title && <desc>{title}</desc>}
                 {paths}
             </svg>,

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -75,7 +75,7 @@ export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
         } else {
             return (
                 <div className={Classes.NON_IDEAL_STATE_VISUAL}>
-                    <Icon icon={icon} iconSize={IconSize.LARGE * 3} />
+                    <Icon icon={icon} size={IconSize.LARGE * 3} />
                 </div>
             );
         }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -255,7 +255,7 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
                 <Icon
                     className={Classes.TAG_INPUT_ICON}
                     icon={leftIcon}
-                    iconSize={isLarge ? IconSize.LARGE : IconSize.STANDARD}
+                    size={isLarge ? IconSize.LARGE : IconSize.STANDARD}
                 />
                 <div className={Classes.TAG_INPUT_VALUES}>
                     {values.map(this.maybeRenderTag)}

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -166,7 +166,7 @@ export class Tag extends AbstractPureComponent2<TagProps> {
                 onClick={this.onRemoveClick}
                 tabIndex={interactive ? tabIndex : undefined}
             >
-                <Icon icon="small-cross" iconSize={isLarge ? IconSize.LARGE : IconSize.STANDARD} />
+                <Icon icon="small-cross" size={isLarge ? IconSize.LARGE : IconSize.STANDARD} />
             </button>
         ) : null;
 

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -151,7 +151,7 @@ describe("<Dialog>", () => {
     function createDialogContents(): JSX.Element[] {
         return [
             <div className={Classes.DIALOG_HEADER} key={0}>
-                <Icon icon="inbox" iconSize={IconSize.LARGE} />
+                <Icon icon="inbox" size={IconSize.LARGE} />
                 <H4>Dialog header</H4>
             </div>,
             <div className={Classes.DIALOG_BODY} key={1}>

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -29,11 +29,10 @@ describe("<Icon>", () => {
         assert.isTrue(icon.setProps({ tagName: "article" }).is("article"));
     });
 
-    it("iconSize=16 renders standard size", () =>
-        assertIconSize(<Icon icon="graph" iconSize={IconSize.STANDARD} />, IconSize.STANDARD));
+    it("size=16 renders standard size", () =>
+        assertIconSize(<Icon icon="graph" size={IconSize.STANDARD} />, IconSize.STANDARD));
 
-    it("iconSize=20 renders large size", () =>
-        assertIconSize(<Icon icon="graph" iconSize={IconSize.LARGE} />, IconSize.LARGE));
+    it("size=20 renders large size", () => assertIconSize(<Icon icon="graph" size={IconSize.LARGE} />, IconSize.LARGE));
 
     it("renders intent class", () =>
         assert.isTrue(shallow(<Icon icon="add" intent={Intent.DANGER} />).hasClass(Classes.INTENT_DANGER)));

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -42,7 +42,7 @@ export class DocsIcon extends React.PureComponent<IDocsIconProps> {
         const { iconName, displayName, tags } = this.props;
         return (
             <ClickToCopy className="docs-icon" data-tags={tags} value={iconName}>
-                <Icon icon={iconName} iconSize={IconSize.LARGE} />
+                <Icon icon={iconName} size={IconSize.LARGE} />
                 <div className="docs-icon-name">{displayName}</div>
                 <div className="docs-icon-detail">
                     <p className="docs-code">{iconName}</p>
@@ -61,12 +61,12 @@ export class DocsIcon extends React.PureComponent<IDocsIconProps> {
         return (
             <Menu>
                 <MenuItem
-                    icon={<Icon icon={iconName} iconSize={IconSize.STANDARD} />}
+                    icon={<Icon icon={iconName} size={IconSize.STANDARD} />}
                     text="Download 16px SVG"
                     onClick={this.handleClick16}
                 />
                 <MenuItem
-                    icon={<Icon icon={iconName} iconSize={IconSize.LARGE} />}
+                    icon={<Icon icon={iconName} size={IconSize.LARGE} />}
                     text="Download 20px SVG"
                     onClick={this.handleClick20}
                 />

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -47,7 +47,7 @@ const WelcomeCard: React.FunctionComponent<{
 }> = props => (
     <a className="blueprint-welcome-card" href={props.href} target={props.sameTab ? "" : "_blank"}>
         <Card interactive={true}>
-            <Icon icon={props.icon} iconSize={40} />
+            <Icon icon={props.icon} size={40} />
             <H4>{props.title}</H4>
             {props.children}
         </Card>

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -64,7 +64,7 @@ export class IconExample extends React.PureComponent<IExampleProps, IIconExample
 
         return (
             <Example options={options} {...this.props}>
-                <Icon icon={icon} iconSize={iconSize} intent={intent} />
+                <Icon icon={icon} size={iconSize} intent={intent} />
             </Example>
         );
     }


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

In v4.0, the `iconSize` prop has been renamed to `size`. This was done to match the `SVGIconProps` interface, which is used in the individual icon component interfaces as well (e.g. `<ArrowRight size={20} />`).

Related: https://github.com/palantir/blueprint/pull/4784