### PR TITLE
[v4] [core] fix: color palette revision

### DIFF
--- a/packages/colors/src/_colors.scss
+++ b/packages/colors/src/_colors.scss
@@ -15,7 +15,7 @@ $dark-gray3: #2f343c;
 $dark-gray4: #383e47;
 $dark-gray5: #404854;
 
-$gray1: #626e7f;
+$gray1: #5f6b7c;
 $gray2: #738091;
 $gray3: #8f99a8;
 $gray4: #abb3bf;
@@ -32,28 +32,28 @@ $white: #ffffff;
 // Core colors
 
 $blue1: #184a90;
-$blue2: #1a5bb7;
-$blue3: #1a69d5;
-$blue4: #498ff3;
+$blue2: #215db0;
+$blue3: #2d72d2;
+$blue4: #4c90f0;
 $blue5: #8abbff;
 
-$green1: #165a32;
-$green2: #176d3a;
-$green3: #168845;
-$green4: #30a660;
-$green5: #72ca96;
+$green1: #165a36;
+$green2: #1C6e42;
+$green3: #238551;
+$green4: #32a467;
+$green5: #72Ca9B;
 
 $orange1: #77450d;
 $orange2: #935610;
-$orange3: #c4761c;
-$orange4: #ea9a3e;
-$orange5: #f7b264;
+$orange3: #c87619;
+$orange4: #ec9a3c;
+$orange5: #fbb360;
 
-$red1: #942427;
-$red2: #b3292d;
-$red3: #d33136;
-$red4: #e96367;
-$red5: #f99498;
+$red1: #8e292c;
+$red2: #ac2f33;
+$red3: #cd4246;
+$red4: #e76a6e;
+$red5: #fa999c;
 
 // Extended colors
 

--- a/packages/colors/src/_colors.scss
+++ b/packages/colors/src/_colors.scss
@@ -38,10 +38,10 @@ $blue4: #4c90f0;
 $blue5: #8abbff;
 
 $green1: #165a36;
-$green2: #1C6e42;
+$green2: #1c6e42;
 $green3: #238551;
 $green4: #32a467;
-$green5: #72Ca9B;
+$green5: #72ca9b;
 
 $orange1: #77450d;
 $orange2: #935610;

--- a/packages/colors/src/colors.ts
+++ b/packages/colors/src/colors.ts
@@ -23,7 +23,7 @@ const grayScale = {
     DARK_GRAY4: "#383E47",
     DARK_GRAY5: "#404854",
 
-    GRAY1: "#626E7F",
+    GRAY1: "#5F6B7C",
     GRAY2: "#738091",
     GRAY3: "#8F99A8",
     GRAY4: "#ABB3BF",
@@ -40,28 +40,28 @@ const grayScale = {
 
 const coreColors = {
     BLUE1: "#184A90",
-    BLUE2: "#1A5BB7",
-    BLUE3: "#1A69D5",
-    BLUE4: "#498FF3",
+    BLUE2: "#215DB0",
+    BLUE3: "#2D72D2",
+    BLUE4: "#4C90F0",
     BLUE5: "#8ABBFF",
 
-    GREEN1: "#165A32",
-    GREEN2: "#176D3A",
-    GREEN3: "#168845",
-    GREEN4: "#30A660",
-    GREEN5: "#72CA96",
+    GREEN1: "#165A36",
+    GREEN2: "#1C6E42",
+    GREEN3: "#238551",
+    GREEN4: "#32A467",
+    GREEN5: "#72CA9B",
 
     ORANGE1: "#77450D",
     ORANGE2: "#935610",
-    ORANGE3: "#C4761C",
-    ORANGE4: "#EA9A3E",
-    ORANGE5: "#F7B264",
+    ORANGE3: "#C87619",
+    ORANGE4: "#EC9A3C",
+    ORANGE5: "#FBB360",
 
-    RED1: "#942427",
-    RED2: "#B3292D",
-    RED3: "#D33136",
-    RED4: "#E96367",
-    RED5: "#F99498",
+    RED1: "#8E292C",
+    RED2: "#AC2F33",
+    RED3: "#CD4246",
+    RED4: "#E76A6E",
+    RED5: "#FA999C",
 };
 
 const extendedColors = {


### PR DESCRIPTION

#### Changes proposed in this pull request:

Color revision:
- `$gray1` barely fails contrast on `$light-gray4`. Tweak should fix that.
![image](https://user-images.githubusercontent.com/3513503/139195640-3338913e-d7b7-48df-96c3-25d70b4d977f.png)

- Toned down `blue` and `red` to better support background use (they are currently very bright).
![image](https://user-images.githubusercontent.com/3513503/139195791-ad6e3273-e123-4668-8692-e7cbcb4acebd.png)

- Added saturation to `$orange3` and `$orange5.
![image](https://user-images.githubusercontent.com/3513503/139195918-f200b7f7-d29c-45d0-9678-8b25b3465d0e.png)

- Shifted `green` hue very slightly from 145 to 148.
![image](https://user-images.githubusercontent.com/3513503/139195946-0c59bcfa-b22e-478b-960c-dc031f3efaee.png)


#### Reviewers should focus on:

Correct file changes

#### Screenshot
(See above)
