### PR TITLE
fix: renamed Placement export in popover2 to PopperPlacements

### DIFF
--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -43,7 +43,7 @@ import {
 import {
     Classes,
     Popover2SharedProps,
-    Placement,
+    PopperPlacements,
     PlacementOptions,
     Popover2,
     Popover2InteractionKind,
@@ -72,7 +72,7 @@ export interface IPopover2ExampleState {
     isOpen?: boolean;
     minimal?: boolean;
     modifiers?: Popover2SharedProps<HTMLElement>["modifiers"];
-    placement?: Placement;
+    placement?: PopperPlacements;
     sliderValue?: number;
     usePortal?: boolean;
 }
@@ -113,7 +113,7 @@ export class Popover2Example extends React.PureComponent<IExampleProps, IPopover
         this.setState({ interactionKind, hasBackdrop });
     });
 
-    private handlePlacementChange = handleValueChange((placement: Placement) => this.setState({ placement }));
+    private handlePlacementChange = handleValueChange((placement: PopperPlacements) => this.setState({ placement }));
 
     private handleBoundaryChange = handleValueChange((boundary: IPopover2ExampleState["boundary"]) =>
         this.setState({ boundary }),

--- a/packages/docs-app/src/examples/popover2-examples/popover2PlacementExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2PlacementExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Button, Classes, Code } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { Popover2, Placement } from "@blueprintjs/popover2";
+import { Popover2, PopperPlacements } from "@blueprintjs/popover2";
 
 const EXAMPLE_CLASS = "docs-popover2-placement-example";
 const SIDE_LABEL_CLASS = "docs-popover2-placement-label-side";
@@ -74,7 +74,7 @@ export class Popover2PlacementExample extends React.PureComponent<IExampleProps>
         );
     }
 
-    private renderPopover(placement: Placement) {
+    private renderPopover(placement: PopperPlacements) {
         const [sideLabel, alignmentLabel] = placement.split("-");
         const sideSpan = <span className={SIDE_LABEL_CLASS}>{sideLabel}</span>;
 

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -31,7 +31,7 @@ export {
     Popover2SharedProps,
     Popover2TargetProps,
     PopperBoundary,
-    Placement,
+    PopperPlacements,
     PlacementOptions,
     StrictModifierNames,
 } from "./popover2SharedProps";

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -19,7 +19,7 @@ import { StrictModifier } from "react-popper";
 
 import { OverlayableProps, Props, PopoverPosition } from "@blueprintjs/core";
 
-export { Boundary as PopperBoundary, Placement, placements as PlacementOptions };
+export { Boundary as PopperBoundary, Placement as PopperPlacements, placements as PlacementOptions };
 // copied from @popperjs/core, where it is not exported as public
 export type StrictModifierNames = NonNullable<StrictModifiers["name"]>;
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

According to current [documentation](https://blueprintjs.com/docs/#popover2-package/popover2.placement), `PopperPlacements` "defines the full set of supported values" for the `Popover` prop `placement`. [Currently](https://github.com/palantir/blueprint/blob/23dea38f732ccc5d81a1e0c82d8e6b79e0c9f9a7/packages/popover2/src/index.ts#L34), this enum is being exported as `Placement`. This PR assumes the docs are correct and seeks to correct the export name.

#### Reviewers should focus on:

N/A

#### Screenshot

N/A
