### PR TITLE
[core] fix: make configureDom4.ts an ES module

### DIFF
--- a/packages/core/src/common/configureDom4.ts
+++ b/packages/core/src/common/configureDom4.ts
@@ -19,3 +19,5 @@ if (typeof require !== "undefined" && typeof window !== "undefined" && typeof do
     require("dom4"); // only import actual dom4 if we're in the browser (not server-compatible)
     // we'll still need dom4 types for the TypeScript to compile, these are included in package.json
 }
+
+export {};


### PR DESCRIPTION
Fixes #4878. This allows it to be compatible with the tsc option `--isolatedModules`.
