### PR TITLE
[v4] [core] fix(Tag): fix colors for remove icon in minimal tags

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -92,7 +92,7 @@ $minimal-dark-tag-intent-colors-modern: (
   "primary": ($pt-intent-primary, $blue5, $blue6, $blue6),
   "success": ($pt-intent-success, $green5, $green6, $green6),
   "warning": ($pt-intent-warning, $orange5, $orange6, $orange6),
-  "danger": ($pt-intent-danger, $red5, $red1, $red6, $red6)
+  "danger": ($pt-intent-danger, $red5, $red6, $red6)
 );
 
 // Toast variables
@@ -550,6 +550,7 @@ table.#{$ns}-html-table {
   ) {
     background: $background-color;
     color: $text-color;
+
     &.#{$ns}-interactive {
       &:hover {
         background-color: $hover-color;
@@ -646,6 +647,14 @@ table.#{$ns}-html-table {
   // Contrast for default intent
   color: $white;
 
+  .#{$ns}-tag-remove {
+    &,
+    &:hover,
+    &:active {
+      opacity: 1;
+    }
+  }
+
   &.#{$ns}-interactive {
     &:hover {
       background: $dark-gray5;
@@ -708,6 +717,7 @@ table.#{$ns}-html-table {
     // Minimal style for default intent
     background-color: rgba($gray3, 0.15);
     color: $pt-text-color;
+
     &.#{$ns}-interactive {
       &:hover {
         background-color: rgba($gray3, 0.3);
@@ -718,17 +728,17 @@ table.#{$ns}-html-table {
         background-color: rgba($gray3, 0.35);
         color: $black;
       }
+    }
 
-      .#{$ns}-tag-remove > .#{$ns}-icon:first-child {
-        color: $gray1;
+    .#{$ns}-tag-remove > .#{$ns}-icon:first-child {
+      color: $gray1;
 
-        &:hover {
-          color: $dark-gray1;
-        }
+      &:hover {
+        color: $dark-gray5;
+      }
 
-        &:active {
-          color: $dark-gray1;
-        }
+      &:active {
+        color: $dark-gray5;
       }
     }
 


### PR DESCRIPTION
#### Fixes #4991

#### Changes proposed in this pull request:

- Override tag remove button `opacity` styles in "modern colors" CSS
- Fix usage of `pt-tag-minimal-dark-intent-modern()` mixin for danger intent

#### Reviewers should focus on:

No regressions

#### Screenshot

![2021-10-28 00 57 18](https://user-images.githubusercontent.com/723999/139190124-b12f782b-1166-4404-a194-fd6c3a2476b3.gif)


