### PR TITLE
[v4] [icons] feat: add getIconFontCodepoint() API

### DIFF
--- a/packages/icons/src/iconCodepoints.ts
+++ b/packages/icons/src/iconCodepoints.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { BLUEPRINT_ICONS_16_CODEPOINTS } from "./generated/16px/blueprint-icons-16";
 import type { IconName } from "./iconNames";
 // icon sets are identical aside from SVG paths, so we just import the info for the 16px set
-import { BLUEPRINT_ICONS_16_CODEPOINTS } from "./generated/16px/blueprint-icons-16";
 
 /**
  * Icon codepoints as base 10 number strings. If you need to render these strings

--- a/packages/icons/src/iconCodepoints.ts
+++ b/packages/icons/src/iconCodepoints.ts
@@ -20,8 +20,8 @@ import type { IconName } from "./iconNames";
 
 /**
  * Icon codepoints as base 10 number strings. If you need to render these strings
- * into an SVG document or as ::before pseudo content, consider using `getIconFontCodepoint()`
- * instead;
+ * into an SVG document or as `::before` pseudo content, consider using `getIconFontCodepoint()`
+ * instead.
  */
 export const IconCodepoints = BLUEPRINT_ICONS_16_CODEPOINTS;
 

--- a/packages/icons/src/iconCodepoints.ts
+++ b/packages/icons/src/iconCodepoints.ts
@@ -16,9 +16,14 @@
 
 import type { IconName } from "./iconNames";
 // icon sets are identical aside from SVG paths, so we just import the info for the 16px set
-import { BLUEPRINT_ICONS_16_CODEPOINTS as IconCodepoints } from "./generated/16px/blueprint-icons-16";
+import { BLUEPRINT_ICONS_16_CODEPOINTS } from "./generated/16px/blueprint-icons-16";
 
-export { IconCodepoints };
+/**
+ * Icon codepoints as base 10 number strings. If you need to render these strings
+ * into an SVG document or as ::before pseudo content, consider using `getIconFontCodepoint()`
+ * instead;
+ */
+export const IconCodepoints = BLUEPRINT_ICONS_16_CODEPOINTS;
 
 /**
  * Returns the hex code content string which represents the codepoint in the icon font

--- a/packages/icons/src/iconCodepoints.ts
+++ b/packages/icons/src/iconCodepoints.ts
@@ -14,5 +14,18 @@
  * limitations under the License.
  */
 
+import type { IconName } from "./iconNames";
 // icon sets are identical aside from SVG paths, so we just import the info for the 16px set
-export { BLUEPRINT_ICONS_16_CODEPOINTS as IconCodepoints } from "./generated/16px/blueprint-icons-16";
+import { BLUEPRINT_ICONS_16_CODEPOINTS as IconCodepoints } from "./generated/16px/blueprint-icons-16";
+
+export { IconCodepoints };
+
+/**
+ * Returns the hex code content string which represents the codepoint in the icon font
+ * for a given icon. You can render this string to the DOM and if the icon font is loaded
+ * as an active font family, this string will be replaced with the associated icon.
+ */
+export function getIconFontCodepoint(icon: IconName) {
+    // parse base 10 number from string, then convert to hex code
+    return parseInt(IconCodepoints[icon], 10).toString(16);
+}

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "./iconSvgPaths";
-export { getIconFontContentString, IconCodepoints } from "./iconCodepoints";
+export { getIconFontCodepoint, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "./iconSvgPaths";
-export { IconCodepoints } from "./iconCodepoints";
+export { getIconFontContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";


### PR DESCRIPTION

#### Changes proposed in this pull request:

It turns out the icon font build pipeline changes made the `IconCodepoints` API much less usable in v4.0. It now contains the base 10 number representations of the icon codepoints, when what you really need when rendering these strings to the DOM is a base 16 hex code.

This new public API getIconFontCodepoint makes it easy to get the hex code, achieving parity with Blueprint 3.x.