### PR TITLE
[popover2] feat(Popover2): allow enter key to open popover

### DIFF
--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -169,7 +169,7 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
                         isOpen={this.state.isControlled ? this.state.isOpen : undefined}
                         content={this.getContents(exampleIndex)}
                     >
-                        <Button intent={Intent.PRIMARY} text="Popover target" />
+                        <Button intent={Intent.PRIMARY} text="Popover target" tabIndex={0} />
                     </Popover2>
                     <p>
                         Scroll around this container to experiment

--- a/packages/popover2/src/popover2.md
+++ b/packages/popover2/src/popover2.md
@@ -229,10 +229,10 @@ The supported values are:
     -   **Opens when:** the target is hovered
     -   **Closes when:** the cursor is no longer inside the target
 -   `CLICK`:
-    -   **Opens when:** the target is clicked
+    -   **Opens when:** the target is clicked, or when Enter key is pressed while target is focused
     -   **Closes when:** the user clicks anywhere outside of the popover (including the target)
 -   `CLICK_TARGET_ONLY`:
-    -   **Opens when:** the target is clicked
+    -   **Opens when:** the target is clicked, or when Enter key is pressed while target is focused
     -   **Closes when:** the target is clicked
 
 The following example demonstrates the various interaction kinds (note: these Popovers contain [`MenuItem`](#core/components/menu.menu-item)s with `shouldDismissPopover={false}`, for clarity):

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -24,6 +24,7 @@ import {
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
     HTMLDivProps,
+    Keys,
     refHandler,
     mergeRefs,
     Overlay,
@@ -308,9 +309,10 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
             : {
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
-                  // For keyboard accessibility, we trigger the same behavior as a click event upon pressing enter
+                  // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
                   onKeyDown: (event: React.KeyboardEvent<HTMLElement>) =>
-                      event.key === "Enter" && this.handleTargetClick(event),
+                      // eslint-disable-next-line deprecation/deprecation
+                      Keys.isKeyboardClick(event.keyCode) && this.handleTargetClick(event),
               };
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
@@ -385,8 +387,9 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         const popoverHandlers: HTMLDivProps = {
             // always check popover clicks for dismiss class
             onClick: this.handlePopoverClick,
-            // treat Enter key the same as a click for accessibility
-            onKeyDown: event => event.key === "Enter" && this.handlePopoverClick(event),
+            // treat ENTER/SPACE keys the same as a click for accessibility
+            // eslint-disable-next-line deprecation/deprecation
+            onKeyDown: event => Keys.isKeyboardClick(event.keyCode) && this.handlePopoverClick(event),
         };
         if (
             interactionKind === Popover2InteractionKind.HOVER ||

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -308,6 +308,8 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
             : {
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
+                  // For keyboard accessibility, we trigger the same behavior as a click event upon pressing enter
+                  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => event.key === "Enter" && this.handleTargetClick(event),
               };
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
@@ -382,6 +384,8 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         const popoverHandlers: HTMLDivProps = {
             // always check popover clicks for dismiss class
             onClick: this.handlePopoverClick,
+            // treat Enter key the same as a click for accessibility
+            onKeyDown: (event) => event.key === "Enter" && this.handlePopoverClick(event),
         };
         if (
             interactionKind === Popover2InteractionKind.HOVER ||
@@ -561,7 +565,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         });
     };
 
-    private handlePopoverClick = (e: React.MouseEvent<HTMLElement>) => {
+    private handlePopoverClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
         const eventTarget = e.target as HTMLElement;
         const eventPopover = eventTarget.closest(`.${Classes.POPOVER2}`);
         const eventPopoverV1 = eventTarget.closest(`.${CoreClasses.POPOVER}`);
@@ -607,7 +611,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         }
     };
 
-    private handleTargetClick = (e: React.MouseEvent<HTMLElement>) => {
+    private handleTargetClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
         // ensure click did not originate from within inline popover before closing
         if (!this.props.disabled && !this.isElementInPopover(e.target as HTMLElement)) {
             if (this.props.isOpen == null) {

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -309,7 +309,8 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
                   // For keyboard accessibility, we trigger the same behavior as a click event upon pressing enter
-                  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => event.key === "Enter" && this.handleTargetClick(event),
+                  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) =>
+                      event.key === "Enter" && this.handleTargetClick(event),
               };
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
@@ -385,7 +386,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
             // always check popover clicks for dismiss class
             onClick: this.handlePopoverClick,
             // treat Enter key the same as a click for accessibility
-            onKeyDown: (event) => event.key === "Enter" && this.handlePopoverClick(event),
+            onKeyDown: event => event.key === "Enter" && this.handlePopoverClick(event),
         };
         if (
             interactionKind === Popover2InteractionKind.HOVER ||


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Currently if the target is focused and the popover is meant to open on click, then you cannot open the popover via keyboard-only navigation.

This change makes it at least so that pressing enter while the target is focused the popover will open. Note that the popover currently always steals focus away from the target, so that you cannot press enter again in the same way that you could click the target again to close the popover. I'm not sure what was intended behavior (stealing focus) or not, so I could use advice as to how would we allow focus to remain on the target such that 2 enter key presses opens and then closes the popover

#### Reviewers should focus on:

Any other gotchas with adding this event listener?

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![focus](https://user-images.githubusercontent.com/1143755/133000328-0aa1e4d9-161f-429a-9661-b67fcf1b0bff.gif)
