### PR TITLE
[v4] [core] chore: fix isolatedModules compilation error

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -21,7 +21,7 @@ import { IconName, IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } fr
 
 import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IntentProps, Props, MaybeElement } from "../../common";
 
-export type { IconName }
+export type { IconName };
 
 export enum IconSize {
     STANDARD = 16,

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -21,7 +21,7 @@ import { IconName, IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } fr
 
 import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IntentProps, Props, MaybeElement } from "../../common";
 
-export { IconName };
+export type { IconName }
 
 export enum IconSize {
     STANDARD = 16,


### PR DESCRIPTION
Simple build error fix, when isolatedModules flag is provided.

```
Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.  TS1205

    22 | import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, IntentProps, Props, MaybeElement } from "../../common";
    23 | 
  > 24 | export { IconName };
       |          ^
    25 | 
    26 | export enum IconSize {
    27 |     STANDARD = 16,

```
