### PR TITLE
[v4] [core] fix(EditableText): do not use disabled text colors

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -276,18 +276,6 @@ $tree-intent-icon-colors-modern: (
   }
 }
 
-
-// Contrast for disabled editable text
-.#{$ns}-editable-text.#{$ns}-disabled {
-  > .#{$ns}-editable-text-content {
-    color: $pt-text-color-disabled;
-
-    .#{$ns}-dark & {
-      color: $pt-dark-text-color-disabled;
-    }
-  }
-}
-
 // Contrast for HTML tables
 table.#{$ns}-html-table {
   &.#{$ns}-html-table-striped {

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -26,6 +26,7 @@ const INPUT_ID = "EditableTextExample-max-length";
 export interface IEditableTextExampleState {
     alwaysRenderInput?: boolean;
     confirmOnEnterKey?: boolean;
+    disabled?: boolean;
     intent?: Intent;
     maxLength?: number;
     report?: string;
@@ -34,11 +35,14 @@ export interface IEditableTextExampleState {
 
 export class EditableTextExample extends React.PureComponent<IExampleProps, IEditableTextExampleState> {
     public state: IEditableTextExampleState = {
-        alwaysRenderInput: true,
+        alwaysRenderInput: false,
         confirmOnEnterKey: false,
+        disabled: false,
         report: "",
         selectAllOnFocus: false,
     };
+
+    private toggleDisabled = handleBooleanChange((disabled: boolean) => this.setState({ disabled }));
 
     private handleIntentChange = handleValueChange((intent: Intent) => this.setState({ intent }));
 
@@ -54,6 +58,7 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                 <H1>
                     <EditableText
                         alwaysRenderInput={this.state.alwaysRenderInput}
+                        disabled={this.state.disabled}
                         intent={this.state.intent}
                         maxLength={this.state.maxLength}
                         placeholder="Edit title..."
@@ -62,6 +67,7 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                 </H1>
                 <EditableText
                     alwaysRenderInput={this.state.alwaysRenderInput}
+                    disabled={this.state.disabled}
                     intent={this.state.intent}
                     maxLength={this.state.maxLength}
                     maxLines={12}
@@ -94,6 +100,7 @@ export class EditableTextExample extends React.PureComponent<IExampleProps, IEdi
                         value={this.state.maxLength || ""}
                     />
                 </FormGroup>
+                <Switch checked={this.state.disabled} label="Disabled" onChange={this.toggleDisabled} />
                 <Switch
                     checked={this.state.selectAllOnFocus}
                     label="Select all on focus"


### PR DESCRIPTION
#### Fixes #4974

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

I believe these color overrides were added in error; we don't want to render text with "disabled" appearance when `disabled={true}`; rather, that prop controls whether the interactive functionality is enabled on this component.

#### Reviewers should focus on:

Was there some other intention behind this code?

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://user-images.githubusercontent.com/723999/138488120-6b670e92-c3b6-47c4-aac3-ef5a1f4ea31b.png)
