### PR TITLE
[eslint-plugin] fix(classes-constants): ignore imports/exports

### DIFF
--- a/packages/eslint-plugin/src/rules/classes-constants.ts
+++ b/packages/eslint-plugin/src/rules/classes-constants.ts
@@ -52,6 +52,13 @@ export const classesConstantsRule = createRule<[], MessageIds>({
 });
 
 function create(context: RuleContext<MessageIds, []>, node: TSESTree.Literal | TSESTree.TemplateElement): void {
+    // We shouldn't lint on strings from imports/exports
+    if (
+        node.parent?.type === AST_NODE_TYPES.ImportDeclaration ||
+        node.parent?.type === AST_NODE_TYPES.ExportNamedDeclaration
+    ) {
+        return;
+    }
     const nodeValue = node.type === AST_NODE_TYPES.Literal ? node.raw : node.value.raw;
     const prefixMatches = getAllMatches(nodeValue);
     if (prefixMatches.length > 0) {

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -41,6 +41,7 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 16, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 <div className={Classes.FILL} />
             `,
         },
@@ -50,15 +51,18 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 16, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 <div className={${"`${Classes.FILL} and-some-other-things`"}} />
             `,
         },
+
         // literal string inside curly brackets
         {
             code: `<div className={"pt-fill"} />`,
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 <div className={Classes.FILL} />
             `,
         },
@@ -68,15 +72,18 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 <div className={${"`${Classes.FILL} and-some-other-things`"}} />
             `,
         },
+
         // template string
         {
             code: "<div className={`pt-fill`} />",
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 <div className={Classes.FILL} />
             `,
         },
@@ -86,44 +93,55 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 <div className={${"`${Classes.FILL} and-some-other-things`"}} />
             `,
         },
+
         // function usage
         {
             code: `classNames("pt-fill");`,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 classNames(Classes.FILL);
             `,
         },
+
         // array index usage
         {
             code: `classNames["pt-fill"] = true;`,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
+
                 classNames[Classes.FILL] = true;
             `,
         },
+
         // adding import to existing import
+
         {
             code: dedent`
                 import { Dialog } from "@blueprintjs/core";
+
                 classNames["pt-fill"] = true;
             `,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 3 }],
             output: dedent`
                 import { Classes, Dialog } from "@blueprintjs/core";
+
                 classNames[Classes.FILL] = true;
             `,
         },
+
         // adding import in alphabetical order
         {
             code: dedent`
                 import { Something } from "@a/somewhere";
                 import { SomethingElse } from "somewhere";
+
                 classNames["pt-fill"] = true;
             `,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 4 }],
@@ -131,6 +149,7 @@ ruleTester.run("classes-constants", classesConstantsRule, {
                 import { Something } from "@a/somewhere";
                 import { Classes } from "@blueprintjs/core";
                 import { SomethingElse } from "somewhere";
+
                 classNames[Classes.FILL] = true;
             `,
         },
@@ -143,7 +162,8 @@ ruleTester.run("classes-constants", classesConstantsRule, {
 
         // it should not touch icons as theyre handled by a different rule
         '<div className="pt-icon-folder-open" />',
-        // don't flag strings in import statements
+
+        // don't flag strings in export/import statements
         'import { test } from "packagewithpt-thatshouldnterror";',
         'export { test } from "packagewithpt-thatshouldnterror";',
     ],

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -41,7 +41,6 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 16, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 <div className={Classes.FILL} />
             `,
         },
@@ -51,18 +50,15 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 16, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 <div className={${"`${Classes.FILL} and-some-other-things`"}} />
             `,
         },
-
         // literal string inside curly brackets
         {
             code: `<div className={"pt-fill"} />`,
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 <div className={Classes.FILL} />
             `,
         },
@@ -72,18 +68,15 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 <div className={${"`${Classes.FILL} and-some-other-things`"}} />
             `,
         },
-
         // template string
         {
             code: "<div className={`pt-fill`} />",
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 <div className={Classes.FILL} />
             `,
         },
@@ -93,55 +86,44 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             errors: [{ messageId: "useBlueprintClasses", column: 17, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 <div className={${"`${Classes.FILL} and-some-other-things`"}} />
             `,
         },
-
         // function usage
         {
             code: `classNames("pt-fill");`,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 classNames(Classes.FILL);
             `,
         },
-
         // array index usage
         {
             code: `classNames["pt-fill"] = true;`,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
             output: dedent`
                 import { Classes } from "@blueprintjs/core";
-
                 classNames[Classes.FILL] = true;
             `,
         },
-
         // adding import to existing import
-
         {
             code: dedent`
                 import { Dialog } from "@blueprintjs/core";
-
                 classNames["pt-fill"] = true;
             `,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 3 }],
             output: dedent`
                 import { Classes, Dialog } from "@blueprintjs/core";
-
                 classNames[Classes.FILL] = true;
             `,
         },
-
         // adding import in alphabetical order
         {
             code: dedent`
                 import { Something } from "@a/somewhere";
                 import { SomethingElse } from "somewhere";
-
                 classNames["pt-fill"] = true;
             `,
             errors: [{ messageId: "useBlueprintClasses", column: 12, line: 4 }],
@@ -149,7 +131,6 @@ ruleTester.run("classes-constants", classesConstantsRule, {
                 import { Something } from "@a/somewhere";
                 import { Classes } from "@blueprintjs/core";
                 import { SomethingElse } from "somewhere";
-
                 classNames[Classes.FILL] = true;
             `,
         },
@@ -162,5 +143,8 @@ ruleTester.run("classes-constants", classesConstantsRule, {
 
         // it should not touch icons as theyre handled by a different rule
         '<div className="pt-icon-folder-open" />',
+        // don't flag strings in import statements
+        'import { test } from "packagewithpt-thatshouldnterror";',
+        'export { test } from "packagewithpt-thatshouldnterror";',
     ],
 });


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

If you have an import from a package like this:

```
import { someFunction } from "packagewithpt-thaterrors";
```

The ESLInt rule will ask you to change that string to use a Blueprint class instead :)

This changes it so that import declarations/named exports are ignored
