### PR TITLE
[v4] [table] fix: sync quadrants on frozen cols/rows resize

### DIFF
--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -367,11 +367,11 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             // it when layout-affecting props change.
             !CoreUtils.shallowCompareKeys(this.props, prevProps, {
                 include: SYNC_TRIGGER_PROP_KEYS,
-            })
+            }) ||
             // in addition to those props, we also care about frozen parts of the grid
             // which may cause the top / left quadrants to change height / width
-            || this.didFrozenColumnWidthsChange(prevProps)
-            || this.didFrozenRowHeightsChange(prevProps)
+            this.didFrozenColumnWidthsChange(prevProps) ||
+            this.didFrozenRowHeightsChange(prevProps)
         ) {
             this.emitRefs();
             this.syncQuadrantViews();
@@ -969,16 +969,22 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     /** Returns true the cumulative width of all frozen columns in the grid changed. */
     private didFrozenColumnWidthsChange(prevProps: ITableQuadrantStackProps) {
-        return this.props.numFrozenColumns > 0
-            && this.props.grid !== prevProps.grid
-            && (this.props.grid.getCumulativeWidthAt(this.props.numFrozenColumns - 1) !== prevProps.grid.getCumulativeWidthAt(prevProps.numFrozenColumns - 1));
+        return (
+            this.props.numFrozenColumns > 0 &&
+            this.props.grid !== prevProps.grid &&
+            this.props.grid.getCumulativeWidthAt(this.props.numFrozenColumns - 1) !==
+                prevProps.grid.getCumulativeWidthAt(prevProps.numFrozenColumns - 1)
+        );
     }
 
     /** Returns true the cumulative height of all frozen rows in the grid changed. */
     private didFrozenRowHeightsChange(prevProps: ITableQuadrantStackProps) {
-        return this.props.numFrozenRows > 0
-            && this.props.grid !== prevProps.grid
-            && (this.props.grid.getCumulativeHeightAt(this.props.numFrozenRows - 1) !== prevProps.grid.getCumulativeHeightAt(prevProps.numFrozenRows - 1));
+        return (
+            this.props.numFrozenRows > 0 &&
+            this.props.grid !== prevProps.grid &&
+            this.props.grid.getCumulativeHeightAt(this.props.numFrozenRows - 1) !==
+                prevProps.grid.getCumulativeHeightAt(prevProps.numFrozenRows - 1)
+        );
     }
 
     /**

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -125,7 +125,7 @@ export interface ITableQuadrantStackProps extends Props {
      *
      * REQUIRES QUADRANT RESYNC
      */
-    numFrozenColumns?: number;
+    numFrozenColumns: number;
 
     /**
      * The number of frozen rows. Affects the layout of the table, so we need to
@@ -133,7 +133,7 @@ export interface ITableQuadrantStackProps extends Props {
      *
      * REQUIRES QUADRANT RESYNC
      */
-    numFrozenRows?: number;
+    numFrozenRows: number;
 
     /**
      * The number of rows. Affects the layout of the table, so we need to know
@@ -362,12 +362,16 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
     }
 
     public componentDidUpdate(prevProps: ITableQuadrantStackProps) {
-        // sync'ing quadrant views triggers expensive reflows, so we only call
-        // it when layout-affecting props change.
         if (
+            // sync'ing quadrant views triggers expensive reflows, so we only call
+            // it when layout-affecting props change.
             !CoreUtils.shallowCompareKeys(this.props, prevProps, {
                 include: SYNC_TRIGGER_PROP_KEYS,
             })
+            // in addition to those props, we also care about frozen parts of the grid
+            // which may cause the top / left quadrants to change height / width
+            || this.didFrozenColumnWidthsChange(prevProps)
+            || this.didFrozenRowHeightsChange(prevProps)
         ) {
             this.emitRefs();
             this.syncQuadrantViews();
@@ -962,6 +966,20 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
 
     // Helpers
     // =======
+
+    /** Returns true the cumulative width of all frozen columns in the grid changed. */
+    private didFrozenColumnWidthsChange(prevProps: ITableQuadrantStackProps) {
+        return this.props.numFrozenColumns > 0
+            && this.props.grid !== prevProps.grid
+            && (this.props.grid.getCumulativeWidthAt(this.props.numFrozenColumns - 1) !== prevProps.grid.getCumulativeWidthAt(prevProps.numFrozenColumns - 1));
+    }
+
+    /** Returns true the cumulative height of all frozen rows in the grid changed. */
+    private didFrozenRowHeightsChange(prevProps: ITableQuadrantStackProps) {
+        return this.props.numFrozenRows > 0
+            && this.props.grid !== prevProps.grid
+            && (this.props.grid.getCumulativeHeightAt(this.props.numFrozenRows - 1) !== prevProps.grid.getCumulativeHeightAt(prevProps.numFrozenRows - 1));
+    }
 
     /**
      * Returns the width or height of *only the grid* in the secondary quadrants


### PR DESCRIPTION
#### Fixes #5028

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add logic to TableQuadrantStack to force it to re-sync quadrant width/heights after its grid changes in a way that causes the left quadrant to change width or the top quadrant to change height, either through resizing frozen columns or frozen rows.

#### Reviewers should focus on:

No regressions

#### Screenshot

Before:

![2022-02-24 18 29 00](https://user-images.githubusercontent.com/723999/155625007-da3db637-033f-4453-8c4c-d5f8d69e794e.gif)

After:

![2022-02-24 18 32 12](https://user-images.githubusercontent.com/723999/155625061-481d48b5-cc10-494d-8d45-aed1dfe6173d.gif)

