### PR TITLE
[v4] [icons] fix: pre-es2017 compatibility

### DIFF
--- a/packages/icons/src/iconNames.ts
+++ b/packages/icons/src/iconNames.ts
@@ -28,7 +28,14 @@ export type { IconName };
 const IconNamesNew = {} as Record<PascalCase<IconName>, IconName>;
 const IconNamesLegacy = {} as Record<ScreamingSnakeCase<IconName>, IconName>;
 
-for (const name of Object.values(BlueprintIcons_16) as IconName[]) {
+const BlueprintIconsMap: Record<string, IconName> = BlueprintIcons_16;
+
+for (const key in BlueprintIconsMap) {
+    if (!BlueprintIconsMap.propertyIsEnumerable(key)) {
+        continue;
+    }
+
+    const name = BlueprintIconsMap[key];
     IconNamesNew[pascalCase(name) as PascalCase<IconName>] = name;
     IconNamesLegacy[snakeCase(name).toUpperCase() as ScreamingSnakeCase<IconName>] = name;
 }


### PR DESCRIPTION
#### Fixes #5097

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Switches an `Object.values` usage to a `for ... in ...` loop for pre-es2017 browser compatibility.

#### Reviewers should focus on:

**Edit**: The `guard-for-in` ESLint rule triggered on the below. Updated the commit for `propertyIsEnumerable`.

According to MDN, [`Object.values` also filters on own enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Object/values), so technically we should also check for  [`Object.prototype.propertyIsEnumerable()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable).

TypeScript doesn't seem to generate non-own enumerable properties for enum objects though, so in practice the extra check isn't needed. https://www.typescriptlang.org/play?#code/KYOwrgtgBAYg9nKBvAsAKCpqAhAhgJygF4oAiAIwNPQF910AzOQgCgGM4QBnAFygGtgATygBLELAQBKZOixQO3OABtgAOmVwA5i0FCptIA

Happy to add it if reviewers think the extra soundness is worthwhile.