### PR TITLE
feat: Add popper modifier classnames

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -244,6 +244,7 @@ export const POPOVER_CONTENT_SIZING = `${POPOVER_CONTENT}-sizing`;
 export const POPOVER_DISMISS = `${POPOVER}-dismiss`;
 export const POPOVER_DISMISS_OVERRIDE = `${POPOVER_DISMISS}-override`;
 export const POPOVER_OPEN = `${POPOVER}-open`;
+export const POPOVER_OUT_OF_BOUNDARIES = `${POPOVER}-out-of-boundaries`;
 export const POPOVER_TARGET = `${POPOVER}-target`;
 export const POPOVER_WRAPPER = `${POPOVER}-wrapper`;
 export const TRANSITION_CONTAINER = `${NS}-transition-container`;

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -339,6 +339,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 [Classes.DARK]: this.props.inheritDarkTheme && this.state.hasDarkParent,
                 [Classes.MINIMAL]: this.props.minimal,
                 [Classes.POPOVER_CAPTURING_DISMISS]: this.props.captureDismiss,
+                [Classes.POPOVER_OUT_OF_BOUNDARIES]: popperProps.outOfBoundaries === true,
             },
             this.props.popoverClassName,
         );

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -33,6 +33,8 @@ export const POPOVER2_CONTENT_SIZING = `${POPOVER2_CONTENT}-sizing`;
 export const POPOVER2_DISMISS = `${POPOVER2}-dismiss`;
 export const POPOVER2_DISMISS_OVERRIDE = `${POPOVER2_DISMISS}-override`;
 export const POPOVER2_OPEN = `${POPOVER2}-open`;
+export const POPOVER2_POPPER_ESCAPED = `${POPOVER2}-popper-escaped`;
+export const POPOVER2_REFERENCE_HIDDEN = `${POPOVER2}-reference-hidden`;
 export const POPOVER2_TARGET = `${POPOVER2}-target`;
 export const POPOVER2_TRANSITION_CONTAINER = `${POPOVER2}-transition-container`;
 

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -422,6 +422,8 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
                 [CoreClasses.DARK]: this.props.inheritDarkTheme && this.state.hasDarkParent,
                 [CoreClasses.MINIMAL]: this.props.minimal,
                 [Classes.POPOVER2_CAPTURING_DISMISS]: this.props.captureDismiss,
+                [Classes.POPOVER2_REFERENCE_HIDDEN]: popperProps.isReferenceHidden === true,
+                [Classes.POPOVER2_POPPER_ESCAPED]: popperProps.hasPopperEscaped === true,
             },
             `${Classes.POPOVER2_CONTENT_PLACEMENT}-${basePlacement}`,
             this.props.popoverClassName,


### PR DESCRIPTION
#### Changes proposed in this pull request:

This adds new classes to the popover using some of the helpful modifiers from PopperJS's hide.  

These classnames can be helpful to allow consumers to hide the popper when the reference element is scrolled out of its scrolling container.  
See example: https://popper.js.org/docs/v2/modifiers/hide/

For Popover (@blueprintjs/core):
- Adds `.bp3-popover-out-of-boundaries` when PopperJS v1's `popperProps.outOfBoundaries` is true

For Popover2 (@blueprintjs/popover2):
- Adds `.bp3-popover-reference-hidden` when the reference element is not visible (scrolled off screen)
- Adds `.bp3-popper-escaped` when the popper escapes the reference element's boundaries

This PR does not change any behavior other than rendering the new classnames, which have no styles applied to them by default.  
