### PR TITLE
[v4] [icons] feat: add iconNameToPathsRecordKey utility fn

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -17,10 +17,9 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IconName, IconSvgPaths16, IconSvgPaths20 } from "@blueprintjs/icons";
+import { IconName, IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "@blueprintjs/icons";
 
 import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IntentProps, Props, MaybeElement } from "../../common";
-import { iconNameToPathsRecordKey } from "./iconUtils";
 
 export { IconName };
 

--- a/packages/icons/src/iconCodepoints.ts
+++ b/packages/icons/src/iconCodepoints.ts
@@ -14,6 +14,5 @@
  * limitations under the License.
  */
 
-export { IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "./iconSvgPaths";
-export { IconCodepoints } from "./iconCodepoints";
-export { IconName, IconNames } from "./iconNames";
+// icon sets are identical aside from SVG paths, so we just import the info for the 16px set
+export { BLUEPRINT_ICONS_16_CODEPOINTS as IconCodepoints } from "./generated/16px/blueprint-icons-16";

--- a/packages/icons/src/iconNames.ts
+++ b/packages/icons/src/iconNames.ts
@@ -19,9 +19,15 @@
 import { snakeCase } from "change-case";
 
 // icon sets are identical aside from SVG paths, so we just import the info for the 16px set
-import { BlueprintIcons_16, BlueprintIcons_16Id, BlueprintIcons_16Key } from "./generated/16px/blueprint-icons-16";
+import {
+    BlueprintIcons_16,
+    BlueprintIcons_16Id as IconName,
+    BlueprintIcons_16Key,
+} from "./generated/16px/blueprint-icons-16";
 
-const IconNamesLegacy: Record<string, BlueprintIcons_16Id> = {};
+export type { IconName };
+
+const IconNamesLegacy: Record<string, IconName> = {};
 
 for (const [pascalCaseKey, iconName] of Object.entries(BlueprintIcons_16)) {
     const screamingSnakeCaseKey = snakeCase(pascalCaseKey).toUpperCase();
@@ -30,7 +36,7 @@ for (const [pascalCaseKey, iconName] of Object.entries(BlueprintIcons_16)) {
 
 export const IconNames = {
     ...BlueprintIcons_16,
-    ...(IconNamesLegacy as Record<ScreamingSnakeCaseIconNames, BlueprintIcons_16Id>),
+    ...(IconNamesLegacy as Record<ScreamingSnakeCaseIconNames, IconName>),
 };
 
 type ScreamingSnakeCaseIconNames = Uppercase<StripLeadingUnderscore<CamelToSnake<BlueprintIcons_16Key>>>;

--- a/packages/icons/src/iconSvgPaths.ts
+++ b/packages/icons/src/iconSvgPaths.ts
@@ -20,6 +20,13 @@ import type { IconName } from "./iconNames";
 
 export { IconSvgPaths16, IconSvgPaths20 };
 
+/**
+ * Type safe string literal conversion of snake-case icon names to camelCase icon names,
+ * useful for indexing into the SVG paths record to extract a single icon's SVG path definition.
+ *
+ * N.B. `IconSvgPaths16` and `IconSvgPaths20` are assignable to each other, so it doesn't matter
+ * which one is used in the return type definition here.
+ */
 export function iconNameToPathsRecordKey(name: IconName): keyof typeof IconSvgPaths16 {
     return kebabCaseToCamelCase(name);
 }

--- a/packages/icons/src/iconSvgPaths.ts
+++ b/packages/icons/src/iconSvgPaths.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { IconName, IconSvgPaths16 } from "@blueprintjs/icons";
+import * as IconSvgPaths16 from "./generated/16px/paths";
+import * as IconSvgPaths20 from "./generated/20px/paths";
+import type { IconName } from "./iconNames";
+
+export { IconSvgPaths16, IconSvgPaths20 };
 
 export function iconNameToPathsRecordKey(name: IconName): keyof typeof IconSvgPaths16 {
     return kebabCaseToCamelCase(name);


### PR DESCRIPTION
Ported from `@blueprintjs/core`, where it was a private utility function.