### PR TITLE
[v4] [core] fix(AnchorButton): warning button colors

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -151,21 +151,24 @@ $tree-intent-icon-colors-modern: (
 // Contrast for buttons
 .#{$ns}-button {
   // Use dark text for warning intent
-  &.#{$ns}-intent-warning:not([class*="#{$ns}-minimal"]) {
-    &:not(:disabled):not(.#{$ns}-disabled) {
-      background: $orange5;
-      color: $pt-text-color;
+  &.#{$ns}-intent-warning {
+    background: $orange5;
+    color: $pt-text-color;
 
-      .#{$ns}-icon > svg {
-        fill: rgba($dark-gray1, 0.7);
-      }
+    .#{$ns}-icon > svg {
+      fill: rgba($dark-gray1, 0.7);
+    }
 
+    &:not(.#{$ns}-disabled):not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       &:hover {
         background: $orange4;
+        color: $pt-text-color;
       }
 
-      &:active {
+      &:active,
+      &.#{$ns}-active {
         background: $orange3;
+        color: $pt-text-color;
       }
     }
 
@@ -175,11 +178,21 @@ $tree-intent-icon-colors-modern: (
       color: rgba($dark-gray1, 0.35);
 
       .#{$ns}-dark & {
-        color: $pt-dark-text-color-disabled;
+        color: rgba($dark-gray1, 0.6);
+      }
+    }
+
+    &.#{$ns}-minimal,
+    &.#{$ns}-outlined {
+      background: none;
+
+      .#{$ns}-dark & {
+        .#{$ns}-icon > svg {
+          fill: $orange5;
+        }
       }
     }
   }
-
 
   &.#{$ns}-minimal {
     @mixin pt-button-minimal-intent-modern($active-text-color) {

--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -152,12 +152,12 @@ $tree-intent-icon-colors-modern: (
 .#{$ns}-button {
   // Use dark text for warning intent
   &.#{$ns}-intent-warning:not([class*="#{$ns}-minimal"]) {
-    &:not(:disabled) {
+    &:not(:disabled):not(.#{$ns}-disabled) {
       background: $orange5;
       color: $pt-text-color;
 
-      .#{$ns}-icon>svg:not([fill]) {
-        color: rgba($dark-gray1, 0.7);
+      .#{$ns}-icon > svg {
+        fill: rgba($dark-gray1, 0.7);
       }
 
       &:hover {
@@ -169,8 +169,10 @@ $tree-intent-icon-colors-modern: (
       }
     }
 
-    &:disabled {
-      color: $pt-text-color-disabled;
+    &:disabled,
+    &.#{$ns}-disabled {
+      background: rgba($orange3, 0.5);
+      color: rgba($dark-gray1, 0.35);
 
       .#{$ns}-dark & {
         color: $pt-dark-text-color-disabled;

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -17,8 +17,9 @@
 import * as React from "react";
 
 import { AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
 
+import { IntentSelect } from "./common/intentSelect"
 import { Size, SizeSelect } from "./common/sizeSelect";
 
 export interface IButtonsExampleState {
@@ -60,6 +61,8 @@ export class ButtonsExample extends React.PureComponent<IExampleProps, IButtonsE
 
     private handleSizeChange = (size: Size) => this.setState({ size });
 
+    private handleIntentChange = handleValueChange((intent: Intent) => this.setState({ intent }));
+
     private wiggleTimeoutId: number;
 
     public componentWillUnmount() {
@@ -78,6 +81,7 @@ export class ButtonsExample extends React.PureComponent<IExampleProps, IButtonsE
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
                 <SizeSelect size={this.state.size} onChange={this.handleSizeChange} />
+                <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <H5>Example</H5>
                 <Switch label="Icons only" checked={this.state.iconOnly} onChange={this.handleIconOnlyChange} />
             </>

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
 
-import { IntentSelect } from "./common/intentSelect"
+import { IntentSelect } from "./common/intentSelect";
 import { Size, SizeSelect } from "./common/sizeSelect";
 
 export interface IButtonsExampleState {


### PR DESCRIPTION
#### Fixes #5017

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update styling for "warning" intent disabled buttons to match the intended designs

Before:

<img width="441" alt="Screen Shot 2021-11-10 at 8 27 13 PM" src="https://user-images.githubusercontent.com/723999/141221406-12cffef0-1222-4b99-aea8-cb1c3f306edc.png">

After:

<img width="416" alt="Screen Shot 2021-11-10 at 8 36 03 PM" src="https://user-images.githubusercontent.com/723999/141221419-be0a2aa5-5d9b-4837-9174-4c70b04b40cc.png">


#### Reviewers should focus on:

No regressions in other buttons

#### Screenshot

See above
