### PR TITLE
[stylelint-plugin] Fix no-prefix-literal test

### DIFF
--- a/packages/stylelint-plugin/test/fixtures/contains-double-bp3-selector.scss
+++ b/packages/stylelint-plugin/test/fixtures/contains-double-bp3-selector.scss
@@ -1,3 +1,3 @@
-.bp-a.bp-b {
+.bp3-a.bp3-b {
   z-index: 1;
 }

--- a/packages/stylelint-plugin/test/no-prefix-literal.test.js
+++ b/packages/stylelint-plugin/test/no-prefix-literal.test.js
@@ -156,9 +156,9 @@ describe("no-prefix-literal", () => {
         expect(result.results[0].invalidOptionWarnings.length).to.be.eq(2);
     });
 
-    it("Works for a double bp selector", async () => {
+    it("Works for a double bp3 selector", async () => {
         const result = await stylelint.lint({
-            files: "test/fixtures/contains-double-bp-selector.scss",
+            files: "test/fixtures/contains-double-bp3-selector.scss",
             config,
         });
         expect(result.errored).to.be.true;


### PR DESCRIPTION
https://github.com/palantir/blueprint/pull/4715 made the `bp` prefix not banned, but I forgot to update this test.

Also, looks like these tests are not being run in CI for some reason and they probably should be.