### PR TITLE
[v4] [core] fix(MenuItem): inherit menu item content colors

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -367,6 +367,16 @@ table.#{$ns}-html-table {
       background: $active-background-color;
       color: $active-text-color;
     }
+
+    &:hover,
+    &:active,
+    &.#{$ns}-active {
+      &::before,
+      &::after,
+      .#{$ns}-menu-item-label {
+        color: inherit;
+      }
+    }
   }
 
   &:not([class*="#{$ns}-intent-"]) {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

* Fixes colors turning to white on menu items on hover/active for `::before` and `::after` elements

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
