### PR TITLE
[v4] [core] fix(MenuItem): improve interactive styles

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -8,16 +8,11 @@ Licensed under the Apache License, Version 2.0.
 // Import files in the same order that they are documented in the docs
 @import "~@blueprintjs/colors/lib/scss/colors";
 @import "common/variables";
+@import "common/mixins";
 
 @import "reset";
 @import "typography";
 @import "accessibility/focus-states";
-
-// Extended color pallete
-$blue6: #99c4ff;
-$green6: #7cd7a2;
-$orange6: #f5c186;
-$red6: #ffa1a4;
 
 // Button variables and overrides
 $button-active-minimal-intent-text-modern: (
@@ -54,14 +49,6 @@ $dark-input-intent-box-shadow-colors: (
   "danger" : $red4,
 );
 $dark-input-shadow-color-focus: $blue4;
-
-// Menu variables
-$menu-item-intent-colors-modern: (
-  "primary": (rgba($blue3, 0.1), $blue2, rgba($blue3, 0.2), $blue1),
-  "success": (rgba($green3, 0.1), $green2, rgba($green3, 0.2), $green1),
-  "warning": (rgba($orange3, 0.1), $orange2, rgba($orange3, 0.2), $orange1),
-  "danger" : (rgba($red3, 0.1), $red2, rgba($red3, 0.2), $red1),
-);
 
 // Slider variable overrides
 $button-box-shadow-overlay:
@@ -335,92 +322,7 @@ table.#{$ns}-html-table {
   }
 }
 
-// Contrast for menus
-.#{$ns}-menu-item {
-  @mixin menu-item-intent-modern(
-    $hover-background-color,
-    $hover-text-color,
-    $active-background-color,
-    $active-text-color) {
-    &:hover {
-      background: $hover-background-color;
-      color: $hover-text-color;
-
-      .#{$ns}-menu-item-label {
-        color: $hover-text-color;
-      }
-    }
-
-    &:active {
-      background: $active-background-color;
-      color: $active-text-color;
-    }
-
-    &:hover,
-    &:active,
-    &.#{$ns}-active {
-      &::before,
-      &::after,
-      .#{$ns}-menu-item-label {
-        color: inherit;
-      }
-    }
-  }
-
-  &:not([class*="#{$ns}-intent-"]) {
-    &:hover {
-      background: rgba($gray3, 0.1);
-    }
-
-    &:active {
-      background: rgba($gray3, 0.2);
-
-      .#{$ns}-menu-item-label {
-        color: $pt-text-color;
-      }
-    }
-  }
-
-  @each $intent, $color in $menu-item-intent-colors-modern {
-    &.#{$ns}-intent-#{$intent} {
-      @include menu-item-intent-modern($color...);
-    }
-  }
-
-  .#{$ns}-dark & {
-    &:not([class*="#{$ns}-intent-"]) {
-      &:hover {
-        .#{$ns}-icon:first-child {
-          color: $pt-dark-icon-color;
-        }
-      }
-
-      &:active {
-        .#{$ns}-menu-item-label {
-          color: $light-gray5;
-        }
-      }
-    }
-
-    @each $intent, $color in $dark-minimal-button-intents-modern {
-      &.#{$ns}-intent-#{$intent} {
-        @include pt-button-minimal-dark-intent-modern($color...);
-
-        &:hover {
-          .#{$ns}-menu-item-label {
-            color: nth($color, 2);
-          }
-        }
-
-        &:active {
-          .#{$ns}-menu-item-label {
-            color: nth($color, 4);
-          }
-        }
-      }
-    }
-  }
-}
+// Contrast for menus - no overrides necessary, modern colors are now built-in
 
 // Contrast for sliders
 .#{$ns}-slider-handle {

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -4,6 +4,12 @@
 @import "~@blueprintjs/colors/lib/scss/colors";
 @import "flex";
 
+// Extended color pallete
+$blue6: #99c4ff;
+$green6: #7cd7a2;
+$orange6: #f5c186;
+$red6: #ffa1a4;
+
 $pt-intent-colors: (
   "primary": $pt-intent-primary,
   "success": $pt-intent-success,

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -41,6 +41,7 @@ export const MINIMAL = `${NS}-minimal`;
 export const OUTLINED = `${NS}-outlined`;
 export const MULTILINE = `${NS}-multiline`;
 export const ROUND = `${NS}-round`;
+export const SELECTED = `${NS}-selected`;
 export const SMALL = `${NS}-small`;
 export const VERTICAL = `${NS}-vertical`;
 export const POSITION_TOP = positionClass(Position.TOP);

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -184,8 +184,10 @@ export const FORM_HELPER_TEXT = `${NS}-form-helper-text`;
 
 export const MENU = `${NS}-menu`;
 export const MENU_ITEM = `${MENU}-item`;
+export const MENU_ITEM_ICON = `${MENU_ITEM}-icon`;
 export const MENU_ITEM_LABEL = `${MENU_ITEM}-label`;
 export const MENU_SUBMENU = `${NS}-submenu`;
+export const MENU_SUBMENU_ICON = `${MENU_SUBMENU}-icon`;
 export const MENU_DIVIDER = `${MENU}-divider`;
 export const MENU_HEADER = `${MENU}-header`;
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -24,15 +24,24 @@ $menu-item-padding-vertical-large:
 $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray4 !default;
 
-$menu-item-color-hover: $minimal-button-background-color-hover !default;
-$menu-item-color-active: $minimal-button-background-color-active !default;
-$dark-menu-item-color-hover: $dark-minimal-button-background-color-hover !default;
-$dark-menu-item-color-active: $dark-minimal-button-background-color-active !default;
+$menu-item-color-hover: rgba($gray3, 0.15) !default;
+$menu-item-color-active: rgba($gray3, 0.3) !default;
 
-// customize modifier classes with params.
-// setting modifier to "" will generally apply it as default styles due to & selectors
+$menu-item-intent-colors: (
+  "primary": (/* bg */ $blue3, /* fg */ $blue2, /* fg active */ $blue1),
+  "success": (/* bg */ $green3, /* fg */ $green2, /* fg active */ $green1),
+  "warning": (/* bg */ $orange3, /* fg */ $orange2, /* fg active */ $orange1),
+  "danger": (/* bg */ $red3, /* fg */ $red2, /* fg active */ $red1),
+) !default;
 
-@mixin menu-item($disabled-selector: ".#{$ns}-disabled", $hover-selector: ":hover") {
+$dark-menu-item-intent-colors: (
+  "primary": (/* bg */ $blue3, /* fg */ $blue5, /* fg active */ $blue6),
+  "success": (/* bg */ $green3, /* fg */ $green5, /* fg active */ $green6),
+  "warning": (/* bg */ $orange3, /* fg */ $orange5, /* fg active */ $orange6),
+  "danger": (/* bg */ $red3, /* fg */ $red5, /* fg active */ $red6),
+) !default;
+
+@mixin menu-item() {
   @include pt-flex-container(row, $menu-item-padding);
   align-items: flex-start;
   border-radius: $menu-item-border-radius;
@@ -46,71 +55,180 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
     word-break: break-word;
   }
 
-  &#{$hover-selector} {
+  .#{$ns}-menu-item-label {
+    color: $pt-text-color-muted;
+  }
+
+  &::before,
+  .#{$ns}-icon {
+    color: $pt-icon-color;
+    margin-top: ($menu-item-line-height - $pt-icon-size-standard) / 2;
+  }
+
+  &:hover {
     background-color: $menu-item-color-hover;
+    color: inherit;
     cursor: pointer;
     text-decoration: none;
   }
 
-  &#{$disabled-selector} {
-    background-color: inherit;
-    color: $pt-text-color-disabled;
-    cursor: not-allowed;
+  &:active,
+  &.#{$ns}-active {
+    background-color: $menu-item-color-active;
+
+    .#{$ns}-menu-item-label {
+      color: $pt-text-color;
+    }
   }
 
-  .#{$ns}-dark & {
-    @include dark-menu-item($disabled-selector, $hover-selector);
-  }
-}
+  &.#{$ns}-selected {
+    &,
+    &:hover,
+    &:active {
+      background-color: rgba(nth(map-get($menu-item-intent-colors, "primary"), 1), 0.1);
+      color: nth(map-get($menu-item-intent-colors, "primary"), 2);
 
-@mixin dark-menu-item($disabled-selector: ".#{$ns}-disabled", $hover-selector: ":hover") {
-  color: inherit;
-
-  &#{$hover-selector} {
-    background-color: $dark-menu-item-color-hover;
-    color: inherit;
-  }
-
-  &#{$disabled-selector} {
-    background-color: inherit;
-    color: $pt-dark-text-color-disabled;
-  }
-}
-
-@mixin menu-item-intent($text-colors: $pt-intent-text-colors) {
-  @each $intent, $color in $text-colors {
-    &.#{$ns}-intent-#{$intent} {
-      color: $color;
-
+      &::before,
       .#{$ns}-icon {
+        color: nth(map-get($menu-item-intent-colors, "primary"), 2);
+      }
+
+      .#{$ns}-menu-item-label {
         color: inherit;
       }
 
-      &::before,
-      &::after,
-      .#{$ns}-menu-item-label {
-        color: $color;
-      }
+      @each $intent in ("success", "warning", "danger") {
+        &.#{$ns}-intent-#{$intent} {
+          background-color: rgba(nth(map-get($menu-item-intent-colors, $intent), 1), 0.1);
+          color: nth(map-get($menu-item-intent-colors, $intent), 2);
 
-      &:hover,
-      &.#{$ns}-active {
-        background-color: nth(map-get($button-intents, $intent), 1);
-      }
-
-      &:active {
-        background-color: nth(map-get($button-intents, $intent), 2);
-      }
-
-      &:hover,
-      &:active,
-      &.#{$ns}-active {
-        &,
-        &::before,
-        &::after,
-        .#{$ns}-menu-item-label {
-          color: $white;
+          &::before,
+          .#{$ns}-icon {
+            color: inherit;
+          }
         }
       }
+    }
+  }
+
+  // pt-disable always overrides over styles
+  /* stylelint-disable declaration-no-important */
+  &.#{$ns}-disabled {
+    background-color: inherit !important;
+    color: $pt-text-color-disabled !important;
+    cursor: not-allowed !important;
+    // override global a:focus styles
+    outline: none !important;
+
+    &::before,
+    > .#{$ns}-icon {
+      color: $pt-icon-color-disabled !important;
+    }
+
+    .#{$ns}-menu-item-label {
+      color: $pt-text-color-disabled !important;
+    }
+  }
+  /* stylelint-enable declaration-no-important */
+}
+
+@mixin dark-menu-item() {
+  color: inherit;
+
+  .#{$ns}-menu-item-label {
+    color: $pt-dark-text-color-muted;
+  }
+
+  &::before,
+  .#{$ns}-icon {
+    color: $pt-dark-icon-color;
+  }
+
+  &:hover {
+    color: inherit;
+
+    // need to override typography styles here
+    .#{$ns}-icon {
+      color: $pt-dark-icon-color;
+    }
+  }
+
+  &:active,
+  &.#{$ns}-active {
+    .#{$ns}-menu-item-label {
+      color: $pt-dark-text-color;
+    }
+  }
+
+  &.#{$ns}-selected {
+    &,
+    &:hover,
+    &:active {
+      background-color: rgba(nth(map-get($dark-menu-item-intent-colors, "primary"), 1), 0.2);
+      color: nth(map-get($dark-menu-item-intent-colors, "primary"), 2);
+
+      &::before,
+      .#{$ns}-icon {
+        color: nth(map-get($dark-menu-item-intent-colors, "primary"), 2);
+      }
+
+      @each $intent in ("success", "warning", "danger") {
+        &.#{$ns}-intent-#{$intent} {
+          background-color: rgba(nth(map-get($dark-menu-item-intent-colors, $intent), 1), 0.2);
+          color: nth(map-get($dark-menu-item-intent-colors, $intent), 2);
+
+          &::before,
+          .#{$ns}-icon {
+            color: inherit;
+          }
+        }
+      }
+    }
+  }
+
+  // pt-disable always overrides over styles
+  /* stylelint-disable declaration-no-important */
+  &.#{$ns}-disabled {
+    color: $pt-dark-text-color-disabled !important;
+
+    &::before,
+    .#{$ns}-icon {
+      color: $pt-dark-icon-color-disabled !important;
+    }
+
+    .#{$ns}-menu-item-label {
+      color: $pt-dark-text-color-disabled !important;
+    }
+  }
+  /* stylelint-enable declaration-no-important */
+}
+
+@mixin menu-item-intent($intent, $is-dark, $bg-color, $fg-color, $fg-color-active) {
+  &.#{$ns}-intent-#{$intent} {
+    color: $fg-color;
+
+    &::before,
+    .#{$ns}-icon,
+    .#{$ns}-menu-item-label {
+      color: inherit;
+    }
+
+    &:hover {
+      @if $is-dark {
+        background-color: rgba($bg-color, 0.2);
+      } @else {
+        background-color: rgba($bg-color, 0.1);
+      }
+    }
+
+    &:active,
+    &.#{$ns}-active {
+      @if $is-dark {
+        background-color: rgba($bg-color, 0.3);
+      } @else {
+        background-color: rgba($bg-color, 0.2);
+      }
+      color: $fg-color-active;
     }
   }
 }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -60,7 +60,8 @@ $dark-menu-item-intent-colors: (
   }
 
   &::before,
-  .#{$ns}-icon {
+  .#{$ns}-menu-item-icon,
+  .#{$ns}-submenu-icon {
     color: $pt-icon-color;
     margin-top: ($menu-item-line-height - $pt-icon-size-standard) / 2;
   }
@@ -89,7 +90,8 @@ $dark-menu-item-intent-colors: (
       color: nth(map-get($menu-item-intent-colors, "primary"), 2);
 
       &::before,
-      .#{$ns}-icon {
+      .#{$ns}-menu-item-icon,
+      .#{$ns}-submenu-icon {
         color: nth(map-get($menu-item-intent-colors, "primary"), 2);
       }
 
@@ -103,7 +105,8 @@ $dark-menu-item-intent-colors: (
           color: nth(map-get($menu-item-intent-colors, $intent), 2);
 
           &::before,
-          .#{$ns}-icon {
+          .#{$ns}-menu-item-icon,
+          .#{$ns}-submenu-icon {
             color: inherit;
           }
         }
@@ -121,7 +124,8 @@ $dark-menu-item-intent-colors: (
     outline: none !important;
 
     &::before,
-    > .#{$ns}-icon {
+    .#{$ns}-menu-item-icon,
+    .#{$ns}-submenu-icon {
       color: $pt-icon-color-disabled !important;
     }
 
@@ -140,7 +144,8 @@ $dark-menu-item-intent-colors: (
   }
 
   &::before,
-  .#{$ns}-icon {
+  .#{$ns}-menu-item-icon,
+  .#{$ns}-submenu-icon {
     color: $pt-dark-icon-color;
   }
 
@@ -148,7 +153,8 @@ $dark-menu-item-intent-colors: (
     color: inherit;
 
     // need to override typography styles here
-    .#{$ns}-icon {
+    .#{$ns}-menu-item-icon,
+    .#{$ns}-submenu-icon {
       color: $pt-dark-icon-color;
     }
   }
@@ -168,7 +174,8 @@ $dark-menu-item-intent-colors: (
       color: nth(map-get($dark-menu-item-intent-colors, "primary"), 2);
 
       &::before,
-      .#{$ns}-icon {
+      .#{$ns}-menu-item-icon,
+      .#{$ns}-submenu-icon {
         color: nth(map-get($dark-menu-item-intent-colors, "primary"), 2);
       }
 
@@ -178,7 +185,8 @@ $dark-menu-item-intent-colors: (
           color: nth(map-get($dark-menu-item-intent-colors, $intent), 2);
 
           &::before,
-          .#{$ns}-icon {
+          .#{$ns}-menu-item-icon,
+          .#{$ns}-submenu-icon {
             color: inherit;
           }
         }
@@ -192,7 +200,8 @@ $dark-menu-item-intent-colors: (
     color: $pt-dark-text-color-disabled !important;
 
     &::before,
-    .#{$ns}-icon {
+    .#{$ns}-menu-item-icon,
+    .#{$ns}-submenu-icon {
       color: $pt-dark-icon-color-disabled !important;
     }
 
@@ -208,7 +217,8 @@ $dark-menu-item-intent-colors: (
     color: $fg-color;
 
     &::before,
-    .#{$ns}-icon,
+    .#{$ns}-menu-item-icon,
+    .#{$ns}-submenu-icon,
     .#{$ns}-menu-item-label {
       color: inherit;
     }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -63,6 +63,10 @@ $dark-menu-item-intent-colors: (
   .#{$ns}-menu-item-icon,
   .#{$ns}-submenu-icon {
     color: $pt-icon-color;
+  }
+
+  &::before,
+  .#{$ns}-submenu-icon {
     margin-top: ($menu-item-line-height - $pt-icon-size-standard) / 2;
   }
 
@@ -247,6 +251,16 @@ $dark-menu-item-intent-colors: (
   font-size: $pt-font-size-large;
   line-height: $menu-item-line-height-large;
   padding: $menu-item-padding-vertical-large $menu-item-padding;
+
+  &::before,
+  .#{$ns}-submenu-icon {
+    // SVG icons remain standard size when menu is large
+    margin-top: ($menu-item-line-height-large - $pt-icon-size-standard) / 2;
+  }
+
+  .#{$ns}-menu-item-icon {
+    margin-top: -1px;
+  }
 }
 
 @mixin menu-divider() {

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -64,15 +64,9 @@ Styleguide menu
   .#{$ns}-large & {
     @include menu-item-large();
 
-    .#{$ns}-icon {
-      // SVG icons remain standard size when menu is large
-      margin-top: ($menu-item-line-height-large - $pt-icon-size-standard) / 2;
-    }
-
     &::before {
       @include pt-icon($pt-icon-size-large);
       margin-right: $menu-item-padding-large;
-      margin-top: ($menu-item-line-height-large - $pt-icon-size-large) / 2;
     }
   }
 }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -50,49 +50,16 @@ Styleguide menu
 
 .#{$ns}-menu-item {
   @include menu-item();
-  @include menu-item-intent();
+
+  @each $intent, $colors in $menu-item-intent-colors {
+    @include menu-item-intent($intent, false, $colors...);
+  }
 
   &::before {
     // support pt-icon-* classes directly on this element
     @include pt-icon();
     margin-right: $menu-item-padding;
   }
-
-  &::before,
-  > .#{$ns}-icon {
-    color: $pt-icon-color;
-    margin-top: ($menu-item-line-height - $pt-icon-size-standard) / 2;
-  }
-
-  .#{$ns}-menu-item-label {
-    color: $pt-text-color-muted;
-  }
-
-  &:hover {
-    color: inherit;
-  }
-
-  &.#{$ns}-active,
-  &:active {
-    background-color: $menu-item-color-active;
-  }
-
-  // pt-disable always overrides over styles
-  /* stylelint-disable declaration-no-important */
-  &.#{$ns}-disabled {
-    background-color: inherit !important;
-    color: $pt-text-color-disabled !important;
-    cursor: not-allowed !important;
-    // override global a:focus styles
-    outline: none !important;
-
-    &::before,
-    > .#{$ns}-icon,
-    .#{$ns}-menu-item-label {
-      color: $pt-icon-color-disabled !important;
-    }
-  }
-  /* stylelint-enable declaration-no-important */
 
   .#{$ns}-large & {
     @include menu-item-large();
@@ -151,34 +118,11 @@ Styleguide menu-header
   }
 
   .#{$ns}-menu-item {
-    @include menu-item-intent($pt-dark-intent-text-colors);
+    @include dark-menu-item();
 
-    &::before,
-    > .#{$ns}-icon {
-      color: $pt-dark-icon-color;
+    @each $intent, $colors in $dark-menu-item-intent-colors {
+      @include menu-item-intent($intent, true, $colors...);
     }
-
-    .#{$ns}-menu-item-label {
-      color: $pt-dark-text-color-muted;
-    }
-
-    &.#{$ns}-active,
-    &:active {
-      background-color: $dark-menu-item-color-active;
-    }
-
-    // pt-disable always overrides over styles
-    /* stylelint-disable declaration-no-important */
-    &.#{$ns}-disabled {
-      color: $pt-dark-text-color-disabled !important;
-
-      &::before,
-      > .#{$ns}-icon,
-      .#{$ns}-menu-item-label {
-        color: $pt-dark-icon-color-disabled !important;
-      }
-    }
-    /* stylelint-enable declaration-no-important */
   }
 
   .#{$ns}-menu-divider,

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -15,8 +15,15 @@
 
     &.#{$ns}-popover-open > .#{$ns}-menu-item {
       // keep a trail of hovered items as submenus are opened
-      /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
-      @extend .#{$ns}-menu-item:hover;
+      /* stylelint-disable scss/at-extend-no-missing-placeholder */
+      &:not([class*="#{$ns}-intent-"]) {
+        @extend .#{$ns}-menu-item:hover;
+      }
+
+      &[class*="#{$ns}-intent-"] {
+        @extend .#{$ns}-menu-item.#{$ns}-selected;
+      }
+      /* stylelint-enable scss/at-extend-no-missing-placeholder */
     }
   }
 

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -4,6 +4,51 @@ Menus display lists of interactive items.
 
 @reactExample MenuExample
 
+The Men` API includes three React components:
+
+* [`Menu`](#core/components/menu.menu)
+* [`MenuItem`](#core/components/menu.menu-item)
+* [`MenuDivider`](#core/components/menu.menu-divider)
+
+```tsx
+<Menu>
+    <MenuItem icon="new-text-box" onClick={handleClick} text="New text box" />
+    <MenuItem icon="new-object" onClick={handleClick} text="New object" />
+    <MenuItem icon="new-link" onClick={handleClick} text="New link" />
+    <MenuDivider />
+    <MenuItem text="Settings..." icon="cog" intent="primary">
+        <MenuItem icon="tick" text="Save on edit" />
+        <Menu.Item icon="blank" text="Compile on edit" />
+    </MenuItem>
+</Menu>
+```
+
+@## Props
+
+A `Menu` is a `<ul>` container for menu items and dividers.
+
+@interface IMenuProps
+
+@## Menu item
+
+A `MenuItem` is a single interactive item in a `Menu`.
+
+This component renders an `<li>` containing an `<a>`. Make the `MenuItem`
+interactive by providing the `href`, `target`, and `onClick` props as necessary.
+
+Create submenus by nesting `MenuItem`s inside each other as `children`. Use the
+required `text` prop for `MenuItem` content.
+
+@reactExample MenuItemExample
+
+@interface IMenuItemProps
+
+@## Menu divider
+
+Use `MenuDivider` to separate menu sections. Optionally, add a title to the divider.
+
+@interface IMenuDividerProps
+
 @## Dropdowns
 
 The `Menu` component by itself simply renders a list of items. To make a
@@ -48,51 +93,6 @@ Submenus are only supported in the React components. They cannot be created with
 they rely on the [`Popover`](#core/components/popover) component for positioning and transitions.
 
 </div>
-
-@## Props
-
-The `Menu` API includes three stateless React components:
-
-* [`Menu`](#core/components/menu.menu)
-* [`MenuItem`](#core/components/menu.menu-item) (aliased as `Menu.Item`)
-* [`MenuDivider`](#core/components/menu.menu-divider) (aliased as `Menu.Divider`)
-
-```tsx
-<Menu>
-    <Menu.Item icon="new-text-box" onClick={this.handleClick} text="New text box" />
-    <Menu.Item icon="new-object" onClick={this.handleClick} text="New object" />
-    <Menu.Item icon="new-link" onClick={this.handleClick} text="New link" />
-    <Menu.Divider />
-    <Menu.Item text="Settings..." icon="cog">
-        <Menu.Item icon="tick" text="Save on edit" />
-        <Menu.Item icon="blank" text="Compile on edit" />
-    </Menu.Item>
-</Menu>
-```
-
-@### Menu
-
-A `Menu` is a `<ul>` container for menu items and dividers.
-
-@interface IMenuProps
-
-@### Menu item
-
-A `MenuItem` is a single interactive item in a `Menu`.
-
-This component renders an `<li>` containing an `<a>`. Make the `MenuItem`
-interactive by providing the `href`, `target`, and `onClick` props as necessary.
-
-Create submenus by nesting `MenuItem`s inside each other as `children`. Use the
-required `text` prop for `MenuItem` content.
-
-@interface IMenuItemProps
-
-@### Menu divider
-
-Use `MenuDivider` to separate menu sections. Optionally, add a title to the divider.
-
-@interface IMenuDividerProps
 
 @## CSS
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -180,12 +180,14 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
                 ...(disabled ? DISABLED_PROPS : {}),
                 className: anchorClasses,
             },
-            <Icon icon={icon} />,
+            <Icon className={Classes.MENU_ITEM_ICON} icon={icon} />,
             <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>
                 {text}
             </Text>,
             this.maybeRenderLabel(labelElement),
-            hasSubmenu ? <Icon title="Open sub menu" icon="caret-right" /> : undefined,
+            hasSubmenu ? (
+                <Icon className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" icon="caret-right" />
+            ) : undefined,
         );
 
         const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -180,7 +180,11 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
                 ...(disabled ? DISABLED_PROPS : {}),
                 className: anchorClasses,
             },
-            <Icon className={Classes.MENU_ITEM_ICON} icon={icon} />,
+            // wrap icon in a <span> in case `icon` is a custom element rather than a built-in icon identifier,
+            // so that we always render this class
+            <span className={Classes.MENU_ITEM_ICON}>
+                <Icon icon={icon} />
+            </span>,
             <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>
                 {text}
             </Text>,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -29,11 +29,20 @@ import { Menu } from "./menu";
 export type MenuItemProps = IMenuItemProps;
 /** @deprecated use MenuItemProps */
 export interface IMenuItemProps extends ActionProps, LinkProps {
-    // override from IActionProps to make it required
     /** Item text, required for usability. */
     text: React.ReactNode;
 
-    /** Whether this menu item should appear with an active state. */
+    /**
+     * Whether this item should render with an active appearance.
+     * This is the same styling as the `:active` CSS element state.
+     *
+     * Note: in Blueprint 3.x, this prop was conflated with a "selected" appearance
+     * when `intent` was undefined. For legacy purposes, we emulate this behavior in
+     * Blueprint 4.x, so setting `active={true} intent={undefined}` is the same as
+     * `selected={true}`. This prop will be removed in a future major version.
+     *
+     * @deprecated use `selected` prop
+     */
     active?: boolean;
 
     /**
@@ -84,6 +93,11 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
     popoverProps?: Partial<IPopoverProps>;
 
     /**
+     * Whether this item should appear selected.
+     */
+    selected?: boolean;
+
+    /**
      * Whether an enabled item without a submenu should automatically close its parent popover when clicked.
      *
      * @default true
@@ -110,9 +124,11 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
 
 export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {
     public static defaultProps: MenuItemProps = {
+        active: false,
         disabled: false,
         multiline: false,
         popoverProps: {},
+        selected: false,
         shouldDismissPopover: true,
         text: "",
     };
@@ -121,6 +137,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
 
     public render() {
         const {
+            // eslint-disable-next-line deprecation/deprecation
             active,
             className,
             children,
@@ -131,6 +148,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
             labelElement,
             multiline,
             popoverProps,
+            selected,
             shouldDismissPopover,
             text,
             textClassName,
@@ -146,10 +164,10 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
             intentClass,
             {
                 [Classes.ACTIVE]: active,
-                [Classes.INTENT_PRIMARY]: active && intentClass == null,
                 [Classes.DISABLED]: disabled,
                 // prevent popover from closing when clicking on submenu trigger or disabled item
                 [Classes.POPOVER_DISMISS]: shouldDismissPopover && !disabled && !hasSubmenu,
+                [Classes.SELECTED]: selected || (active && intentClass === undefined),
             },
             className,
         );

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -64,7 +64,7 @@ export class IconSelect extends React.PureComponent<IIconSelectProps> {
         }
         return (
             <MenuItem
-                active={modifiers.active}
+                selected={modifiers.active}
                 icon={icon === NONE ? undefined : icon}
                 key={icon}
                 onClick={handleClick}

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -42,6 +42,7 @@ export * from "./hotkeyTester";
 export { HotkeysTarget2Example } from "./hotkeysTarget2Example";
 export * from "./iconExample";
 export * from "./menuExample";
+export { MenuItemExample } from "./menuItemExample";
 export * from "./multiSliderExample";
 export * from "./navbarExample";
 export * from "./numericInputBasicExample";

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -30,7 +30,7 @@ export class MenuExample extends React.PureComponent<IExampleProps> {
                     <MenuItem icon="new-object" text="New object" />
                     <MenuItem icon="new-link" text="New link" />
                     <MenuDivider />
-                    <MenuItem icon="cog" labelElement={<Icon icon="share" />} text="Settings..." />
+                    <MenuItem icon="cog" labelElement={<Icon icon="share" />} text="Settings..." intent="primary" />
                 </Menu>
                 <Menu className={Classes.ELEVATION_1}>
                     <MenuDivider title="Edit" />

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { Classes, H5, Intent, Menu, MenuItem, Switch } from "@blueprintjs/core";
+import { Example, IExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
+
+import { IntentSelect } from "./common/intentSelect";
+
+export function MenuItemExample(props: IExampleProps) {
+    const [disabled, setDisabled] = React.useState(false);
+    const [selected, setSelected] = React.useState(false);
+    const [intent, setIntent] = React.useState<Intent>("none");
+    const [submenuEnabled, setSubmenuEnabled] = React.useState(false);
+
+    const options = (
+        <>
+            <H5>Props</H5>
+            <Switch label="Disabled" checked={disabled} onChange={handleBooleanChange(setDisabled)} />
+            <Switch label="Selected" checked={selected} onChange={handleBooleanChange(setSelected)} />
+            <Switch label="Enable submenu" checked={submenuEnabled} onChange={handleBooleanChange(setSubmenuEnabled)} />
+            <IntentSelect intent={intent} onChange={handleValueChange(setIntent)} />
+        </>
+    );
+
+    return (
+        <Example className="docs-menu-example" options={options} {...props}>
+            <Menu className={Classes.ELEVATION_1}>
+                <MenuItem
+                    disabled={disabled}
+                    selected={selected}
+                    text="Settings"
+                    icon="cog"
+                    intent={intent}
+                    labelElement={submenuEnabled ? undefined : "⌘,"}
+                    children={
+                        submenuEnabled ? (
+                            <>
+                                <MenuItem icon="add" text="Add new application" />
+                                <MenuItem icon="remove" text="Remove application" />
+                            </>
+                        ) : undefined
+                    }
+                />
+            </Menu>
+        </Example>
+    );
+}

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -22,6 +22,7 @@ import { Example, IExampleProps, handleBooleanChange, handleValueChange } from "
 import { IntentSelect } from "./common/intentSelect";
 
 export function MenuItemExample(props: IExampleProps) {
+    const [large, setLarge] = React.useState(false);
     const [disabled, setDisabled] = React.useState(false);
     const [selected, setSelected] = React.useState(false);
     const [intent, setIntent] = React.useState<Intent>("none");
@@ -30,6 +31,7 @@ export function MenuItemExample(props: IExampleProps) {
     const options = (
         <>
             <H5>Props</H5>
+            <Switch label="Large" checked={large} onChange={handleBooleanChange(setLarge)} />
             <Switch label="Disabled" checked={disabled} onChange={handleBooleanChange(setDisabled)} />
             <Switch label="Selected" checked={selected} onChange={handleBooleanChange(setSelected)} />
             <Switch label="Enable submenu" checked={submenuEnabled} onChange={handleBooleanChange(setSubmenuEnabled)} />
@@ -39,7 +41,7 @@ export function MenuItemExample(props: IExampleProps) {
 
     return (
         <Example className="docs-menu-example" options={options} {...props}>
-            <Menu className={Classes.ELEVATION_1}>
+            <Menu className={Classes.ELEVATION_1} large={large}>
                 <MenuItem
                     disabled={disabled}
                     selected={selected}

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -182,7 +182,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         }
         return (
             <MenuItem
-                active={modifiers.active}
+                selected={modifiers.active}
                 icon={this.isFilmSelected(film) ? "tick" : "blank"}
                 key={film.rank}
                 label={film.year.toString()}

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -113,7 +113,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
         );
         return (
             <MenuItem
-                active={props.modifiers.active}
+                selected={props.modifiers.active}
                 href={"#" + section.route}
                 key={section.route}
                 multiline={true}

--- a/packages/popover2/src/_popover2-in-submenu.scss
+++ b/packages/popover2/src/_popover2-in-submenu.scss
@@ -11,7 +11,11 @@
     &.#{$ns}-popover2-open > .#{$ns}-menu-item {
       // keep a trail of hovered items as submenus are opened
       @include menu-item();
-      @include menu-item-intent();
+
+      @each $intent, $colors in $menu-item-intent-colors {
+        @include menu-item-intent($intent, false, $colors...);
+      }
+
       color: inherit;
     }
   }

--- a/packages/popover2/src/_popover2-in-submenu.scss
+++ b/packages/popover2/src/_popover2-in-submenu.scss
@@ -8,16 +8,8 @@
   .#{$ns}-popover2-target {
     display: block;
 
-    &.#{$ns}-popover2-open > .#{$ns}-menu-item {
-      // keep a trail of hovered items as submenus are opened
-      @include menu-item();
-
-      @each $intent, $colors in $menu-item-intent-colors {
-        @include menu-item-intent($intent, false, $colors...);
-      }
-
-      color: inherit;
-    }
+    // MenuItem doesn't render Popover2, only Popover, so we don't need the styles
+    // which render open submenu items as hovered/selected as we do in _submenu.scss
   }
 
   &.#{$ns}-popover2 {

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -130,7 +130,7 @@ function renderCreateFilmOption(
         <MenuItem
             icon="add"
             text={`Create "${query}"`}
-            active={active}
+            selected={active}
             onClick={handleClick}
             shouldDismissPopover={false}
         />
@@ -229,7 +229,7 @@ const renderFilm: ItemRenderer<Film> = (film, { handleClick, modifiers }) => {
     }
     return (
         <MenuItem
-            active={modifiers.active}
+            selected={modifiers.active}
             key={film.title}
             label={film.year}
             onClick={handleClick}

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -218,7 +218,7 @@ export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, 
         return (
             <MenuItem
                 key={item.key}
-                active={modifiers.active}
+                selected={modifiers.active}
                 icon={item.iconName}
                 text={item.text}
                 label={item.label}


### PR DESCRIPTION
#### Fixes #4985

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Update MenuItem colors to match the intended v4 designs
- Move MenuItem "modern colors" style overrides into the default style code in `components/menu/`

#### Reviewers should focus on:

- All the different states & props for MenuItem (see new example)
- Select dropdown interactions
- MultiSelect dropdown interactions

#### Screenshot

![2021-10-27 01 32 37](https://user-images.githubusercontent.com/723999/139005635-ed03655a-5510-425c-a3db-7ab819d507f7.gif)

