### PR TITLE
[select] fix: pass event to popoverProps.onInteraction

### DIFF
--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -216,7 +216,7 @@ export class MultiSelect<T> extends AbstractPureComponent2<MultiSelectProps<T>, 
 
     // Popover interaction kind is CLICK, so this only handles click events.
     // Note that we defer to the next animation frame in order to get the latest document.activeElement
-    private handlePopoverInteraction = (nextOpenState: boolean) =>
+    private handlePopoverInteraction = (nextOpenState: boolean, evt?: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
             const isInputFocused = this.input === document.activeElement;
 
@@ -228,7 +228,7 @@ export class MultiSelect<T> extends AbstractPureComponent2<MultiSelectProps<T>, 
                 this.setState({ isOpen: true });
             }
 
-            this.props.popoverProps?.onInteraction?.(nextOpenState);
+            this.props.popoverProps?.onInteraction?.(nextOpenState, evt);
         });
 
     private handlePopoverOpened = (node: HTMLElement) => {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -194,9 +194,9 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
         this.props.onItemSelect?.(item, event);
     };
 
-    private handlePopoverInteraction = (isOpen: boolean) => {
+    private handlePopoverInteraction = (isOpen: boolean, event?: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isOpen });
-        this.props.popoverProps?.onInteraction?.(isOpen);
+        this.props.popoverProps?.onInteraction?.(isOpen, event);
     };
 
     private handlePopoverOpening = (node: HTMLElement) => {

--- a/packages/select/src/components/select/suggest.tsx
+++ b/packages/select/src/components/select/suggest.tsx
@@ -287,7 +287,7 @@ export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggest
 
     // Popover interaction kind is CLICK, so this only handles click events.
     // Note that we defer to the next animation frame in order to get the latest document.activeElement
-    private handlePopoverInteraction = (nextOpenState: boolean) =>
+    private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
             const isInputFocused = this.inputElement === document.activeElement;
 
@@ -295,7 +295,7 @@ export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggest
                 // the input is no longer focused, we should close the popover
                 this.setState({ isOpen: false });
             }
-            this.props.popoverProps?.onInteraction?.(nextOpenState);
+            this.props.popoverProps?.onInteraction?.(nextOpenState, event);
         });
 
     private handlePopoverOpening = (node: HTMLElement) => {


### PR DESCRIPTION
#### Fixes #4825

#### Checklist

- [ ] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

Thread event handlers through in `handlePopoverInteraction`.

Let me know if this seems to warrant test cases, as it seemed a pretty trivial fix. This also just brings the source in line with the existing documentation, so no changes necessary there afaict.

Thank you!