### PR TITLE
[core] fix(MenuItem): make items focusable for a11y consistency

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -161,6 +161,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
+                tabIndex: 0,
                 ...htmlProps,
                 ...(disabled ? DISABLED_PROPS : {}),
                 className: anchorClasses,


### PR DESCRIPTION
#### Fixes #4810

#### Changes proposed in this pull request:

Apply `tabIndex="0"` to all MenuItems by default, even if they don't have an `href` or `onChange`. The reasoning for this is that we make MenuItems look interactive regardless of whether they are actually hooked up to _do_ something in an application (with `:hover` and `:active` styles), so for accessible consistency we should also make them focusable via the keyboard.

#### Reviewers should focus on:

N/A

#### Screenshot

Before this PR (pressing TAB, TAB, TAB, TAB, SHIFT+TAB, SHIFT+TAB, SHIFT+TAB, SHIFT+TAB):

![2021-09-08 16 01 12](https://user-images.githubusercontent.com/723999/132577436-bafb1ade-1b12-416a-92eb-a9a3c99adc5e.gif)

After this PR (pressing TAB, TAB, TAB, TAB, SHIFT+TAB, SHIFT+TAB, SHIFT+TAB, SHIFT+TAB):

![2021-09-08 16 01 26](https://user-images.githubusercontent.com/723999/132577477-93045ea1-5316-4474-8786-0475ae60952d.gif)

