### PR TITLE
[v4] [core] feat(PanelStack): remove prop injection

### DIFF
--- a/packages/core/src/components/panel-stack/panel-stack.md
+++ b/packages/core/src/components/panel-stack/panel-stack.md
@@ -18,15 +18,15 @@ React trees mounted, change the `renderActivePanelOnly` prop.
 
 @## Panels
 
-Panels are supplied as `Panel<T>` objects, where `renderPanel` and `props` are
-used to render the panel element and `title` will appear in the header and back button.
-This breakdown allows the component to avoid cloning elements.
-Note that each panel is only mounted when it is atop the stack and is unmounted when
+Panels are supplied as `Panel` objects, where `renderPanel` and `props` are
+used to render the panel element and `title` will appear in the header and back
+button. This breakdown allows the component to avoid cloning elements. Note
+that each panel is only mounted when it is atop the stack and is unmounted when
 it is closed or when a panel opens above it.
 
-`PanelStack` injects panel action callbacks into each panel renderer in addition to
-the `props` defined by `Panel<T>`. These allow you to close the current panel or open a
-new one on top of it during the panel's lifecycle. For example:
+`PanelStack` injects panel action callbacks into each panel renderer. These
+allow you to close the current panel or open a new one on top of it during the
+panel's lifecycle. For example:
 
 ```tsx
 import { Button, PanelProps } from "@blueprintjs/core";
@@ -35,31 +35,25 @@ type SettingsPanelInfo = { /* ...  */ };
 type AccountSettingsPanelInfo = { /* ...  */ };
 type NotificationSettingsPanelInfo = { /* ...  */ };
 
-const AccountSettingsPanel: React.FC<PanelProps<AccountSettingsPanelInfo>> = props => {
+const AccountSettingsPanel: React.FC<PanelProps & AccountSettingsPanelInfo> = props => {
     // implementation
 };
 
-const NotificationSettingsPanel: React.FC<PanelProps<NotificationSettingsPanelInfo>> = props => {
+const NotificationSettingsPanel: React.FC<PanelProps & NotificationSettingsPanelInfo> = props => {
     // implementation
 };
 
-const SettingsPanel: React.FC<PanelProps<SettingsPanelInfo>> = props => {
+const SettingsPanel: React.FC<PanelProps & SettingsPanelInfo> = props => {
     const { openPanel, closePanel, ...info } = props;
 
     const openAccountSettings = () =>
         openPanel({
-            props: {
-                /* ... */
-            },
-            renderPanel: AccountSettingsPanel,
+            renderPanel: panelProps => <AccountSettingsPanel {...panelProps} {...} />,
             title: "Account settings",
         });
     const openNotificationSettings = () =>
         openPanel({
-            props: {
-                /* ... */
-            },
-            renderPanel: NotificationSettingsPanel,
+            renderPanel: panelProps => <NotificationSettingsPanel {...panelProps} {...} />,
             title: "Notification settings",
         });
 
@@ -74,7 +68,7 @@ const SettingsPanel: React.FC<PanelProps<SettingsPanelInfo>> = props => {
 
 @interface Panel
 
-@interface PanelActions
+@interface PanelProps
 
 @## Props
 

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -71,9 +71,6 @@ interface PanelStackComponent {
     displayName: string;
 }
 
-/**
- * @template T type union of all possible panels in this stack
- */
 export const PanelStack: PanelStackComponent = (props: PanelStackProps) => {
     const { renderActivePanelOnly = true, showPanelHeader = true } = props;
     const [direction, setDirection] = useState("push");

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -22,30 +22,26 @@ import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { Panel } from "./panelTypes";
 import { PanelView } from "./panelView";
 
-/**
- * @template T type union of all possible panels in this stack
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export interface PanelStackProps<T extends Panel<object>> extends Props {
+export interface PanelStackProps extends Props {
     /**
      * The initial panel to show on mount. This panel cannot be removed from the
      * stack and will appear when the stack is empty.
      * This prop is only used in uncontrolled mode and is thus mutually
      * exclusive with the `stack` prop.
      */
-    initialPanel?: T;
+    initialPanel?: Panel;
 
     /**
      * Callback invoked when the user presses the back button or a panel
      * closes itself with a `closePanel()` action.
      */
-    onClose?: (removedPanel: T) => void;
+    onClose?: (removedPanel: Panel) => void;
 
     /**
      * Callback invoked when a panel opens a new panel with an `openPanel(panel)`
      * action.
      */
-    onOpen?: (addedPanel: T) => void;
+    onOpen?: (addedPanel: Panel) => void;
 
     /**
      * If false, PanelStack will render all panels in the stack to the DOM, allowing their
@@ -67,27 +63,22 @@ export interface PanelStackProps<T extends Panel<object>> extends Props {
      * The full stack of panels in controlled mode. The last panel in the stack
      * will be displayed.
      */
-    stack?: T[];
+    stack?: Panel[];
 }
 
 interface PanelStackComponent {
-    /**
-     * @template T type union of all possible panels in this stack
-     */
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    <T extends Panel<object>>(props: PanelStackProps<T>): JSX.Element | null;
+    (props: PanelStackProps): JSX.Element | null;
     displayName: string;
 }
 
 /**
  * @template T type union of all possible panels in this stack
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: PanelStackProps<T>) => {
+export const PanelStack: PanelStackComponent = (props: PanelStackProps) => {
     const { renderActivePanelOnly = true, showPanelHeader = true } = props;
     const [direction, setDirection] = useState("push");
 
-    const [localStack, setLocalStack] = useState<T[]>(props.initialPanel !== undefined ? [props.initialPanel] : []);
+    const [localStack, setLocalStack] = useState<Panel[]>(props.initialPanel !== undefined ? [props.initialPanel] : []);
     const stack = props.stack != null ? props.stack.slice().reverse() : localStack;
 
     if (stack.length === 0) {
@@ -95,7 +86,7 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
     }
 
     const handlePanelOpen = useCallback(
-        (panel: T) => {
+        (panel: Panel) => {
             props.onOpen?.(panel);
             if (props.stack == null) {
                 setDirection("push");
@@ -105,7 +96,7 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
         [props.onOpen],
     );
     const handlePanelClose = React.useCallback(
-        (panel: T) => {
+        (panel: Panel) => {
             // only remove this panel if it is at the top and not the only one.
             if (stack[0] !== panel || stack.length <= 1) {
                 return;
@@ -121,7 +112,7 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
 
     const panelsToRender = renderActivePanelOnly ? [stack[0]] : stack;
     const panels = panelsToRender
-        .map((panel: T, index: number) => {
+        .map((panel, index) => {
             // With renderActivePanelOnly={false} we would keep all the CSSTransitions rendered,
             // therefore they would not trigger the "enter" transition event as they were entered.
             // To force the enter event, we want to change the key, but stack.length is not enough
@@ -133,7 +124,7 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
 
             return (
                 <CSSTransition classNames={Classes.PANEL_STACK} key={key} timeout={400}>
-                    <PanelView<T>
+                    <PanelView
                         onClose={handlePanelClose}
                         onOpen={handlePanelOpen}
                         panel={panel}

--- a/packages/core/src/components/panel-stack/panelTypes.ts
+++ b/packages/core/src/components/panel-stack/panelTypes.ts
@@ -17,22 +17,16 @@
 /**
  * An object describing a panel in a `PanelStack`.
  */
-export interface Panel<P> {
+export interface Panel {
     /**
      * The renderer for this panel.
      */
-    renderPanel: (props: PanelProps<P>) => JSX.Element | null;
+    renderPanel: (props: PanelProps) => JSX.Element | null;
 
     /**
      * HTML title to be passed to the <Text> component
      */
     htmlTitle?: string;
-
-    /**
-     * The props passed to the component type when it is rendered. The methods
-     * in `PanelActions` will be injected by `PanelStack`.
-     */
-    props?: P;
 
     /**
      * The title to be displayed above this panel. It is also used as the text
@@ -41,7 +35,7 @@ export interface Panel<P> {
     title?: React.ReactNode;
 }
 
-export interface PanelActions {
+export interface PanelProps {
     /**
      * Call this method to programatically close this panel. If this is the only
      * panel on the stack then this method will do nothing.
@@ -54,15 +48,5 @@ export interface PanelActions {
     /**
      * Call this method to open a new panel on the top of the stack.
      */
-    openPanel<P>(panel: Panel<P>): void;
+    openPanel(panel: Panel): void;
 }
-
-/**
- * Use this interface in your panel component's props type to access these
- * panel action callbacks which are injected by `PanelStack`.
- *
- * See the code example in the docs website.
- *
- * @see https://blueprintjs.com/docs/#core/components/panel-stack
- */
-export type PanelProps<P> = P & PanelActions;

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -21,40 +21,37 @@ import { ChevronLeft } from "@blueprintjs/icons";
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Button } from "../button/buttons";
 import { Text } from "../text/text";
-import { Panel, PanelProps } from "./panelTypes";
+import { Panel } from "./panelTypes";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export interface PanelViewProps<T extends Panel<object>> {
+export interface PanelViewProps {
     /**
      * Callback invoked when the user presses the back button or a panel invokes
      * the `closePanel()` injected prop method.
      */
-    onClose: (removedPanel: T) => void;
+    onClose: (removedPanel: Panel) => void;
 
     /**
      * Callback invoked when a panel invokes the `openPanel(panel)` injected
      * prop method.
      */
-    onOpen: (addedPanel: T) => void;
+    onOpen: (addedPanel: Panel) => void;
 
     /** The panel to be displayed. */
-    panel: T;
+    panel: Panel;
 
     /** The previous panel in the stack, for rendering the "back" button. */
-    previousPanel?: T;
+    previousPanel?: Panel;
 
     /** Whether to show the header with the "back" button. */
     showHeader: boolean;
 }
 
 interface PanelViewComponent {
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    <T extends Panel<object>>(props: PanelViewProps<T>): JSX.Element | null;
+    (props: PanelViewProps): JSX.Element | null;
     displayName: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const PanelView: PanelViewComponent = <T extends Panel<object>>(props: PanelViewProps<T>) => {
+export const PanelView: PanelViewComponent = (props: PanelViewProps) => {
     const handleClose = useCallback(() => props.onClose(props.panel), [props.onClose, props.panel]);
 
     const maybeBackButton =
@@ -82,17 +79,10 @@ export const PanelView: PanelViewComponent = <T extends Panel<object>>(props: Pa
                     <span />
                 </div>
             )}
-            {/*
-             * Cast is required because of error TS2345, where technically `panel.props` could be
-             * instantiated with a type unrelated to our generic constraint `T` here. We know
-             * we're sending the right values here though, and it makes the consumer API for this
-             * component type safe, so it's ok to do this...
-             */}
             {props.panel.renderPanel({
                 closePanel: handleClose,
                 openPanel: props.onOpen,
-                ...props.panel.props,
-            } as PanelProps<T>)}
+            })}
         </div>
     );
 };

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -21,11 +21,7 @@ import { spy } from "sinon";
 
 import { Classes, Panel, PanelProps, PanelStackProps, PanelStack } from "../../src";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type TestPanelInfo = {};
-type TestPanelType = Panel<TestPanelInfo>;
-
-const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
+const TestPanel: React.FC<PanelProps> = props => {
     const newPanel = { renderPanel: TestPanel, title: "New Panel 1" };
 
     return (
@@ -39,16 +35,14 @@ const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
 
 describe("<PanelStack>", () => {
     let testsContainerElement: HTMLElement;
-    let panelStackWrapper: PanelStackWrapper<TestPanelType>;
+    let panelStackWrapper: PanelStackWrapper;
 
-    const initialPanel: Panel<TestPanelInfo> = {
-        props: {},
+    const initialPanel: Panel = {
         renderPanel: TestPanel,
         title: "Test Title",
     };
 
-    const emptyTitleInitialPanel: Panel<TestPanelInfo> = {
-        props: {},
+    const emptyTitleInitialPanel: Panel = {
         renderPanel: TestPanel,
     };
 
@@ -205,7 +199,7 @@ describe("<PanelStack>", () => {
     });
 
     it("can render a panel stack with multiple initial panels and close one", () => {
-        let stack: Array<Panel<TestPanelInfo>> = [initialPanel, { renderPanel: TestPanel, title: "New Panel 1" }];
+        let stack: Panel[] = [initialPanel, { renderPanel: TestPanel, title: "New Panel 1" }];
         panelStackWrapper = renderPanelStack({
             onClose: () => {
                 const newStack = stack.slice();
@@ -258,15 +252,14 @@ describe("<PanelStack>", () => {
         assert.equal(panelHeaders.at(1).text(), stack[1].title);
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    interface PanelStackWrapper<T extends Panel<object>> extends ReactWrapper<PanelStackProps<T>, any> {
+    interface PanelStackWrapper extends ReactWrapper<PanelStackProps, any> {
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
     }
 
-    function renderPanelStack(props: PanelStackProps<TestPanelType>): PanelStackWrapper<TestPanelType> {
+    function renderPanelStack(props: PanelStackProps): PanelStackWrapper {
         panelStackWrapper = mount(<PanelStack {...props} />, {
             attachTo: testsContainerElement,
-        }) as PanelStackWrapper<TestPanelType>;
+        }) as PanelStackWrapper;
         panelStackWrapper.findClass = (className: string) => panelStackWrapper.find(`.${className}`).hostNodes();
         return panelStackWrapper;
     }

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -26,26 +26,21 @@ import React, { useCallback, useState } from "react";
 import { Button, H5, Intent, Panel, PanelProps, NumericInput, PanelStack, Switch, UL } from "@blueprintjs/core";
 import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Panel1Info {
-    // empty
-}
-
-const Panel1: React.FC<PanelProps<Panel1Info>> = props => {
+const Panel1: React.FC<PanelProps> = props => {
     const [counter, setCounter] = useState(0);
     const shouldOpenPanelType2 = counter % 2 === 0;
 
     const openNewPanel = () => {
         if (shouldOpenPanelType2) {
             props.openPanel({
-                props: { counter },
-                renderPanel: Panel2,
+                renderPanel: panelProps => <Panel2 {...panelProps} counter={counter} />,
                 title: `Panel 2`,
             });
         } else {
             props.openPanel({
-                props: { intent: counter % 3 === 0 ? Intent.SUCCESS : Intent.WARNING },
-                renderPanel: Panel3,
+                renderPanel: panelProps => (
+                    <Panel3 {...panelProps} intent={counter % 3 === 0 ? Intent.SUCCESS : Intent.WARNING} />
+                ),
                 title: `Panel 3`,
             });
         }
@@ -63,14 +58,13 @@ const Panel1: React.FC<PanelProps<Panel1Info>> = props => {
     );
 };
 
-interface Panel2Info {
+interface Panel2Props {
     counter: number;
 }
 
-const Panel2: React.FC<PanelProps<Panel2Info>> = props => {
+const Panel2: React.FC<PanelProps & Panel2Props> = props => {
     const openNewPanel = () => {
         props.openPanel({
-            props: {},
             renderPanel: Panel1,
             title: `Panel 1`,
         });
@@ -84,14 +78,13 @@ const Panel2: React.FC<PanelProps<Panel2Info>> = props => {
     );
 };
 
-interface Panel3Info {
+interface Panel3Props {
     intent: Intent;
 }
 
-const Panel3: React.FC<PanelProps<Panel3Info>> = props => {
+const Panel3: React.FC<PanelProps & Panel3Props> = props => {
     const openNewPanel = () => {
         props.openPanel({
-            props: {},
             renderPanel: Panel1,
             title: `Panel 1`,
         });
@@ -104,10 +97,7 @@ const Panel3: React.FC<PanelProps<Panel3Info>> = props => {
     );
 };
 
-const initialPanel: Panel<Panel1Info> = {
-    props: {
-        panelNumber: 1,
-    },
+const initialPanel: Panel = {
     renderPanel: Panel1,
     title: "Panel 1",
 };
@@ -115,16 +105,11 @@ const initialPanel: Panel<Panel1Info> = {
 export const PanelStackExample: React.FC<ExampleProps> = props => {
     const [activePanelOnly, setActivePanelOnly] = useState(true);
     const [showHeader, setShowHeader] = useState(true);
-    const [currentPanelStack, setCurrentPanelStack] = useState<Array<Panel<Panel1Info | Panel2Info | Panel3Info>>>([
-        initialPanel,
-    ]);
+    const [currentPanelStack, setCurrentPanelStack] = useState<Panel[]>([initialPanel]);
 
     const toggleActiveOnly = useCallback(handleBooleanChange(setActivePanelOnly), []);
     const toggleShowHeader = useCallback(handleBooleanChange(setShowHeader), []);
-    const addToPanelStack = useCallback(
-        (newPanel: Panel<Panel1Info | Panel2Info | Panel3Info>) => setCurrentPanelStack(stack => [newPanel, ...stack]),
-        [],
-    );
+    const addToPanelStack = useCallback((newPanel: Panel) => setCurrentPanelStack(stack => [newPanel, ...stack]), []);
     const removeFromPanelStack = useCallback(() => setCurrentPanelStack(stack => stack.slice(1)), []);
 
     const stackList = (


### PR DESCRIPTION
The prop injection only really existed because the old (pre-v4) PanelStack API required users to pass in a component. That component would be injected with the PanelProps and the custom additional props. Now that we've switched to a render function-based API, there is no more reason to do this. You can just refactor `openPanel({ props: { someProp: "value" }, renderPanel: PanelComponent)` to `openPanel({ renderPanel: panelProps => <PanelComponent {...panelProps} someProp="value" /> })`.

This is a breaking change, which is why I'm not proposing it to PanelStack2 on develop. I believe breaks are still ok on the v4 branch, since 4.0.0 has not been released.