### PR TITLE
[core] feat(Overlay): add shouldReturnFocusOnClose prop

### DIFF
--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -67,14 +67,6 @@ export interface IDrawerProps extends OverlayableProps, IBackdropProps, Props {
     position?: Position;
 
     /**
-     * Whether the application should return focus to the last active element in the
-     * document after this drawer closes.
-     *
-     * @default true
-     */
-    shouldReturnFocusOnClose?: boolean;
-
-    /**
      * CSS size of the drawer. This sets `width` if `vertical={false}` (default)
      * and `height` otherwise.
      *
@@ -123,7 +115,6 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
     public static defaultProps: DrawerProps = {
         canOutsideClickClose: true,
         isOpen: false,
-        shouldReturnFocusOnClose: true,
         style: {},
         vertical: false,
     };
@@ -136,8 +127,6 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
 
     /** @deprecated use DrawerSize.LARGE */
     public static readonly SIZE_LARGE = DrawerSize.LARGE;
-
-    private lastActiveElementBeforeOpened: Element | null | undefined;
 
     public render() {
         // eslint-disable-next-line deprecation/deprecation
@@ -161,12 +150,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
                       [(realPosition ? isPositionHorizontal(realPosition) : vertical) ? "height" : "width"]: size,
                   };
         return (
-            <Overlay
-                {...this.props}
-                className={Classes.OVERLAY_CONTAINER}
-                onOpening={this.handleOpening}
-                onClosed={this.handleClosed}
-            >
+            <Overlay {...this.props} className={Classes.OVERLAY_CONTAINER}>
                 <div className={classes} style={styleProp}>
                     {this.maybeRenderHeader()}
                     {this.props.children}
@@ -226,16 +210,4 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
             </div>
         );
     }
-
-    private handleOpening = (node: HTMLElement) => {
-        this.lastActiveElementBeforeOpened = document.activeElement;
-        this.props.onOpening?.(node);
-    };
-
-    private handleClosed = (node: HTMLElement) => {
-        if (this.props.shouldReturnFocusOnClose && this.lastActiveElementBeforeOpened instanceof HTMLElement) {
-            this.lastActiveElementBeforeOpened.focus();
-        }
-        this.props.onClosed?.(node);
-    };
 }

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -66,6 +66,14 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
     lazy?: boolean;
 
     /**
+     * Whether the application should return focus to the last active element in the
+     * document after this overlay closes.
+     *
+     * @default true
+     */
+    shouldReturnFocusOnClose?: boolean;
+
+    /**
      * Indicates how long (in milliseconds) the overlay's enter/leave transition takes.
      * This is used by React `CSSTransition` to know when a transition completes and must match
      * the duration of the animation in CSS. Only set this prop if you override Blueprint's default
@@ -206,6 +214,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         hasBackdrop: true,
         isOpen: false,
         lazy: true,
+        shouldReturnFocusOnClose: true,
         transitionDuration: 300,
         transitionName: Classes.OVERLAY,
         usePortal: true,
@@ -221,6 +230,8 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
     private static openStack: Overlay[] = [];
 
     private static getLastOpened = () => Overlay.openStack[Overlay.openStack.length - 1];
+
+    private lastActiveElementBeforeOpened: Element | null | undefined;
 
     public state: IOverlayState = {
         hasEverOpened: this.props.isOpen,
@@ -351,7 +362,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             ) : (
                 <span className={Classes.OVERLAY_CONTENT}>{child}</span>
             );
-        const { onOpening, onOpened, onClosing, onClosed, transitionDuration, transitionName } = this.props;
+        const { onOpening, onOpened, onClosing, transitionDuration, transitionName } = this.props;
 
         // a breaking change in react-transition-group types requires us to be explicit about the type overload here,
         // using a technique similar to Select.ofType() in @blueprintjs/select
@@ -365,7 +376,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
                 onEntering={onOpening}
                 onEntered={onOpened}
                 onExiting={onClosing}
-                onExited={onClosed}
+                onExited={this.handleTransitionExited}
                 timeout={transitionDuration}
                 addEndListener={this.handleTransitionAddEnd}
             >
@@ -448,7 +459,16 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             // add a class to the body to prevent scrolling of content below the overlay
             document.body.classList.add(Classes.OVERLAY_OPEN);
         }
+
+        this.lastActiveElementBeforeOpened = document.activeElement;
     }
+
+    private handleTransitionExited = (node: HTMLElement) => {
+        if (this.props.shouldReturnFocusOnClose && this.lastActiveElementBeforeOpened instanceof HTMLElement) {
+            this.lastActiveElementBeforeOpened.focus();
+        }
+        this.props.onClosed?.(node);
+    };
 
     private handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
         const { backdropProps, canOutsideClickClose, enforceFocus, onClose } = this.props;


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Building on #4422 and #4620, this PR moves the `shouldReturnFocusOnClose` functionality to the `Overlay` component, thereby enabling it by default for Popover/Popover2, Tooltip/Tooltip2, and Dialogs. This is desirable for keyboard accessibility. Drawers still retain this behavior since they extend Overlay / OverlayableProps.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

![2021-09-14 12 56 46](https://user-images.githubusercontent.com/723999/133301446-22c30d04-e4c2-4ad3-bc02-02c2ac4ce1d1.gif)

