### PR TITLE
[core] fix(Overlay): use focus traps to fix enforceFocus

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -487,13 +487,13 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
                       // https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus
                       this.containerElement.querySelectorAll(
                           [
-                              'a[href]:not([tabindex="-1"]',
-                              'button:not([disabled]):not([tabindex="-1"]',
-                              'details:not([tabindex="-1"]',
-                              'input:not([disabled]):not([tabindex="-1"]',
-                              'select:not([disabled]):not([tabindex="-1"]',
-                              'textarea:not([disabled]):not([tabindex="-1"]',
-                              '[tabindex]:not([tabindex="-1"]',
+                              'a[href]:not([tabindex="-1"])',
+                              'button:not([disabled]):not([tabindex="-1"])',
+                              'details:not([tabindex="-1"])',
+                              'input:not([disabled]):not([tabindex="-1"])',
+                              'select:not([disabled]):not([tabindex="-1"])',
+                              'textarea:not([disabled]):not([tabindex="-1"])',
+                              '[tabindex]:not([tabindex="-1"])',
                           ].join(","),
                       ),
                   )

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -229,10 +229,22 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
     // an HTMLElement that contains the backdrop and any children, to query for focus target
     public containerElement: HTMLElement | null = null;
 
+    private startFocusTrapElement: HTMLDivElement | null = null;
+
+    private endFocusTrapElement: HTMLDivElement | null = null;
+
     private refHandlers = {
         // HACKHACK: see https://github.com/palantir/blueprint/issues/3979
         /* eslint-disable-next-line react/no-find-dom-node */
         container: (ref: TransitionGroup) => (this.containerElement = findDOMNode(ref) as HTMLElement),
+        firstFocusable: (ref: HTMLDivElement | null) => {
+            this.startFocusTrapElement = ref;
+            ref?.addEventListener("focusin", this.handleStartFocusTrapElementFocusIn);
+        },
+        lastFocusable: (ref: HTMLDivElement | null) => {
+            this.endFocusTrapElement = ref;
+            ref?.addEventListener("focusin", this.handleEndFocusTrapElementFocusIn);
+        },
     };
 
     public render() {
@@ -241,7 +253,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             return null;
         }
 
-        const { children, className, usePortal, isOpen } = this.props;
+        const { children, className, enforceFocus, usePortal, isOpen } = this.props;
 
         // TransitionGroup types require single array of children; does not support nested arrays.
         // So we must collapse backdrop and children into one array, and every item must be wrapped in a
@@ -251,6 +263,10 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         const maybeBackdrop = this.maybeRenderBackdrop();
         if (maybeBackdrop !== null) {
             childrenWithTransitions.unshift(maybeBackdrop);
+        }
+        if (enforceFocus && childrenWithTransitions.length > 0) {
+            childrenWithTransitions.unshift(this.renderDummyElement(this.refHandlers.firstFocusable, "__first"));
+            childrenWithTransitions.push(this.renderDummyElement(this.refHandlers.lastFocusable, "__last"));
         }
 
         const containerClasses = classNames(
@@ -319,11 +335,11 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             if (isFocusOutsideModal) {
                 // element marked autofocus has higher priority than the other clowns
                 const autofocusElement = this.containerElement.querySelector("[autofocus]") as HTMLElement;
-                const wrapperElement = this.containerElement.querySelector("[tabindex]") as HTMLElement;
+                const firstKeyboardFocusableElement = this.keyboardFocusableElements().shift();
                 if (autofocusElement != null) {
                     autofocusElement.focus();
-                } else if (wrapperElement != null) {
-                    wrapperElement.focus();
+                } else if (firstKeyboardFocusableElement != null) {
+                    firstKeyboardFocusableElement.focus();
                 }
             }
         });
@@ -395,7 +411,6 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
                         {...backdropProps}
                         className={classNames(Classes.OVERLAY_BACKDROP, backdropClassName, backdropProps?.className)}
                         onMouseDown={this.handleBackdropMouseDown}
-                        tabIndex={this.props.canOutsideClickClose ? 0 : undefined}
                     />
                 </CSSTransition>
             );
@@ -404,9 +419,76 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         }
     }
 
+    private renderDummyElement(ref: (element: HTMLDivElement) => void, key: string) {
+        const { transitionDuration, transitionName } = this.props;
+        return (
+            <CSSTransition
+                classNames={transitionName}
+                key={key}
+                addEndListener={this.handleTransitionAddEnd}
+                timeout={transitionDuration}
+                unmountOnExit={true}
+            >
+                <div ref={ref} tabIndex={0} />
+            </CSSTransition>
+        );
+    }
+
+    private handleStartFocusTrapElementFocusIn = (e: FocusEvent) => {
+        if (
+            e.relatedTarget != null &&
+            this.containerElement!.contains(e.relatedTarget as Element) &&
+            e.relatedTarget !== this.endFocusTrapElement
+        ) {
+            this.endFocusTrapElement?.focus();
+        } else {
+            this.keyboardFocusableElements().shift()?.focus();
+        }
+    };
+
+    private handleEndFocusTrapElementFocusIn = (e: FocusEvent) => {
+        if (
+            e.relatedTarget != null &&
+            this.containerElement!.contains(e.relatedTarget as Element) &&
+            e.relatedTarget !== this.startFocusTrapElement
+        ) {
+            this.startFocusTrapElement?.focus();
+        } else {
+            this.keyboardFocusableElements().pop()?.focus();
+        }
+    };
+
+    private keyboardFocusableElements() {
+        const focusableElements: HTMLElement[] =
+            this.containerElement !== null
+                ? Array.from(
+                      this.containerElement.querySelectorAll(
+                          [
+                              "a[href]",
+                              "button:not([disabled])",
+                              "details",
+                              "input:not([disabled])",
+                              "select:not([disabled])",
+                              "textarea:not([disabled])",
+                              '[tabindex]:not([tabindex="-1"]',
+                          ].join(","),
+                      ),
+                  )
+                : [];
+        if (this.props.enforceFocus) {
+            // The first and last elements are dummy elements that help trap focus when enforceFocus
+            // is enabled
+            focusableElements.shift();
+            focusableElements.pop();
+        }
+        return focusableElements;
+    }
+
     private overlayWillClose() {
         document.removeEventListener("focus", this.handleDocumentFocus, /* useCapture */ true);
         document.removeEventListener("mousedown", this.handleDocumentClick);
+        this.startFocusTrapElement?.removeEventListener("focusin", this.handleStartFocusTrapElementFocusIn);
+        this.endFocusTrapElement?.removeEventListener("focusin", this.handleEndFocusTrapElementFocusIn);
 
         const { openStack } = Overlay;
         const stackIndex = openStack.indexOf(this);
@@ -482,7 +564,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
     };
 
     private handleDocumentFocus = (e: FocusEvent) => {
-        // get the actually target even if we are in an open mode Shadow DOM
+        // get the actual target even if we are in an open mode Shadow DOM
         const eventTarget = e.composed ? e.composedPath()[0] : e.target;
         if (
             this.props.enforceFocus &&

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -264,7 +264,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         if (maybeBackdrop !== null) {
             childrenWithTransitions.unshift(maybeBackdrop);
         }
-        if (enforceFocus && childrenWithTransitions.length > 0) {
+        if (isOpen && enforceFocus && childrenWithTransitions.length > 0) {
             childrenWithTransitions.unshift(this.renderDummyElement(this.refHandlers.firstFocusable, "__first"));
             childrenWithTransitions.push(this.renderDummyElement(this.refHandlers.lastFocusable, "__last"));
         }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -229,8 +229,10 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
     // an HTMLElement that contains the backdrop and any children, to query for focus target
     public containerElement: HTMLElement | null = null;
 
+    // An empty, keyboard-focusable div at the beginning of the Overlay content
     private startFocusTrapElement: HTMLDivElement | null = null;
 
+    // An empty, keyboard-focusable div at the end of the Overlay content
     private endFocusTrapElement: HTMLDivElement | null = null;
 
     private refHandlers = {
@@ -335,7 +337,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             if (isFocusOutsideModal) {
                 // element marked autofocus has higher priority than the other clowns
                 const autofocusElement = this.containerElement.querySelector("[autofocus]") as HTMLElement;
-                const firstKeyboardFocusableElement = this.keyboardFocusableElements().shift();
+                const firstKeyboardFocusableElement = this.getKeyboardFocusableElements().shift();
                 if (autofocusElement != null) {
                     autofocusElement.focus();
                 } else if (firstKeyboardFocusableElement != null) {
@@ -434,6 +436,12 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         );
     }
 
+    /**
+     * Ensures repeatedly pressing shift+tab keeps focus inside the Overlay. Moves focus to
+     * the `endFocusTrapElement` or the first keyboard-focusable element in the Overlay (excluding
+     * the `startFocusTrapElement`), depending on whether the element losing focus is inside the
+     * Overlay.
+     */
     private handleStartFocusTrapElementFocusIn = (e: FocusEvent) => {
         e.preventDefault();
         e.stopImmediatePropagation();
@@ -444,10 +452,16 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         ) {
             this.endFocusTrapElement?.focus();
         } else {
-            this.keyboardFocusableElements().shift()?.focus();
+            this.getKeyboardFocusableElements().shift()?.focus();
         }
     };
 
+    /**
+     * Ensures repeatedly pressing tab keeps focus inside the Overlay. Moves focus to the
+     * `startFocusTrapElement` or the last keyboard-focusable element in the Overlay (excluding the
+     * `startFocusTrapElement`), depending on whether the element losing focus is inside the
+     * Overlay.
+     */
     private handleEndFocusTrapElementFocusIn = (e: FocusEvent) => {
         e.preventDefault();
         e.stopImmediatePropagation();
@@ -458,11 +472,11 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         ) {
             this.startFocusTrapElement?.focus();
         } else {
-            this.keyboardFocusableElements().pop()?.focus();
+            this.getKeyboardFocusableElements().pop()?.focus();
         }
     };
 
-    private keyboardFocusableElements() {
+    private getKeyboardFocusableElements() {
         const focusableElements: HTMLElement[] =
             this.containerElement !== null
                 ? Array.from(

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -342,6 +342,8 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
                     autofocusElement.focus();
                 } else if (firstKeyboardFocusableElement != null) {
                     firstKeyboardFocusableElement.focus();
+                } else {
+                    this.startFocusTrapElement?.focus();
                 }
             }
         });

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -480,15 +480,17 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         const focusableElements: HTMLElement[] =
             this.containerElement !== null
                 ? Array.from(
-                      // Order may not be correct if children elements use tabindex values > 0
+                      // Order may not be correct if children elements use tabindex values > 0.
+                      // Selectors derived from this SO question:
+                      // https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus
                       this.containerElement.querySelectorAll(
                           [
-                              "a[href]",
-                              "button:not([disabled])",
-                              "details",
-                              "input:not([disabled])",
-                              "select:not([disabled])",
-                              "textarea:not([disabled])",
+                              'a[href]:not([tabindex="-1"]',
+                              'button:not([disabled]):not([tabindex="-1"]',
+                              'details:not([tabindex="-1"]',
+                              'input:not([disabled]):not([tabindex="-1"]',
+                              'select:not([disabled]):not([tabindex="-1"]',
+                              'textarea:not([disabled]):not([tabindex="-1"]',
                               '[tabindex]:not([tabindex="-1"]',
                           ].join(","),
                       ),

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -15,47 +15,18 @@
  */
 
 import { assert } from "chai";
-import { mount, ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
 import * as React from "react";
 
 import { Classes, MultistepDialog, DialogStep } from "../../src";
-import { MultistepDialogProps } from "../../src/components/dialog/multistepDialog";
 
 const NEXT_BUTTON = "[text='Next']";
 const BACK_BUTTON = "[text='Back']";
 const SUBMIT_BUTTON = "[text='Submit']";
 
 describe("<MultistepDialog>", () => {
-    let wrapper: ReactWrapper<MultistepDialogProps, any, MultistepDialog>;
-    let isMounted = false;
-    const testsContainerElement = document.createElement("div");
-    document.documentElement.appendChild(testsContainerElement);
-
-    /**
-     * Mount the `content` into `testsContainerElement` and assign to local `wrapper` variable.
-     * Use this method in this suite instead of Enzyme's `mount` method.
-     */
-    function mountWrapper(content: JSX.Element) {
-        wrapper = mount(content, { attachTo: testsContainerElement });
-        isMounted = true;
-        return wrapper;
-    }
-
-    afterEach(() => {
-        if (isMounted) {
-            // clean up wrapper after each test, if it was used
-            wrapper?.unmount();
-            wrapper?.detach();
-            isMounted = false;
-        }
-    });
-
-    after(() => {
-        document.documentElement.removeChild(testsContainerElement);
-    });
-
     it("renders its content correctly", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
             </MultistepDialog>,
@@ -74,10 +45,11 @@ describe("<MultistepDialog>", () => {
         ].forEach(className => {
             assert.lengthOf(dialog.find(`.${className}`), 1, `missing ${className}`);
         });
+        dialog.unmount();
     });
 
     it("initially selected step is first step", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -87,10 +59,11 @@ describe("<MultistepDialog>", () => {
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 0);
+        dialog.unmount();
     });
 
     it("clicking next should select the next element", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -101,10 +74,11 @@ describe("<MultistepDialog>", () => {
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(steps.at(0).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
+        dialog.unmount();
     });
 
     it("clicking back should select the prev element", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -122,10 +96,11 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         assert.strictEqual(newSteps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(newSteps.at(1).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
+        dialog.unmount();
     });
 
     it("footer on last step of multiple steps should contain back and submit buttons", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -136,10 +111,11 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).length, 1);
         assert.strictEqual(dialog.find(NEXT_BUTTON).length, 0);
         assert.strictEqual(dialog.find(SUBMIT_BUTTON).length, 1);
+        dialog.unmount();
     });
 
     it("footer on first step of multiple steps should contain next button only", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -150,10 +126,11 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).length, 0);
         assert.strictEqual(dialog.find(NEXT_BUTTON).length, 1);
         assert.strictEqual(dialog.find(SUBMIT_BUTTON).length, 0);
+        dialog.unmount();
     });
 
     it("footer on first step of single step should contain submit button only", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
             </MultistepDialog>,
@@ -163,10 +140,11 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).length, 0);
         assert.strictEqual(dialog.find(NEXT_BUTTON).length, 0);
         assert.strictEqual(dialog.find(SUBMIT_BUTTON).length, 1);
+        dialog.unmount();
     });
 
     it("selecting older step should leave already viewed steps active", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -181,47 +159,54 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
+        dialog.unmount();
     });
 
     it("gets by without children", () => {
-        assert.doesNotThrow(() => mountWrapper(<MultistepDialog isOpen={true} />));
+        assert.doesNotThrow(() => {
+            const dialog = mount(<MultistepDialog isOpen={true} />);
+            dialog.unmount();
+        });
     });
 
     it("supports non-existent children", () => {
-        assert.doesNotThrow(() =>
-            mountWrapper(
+        assert.doesNotThrow(() => {
+            const dialog = mount(
                 <MultistepDialog>
                     {null}
                     <DialogStep id="one" panel={<Panel />} />
                     {undefined}
                     <DialogStep id="two" panel={<Panel />} />
                 </MultistepDialog>,
-            ),
-        );
+            );
+            dialog.unmount();
+        });
     });
 
     it("enables next by default", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
             </MultistepDialog>,
         );
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), undefined);
+        dialog.unmount();
     });
 
     it("disables next if disabled on nextButtonProps is set to true", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog nextButtonProps={{ disabled: true }} isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
             </MultistepDialog>,
         );
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
+        dialog.unmount();
     });
 
     it("disables next for second step when disabled on nextButtonProps is set to true", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} nextButtonProps={{ disabled: true }} />
@@ -236,10 +221,11 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
         dialog.find(NEXT_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
+        dialog.unmount();
     });
 
     it("disables back for second step when disabled on backButtonProps is set to true", () => {
-        const dialog = mountWrapper(
+        const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} backButtonProps={{ disabled: true }} />
@@ -253,6 +239,7 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).prop("disabled"), true);
         dialog.find(BACK_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
+        dialog.unmount();
     });
 });
 

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -15,18 +15,47 @@
  */
 
 import { assert } from "chai";
-import { mount } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
 import { Classes, MultistepDialog, DialogStep } from "../../src";
+import { MultistepDialogProps } from "../../src/components/dialog/multistepDialog";
 
 const NEXT_BUTTON = "[text='Next']";
 const BACK_BUTTON = "[text='Back']";
 const SUBMIT_BUTTON = "[text='Submit']";
 
 describe("<MultistepDialog>", () => {
+    let wrapper: ReactWrapper<MultistepDialogProps, any, MultistepDialog>;
+    let isMounted = false;
+    const testsContainerElement = document.createElement("div");
+    document.documentElement.appendChild(testsContainerElement);
+
+    /**
+     * Mount the `content` into `testsContainerElement` and assign to local `wrapper` variable.
+     * Use this method in this suite instead of Enzyme's `mount` method.
+     */
+    function mountWrapper(content: JSX.Element) {
+        wrapper = mount(content, { attachTo: testsContainerElement });
+        isMounted = true;
+        return wrapper;
+    }
+
+    afterEach(() => {
+        if (isMounted) {
+            // clean up wrapper after each test, if it was used
+            wrapper?.unmount();
+            wrapper?.detach();
+            isMounted = false;
+        }
+    });
+
+    after(() => {
+        document.documentElement.removeChild(testsContainerElement);
+    });
+
     it("renders its content correctly", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
             </MultistepDialog>,
@@ -45,11 +74,10 @@ describe("<MultistepDialog>", () => {
         ].forEach(className => {
             assert.lengthOf(dialog.find(`.${className}`), 1, `missing ${className}`);
         });
-        dialog.unmount();
     });
 
     it("initially selected step is first step", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -59,11 +87,10 @@ describe("<MultistepDialog>", () => {
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 0);
-        dialog.unmount();
     });
 
     it("clicking next should select the next element", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -74,11 +101,10 @@ describe("<MultistepDialog>", () => {
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.strictEqual(steps.at(0).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.ACTIVE}`).length, 1);
-        dialog.unmount();
     });
 
     it("clicking back should select the prev element", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -96,11 +122,10 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         assert.strictEqual(newSteps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(newSteps.at(1).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
-        dialog.unmount();
     });
 
     it("footer on last step of multiple steps should contain back and submit buttons", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -111,11 +136,10 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).length, 1);
         assert.strictEqual(dialog.find(NEXT_BUTTON).length, 0);
         assert.strictEqual(dialog.find(SUBMIT_BUTTON).length, 1);
-        dialog.unmount();
     });
 
     it("footer on first step of multiple steps should contain next button only", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -126,11 +150,10 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).length, 0);
         assert.strictEqual(dialog.find(NEXT_BUTTON).length, 1);
         assert.strictEqual(dialog.find(SUBMIT_BUTTON).length, 0);
-        dialog.unmount();
     });
 
     it("footer on first step of single step should contain submit button only", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
             </MultistepDialog>,
@@ -140,11 +163,10 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).length, 0);
         assert.strictEqual(dialog.find(NEXT_BUTTON).length, 0);
         assert.strictEqual(dialog.find(SUBMIT_BUTTON).length, 1);
-        dialog.unmount();
     });
 
     it("selecting older step should leave already viewed steps active", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
@@ -159,16 +181,15 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         assert.strictEqual(steps.at(0).find(`.${Classes.ACTIVE}`).length, 1);
         assert.strictEqual(steps.at(1).find(`.${Classes.DIALOG_STEP_VIEWED}`).length, 1);
-        dialog.unmount();
     });
 
     it("gets by without children", () => {
-        assert.doesNotThrow(() => mount(<MultistepDialog isOpen={true} />));
+        assert.doesNotThrow(() => mountWrapper(<MultistepDialog isOpen={true} />));
     });
 
     it("supports non-existent children", () => {
         assert.doesNotThrow(() =>
-            mount(
+            mountWrapper(
                 <MultistepDialog>
                     {null}
                     <DialogStep id="one" panel={<Panel />} />
@@ -180,29 +201,27 @@ describe("<MultistepDialog>", () => {
     });
 
     it("enables next by default", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
             </MultistepDialog>,
         );
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), undefined);
-        dialog.unmount();
     });
 
     it("disables next if disabled on nextButtonProps is set to true", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog nextButtonProps={{ disabled: true }} isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} />
             </MultistepDialog>,
         );
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
-        dialog.unmount();
     });
 
     it("disables next for second step when disabled on nextButtonProps is set to true", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} nextButtonProps={{ disabled: true }} />
@@ -217,11 +236,10 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(NEXT_BUTTON).prop("disabled"), true);
         dialog.find(NEXT_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
-        dialog.unmount();
     });
 
     it("disables back for second step when disabled on backButtonProps is set to true", () => {
-        const dialog = mount(
+        const dialog = mountWrapper(
             <MultistepDialog isOpen={true} usePortal={false}>
                 <DialogStep id="one" title="Step 1" panel={<Panel />} />
                 <DialogStep id="two" title="Step 2" panel={<Panel />} backButtonProps={{ disabled: true }} />
@@ -235,7 +253,6 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.find(BACK_BUTTON).prop("disabled"), true);
         dialog.find(BACK_BUTTON).simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
-        dialog.unmount();
     });
 });
 

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -60,6 +60,10 @@ describe("<Overlay>", () => {
         }
     });
 
+    after(() => {
+        document.documentElement.removeChild(testsContainerElement);
+    });
+
     it("renders its content correctly", () => {
         const overlay = shallow(
             <Overlay isOpen={true} usePortal={false}>
@@ -252,11 +256,11 @@ describe("<Overlay>", () => {
             }, done);
         });
 
-        it("does not bring focus to overlay if autoFocus=false", done => {
+        it("does not bring focus to overlay if autoFocus=false and enforceFocus=false", done => {
             mountWrapper(
                 <div>
                     <button>something outside overlay for browser to focus on</button>
-                    <Overlay autoFocus={false} isOpen={true} usePortal={true}>
+                    <Overlay autoFocus={false} enforceFocus={false} isOpen={true} usePortal={true}>
                         <input type="text" />
                     </Overlay>
                 </div>,

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -247,8 +247,8 @@ describe("<Overlay>", () => {
                 </Overlay>,
             );
             assertFocus(() => {
-                const backdrops = Array.from(document.querySelectorAll("." + Classes.OVERLAY_BACKDROP));
-                assert.include(backdrops, document.activeElement);
+                const contents = Array.from(document.querySelectorAll("." + Classes.OVERLAY_CONTENT));
+                assert.include(contents, document.activeElement);
             }, done);
         });
 
@@ -290,10 +290,7 @@ describe("<Overlay>", () => {
             buttonRef!.focus();
             assertFocus(() => {
                 assert.notStrictEqual(document.activeElement, buttonRef);
-                assert.isTrue(
-                    document.activeElement?.classList.contains(Classes.OVERLAY_BACKDROP),
-                    "focus on backdrop",
-                );
+                assert.isTrue(document.activeElement?.classList.contains(Classes.OVERLAY_CONTENT), "focus on content");
             }, done);
         });
 

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -304,6 +304,25 @@ describe("<Overlay>", () => {
             assertFocus(`strong.${Classes.OVERLAY_CONTENT}`, done);
         });
 
+        it("returns focus to overlay after clicking an outside element if enforceFocus=true", done => {
+            mountWrapper(
+                <div>
+                    <Overlay
+                        enforceFocus={true}
+                        canOutsideClickClose={false}
+                        isOpen={true}
+                        usePortal={false}
+                        hasBackdrop={false}
+                    >
+                        {createOverlayContents()}
+                    </Overlay>
+                    <button id="buttonId" />
+                </div>,
+            );
+            wrapper.find("#buttonId").simulate("click");
+            assertFocus(`strong.${Classes.OVERLAY_CONTENT}`, done);
+        });
+
         it("does not result in maximum call stack if two overlays open with enforceFocus=true", () => {
             const anotherContainer = document.createElement("div");
             document.documentElement.appendChild(anotherContainer);


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/3445

#### Checklist

- [x] Includes tests
- [x] Update documentation (n/a)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

When enforceFocus is enabled, surround Overlay content with dummy div
elements with focus event listeners that keep focus inside the Overlay.

#### Reviewers should focus on:

I want to flag that I've removed the `tabindex` attribute from the backdrop to prevent it from being keyboard focusable.

This change also fixes an issue where multiple open overlays will compete with each for focus. As an example, go to https://blueprintjs.com/docs/#core/components/overlay and open the overlay and then hit shift+s to open the omnibar search (also powered by Overlay). The search input will not get autofocused. Repeat the same workflow on https://46971-71939872-gh.circle-artifacts.com/0/packages/docs-app/dist/index.html#core/components/overlay and note that the omnibar search does get focus correctly.

#### Screenshot

##### Before

When using a portal, the portal is the last element on the page so tabbing will eventually cause focus to leave the document and none of the existing event handlers run before that happens. Note that shift+tabbing is not closing the overlay, the gif is just looping.

![2021-09-09 19 59 13](https://user-images.githubusercontent.com/3681045/132777763-9172c91e-f09b-449a-be2e-b73640513f0b.gif)

##### After

Tab/shift+tab will never allow focus to leave the overlay if `enforceFocus`.

![2021-09-09 19 58 14](https://user-images.githubusercontent.com/3681045/132777789-519292e2-b57b-48b1-8fe1-271101143d2e.gif)