### PR TITLE
[popover2] fix(Popover2): close properly when target focus lost

### DIFF
--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -536,10 +536,6 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
 
     private handleTargetBlur = (e: React.FocusEvent<HTMLElement>) => {
         if (this.props.openOnTargetFocus && this.isHoverInteractionKind()) {
-            // e.relatedTarget ought to tell us the next element to receive focus, but if the user just
-            // clicked on an element which is not focusable (either by default or with a tabIndex attribute),
-            // it won't be set. So, we filter those out here and assume that a click handler somewhere else will
-            // close the popover if necessary.
             if (e.relatedTarget != null) {
                 // if the next element to receive focus is within the popover, we'll want to leave the
                 // popover open.
@@ -549,6 +545,8 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
                 ) {
                     this.handleMouseLeave((e as unknown) as React.MouseEvent<HTMLElement>);
                 }
+            } else {
+                this.handleMouseLeave((e as unknown) as React.MouseEvent<HTMLElement>);
             }
         }
         this.lostFocusOnSamePage = e.relatedTarget != null;


### PR DESCRIPTION
The assumption that "a click handler somewhere else will close the popover if necessary" does not appear to be valid. If the user clicks on a non-focusable element. There are no other events that cause the popover to close other than mouseleave, but the mouse is not over the target when focus is lost.

Fixes #4503.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
