### PR TITLE
[popover2] fix(ContextMenu2): remove obsolete target CSS

### DIFF
--- a/packages/popover2/src/_context-menu2.scss
+++ b/packages/popover2/src/_context-menu2.scss
@@ -3,7 +3,7 @@
 
 @import "./common";
 
-.#{$ns}-context-menu2 .#{$ns}-popover2-target {
+.#{$ns}-context-menu2 > .#{$ns}-popover2-target {
   display: block;
 }
 

--- a/packages/popover2/src/_context-menu2.scss
+++ b/packages/popover2/src/_context-menu2.scss
@@ -3,10 +3,6 @@
 
 @import "./common";
 
-.#{$ns}-context-menu2 > .#{$ns}-popover2-target {
-  display: block;
-}
-
 .#{$ns}-context-menu2-virtual-target {
   position: fixed;
 }


### PR DESCRIPTION
The `context-menu` class was previously applied to the context menu itself. In `ContextMenu2`, it's applied to the _target_. Since it's not using a direct child operator, _any_ descendant popover target inside a context menu target will end up getting `display: block`.

Given that this was previously not set on the target, and there doesn't appear to ever _be_ a `popover-target` for the context menu, we may be able to just remove this entirely.