### PR TITLE
[table] chore: rename more types, export more types from root

### DIFF
--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -30,7 +30,7 @@ import {
     EditableName,
     IColumnHeaderCellProps,
     IMenuContext,
-    IRegion,
+    Region,
     JSONFormat,
     RegionCardinality,
     Regions,
@@ -363,11 +363,11 @@ class RowSelectableTable extends React.Component {
         this.setState({ selectedRegions: [] });
     };
 
-    private handleSelection = (selectedRegions: IRegion[]) => {
+    private handleSelection = (selectedRegions: Region[]) => {
         this.setState({ selectedRegions });
     };
 
-    private selectedRegionTransform = (region: IRegion) => {
+    private selectedRegionTransform = (region: Region) => {
         // convert cell selection to row selection
         if (Regions.getRegionCardinality(region) === RegionCardinality.CELLS) {
             return Regions.row(region.rows[0], region.rows[1]);

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -39,8 +39,9 @@ import {
     ColumnHeaderCell,
     EditableCell2,
     EditableName,
-    IStyledRegionGroup,
+    StyledRegionGroup,
     JSONFormat,
+    Region,
     RegionCardinality,
     Regions,
     RowHeaderCell,
@@ -53,7 +54,6 @@ import {
 import { IFocusedCellCoordinates } from "@blueprintjs/table/src/common/cell";
 import { IColumnIndices, IRowIndices } from "@blueprintjs/table/src/common/grid";
 import { RenderMode } from "@blueprintjs/table/src/common/renderMode";
-import { IRegion } from "@blueprintjs/table/src/regions";
 
 import { DenseGridMutableStore } from "./denseGridMutableStore";
 import { LocalStore } from "./localStore";
@@ -206,12 +206,12 @@ function contains(arr: any[], value: any) {
     return arr.indexOf(value) >= 0;
 }
 
-function enforceWholeColumnSelection(region: IRegion) {
+function enforceWholeColumnSelection(region: Region) {
     delete region.rows;
     return region;
 }
 
-function enforceWholeRowSelection(region: IRegion) {
+function enforceWholeRowSelection(region: Region) {
     delete region.cols;
     return region;
 }
@@ -248,7 +248,7 @@ export interface IMutableTableState {
     scrollToRowIndex?: number;
     selectedFocusStyle?: FocusStyle;
     selectedRegionTransformPreset?: SelectedRegionTransformPreset;
-    selectedRegions?: IRegion[];
+    selectedRegions?: Region[];
     showCallbackLogs?: boolean;
     showCellsLoading?: boolean;
     showColumnHeadersLoading?: boolean;
@@ -881,7 +881,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         this.maybeLogCallback("[onCompleteRender]");
     };
 
-    private onSelection = (selectedRegions: IRegion[]) => {
+    private onSelection = (selectedRegions: Region[]) => {
         this.maybeLogCallback(`[onSelection] selectedRegions =`, ...selectedRegions);
         this.setState({ selectedRegions });
     };
@@ -946,7 +946,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
     private handleScrollToButtonClick = () => {
         const { scrollToRowIndex, scrollToColumnIndex, scrollToRegionType } = this.state;
 
-        let region: IRegion;
+        let region: Region;
         switch (scrollToRegionType) {
             case RegionCardinality.CELLS:
                 region = Regions.cell(scrollToRowIndex, scrollToColumnIndex);
@@ -1107,7 +1107,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                       className: "tbl-styled-region-danger",
                       regions: [Regions.cell(5, 3, 7, 7)],
                   },
-              ] as IStyledRegionGroup[]);
+              ] as StyledRegionGroup[]);
     }
 }
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -111,7 +111,9 @@ export interface ICellProps extends IntentProps, Props {
     cellRef?: IRef<HTMLDivElement>;
 }
 
+/** @deprecated use CellRenderer */
 export type ICellRenderer = (rowIndex: number, columnIndex: number) => React.ReactElement<ICellProps>;
+// eslint-disable-next-line deprecation/deprecation
 export type CellRenderer = ICellRenderer;
 
 export const emptyCellRenderer = () => <Cell />;

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -18,8 +18,8 @@ import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, Props } from "@blueprintjs/core";
 
-import { emptyCellRenderer, ICellRenderer } from "./cell/cell";
-import { IColumnHeaderRenderer } from "./headers/columnHeader";
+import { emptyCellRenderer, CellRenderer } from "./cell/cell";
+import { ColumnHeaderRenderer } from "./headers/columnHeader";
 import { IColumnNameProps } from "./headers/columnHeaderCell";
 import { ColumnLoadingOption } from "./regions";
 
@@ -45,16 +45,16 @@ export interface IColumnProps extends IColumnNameProps, Props {
     loadingOptions?: ColumnLoadingOption[];
 
     /**
-     * An instance of `ICellRenderer`, a function that takes a row and column
+     * An instance of `CellRenderer`, a function that takes a row and column
      * index, and returns a `Cell` React element.
      */
-    cellRenderer?: ICellRenderer;
+    cellRenderer?: CellRenderer;
 
     /**
-     * An instance of `IColumnHeaderRenderer`, a function that takes a column
+     * An instance of `ColumnHeaderRenderer`, a function that takes a column
      * index and returns a `ColumnHeaderCell` React element.
      */
-    columnHeaderCellRenderer?: IColumnHeaderRenderer;
+    columnHeaderCellRenderer?: ColumnHeaderRenderer;
 }
 
 export class Column extends React.PureComponent<IColumnProps> {

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -16,7 +16,7 @@
 
 import { CSSProperties } from "react";
 
-import { IRegion, RegionCardinality, Regions } from "../regions";
+import { Region, RegionCardinality, Regions } from "../regions";
 import * as Classes from "./classes";
 import { Rect } from "./rect";
 import { Utils } from "./utils";
@@ -319,7 +319,7 @@ export class Grid {
         return [];
     }
 
-    public getRegionStyle(region: IRegion): CSSProperties {
+    public getRegionStyle(region: Region): CSSProperties {
         const cardinality = Regions.getRegionCardinality(region);
         switch (cardinality) {
             case RegionCardinality.CELLS: {

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { IRegion, RegionCardinality, Regions } from "../../regions";
-import { ICellCoordinates, IFocusedCellCoordinates } from "../cell";
+import { Region, RegionCardinality, Regions } from "../../regions";
+import { CellCoordinates, FocusedCellCoordinates } from "../cell";
 import * as Errors from "../errors";
 
 /**
@@ -23,7 +23,7 @@ import * as Errors from "../errors";
  * property are defined, or the last index of `selectedRegions` otherwise. If
  * `selectedRegions` is empty, the function always returns `undefined`.
  */
-export function getFocusedOrLastSelectedIndex(selectedRegions: IRegion[], focusedCell?: IFocusedCellCoordinates) {
+export function getFocusedOrLastSelectedIndex(selectedRegions: Region[], focusedCell?: FocusedCellCoordinates) {
     if (selectedRegions.length === 0) {
         return undefined;
     } else if (focusedCell != null) {
@@ -38,10 +38,10 @@ export function getFocusedOrLastSelectedIndex(selectedRegions: IRegion[], focuse
  */
 export function getInitialFocusedCell(
     enableFocusedCell: boolean,
-    focusedCellFromProps: IFocusedCellCoordinates,
-    focusedCellFromState: IFocusedCellCoordinates,
-    selectedRegions: IRegion[],
-): IFocusedCellCoordinates {
+    focusedCellFromProps: FocusedCellCoordinates,
+    focusedCellFromState: FocusedCellCoordinates,
+    selectedRegions: Region[],
+): FocusedCellCoordinates {
     if (!enableFocusedCell) {
         return undefined;
     } else if (focusedCellFromProps != null) {
@@ -67,7 +67,7 @@ export function getInitialFocusedCell(
  * Returns `true` if the focused cell is located along the top boundary of the
  * provided region, or `false` otherwise.
  */
-export function isFocusedCellAtRegionTop(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+export function isFocusedCellAtRegionTop(region: Region, focusedCell: FocusedCellCoordinates) {
     return region.rows != null && focusedCell.row === region.rows[0];
 }
 
@@ -75,7 +75,7 @@ export function isFocusedCellAtRegionTop(region: IRegion, focusedCell: IFocusedC
  * Returns `true` if the focused cell is located along the bottom boundary of
  * the provided region, or `false` otherwise.
  */
-export function isFocusedCellAtRegionBottom(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+export function isFocusedCellAtRegionBottom(region: Region, focusedCell: FocusedCellCoordinates) {
     return region.rows != null && focusedCell.row === region.rows[1];
 }
 
@@ -83,7 +83,7 @@ export function isFocusedCellAtRegionBottom(region: IRegion, focusedCell: IFocus
  * Returns `true` if the focused cell is located along the left boundary of the
  * provided region, or `false` otherwise.
  */
-export function isFocusedCellAtRegionLeft(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+export function isFocusedCellAtRegionLeft(region: Region, focusedCell: FocusedCellCoordinates) {
     return region.cols != null && focusedCell.col === region.cols[0];
 }
 
@@ -91,18 +91,18 @@ export function isFocusedCellAtRegionLeft(region: IRegion, focusedCell: IFocused
  * Returns `true` if the focused cell is located along the right boundary of the
  * provided region, or `false` otherwise.
  */
-export function isFocusedCellAtRegionRight(region: IRegion, focusedCell: IFocusedCellCoordinates) {
+export function isFocusedCellAtRegionRight(region: Region, focusedCell: FocusedCellCoordinates) {
     return region.cols != null && focusedCell.col === region.cols[1];
 }
 
 /**
  * Returns a new cell-coordinates object that includes a focusSelectionIndex property.
- * The returned object will have the proper IFocusedCellCoordinates type.
+ * The returned object will have the proper FocusedCellCoordinates type.
  */
 export function toFullCoordinates(
-    cellCoords: ICellCoordinates,
+    cellCoords: CellCoordinates,
     focusSelectionIndex: number = 0,
-): IFocusedCellCoordinates {
+): FocusedCellCoordinates {
     return { ...cellCoords, focusSelectionIndex };
 }
 
@@ -112,7 +112,7 @@ export function toFullCoordinates(
  * operation. This function is used, for instance, to expand a selected region
  * on shift+click.
  */
-export function expandFocusedRegion(focusedCell: IFocusedCellCoordinates, newRegion: IRegion) {
+export function expandFocusedRegion(focusedCell: FocusedCellCoordinates, newRegion: Region) {
     switch (Regions.getRegionCardinality(newRegion)) {
         case RegionCardinality.FULL_COLUMNS: {
             const [indexStart, indexEnd] = getExpandedRegionIndices(focusedCell, newRegion, "col", "cols");
@@ -133,8 +133,8 @@ export function expandFocusedRegion(focusedCell: IFocusedCellCoordinates, newReg
 }
 
 function getExpandedRegionIndices(
-    focusedCell: IFocusedCellCoordinates,
-    newRegion: IRegion,
+    focusedCell: FocusedCellCoordinates,
+    newRegion: Region,
     focusedCellDimension: "row" | "col",
     regionDimension: "rows" | "cols",
 ) {

--- a/packages/table/src/common/internal/scrollUtils.ts
+++ b/packages/table/src/common/internal/scrollUtils.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { IRegion, RegionCardinality, Regions } from "../../regions";
+import { Region, RegionCardinality, Regions } from "../../regions";
 
 /**
  * Returns the scroll{Left,Top} offsets of the provided region based on its
  * cardinality.
  */
 export function getScrollPositionForRegion(
-    region: IRegion,
+    region: Region,
     currScrollLeft: number,
     currScrollTop: number,
     getLeftOffset: (columnIndex: number) => number,

--- a/packages/table/src/common/internal/selectionUtils.ts
+++ b/packages/table/src/common/internal/selectionUtils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { IRegion, RegionCardinality, Regions } from "../../regions";
-import { IFocusedCellCoordinates } from "../cell";
+import { Region, RegionCardinality, Regions } from "../../regions";
+import { FocusedCellCoordinates } from "../cell";
 import { Direction } from "../direction";
 import * as DirectionUtils from "./directionUtils";
 import * as FocusedCellUtils from "./focusedCellUtils";
@@ -47,14 +47,14 @@ import * as FocusedCellUtils from "./focusedCellUtils";
  * This function does not clamp the indices of the returned region; that is the
  * responsibility of the caller.
  */
-export function resizeRegion(region: IRegion, direction: Direction, focusedCell?: IFocusedCellCoordinates) {
+export function resizeRegion(region: Region, direction: Direction, focusedCell?: FocusedCellCoordinates) {
     if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_TABLE) {
         // return the same instance to maintain referential integrity and
         // possibly avoid unnecessary update lifecycles.
         return region;
     }
 
-    const nextRegion: IRegion = Regions.copy(region);
+    const nextRegion: Region = Regions.copy(region);
 
     let affectedRowIndex: number = 0;
     let affectedColumnIndex: number = 0;

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -29,7 +29,10 @@ import { RegionCardinality, Regions } from "../regions";
 import { ColumnHeaderCell, IColumnHeaderCellProps } from "./columnHeaderCell";
 import { Header, IHeaderProps } from "./header";
 
+/** @deprecated use ColumnHeaderRenderer */
 export type IColumnHeaderRenderer = (columnIndex: number) => React.ReactElement<IColumnHeaderCellProps>;
+// eslint-disable-next-line deprecation/deprecation
+export type ColumnHeaderRenderer = IColumnHeaderRenderer;
 
 export interface IColumnWidths {
     minColumnWidth?: number;
@@ -44,7 +47,7 @@ export interface IColumnHeaderProps extends IHeaderProps, IColumnWidths, IColumn
      * 2. A `<ColumnHeaderCell>` using the `name` prop from the `<Column>`
      * 3. A `<ColumnHeaderCell>` with a `name` generated from `Utils.toBase26Alpha`
      */
-    cellRenderer: IColumnHeaderRenderer;
+    cellRenderer: ColumnHeaderRenderer;
 
     /**
      * Ref handler that receives the HTML element that should be measured to

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { Icon, Utils as CoreUtils } from "@blueprintjs/core";
 
 import { Grid } from "../common";
-import { IFocusedCellCoordinates } from "../common/cell";
+import { FocusedCellCoordinates } from "../common/cell";
 import * as Classes from "../common/classes";
 import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
 import { DragEvents } from "../interactions/dragEvents";
@@ -30,7 +30,7 @@ import { Resizable } from "../interactions/resizable";
 import { ILockableLayout, Orientation } from "../interactions/resizeHandle";
 import { DragSelectable, ISelectableProps } from "../interactions/selectable";
 import { ILocator } from "../locator";
-import { IRegion, RegionCardinality, Regions } from "../regions";
+import { Region, RegionCardinality, Regions } from "../regions";
 import { IHeaderCellProps } from "./headerCell";
 
 export type IHeaderCellRenderer = (index: number) => React.ReactElement<IHeaderCellProps>;
@@ -39,7 +39,7 @@ export interface IHeaderProps extends ILockableLayout, IReorderableProps, ISelec
     /**
      * The currently focused cell.
      */
-    focusedCell?: IFocusedCellCoordinates;
+    focusedCell?: FocusedCellCoordinates;
 
     /**
      * The grid computes sizes of cells, rows, or columns from the
@@ -140,7 +140,7 @@ export interface IInternalHeaderProps extends IHeaderProps {
     /**
      * An array containing the table's selection Regions.
      */
-    selectedRegions: IRegion[];
+    selectedRegions: Region[];
 
     /**
      * Converts a point on the screen to a row or column index in the table grid.
@@ -216,7 +216,7 @@ export interface IInternalHeaderProps extends IHeaderProps {
      * Converts a range to a region. This should be Regions.column for column headers and
      * Regions.row for row headers.
      */
-    toRegion: (index1: number, index2?: number) => IRegion;
+    toRegion: (index1: number, index2?: number) => Region;
 
     /**
      * A callback that wraps the rendered cell components in additional parent elements as needed.
@@ -274,12 +274,12 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
         return this.props.convertPointToIndex(coord);
     };
 
-    private locateClick = (event: MouseEvent): IRegion => {
+    private locateClick = (event: MouseEvent): Region => {
         this.activationIndex = this.convertEventToIndex(event);
         return this.props.toRegion(this.activationIndex);
     };
 
-    private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData, returnEndOnly = false): IRegion => {
+    private locateDragForSelection = (_event: MouseEvent, coords: ICoordinateData, returnEndOnly = false): Region => {
         const coord = this.props.getDragCoordinate(coords.current);
         const indexStart = this.activationIndex;
         const indexEnd = this.props.convertPointToIndex(coord);
@@ -430,7 +430,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
         );
     }
 
-    private handleDragSelectableSelection = (selectedRegions: IRegion[]) => {
+    private handleDragSelectableSelection = (selectedRegions: Region[]) => {
         this.props.onSelection(selectedRegions);
         this.setState({ hasValidSelection: false });
     };

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -26,7 +26,9 @@ import { RegionCardinality, Regions } from "../regions";
 import { Header, IHeaderProps } from "./header";
 import { IRowHeaderCellProps, RowHeaderCell } from "./rowHeaderCell";
 
+/** @deprecated use RowHeaderRenderer */
 export type IRowHeaderRenderer = (rowIndex: number) => React.ReactElement<IRowHeaderCellProps>;
+// eslint-disable-next-line deprecation/deprecation
 export type RowHeaderRenderer = IRowHeaderRenderer;
 
 export interface IRowHeights {
@@ -44,7 +46,7 @@ export interface IRowHeaderProps extends IHeaderProps, IRowHeights, IRowIndices 
     /**
      * Renders the cell for each row header
      */
-    rowHeaderCellRenderer?: IRowHeaderRenderer;
+    rowHeaderCellRenderer?: RowHeaderRenderer;
 }
 
 export class RowHeader extends React.Component<IRowHeaderProps> {

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable deprecation/deprecation */
+
 export { Cell, CellProps, ICellProps, ICellRenderer, CellRenderer } from "./cell/cell";
 
 export { EditableCell, IEditableCellProps, EditableCellProps } from "./cell/editableCell";
@@ -50,7 +52,9 @@ export { ILockableLayout, IResizeHandleProps, Orientation, ResizeHandle } from "
 
 export { ISelectableProps, IDragSelectableProps, DragSelectable } from "./interactions/selectable";
 
-export { IColumnHeaderRenderer } from "./headers/columnHeader";
+export { ColumnHeaderRenderer, IColumnHeaderRenderer } from "./headers/columnHeader";
+
+export { RowHeaderRenderer } from "./headers/rowHeader";
 
 export { ColumnHeaderCell, IColumnHeaderCellProps, HorizontalCellDivider } from "./headers/columnHeaderCell";
 
@@ -59,6 +63,8 @@ export { IRowHeaderCellProps, RowHeaderCell } from "./headers/rowHeaderCell";
 export { IEditableNameProps, EditableNameProps, EditableName } from "./headers/editableName";
 
 export {
+    CellInterval,
+    CellCoordinate,
     ColumnLoadingOption,
     ICellInterval,
     IRegion,
@@ -68,13 +74,12 @@ export {
     Regions,
     RowLoadingOption,
     SelectionModes,
+    StyledRegionGroup,
     TableLoadingOption,
 } from "./regions";
 
-// eslint-disable-next-line deprecation/deprecation
 export { ITableProps, TableProps } from "./tableProps";
 
-// eslint-disable-next-line deprecation/deprecation
 export { Table } from "./table";
 
 export { Table2 } from "./table2";

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -14,47 +14,47 @@
  * limitations under the License.
  */
 
-import { ICellCoordinate, IRegion, Regions } from "../../regions";
+import { CellCoordinate, Region, Regions } from "../../regions";
 
 export type IContextMenuRenderer = (context: IMenuContext) => JSX.Element;
 export type ContextMenuRenderer = IContextMenuRenderer;
 
 export interface IMenuContext {
     /**
-     * Returns an array of `IRegion`s that represent the user-intended context
+     * Returns an array of `Region`s that represent the user-intended context
      * of this menu. If the mouse click was on a selection, the array will
-     * contain all selected regions. Otherwise it will have one `IRegion` that
-     * represents the clicked cell (the same `IRegion` from `getTarget`).
+     * contain all selected regions. Otherwise it will have one `Region` that
+     * represents the clicked cell (the same `Region` from `getTarget`).
      */
-    getRegions: () => IRegion[];
+    getRegions: () => Region[];
 
     /**
-     * Returns the list of selected `IRegion` in the table, regardless of
+     * Returns the list of selected `Region` in the table, regardless of
      * where the users clicked to launch the context menu. For the user-
      * intended regions for this context, use `getRegions` instead.
      */
-    getSelectedRegions: () => IRegion[];
+    getSelectedRegions: () => Region[];
 
     /**
      * Returns a region containing the single cell that was clicked to launch
      * this context menu.
      */
-    getTarget: () => IRegion;
+    getTarget: () => Region;
 
     /**
      * Returns an array containing all of the unique, potentially non-
      * contiguous, cells contained in all the regions from `getRegions`. The
      * cell coordinates are sorted by rows then columns.
      */
-    getUniqueCells: () => ICellCoordinate[];
+    getUniqueCells: () => CellCoordinate[];
 }
 
 export class MenuContext implements IMenuContext {
-    private regions: IRegion[];
+    private regions: Region[];
 
     constructor(
-        private target: IRegion,
-        private selectedRegions: IRegion[],
+        private target: Region,
+        private selectedRegions: Region[],
         private numRows: number,
         private numCols: number,
     ) {

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -18,9 +18,9 @@ import * as React from "react";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
 
-import { IFocusedCellCoordinates } from "../common/cell";
+import { FocusedCellCoordinates } from "../common/cell";
 import { Utils } from "../common/utils";
-import { IRegion, RegionCardinality, Regions } from "../regions";
+import { Region, RegionCardinality, Regions } from "../regions";
 import { Draggable, IDraggableProps } from "./draggable";
 import { ICoordinateData } from "./dragTypes";
 
@@ -48,20 +48,20 @@ export interface IReorderableProps {
      * array of `Region`s. This array should be considered the new selection
      * state for the entire table.
      */
-    onSelection: (regions: IRegion[]) => void;
+    onSelection: (regions: Region[]) => void;
 
     /**
      * When the user reorders something, this callback is called with the new
      * focus cell for the newly selected set of regions.
      */
-    onFocusedCell: (focusedCell: IFocusedCellCoordinates) => void;
+    onFocusedCell: (focusedCell: FocusedCellCoordinates) => void;
 
     /**
      * An array containing the table's selection Regions.
      *
      * @default []
      */
-    selectedRegions?: IRegion[];
+    selectedRegions?: Region[];
 }
 
 export interface IDragReorderable extends IReorderableProps {
@@ -76,7 +76,7 @@ export interface IDragReorderable extends IReorderableProps {
      * A callback that determines a `Region` for the single `MouseEvent`. If
      * no valid region can be found, `null` may be returned.
      */
-    locateClick: (event: MouseEvent) => IRegion;
+    locateClick: (event: MouseEvent) => Region;
 
     /**
      * A callback that determines the index at which to show the preview guide.
@@ -89,7 +89,7 @@ export interface IDragReorderable extends IReorderableProps {
      * A callback that converts the provided index into a region. The returned
      * region will be used to update the current selection after drag-reordering.
      */
-    toRegion: (index1: number, index2?: number) => IRegion;
+    toRegion: (index1: number, index2?: number) => Region;
 }
 
 export class DragReorderable extends React.PureComponent<IDragReorderable> {
@@ -198,7 +198,7 @@ export class DragReorderable extends React.PureComponent<IDragReorderable> {
         return !Utils.isLeftClick(event) || isDisabled;
     }
 
-    private maybeSelectRegion(region: IRegion) {
+    private maybeSelectRegion(region: Region) {
         const nextSelectedRegions = [region];
 
         if (!CoreUtils.deepCompareKeys(nextSelectedRegions, this.props.selectedRegions)) {

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -22,16 +22,16 @@ import { IFocusedCellCoordinates } from "../common/cell";
 import * as FocusedCellUtils from "../common/internal/focusedCellUtils";
 import * as PlatformUtils from "../common/internal/platformUtils";
 import { Utils } from "../common/utils";
-import { IRegion, Regions } from "../regions";
+import { Region, Regions } from "../regions";
 import { DragEvents } from "./dragEvents";
 import { Draggable, IDraggableProps } from "./draggable";
 import { ICoordinateData } from "./dragTypes";
 
 export type ISelectedRegionTransform = (
-    region: IRegion,
+    region: Region,
     event: MouseEvent | KeyboardEvent,
     coords?: ICoordinateData,
-) => IRegion;
+) => Region;
 export type SelectedRegionTransform = ISelectedRegionTransform;
 
 export interface ISelectableProps {
@@ -61,21 +61,21 @@ export interface ISelectableProps {
      * array of `Region`s. This array should be considered the new selection
      * state for the entire table.
      */
-    onSelection: (regions: IRegion[]) => void;
+    onSelection: (regions: Region[]) => void;
 
     /**
      * An additional convenience callback invoked when the user releases the
      * mouse from either a click or a drag, indicating that the selection
      * interaction has ended.
      */
-    onSelectionEnd?: (regions: IRegion[]) => void;
+    onSelectionEnd?: (regions: Region[]) => void;
 
     /**
      * An array containing the table's selection Regions.
      *
      * @default []
      */
-    selectedRegions?: IRegion[];
+    selectedRegions?: Region[];
 
     /**
      * An optional transform function that will be applied to the located
@@ -105,14 +105,14 @@ export interface IDragSelectableProps extends ISelectableProps {
      * A callback that determines a `Region` for the single `MouseEvent`. If
      * no valid region can be found, `null` may be returned.
      */
-    locateClick: (event: MouseEvent) => IRegion;
+    locateClick: (event: MouseEvent) => Region;
 
     /**
      * A callback that determines a `Region` for the `MouseEvent` and
      * coordinate data representing a drag. If no valid region can be found,
      * `null` may be returned.
      */
-    locateDrag: (event: MouseEvent, coords: ICoordinateData, returnEndOnly?: boolean) => IRegion;
+    locateDrag: (event: MouseEvent, coords: ICoordinateData, returnEndOnly?: boolean) => Region;
 }
 
 export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
@@ -124,7 +124,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
 
     private didExpandSelectionOnActivate = false;
 
-    private lastEmittedSelectedRegions: IRegion[];
+    private lastEmittedSelectedRegions: Region[];
 
     public render() {
         const draggableProps = this.getDraggableProps();
@@ -285,7 +285,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
         this.invokeOnFocusCallbackForRegion(nextSelectedRegion, 0);
     };
 
-    private handleExpandSelection = (region: IRegion) => {
+    private handleExpandSelection = (region: Region) => {
         const { focusedCell, selectedRegions } = this.props;
         this.didExpandSelectionOnActivate = true;
 
@@ -300,7 +300,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
         }
     };
 
-    private handleAddDisjointSelection = (region: IRegion) => {
+    private handleAddDisjointSelection = (region: Region) => {
         const { selectedRegions } = this.props;
 
         // add the new region to the existing selections
@@ -311,7 +311,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
         this.invokeOnFocusCallbackForRegion(region, nextSelectedRegions.length - 1);
     };
 
-    private handleReplaceSelection = (region: IRegion) => {
+    private handleReplaceSelection = (region: Region) => {
         // clear all selections and retain only the new one
         const nextSelectedRegions = [region];
         this.maybeInvokeSelectionCallback(nextSelectedRegions);
@@ -323,7 +323,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
     // Callbacks
     // =========
 
-    private maybeInvokeSelectionCallback(nextSelectedRegions: IRegion[]) {
+    private maybeInvokeSelectionCallback(nextSelectedRegions: Region[]) {
         const { onSelection } = this.props;
         // invoke only if the selection changed. this is useful only on
         // mousemove; there's special handling for mousedown interactions that
@@ -337,7 +337,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
         }
     }
 
-    private invokeOnFocusCallbackForRegion = (focusRegion: IRegion, focusSelectionIndex = 0) => {
+    private invokeOnFocusCallbackForRegion = (focusRegion: Region, focusSelectionIndex = 0) => {
         const { onFocusedCell } = this.props;
         const focusedCellCoords = Regions.getFocusCellCoordinatesFromRegion(focusRegion);
         onFocusedCell(FocusedCellUtils.toFullCoordinates(focusedCellCoords, focusSelectionIndex));
@@ -357,7 +357,7 @@ export class DragSelectable extends React.PureComponent<IDragSelectableProps> {
      * last-selected region with the expanded region. If a focused cell is provided,
      * the focused cell will serve as an anchor for the expansion.
      */
-    private expandSelectedRegions(regions: IRegion[], region: IRegion, focusedCell?: IFocusedCellCoordinates) {
+    private expandSelectedRegions(regions: Region[], region: Region, focusedCell?: IFocusedCellCoordinates) {
         if (regions.length === 0) {
             return [region];
         } else if (focusedCell != null) {

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -21,15 +21,15 @@ import { Props, Utils as CoreUtils } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { QuadrantType } from "../quadrants/tableQuadrant";
-import { IRegion, Regions } from "../regions";
+import { Region, Regions } from "../regions";
 
-export type IRegionStyler = (region: IRegion, quadrantType?: QuadrantType) => React.CSSProperties;
+export type RegionStyler = (region: Region, quadrantType?: QuadrantType) => React.CSSProperties;
 
-export interface IRegionLayerProps extends Props {
+export interface RegionLayerProps extends Props {
     /**
      * The array of regions to render.
      */
-    regions?: IRegion[];
+    regions?: Region[];
 
     /**
      * The array of CSS styles to apply to each region. The ith style object in this array will be
@@ -39,10 +39,10 @@ export interface IRegionLayerProps extends Props {
 }
 
 // don't include "regions" or "regionStyles" in here, because they can't be shallowly compared
-const UPDATE_PROPS_KEYS = ["className"] as Array<keyof IRegionLayerProps>;
+const UPDATE_PROPS_KEYS = ["className"] as Array<keyof RegionLayerProps>;
 
-export class RegionLayer extends React.Component<IRegionLayerProps> {
-    public shouldComponentUpdate(nextProps: IRegionLayerProps) {
+export class RegionLayer extends React.Component<RegionLayerProps> {
+    public shouldComponentUpdate(nextProps: RegionLayerProps) {
         // shallowly comparable props like "className" tend not to change in the default table
         // implementation, so do that check last with hope that we return earlier and avoid it
         // altogether.
@@ -65,7 +65,7 @@ export class RegionLayer extends React.Component<IRegionLayerProps> {
         return regions.map(this.renderRegion);
     }
 
-    private renderRegion = (_region: IRegion, index: number) => {
+    private renderRegion = (_region: Region, index: number) => {
         const { className, regionStyles } = this.props;
         return (
             <div

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -79,24 +79,35 @@ export enum TableLoadingOption {
     ROW_HEADERS = "row-header",
 }
 
-export type StyledRegionGroup = IStyledRegionGroup;
+/** @deprecated use StyledRegionGroup */
 export interface IStyledRegionGroup {
     className?: string;
-    regions: IRegion[];
+    regions: Region[];
 }
+// eslint-disable-next-line deprecation/deprecation
+export type StyledRegionGroup = IStyledRegionGroup;
 
 /**
  * An _inclusive_ interval of ZERO-indexed cell indices.
+ *
+ * @deprecated use CellInterval
  */
 export type ICellInterval = [number, number];
+// eslint-disable-next-line deprecation/deprecation
+export type CellInterval = ICellInterval;
 
 /**
  * Small datastructure for storing cell coordinates [row, column]
+ *
+ * @deprecated use CellCoordinate
  */
 export type ICellCoordinate = [number, number];
+// eslint-disable-next-line deprecation/deprecation
+export type CellCoordinate = ICellCoordinate;
 
 /**
  * @see Regions.getRegionCardinality for more about the format of this object.
+ * @deprecated use Region
  */
 export interface IRegion {
     /**
@@ -104,15 +115,16 @@ export interface IRegion {
      * If `rows` is `null`, then all rows are understood to be included in the
      * region.
      */
-    rows?: ICellInterval | null;
+    rows?: CellInterval | null;
 
     /**
      * The first and last column indices in the region, inclusive and
      * zero-indexed. If `cols` is `null`, then all columns are understood to be
      * included in the region.
      */
-    cols?: ICellInterval | null;
+    cols?: CellInterval | null;
 }
+// eslint-disable-next-line deprecation/deprecation
 export type Region = IRegion;
 
 export class Regions {
@@ -144,7 +156,7 @@ export class Regions {
      *
      * In this case, this method would return `RegionCardinality.CELLS`.
      */
-    public static getRegionCardinality(region: IRegion) {
+    public static getRegionCardinality(region: Region) {
         if (region.cols != null && region.rows != null) {
             return RegionCardinality.CELLS;
         } else if (region.cols != null) {
@@ -156,7 +168,7 @@ export class Regions {
         }
     }
 
-    public static getFocusCellCoordinatesFromRegion(region: IRegion) {
+    public static getFocusCellCoordinatesFromRegion(region: Region) {
         const regionCardinality = Regions.getRegionCardinality(region);
 
         switch (regionCardinality) {
@@ -176,7 +188,7 @@ export class Regions {
     /**
      * Returns a deep copy of the provided region.
      */
-    public static copy(region: IRegion): IRegion {
+    public static copy(region: Region): Region {
         const cardinality = Regions.getRegionCardinality(region);
 
         // we need to be careful not to explicitly spell out `rows: undefined`
@@ -196,7 +208,7 @@ export class Regions {
     /**
      * Returns a region containing one or more cells.
      */
-    public static cell(row: number, col: number, row2?: number, col2?: number): IRegion {
+    public static cell(row: number, col: number, row2?: number, col2?: number): Region {
         return {
             cols: this.normalizeInterval(col, col2),
             rows: this.normalizeInterval(row, row2),
@@ -206,21 +218,21 @@ export class Regions {
     /**
      * Returns a region containing one or more full rows.
      */
-    public static row(row: number, row2?: number): IRegion {
+    public static row(row: number, row2?: number): Region {
         return { rows: this.normalizeInterval(row, row2) };
     }
 
     /**
      * Returns a region containing one or more full columns.
      */
-    public static column(col: number, col2?: number): IRegion {
+    public static column(col: number, col2?: number): Region {
         return { cols: this.normalizeInterval(col, col2) };
     }
 
     /**
      * Returns a region containing the entire table.
      */
-    public static table(): IRegion {
+    public static table(): Region {
         return {};
     }
 
@@ -228,7 +240,7 @@ export class Regions {
      * Adds the region to the end of a cloned copy of the supplied region
      * array.
      */
-    public static add(regions: IRegion[], region: IRegion) {
+    public static add(regions: Region[], region: Region) {
         const copy = regions.slice();
         copy.push(region);
         return copy;
@@ -238,7 +250,7 @@ export class Regions {
      * Replaces the region at the end of a cloned copy of the supplied region
      * array, or at the specific index if one is provided.
      */
-    public static update(regions: IRegion[], region: IRegion, index?: number) {
+    public static update(regions: Region[], region: Region, index?: number) {
         const copy = regions.slice();
         if (index != null) {
             copy.splice(index, 1, region);
@@ -253,7 +265,7 @@ export class Regions {
      * Clamps the region's start and end indices between 0 and the provided
      * maximum values.
      */
-    public static clampRegion(region: IRegion, maxRowIndex: number, maxColumnIndex: number) {
+    public static clampRegion(region: Region, maxRowIndex: number, maxColumnIndex: number) {
         const nextRegion = Regions.copy(region);
         if (region.rows != null) {
             nextRegion.rows[0] = Utils.clamp(region.rows[0], 0, maxRowIndex);
@@ -270,7 +282,7 @@ export class Regions {
      * Returns true iff the specified region is equal to the last region in
      * the region list. This allows us to avoid immediate additive re-selection.
      */
-    public static lastRegionIsEqual(regions: IRegion[], region: IRegion) {
+    public static lastRegionIsEqual(regions: Region[], region: Region) {
         if (regions == null || regions.length === 0) {
             return false;
         }
@@ -282,7 +294,7 @@ export class Regions {
      * Returns the index of the region that is equal to the supplied
      * parameter. Returns -1 if no such region is found.
      */
-    public static findMatchingRegion(regions: IRegion[], region: IRegion) {
+    public static findMatchingRegion(regions: Region[], region: Region) {
         if (regions == null) {
             return -1;
         }
@@ -299,7 +311,7 @@ export class Regions {
      * Returns the index of the region that wholly contains the supplied
      * parameter. Returns -1 if no such region is found.
      */
-    public static findContainingRegion(regions: IRegion[], region: IRegion) {
+    public static findContainingRegion(regions: Region[], region: Region) {
         if (regions == null) {
             return -1;
         }
@@ -316,7 +328,7 @@ export class Regions {
      * Returns true if the regions contain a region that has FULL_COLUMNS
      * cardinality and contains the specified column index.
      */
-    public static hasFullColumn(regions: IRegion[], col: number) {
+    public static hasFullColumn(regions: Region[], col: number) {
         if (regions == null) {
             return false;
         }
@@ -338,7 +350,7 @@ export class Regions {
      * Returns true if the regions contain a region that has FULL_ROWS
      * cardinality and contains the specified row index.
      */
-    public static hasFullRow(regions: IRegion[], row: number) {
+    public static hasFullRow(regions: Region[], row: number) {
         if (regions == null) {
             return false;
         }
@@ -359,7 +371,7 @@ export class Regions {
     /**
      * Returns true if the regions contain a region that has FULL_TABLE cardinality
      */
-    public static hasFullTable(regions: IRegion[]) {
+    public static hasFullTable(regions: Region[]) {
         if (regions == null) {
             return false;
         }
@@ -377,14 +389,14 @@ export class Regions {
     /**
      * Returns true if the regions fully contain the query region.
      */
-    public static containsRegion(regions: IRegion[], query: IRegion) {
+    public static containsRegion(regions: Region[], query: Region) {
         return Regions.overlapsRegion(regions, query, false);
     }
 
     /**
      * Returns true if the regions at least partially overlap the query region.
      */
-    public static overlapsRegion(regions: IRegion[], query: IRegion, allowPartialOverlap = false) {
+    public static overlapsRegion(regions: Region[], query: Region, allowPartialOverlap = false) {
         const intervalCompareFn = allowPartialOverlap ? Regions.intervalOverlaps : Regions.intervalContains;
 
         if (regions == null || query == null) {
@@ -419,13 +431,13 @@ export class Regions {
         return false;
     }
 
-    public static eachUniqueFullColumn(regions: IRegion[], iteratee: (col: number) => void) {
+    public static eachUniqueFullColumn(regions: Region[], iteratee: (col: number) => void) {
         if (regions == null || regions.length === 0 || iteratee == null) {
             return;
         }
 
         const seen: { [col: number]: boolean } = {};
-        regions.forEach((region: IRegion) => {
+        regions.forEach((region: Region) => {
             if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_COLUMNS) {
                 const [start, end] = region.cols;
                 for (let col = start; col <= end; col++) {
@@ -438,13 +450,13 @@ export class Regions {
         });
     }
 
-    public static eachUniqueFullRow(regions: IRegion[], iteratee: (row: number) => void) {
+    public static eachUniqueFullRow(regions: Region[], iteratee: (row: number) => void) {
         if (regions == null || regions.length === 0 || iteratee == null) {
             return;
         }
 
         const seen: { [row: number]: boolean } = {};
-        regions.forEach((region: IRegion) => {
+        regions.forEach((region: Region) => {
             if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_ROWS) {
                 const [start, end] = region.rows;
                 for (let row = start; row <= end; row++) {
@@ -458,17 +470,17 @@ export class Regions {
     }
 
     /**
-     * Using the supplied array of non-contiguous `IRegion`s, this method
+     * Using the supplied array of non-contiguous `Region`s, this method
      * returns an ordered array of every unique cell that exists in those
      * regions.
      */
-    public static enumerateUniqueCells(regions: IRegion[], numRows: number, numCols: number): ICellCoordinate[] {
+    public static enumerateUniqueCells(regions: Region[], numRows: number, numCols: number): CellCoordinate[] {
         if (regions == null || regions.length === 0) {
             return [];
         }
 
         const seen: { [key: string]: boolean } = {};
-        const list: ICellCoordinate[] = [];
+        const list: CellCoordinate[] = [];
         for (const region of regions) {
             Regions.eachCellInRegion(region, numRows, numCols, (row: number, col: number) => {
                 // add to list if not seen
@@ -489,7 +501,7 @@ export class Regions {
      * Using the supplied region, returns an "equivalent" region of
      * type CELLS that define the bounds of the given region
      */
-    public static getCellRegionFromRegion(region: IRegion, numRows: number, numCols: number) {
+    public static getCellRegionFromRegion(region: Region, numRows: number, numCols: number) {
         const regionCardinality = Regions.getRegionCardinality(region);
 
         switch (regionCardinality) {
@@ -511,11 +523,11 @@ export class Regions {
      * of cell values.
      *
      * We create a new 2-dimensional array representing the smallest single
-     * contiguous `IRegion` that contains all cells in the supplied array. We
+     * contiguous `Region` that contains all cells in the supplied array. We
      * invoke the mapper callback only on the cells in the supplied coordinate
      * array and store the result. Returns the resulting 2-dimensional array.
      */
-    public static sparseMapCells<T>(cells: ICellCoordinate[], mapper: (row: number, col: number) => T): T[][] {
+    public static sparseMapCells<T>(cells: CellCoordinate[], mapper: (row: number, col: number) => T): T[][] {
         const bounds = Regions.getBoundingRegion(cells);
         if (bounds == null) {
             return null;
@@ -531,10 +543,10 @@ export class Regions {
     }
 
     /**
-     * Returns the smallest single contiguous `IRegion` that contains all cells in the
+     * Returns the smallest single contiguous `Region` that contains all cells in the
      * supplied array.
      */
-    public static getBoundingRegion(cells: ICellCoordinate[]): IRegion {
+    public static getBoundingRegion(cells: CellCoordinate[]): Region {
         let minRow: number;
         let maxRow: number;
         let minCol: number;
@@ -554,7 +566,7 @@ export class Regions {
         };
     }
 
-    public static isValid(region: IRegion) {
+    public static isValid(region: Region) {
         if (region == null) {
             return false;
         }
@@ -567,7 +579,7 @@ export class Regions {
         return true;
     }
 
-    public static isRegionValidForTable(region: IRegion, numRows: number, numCols: number) {
+    public static isRegionValidForTable(region: Region, numRows: number, numCols: number) {
         if (numRows === 0 || numCols === 0) {
             return false;
         } else if (region.rows != null && !intervalInRangeInclusive(region.rows, 0, numRows - 1)) {
@@ -579,11 +591,11 @@ export class Regions {
     }
 
     public static joinStyledRegionGroups(
-        selectedRegions: IRegion[],
-        otherRegions: IStyledRegionGroup[],
+        selectedRegions: Region[],
+        otherRegions: StyledRegionGroup[],
         focusedCell: IFocusedCellCoordinates,
     ) {
-        let regionGroups: IStyledRegionGroup[] = [];
+        let regionGroups: StyledRegionGroup[] = [];
         if (otherRegions != null) {
             regionGroups = regionGroups.concat(otherRegions);
         }
@@ -603,7 +615,7 @@ export class Regions {
         return regionGroups;
     }
 
-    public static regionsEqual(regionA: IRegion, regionB: IRegion) {
+    public static regionsEqual(regionA: Region, regionB: Region) {
         return Regions.intervalsEqual(regionA.rows, regionB.rows) && Regions.intervalsEqual(regionA.cols, regionB.cols);
     }
 
@@ -613,7 +625,7 @@ export class Regions {
      * region is returned. Useful for expanding a selected region on
      * shift+click, for instance.
      */
-    public static expandRegion(oldRegion: IRegion, newRegion: IRegion): IRegion {
+    public static expandRegion(oldRegion: Region, newRegion: Region): Region {
         const oldRegionCardinality = Regions.getRegionCardinality(oldRegion);
         const newRegionCardinality = Regions.getRegionCardinality(newRegion);
 
@@ -645,11 +657,11 @@ export class Regions {
     }
 
     /**
-     * Iterates over the cells within an `IRegion`, invoking the callback with
+     * Iterates over the cells within an `Region`, invoking the callback with
      * each cell's coordinates.
      */
     private static eachCellInRegion(
-        region: IRegion,
+        region: Region,
         numRows: number,
         numCols: number,
         iteratee: (row: number, col: number) => void,
@@ -689,12 +701,12 @@ export class Regions {
         }
     }
 
-    private static regionContains(regionA: IRegion, regionB: IRegion) {
+    private static regionContains(regionA: Region, regionB: Region) {
         // containsRegion expects an array of regions as the first param
         return Regions.overlapsRegion([regionA], regionB, false);
     }
 
-    private static intervalsEqual(ivalA: ICellInterval, ivalB: ICellInterval) {
+    private static intervalsEqual(ivalA: CellInterval, ivalB: CellInterval) {
         if (ivalA == null) {
             return ivalB == null;
         } else if (ivalB == null) {
@@ -704,21 +716,21 @@ export class Regions {
         }
     }
 
-    private static intervalContainsIndex(interval: ICellInterval, index: number) {
+    private static intervalContainsIndex(interval: CellInterval, index: number) {
         if (interval == null) {
             return false;
         }
         return interval[0] <= index && interval[1] >= index;
     }
 
-    private static intervalContains(ivalA: ICellInterval, ivalB: ICellInterval) {
+    private static intervalContains(ivalA: CellInterval, ivalB: CellInterval) {
         if (ivalA == null || ivalB == null) {
             return false;
         }
         return ivalA[0] <= ivalB[0] && ivalB[1] <= ivalA[1];
     }
 
-    private static intervalOverlaps(ivalA: ICellInterval, ivalB: ICellInterval) {
+    private static intervalOverlaps(ivalA: CellInterval, ivalB: CellInterval) {
         if (ivalA == null || ivalB == null) {
             return false;
         }
@@ -728,7 +740,7 @@ export class Regions {
         return true;
     }
 
-    private static rowFirstComparator(a: ICellCoordinate, b: ICellCoordinate) {
+    private static rowFirstComparator(a: CellCoordinate, b: CellCoordinate) {
         const rowDiff = a[0] - b[0];
         return rowDiff === 0 ? a[1] - b[1] : rowDiff;
     }
@@ -744,11 +756,11 @@ export class Regions {
 
         const interval = [coord, coord2];
         interval.sort(Regions.numericalComparator);
-        return interval as ICellInterval;
+        return interval as CellInterval;
     }
 }
 
-function intervalInRangeInclusive(interval: ICellInterval, minInclusive: number, maxInclusive: number) {
+function intervalInRangeInclusive(interval: CellInterval, minInclusive: number, maxInclusive: number) {
     return (
         inRangeInclusive(interval[0], minInclusive, maxInclusive) &&
         inRangeInclusive(interval[1], minInclusive, maxInclusive)

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -45,7 +45,7 @@ import { ColumnHeaderCell, IColumnHeaderCellProps } from "./headers/columnHeader
 import { renderDefaultRowHeader, RowHeader } from "./headers/rowHeader";
 import { ResizeSensor } from "./interactions/resizeSensor";
 import { GuideLayer } from "./layers/guides";
-import { IRegionStyler, RegionLayer } from "./layers/regions";
+import { RegionStyler, RegionLayer } from "./layers/regions";
 import { Locator } from "./locator";
 import { QuadrantType } from "./quadrants/tableQuadrant";
 import { TableQuadrantStack } from "./quadrants/tableQuadrantStack";
@@ -1091,11 +1091,11 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
 
     /**
      * Renders a `RegionLayer`, applying styles to the regions using the
-     * supplied `IRegionStyler`. `RegionLayer` is a `PureRender` component, so
-     * the `IRegionStyler` should be a new instance on every render if we
+     * supplied `RegionStyler`. `RegionLayer` is a `PureRender` component, so
+     * the `RegionStyler` should be a new instance on every render if we
      * intend to redraw the region layer.
      */
-    private maybeRenderRegions(getRegionStyle: IRegionStyler, quadrantType?: QuadrantType) {
+    private maybeRenderRegions(getRegionStyle: RegionStyler, quadrantType?: QuadrantType) {
         if (this.isGuidesShowing() && !this.state.isReordering) {
             // we want to show guides *and* the selection styles when reordering rows or columns
             return undefined;

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -43,18 +43,11 @@ import { ColumnHeaderCell, IColumnHeaderCellProps } from "./headers/columnHeader
 import { renderDefaultRowHeader, RowHeader } from "./headers/rowHeader";
 import { ResizeSensor } from "./interactions/resizeSensor";
 import { GuideLayer } from "./layers/guides";
-import { IRegionStyler, RegionLayer } from "./layers/regions";
+import { RegionStyler, RegionLayer } from "./layers/regions";
 import { Locator } from "./locator";
 import { QuadrantType } from "./quadrants/tableQuadrant";
 import { TableQuadrantStack } from "./quadrants/tableQuadrantStack";
-import {
-    ColumnLoadingOption,
-    IRegion,
-    RegionCardinality,
-    Regions,
-    SelectionModes,
-    TableLoadingOption,
-} from "./regions";
+import { ColumnLoadingOption, Region, RegionCardinality, Regions, SelectionModes, TableLoadingOption } from "./regions";
 import {
     IResizeRowsByApproximateHeightOptions,
     resizeRowsByApproximateHeight,
@@ -253,7 +246,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         let newRowHeights = Utils.times(numRows, () => defaultRowHeight);
         newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
 
-        const selectedRegions = props.selectedRegions == null ? ([] as IRegion[]) : props.selectedRegions;
+        const selectedRegions = props.selectedRegions == null ? ([] as Region[]) : props.selectedRegions;
         const focusedCell = FocusedCellUtils.getInitialFocusedCell(
             props.enableFocusedCell,
             props.focusedCell,
@@ -344,7 +337,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
      * simply scroll the target region as close to the top-left as possible until the bottom-right
      * corner is reached.
      */
-    public scrollToRegion(region: IRegion) {
+    public scrollToRegion(region: Region) {
         const { numFrozenColumnsClamped: numFrozenColumns, numFrozenRowsClamped: numFrozenRows } = this.state;
         const { left: currScrollLeft, top: currScrollTop } = this.state.viewportRect;
 
@@ -944,11 +937,11 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
 
     /**
      * Renders a `RegionLayer`, applying styles to the regions using the
-     * supplied `IRegionStyler`. `RegionLayer` is a `PureRender` component, so
-     * the `IRegionStyler` should be a new instance on every render if we
+     * supplied `RegionStyler`. `RegionLayer` is a `PureRender` component, so
+     * the `RegionStyler` should be a new instance on every render if we
      * intend to redraw the region layer.
      */
-    private maybeRenderRegions(getRegionStyle: IRegionStyler, quadrantType?: QuadrantType) {
+    private maybeRenderRegions(getRegionStyle: RegionStyler, quadrantType?: QuadrantType) {
         if (this.isGuidesShowing() && !this.state.isReordering) {
             // we want to show guides *and* the selection styles when reordering rows or columns
             return undefined;
@@ -984,7 +977,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
     };
 
-    private styleBodyRegion = (region: IRegion, quadrantType: QuadrantType): React.CSSProperties => {
+    private styleBodyRegion = (region: Region, quadrantType: QuadrantType): React.CSSProperties => {
         const { numFrozenColumns } = this.props;
 
         const cardinality = Regions.getRegionCardinality(region);
@@ -1031,7 +1024,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
     };
 
-    private styleMenuRegion = (region: IRegion): React.CSSProperties => {
+    private styleMenuRegion = (region: Region): React.CSSProperties => {
         const { viewportRect } = this.state;
         if (viewportRect == null) {
             return {};
@@ -1054,7 +1047,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
     };
 
-    private styleColumnHeaderRegion = (region: IRegion): React.CSSProperties => {
+    private styleColumnHeaderRegion = (region: Region): React.CSSProperties => {
         const { viewportRect } = this.state;
         if (viewportRect == null) {
             return {};
@@ -1077,7 +1070,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
     };
 
-    private styleRowHeaderRegion = (region: IRegion): React.CSSProperties => {
+    private styleRowHeaderRegion = (region: Region): React.CSSProperties => {
         const { viewportRect } = this.state;
         if (viewportRect == null) {
             return {};
@@ -1173,7 +1166,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
     };
 
-    private clearSelection = (_selectedRegions: IRegion[]) => {
+    private clearSelection = (_selectedRegions: Region[]) => {
         this.handleSelection([]);
     };
 
@@ -1216,7 +1209,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         this.props.onFocusedCell?.(focusedCell);
     };
 
-    private handleSelection = (selectedRegions: IRegion[]) => {
+    private handleSelection = (selectedRegions: Region[]) => {
         // only set selectedRegions state if not specified in props
         if (this.props.selectedRegions == null) {
             this.setState({ selectedRegions });

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -27,14 +27,14 @@ import { ICoordinateData } from "./interactions/dragTypes";
 import { IContextMenuRenderer, MenuContext } from "./interactions/menus";
 import { DragSelectable, ISelectableProps } from "./interactions/selectable";
 import { ILocator } from "./locator";
-import { IRegion, Regions } from "./regions";
+import { Region, Regions } from "./regions";
 import { cellClassNames, ITableBodyCellsProps, TableBodyCells } from "./tableBodyCells";
 
 export interface ITableBodyProps extends ISelectableProps, ITableBodyCellsProps {
     /**
      * An optional callback for displaying a context menu when right-clicking
      * on the table body. The callback is supplied with an `IMenuContext`
-     * containing the `IRegion`s of interest.
+     * containing the `Region`s of interest.
      */
     bodyContextMenuRenderer?: IContextMenuRenderer;
 
@@ -131,7 +131,7 @@ export class TableBody extends AbstractComponent2<ITableBodyProps> {
 
         const targetRegion = this.locateClick(e.nativeEvent as MouseEvent);
 
-        let nextSelectedRegions: IRegion[] = selectedRegions;
+        let nextSelectedRegions: Region[] = selectedRegions;
 
         // if the event did not happen within a selected region, clear all
         // selections and select the right-clicked cell.

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { AbstractComponent2, Props, Utils as CoreUtils } from "@blueprintjs/core";
 
-import { emptyCellRenderer, ICellRenderer } from "./cell/cell";
+import { emptyCellRenderer, CellRenderer } from "./cell/cell";
 import { Batcher } from "./common/batcher";
 import { IFocusedCellCoordinates } from "./common/cell";
 import * as Classes from "./common/classes";
@@ -31,7 +31,7 @@ export interface ITableBodyCellsProps extends IRowIndices, IColumnIndices, Props
     /**
      * A cell renderer for the cells in the body.
      */
-    cellRenderer: ICellRenderer;
+    cellRenderer: CellRenderer;
 
     /**
      * The coordinates of the currently focused cell, for setting the "isFocused" prop on cells.

--- a/packages/table/src/tableHotkeys.ts
+++ b/packages/table/src/tableHotkeys.ts
@@ -21,14 +21,14 @@ import { Direction } from "./common/direction";
 import { Grid } from "./common/grid";
 import * as FocusedCellUtils from "./common/internal/focusedCellUtils";
 import * as SelectionUtils from "./common/internal/selectionUtils";
-import { IRegion, RegionCardinality, Regions } from "./regions";
+import { Region, RegionCardinality, Regions } from "./regions";
 import type { TableProps } from "./tableProps";
 import type { TableState, TableSnapshot } from "./tableState";
 
 export interface TableHandlers {
-    handleSelection: (selectedRegions: IRegion[]) => void;
+    handleSelection: (selectedRegions: Region[]) => void;
     handleFocus: (focusedCell: IFocusedCellCoordinates) => void;
-    getEnabledSelectionHandler: (selectionMode: RegionCardinality) => (selectedRegions: IRegion[]) => void;
+    getEnabledSelectionHandler: (selectionMode: RegionCardinality) => (selectedRegions: Region[]) => void;
     syncViewportPosition: (snapshot: TableSnapshot) => void;
 }
 
@@ -107,7 +107,7 @@ export class TableHotkeys {
      * Replaces the selected region at the specified array index, with the
      * region provided.
      */
-    private updateSelectedRegionAtIndex(region: IRegion, index: number) {
+    private updateSelectedRegionAtIndex(region: Region, index: number) {
         const { children, numRows } = this.props;
         const { selectedRegions } = this.state;
         const numColumns = React.Children.count(children);
@@ -345,7 +345,7 @@ export class TableHotkeys {
         secondaryAxis: "row" | "col",
         isUpOrLeft: boolean,
         newFocusedCell: IFocusedCellCoordinates,
-        focusCellRegion: IRegion,
+        focusCellRegion: Region,
     ) {
         const { selectedRegions } = this.state;
 

--- a/packages/table/src/tableProps.ts
+++ b/packages/table/src/tableProps.ts
@@ -21,11 +21,11 @@ import type { IFocusedCellCoordinates } from "./common/cell";
 import type { IColumnIndices, IRowIndices } from "./common/grid";
 import type { RenderMode } from "./common/renderMode";
 import type { IColumnWidths } from "./headers/columnHeader";
-import type { IRowHeaderRenderer, IRowHeights } from "./headers/rowHeader";
+import type { RowHeaderRenderer, IRowHeights } from "./headers/rowHeader";
 import type { IContextMenuRenderer } from "./interactions/menus";
 import type { IIndexedResizeCallback } from "./interactions/resizable";
 import type { ISelectedRegionTransform } from "./interactions/selectable";
-import type { IRegion, IStyledRegionGroup, RegionCardinality, TableLoadingOption } from "./regions";
+import type { Region, StyledRegionGroup, RegionCardinality, TableLoadingOption } from "./regions";
 
 // eslint-disable-next-line deprecation/deprecation
 export type TableProps = ITableProps;
@@ -48,8 +48,8 @@ export interface ITableProps extends Props, IRowHeights, IColumnWidths {
     /**
      * An optional callback for displaying a context menu when right-clicking
      * on the table body. The callback is supplied with an array of
-     * `IRegion`s. If the mouse click was on a selection, the array will
-     * contain all selected regions. Otherwise it will have one `IRegion` that
+     * `Region`s. If the mouse click was on a selection, the array will
+     * contain all selected regions. Otherwise it will have one `Region` that
      * represents the clicked cell.
      */
     bodyContextMenuRenderer?: IContextMenuRenderer;
@@ -224,7 +224,7 @@ export interface ITableProps extends Props, IRowHeights, IColumnWidths {
     /**
      * A callback called when the selection is changed in the table.
      */
-    onSelection?: (selectedRegions: IRegion[]) => void;
+    onSelection?: (selectedRegions: Region[]) => void;
 
     /**
      * A callback called when the visible cell indices change in the table.
@@ -245,7 +245,7 @@ export interface ITableProps extends Props, IRowHeights, IColumnWidths {
     /**
      * Render each row's header cell.
      */
-    rowHeaderCellRenderer?: IRowHeaderRenderer;
+    rowHeaderCellRenderer?: RowHeaderRenderer;
 
     /**
      * A sparse number array with a length equal to the number of rows. Any
@@ -266,7 +266,7 @@ export interface ITableProps extends Props, IRowHeights, IColumnWidths {
      * selection you can pass to the `selectedRegions` prop. Therefore you can,
      * for example, convert cell clicks into row selections.
      */
-    selectedRegions?: IRegion[];
+    selectedRegions?: Region[];
 
     /**
      * An optional transform function that will be applied to the located
@@ -305,5 +305,5 @@ export interface ITableProps extends Props, IRowHeights, IColumnWidths {
      * Styled region groups are rendered as overlays above the table and are
      * marked with their own `className` for custom styling.
      */
-    styledRegionGroups?: IStyledRegionGroup[];
+    styledRegionGroups?: StyledRegionGroup[];
 }

--- a/packages/table/src/tableState.ts
+++ b/packages/table/src/tableState.ts
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import type { IColumnProps } from "./column";
+import type { ColumnProps } from "./column";
 import type { Rect } from "./common";
 import type { IFocusedCellCoordinates } from "./common/cell";
-import type { IRegion } from "./regions";
+import type { Region } from "./regions";
 
 export interface TableState {
     /**
@@ -70,7 +70,7 @@ export interface TableState {
     /**
      * An array of Regions representing the selections of the table.
      */
-    selectedRegions?: IRegion[];
+    selectedRegions?: Region[];
 
     /**
      * An array of pixel offsets for resize guides, which are drawn over the
@@ -86,7 +86,7 @@ export interface TableState {
 
     columnIdToIndex: { [key: string]: number };
 
-    childrenArray: Array<React.ReactElement<IColumnProps>>;
+    childrenArray: Array<React.ReactElement<ColumnProps>>;
 }
 
 export interface TableSnapshot {


### PR DESCRIPTION

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Deprecate more types in favor of their renamed versions without the `I` prefix
- Export some more types from the root of the package which I noticed were being used by consumers who reached in with a submodule import (e.g. `ColumnHeaderRenderer`)

