### PR TITLE
[v4] [core] fix(Textarea): match text input border style

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -286,38 +286,36 @@ table.#{$ns}-html-table {
 }
 
 // Contrast for inputs
-.#{$ns}-input-group {
-  .#{$ns}-input {
-    // Use intent-styled box-shadows for default intent
-    box-shadow: input-transition-shadow($input-shadow-color-focus),
-        inset border-shadow(1, $gray2),
-        $pt-input-box-shadow;
+.#{$ns}-input {
+  // Use intent-styled box-shadows for default intent
+  box-shadow: input-transition-shadow($input-shadow-color-focus),
+      inset border-shadow(1, $gray2),
+      $pt-input-box-shadow;
+
+  &:focus {
+    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+  }
+
+  .#{$ns}-dark & {
+    box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus),
+      inset border-shadow(1, $gray3),
+      $pt-dark-input-box-shadow;
 
     &:focus {
-      box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
-    }
-
-    .#{$ns}-dark & {
-      box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus),
-        inset border-shadow(1, $gray3),
-        $pt-dark-input-box-shadow;
-
-      &:focus {
-        box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true),
-                      $pt-dark-input-box-shadow;
-      }
-    }
-
-    &:disabled {
-      box-shadow: none;
+      box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true),
+                    $pt-dark-input-box-shadow;
     }
   }
 
-  @each $intent, $color in $dark-input-intent-box-shadow-colors {
-    &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-input {
-        @include pt-dark-input-intent($color);
-      }
+  &:disabled {
+    box-shadow: none;
+  }
+}
+
+@each $intent, $color in $dark-input-intent-box-shadow-colors {
+  &.#{$ns}-intent-#{$intent} {
+    .#{$ns}-input {
+      @include pt-dark-input-intent($color);
     }
   }
 }

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -108,8 +108,4 @@ textarea.#{$ns}-input {
   &.#{$ns}-small {
     padding: $input-small-padding;
   }
-
-  .#{$ns}-dark & {
-    @include pt-dark-input();
-  }
 }


### PR DESCRIPTION
#### Fixes #5003

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Expand CSS selectors for the "modern colors" style overrides for text inputs so that they cover textarea elements as well.

#### Reviewers should focus on:

No regressions for text inputs or other form controls

#### Screenshot

![image](https://user-images.githubusercontent.com/723999/140168095-4bbbbc27-806e-4b75-b454-97d468c22930.png)

![image](https://user-images.githubusercontent.com/723999/140168114-6b28e547-526b-4949-9cce-e834fed1f861.png)

