### PR TITLE
[core] fix: add aria-label to some buttons

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -431,12 +431,14 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
         return (
             <ButtonGroup className={Classes.FIXED} key="button-group" vertical={true}>
                 <Button
+                    aria-label="increment"
                     disabled={disabled || isIncrementDisabled}
                     icon="chevron-up"
                     intent={intent}
                     {...this.incrementButtonHandlers}
                 />
                 <Button
+                    aria-label="decrement"
                     disabled={disabled || isDecrementDisabled}
                     icon="chevron-down"
                     intent={intent}

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -82,6 +82,7 @@ export class PanelView extends AbstractPureComponent2<IPanelViewProps> {
         }
         return (
             <Button
+                aria-label="Back"
                 className={Classes.PANEL_STACK_HEADER_BACK}
                 icon="chevron-left"
                 minimal={true}

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -58,6 +58,7 @@ export const PanelView2: PanelView2Component = <T extends Panel<object>>(props: 
     const maybeBackButton =
         props.previousPanel === undefined ? null : (
             <Button
+                aria-label="Back"
                 className={Classes.PANEL_STACK_HEADER_BACK}
                 icon="chevron-left"
                 minimal={true}

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -161,6 +161,7 @@ export class Tag extends AbstractPureComponent2<TagProps> {
         const isLarge = large || tagClasses.indexOf(Classes.LARGE) >= 0;
         const removeButton = isRemovable ? (
             <button
+                aria-label="Remove"
                 type="button"
                 className={Classes.TAG_REMOVE}
                 onClick={this.onRemoveClick}

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -80,7 +80,7 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
                 <span className={Classes.TOAST_MESSAGE}>{message}</span>
                 <ButtonGroup minimal={true}>
                     {this.maybeRenderActionButton()}
-                    <Button icon="cross" onClick={this.handleCloseClick} />
+                    <Button aria-label="Close" icon="cross" onClick={this.handleCloseClick} />
                 </ButtonGroup>
             </div>
         );


### PR DESCRIPTION
#### Fixes #4527

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

don't think either are applicable here

#### Changes proposed in this pull request:
Add aria-label to buttons in blueprint that don't have other text. Issue mentions `title`, could use that if preferred but I had seen `aria-label` used in some other places.

#### Screenshot
<img width="700" alt="Screen Shot 2021-08-04 at 5 03 08 PM" src="https://user-images.githubusercontent.com/14102129/128254718-f0751641-3e72-4580-bc33-c7c684b1dbee.png">