### PR TITLE
[core] feat(Text): allow passing HTML props

### DIFF
--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -52,7 +52,10 @@ export interface ITextState {
 }
 
 @polyfill
-export class Text extends AbstractPureComponent2<TextProps & Omit<React.HTMLAttributes<HTMLElement>, "title">, ITextState> {
+export class Text extends AbstractPureComponent2<
+    TextProps & Omit<React.HTMLAttributes<HTMLElement>, "title">,
+    ITextState
+> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Text`;
 
     public static defaultProps: Partial<TextProps> = {
@@ -76,12 +79,9 @@ export class Text extends AbstractPureComponent2<TextProps & Omit<React.HTMLAttr
 
     public render() {
         const { children, className, ellipsize, tagName = "div", title, ...htmlProps } = this.props;
-        const classes = classNames(
-            {
-                [Classes.TEXT_OVERFLOW_ELLIPSIS]: ellipsize,
-            },
-            className,
-        );
+        const classes = classNames(className, {
+            [Classes.TEXT_OVERFLOW_ELLIPSIS]: ellipsize,
+        });
 
         return React.createElement(
             tagName,

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -52,12 +52,11 @@ export interface ITextState {
 }
 
 @polyfill
-export class Text extends AbstractPureComponent2<TextProps, ITextState> {
+export class Text extends AbstractPureComponent2<TextProps & Omit<React.HTMLAttributes<HTMLElement>, "title">, ITextState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Text`;
 
     public static defaultProps: Partial<TextProps> = {
         ellipsize: false,
-        tagName: "div",
     };
 
     public state: ITextState = {
@@ -76,17 +75,18 @@ export class Text extends AbstractPureComponent2<TextProps, ITextState> {
     }
 
     public render() {
+        const { children, className, ellipsize, tagName = "div", title, ...htmlProps } = this.props;
         const classes = classNames(
             {
-                [Classes.TEXT_OVERFLOW_ELLIPSIS]: this.props.ellipsize,
+                [Classes.TEXT_OVERFLOW_ELLIPSIS]: ellipsize,
             },
-            this.props.className,
+            className,
         );
-        const { children, tagName, title } = this.props;
 
         return React.createElement(
-            tagName!,
+            tagName,
             {
+                ...htmlProps,
                 className: classes,
                 ref: (ref: HTMLElement | null) => (this.textRef = ref),
                 title: title ?? (this.state.isContentOverflowing ? this.state.textContent : undefined),


### PR DESCRIPTION
#### Fixes #4682

The main use case I have is to pass down accessibility arguments (e.g. `role`) to the underlying element. cc @styu 

#### Changes proposed in this pull request:

Forward all non-BP props to the created element

#### Reviewers should focus on:

Typings. I'm allowing all HTML props, even though _technically_ you could create a `Text` component with a `tagName` that _isn't_ HTML.
