### PR TITLE
Fixed types of Tree Node IDs

### DIFF
--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -22,10 +22,12 @@ import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isFunction } from "../../common/utils";
 import { TreeNodeInfo, TreeNode } from "./treeNode";
 
+type NodeID = string | number
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type TreeEventHandler<T = {}> = (
     node: TreeNodeInfo<T>,
-    nodePath: number[],
+    nodePath: NodeID[],
     e: React.MouseEvent<HTMLElement>,
 ) => void;
 
@@ -85,7 +87,7 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
         return Tree as new (props: TreeProps<U>) => Tree<U>;
     }
 
-    public static nodeFromPath<U>(path: number[], treeNodes?: Array<TreeNodeInfo<U>>): TreeNodeInfo<U> {
+    public static nodeFromPath<U>(path: NodeID[], treeNodes?: Array<TreeNodeInfo<U>>): TreeNodeInfo<U> {
         if (path.length === 1) {
             return treeNodes![path[0]];
         } else {
@@ -108,11 +110,11 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
      * This element does not contain the children of the node, only its label and controls.
      * If the node is not currently mounted, `undefined` is returned.
      */
-    public getNodeContentElement(nodeId: string | number): HTMLElement | undefined {
+    public getNodeContentElement(nodeId: NodeID): HTMLElement | undefined {
         return this.nodeRefs[nodeId];
     }
 
-    private renderNodes(treeNodes: Array<TreeNodeInfo<T>> | undefined, currentPath?: number[], className?: string) {
+    private renderNodes(treeNodes: Array<TreeNodeInfo<T>> | undefined, currentPath?: NodeID[], className?: string) {
         if (treeNodes == null) {
             return null;
         }


### PR DESCRIPTION
I noticed when trying to build a Tree with strings as the Node IDs that the static method `Tree.nodeFromPath` had an incorrect type for the path argument. 

https://github.com/Mike-Dax/blueprint/blob/0be8e951f857134afffcc57e74bff143a542d2e2/packages/core/src/components/tree/treeNode.tsx#L55

The treeNode ID is `string | number`, and it's stored in an object, so it's always cast to a string internally.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

I presume the relevant types in the documentation will be automatically updated, namely the `path` prop of `ITreeNodeProps` is incorrect, it should be `(string | number)[]`.

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Changes the exposed methods to use `string | number` instead of just `number` for the IDs. Similarly paths use the array of the union instead of just `number[]` 

#### Reviewers should focus on:

I'm not sure if this is all the instances of this type, there may be more.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://user-images.githubusercontent.com/13504878/148012494-f95d8c4b-bb4c-42a8-8098-b54a76101676.png)
to
![image](https://user-images.githubusercontent.com/13504878/148012534-7e3c26a4-c87c-4fbc-bfb2-09742d949146.png)
