### PR TITLE
[core] fix(ControlGroup): correct border radius when Tooltip wraps InputGroup

### DIFF
--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -172,6 +172,11 @@ Styleguide control-group
     }
   }
 
+  .#{$ns}-input-group {
+    // also need inheritance here, in case an input is wrapped by a popover or tooltip
+    border-radius: inherit;
+  }
+
   // input group contents appear above input always
   .#{$ns}-input-group > .#{$ns}-icon,
   .#{$ns}-input-group > .#{$ns}-button,


### PR DESCRIPTION
#### Fixes #1750, supersedes #5059

#### Changes proposed in this pull request:

Limited change to add border-radius style inheritance to input groups inside control groups to fix the linked issue

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

See example of fix in https://codesandbox.io/s/blueprint-sandbox-forked-zslf0?file=/src/app.css

![image](https://user-images.githubusercontent.com/723999/145467549-d6afbaeb-8e21-4633-865a-926cca315375.png)

