### PR TITLE
Fix popover click behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "copy:docs-app": "cp -rf packages/docs-app/dist/ site/docs",
         "copy:landing-app": "cp -rf packages/landing-app/dist/ site",
         "deploy": "gh-pages -d site -b gh-pages",
-        "dev": "lerna run dev --parallel --ignore \"@blueprintjs/{landing-app,table-dev-app}\"",
+        "dev": "lerna run dev --parallel --ignore \"@blueprintjs/{demo-app,landing-app,table-dev-app}\"",
         "dev:core": "lerna run dev --parallel --scope \"@blueprintjs/{core,icons,docs-app}\"",
         "dev:docs": "lerna run dev --parallel --scope \"@blueprintjs/{core,docs-app,docs-theme}\"",
         "dev:datetime": "lerna run dev --parallel --scope \"@blueprintjs/{core,datetime,timezone,docs-app}\"",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -14,7 +14,6 @@
         "lint:scss": "sass-lint",
         "lint:es": "es-lint",
         "lint-fix": "es-lint --fix && sass-lint --fix",
-        "test": "mocha test/index.js",
         "verify": "npm-run-all compile -p dist lint"
     },
     "devDependencies": {

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -170,7 +170,6 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         /* eslint-disable deprecation/deprecation */
         if (Keys.isKeyboardClick(e.which)) {
             this.setState({ isActive: false });
-            this.buttonRef?.click();
         }
         this.currentKeyDown = undefined;
         this.props.onKeyUp?.(e);

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -156,7 +156,6 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         // HACKHACK: https://github.com/palantir/blueprint/issues/4165
         /* eslint-disable deprecation/deprecation */
         if (Keys.isKeyboardClick(e.which)) {
-            e.preventDefault();
             if (e.which !== this.currentKeyDown) {
                 this.setState({ isActive: true });
             }

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -379,11 +379,19 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                   onMouseLeave: this.handleMouseLeave,
               }
             : {
-                  // CLICK needs only one handler
-                  onClick: this.handleTargetClick,
-                  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) =>
+                  // CLICK handlers
+                  onClick: (event: React.MouseEvent<HTMLElement>) => {
+                      this.props.targetProps?.onClick?.(event);
+                      this.handleTargetClick(event);
+                  },
+                  // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
+                  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+                      this.props.targetProps?.onKeyDown?.(event);
                       // eslint-disable-next-line deprecation/deprecation
-                      Keys.isKeyboardClick(event.keyCode) && this.handleTargetClick(event),
+                      if (Keys.isKeyboardClick(event.keyCode)) {
+                          this.handleTargetClick(event);
+                      }
+                  },
               };
         finalTargetProps["aria-haspopup"] = "true";
         finalTargetProps.className = classNames(
@@ -569,9 +577,6 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             } else {
                 this.setOpenState(!this.props.isOpen, e);
             }
-        }
-        if (e.type === "click") {
-            this.props.targetProps?.onClick?.(e as React.MouseEvent<HTMLElement>);
         }
     };
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from "react-popper";
 
-import { AbstractPureComponent2, Classes, IRef, refHandler, setRef } from "../../common";
+import { AbstractPureComponent2, Classes, IRef, Keys, refHandler, setRef } from "../../common";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, HTMLDivProps } from "../../common/props";
 import * as Utils from "../../common/utils";
@@ -381,6 +381,9 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             : {
                   // CLICK needs only one handler
                   onClick: this.handleTargetClick,
+                  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) =>
+                      // eslint-disable-next-line deprecation/deprecation
+                      Keys.isKeyboardClick(event.keyCode) && this.handleTargetClick(event),
               };
         finalTargetProps["aria-haspopup"] = "true";
         finalTargetProps.className = classNames(
@@ -556,7 +559,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         }
     };
 
-    private handleTargetClick = (e: React.MouseEvent<HTMLElement>) => {
+    private handleTargetClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
         // ensure click did not originate from within inline popover before closing
         if (!this.props.disabled && !this.isElementInPopover(e.target as HTMLElement)) {
             if (this.props.isOpen == null) {
@@ -565,7 +568,9 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 this.setOpenState(!this.props.isOpen, e);
             }
         }
-        this.props.targetProps?.onClick?.(e);
+        if (e.type === "click") {
+            this.props.targetProps?.onClick?.(e as React.MouseEvent<HTMLElement>);
+        }
     };
 
     // a wrapper around setState({isOpen}) that will call props.onInteraction instead when in controlled mode.

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -560,6 +560,8 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
     };
 
     private handleTargetClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+        // prevents default click action in case focus popover moves focus to a clickable element
+        e.preventDefault();
         // ensure click did not originate from within inline popover before closing
         if (!this.props.disabled && !this.isElementInPopover(e.target as HTMLElement)) {
             if (this.props.isOpen == null) {

--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -63,8 +63,10 @@ const INTERACTION_KINDS = [
 ];
 
 export interface IPopover2ExampleState {
+    autoFocus: boolean;
     boundary?: "scrollParent" | "body" | "clippingParents";
     canEscapeKeyClose?: boolean;
+    enforceFocus: boolean;
     exampleIndex?: number;
     hasBackdrop?: boolean;
     inheritDarkTheme?: boolean;
@@ -82,8 +84,10 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
     public static displayName = "Popover2Example";
 
     public state: IPopover2ExampleState = {
+        autoFocus: false,
         boundary: "scrollParent",
         canEscapeKeyClose: true,
+        enforceFocus: false,
         exampleIndex: 0,
         hasBackdrop: false,
         inheritDarkTheme: true,
@@ -126,6 +130,10 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
 
     private toggleIsOpen = handleBooleanChange(isOpen => this.setState({ isOpen }));
 
+    private toggleAutoFocus = handleBooleanChange(autoFocus => this.setState({ autoFocus }));
+
+    private toggleEnforceFocus = handleBooleanChange(enforceFocus => this.setState({ enforceFocus }));
+
     private toggleMinimal = handleBooleanChange(minimal => this.setState({ minimal }));
 
     private toggleUsePortal = handleBooleanChange(usePortal => {
@@ -166,7 +174,6 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
                                 ? this.bodyElement ?? undefined
                                 : boundary
                         }
-                        enforceFocus={false}
                         isOpen={this.state.isControlled ? this.state.isOpen : undefined}
                         content={this.getContents(exampleIndex)}
                     >
@@ -228,6 +235,10 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
                     label="Open"
                     onChange={this.toggleIsOpen}
                 />
+
+                <H5>Focus</H5>
+                <Switch checked={this.state.autoFocus} label="Autofocus" onChange={this.toggleAutoFocus} />
+                <Switch checked={this.state.enforceFocus} label="Enforce focus" onChange={this.toggleEnforceFocus} />
 
                 <H5>Interactions</H5>
                 <RadioGroup
@@ -305,7 +316,10 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
             </div>,
             <Slider key="slider" min={0} max={10} onChange={this.handleSliderChange} value={this.state.sliderValue} />,
             <div key="popover">
+                <p>You can nest popovers inside one another.</p>
                 <Popover2
+                    autoFocus={false}
+                    enforceFocus={false}
                     content={<div>A nested popover</div>}
                     interactionKind={PopoverInteractionKind.HOVER}
                     popoverClassName={Classes.POPOVER2_CONTENT_SIZING}

--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -50,6 +50,7 @@ import {
     StrictModifierNames,
 } from "@blueprintjs/popover2";
 
+import { PopoverInteractionKind } from "../../../../core/src/components/popover/popover";
 import FilmSelect from "../../common/filmSelect";
 
 const POPPER_DOCS_URL = "https://popper.js.org/docs/v2/";
@@ -155,7 +156,7 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
             <Example options={this.renderOptions()} {...this.props}>
                 <div className="docs-popover2-example-scroll" ref={this.centerScroll}>
                     <Popover2
-                        popoverClassName={exampleIndex <= 2 ? Classes.POPOVER2_CONTENT_SIZING : ""}
+                        popoverClassName={exampleIndex <= 3 ? Classes.POPOVER2_CONTENT_SIZING : ""}
                         portalClassName="foo"
                         {...popoverProps}
                         boundary={
@@ -208,9 +209,10 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
                         <option value="0">Text</option>
                         <option value="1">Input</option>
                         <option value="2">Slider</option>
-                        <option value="3">Menu</option>
-                        <option value="4">Select</option>
-                        <option value="5">Empty</option>
+                        <option value="3">Popover</option>
+                        <option value="4">Menu</option>
+                        <option value="5">Select</option>
+                        <option value="6">Empty</option>
                     </HTMLSelect>
                 </Label>
                 <Switch checked={this.state.usePortal} onChange={this.toggleUsePortal}>
@@ -302,6 +304,15 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
                 </label>
             </div>,
             <Slider key="slider" min={0} max={10} onChange={this.handleSliderChange} value={this.state.sliderValue} />,
+            <div key="popover">
+                <Popover2
+                    content={<div>A nested popover</div>}
+                    interactionKind={PopoverInteractionKind.HOVER}
+                    popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
+                >
+                    <Button text="Hover me" />
+                </Popover2>
+            </div>,
             <Menu key="menu">
                 <MenuDivider title="Edit" />
                 <MenuItem icon="cut" text="Cut" label="⌘X" />

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -435,7 +435,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
 
         return (
             <Overlay
-                autoFocus={this.props.autoFocus}
+                autoFocus={this.props.autoFocus ?? (this.isHoverInteractionKind() ? false : undefined)}
                 backdropClassName={Classes.POPOVER2_BACKDROP}
                 backdropProps={this.props.backdropProps}
                 canEscapeKeyClose={this.props.canEscapeKeyClose}

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -400,11 +400,18 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         this.popperScheduleUpdate = popperProps.update;
 
         const popoverHandlers: HTMLDivProps = {
-            // always check popover clicks for dismiss class
-            onClick: this.handlePopoverClick,
             // treat ENTER/SPACE keys the same as a click for accessibility
             // eslint-disable-next-line deprecation/deprecation
             onKeyDown: event => Keys.isKeyboardClick(event.keyCode) && this.handlePopoverClick(event),
+            // Always check popover clicks for dismiss class. Using onMouseDown instead of onClick.
+            // If the Overlay is opened with autofocus=true, it will move focus to the first
+            // keyboard-focusable element. After pressing the enter key, programmatically moving
+            // focus to another element will result in new click event being created for that
+            // element. The usual workaround is to call event#preventDefault but because the overlay
+            // autofocus behavior is event-based, we cannot prevent the click event being created.
+            // Using onMouseDown instead of onClick allows us to sidestep the problem by listening
+            // to a different event.
+            onMouseDown: this.handlePopoverClick,
         };
         if (
             interactionKind === Popover2InteractionKind.HOVER ||
@@ -639,6 +646,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
     };
 
     private handleTargetClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+        e.preventDefault();
         // ensure click did not originate from within inline popover before closing
         if (!this.props.disabled && !this.isElementInPopover(e.target as HTMLElement)) {
             if (this.props.isOpen == null) {

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -322,7 +322,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
                   onMouseLeave: this.handleMouseLeave,
               }
             : {
-                  // CLICK needs only one handler
+                  // CLICK handlers
                   onClick: this.handleTargetClick,
                   // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
                   onKeyDown: (event: React.KeyboardEvent<HTMLElement>) =>

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -400,18 +400,11 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         this.popperScheduleUpdate = popperProps.update;
 
         const popoverHandlers: HTMLDivProps = {
+            // always check popover clicks for dismiss class
+            onClick: this.handlePopoverClick,
             // treat ENTER/SPACE keys the same as a click for accessibility
             // eslint-disable-next-line deprecation/deprecation
             onKeyDown: event => Keys.isKeyboardClick(event.keyCode) && this.handlePopoverClick(event),
-            // Always check popover clicks for dismiss class. Using onMouseDown instead of onClick.
-            // If the Overlay is opened with autofocus=true, it will move focus to the first
-            // keyboard-focusable element. After pressing the enter key, programmatically moving
-            // focus to another element will result in new click event being created for that
-            // element. The usual workaround is to call event#preventDefault but because the overlay
-            // autofocus behavior is event-based, we cannot prevent the click event being created.
-            // Using onMouseDown instead of onClick allows us to sidestep the problem by listening
-            // to a different event.
-            onMouseDown: this.handlePopoverClick,
         };
         if (
             interactionKind === Popover2InteractionKind.HOVER ||
@@ -435,7 +428,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
 
         return (
             <Overlay
-                autoFocus={this.props.autoFocus ?? (this.isHoverInteractionKind() ? false : undefined)}
+                autoFocus={this.props.autoFocus}
                 backdropClassName={Classes.POPOVER2_BACKDROP}
                 backdropProps={this.props.backdropProps}
                 canEscapeKeyClose={this.props.canEscapeKeyClose}
@@ -646,6 +639,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
     };
 
     private handleTargetClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+        // prevents default click action in case focus popover moves focus to a clickable element
         e.preventDefault();
         // ensure click did not originate from within inline popover before closing
         if (!this.props.disabled && !this.isElementInPopover(e.target as HTMLElement)) {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/4956

Currently failing checks due to code coverage, which I'm happy to fix if we want to go with this approach.

#### Checklist

- [x] Includes tests
- [x] Update documentation (n/a)

#### Changes proposed in this pull request:

There are 2 problems at play that lead to the popover auto-closing behavior reported in https://github.com/palantir/blueprint/issues/4956:
1. When handling `keydown` events triggered by enter or space, programmatically moving focus to another element (as is the case for autofocus Popovers), will cause a `click` event to be created on the new element. This is because `keydown` events occur before `click` and browsers treat enter/space keypresses as clicks for a11y reasons (devs historically implemented onClick but not onKeyDown and it seemed like a cheap way to make websites compliant without code change). Simple repro: https://codesandbox.io/s/focus-change-clicks-lpud5?file=/src/App.jsx

   **Solution:** call `Event#preventDefault` in the Popover(2) click event handler to prevent the click event from being created.

2. AbstractButton calls preventDefault for keyboard clicks (enter/space keys) on keydown and sends a fake "click" event on keyup. As it turns out, the keyup event cannot be prevented with `Event#preventDefault`; assuming you release the key eventually, it will always run! This in turn means the fake click cannot be prevented. When handling keydown and programmatically moving focus, this means that the new element will always receive a fake click event. Here is a simple repro demonstrating this bizarre behavior: https://codesandbox.io/s/cannot-prevent-keyup-1vs20?file=/src/App.jsx

   **Solution:** AbstractButton no longer prevents native clicks on keydown nor does it send a fake "click" on keyup. It seems better to let the native browser click events flow through.

#### Screenshot

No loner autocloses:
![2021-10-14 21 35 50](https://user-images.githubusercontent.com/3681045/137426641-3ff60c07-7706-4518-be80-4c36fd87d9cb.gif)

If users do not want to have the single focusable element be focused, they should set `autoFocus: false`
![2021-10-14 21 36 32](https://user-images.githubusercontent.com/3681045/137426670-2e8559c3-f8fc-436b-bbc2-b43921219ad2.gif)


