### PR TITLE
Add prop to ignore max and min date ranges

### DIFF
--- a/packages/datetime/src/dateFormat.tsx
+++ b/packages/datetime/src/dateFormat.tsx
@@ -65,13 +65,13 @@ export interface IDateFormatProps {
 export function getFormattedDateString(
     date: Date | false | null,
     props: DateFormatProps & IDatePickerBaseProps,
-    ignoreRange = false,
+    ignoreRange: boolean = false,
 ) {
     if (date == null) {
         return "";
     } else if (!isDateValid(date)) {
         return props.invalidDateMessage;
-    } else if (ignoreRange || isDayInRange(date, [props.minDate, props.maxDate])) {
+    } else if (props.ignoreRange || ignoreRange || isDayInRange(date, [props.minDate, props.maxDate])) {
         return props.formatDate(date, props.locale);
     } else {
         return props.outOfRangeMessage;

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -168,6 +168,7 @@ export class DateInput extends AbstractPureComponent2<DateInputProps, IDateInput
         closeOnSelection: true,
         dayPickerProps: {},
         disabled: false,
+        ignoreRange: false,
         invalidDateMessage: "Invalid date",
         maxDate: getDefaultMaxDate(),
         minDate: getDefaultMinDate(),
@@ -294,7 +295,7 @@ export class DateInput extends AbstractPureComponent2<DateInputProps, IDateInput
     }
 
     private isDateInRange(value: Date) {
-        return isDayInRange(value, [this.props.minDate, this.props.maxDate]);
+        return this.props.ignoreRange || isDayInRange(value, [this.props.minDate, this.props.maxDate]);
     }
 
     private handleClosePopover = (e?: React.SyntheticEvent<HTMLElement>) => {

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -69,7 +69,7 @@ export class DatePickerCaption extends AbstractPureComponent2<IDatePickerCaption
             years.push(year);
         }
         // allow out-of-bounds years but disable the option. this handles the Dec 2016 case in #391.
-        if (displayYear > maxYear) {
+        if (displayYear > maxYear || displayYear < minYear) {
             years.push({ value: displayYear, disabled: true });
         }
 

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -96,7 +96,7 @@ export interface IDatePickerBaseProps {
 
     /**
      * If `true`, the month menu will appear to the left of the year menu.
-     * Otherwise, the month menu will apear to the right of the year menu.
+     * Otherwise, the month menu will appear to the right of the year menu.
      *
      * @default false
      */
@@ -120,6 +120,13 @@ export interface IDatePickerBaseProps {
      * Passing any non-empty object to this prop will cause the `TimePicker` to appear.
      */
     timePickerProps?: TimePickerProps;
+
+    /**
+     * Allow selecting dates that fall outside of minDate and maxDate.
+     *
+     * @default false
+     */
+    ignoreRange?: boolean;
 }
 
 export const DISABLED_MODIFIER = "disabled";

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -26,6 +26,7 @@ import { areSameMonth } from "./common/dateUtils";
 export interface IDatePickerNavbarProps extends NavbarElementProps {
     maxDate: Date;
     minDate: Date;
+    ignoreRange: boolean;
 
     hideLeftNavButton?: boolean;
     hideRightNavButton?: boolean;
@@ -33,14 +34,14 @@ export interface IDatePickerNavbarProps extends NavbarElementProps {
 
 export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps> {
     public render() {
-        const { classNames: classes, month, maxDate, minDate } = this.props;
+        const { classNames: classes, month, maxDate, minDate, ignoreRange } = this.props;
 
         return (
             <div className={classNames(Classes.DATEPICKER_NAVBAR, classes.navBar)}>
                 {this.props.hideLeftNavButton || (
                     <Button
                         className={classes.navButtonPrev}
-                        disabled={areSameMonth(month, minDate)}
+                        disabled={!ignoreRange && areSameMonth(month, minDate)}
                         icon="chevron-left"
                         minimal={true}
                         onClick={this.handlePreviousClick}
@@ -49,7 +50,7 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
                 {this.props.hideRightNavButton || (
                     <Button
                         className={classes.navButtonNext}
-                        disabled={areSameMonth(month, maxDate)}
+                        disabled={!ignoreRange && areSameMonth(month, maxDate)}
                         icon="chevron-right"
                         minimal={true}
                         onClick={this.handleNextClick}

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -974,7 +974,10 @@ export class DateRangeInput extends AbstractPureComponent2<DateRangeInputProps, 
     };
 
     private isDateValidAndInRange = (date: Date | false | null): date is Date => {
-        return isDateValid(date) && isDayInRange(date, [this.props.minDate, this.props.maxDate]);
+        return (
+            isDateValid(date) &&
+            (this.props.ignoreRange || isDayInRange(date, [this.props.minDate, this.props.maxDate]))
+        );
     };
 
     private isNextDateRangeValid(nextDate: Date | false | null, boundary: Boundary): nextDate is Date {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -269,7 +269,12 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     }
 
     protected validateProps(props: DateRangePickerProps) {
-        const { defaultValue, initialMonth, maxDate, minDate, boundaryToModify, value } = props;
+        const { defaultValue, initialMonth, maxDate, minDate, boundaryToModify, value, ignoreRange } = props;
+
+        if (ignoreRange) {
+            return;
+        }
+
         const dateRange: DateRange = [minDate, maxDate];
 
         if (defaultValue != null && !DateUtils.isDayRangeInRange(defaultValue, dateRange)) {
@@ -314,7 +319,8 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
         return <div className={DateClasses.DATEPICKER_DAY_WRAPPER}>{date}</div>;
     };
 
-    private disabledDays = (day: Date) => !DateUtils.isDayInRange(day, [this.props.minDate, this.props.maxDate]);
+    private disabledDays = (day: Date) =>
+        !this.props.ignoreRange && !DateUtils.isDayInRange(day, [this.props.minDate, this.props.maxDate]);
 
     private getDisabledDaysModifier = () => {
         const {
@@ -397,7 +403,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     };
 
     private renderCalendars(isShowingOneMonth: boolean) {
-        const { dayPickerProps, locale, localeUtils, maxDate, minDate } = this.props;
+        const { dayPickerProps, locale, localeUtils, maxDate, minDate, ignoreRange } = this.props;
         const dayPickerBaseProps: DayPickerProps = {
             locale,
             localeUtils,
@@ -417,11 +423,11 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
                     {...dayPickerBaseProps}
                     captionElement={this.renderSingleCaption}
                     navbarElement={this.renderSingleNavbar}
-                    fromMonth={minDate}
+                    fromMonth={ignoreRange ? undefined : minDate}
                     month={this.state.leftView.getFullDate()}
                     numberOfMonths={1}
                     onMonthChange={this.handleLeftMonthChange}
-                    toMonth={maxDate}
+                    toMonth={ignoreRange ? undefined : maxDate}
                     renderDay={dayPickerProps?.renderDay ?? this.renderDay}
                 />
             );
@@ -433,11 +439,11 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
                     canChangeMonth={true}
                     captionElement={this.renderLeftCaption}
                     navbarElement={this.renderLeftNavbar}
-                    fromMonth={minDate}
+                    fromMonth={ignoreRange ? undefined : minDate}
                     month={this.state.leftView.getFullDate()}
                     numberOfMonths={1}
                     onMonthChange={this.handleLeftMonthChange}
-                    toMonth={DateUtils.getDatePreviousMonth(maxDate)}
+                    toMonth={ignoreRange ? undefined : DateUtils.getDatePreviousMonth(maxDate)}
                     renderDay={dayPickerProps?.renderDay ?? this.renderDay}
                 />,
                 <DayPicker
@@ -446,11 +452,11 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
                     canChangeMonth={true}
                     captionElement={this.renderRightCaption}
                     navbarElement={this.renderRightNavbar}
-                    fromMonth={DateUtils.getDateNextMonth(minDate)}
+                    fromMonth={ignoreRange ? undefined : DateUtils.getDateNextMonth(minDate)}
                     month={this.state.rightView.getFullDate()}
                     numberOfMonths={1}
                     onMonthChange={this.handleRightMonthChange}
-                    toMonth={maxDate}
+                    toMonth={ignoreRange ? undefined : maxDate}
                     renderDay={dayPickerProps?.renderDay ?? this.renderDay}
                 />,
             ];
@@ -458,7 +464,12 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     }
 
     private renderSingleNavbar = (navbarProps: NavbarElementProps) => (
-        <DatePickerNavbar {...navbarProps} maxDate={this.props.maxDate} minDate={this.props.minDate} />
+        <DatePickerNavbar
+            {...navbarProps}
+            maxDate={this.props.maxDate}
+            minDate={this.props.minDate}
+            ignoreRange={this.props.ignoreRange}
+        />
     );
 
     private renderLeftNavbar = (navbarProps: NavbarElementProps) => (
@@ -467,6 +478,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
             hideRightNavButton={this.props.contiguousCalendarMonths}
             maxDate={this.props.maxDate}
             minDate={this.props.minDate}
+            ignoreRange={this.props.ignoreRange}
         />
     );
 
@@ -476,6 +488,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
             hideLeftNavButton={this.props.contiguousCalendarMonths}
             maxDate={this.props.maxDate}
             minDate={this.props.minDate}
+            ignoreRange={this.props.ignoreRange}
         />
     );
 
@@ -649,10 +662,12 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
         const minMonthAndYear = new MonthAndYear(minDate.getMonth(), minDate.getFullYear());
         const maxMonthAndYear = new MonthAndYear(adjustedMaxDate.getMonth(), adjustedMaxDate.getFullYear());
 
-        if (leftView.isBefore(minMonthAndYear)) {
-            leftView = minMonthAndYear;
-        } else if (leftView.isAfter(maxMonthAndYear)) {
-            leftView = maxMonthAndYear;
+        if (!this.props.ignoreRange) {
+            if (leftView.isBefore(minMonthAndYear)) {
+                leftView = minMonthAndYear;
+            } else if (leftView.isAfter(maxMonthAndYear)) {
+                leftView = maxMonthAndYear;
+            }
         }
 
         let rightView = this.state.rightView.clone();
@@ -672,10 +687,12 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
         const minMonthAndYear = MonthAndYear.fromDate(adjustedMinDate);
         const maxMonthAndYear = MonthAndYear.fromDate(maxDate);
 
-        if (rightView.isBefore(minMonthAndYear)) {
-            rightView = minMonthAndYear;
-        } else if (rightView.isAfter(maxMonthAndYear)) {
-            rightView = maxMonthAndYear;
+        if (!this.props.ignoreRange) {
+            if (rightView.isBefore(minMonthAndYear)) {
+                rightView = minMonthAndYear;
+            } else if (rightView.isAfter(maxMonthAndYear)) {
+                rightView = maxMonthAndYear;
+            }
         }
 
         let leftView = this.state.leftView.clone();

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -485,6 +485,28 @@ describe("<DateInput>", () => {
             assertDateEquals(onError.args[0][0], new Date(value));
         });
 
+        it("Typing in a date out of range does not display an error message if ignoreRange is set to true", () => {
+            const rangeMessage = "RANGE ERROR";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput
+                    {...DATE_FORMAT}
+                    defaultValue={new Date(2015, Months.MAY, 1)}
+                    minDate={new Date(2015, Months.MARCH, 1)}
+                    onError={onError}
+                    outOfRangeMessage={rangeMessage}
+                    ignoreRange={true}
+                />,
+            );
+            const value = "2/1/2030";
+            wrapper.find("input").simulate("change", { target: { value } }).simulate("blur");
+
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.NONE);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), "2/1/2030");
+
+            assert.isTrue(onError.notCalled);
+        });
+
         it("Typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {
             const invalidDateMessage = "INVALID DATE";
             const onError = sinon.spy();

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -116,6 +116,32 @@ describe("<DatePicker>", () => {
             assertDayDisabled(getDay(21), false);
         });
 
+        it("enable out-of-range min dates if ignoreRange is true", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const { getDay, clickPreviousMonth } = wrap(
+                <DatePicker
+                    defaultValue={defaultValue}
+                    minDate={new Date(2017, Months.AUGUST, 20)}
+                    ignoreRange={true}
+                />,
+            );
+            clickPreviousMonth();
+            assertDayDisabled(getDay(10), false);
+            assertDayDisabled(getDay(21), false);
+        });
+
+        it("enable out-of-range max dates if ignoreRange is true", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const { getDay } = wrap(
+                <DatePicker
+                    defaultValue={defaultValue}
+                    maxDate={new Date(2017, Months.SEPTEMBER, 20)}
+                    ignoreRange={true}
+                />,
+            );
+            assertDayDisabled(getDay(10), false);
+        });
+
         it("allows top-level locale, localeUtils, and modifiers to be overridden by same props in dayPickerProps", () => {
             const blueprintModifiers: IDatePickerModifiers = {
                 blueprint: () => true,

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -34,6 +34,7 @@ export interface IDateInputExampleState {
     shortcuts: boolean;
     timePrecision: TimePrecision | undefined;
     showTimeArrowButtons: boolean;
+    ignoreRange: boolean;
 }
 
 export class DateInputExample extends React.PureComponent<IExampleProps, IDateInputExampleState> {
@@ -43,6 +44,7 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
         disabled: false,
         fill: false,
         format: FORMATS[0],
+        ignoreRange: false,
         reverseMonthAndYearMenus: false,
         shortcuts: false,
         showTimeArrowButtons: false,
@@ -66,6 +68,8 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
     private toggleTimepickerArrowButtons = handleBooleanChange(showTimeArrowButtons =>
         this.setState({ showTimeArrowButtons }),
     );
+
+    private toggleIgnoreRange = handleBooleanChange(ignoreRange => this.setState({ ignoreRange }));
 
     public render() {
         const { date, format, showTimeArrowButtons, timePrecision, ...spreadProps } = this.state;
@@ -107,6 +111,11 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
                 <Switch label="Disabled" checked={disabled} onChange={this.toggleDisabled} />
                 <Switch label="Fill" checked={fill} onChange={this.toggleFill} />
                 <Switch label="Reverse month and year menus" checked={reverse} onChange={this.toggleReverseMenus} />
+                <Switch
+                    checked={this.state.ignoreRange}
+                    label="Ignore max and min date range"
+                    onChange={this.toggleIgnoreRange}
+                />
                 <FormatSelect format={format} onChange={this.handleFormatChange} />
                 <PrecisionSelect
                     allowNone={true}

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -31,12 +31,14 @@ export interface IDatePickerExampleState {
     showActionsBar: boolean;
     timePrecision: TimePrecision | undefined;
     showTimeArrowButtons: boolean;
+    ignoreRange: boolean;
 }
 
 export class DatePickerExample extends React.PureComponent<IExampleProps, IDatePickerExampleState> {
     public state: IDatePickerExampleState = {
         date: null,
         highlightCurrentDay: false,
+        ignoreRange: false,
         reverseMonthAndYearMenus: false,
         shortcuts: false,
         showActionsBar: false,
@@ -60,6 +62,8 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
         this.setState({ showTimeArrowButtons }),
     );
 
+    private toggleIgnoreRange = handleBooleanChange(ignoreRange => this.setState({ ignoreRange }));
+
     public render() {
         const { date, showTimeArrowButtons, ...props } = this.state;
 
@@ -77,6 +81,11 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
                     checked={props.reverseMonthAndYearMenus}
                     label="Reverse month and year menus"
                     onChange={this.toggleReverseMenus}
+                />
+                <Switch
+                    checked={this.state.ignoreRange}
+                    label="Ignore max and min date range"
+                    onChange={this.toggleIgnoreRange}
                 />
                 <PrecisionSelect
                     allowNone={true}

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -36,6 +36,7 @@ export interface IDateRangeInputExampleState {
     shortcuts: boolean;
     singleMonthOnly: boolean;
     showTimeArrowButtons: boolean;
+    ignoreRange: boolean;
 }
 
 export class DateRangeInputExample extends React.PureComponent<IExampleProps, IDateRangeInputExampleState> {
@@ -46,6 +47,7 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
         disabled: false,
         enableTimePicker: false,
         format: FORMATS[0],
+        ignoreRange: false,
         range: [null, null],
         reverseMonthAndYearMenus: false,
         selectAllOnFocus: false,
@@ -79,6 +81,8 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
     private toggleTimepickerArrowButtons = handleBooleanChange(showTimeArrowButtons =>
         this.setState({ showTimeArrowButtons }),
     );
+
+    private toggleIgnoreRange = handleBooleanChange(ignoreRange => this.setState({ ignoreRange }));
 
     public render() {
         const { enableTimePicker, format, range, showTimeArrowButtons, ...spreadProps } = this.state;
@@ -145,6 +149,11 @@ export class DateRangeInputExample extends React.PureComponent<IExampleProps, ID
                     checked={this.state.showTimeArrowButtons}
                     label="Show timepicker arrow buttons"
                     onChange={this.toggleTimepickerArrowButtons}
+                />
+                <Switch
+                    checked={this.state.ignoreRange}
+                    label="Ignore max and min date range"
+                    onChange={this.toggleIgnoreRange}
                 />
                 <FormatSelect key="Format" format={this.state.format} onChange={this.handleFormatChange} />
             </>

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -40,6 +40,7 @@ export interface IDateRangePickerExampleState {
     reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
     timePrecision?: TimePrecision;
+    ignoreRange: boolean;
 }
 
 interface IDateOption {
@@ -76,6 +77,7 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,
         dateRange: [null, null],
+        ignoreRange: false,
         maxDateIndex: 0,
         minDateIndex: 0,
         reverseMonthAndYearMenus: false,
@@ -94,6 +96,8 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
     private toggleReverseMonthAndYearMenus = handleBooleanChange(reverseMonthAndYearMenus =>
         this.setState({ reverseMonthAndYearMenus }),
     );
+
+    private toggleIgnoreRange = handleBooleanChange(ignoreRange => this.setState({ ignoreRange }));
 
     private toggleSingleDay = handleBooleanChange(allowSingleDayRange => this.setState({ allowSingleDayRange }));
 
@@ -148,6 +152,11 @@ export class DateRangePickerExample extends React.PureComponent<IExampleProps, I
                         checked={this.state.reverseMonthAndYearMenus}
                         label="Reverse month and year menus"
                         onChange={this.toggleReverseMonthAndYearMenus}
+                    />
+                    <Switch
+                        checked={this.state.ignoreRange}
+                        label="Ignore max and min date range"
+                        onChange={this.toggleIgnoreRange}
                     />
                 </div>
                 <div>


### PR DESCRIPTION
#### Fixes #877

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Allows selecting dates that fall outside of the `minDate` and `maxDate`.

`minDate` and `maxDate` are still useful to narrow the dropdown options for the available years in the date picker, but if a user wants to select a year outside the min/max (e.g. using the date input), it should still be allowed.

#### Reviewers should focus on:

Making sure all date time related components have correct behaviour when enabling the `ignoreRange` prop.

#### Screenshot

![CleanShot 2021-06-29 at 15 45 30](https://user-images.githubusercontent.com/16786990/123858096-1c648600-d8f1-11eb-97a0-560ab160eee1.gif)
