### PR TITLE
[v4] [core] feat: update checkbox and radio colors

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -28,14 +28,6 @@ $dark-minimal-button-intents-modern: (
   "warning": (rgba($orange3, 0.2), $orange5, rgba($orange3, 0.3), $orange6),
   "danger": (rgba($red3, 0.2), $red5, rgba($red3, 0.3), $red6)
 );
-$minimal-button-background-color-hover: rgba($gray3, 0.15);
-$minimal-button-background-color-active: rgba($gray3, 0.3);
-
-// Checkbox and Radio variable overrides
-$dark-control-background-color: $gray4;
-$dark-control-background-color-hover: $gray3;
-$dark-control-background-color-active: linear-gradient(0deg, rgba($white, 0.1), rgba($white, 0.1)),
-  linear-gradient(0deg, $gray2, $gray2);
 
 // Editable text variable overrides
 $input-placeholder-color: $gray1;
@@ -237,37 +229,7 @@ $tree-intent-icon-colors-modern: (
   }
 }
 
-// Contrast for checkboxes and radio buttons
-.#{$ns}-control {
-  input:focus ~ .#{$ns}-control-indicator {
-    outline: $blue3 auto 2px;
-  }
-
-  &.#{$ns}-checkbox, &.#{$ns}-radio {
-    .#{$ns}-control-indicator {
-      box-shadow:
-        inset 0 0 0 $button-border-width rgba($black, 0.5),
-        inset 0 (-$button-border-width) 0 rgba($black, 0.1);
-    }
-  }
-
-  .#{$ns}-dark & {
-    input:focus ~ .#{$ns}-control-indicator {
-      outline: $blue5 auto 2px;
-    }
-
-    &.#{$ns}-checkbox, &.#{$ns}-radio {
-      input:not(:disabled):not(:checked) ~ .#{$ns}-control-indicator {
-        box-shadow: $dark-button-box-shadow-active;
-      }
-
-      input:not(:disabled):active:checked ~ .#{$ns}-control-indicator {
-        background: linear-gradient(180deg, rgba($white, 0.1) 0%, rgba($white, 0) 100%),
-          linear-gradient(0deg, $blue1, $blue1);
-      }
-    }
-  }
-}
+// Contrast for checkboxes and radio buttons - no overrides necessary, modern colors are now built-in
 
 // Contrast for HTML tables
 table.#{$ns}-html-table {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -77,8 +77,8 @@ $dark-button-intent-color-disabled: rgba($white, 0.3);
 
 $minimal-button-divider-width: 1px !default;
 $minimal-button-background-color: none !default;
-$minimal-button-background-color-hover: rgba($gray4, 0.3) !default;
-$minimal-button-background-color-active: rgba($gray2, 0.3) !default;
+$minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
+$minimal-button-background-color-active: rgba($gray3, 0.3) !default;
 $dark-minimal-button-background-color: none !default;
 $dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
 $dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -5,16 +5,24 @@
 @import "../../common/variables";
 @import "../button/common";
 
-$control-background-color: $button-background-color !default;
-$control-background-color-hover: $button-background-color-hover !default;
-$control-background-color-active: $button-background-color-active !default;
-$dark-control-background-color: $dark-button-background-color !default;
-$dark-control-background-color-hover: $dark-button-background-color-hover !default;
-$dark-control-background-color-active: $dark-button-background-color-active !default;
+$control-background-color: transparent !default;
+$control-background-color-hover: $minimal-button-background-color-hover !default;
+$control-background-color-active: $minimal-button-background-color-active !default;
+$control-background-color-disabled: $minimal-button-background-color-hover !default;
+$dark-control-background-color: transparent !default;
+$dark-control-background-color-hover: $minimal-button-background-color-hover !default;
+$dark-control-background-color-active: $minimal-button-background-color-active !default;
+$dark-control-background-color-disabled: $minimal-button-background-color-hover !default;
 
 $control-checked-background-color: nth(map-get($button-intents, "primary"), 1) !default;
 $control-checked-background-color-hover: nth(map-get($button-intents, "primary"), 2) !default;
 $control-checked-background-color-active: nth(map-get($button-intents, "primary"), 3) !default;
+$control-checked-background-color-disabled: rgba($control-checked-background-color, 0.5) !default;
+
+$control-box-shadow: inset 0 0 0 $button-border-width $gray2 !default;
+$control-checked-box-shadow: inset 0 0 0 $button-border-width rgba($black, 0.2) !default;
+$dark-control-box-shadow: inset 0 0 0 $button-border-width $gray3 !default;
+$dark-control-checked-box-shadow: inset 0 0 0 $button-border-width rgba($white, 0.1) !default;
 
 $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
@@ -24,43 +32,43 @@ $control-indicator-spacing: $pt-grid-size !default;
   input#{$selector} ~ .#{$ns}-control-indicator {
     background-color: $control-checked-background-color;
     background-image: $button-intent-gradient;
-    box-shadow: $button-intent-box-shadow;
+    box-shadow: $control-checked-box-shadow;
     color: $white;
   }
 
   &:hover input#{$selector} ~ .#{$ns}-control-indicator {
     background-color: $control-checked-background-color-hover;
-    box-shadow: $button-intent-box-shadow;
   }
 
   input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
     background: $control-checked-background-color-active;
-    box-shadow: $button-intent-box-shadow-active;
   }
 
   input:disabled#{$selector} ~ .#{$ns}-control-indicator {
-    background: rgba($control-checked-background-color, 0.5);
+    background: $control-checked-background-color-disabled;
     box-shadow: none;
+    color: rgba($white, 0.6);
   }
 
   .#{$ns}-dark & {
     input#{$selector} ~ .#{$ns}-control-indicator {
-      box-shadow: $dark-button-intent-box-shadow;
+      box-shadow: $dark-control-checked-box-shadow;
     }
 
     &:hover input#{$selector} ~ .#{$ns}-control-indicator {
       background-color: $control-checked-background-color-hover;
-      box-shadow: $dark-button-intent-box-shadow;
+      box-shadow: $dark-control-checked-box-shadow;
     }
 
     input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
       background-color: $control-checked-background-color-active;
-      box-shadow: $dark-button-intent-box-shadow-active;
+      box-shadow: $dark-control-checked-box-shadow;
     }
 
     input:disabled#{$selector} ~ .#{$ns}-control-indicator {
-      background: rgba($control-checked-background-color-active, 0.5);
+      background: $control-checked-background-color-disabled;
       box-shadow: none;
+      color: rgba($white, 0.6);
     }
   }
 }
@@ -118,7 +126,7 @@ $control-indicator-spacing: $pt-grid-size !default;
     background-color: $control-background-color;
     background-image: $button-gradient;
     border: none;
-    box-shadow: $button-box-shadow;
+    box-shadow: $control-box-shadow;
     cursor: pointer;
     display: inline-block;
     // font-size is used to size indicator for all control types,
@@ -146,17 +154,18 @@ $control-indicator-spacing: $pt-grid-size !default;
 
   input:not(:disabled):active ~ .#{$ns}-control-indicator {
     background: $control-background-color-active;
-    box-shadow: $button-box-shadow-active;
+    box-shadow: $control-box-shadow;
   }
 
   input:disabled ~ .#{$ns}-control-indicator {
-    background: $button-background-color-disabled;
+    background: $control-background-color-disabled;
     box-shadow: none;
     cursor: not-allowed;
   }
 
   input:focus ~ .#{$ns}-control-indicator {
     @include focus-outline();
+    outline: $blue3 auto 2px;
   }
 
   // right-aligned indicator is glued to the right side of the container
@@ -468,20 +477,24 @@ $control-indicator-spacing: $pt-grid-size !default;
     .#{$ns}-control-indicator {
       background-color: $dark-control-background-color;
       background-image: $dark-button-gradient;
-      box-shadow: $dark-button-box-shadow;
+      box-shadow: $dark-control-box-shadow;
     }
 
     &:hover .#{$ns}-control-indicator {
       background-color: $dark-control-background-color-hover;
     }
 
+    input:focus ~ .#{$ns}-control-indicator {
+      outline: $blue5 auto 2px;
+    }
+
     input:not(:disabled):active ~ .#{$ns}-control-indicator {
       background: $dark-control-background-color-active;
-      box-shadow: $dark-button-box-shadow-active;
+      box-shadow: $dark-control-box-shadow;
     }
 
     input:disabled ~ .#{$ns}-control-indicator {
-      background: $dark-button-background-color-disabled;
+      background: $dark-control-background-color-disabled;
       box-shadow: none;
       cursor: not-allowed;
     }
@@ -490,7 +503,7 @@ $control-indicator-spacing: $pt-grid-size !default;
       &:checked,
       &:indeterminate {
         ~ .#{$ns}-control-indicator {
-          color: $dark-button-color-disabled;
+          background: $control-checked-background-color-disabled;
         }
       }
     }


### PR DESCRIPTION

#### Changes proposed in this pull request:

Checkboxes and radio buttons currently follow default button styling. However, in dark mode, the need to have a darker border means the fill has to be light, making it stand out as a light box in context.

The visual change not only converts the dark mode unselected states to an outline, but changes the style overall. Unselected states now follow minimal button backgrounds when unselected, and dark mode selected states using a lighter border to match.

#### Reviewers should focus on:

No regressions, and styles match mocks

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->

_Checkbox_

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/723999/144621720-c21435e0-b6cd-4ade-ae81-58c282999ec6.png) | ![image](https://user-images.githubusercontent.com/723999/144621692-909c62fb-2c14-4fd1-937c-81ac2d4bd9d9.png) |
| ![image](https://user-images.githubusercontent.com/723999/144621801-eaf058f1-d327-4c22-a4e4-a392f01df528.png) | ![image](https://user-images.githubusercontent.com/723999/144621836-4e9d33fa-0ac7-4262-8074-860ee95ac5f0.png) |

_Radio_

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/723999/144622116-4eba1e6e-d772-4b33-8ee7-8a4b597066d6.png) | ![image](https://user-images.githubusercontent.com/723999/144622172-99b5c50e-d3d3-4be4-a463-9827cabd081f.png) |
| ![image](https://user-images.githubusercontent.com/723999/144622151-1127228b-0f77-46e5-9d1c-fc723fd696ba.png) | ![image](https://user-images.githubusercontent.com/723999/144622200-240b8dd5-25d3-405f-adf4-d987b77b9dec.png) |
