### PR TITLE
[v4] [core] Update button borders and background gradient

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -50,11 +50,11 @@ $button-box-shadow-overlay-active:
 $dark-button-box-shadow:
   inset 0 0 0 1px rgba(17, 20, 24, 0.8) !default;
 $dark-button-box-shadow-active:
-  inset 0 0 0 1px rgba(17, 20, 24, 0.8)!default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8) !default;
 $dark-button-intent-box-shadow:
-  inset 0 0 0 1px rgba(17, 20, 24, 0.8)!default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8) !default;
 $dark-button-intent-box-shadow-active:
-  inset 0 0 0 1px rgba(17, 20, 24, 0.8)!default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8) !default;
 
 $button-gradient: linear-gradient(to bottom, rgba($black, 0), rgba($black, 0.05)) !default;
 $button-intent-gradient: linear-gradient(to bottom, rgba($black, 0), rgba($black, 0.05)) !default;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -48,19 +48,17 @@ $button-box-shadow-overlay-active:
   inset 0 1px 1px rgba($black, 0.1) !default;
 
 $dark-button-box-shadow:
-  0 0 0 $button-border-width rgba($black, 0.4) !default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8) !default;
 $dark-button-box-shadow-active:
-  0 0 0 $button-border-width rgba($black, 0.6),
-  inset 0 1px 2px rgba($black, 0.2) !default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8)!default;
 $dark-button-intent-box-shadow:
-  0 0 0 $button-border-width rgba($black, 0.4) !default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8)!default;
 $dark-button-intent-box-shadow-active:
-  0 0 0 $button-border-width rgba($black, 0.4),
-  inset 0 1px 2px rgba($black, 0.2) !default;
+  inset 0 0 0 1px rgba(17, 20, 24, 0.8)!default;
 
-$button-gradient: linear-gradient(to bottom, rgba($white, 0.8), rgba($white, 0)) !default;
-$button-intent-gradient: linear-gradient(to bottom, rgba($white, 0.1), rgba($white, 0)) !default;
-$dark-button-gradient: linear-gradient(to bottom, rgba($white, 0.05), rgba($white, 0)) !default;
+$button-gradient: linear-gradient(to bottom, rgba($black, 0), rgba($black, 0.05)) !default;
+$button-intent-gradient: linear-gradient(to bottom, rgba($black, 0), rgba($black, 0.05)) !default;
+$dark-button-gradient: linear-gradient(to bottom, rgba($black, 0), rgba($black, 0.05)) !default;
 
 $button-color-disabled: $pt-text-color-disabled !default;
 $button-background-color: $light-gray5 !default;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
* Update button borders to be consistently inset across light mode and dark mode
* Update button background gradients 

#### Reviewers should focus on:

<!-- Fill this out. -->


#### Screenshot
##### Light mode 
| Static | Hover | Active |
| --- | --- | --- |
| Before | 
![1  before static light](https://user-images.githubusercontent.com/5934779/144130909-07264a37-cd90-468c-b122-f8b9af9525ff.png) | ![2  before hover light](https://user-images.githubusercontent.com/5934779/144130920-f876330d-4218-4476-bfac-8d5c7209f989.png) | ![3  before active light](https://user-images.githubusercontent.com/5934779/144130923-489ded24-1142-4b98-99cf-a5caf0f0800b.png) |
| After |
| ![1  after static light](https://user-images.githubusercontent.com/5934779/144131041-73f00825-f5f6-40b0-9fbf-cffe6d127ecc.png) | ![2  after hover light](https://user-images.githubusercontent.com/5934779/144131045-9339375a-6d13-434b-8e4f-faf8092350dd.png) | ![3  after active light](https://user-images.githubusercontent.com/5934779/144131052-55cfa5d9-b04e-4b48-8e3b-bf27cbf7f429.png) |

##### Dark mode
| Static | Hover | Active |
| --- | --- | --- |
| Before | 
| ![4  before static dark](https://user-images.githubusercontent.com/5934779/144131244-c8b68023-ee5f-4732-b105-9e57c04f2da9.png) | ![5  before hover dark](https://user-images.githubusercontent.com/5934779/144131251-281a6ab1-6aa2-47cd-84e1-6c0b1287af33.png) | ![6  before active dark](https://user-images.githubusercontent.com/5934779/144131268-9075c1c9-c52a-4576-b525-328cf93933ee.png) |
| After | 
| ![4  after static dark](https://user-images.githubusercontent.com/5934779/144131415-49ee3156-fc4e-40bc-9587-847a3d514994.png) | ![5  after hover dark](https://user-images.githubusercontent.com/5934779/144131434-52670744-f4f7-45df-bb32-d7303a9d6f74.png) | ![6  after active dark](https://user-images.githubusercontent.com/5934779/144131453-e623b237-2e9e-42b1-8201-c532be05a7cb.png) |



