### PR TITLE
[core,popover2] Fix heading colors in tooltips in dark mode

### DIFF
--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -139,6 +139,10 @@ $dark-popover-background-color: $dark-gray4 !default;
 
   .#{$ns}-popover-content {
     background: $background-color;
+  }
+
+  .#{$ns}-popover-content,
+  .#{$ns}-heading {
     color: $text-color;
   }
 

--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -141,6 +141,9 @@ $dark-popover-background-color: $dark-gray4 !default;
     background: $background-color;
   }
 
+  // Some popovers (like tooltips) invert their foreground/background colors relative
+  // to what we expect for the theme. In those cases, we need to override global typography
+  // styles to get the right colors.
   .#{$ns}-popover-content,
   .#{$ns}-heading {
     color: $text-color;

--- a/packages/popover2/src/_common.scss
+++ b/packages/popover2/src/_common.scss
@@ -58,6 +58,9 @@ $pt-dark-tooltip2-box-shadow: $pt-dark-popover-box-shadow !default;
     background: $background-color;
   }
 
+  // Some popovers (like tooltips) invert their foreground/background colors relative
+  // to what we expect for the theme. In those cases, we need to override global typography
+  // styles to get the right colors.
   .#{$ns}-popover2-content,
   .#{$ns}-heading {
     color: $text-color;

--- a/packages/popover2/src/_common.scss
+++ b/packages/popover2/src/_common.scss
@@ -56,6 +56,10 @@ $pt-dark-tooltip2-box-shadow: $pt-dark-popover-box-shadow !default;
 
   .#{$ns}-popover2-content {
     background: $background-color;
+  }
+
+  .#{$ns}-popover2-content,
+  .#{$ns}-heading {
     color: $text-color;
   }
 


### PR DESCRIPTION
#### Fixes #3773

#### Checklist

- [ ] Includes tests N/A
- [ ] Update documentation N/A

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Uses text color to set heading color explicitly to override default header colors in dark mode tooltips
- Fixed in both soon-to-be-deprecated Tooltip and Tooltip2

#### Reviewers should focus on:

- Does this lead to any unexpected styling issues, since this changes the popover appearance mixin?
- Should I add a "test" example for this case? i.e. adding an example to the tooltip docs that uses an header

Here is a Tooltip2 repro: https://codesandbox.io/s/blueprint-sandbox-forked-u378j

#### Screenshot

Before:

<img width="191" alt="Screen Shot 2021-08-02 at 3 24 45 PM" src="https://user-images.githubusercontent.com/2065456/127912890-ae1792e9-77c9-470c-be68-62b8abe633bb.png">

After:

<img width="164" alt="Screen Shot 2021-08-02 at 3 24 31 PM" src="https://user-images.githubusercontent.com/2065456/127912900-0cb1f181-2aca-46d8-b49e-0254a923d397.png">
