### PR TITLE
[datetime] fix(TimePicker): reset input fields when value={null}

### DIFF
--- a/packages/datetime/src/dateTimePicker.tsx
+++ b/packages/datetime/src/dateTimePicker.tsx
@@ -100,7 +100,11 @@ export class DateTimePicker extends AbstractPureComponent2<IDateTimePickerProps,
                     onChange={this.handleDateChange}
                     value={value}
                 />
-                <TimePicker {...this.props.timePickerProps} onChange={this.handleTimeChange} value={value} />
+                <TimePicker
+                    {...this.props.timePickerProps}
+                    onChange={this.handleTimeChange}
+                    value={this.state.timeValue}
+                />
             </div>
         );
     }

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -169,9 +169,7 @@ export class TimePicker extends React.Component<TimePickerProps, ITimePickerStat
     public constructor(props?: TimePickerProps, context?: any) {
         super(props, context);
 
-        const value = this.getInitialValue();
-
-        this.state = this.getFullStateFromValue(value, props.useAmPm);
+        this.state = this.getFullStateFromValue(this.getInitialValue(), props.useAmPm);
     }
 
     public render() {
@@ -217,17 +215,17 @@ export class TimePicker extends React.Component<TimePickerProps, ITimePickerStat
         const didMaxTimeChange = prevProps.maxTime !== this.props.maxTime;
         const didBoundsChange = didMinTimeChange || didMaxTimeChange;
         const didPropValueChange = prevProps.value !== this.props.value;
-        const shouldStateUpdate = didMinTimeChange || didMaxTimeChange || didBoundsChange || didPropValueChange;
+        const shouldStateUpdate = didBoundsChange || didPropValueChange;
 
-        let value = this.props.value;
+        let value = this.state.value;
+        if (this.props.value == null) {
+            value = this.getInitialValue();
+        }
         if (didBoundsChange) {
             value = DateUtils.getTimeInRange(this.state.value, this.props.minTime, this.props.maxTime);
         }
         if (this.props.value != null && !DateUtils.areSameTime(this.props.value, prevProps.value)) {
             value = this.props.value;
-        }
-        if (this.props.value == null) {
-            value = this.getInitialValue();
         }
 
         if (shouldStateUpdate) {
@@ -427,7 +425,7 @@ export class TimePicker extends React.Component<TimePickerProps, ITimePickerStat
         }
     }
 
-    private getInitialValue() {
+    private getInitialValue(): Date {
         let value = this.props.minTime;
         if (this.props.value != null) {
             value = this.props.value;

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -169,12 +169,7 @@ export class TimePicker extends React.Component<TimePickerProps, ITimePickerStat
     public constructor(props?: TimePickerProps, context?: any) {
         super(props, context);
 
-        let value = props.minTime;
-        if (props.value != null) {
-            value = props.value;
-        } else if (props.defaultValue != null) {
-            value = props.defaultValue;
-        }
+        const value = this.getInitialValue();
 
         this.state = this.getFullStateFromValue(value, props.useAmPm);
     }
@@ -224,12 +219,15 @@ export class TimePicker extends React.Component<TimePickerProps, ITimePickerStat
         const didPropValueChange = prevProps.value !== this.props.value;
         const shouldStateUpdate = didMinTimeChange || didMaxTimeChange || didBoundsChange || didPropValueChange;
 
-        let value = this.state.value;
+        let value = this.props.value;
         if (didBoundsChange) {
             value = DateUtils.getTimeInRange(this.state.value, this.props.minTime, this.props.maxTime);
         }
         if (this.props.value != null && !DateUtils.areSameTime(this.props.value, prevProps.value)) {
             value = this.props.value;
+        }
+        if (this.props.value == null) {
+            value = this.getInitialValue();
         }
 
         if (shouldStateUpdate) {
@@ -427,6 +425,17 @@ export class TimePicker extends React.Component<TimePickerProps, ITimePickerStat
         if (hasNewValue) {
             this.props.onChange?.(newState.value);
         }
+    }
+
+    private getInitialValue() {
+        let value = this.props.minTime;
+        if (this.props.value != null) {
+            value = this.props.value;
+        } else if (this.props.defaultValue != null) {
+            value = this.props.defaultValue;
+        }
+
+        return value;
     }
 }
 

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -614,6 +614,32 @@ describe("<TimePicker>", () => {
             assert.strictEqual(value.getMilliseconds(), 4);
         });
 
+        it("changing value to null resets state", () => {
+            const root = mount<TimePicker>(<TimePicker defaultValue={new Date(2015, 1, 1, 1, 2, 3, 4)} />);
+
+            const initialValue = root.state("value");
+            assert.strictEqual(initialValue.getHours(), 1);
+            assert.strictEqual(initialValue.getMinutes(), 2);
+            assert.strictEqual(initialValue.getSeconds(), 3);
+            assert.strictEqual(initialValue.getMilliseconds(), 4);
+
+            root.setProps({ value: new Date(2015, 1, 1, 5, 6, 7, 8) });
+
+            const updatedValue = root.state("value");
+            assert.strictEqual(updatedValue.getHours(), 5);
+            assert.strictEqual(updatedValue.getMinutes(), 6);
+            assert.strictEqual(updatedValue.getSeconds(), 7);
+            assert.strictEqual(updatedValue.getMilliseconds(), 8);
+
+            root.setProps({ value: null });
+
+            const resetValue = root.state("value");
+            assert.strictEqual(resetValue.getHours(), 1);
+            assert.strictEqual(resetValue.getMinutes(), 2);
+            assert.strictEqual(resetValue.getSeconds(), 3);
+            assert.strictEqual(resetValue.getMilliseconds(), 4);
+        });
+
         it("should fire onChange events on up-arrow key down", () => {
             renderTimePicker({ value: zeroDate });
             assert.isTrue(onTimePickerChange.notCalled);

--- a/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
@@ -16,34 +16,23 @@
 
 import * as React from "react";
 
-import { Classes, H5, Switch } from "@blueprintjs/core";
+import { Classes } from "@blueprintjs/core";
 import { DateTimePicker } from "@blueprintjs/datetime";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 
-export class DateTimePickerExample extends React.PureComponent<
-    IExampleProps,
-    { date: Date; showArrowButtons: boolean; useAmPm: boolean }
-> {
-    public state = {
-        date: new Date(),
-        showArrowButtons: false,
-        useAmPm: true,
-    };
+export class DateTimePickerExample extends React.PureComponent<IExampleProps, { date: Date }> {
+    public state = { date: new Date() };
 
     public render() {
         return (
-            <Example options={this.renderOptions()} {...this.props}>
+            <Example options={false} {...this.props}>
                 {/* eslint-disable-next-line deprecation/deprecation */}
                 <DateTimePicker
                     className={Classes.ELEVATION_1}
                     value={this.state.date}
-                    timePickerProps={{
-                        precision: "second",
-                        showArrowButtons: this.state.showArrowButtons,
-                        useAmPm: this.state.useAmPm,
-                    }}
+                    timePickerProps={{ precision: "second", useAmPm: true }}
                     onChange={this.handleDateChange}
                 />
                 <div>
@@ -52,28 +41,6 @@ export class DateTimePickerExample extends React.PureComponent<
             </Example>
         );
     }
-
-    private renderOptions() {
-        return (
-            <>
-                <H5>Props</H5>
-                <Switch checked={this.state.useAmPm} label="Use AM/PM" onChange={this.toggleUseAmPm} />
-                <Switch
-                    checked={this.state.showArrowButtons}
-                    label="Show arrow buttons"
-                    onChange={this.toggleShowArrowButtons}
-                />
-            </>
-        );
-    }
-
-    private toggleUseAmPm = () => {
-        this.setState({ useAmPm: !this.state.useAmPm });
-    };
-
-    private toggleShowArrowButtons = () => {
-        this.setState({ showArrowButtons: !this.state.showArrowButtons });
-    };
 
     private handleDateChange = (date: Date) => this.setState({ date });
 }

--- a/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
@@ -16,23 +16,34 @@
 
 import * as React from "react";
 
-import { Classes } from "@blueprintjs/core";
+import { Classes, H5, Switch } from "@blueprintjs/core";
 import { DateTimePicker } from "@blueprintjs/datetime";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 
-export class DateTimePickerExample extends React.PureComponent<IExampleProps, { date: Date }> {
-    public state = { date: new Date() };
+export class DateTimePickerExample extends React.PureComponent<
+    IExampleProps,
+    { date: Date; showArrowButtons: boolean; useAmPm: boolean }
+> {
+    public state = {
+        date: new Date(),
+        showArrowButtons: false,
+        useAmPm: true,
+    };
 
     public render() {
         return (
-            <Example options={false} {...this.props}>
+            <Example options={this.renderOptions()} {...this.props}>
                 {/* eslint-disable-next-line deprecation/deprecation */}
                 <DateTimePicker
                     className={Classes.ELEVATION_1}
                     value={this.state.date}
-                    timePickerProps={{ precision: "second", useAmPm: true }}
+                    timePickerProps={{
+                        precision: "second",
+                        showArrowButtons: this.state.showArrowButtons,
+                        useAmPm: this.state.useAmPm,
+                    }}
                     onChange={this.handleDateChange}
                 />
                 <div>
@@ -41,6 +52,28 @@ export class DateTimePickerExample extends React.PureComponent<IExampleProps, { 
             </Example>
         );
     }
+
+    private renderOptions() {
+        return (
+            <>
+                <H5>Props</H5>
+                <Switch checked={this.state.useAmPm} label="Use AM/PM" onChange={this.toggleUseAmPm} />
+                <Switch
+                    checked={this.state.showArrowButtons}
+                    label="Show arrow buttons"
+                    onChange={this.toggleShowArrowButtons}
+                />
+            </>
+        );
+    }
+
+    private toggleUseAmPm = () => {
+        this.setState({ useAmPm: !this.state.useAmPm });
+    };
+
+    private toggleShowArrowButtons = () => {
+        this.setState({ showArrowButtons: !this.state.showArrowButtons });
+    };
 
     private handleDateChange = (date: Date) => this.setState({ date });
 }


### PR DESCRIPTION
#### Fixes #4775 

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Updating `TimePickers` value to null should behave the same way as when it was constructed: get min time or default value. 

#### Reviewers should focus on:

Whether this breaks any existing functionality.

#### Screenshot

![output](https://user-images.githubusercontent.com/5015365/128551917-fd920ca8-e7a1-4c9e-897c-dc116a90d7a2.gif)
