### PR TITLE
[select] feat(Select): new prop "matchTargetWidth"

### DIFF
--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -34,6 +34,7 @@ export interface ISelectExampleState {
     resetOnSelect: boolean;
     disableItems: boolean;
     disabled: boolean;
+    matchTargetWidth: false;
 }
 
 export class SelectExample extends React.PureComponent<IExampleProps, ISelectExampleState> {
@@ -45,6 +46,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
         disabled: false,
         filterable: true,
         hasInitialContent: false,
+        matchTargetWidth: false,
         minimal: false,
         resetOnClose: false,
         resetOnQuery: true,
@@ -70,6 +72,8 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
     private handleResetOnQueryChange = this.handleSwitchChange("resetOnQuery");
 
     private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
+
+    private handleMatchTargetWidthChange = this.handleSwitchChange("matchTargetWidth");
 
     public render() {
         const { allowCreate, disabled, disableItems, minimal, ...flags } = this.state;
@@ -123,6 +127,11 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     label="Disable films before 2000"
                     checked={this.state.disableItems}
                     onChange={this.handleItemDisabledChange}
+                />
+                <Switch
+                    label="Match target width"
+                    checked={this.state.matchTargetWidth}
+                    onChange={this.handleMatchTargetWidthChange}
                 />
                 <Switch
                     label="Allow creating new items"

--- a/packages/select/src/common/classes.ts
+++ b/packages/select/src/common/classes.ts
@@ -25,4 +25,4 @@ export const OMNIBAR = `${NS}-omnibar`;
 export const OMNIBAR_OVERLAY = `${OMNIBAR}-overlay`;
 export const SELECT = `${NS}-select`;
 export const SELECT_POPOVER = `${SELECT}-popover`;
-export const MATCH_TARGET_WIDTH = `${SELECT}-match-target-width`;
+export const SELECT_MATCH_TARGET_WIDTH = `${SELECT}-match-target-width`;

--- a/packages/select/src/common/classes.ts
+++ b/packages/select/src/common/classes.ts
@@ -25,4 +25,4 @@ export const OMNIBAR = `${NS}-omnibar`;
 export const OMNIBAR_OVERLAY = `${OMNIBAR}-overlay`;
 export const SELECT = `${NS}-select`;
 export const SELECT_POPOVER = `${SELECT}-popover`;
-export const MATCH_TARGET_WIDTH = "full-width";
+export const MATCH_TARGET_WIDTH = `${SELECT}-match-target-width`;

--- a/packages/select/src/common/classes.ts
+++ b/packages/select/src/common/classes.ts
@@ -25,3 +25,4 @@ export const OMNIBAR = `${NS}-omnibar`;
 export const OMNIBAR_OVERLAY = `${OMNIBAR}-overlay`;
 export const SELECT = `${NS}-select`;
 export const SELECT_POPOVER = `${SELECT}-popover`;
+export const MATCH_TARGET_WIDTH = "full-width";

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -29,3 +29,12 @@ $select-popover-max-width: $pt-grid-size * 40 !default;
     }
   }
 }
+
+.full-width {
+  width: 100%;
+
+  .#{$ns}-menu {
+    max-width: none;
+    min-width: 0;
+  }
+}

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -7,6 +7,15 @@ $select-popover-max-height: $pt-grid-size * 30 !default;
 $select-popover-max-width: $pt-grid-size * 40 !default;
 
 .#{$ns}-select-popover {
+  &.#{$ns}-select-match-target-width {
+    width: 100%;
+
+    .#{$ns}-menu {
+      max-width: none;
+      min-width: 0;
+    }
+  }
+
   .#{$ns}-popover-content {
     // use padding on container rather than margin on input group
     // because top margin leaves some empty space with no background color.
@@ -27,14 +36,5 @@ $select-popover-max-width: $pt-grid-size * 40 !default;
       // adjust padding to account for that on .#{$ns}-popover-content above
       padding-top: $pt-grid-size / 2;
     }
-  }
-}
-
-.full-width {
-  width: 100%;
-
-  .#{$ns}-menu {
-    max-width: none;
-    min-width: 0;
   }
 }

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -74,6 +74,13 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      * @default false
      */
     resetOnClose?: boolean;
+
+    /**
+     * Whether the select popover should match the width of the target.
+     *
+     * @default false
+     */
+    matchTargetWidth?: boolean;
 }
 
 export interface ISelectState {
@@ -129,7 +136,31 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
-        const { filterable = true, disabled = false, inputProps = {}, popoverProps = {} } = this.props;
+        const {
+            filterable = true,
+            disabled = false,
+            inputProps = {},
+            popoverProps = {},
+            matchTargetWidth,
+        } = this.props;
+
+        if (matchTargetWidth) {
+            if (popoverProps.modifiers == null) {
+                popoverProps.modifiers = {};
+            }
+
+            popoverProps.modifiers.minWidth = {
+                enabled: true,
+                fn: data => {
+                    data.styles.width = `${data.offsets.reference.width}px`;
+                    return data;
+                },
+                order: 800,
+            };
+
+            popoverProps.usePortal = false;
+            popoverProps.wrapperTagName = "div";
+        }
 
         const input = (
             <InputGroup
@@ -155,7 +186,11 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
-                popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
+                popoverClassName={classNames(
+                    Classes.SELECT_POPOVER,
+                    popoverProps.popoverClassName,
+                    matchTargetWidth ? Classes.MATCH_TARGET_WIDTH : undefined,
+                )}
                 onOpening={this.handlePopoverOpening}
                 onOpened={this.handlePopoverOpened}
                 onClosing={this.handlePopoverClosing}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -64,11 +64,10 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
     inputProps?: InputGroupProps2;
 
     /**
-     * Whether the select popover should match the width of the target.
-     * Setting this to `true` will also set `usePortal` and `wrapperTagName` in `popoverProps` to `false`
-     * and `"div"` respectively.
-     * A popover modifier named `minWidth` with property of `order: 800` is also passed
-     * to `modifiers` in `popoverProps`.
+     * Whether the select popover should be styled so that it matches the width of the target.
+     * This is done using a popper.js modifier passed through `popoverProps`.
+     *
+     * Note that setting `matchTargetWidth={true}` will also set `popoverProps.usePortal={false}` and `popoverProps.wrapperTagName="div"`.
      *
      * @default false
      */

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -63,6 +63,13 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      */
     inputProps?: InputGroupProps2;
 
+    /**
+     * Whether the select popover should match the width of the target.
+     *
+     * @default false
+     */
+    matchTargetWidth?: boolean;
+
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
     // eslint-disable-next-line @typescript-eslint/ban-types
     popoverProps?: Partial<IPopoverProps> & object;
@@ -74,13 +81,6 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
      * @default false
      */
     resetOnClose?: boolean;
-
-    /**
-     * Whether the select popover should match the width of the target.
-     *
-     * @default false
-     */
-    matchTargetWidth?: boolean;
 }
 
 export interface ISelectState {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -65,6 +65,10 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
 
     /**
      * Whether the select popover should match the width of the target.
+     * Setting this to `true` will also set `usePortal` and `wrapperTagName` in `popoverProps` to `false`
+     * and `"div"` respectively.
+     * A popover modifier named `minWidth` with property of `order: 800` is also passed
+     * to `modifiers` in `popoverProps`.
      *
      * @default false
      */
@@ -186,11 +190,9 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
-                popoverClassName={classNames(
-                    Classes.SELECT_POPOVER,
-                    popoverProps.popoverClassName,
-                    matchTargetWidth ? Classes.MATCH_TARGET_WIDTH : undefined,
-                )}
+                popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName, {
+                    [Classes.MATCH_TARGET_WIDTH]: matchTargetWidth,
+                })}
                 onOpening={this.handlePopoverOpening}
                 onOpened={this.handlePopoverOpened}
                 onClosing={this.handlePopoverClosing}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -190,7 +190,7 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
                 className={classNames(listProps.className, popoverProps.className)}
                 onInteraction={this.handlePopoverInteraction}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName, {
-                    [Classes.MATCH_TARGET_WIDTH]: matchTargetWidth,
+                    [Classes.SELECT_MATCH_TARGET_WIDTH]: matchTargetWidth,
                 })}
                 onOpening={this.handlePopoverOpening}
                 onOpened={this.handlePopoverOpened}


### PR DESCRIPTION
#### Fixes #2956

#### Checklist

- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added a prop `matchTargetWidth` that will make the `Select` component's popover have the same width as the target. This was done using a modifier passed to PopoverProps


#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
Before:
![image](https://user-images.githubusercontent.com/43376033/128367071-25ae6134-e171-4f21-b295-7cdcace3d801.png)

After:
![image](https://user-images.githubusercontent.com/43376033/128367024-9d0b8785-bf3d-433f-b222-e821a5f2725a.png)

