### PR TITLE
[core] feat(colors): add aliases for cerulean

### DIFF
--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -41,3 +41,12 @@ $pt-code-text-color: $pt-text-color-muted !default;
 $pt-dark-code-text-color: $pt-dark-text-color-muted !default;
 $pt-code-background-color: rgba($white, 0.7) !default;
 $pt-dark-code-background-color: rgba($black, 0.3) !default;
+
+// "cobalt" is becoming "cerulean" in Blueprint 4.0
+// for a smoother migration, we provide these aliases so that consumers
+// can reference the new names in 3.x
+$cerulean1: $cobalt1;
+$cerulean2: $cobalt2;
+$cerulean3: $cobalt3;
+$cerulean4: $cobalt4;
+$cerulean5: $cobalt5;

--- a/packages/core/src/common/colors.ts
+++ b/packages/core/src/common/colors.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LegacyColors } from "@blueprintjs/colors";
+
+export const Colors = {
+    ...LegacyColors,
+    // "cobalt" is becoming "cerulean" in Blueprint 4.0
+    // for a smoother migration, we provide these aliases so that consumers
+    // can reference the new names in 3.x
+    CERULEAN1: LegacyColors.COBALT1,
+    CERULEAN2: LegacyColors.COBALT2,
+    CERULEAN3: LegacyColors.COBALT3,
+    CERULEAN4: LegacyColors.COBALT4,
+    CERULEAN5: LegacyColors.COBALT5,
+};

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -20,6 +20,7 @@ export * from "./abstractPureComponent";
 export * from "./abstractPureComponent2";
 export * from "./alignment";
 export * from "./boundary";
+export { Colors } from "./colors";
 export * from "./constructor";
 export * from "./elevation";
 export * from "./intent";
@@ -27,11 +28,9 @@ export * from "./position";
 export * from "./props";
 export * from "./refs";
 
-import { LegacyColors } from "@blueprintjs/colors";
-
 import * as Classes from "./classes";
 import * as Keys from "./keys";
 import * as Utils from "./utils";
 
-export { Classes, Keys, Utils, LegacyColors as Colors };
+export { Classes, Keys, Utils };
 // NOTE: Errors is not exported in public API


### PR DESCRIPTION

#### Changes proposed in this pull request:

Add Sass and TypeScript aliases for the new "cerulean" color variables. These are close enough to the existing "cobalt" colors and have a 1:1 mapping. Consumers of Blueprint v3.x can migrate to these new names to reduce the code diff required in the v4.0 upgrade.

#### Reviewers should focus on:

N/A

#### Screenshot

N/A
