### PR TITLE
[core] feat(EditableText): new HTML prop "contentId"

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -113,6 +113,9 @@ export interface IEditableTextProps extends IntentProps, Props {
     /** Text value of controlled input. */
     value?: string;
 
+    /** ID attribute to pass to the underlying element that contains the text contents. This allows for referencing via aria attributes */
+    textId?: string;
+
     /** Callback invoked when user cancels input with the `esc` key. Receives last confirmed value. */
     onCancel?(value: string): void;
 
@@ -204,7 +207,7 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
     }
 
     public render() {
-        const { alwaysRenderInput, disabled, multiline } = this.props;
+        const { alwaysRenderInput, disabled, multiline, textId } = this.props;
         const value = this.props.value ?? this.state.value;
         const hasValue = value != null && value !== "";
 
@@ -243,11 +246,18 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         // and size the container element responsively
         const shouldHideContents = alwaysRenderInput && !this.state.isEditing;
 
+        const spanProps: React.HTMLProps<HTMLSpanElement> = textId != null ? { id: textId } : {};
+
         return (
             <div className={classes} onFocus={this.handleFocus} tabIndex={tabIndex}>
                 {alwaysRenderInput || this.state.isEditing ? this.renderInput(value) : undefined}
                 {shouldHideContents ? undefined : (
-                    <span className={Classes.EDITABLE_TEXT_CONTENT} ref={this.refHandlers.content} style={contentStyle}>
+                    <span
+                        {...spanProps}
+                        className={Classes.EDITABLE_TEXT_CONTENT}
+                        ref={this.refHandlers.content}
+                        style={contentStyle}
+                    >
                         {hasValue ? value : this.props.placeholder}
                     </span>
                 )}

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -114,7 +114,7 @@ export interface IEditableTextProps extends IntentProps, Props {
     value?: string;
 
     /** ID attribute to pass to the underlying element that contains the text contents. This allows for referencing via aria attributes */
-    textId?: string;
+    contentId?: string;
 
     /** Callback invoked when user cancels input with the `esc` key. Receives last confirmed value. */
     onCancel?(value: string): void;
@@ -207,7 +207,7 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
     }
 
     public render() {
-        const { alwaysRenderInput, disabled, multiline, textId } = this.props;
+        const { alwaysRenderInput, disabled, multiline, contentId } = this.props;
         const value = this.props.value ?? this.state.value;
         const hasValue = value != null && value !== "";
 
@@ -246,7 +246,7 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         // and size the container element responsively
         const shouldHideContents = alwaysRenderInput && !this.state.isEditing;
 
-        const spanProps: React.HTMLProps<HTMLSpanElement> = textId != null ? { id: textId } : {};
+        const spanProps: React.HTMLProps<HTMLSpanElement> = contentId != null ? { id: contentId } : {};
 
         return (
             <div className={classes} onFocus={this.handleFocus} tabIndex={tabIndex}>

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -48,7 +48,7 @@ describe("<EditableText>", () => {
     });
 
     it("passes an ID to the underlying span", () => {
-        const editable = shallow(<EditableText disabled={true} isEditing={true} textId="my-id" />).find("span");
+        const editable = shallow(<EditableText disabled={true} isEditing={true} contentId="my-id" />).find("span");
         assert.strictEqual(editable.prop("id"), "my-id");
     });
 

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -47,6 +47,11 @@ describe("<EditableText>", () => {
         assert.strictEqual(editable.text(), "placeholder");
     });
 
+    it("passes an ID to the underlying span", () => {
+        const editable = shallow(<EditableText disabled={true} isEditing={true} textId="my-id" />).find("span");
+        assert.strictEqual(editable.prop("id"), "my-id");
+    });
+
     describe("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

I would like to associate the underlying text in `EditableText` to different content outside the `EditableText` via `aria-labeledby`. Doing so requires that the span that contains the text has an `id` attribute that can be passed in, so this PR plumbs such a prop through. Open to better naming suggestions though.

