### PR TITLE
[core] fix(Overlay): less aggressive enforceFocus behavior

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -567,7 +567,10 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             openStack.splice(stackIndex, 1);
             if (openStack.length > 0) {
                 const lastOpenedOverlay = Overlay.getLastOpened();
-                if (lastOpenedOverlay.props.enforceFocus) {
+                // Only bring focus back to last overlay if it had autoFocus _and_ enforceFocus enabled.
+                // If `autoFocus={false}`, it's likely that the overlay never received focus in the first place,
+                // so it would be surprising for us to send it there. See https://github.com/palantir/blueprint/issues/4921
+                if (lastOpenedOverlay.props.autoFocus && lastOpenedOverlay.props.enforceFocus) {
                     lastOpenedOverlay.bringFocusInsideOverlay();
                     document.addEventListener("focus", lastOpenedOverlay.handleDocumentFocus, /* useCapture */ true);
                 }

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -130,6 +130,9 @@ export interface IPopoverSharedProps extends OverlayableProps, Props {
      * target will render with `tabindex="0"` to make it focusable via keyboard
      * navigation.
      *
+     * Note that this functionality is only enabled for hover interaction
+     * popovers/tooltips.
+     *
      * @default true
      */
     openOnTargetFocus?: boolean;

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -156,6 +156,9 @@ export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
      * target will render with `tabindex="0"` to make it focusable via keyboard
      * navigation.
      *
+     * Note that this functionality is only enabled for hover interaction
+     * popovers/tooltips.
+     *
      * @default true
      */
     openOnTargetFocus?: boolean;


### PR DESCRIPTION
#### Fixes #4921

#### Changes proposed in this pull request:

Do not bring focus back to the last opened overlay unless it has both `enforceFocus={true}` _and_ `autoFocus={true}`. See the code comment added in this PR and the linked issue.

#### Screenshot

![2021-10-18 12 13 33](https://user-images.githubusercontent.com/723999/137769238-9392358b-ddb9-407a-b8ea-8ba3d323771a.gif)

