### PR TITLE
[core] fix: InputGroups should inherit border radius

### DIFF
--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -40,6 +40,7 @@ $input-button-height-large: $pt-button-height !default;
 $input-button-height-small: $pt-button-height-smaller !default;
 
 .#{$ns}-input-group {
+  border-radius: inherit;
   display: block;
   position: relative;
 


### PR DESCRIPTION
#### Fixes #1750

#### Changes proposed in this pull request:

Adds `border-radius: inherit;` to `input-group` so that input group corners are properly rounded when used inside of a Tooltip/Popover.

Repro:

```tsx
<ControlGroup>
    <InputGroup placeholder="Username" />
    <Tooltip>
        <InputGroup placeholder="Password" />
    </Tooltip>
</ControlGroup>
```

#### Screenshot

Before:
![Screen Shot 2021-12-06 at 3 15 41 PM](https://user-images.githubusercontent.com/1046198/144940715-d2f7c8fb-54e2-45df-a523-37df9de63058.png)

After:
![Screen Shot 2021-12-06 at 3 39 32 PM](https://user-images.githubusercontent.com/1046198/144940726-93cc62ed-3e1e-4698-a651-7f88b8dee589.png)
