### PR TITLE
Readonly select items prop

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -37,13 +37,13 @@ export interface IItemListRendererProps<T> {
      * map each item in this array through `renderItem`, with support for
      * optional `noResults` and `initialContent` states.
      */
-    filteredItems: T[];
+    filteredItems: readonly T[];
 
     /**
      * Array of all items in the list.
      * See `filteredItems` for a filtered array based on `query` and predicate props.
      */
-    items: T[];
+    items: readonly T[];
 
     /**
      * The current query string.

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -44,7 +44,7 @@ export interface IListItemsProps<T> extends Props {
     activeItem?: T | ICreateNewItem | null;
 
     /** Array of items in the list. */
-    items: T[];
+    items: readonly T[];
 
     /**
      * Specifies how to test if two items are equal. By default, simple strict

--- a/packages/select/src/common/predicate.ts
+++ b/packages/select/src/common/predicate.ts
@@ -18,7 +18,7 @@
  * A custom predicate for returning an entirely new `items` array based on the provided query.
  * See usage sites in `IListItemsProps`.
  */
-export type ItemListPredicate<T> = (query: string, items: T[]) => T[];
+export type ItemListPredicate<T> = (query: string, items: readonly T[]) => T[];
 
 /**
  * A custom predicate for filtering items based on the provided query.

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -134,7 +134,7 @@ export interface IQueryListState<T> {
     createNewItem: T | undefined;
 
     /** The original `items` array filtered by `itemListPredicate` or `itemPredicate`. */
-    filteredItems: T[];
+    filteredItems: readonly T[];
 
     /** The current query string. */
     query: string;
@@ -645,7 +645,7 @@ function isItemDisabled<T>(item: T | null, index: number, itemDisabled?: IListIt
  * @param startIndex which index to begin moving from
  */
 export function getFirstEnabledItem<T>(
-    items: T[],
+    items: readonly T[],
     itemDisabled?: keyof T | ((item: T, index: number) => boolean),
     direction = 1,
     startIndex = items.length - 1,

--- a/packages/select/src/components/select/multiSelect.tsx
+++ b/packages/select/src/components/select/multiSelect.tsx
@@ -83,7 +83,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     popoverProps?: Partial<IPopoverProps> & object;
 
     /** Controlled selected values. */
-    selectedItems?: T[];
+    selectedItems?: readonly T[];
 
     /** Props to spread to `TagInput`. Use `query` and `onQueryChange` to control the input. */
     // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
#### Fixes #4976

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

Added readonly annotations to select props

#### Reviewers should focus on:

The types

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
