### PR TITLE
[datetime] fix: change default max date to 6 months from now

### DIFF
--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -76,7 +76,7 @@ export interface IDatePickerBaseProps {
     /**
      * The latest date the user can select.
      *
-     * @default Dec. 31st of this year.
+     * @default 6 months from now.
      */
     maxDate?: Date;
 
@@ -138,8 +138,7 @@ export const DISALLOWED_MODIFIERS = [
 
 export function getDefaultMaxDate() {
     const date = new Date();
-    date.setFullYear(date.getFullYear());
-    date.setMonth(Months.DECEMBER, 31);
+    date.setMonth(date.getMonth() + 6);
     return date;
 }
 


### PR DESCRIPTION
It is an inconvenience to use date picker component around end of the year with default value of `maxDate` set to end of the year. Setting the `maxDate` to 6 months from now is a better idea.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->
Default value of `maxDate` set to 6 months from now for date picker.

#### Reviewers should focus on:

<!-- Fill this out. -->
I don't know what's supposed to go here.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
