### PR TITLE
[core] fix(PanelStack2): renderActivePanelOnly={false} keeps panels mounted

### DIFF
--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -72,19 +72,18 @@ export const PanelView2: PanelView2Component = <T extends Panel<object>>(props: 
     // `props.panel.renderPanel` is simply a function that returns a JSX.Element. It may be an FC which
     // uses hooks. In order to avoid React errors due to inconsistent hook calls, we must encapsulate
     // those hooks with their own lifecycle through a very simple wrapper component.
-
-    // N.B. A type cast is required because of error TS2345, where technically `panel.props` could be
-    // instantiated with a type unrelated to our generic constraint `T` here. We know
-    // we're sending the right values here though, and it makes the consumer API for this
-    // component type safe, so it's ok to do this...
     const PanelWrapper: React.FunctionComponent = React.useMemo(
         () => () =>
+            // N.B. A type cast is required because of error TS2345, where technically `panel.props` could be
+            // instantiated with a type unrelated to our generic constraint `T` here. We know
+            // we're sending the right values here though, and it makes the consumer API for this
+            // component type safe, so it's ok to do this...
             props.panel.renderPanel({
                 closePanel: handleClose,
                 openPanel: props.onOpen,
                 ...props.panel.props,
             } as PanelProps<T>),
-        [props.panel.renderPanel, handleClose, props.onOpen, props.panel.props],
+        [props.panel, props.onOpen],
     );
 
     return (

--- a/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
@@ -113,7 +113,7 @@ const initialPanel: Panel<Panel1Info> = {
 };
 
 export const PanelStack2Example: React.FC<IExampleProps> = props => {
-    const [activePanelOnly, setActivePanelOnly] = React.useState(true);
+    const [activePanelOnly, setActivePanelOnly] = React.useState(false);
     const [showHeader, setShowHeader] = React.useState(true);
     const [currentPanelStack, setCurrentPanelStack] = React.useState<
         Array<Panel<Panel1Info | Panel2Info | Panel3Info>>


### PR DESCRIPTION

#### Fixes #4918

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Tweak PanelWrapper memoization so that we don't create a new wrapper FC every time we want to render a panel

#### Reviewers should focus on:

Fixes the linked bug

#### Screenshot

![2021-09-21 16 47 50](https://user-images.githubusercontent.com/723999/134245339-6cad983b-9130-46b5-8892-52191832d562.gif)

