### PR TITLE
[core] fix(Toaster): disable invasive focus management

### DIFF
--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -197,6 +197,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
                 hasBackdrop={false}
                 isOpen={this.state.toasts.length > 0 || this.props.children != null}
                 onClose={this.handleClose}
+                shouldReturnFocusOnClose={false}
                 // $pt-transition-duration * 3 + $pt-transition-duration / 2
                 transitionDuration={350}
                 transitionName={Classes.TOAST}


### PR DESCRIPTION
#### Fixes #5032

#### Changes proposed in this pull request:

Disable the Overlay `shouldReturnFocusOnClose` feature for toasts, since it doesn't make sense to do this kind of focus management for toasts.

#### Reviewers should focus on:

Pretty simple change, you can see that it only affects these lines of code execution for the Toaster Overlay:

https://github.com/palantir/blueprint/blob/b80422a6377b9b4999d87a82724990876fe39080/packages/core/src/components/overlay/overlay.tsx#L616-L618

#### Screenshot

N/A
