### PR TITLE
[core] fix(Dialog): set dialog header z-index to 0

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -67,7 +67,6 @@ $pt-navbar-height: $pt-grid-size * 5 !default;
 $pt-z-index-base: 0 !default;
 $pt-z-index-content: $pt-z-index-base + 10 !default;
 $pt-z-index-overlay: $pt-z-index-content + 10 !default;
-$pt-z-index-dialog-header: $pt-z-index-overlay + 10 !default;
 
 // Shadow opacities
 $pt-border-shadow-opacity: 0.1 !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -67,6 +67,7 @@ $pt-navbar-height: $pt-grid-size * 5 !default;
 $pt-z-index-base: 0 !default;
 $pt-z-index-content: $pt-z-index-base + 10 !default;
 $pt-z-index-overlay: $pt-z-index-content + 10 !default;
+$pt-z-index-dialog-header: $pt-z-index-overlay + 10 !default;
 
 // Shadow opacities
 $pt-border-shadow-opacity: 0.1 !default;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -95,7 +95,7 @@ $dialog-padding: $pt-grid-size * 2 !default;
   min-height: $pt-icon-size-large + $dialog-padding;
   padding-left: $dialog-padding;
   padding-right: $dialog-padding / 4;
-  z-index: $pt-z-index-dialog-header;
+  z-index: 0;
 
   .#{$ns}-icon-large,
   .#{$ns}-icon {


### PR DESCRIPTION
#### Changes proposed in this pull request:
remove z-index from `dialog-header` class

#### Reviewers should focus on:
any reasons this high z-index may be needed? without more context it seems unlikely the highest constant z-index should be for the dialog header but I could be missing something.

#### Screenshot
![DialogHeaderZIndexDemo](https://user-images.githubusercontent.com/14102129/131729604-ee017b4a-6375-4c7c-8d8f-1b44a0529e29.gif)
gif showing:
- header overlaps select if `usePortal` is `false` in `popoverProps`
- `z-index: 0` is needed for `MultistepDialog` - the PR that introduced this component added this z-index ([see here](https://github.com/palantir/blueprint/commit/f4cf4a70ec3a59c86f292d841fb0e1bc65237abe#diff-f2cb0b8a1c94a94bb2b9c6125da4c28d67adbc0f8534eb74ce3dfe0f64208b83R98)) and I think it was just set higher than it needed to be
- https://lvepb.csb.app/ should be a working demo
- https://codesandbox.io/s/dialog-header-overlap-reproducer-lvepb?file=/src/index.tsx should let you play around/examine sandbox code