### PR TITLE
[core] feat(FormGroup): add support for "sub label" text

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -184,6 +184,7 @@ export const HOTKEY_COLUMN = `${HOTKEY}-column`;
 export const HOTKEY_DIALOG = `${HOTKEY}-dialog`;
 
 export const LABEL = `${NS}-label`;
+export const LABEL_HELPER_TEXT = `${NS}-label-helper-text`;
 export const FORM_GROUP = `${NS}-form-group`;
 export const FORM_CONTENT = `${NS}-form-content`;
 export const FORM_HELPER_TEXT = `${NS}-form-helper-text`;

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -188,6 +188,7 @@ export const LABEL_HELPER_TEXT = `${NS}-label-helper-text`;
 export const FORM_GROUP = `${NS}-form-group`;
 export const FORM_CONTENT = `${NS}-form-content`;
 export const FORM_HELPER_TEXT = `${NS}-form-helper-text`;
+export const FORM_GROUP_SUB_LABEL = `${NS}-form-group-sub-label`;
 
 export const MENU = `${NS}-menu`;
 export const MENU_ITEM = `${MENU}-item`;

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -184,7 +184,6 @@ export const HOTKEY_COLUMN = `${HOTKEY}-column`;
 export const HOTKEY_DIALOG = `${HOTKEY}-dialog`;
 
 export const LABEL = `${NS}-label`;
-export const LABEL_HELPER_TEXT = `${NS}-label-helper-text`;
 export const FORM_GROUP = `${NS}-form-group`;
 export const FORM_CONTENT = `${NS}-form-content`;
 export const FORM_HELPER_TEXT = `${NS}-form-helper-text`;

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -45,15 +45,24 @@ Styleguide form-group
     margin-top: ($pt-input-height - $control-indicator-size) / 2;
   }
 
+  .#{$ns}-label-helper-text,
   .#{$ns}-form-helper-text {
     color: $pt-text-color-muted;
     font-size: $pt-font-size-small;
+  }
+
+  .#{$ns}-label-helper-text {
+    margin-bottom: $pt-grid-size / 2;
+  }
+
+  .#{$ns}-form-helper-text {
     margin-top: $pt-grid-size / 2;
   }
 
   /* stylelint-disable-next-line order/declaration-block-order */
   @each $intent, $color in $pt-intent-text-colors {
     &.#{$ns}-intent-#{$intent} {
+      .#{$ns}-label-helper-text,
       .#{$ns}-form-helper-text {
         color: $color;
       }
@@ -78,6 +87,7 @@ Styleguide form-group
   &.#{$ns}-disabled {
     .#{$ns}-label,
     .#{$ns}-text-muted,
+    .#{$ns}-label-helper-text,
     .#{$ns}-form-helper-text {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
@@ -88,6 +98,7 @@ Styleguide form-group
   .#{$ns}-dark & {
     @each $intent, $color in $pt-dark-intent-text-colors {
       &.#{$ns}-intent-#{$intent} {
+        .#{$ns}-label-helper-text,
         .#{$ns}-form-helper-text {
           color: $color;
         }
@@ -101,6 +112,7 @@ Styleguide form-group
     &.#{$ns}-disabled {
       .#{$ns}-label,
       .#{$ns}-text-muted,
+      .#{$ns}-label-helper-text,
       .#{$ns}-form-helper-text {
         // disabled state always overrides over styles
         /* stylelint-disable-next-line declaration-no-important */

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -45,13 +45,13 @@ Styleguide form-group
     margin-top: ($pt-input-height - $control-indicator-size) / 2;
   }
 
-  .#{$ns}-label-helper-text,
+  .#{$ns}-form-group-sub-label,
   .#{$ns}-form-helper-text {
     color: $pt-text-color-muted;
     font-size: $pt-font-size-small;
   }
 
-  .#{$ns}-label-helper-text {
+  .#{$ns}-form-group-sub-label {
     margin-bottom: $pt-grid-size / 2;
   }
 
@@ -62,7 +62,7 @@ Styleguide form-group
   /* stylelint-disable-next-line order/declaration-block-order */
   @each $intent, $color in $pt-intent-text-colors {
     &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-label-helper-text,
+      .#{$ns}-form-group-sub-label,
       .#{$ns}-form-helper-text {
         color: $color;
       }
@@ -87,7 +87,7 @@ Styleguide form-group
   &.#{$ns}-disabled {
     .#{$ns}-label,
     .#{$ns}-text-muted,
-    .#{$ns}-label-helper-text,
+    .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
@@ -98,7 +98,7 @@ Styleguide form-group
   .#{$ns}-dark & {
     @each $intent, $color in $pt-dark-intent-text-colors {
       &.#{$ns}-intent-#{$intent} {
-        .#{$ns}-label-helper-text,
+        .#{$ns}-form-group-sub-label,
         .#{$ns}-form-helper-text {
           color: $color;
         }
@@ -112,7 +112,7 @@ Styleguide form-group
     &.#{$ns}-disabled {
       .#{$ns}-label,
       .#{$ns}-text-muted,
-      .#{$ns}-label-helper-text,
+      .#{$ns}-form-group-sub-label,
       .#{$ns}-form-helper-text {
         // disabled state always overrides over styles
         /* stylelint-disable-next-line declaration-no-important */

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -51,6 +51,13 @@ export interface IFormGroupProps extends IntentProps, Props {
     label?: React.ReactNode;
 
     /**
+     * Optional helper text for `label`. The given content will be wrapped in
+     * `Classes.FORM_HELPER_TEXT` and displayed beneath `label`. Helper text
+     * color is determined by the `intent`.
+     */
+    labelHelperText?: React.ReactNode;
+
+    /**
      * `id` attribute of the labelable form element that this `FormGroup` controls,
      * used as `<label for>` attribute.
      */
@@ -70,7 +77,16 @@ export class FormGroup extends AbstractPureComponent2<FormGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.FormGroup`;
 
     public render() {
-        const { children, contentClassName, helperText, label, labelFor, labelInfo, style } = this.props;
+        const {
+            children,
+            contentClassName,
+            helperText,
+            label,
+            labelFor,
+            labelHelperText,
+            labelInfo,
+            style,
+        } = this.props;
         return (
             <div className={this.getClassName()} style={style}>
                 {label && (
@@ -78,6 +94,7 @@ export class FormGroup extends AbstractPureComponent2<FormGroupProps> {
                         {label} <span className={Classes.TEXT_MUTED}>{labelInfo}</span>
                     </label>
                 )}
+                {labelHelperText && <div className={Classes.LABEL_HELPER_TEXT}>{labelHelperText}</div>}
                 <div className={classNames(Classes.FORM_CONTENT, contentClassName)}>
                     {children}
                     {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -51,13 +51,6 @@ export interface IFormGroupProps extends IntentProps, Props {
     label?: React.ReactNode;
 
     /**
-     * Optional helper text for `label`. The given content will be wrapped in
-     * `Classes.FORM_HELPER_TEXT` and displayed beneath `label`. Helper text
-     * color is determined by the `intent`.
-     */
-    labelHelperText?: React.ReactNode;
-
-    /**
      * `id` attribute of the labelable form element that this `FormGroup` controls,
      * used as `<label for>` attribute.
      */
@@ -70,6 +63,13 @@ export interface IFormGroupProps extends IntentProps, Props {
 
     /** CSS properties to apply to the root element. */
     style?: React.CSSProperties;
+
+    /**
+     * Optional text for `label`. The given content will be wrapped in
+     * `Classes.FORM_GROUP_SUB_LABEL` and displayed beneath `label`. The text color
+     * is determined by the `intent`.
+     */
+    subLabel?: React.ReactNode;
 }
 
 @polyfill
@@ -77,16 +77,7 @@ export class FormGroup extends AbstractPureComponent2<FormGroupProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.FormGroup`;
 
     public render() {
-        const {
-            children,
-            contentClassName,
-            helperText,
-            label,
-            labelFor,
-            labelHelperText,
-            labelInfo,
-            style,
-        } = this.props;
+        const { children, contentClassName, helperText, label, labelFor, labelInfo, style, subLabel } = this.props;
         return (
             <div className={this.getClassName()} style={style}>
                 {label && (
@@ -94,7 +85,7 @@ export class FormGroup extends AbstractPureComponent2<FormGroupProps> {
                         {label} <span className={Classes.TEXT_MUTED}>{labelInfo}</span>
                     </label>
                 )}
-                {labelHelperText && <div className={Classes.LABEL_HELPER_TEXT}>{labelHelperText}</div>}
+                {subLabel && <div className={Classes.FORM_GROUP_SUB_LABEL}>{subLabel}</div>}
                 <div className={classNames(Classes.FORM_CONTENT, contentClassName)}>
                     {children}
                     {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -27,6 +27,7 @@ export interface IFormGroupExampleState {
     inline: boolean;
     intent: Intent;
     label: boolean;
+    labelHelperText: boolean;
     requiredLabel: boolean;
 }
 
@@ -37,6 +38,7 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
         inline: false,
         intent: Intent.NONE,
         label: true,
+        labelHelperText: false,
         requiredLabel: true,
     };
 
@@ -50,10 +52,12 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
 
     private handleRequiredLabelChange = handleBooleanChange(requiredLabel => this.setState({ requiredLabel }));
 
+    private handleLabelHelperTextChange = handleBooleanChange(labelHelperText => this.setState({ labelHelperText }));
+
     private handleIntentChange = handleValueChange((intent: Intent) => this.setState({ intent }));
 
     public render() {
-        const { disabled, helperText, inline, intent, label, requiredLabel } = this.state;
+        const { disabled, helperText, inline, intent, label, labelHelperText, requiredLabel } = this.state;
 
         const options = (
             <>
@@ -63,6 +67,11 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                 <Switch label="Show helper text" checked={helperText} onChange={this.handleHelperTextChange} />
                 <Switch label="Show label" checked={label} onChange={this.handleLabelChange} />
                 <Switch label="Show label info" checked={requiredLabel} onChange={this.handleRequiredLabelChange} />
+                <Switch
+                    label="Show label helper text"
+                    checked={labelHelperText}
+                    onChange={this.handleLabelHelperTextChange}
+                />
                 <IntentSelect intent={intent} onChange={this.handleIntentChange} />
             </>
         );
@@ -76,6 +85,7 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                     intent={intent}
                     label={label && "Label"}
                     labelFor="text-input"
+                    labelHelperText={labelHelperText && "Label helper text with details..."}
                     labelInfo={requiredLabel && "(required)"}
                 >
                     <InputGroup id="text-input" placeholder="Placeholder text" disabled={disabled} intent={intent} />

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -27,7 +27,7 @@ export interface IFormGroupExampleState {
     inline: boolean;
     intent: Intent;
     label: boolean;
-    labelHelperText: boolean;
+    subLabel: boolean;
     requiredLabel: boolean;
 }
 
@@ -38,8 +38,8 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
         inline: false,
         intent: Intent.NONE,
         label: true,
-        labelHelperText: false,
         requiredLabel: true,
+        subLabel: false,
     };
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
@@ -52,12 +52,12 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
 
     private handleRequiredLabelChange = handleBooleanChange(requiredLabel => this.setState({ requiredLabel }));
 
-    private handleLabelHelperTextChange = handleBooleanChange(labelHelperText => this.setState({ labelHelperText }));
+    private handleSubLabelChange = handleBooleanChange(subLabel => this.setState({ subLabel }));
 
     private handleIntentChange = handleValueChange((intent: Intent) => this.setState({ intent }));
 
     public render() {
-        const { disabled, helperText, inline, intent, label, labelHelperText, requiredLabel } = this.state;
+        const { disabled, helperText, inline, intent, label, subLabel, requiredLabel } = this.state;
 
         const options = (
             <>
@@ -67,11 +67,7 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                 <Switch label="Show helper text" checked={helperText} onChange={this.handleHelperTextChange} />
                 <Switch label="Show label" checked={label} onChange={this.handleLabelChange} />
                 <Switch label="Show label info" checked={requiredLabel} onChange={this.handleRequiredLabelChange} />
-                <Switch
-                    label="Show label helper text"
-                    checked={labelHelperText}
-                    onChange={this.handleLabelHelperTextChange}
-                />
+                <Switch label="Show sub label" checked={subLabel} onChange={this.handleSubLabelChange} />
                 <IntentSelect intent={intent} onChange={this.handleIntentChange} />
             </>
         );
@@ -85,8 +81,8 @@ export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGr
                     intent={intent}
                     label={label && "Label"}
                     labelFor="text-input"
-                    labelHelperText={labelHelperText && "Label helper text with details..."}
                     labelInfo={requiredLabel && "(required)"}
+                    subLabel={subLabel && "Label helper text with details..."}
                 >
                     <InputGroup id="text-input" placeholder="Placeholder text" disabled={disabled} intent={intent} />
                 </FormGroup>


### PR DESCRIPTION
#### Fixes #5019

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
To resolve #5019 this PR adds a new prop `labelHelperText` to `FormGroup` which adds helperText between `label` and `children`.

#### Reviewers should focus on:
We could have ignored the `labelHelperText` if `label` is empty, but decided against it as it seemed to add unnecessary complexity. Similarly, there's no restriction on specifying only one type of helperText. It looks slightly odd when both helper texts are used, but we may end up using both with one of our use case where we have a list of fields specified as `children`.

#### Screenshot
<img width="794" alt="Screen Shot 2021-11-22 at 10 36 24 AM" src="https://user-images.githubusercontent.com/16532/142916641-3517e941-3149-4d8a-9e70-9c8cad3ddc50.png">
