### PR TITLE
[icons] fix: replace require import with esm import

### DIFF
--- a/packages/icons/src/iconSvgPaths.ts
+++ b/packages/icons/src/iconSvgPaths.ts
@@ -16,13 +16,12 @@
 
 import { pascalCase } from "change-case";
 
+import * as IconSvgPaths16 from "./generated/16px/paths";
+import * as IconSvgPaths20 from "./generated/20px/paths";
 import type { IconName } from "./iconNames";
 import type { PascalCase } from "./type-utils";
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-export const IconSvgPaths16 = require("./generated/16px/paths") as Record<PascalCase<IconName>, string[]>;
-export const IconSvgPaths20 = require("./generated/20px/paths") as Record<PascalCase<IconName>, string[]>;
-/* eslint-enable @typescript-eslint/no-var-requires */
+export { IconSvgPaths16, IconSvgPaths20 };
 
 /**
  * Type safe string literal conversion of snake-case icon names to PascalCase icon names,


### PR DESCRIPTION
#### Fixes #5054

#### Changes proposed in this pull request:

Revert the imports to use esm, so that it does not fail in vite

#### Reviewers should focus on:

n/a
