### PR TITLE
[core] fix(Tabs): use tabIndex of -1 for non-active tabs

### DIFF
--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -54,7 +54,7 @@ export class TabTitle extends AbstractPureComponent2<TabTitleProps> {
                 id={generateTabTitleId(parentId, id)}
                 onClick={disabled ? undefined : this.handleClick}
                 role="tab"
-                tabIndex={disabled ? undefined : 0}
+                tabIndex={disabled ? undefined : selected ? 0 : -1}
             >
                 {title}
                 {children}


### PR DESCRIPTION
I learned recently that the recommendation (from https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role#best_practices) for tab behavior is to only set `tabIndex={0}` for the active tab, and rely on left/right keyboard navigation for navigating the other tabs. This helps reduce the clutter on the screen for a user to have to tab through, while still allowing for navigation within the tablist

The blueprint tabs already support left/right key navigation, so it's mostly just the tabIndex that needed to be changed to respect the above

cc @evansjohnson 