### PR TITLE
[core,datetime,table] feat: Add semantic color variables

### DIFF
--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -2,9 +2,24 @@
 // Licensed under the Apache License, Version 2.0.
 
 $pt-intent-primary: $blue3 !default;
+$pt-intent-primary2: $blue2 !default;
+$pt-intent-primary1: $blue1 !default;
+$pt-dark-intent-primary: $blue5 !default;
+
 $pt-intent-success: $green3 !default;
+$pt-intent-success2: $green2 !default;
+$pt-intent-success1: $green1 !default;
+$pt-dark-intent-success: $green5 !default;
+
 $pt-intent-warning: $orange3 !default;
+$pt-intent-warning2: $orange2 !default;
+$pt-intent-warning1: $orange1 !default;
+$pt-dark-intent-warning: $orange5 !default;
+
 $pt-intent-danger: $red3 !default;
+$pt-intent-danger2: $red2 !default;
+$pt-intent-danger1: $red1 !default;
+$pt-dark-intent-danger: $red5 !default;
 
 $pt-app-background-color: $light-gray5 !default;
 $pt-dark-app-background-color: $dark-gray3 !default;

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -12,17 +12,17 @@ $pt-intent-colors: (
 ) !default;
 
 $pt-intent-text-colors: (
-  "primary": $blue2,
-  "success": $green2,
-  "warning": $orange2,
-  "danger" : $red2,
+  "primary": $pt-intent-primary2,
+  "success": $pt-intent-success2,
+  "warning": $pt-intent-warning2,
+  "danger" : $pt-intent-danger2,
 ) !default;
 
 $pt-dark-intent-text-colors: (
-  "primary": $blue5,
-  "success": $green5,
-  "warning": $orange5,
-  "danger" : $red5,
+  "primary": $pt-dark-intent-primary,
+  "success": $pt-dark-intent-success,
+  "warning": $pt-dark-intent-warning,
+  "danger" : $pt-dark-intent-danger,
 ) !default;
 
 @mixin intent-color($intentName) {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -91,10 +91,10 @@ $button-outlined-border-disabled-intent-opacity: 0.2 !default;
 
 // "intent": (default, hover, active colors)
 $button-intents: (
-  "primary": ($pt-intent-primary, $blue2, $blue1),
-  "success": ($pt-intent-success, $green2, $green1),
-  "warning": ($pt-intent-warning, $orange2, $orange1),
-  "danger": ($pt-intent-danger, $red2, $red1)
+  "primary": ($pt-intent-primary, $pt-intent-primary2, $pt-intent-primary1),
+  "success": ($pt-intent-success, $pt-intent-success2, $pt-intent-success1),
+  "warning": ($pt-intent-warning, $pt-intent-warning2, $pt-intent-warning1),
+  "danger": ($pt-intent-danger, $pt-intent-danger2, $pt-intent-danger1)
 ) !default;
 
 @mixin pt-button-base() {

--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -122,12 +122,12 @@ $header-margin: ($header-height - $pt-input-height) / 2 !default;
     }
 
     &.DayPicker-Day--selected {
-      background-color: $blue3;
+      background-color: $pt-intent-primary;
       border-radius: $pt-border-radius;
       color: $white;
 
       &:hover {
-        background-color: $blue2;
+        background-color: $pt-intent-primary2;
       }
     }
 

--- a/packages/table/src/common/_variables.scss
+++ b/packages/table/src/common/_variables.scss
@@ -18,10 +18,10 @@ $pt-intent-text-colors: (
 );
 
 $pt-dark-intent-text-colors: (
-  "primary": $blue4,
-  "success": $green4,
-  "warning": $orange4,
-  "danger" : $red4,
+  "primary": $pt-dark-intent-primary,
+  "success": $pt-dark-intent-success,
+  "warning": $pt-dark-intent-warning,
+  "danger" : $pt-dark-intent-danger,
 );
 
 $cell-border-width : 1px !default;


### PR DESCRIPTION
#### Fixes #4127 and #3673 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Changing theme colors in Blueprint only works if you overwrite the colors itself. For example (as mentioned in #4127), for the primary-intent this means that users need to overwrite `$blue2` and `$blue1` to change the color of hover/active states in buttons. This affects success, warning and danger intents as well. This PR replaces the 'hardcoded' color variables with color-aliases. So everyone can theme as they like, without changing the meaning of `$blue`.

To avoid multiple dark-intent-text color-aliases, in `table/src/common/_variables.scss` this PR levels up colors from level 4 to 5. In my tests level 5 gave better contrast ratios in dark table cells and it was already used in `core/src/common/_mixins.scss` >> `$pt-dark-intent-text-colors`.

It's a non-breaking change, the same colors are referenced as before, but with one additional step (except for dark tables as detailed above where colors actually changed).

#### Reviewers should focus on:

This change does not modify the default blueprint setup, only gives a cleaner option to overwrite intent colors.
Contrast ratio for texts in dark tables might worth a look, as the color got a bit brighter.
