### PR TITLE
[core] fix(blueprint-modern): remove disabled input border

### DIFF
--- a/packages/core/src/blueprint-modern.scss
+++ b/packages/core/src/blueprint-modern.scss
@@ -332,6 +332,10 @@ table.#{$ns}-html-table {
                       $pt-dark-input-box-shadow;
       }
     }
+
+    &:disabled {
+      box-shadow: none;
+    }
   }
 
   @each $intent, $color in $dark-input-intent-box-shadow-colors {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Removes border on non-intent disabled inputs (for both light and dark theme)

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://user-images.githubusercontent.com/5934779/135139429-338711f8-9a9f-462d-8b07-eccb30a70e5a.png) ![image](https://user-images.githubusercontent.com/5934779/135139447-63b90d3d-8790-4458-bfb3-6f898ded64a4.png)
