### PR TITLE
[core] fix(Button): revert 12px font size change in small button

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -130,7 +130,6 @@ $button-intents: (
 
 @mixin pt-button-height-small() {
   @include pt-button-height($pt-button-height-small);
-  font-size: $pt-font-size-small;
   padding: $button-padding-small;
 }
 


### PR DESCRIPTION
#### Reverts the functional part of #4885

#### Changes proposed in this pull request:

After testing out this 12px font change in practice, we found that it had an outsized impact and cost which outweighed its benefits of achieving button/input consistency. We found many places where small buttons were used for their small padding styling but were not suitable for displaying 12px text. In the interest of Blueprint 4.0 rollout speed, we've decided to revert this change and address it at a different time.
