### PR TITLE
fix: disable shouldReturnFocusOnClose for hover interactions

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -78,6 +78,18 @@ export interface IPopoverProps extends IPopoverSharedProps {
     hasBackdrop?: boolean;
 
     /**
+     * Whether the application should return focus to the last active element in the
+     * document after this popover closes.
+     *
+     * This is automatically set to `false` if this is a hover interaction popover.
+     *
+     * If you are attaching a popover _and_ a tooltip to the same target, you must take
+     * care to either disable this prop for the popover _or_ disable the tooltip's
+     * `openOnTargetFocus` prop.
+     */
+    shouldReturnFocusOnClose?: boolean;
+
+    /**
      * Ref supplied to the `Classes.POPOVER` element.
      */
     popoverRef?: IRef<HTMLElement>;
@@ -163,7 +175,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         // as JSX component instead of intrinsic element. but because of its
         // type, tsc actually recognizes that it is _any_ intrinsic element, so
         // it can typecheck the HTML props!!
-        const { className, disabled, fill, placement, position = "auto" } = this.props;
+        const { className, disabled, fill, placement, position = "auto", shouldReturnFocusOnClose } = this.props;
         const { isOpen } = this.state;
         let { wrapperTagName } = this.props;
         if (fill) {
@@ -204,6 +216,8 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 transitionName={Classes.POPOVER}
                 usePortal={this.props.usePortal}
                 portalContainer={this.props.portalContainer}
+                // if hover interaciton, it doesn't make sense to take over focus control
+                shouldReturnFocusOnClose={this.isHoverInteractionKind() ? false : shouldReturnFocusOnClose}
             >
                 <Popper
                     innerRef={this.handlePopoverRef}
@@ -296,7 +310,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
     }
 
     private renderPopover = (popperProps: PopperChildrenProps) => {
-        const { usePortal, interactionKind } = this.props;
+        const { interactionKind, usePortal } = this.props;
         const { transformOrigin } = this.state;
 
         // Need to update our reference to this on every render as it will change.

--- a/packages/core/src/components/tooltip/tooltip.md
+++ b/packages/core/src/components/tooltip/tooltip.md
@@ -26,11 +26,15 @@ You must put the `Tooltip` _inside_ the `Popover` (and the target inside the
 required because the popover will disable the tooltip when it is open,
 preventing both elements from appearing at the same time.
 
+Also, you must take to either set `<Popover2 shouldReturnFocusOnClose={false}>`
+or `<Tooltip2 openOnTargetFocus={false}>` in this scenario in order to avoid undesirable
+UX where the tooltip could open automatically when a user doesn't want it to.
+
 ```tsx
 import { Button, Popover, Position, Tooltip } from "@blueprintjs/core";
 
 <Popover content={<h1>Popover!</h1>} position={Position.RIGHT}>
-    <Tooltip content="I has a popover!" position={Position.RIGHT}>
+    <Tooltip content="I have a popover!" position={Position.RIGHT} openOnTargetFocus={false}>
         <Button>Hover and click me</Button>
     </Tooltip>
 </Popover>;

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -129,6 +129,7 @@ export class TooltipExample extends React.PureComponent<IExampleProps, { isOpen:
                 >
                     <Tooltip
                         content={<span>This button also has a popover!</span>}
+                        openOnTargetFocus={false}
                         position={Position.RIGHT}
                         usePortal={false}
                     >

--- a/packages/docs-app/src/examples/popover2-examples/tooltip2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/tooltip2Example.tsx
@@ -134,6 +134,7 @@ export class Tooltip2Example extends React.PureComponent<IExampleProps, ITooltip
                 >
                     <Tooltip2
                         content={<span>This button also has a popover!</span>}
+                        openOnTargetFocus={false}
                         placement="right"
                         usePortal={false}
                     >

--- a/packages/popover2/src/tooltip2.md
+++ b/packages/popover2/src/tooltip2.md
@@ -28,6 +28,10 @@ You must put the `Tooltip2` _inside_ the `Popover2` (and the target inside the
 required because the tooltip needs information from popover disable itself when the
 popover is open is open, thus preventing both elements from appearing at the same time.
 
+Also, you must take to either set `<Popover2 shouldReturnFocusOnClose={false}>`
+or `<Tooltip2 openOnTargetFocus={false}>` in this scenario in order to avoid undesirable
+UX where the tooltip could open automatically when a user doesn't want it to.
+
 ```tsx
 import { Button, mergeRefs } from "@blueprintjs/core";
 import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
@@ -38,6 +42,7 @@ import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
         <Tooltip2
             content="I have a popover!"
             disabled={isPopoverOpen}
+            openOnTargetFocus={false}
             renderTarget={({ isOpen: isTooltipOpen, ref: ref2, ...tooltipProps }) => (
                 <Button
                     {...popoverProps}

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -30,7 +30,7 @@ import { Tooltip2Context, Tooltip2ContextState, Tooltip2Provider } from "./toolt
 export type Tooltip2Props<TProps = React.HTMLProps<HTMLElement>> = ITooltip2Props<TProps>;
 /** @deprecated use Tooltip2Props */
 export interface ITooltip2Props<TProps = React.HTMLProps<HTMLElement>>
-    extends Popover2SharedProps<TProps>,
+    extends Omit<Popover2SharedProps<TProps>, "shouldReturnFocusOnClose">,
         IntentProps {
     /**
      * The content that will be displayed inside of the tooltip.


### PR DESCRIPTION
#### Fixes #4912

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Disable `shouldReturnFocusOnClose` for hover interaction Popover & Popover2 (and transitively, Tooltip & Tooltip2)
- Address an edge case in `handleTargetBlur` which ignored focus returning to the popover element itself
- Update docs around popover + tooltip composition to highlight a usage edge case

#### Reviewers should focus on:

Fixes the linked bug

#### Screenshot

![2021-09-16 14 26 04](https://user-images.githubusercontent.com/723999/133665318-9a00e9e4-c28c-41d9-9364-4978f291500a.gif)



