### PR TITLE
[v4] [core] fix(Drawer): revert breaking change to position prop

### DIFF
--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -63,7 +63,7 @@ export interface IDrawerProps extends OverlayableProps, IBackdropProps, Props {
      *
      * @default Position.RIGHT
      */
-    position: Position;
+    position?: Position;
 
     /**
      * CSS size of the drawer. This sets `width` if horizontal position (default)
@@ -110,7 +110,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
 
     public render() {
         const { size, style, position } = this.props;
-        const realPosition = getPositionIgnoreAngles(position);
+        const realPosition = getPositionIgnoreAngles(position!);
 
         const classes = classNames(
             Classes.DRAWER,


### PR DESCRIPTION

#### Changes proposed in this pull request:

https://github.com/palantir/blueprint/pull/4583 accidentally made `position` a required prop on `<Drawer>`, even though we set a default of `position="right"`. This PR reverts that break so it's no longer a part of v4.0 changes.

