### PR TITLE
Add prop to prevent event propagation on EditableText escape

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -354,7 +354,7 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         /* eslint-disable-next-line deprecation/deprecation */
         const { altKey, ctrlKey, metaKey, shiftKey, which } = event;
         if (which === Keys.ESCAPE) {
-            if (this.props.stopPropagation) {
+            if (this.props.stopEscapeKeyPropagation) {
                 event.stopPropagation();
             }
             this.cancelEditing();

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -110,7 +110,7 @@ export interface IEditableTextProps extends IntentProps, Props {
      *
      * @default false
      */
-    stopPropagation?: boolean;
+    stopEscapeKeyPropagation?: boolean;
 
     /**
      * The type of input that should be shown, when not `multiline`.

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -354,7 +354,7 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         /* eslint-disable-next-line deprecation/deprecation */
         const { altKey, ctrlKey, metaKey, shiftKey, which } = event;
         if (which === Keys.ESCAPE) {
-            if (this.props.stopPropagation === true) {
+            if (this.props.stopPropagation) {
                 event.stopPropagation();
             }
             this.cancelEditing();

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -106,7 +106,7 @@ export interface IEditableTextProps extends IntentProps, Props {
     selectAllOnFocus?: boolean;
 
     /**
-     * Whether the input should stop the evnet propagation when escape is pressed
+     * Whether the input should stop the event propagation when escape is pressed
      *
      * @default false
      */

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -106,6 +106,13 @@ export interface IEditableTextProps extends IntentProps, Props {
     selectAllOnFocus?: boolean;
 
     /**
+     * Whether the input should stop the evnet propagation when escape is pressed
+     *
+     * @default false
+     */
+    stopPropagation?: boolean;
+
+    /**
      * The type of input that should be shown, when not `multiline`.
      */
     type?: string;
@@ -347,6 +354,9 @@ export class EditableText extends AbstractPureComponent2<EditableTextProps, IEdi
         /* eslint-disable-next-line deprecation/deprecation */
         const { altKey, ctrlKey, metaKey, shiftKey, which } = event;
         if (which === Keys.ESCAPE) {
+            if (this.props.stopPropagation === true) {
+                event.stopPropagation();
+            }
             this.cancelEditing();
             return;
         }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added a new prop on the `EditableText` component to prevent event propagation when pressing the Esc key. This is useful when the `EditableText` component is used inside a Dialog/Modal which has `canEscapeKeyClose` as `true`

#### Reviewers should focus on:

Nothing really, this is a simple change

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
