### PR TITLE
[core] fix(Button): icon intent color in dark mode

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -136,7 +136,9 @@ Styleguide button
       }
 
       #{$icon-classes} {
-        color: $pt-dark-icon-color;
+        &:not([class*="#{$ns}-intent-"]) {
+          color: $pt-dark-icon-color;
+        }
       }
     }
 


### PR DESCRIPTION
#### Fixes #3696

#### Checklist

- [X] Includes tests
- [X] Update documentation

#### Changes proposed in this pull request:

- Only set default dark icon color if there is no intent on the icon itself

#### Screenshot

Before:

![Screen Shot 2021-08-03 at 4 38 37 PM](https://user-images.githubusercontent.com/2065456/128082863-b9c33e43-207f-4d9a-aea3-273d9f12db20.png)

After:

![Screen Shot 2021-08-03 at 4 36 38 PM](https://user-images.githubusercontent.com/2065456/128082845-2e4375e8-6522-454f-8339-cd3f58378b31.png)

