### PR TITLE
[docs-app] feat(DatePickerExample): add timepicker AM/PM option

### DIFF
--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -122,7 +122,6 @@ export class DatePicker extends AbstractPureComponent2<DatePickerProps, IDatePic
         reverseMonthAndYearMenus: false,
         shortcuts: false,
         showActionsBar: false,
-        timePickerProps: {},
         todayButtonText: "Today",
     };
 
@@ -277,7 +276,7 @@ export class DatePicker extends AbstractPureComponent2<DatePickerProps, IDatePic
 
     private maybeRenderTimePicker() {
         const { timePrecision, timePickerProps, minDate, maxDate } = this.props;
-        if (timePrecision == null && timePickerProps === DatePicker.defaultProps.timePickerProps) {
+        if (timePrecision == null && timePickerProps === undefined) {
             return null;
         }
         const applyMin = DateUtils.areSameDay(this.state.value, minDate);
@@ -418,7 +417,7 @@ export class DatePicker extends AbstractPureComponent2<DatePickerProps, IDatePic
     };
 
     private handleTimeChange = (time: Date) => {
-        this.props.timePickerProps.onChange?.(time);
+        this.props.timePickerProps?.onChange?.(time);
         const { value } = this.state;
         const newValue = DateUtils.getDateTime(value != null ? value : new Date(), time);
         this.updateValue(newValue, true);

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -66,6 +66,7 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
 
     public render() {
         const { date, showTimeArrowButtons, useAmPm, ...props } = this.state;
+        const showTimePicker = this.state.timePrecision !== undefined;
 
         const options = (
             <>
@@ -89,13 +90,13 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
                     onChange={this.handlePrecisionChange}
                 />
                 <Switch
-                    disabled={this.state.timePrecision === undefined}
+                    disabled={!showTimePicker}
                     checked={showTimeArrowButtons}
                     label="Show timepicker arrow buttons"
                     onChange={this.toggleTimepickerArrowButtons}
                 />
                 <Switch
-                    disabled={this.state.timePrecision === undefined}
+                    disabled={!showTimePicker}
                     checked={this.state.useAmPm}
                     label="Use AM/PM"
                     onChange={this.toggleUseAmPm}
@@ -103,12 +104,19 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
             </>
         );
 
+        const timePickerProps = showTimePicker
+            ? {
+                  showArrowButtons: showTimeArrowButtons,
+                  useAmPm,
+              }
+            : undefined;
+
         return (
             <Example options={options} {...this.props}>
                 <DatePicker
                     className={Classes.ELEVATION_1}
                     onChange={this.handleDateChange}
-                    timePickerProps={{ showArrowButtons: showTimeArrowButtons, useAmPm }}
+                    timePickerProps={timePickerProps}
                     {...props}
                 />
                 <MomentDate date={date} withTime={props.timePrecision !== undefined} />

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -31,6 +31,7 @@ export interface IDatePickerExampleState {
     showActionsBar: boolean;
     timePrecision: TimePrecision | undefined;
     showTimeArrowButtons: boolean;
+    useAmPm?: boolean;
 }
 
 export class DatePickerExample extends React.PureComponent<IExampleProps, IDatePickerExampleState> {
@@ -42,6 +43,7 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
         showActionsBar: false,
         showTimeArrowButtons: false,
         timePrecision: undefined,
+        useAmPm: false,
     };
 
     private toggleHighlight = handleBooleanChange(highlightCurrentDay => this.setState({ highlightCurrentDay }));
@@ -60,8 +62,10 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
         this.setState({ showTimeArrowButtons }),
     );
 
+    private toggleUseAmPm = handleBooleanChange(useAmPm => this.setState({ useAmPm }));
+
     public render() {
-        const { date, showTimeArrowButtons, ...props } = this.state;
+        const { date, showTimeArrowButtons, useAmPm, ...props } = this.state;
 
         const options = (
             <>
@@ -90,6 +94,12 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
                     label="Show timepicker arrow buttons"
                     onChange={this.toggleTimepickerArrowButtons}
                 />
+                <Switch
+                    disabled={this.state.timePrecision === undefined}
+                    checked={this.state.useAmPm}
+                    label="Use AM/PM"
+                    onChange={this.toggleUseAmPm}
+                />
             </>
         );
 
@@ -98,7 +108,7 @@ export class DatePickerExample extends React.PureComponent<IExampleProps, IDateP
                 <DatePicker
                     className={Classes.ELEVATION_1}
                     onChange={this.handleDateChange}
-                    timePickerProps={{ showArrowButtons: showTimeArrowButtons }}
+                    timePickerProps={{ showArrowButtons: showTimeArrowButtons, useAmPm }}
                     {...props}
                 />
                 <MomentDate date={date} withTime={props.timePrecision !== undefined} />


### PR DESCRIPTION
#### Related to #4846

#### Checklist

- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Add AM/PM dropdown option for time picker in DatePicker docs example. This demonstrates that #4846 is not a bug with DatePicker.
- Fix DatePickerExample to _not_ show a time picker when time precision is "None". This seems to have been a bug for a while in this component example.
  - To do this, I slightly changed the implementation in `<DatePicker>` which checks `props.timePickerProps` to see if a time picker should be rendered. In the absence of `timePrecision`: instead of an empty object, users are now expected to use `undefined` (or the lack of the `timePickerProps` prop) to signify that a time picker should not be rendered.

#### Reviewers should focus on:

If this small DatePicker API break is ok

#### Screenshot

![2021-08-18 17 33 11](https://user-images.githubusercontent.com/723999/129975214-df3b114d-60a4-45e2-aca8-023f37bd932e.gif)

