### PR TITLE
[v4] [colors] fix: color palette revision

### DIFF
--- a/packages/colors/src/_colors.scss
+++ b/packages/colors/src/_colors.scss
@@ -15,7 +15,7 @@ $dark-gray3: #2f343c !default;
 $dark-gray4: #383e47 !default;
 $dark-gray5: #404854 !default;
 
-$gray1: #626e7f !default;
+$gray1: #5f6b7c !default;
 $gray2: #738091 !default;
 $gray3: #8f99a8 !default;
 $gray4: #abb3bf !default;

--- a/packages/colors/src/colors.ts
+++ b/packages/colors/src/colors.ts
@@ -23,7 +23,7 @@ const grayScale = {
     DARK_GRAY4: "#383E47",
     DARK_GRAY5: "#404854",
 
-    GRAY1: "#626E7F",
+    GRAY1: "#5F6B7C",
     GRAY2: "#738091",
     GRAY3: "#8F99A8",
     GRAY4: "#ABB3BF",
@@ -40,28 +40,28 @@ const grayScale = {
 
 const coreColors = {
     BLUE1: "#184A90",
-    BLUE2: "#1A5BB7",
-    BLUE3: "#1A69D5",
-    BLUE4: "#498FF3",
+    BLUE2: "#215DB0",
+    BLUE3: "#2D72D2",
+    BLUE4: "#4C90F0",
     BLUE5: "#8ABBFF",
 
-    GREEN1: "#165A32",
-    GREEN2: "#176D3A",
-    GREEN3: "#168845",
-    GREEN4: "#30A660",
-    GREEN5: "#72CA96",
+    GREEN1: "#165A36",
+    GREEN2: "#1C6E42",
+    GREEN3: "#238551",
+    GREEN4: "#32A467",
+    GREEN5: "#72CA9B",
 
     ORANGE1: "#77450D",
     ORANGE2: "#935610",
-    ORANGE3: "#C4761C",
-    ORANGE4: "#EA9A3E",
-    ORANGE5: "#F7B264",
+    ORANGE3: "#C87619",
+    ORANGE4: "#EC9A3C",
+    ORANGE5: "#FBB360",
 
-    RED1: "#942427",
-    RED2: "#B3292D",
-    RED3: "#D33136",
-    RED4: "#E96367",
-    RED5: "#F99498",
+    RED1: "#8E292C",
+    RED2: "#AC2F33",
+    RED3: "#CD4246",
+    RED4: "#E76A6E",
+    RED5: "#FA999C",
 };
 
 const extendedColors = {


### PR DESCRIPTION
#### Supersedes https://github.com/palantir/blueprint/pull/4993; colors designed by @aycai 

#### Changes proposed in this pull request:

Color revision:
- `$gray1` barely fails contrast on `$light-gray4`. Tweak should fix that.
![image](https://user-images.githubusercontent.com/3513503/139195640-3338913e-d7b7-48df-96c3-25d70b4d977f.png)

- Toned down `blue` and `red` to better support background use (they are currently very bright).
![image](https://user-images.githubusercontent.com/3513503/139195791-ad6e3273-e123-4668-8692-e7cbcb4acebd.png)

- Added saturation to `$orange3` and `$orange5.
![image](https://user-images.githubusercontent.com/3513503/139195918-f200b7f7-d29c-45d0-9678-8b25b3465d0e.png)

- Shifted `green` hue very slightly from 145 to 148.
![image](https://user-images.githubusercontent.com/3513503/139195946-0c59bcfa-b22e-478b-960c-dc031f3efaee.png)
