### PR TITLE
[core, popover2] feat: add aria-haspopup attribute

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -365,6 +365,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
               };
+        finalTargetProps["aria-haspopup"] = "true";
         finalTargetProps.className = classNames(
             Classes.POPOVER_TARGET,
             { [Classes.POPOVER_OPEN]: isOpen },

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -311,6 +311,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const targetProps = {
+            "aria-haspopup": "true",
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
             // applied to the generated target wrapper element.

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -187,6 +187,11 @@ describe("<Popover2>", () => {
             });
             assert.isNotNull(popoverElement.matches(`.${CoreClasses.DARK}`));
         });
+
+        it("renders with aria-haspopup attr", () => {
+            wrapper = renderPopover({ isOpen: true });
+            assert.isTrue(wrapper.find("[aria-haspopup='true']").exists());
+        });
     });
 
     describe("basic functionality", () => {


### PR DESCRIPTION
#### Fixes #4794

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `aria-haspopup="true"` attribute to the target element rendered by Popover & Popover2 to indicate that it triggers an interactive popup element. I've gone with the generic value of `"true"`; if users wish to customize this they can use the Popover2 renderTarget prop API.

Docs: https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaHasPopup

#### Reviewers should focus on:

Attribute is being added to the right element... it should be the one which has the popover mouse event handlers, I think.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
