### PR TITLE
[core,popover2] disable shouldReturnFocusOnClose for popovers

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -86,6 +86,8 @@ export interface IPopoverProps extends IPopoverSharedProps {
      * If you are attaching a popover _and_ a tooltip to the same target, you must take
      * care to either disable this prop for the popover _or_ disable the tooltip's
      * `openOnTargetFocus` prop.
+     *
+     * @default false
      */
     shouldReturnFocusOnClose?: boolean;
 
@@ -129,6 +131,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         minimal: false,
         modifiers: {},
         openOnTargetFocus: true,
+        shouldReturnFocusOnClose: false,
         // N.B. we don't set a default for `placement` or `position` here because that would trigger
         // a warning in validateProps if the other prop is specified by a user of this component
         targetTagName: "span",

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -96,6 +96,8 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends P
      * If you are attaching a popover _and_ a tooltip to the same target, you must take
      * care to either disable this prop for the popover _or_ disable the tooltip's
      * `openOnTargetFocus` prop.
+     *
+     * @default false
      */
     shouldReturnFocusOnClose?: boolean;
 
@@ -141,6 +143,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         // a warning in validateProps if the other prop is specified by a user of this component
         positioningStrategy: "absolute",
         renderTarget: undefined as any,
+        shouldReturnFocusOnClose: false,
         targetTagName: "span",
         transitionDuration: 300,
         usePortal: true,


### PR DESCRIPTION
#### Fixes #4913 and related popover focus bugs in v3.50.0

#### Changes proposed in this pull request:

- Disable `shouldReturnFocusOnClose` by default for popovers & tooltips

#### Reviewers should focus on:

Fixes the linked bug, and focus issues in DateRangeInput component

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
