### PR TITLE
[v4] [table] fix(TableQuadrantStack): cancel handler on unmount

### DIFF
--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -304,9 +304,8 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     private throttledHandleWheel: (event: React.WheelEvent<HTMLElement>) => any;
 
-    // the interval instance that we maintain to enable debouncing of view
-    // updates on scroll
-    private debouncedViewSyncInterval?: number;
+    // cancel function for the debounced view sync handler
+    private cancelPendingViewSync?: () => void;
 
     private cache: TableQuadrantStackCache;
 
@@ -813,8 +812,8 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             this.syncQuadrantViews();
         } else {
             // update asynchronously after a debounced delay
-            clearInterval(this.debouncedViewSyncInterval);
-            this.debouncedViewSyncInterval = window.setTimeout(this.syncQuadrantViews, viewSyncDelay);
+            this.cancelPendingViewSync?.();
+            this.cancelPendingViewSync = this.setTimeout(this.syncQuadrantViews, viewSyncDelay);
         }
     };
 


### PR DESCRIPTION
#### Fixes #4472

#### Changes proposed in this pull request:

Use `AbstractComponent2`'s shared utility for keeping track of `setTimeout` intervals to cancel this DOM interaction after TableQuadrantStack unmounts.

#### Reviewers should focus on:

Scrolling / view syncing should have no regressions.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
