### PR TITLE
[eslint-plugin] fix(classes-constants): fix more false positives

### DIFF
--- a/packages/eslint-plugin/src/rules/classes-constants.ts
+++ b/packages/eslint-plugin/src/rules/classes-constants.ts
@@ -25,7 +25,7 @@ import { getProgram } from "./utils/getProgram";
 
 // find all pt- prefixed classes, except those that begin with pt-icon (handled by other rules).
 // currently support pt- and bp3- prefixes.
-const BLUEPRINT_CLASSNAME_PATTERN = /[^\w-<.]?((pt|bp3)-(?!icon-?)[\w-]+)/g;
+const BLUEPRINT_CLASSNAME_PATTERN = /(?<![\w])((?:pt|bp3)-(?!icon)[\w-]+)/g;
 
 type MessageIds = "useBlueprintClasses";
 

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -166,5 +166,9 @@ ruleTester.run("classes-constants", classesConstantsRule, {
         // don't flag strings in export/import statements
         'import { test } from "packagewithpt-thatshouldnterror";',
         'export { test } from "packagewithpt-thatshouldnterror";',
+
+        // don't flag non applicable strings in function calls
+        `myFunction("stringwithpt-thatshouldnt-error");`,
+        "myFunction(`stringwithpt-thatshouldnt-error-${withVariable}`);",
     ],
 });

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -169,6 +169,6 @@ ruleTester.run("classes-constants", classesConstantsRule, {
 
         // don't flag non applicable strings in function calls
         `myFunction("stringwithpt-thatshouldnt-error");`,
-        "myFunction(`stringwithpt-thatshouldnt-error-${withVariable}`);",
+        "myFunction(`stringwithpt-thatshouldnt-error`);",
     ],
 });


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

A function call like this was getting flagged when it shouldn't:

```
foo("stringwithpt-but-not-actually-blueprint")
```

Credit to @walkerburgin for helping me figure out the regex 🙂 

