### PR TITLE
[core] fix(HTMLSelect): clarify CSS API markup

### DIFF
--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -9,7 +9,7 @@
 HTML select
 
 Markup:
-<div class="#{$ns}-select {{.modifier}}">
+<div class="#{$ns}-html-select {{.modifier}}">
   <select {{:modifier}}>
     <option selected>Choose an item...</option>
     <option value="1">One</option>
@@ -17,6 +17,7 @@ Markup:
     <option value="3">Three</option>
     <option value="4">Four</option>
   </select>
+  <span class="#{$ns}-icon #{$ns}-icon-double-caret-vertical"></span>
 </div>
 
 :disabled - Disabled. Also add <code>.#{$ns}-disabled</code> to <code>.#{$ns}-select</code> for icon coloring (not shown below).
@@ -95,6 +96,13 @@ Styleguide select
   }
 }
 
+.#{$ns}-html-select {
+  .#{$ns}-icon {
+    @extend %pt-select-arrow;
+  }
+}
+
+// N.B. this icon implementation is deprecated and will be removed in Blueprint 4.0
 .#{$ns}-select {
   &::after {
     @extend %pt-select-arrow;

--- a/packages/core/src/components/html-select/html-select.md
+++ b/packages/core/src/components/html-select/html-select.md
@@ -22,10 +22,6 @@ full flexibility or via the `options` prop for simple shorthand.
 
 @## CSS
 
-The CSS API for this component uses a different CSS class than the React component
-in order to apply the icon via the CSS-only icon font. (The React component
-renders the icon as SVG.)
-
 Put class modifiers on the wrapper and attribute modifiers and event handlers
 directly on the `<select>`.
 


### PR DESCRIPTION
#### Fixes #4466

#### Checklist

- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update HTMLSelect CSS API docs to reflect that users must render their own icon markup. In general most users should prefer using the React component API instead of this CSS API since it is easier to use.

