### PR TITLE
[v4] [core] fix: enable dark scrollbars in dark theme

### DIFF
--- a/packages/core/src/_dark-theme.scss
+++ b/packages/core/src/_dark-theme.scss
@@ -1,0 +1,8 @@
+// Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+.#{$ns}-dark {
+  // this tells the browser to use a dark theme UI, which is most useful for enabling
+  // dark scrollbars (only works in Chrome and Edge, not IE or Firefox)
+  color-scheme: dark;
+}

--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -13,6 +13,7 @@ Licensed under the Apache License, Version 2.0.
 @import "reset";
 @import "typography";
 @import "accessibility/focus-states";
+@import "dark-theme";
 
 // Button variables and overrides
 $button-active-minimal-intent-text-modern: (


### PR DESCRIPTION
#### Fixes #956

## Screenshots

Environment:
- macOS 10.15
- OS setting scrollbars always enabled
- Chrome 96

### Before

![image](https://user-images.githubusercontent.com/723999/145462969-35791620-da39-465f-9d95-20322ff1327d.png)
![image](https://user-images.githubusercontent.com/723999/145463002-38a7857d-d7aa-49d1-8f71-d20f09624655.png)


### After 

![image](https://user-images.githubusercontent.com/723999/145463074-6aa1d2ba-89b0-45d0-8ffd-e1775223199d.png)
![image](https://user-images.githubusercontent.com/723999/145463089-087e1a9b-30c9-4db7-9c57-4997bf0e5682.png)
