### PR TITLE
[core] docs(Button): buttons are disabled when loading={true}

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -62,7 +62,7 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     large?: boolean;
 
     /**
-     * If set to `true`, the button will display a centered loading spinner instead of its contents.
+     * If set to `true`, the button will display a centered loading spinner instead of its contents, and the button will be disabled.
      * The width of the button is not affected by the value of this prop.
      *
      * @default false

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -62,7 +62,7 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     large?: boolean;
 
     /**
-     * If set to `true`, the button will display a centered loading spinner instead of its contents, and the button will be disabled.
+     * If set to `true`, the button will display a centered loading spinner instead of its contents, and the button will appear disabled.
      * The width of the button is not affected by the value of this prop.
      *
      * @default false

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -62,7 +62,7 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     large?: boolean;
 
     /**
-     * If set to `true`, the button will display a centered loading spinner instead of its contents, and the button will appear disabled.
+     * If set to `true`, the button will display a centered loading spinner instead of its contents, and the button will be disabled.
      * The width of the button is not affected by the value of this prop.
      *
      * @default false


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Clarify that the `loading` prop on `IButtonProps` will also disable the button

#### Reviewers should focus on:

The docs
