### PR TITLE
[core] feat(Overlay): set aria-live attribute for a11y

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -265,6 +265,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         const transitionGroup = (
             <TransitionGroup
                 appear={true}
+                aria-live="polite"
                 className={containerClasses}
                 component="div"
                 onKeyDown={this.handleKeyDown}

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -84,6 +84,16 @@ describe("<Overlay>", () => {
         document.body.removeChild(container);
     });
 
+    it("sets aria-live", () => {
+        // Using an open Overlay because an initially closed Overlay will not render anything to the
+        // DOM
+        mountWrapper(<Overlay className="aria-test" isOpen={true} usePortal={false} />);
+        const overlayElement = document.querySelector(".aria-test");
+        assert.exists(overlayElement);
+        // Element#ariaLive not supported in Firefox or IE
+        assert.equal(overlayElement?.getAttribute("aria-live"), "polite");
+    });
+
     it("portalClassName appears on Portal", () => {
         const CLASS_TO_TEST = "bp-test-content";
         mountWrapper(


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/4813

#### Checklist

- [x] Includes tests
- [x] Update documentation (n/a)

#### Changes proposed in this pull request:

Set aria-live on Overlay

This allows screen readers to read content in Tooltips, Popovers,
Dialogs, and Overlays when they are opened.

Not using aria-describedby because the Overlay content is typically
added to the DOM after interaction with some other element, leaving
screen readers unable to consistently see the content in time. Setting
aria-live on the Overlay works because it remains mounted after the
initial open. VoiceOver is also able to read the content on initial
open (did not test with other screen readers).

#### Reviewers should focus on:

This behavior change is not limited to Tooltips/Tooltips2 but affects all consumers of the Overlay component. When using a screen reader, Overlay contents will be read on open. I _think_ this is desirable, because otherwise non-keyboard-focusable elements in Overlay contents, namely large blocks of text, will not get read.

#### Screenshot

__Initial attempt with `aria-describedby` and setting content `id` results in inconsistent reading of tooltip__

First focus over "Or, hover of this whole line" does not read the tooltip, but a second focus does.

![2021-09-13 17 15 56](https://user-images.githubusercontent.com/3681045/133172779-891e1c7a-9025-454c-b5b3-788c1f3569c1.gif)


__(In this PR) Using `aria-live="polite"`__

Works consistently with or without portals. The tooltips on the last line have `usePortal` set to `false`.

In Chrome:
![2021-09-13 19 03 41](https://user-images.githubusercontent.com/3681045/133172965-f5dfd592-938b-4c62-b46c-ef84737050bc.gif)

In FF:
![2021-09-13 20 13 04](https://user-images.githubusercontent.com/3681045/133173232-e4d7fefb-f921-4f8f-ba64-0c2a01fa10c0.gif)
