### PR TITLE
[table] fix issues with blank rows/columns on mount/resize

### DIFF
--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -19,13 +19,20 @@ import * as React from "react";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2 } from "@blueprintjs/table";
 
+// this will obviously get outdated, it's valid only as of August 2021
+const USD_TO_EURO_CONVERSION = 0.85;
+
 export class TableDollarExample extends React.PureComponent<IExampleProps> {
     public render() {
-        const cellRenderer = (rowIndex: number) => <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>;
+        const dollarCellRenderer = (rowIndex: number) => <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>;
+        const euroCellRenderer = (rowIndex: number) => (
+            <Cell>{`€${(rowIndex * 10 * USD_TO_EURO_CONVERSION).toFixed(2)}`}</Cell>
+        );
         return (
             <Example options={false} showOptionsBelowExample={true} {...this.props}>
-                <Table2 numRows={10}>
-                    <Column name="Dollars" cellRenderer={cellRenderer} />
+                <Table2 numRows={20}>
+                    <Column name="Dollars" cellRenderer={dollarCellRenderer} />
+                    <Column name="Euros" cellRenderer={euroCellRenderer} />
                 </Table2>
             </Example>
         );

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -253,9 +253,10 @@ export class Grid {
         }
 
         const searchEnd = includeGhostCells ? Math.max(this.numRows, Grid.DEFAULT_MAX_ROWS) : this.numRows;
+        const { top = 0, height } = rect;
         const { start, end } = this.getIndicesInInterval(
-            rect.top,
-            rect.top + rect.height,
+            top,
+            top + height,
             searchEnd,
             !includeGhostCells,
             this.getCumulativeHeightAt,
@@ -282,9 +283,10 @@ export class Grid {
         }
 
         const searchEnd = includeGhostCells ? Math.max(this.numCols, Grid.DEFAULT_MAX_COLUMNS) : this.numCols;
+        const { left = 0, width } = rect;
         const { start, end } = this.getIndicesInInterval(
-            rect.left,
-            rect.left + rect.width,
+            left,
+            left + width,
             searchEnd,
             !includeGhostCells,
             this.getCumulativeWidthAt,

--- a/packages/table/src/docs/table.md
+++ b/packages/table/src/docs/table.md
@@ -52,16 +52,21 @@ The table is **data-agnostic**. It doesn't store any data internally, so it is u
 You can specify how the data is displayed by defining the `cellRenderer` prop on each `Column` component.
 This is useful when working with typed columnar data, like database results.
 
-For example, this creates a table that renders dollar values:
+For example, this creates a table that renders dollar and euro values:
 
 ```tsx
 import { Cell, Column, Table } from "@blueprintjs/table";
 
-const cellRenderer = (rowIndex: number) => {
-    return <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>
-};
+const dollarCellRenderer = (rowIndex: number) => (
+    <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>
+);
+const euroCellRenderer = (rowIndex: number) => (
+    <Cell>{`€${(rowIndex * 10 * 0.85).toFixed(2)}`}</Cell>
+);
+
 <Table numRows={10}>
-    <Column name="Dollars" cellRenderer={cellRenderer}/>
+    <Column name="Dollars" cellRenderer={dollarCellRenderer}/>
+    <Column name="Euros" cellRenderer={euroCellRenderer} />
 </Table>
 ```
 

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -103,8 +103,8 @@ export class Locator implements ILocator {
 
     public getViewportRect() {
         return new Rect(
-            this.scrollContainerElement.scrollLeft,
-            this.scrollContainerElement.scrollTop,
+            this.scrollContainerElement.scrollLeft || 0,
+            this.scrollContainerElement.scrollTop || 0,
             this.scrollContainerElement.clientWidth,
             this.scrollContainerElement.clientHeight,
         );


### PR DESCRIPTION
#### fixes #3779, #3941

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Update the "basic usage" table example to repro the bug described in #3941 
- Adjust some viewport rect code to be more defensive about and provide defaults (top = 0, left = 0) for when the scroll container element ref is null, or doesn't have client coordinates. This fixes the edge cases where the visible grid would be incorrectly calculated as the top left 4x4 cells, and only those cells would render

#### Reviewers should focus on:

N/A

#### Screenshot

![2021-08-30 17 24 14](https://user-images.githubusercontent.com/723999/131407685-6300a517-94f2-44a5-895a-710badae43e2.gif)

