### PR TITLE
[eslint-plugin] fix(classes-constants): improve fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/classes-constants.ts
+++ b/packages/eslint-plugin/src/rules/classes-constants.ts
@@ -66,9 +66,8 @@ function create(context: RuleContext<MessageIds, []>, node: TSESTree.Literal | T
         const replacementText =
             node.type === AST_NODE_TYPES.Literal
                 ? // "string literal" likely becomes `${template} string` so we may need to change how it is assigned
-                  wrapForParent(getLiteralReplacement(nodeValue, ptClassStrings), node)
+                  wrapForParent(getLiteralReplacement(nodeValue, prefixMatches), node)
                 : getTemplateReplacement(nodeValue, ptClassStrings);
-
         context.report({
             messageId: "useBlueprintClasses",
             node,
@@ -100,20 +99,37 @@ function getAllMatches(className: string) {
 }
 
 /** Produce replacement text for a string literal that contains invalid classes. */
-function getLiteralReplacement(className: string, ptClassStrings: string[]) {
-    // remove all illegal classnames, then slice off the quotes, then merge & trim any remaining white space
-    const stringWithoutPtClasses = ptClassStrings
-        .reduce((value, cssClass) => value.replace(cssClass, ""), className)
-        .slice(1, -1)
-        .replace(/(\s)+/, "$1")
-        .trim();
-    // special case: only one invalid class name
-    if (stringWithoutPtClasses.length === 0 && ptClassStrings.length === 1) {
-        return convertPtClassName(ptClassStrings[0]);
+function getLiteralReplacement(className: string, prefixMatches: Array<{ match: string; index: number }>) {
+    // Special case: the string consists entirely of the invalid class name (ignoring quotes/spaces)
+    // In this scenario, we just want to return the converted classnames without surrounding with ${} for interpolation
+    if (prefixMatches.length === 1) {
+        const remainingString = className
+            .replace(prefixMatches[0].match, "")
+            .slice(1, -1)
+            .replace(/(\s)+/, "$1")
+            .trim();
+        if (remainingString.length === 0) {
+            return convertPtClassName(prefixMatches[0].match);
+        }
     }
-    // otherwise produce a `template string`
-    const templateStrings = ptClassStrings.map(n => `\${${convertPtClassName(n)}}`).join(" ");
-    return `\`${[templateStrings, stringWithoutPtClasses].join(" ").trim()}\``;
+
+    // Start with the beginning of the string until the first match of an invalid classname
+    let newString = "";
+    let currentIndex = 0;
+    for (const { match, index } of prefixMatches) {
+        // Add the strings between the currentIndex and this invalid class name's index
+        newString += className.slice(currentIndex, index);
+        // Add the converted string instead of the original string
+        newString += `\${${convertPtClassName(match)}}`;
+        // Update the index to immediately after this invalid class name
+        currentIndex = index + match.length;
+    }
+    // Add remaining parts of string that occurred after the last invalid class name
+    newString += className.slice(currentIndex, className.length);
+    // Slice off the quotes, and merge & trim any remaining white space
+    newString = newString.slice(1, -1).replace(/(\s)+/, "$1").trim();
+    // Surround with backticks instead for the newly added template strings
+    return `\`${newString}\``;
 }
 
 /** Produce replacement text for a `template string` that contains invalid classes. */

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -109,6 +109,39 @@ ruleTester.run("classes-constants", classesConstantsRule, {
             `,
         },
 
+        // function usage with literal string and preceding period
+        {
+            code: `myFunction(".pt-fill");`,
+            errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
+            output: dedent`
+                import { Classes } from "@blueprintjs/core";
+
+                myFunction(${"`.${Classes.FILL}`"});
+            `,
+        },
+
+        // function usage literal string with preceding period and preceding class
+        {
+            code: `myFunction("my-class .pt-fill");`,
+            errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
+            output: dedent`
+                import { Classes } from "@blueprintjs/core";
+
+                myFunction(${"`my-class .${Classes.FILL}`"});
+            `,
+        },
+
+        // function usage with template string and preceding period
+        {
+            code: "myFunction(`my-class .pt-fill`);",
+            errors: [{ messageId: "useBlueprintClasses", column: 12, line: 1 }],
+            output: dedent`
+                import { Classes } from "@blueprintjs/core";
+
+                myFunction(${"`my-class .${Classes.FILL}`"});
+            `,
+        },
+
         // array index usage
         {
             code: `classNames["pt-fill"] = true;`,


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The way the fixer for non-templated strings previously worked is it would replace the class names with the correct class names, and then append the rest of the string. Unfortunately, in the scenario where the string looked like this:

```
myFunction(".pt-fill");
```

It would get autofixed to this:

```
myFunction(`${Classes.FILL} .`);
```

Which is not correct at all. This change changes how we replace the strings to not do a blind replace + concat, but instead does the replace inline by iterating through the string + matches. I added more tests to make sure the different cases I could think of were caught

