### PR TITLE
[v4] [core] fix(InputGroup): no border on disabled inputs

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -320,10 +320,10 @@ table.#{$ns}-html-table {
                       $pt-dark-input-box-shadow;
       }
     }
-  }
 
-  &:disabled {
-    box-shadow: none;
+    &:disabled {
+      box-shadow: none;
+    }
   }
 
   @each $intent, $color in $dark-input-intent-box-shadow-colors {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -137,6 +137,10 @@ $control-group-stack: (
   color: $input-color-disabled;
   cursor: not-allowed;
   resize: none;
+
+  &::placeholder {
+    color: $input-color-disabled;
+  }
 }
 
 @mixin pt-input-large() {


### PR DESCRIPTION
#### Fixes #4986, fixes #4988

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix selector for disabled text inputs in "modern colors" Sass code

#### Reviewers should focus on:

No regressions

#### Screenshot

![image](https://user-images.githubusercontent.com/723999/138916661-ec7efc98-8c05-46c9-8762-f2ec10b0f600.png)
