### PR TITLE
[core] fix(Button): remove iconTitle prop

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -88,12 +88,6 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
      * @default "button"
      */
     type?: "submit" | "reset" | "button";
-
-    /**
-     * Provide this to give a text label to icon only buttons. You likely don't need this prop
-     * if there is other text in the button already.
-     */
-    iconTitle?: string;
 }
 
 /** @deprecated use AnchorButtonProps */
@@ -190,10 +184,10 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
     };
 
     protected renderChildren(): React.ReactNode {
-        const { children, icon, loading, rightIcon, text, iconTitle } = this.props;
+        const { children, icon, loading, rightIcon, text } = this.props;
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={IconSize.LARGE} />,
-            <Icon key="leftIcon" icon={icon} title={iconTitle} />,
+            <Icon key="leftIcon" icon={icon} />,
             (!Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children)) && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -90,7 +90,6 @@ export class PanelView extends AbstractPureComponent2<IPanelViewProps> {
                 small={true}
                 text={this.props.previousPanel.title}
                 title={this.props.previousPanel.htmlTitle}
-                iconTitle="Go back"
             />
         );
     }

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -66,7 +66,6 @@ export const PanelView2: PanelView2Component = <T extends Panel<object>>(props: 
                 small={true}
                 text={props.previousPanel.title}
                 title={props.previousPanel.htmlTitle}
-                iconTitle="Go back"
             />
         );
 

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -160,9 +160,9 @@ describe("<PanelStack>", () => {
 
         const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
         assert.equal(
-            backButtonWithoutTitle.text(),
-            "Go back",
-            "expected icon-only back button to have accessible title",
+            backButtonWithoutTitle.prop("aria-label"),
+            "Back",
+            "expected icon-only back button to have accessible label",
         );
 
         const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
@@ -170,7 +170,11 @@ describe("<PanelStack>", () => {
         newPanelButtonOnNotEmpty.simulate("click");
 
         const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK).hostNodes().at(1);
-        assert.equal(backButtonWithTitle.text(), "Go back", "expected icon-only back button to have accessible title");
+        assert.equal(
+            backButtonWithTitle.prop("aria-label"),
+            "Back",
+            "expected icon-only back button to have accessible label",
+        );
     });
 
     it("can render a panel stack in controlled mode", () => {

--- a/packages/core/test/panel-stack2/panelStack2Tests.tsx
+++ b/packages/core/test/panel-stack2/panelStack2Tests.tsx
@@ -167,9 +167,9 @@ describe("<PanelStack2>", () => {
 
             const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
             assert.equal(
-                backButtonWithoutTitle.text(),
-                "Go back",
-                "expected icon-only back button to have accessible title",
+                backButtonWithoutTitle.prop("aria-label"),
+                "Back",
+                "expected icon-only back button to have accessible label",
             );
 
             const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
@@ -178,9 +178,9 @@ describe("<PanelStack2>", () => {
 
             const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK).hostNodes().at(1);
             assert.equal(
-                backButtonWithTitle.text(),
-                "Go back",
-                "expected icon-only back button to have accessible title",
+                backButtonWithTitle.prop("aria-label"),
+                "Back",
+                "expected icon-only back button to have accessible label",
             );
         });
     });


### PR DESCRIPTION
#### Addresses my concern in https://github.com/palantir/blueprint/pull/4835#issuecomment-908581449

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Remove `iconTitle` prop from `<Button>` and `<AnchorButton>`, as it is superfluous
  - icon-only buttons without text/children should have their accessible labels set with the `aria-label` and/or `title` attributes, not by labeling the icon
- Note that this is not a breaking change because #4835 (which added `iconTitle`) has not been released yet

#### Reviewers should focus on:

N/A

#### Screenshot

N/A
