### PR TITLE
Add `asyncControl` to `EditableText`

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -22,6 +22,7 @@ import { AbstractPureComponent2, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 import { Browser } from "../../compatibility";
+import { AsyncControllableInput } from "../forms/asyncControllableInput";
 
 // eslint-disable-next-line deprecation/deprecation
 export type EditableTextProps = IEditableTextProps;
@@ -40,6 +41,15 @@ export interface IEditableTextProps extends IntentProps, Props {
      * @default false
      */
     alwaysRenderInput?: boolean;
+
+    /**
+     * Set this to `true` if you will be controlling the `value` of this input with asynchronous updates.
+     * These may occur if you do not immediately call setState in a parent component with the value from
+     * the `onChange` handler, or if working with certain libraries like __redux-form__.
+     *
+     * @default false
+     */
+    asyncControl?: boolean;
 
     /**
      * If `true` and in multiline mode, the `enter` key will trigger onConfirm and `mod+enter`
@@ -363,7 +373,7 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
     };
 
     private renderInput(value: string | undefined) {
-        const { disabled, maxLength, multiline, type, placeholder } = this.props;
+        const { asyncControl, disabled, maxLength, multiline, type, placeholder } = this.props;
         const props: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> = {
             className: Classes.EDITABLE_TEXT_INPUT,
             disabled,
@@ -384,7 +394,9 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
             };
         }
 
-        return multiline ? (
+        return asyncControl ? (
+            <AsyncControllableInput inputRef={this.refHandlers.input} type={type} multiline={multiline} {...props} />
+        ) : multiline ? (
             <textarea ref={this.refHandlers.input} {...props} />
         ) : (
             <input ref={this.refHandlers.input} type={type} {...props} />

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -149,4 +149,11 @@ describe("<AsyncControllableInput>", () => {
             });
         }
     });
+
+    describe("multiline", () => {
+        it("renders a textarea", () => {
+            const wrapper = mount(<AsyncControllableInput type="text" value="hi" multiline={true} />);
+            assert.strictEqual(wrapper.childAt(0).type(), "textarea");
+        });
+    });
 });


### PR DESCRIPTION
#### Fixes #4678

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Similarly to `InputGroup`, `EditableText` should support the `asyncControl` prop.

#### Reviewers should focus on:

Currently, I reuse `AsyncControllableInput` but also had to make that class support the `multiline` scenario. I wonder whether it is better to copy this class to a `AsyncControllableTextArea` and figure out another way of sharing code instead of having one class. What do you think?

After that decision is made, I will gladly write more tests if required. Any pointers here would also be welcome.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
