### PR TITLE
[v4] [table] fix layout measuring headers on initial mount

### DIFF
--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -16,8 +16,9 @@
 
 import * as React from "react";
 
+import { H2 } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { Cell, Column, Table2 } from "@blueprintjs/table";
+import { Cell, Column, ColumnHeaderCell, Table2 } from "@blueprintjs/table";
 
 // this will obviously get outdated, it's valid only as of August 2021
 const USD_TO_EURO_CONVERSION = 0.85;
@@ -31,10 +32,23 @@ export class TableDollarExample extends React.PureComponent<IExampleProps> {
         return (
             <Example options={false} showOptionsBelowExample={true} {...this.props}>
                 <Table2 numRows={20} enableGhostCells={true}>
-                    <Column name="Dollars" cellRenderer={dollarCellRenderer} />
-                    <Column name="Euros" cellRenderer={euroCellRenderer} />
+                    <Column cellRenderer={dollarCellRenderer} columnHeaderCellRenderer={renderColumnHeader} />
+                    <Column cellRenderer={euroCellRenderer} columnHeaderCellRenderer={renderColumnHeader} />
                 </Table2>
             </Example>
         );
     }
+}
+
+function renderColumnHeader(index: number) {
+    const name = ["Dollars", "Euros"][index]!;
+    return (
+        <ColumnHeaderCell name={name} index={index} nameRenderer={renderName} />
+    );
+}
+
+function renderName(name: string) {
+    return (
+        <H2>{name}</H2>
+    )
 }

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -48,8 +48,10 @@ function renderColumnHeader(index: number) {
 function renderName(name: string) {
     return (
         <div style={{ lineHeight: "24px" }}>
-            <div className={Classes.TEXT_LARGE}><strong>{name}</strong></div>
+            <div className={Classes.TEXT_LARGE}>
+                <strong>{name}</strong>
+            </div>
             <div className={Classes.MONOSPACE_TEXT}>Number</div>
         </div>
-    )
+    );
 }

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { H2 } from "@blueprintjs/core";
+import { Classes } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnHeaderCell, Table2 } from "@blueprintjs/table";
 
@@ -42,13 +42,14 @@ export class TableDollarExample extends React.PureComponent<IExampleProps> {
 
 function renderColumnHeader(index: number) {
     const name = ["Dollars", "Euros"][index]!;
-    return (
-        <ColumnHeaderCell name={name} index={index} nameRenderer={renderName} />
-    );
+    return <ColumnHeaderCell name={name} index={index} nameRenderer={renderName} />;
 }
 
 function renderName(name: string) {
     return (
-        <H2>{name}</H2>
+        <div style={{ lineHeight: "24px" }}>
+            <div className={Classes.TEXT_LARGE}><strong>{name}</strong></div>
+            <div className={Classes.MONOSPACE_TEXT}>Number</div>
+        </div>
     )
 }

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -59,6 +59,11 @@ export interface IColumnHeaderProps extends IHeaderProps, IColumnWidths, ColumnI
      * A callback invoked when user is done resizing the column
      */
     onColumnWidthChanged: IIndexedResizeCallback;
+
+    /**
+     * Called on component mount.
+     */
+    onMount?: (whichHeader: "column" | "row") => void;
 }
 
 export class ColumnHeader extends React.Component<IColumnHeaderProps> {
@@ -67,6 +72,10 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps> {
         isResizable: true,
         loading: false,
     };
+
+    public componentDidMount() {
+        this.props.onMount?.("column");
+    }
 
     public render() {
         const {
@@ -101,8 +110,8 @@ export class ColumnHeader extends React.Component<IColumnHeaderProps> {
                 handleResizeDoubleClick={this.handleResizeDoubleClick}
                 handleResizeEnd={this.handleResizeEnd}
                 handleSizeChanged={this.handleSizeChanged}
-                headerCellIsReorderablePropName={"enableColumnReordering"}
-                headerCellIsSelectedPropName={"isColumnSelected"}
+                headerCellIsReorderablePropName="enableColumnReordering"
+                headerCellIsSelectedPropName="isColumnSelected"
                 headerCellRenderer={renderHeaderCell}
                 indexEnd={indexEnd}
                 indexStart={indexStart}

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -47,12 +47,21 @@ export interface IRowHeaderProps extends IHeaderProps, IRowHeights, RowIndices {
      * Renders the cell for each row header
      */
     rowHeaderCellRenderer?: RowHeaderRenderer;
+
+    /**
+     * Called on component mount.
+     */
+    onMount?: (whichHeader: "column" | "row") => void;
 }
 
 export class RowHeader extends React.Component<IRowHeaderProps> {
     public static defaultProps = {
         rowHeaderCellRenderer: renderDefaultRowHeader,
     };
+
+    public componentDidMount() {
+        this.props.onMount?.("row");
+    }
 
     public render() {
         const {

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -505,12 +505,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderRenderer?.(
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenColumnsOnly,
-        );
+        return this.props.columnHeaderRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenColumnsOnly);
     };
 
     private renderTopQuadrantColumnHeader = (showFrozenColumnsOnly: boolean) => {
@@ -522,12 +517,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderRenderer?.(
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenColumnsOnly,
-        );
+        return this.props.columnHeaderRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenColumnsOnly);
     };
 
     private renderLeftQuadrantColumnHeader = (showFrozenColumnsOnly: boolean) => {
@@ -539,12 +529,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderRenderer?.(
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenColumnsOnly,
-        );
+        return this.props.columnHeaderRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenColumnsOnly);
     };
 
     private renderTopLeftQuadrantColumnHeader = (showFrozenColumnsOnly: boolean) => {
@@ -556,12 +541,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderRenderer?.(
-            refHandler,
-            resizeHandler,
-            reorderingHandler,
-            showFrozenColumnsOnly,
-        );
+        return this.props.columnHeaderRenderer?.(refHandler, resizeHandler, reorderingHandler, showFrozenColumnsOnly);
     };
 
     // Row header

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -167,7 +167,7 @@ export interface ITableQuadrantStackProps extends Props {
      * A callback that renders either all of or just the frozen section of the column header.
      * May return undefined if the table is not attached to the DOM yet.
      */
-    columnHeaderCellRenderer?: (
+    columnHeaderRenderer?: (
         refHandler: IRef<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
@@ -183,7 +183,7 @@ export interface ITableQuadrantStackProps extends Props {
      * A callback that renders either all of or just the frozen section of the row header.
      * May return undefined if the table is not attached to the DOM yet.
      */
-    rowHeaderCellRenderer?: (
+    rowHeaderRenderer?: (
         refHandler: IRef<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
@@ -234,6 +234,13 @@ export interface ITableQuadrantStackProps extends Props {
      * @default undefined
      */
     enableColumnInteractionBar?: boolean;
+
+    /**
+     * Flag indicating that both the column headers (if present)
+     * and row headers (if present) have been rendered and mounted, including any
+     * custom renderers which may affect quadrant layout measurements.
+     */
+    didHeadersMount: boolean;
 }
 
 // Used on first render of the top-left and top quadrants to avoid collapsing
@@ -263,6 +270,7 @@ const SYNC_TRIGGER_PROP_KEYS: Array<keyof ITableQuadrantStackProps> = [
     "numColumns",
     "numRows",
     "enableColumnInteractionBar",
+    "didHeadersMount",
 ];
 
 export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackProps> {
@@ -497,7 +505,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderCellRenderer?.(
+        return this.props.columnHeaderRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -514,7 +522,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderCellRenderer?.(
+        return this.props.columnHeaderRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -531,7 +539,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderCellRenderer?.(
+        return this.props.columnHeaderRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -548,7 +556,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.columnHeaderCellRenderer?.(
+        return this.props.columnHeaderRenderer?.(
             refHandler,
             resizeHandler,
             reorderingHandler,
@@ -564,7 +572,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.rowHeaderCellRenderer?.(
+        return this.props.rowHeaderRenderer?.(
             refHandler,
             this.handleRowResizeGuideMain,
             this.handleRowsReordering,
@@ -578,7 +586,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.rowHeaderCellRenderer?.(
+        return this.props.rowHeaderRenderer?.(
             refHandler,
             this.handleRowResizeGuideTop,
             this.handleRowsReordering,
@@ -592,7 +600,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.rowHeaderCellRenderer?.(
+        return this.props.rowHeaderRenderer?.(
             refHandler,
             this.handleRowResizeGuideLeft,
             this.handleRowsReordering,
@@ -606,7 +614,7 @@ export class TableQuadrantStack extends AbstractComponent2<ITableQuadrantStackPr
             return undefined;
         }
 
-        return this.props.rowHeaderCellRenderer?.(
+        return this.props.rowHeaderRenderer?.(
             refHandler,
             this.handleRowResizeGuideTopLeft,
             this.handleRowsReordering,

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -276,6 +276,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             childrenArray,
             columnIdToIndex,
             columnWidths: newColumnWidths,
+            didHeadersMount: false,
             focusedCell,
             horizontalGuides: [],
             isLayoutLocked: false,
@@ -449,7 +450,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
                 <TableQuadrantStack
                     bodyRef={this.refHandlers.cellContainer}
                     bodyRenderer={this.renderBody}
-                    columnHeaderCellRenderer={this.renderColumnHeader}
+                    columnHeaderRenderer={this.renderColumnHeader}
                     columnHeaderRef={this.refHandlers.columnHeader}
                     enableColumnInteractionBar={enableColumnInteractionBar}
                     enableRowHeader={enableRowHeader}
@@ -468,7 +469,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
                     onScroll={this.handleBodyScroll}
                     ref={this.refHandlers.quadrantStack}
                     menuRenderer={this.renderMenu}
-                    rowHeaderCellRenderer={this.renderRowHeader}
+                    rowHeaderRenderer={this.renderRowHeader}
                     rowHeaderRef={this.refHandlers.rowHeader}
                     scrollContainerRef={this.refHandlers.scrollContainer}
                 />

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -240,6 +240,10 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
 
     private scrollContainerElement?: HTMLElement | null;
 
+    private didColumnHeaderMount = false;
+
+    private didRowHeaderMount = false;
+
     /*
      * This value is set to `true` when all cells finish mounting for the first
      * time. It serves as a signal that we can switch to batch rendering.
@@ -285,6 +289,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
             childrenArray,
             columnIdToIndex,
             columnWidths: newColumnWidths,
+            didHeadersMount: false,
             focusedCell,
             horizontalGuides: [],
             isLayoutLocked: false,
@@ -457,15 +462,6 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
             className,
         );
 
-        // if (this.grid == null) {
-        //     return (
-        //         <div
-        //             className={classes}
-        //             ref={this.refHandlers.rootTable}
-        //         />
-        //     );
-        // }
-
         return (
             <div
                 className={classes}
@@ -478,8 +474,9 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
                 <TableQuadrantStack
                     bodyRef={this.refHandlers.cellContainer}
                     bodyRenderer={this.renderBody}
-                    columnHeaderCellRenderer={this.renderColumnHeader}
+                    columnHeaderRenderer={this.renderColumnHeader}
                     columnHeaderRef={this.refHandlers.columnHeader}
+                    didHeadersMount={this.state.didHeadersMount}
                     enableColumnInteractionBar={enableColumnInteractionBar}
                     enableRowHeader={enableRowHeader}
                     grid={grid}
@@ -497,7 +494,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
                     onScroll={this.handleBodyScroll}
                     ref={this.refHandlers.quadrantStack}
                     menuRenderer={this.renderMenu}
-                    rowHeaderCellRenderer={this.renderRowHeader}
+                    rowHeaderRenderer={this.renderRowHeader}
                     rowHeaderRef={this.refHandlers.rowHeader}
                     scrollContainerRef={this.refHandlers.scrollContainer}
                 />
@@ -825,6 +822,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
                     minColumnWidth={minColumnWidth!}
                     onColumnWidthChanged={this.handleColumnWidthChanged}
                     onFocusedCell={this.handleFocus}
+                    onMount={this.handleHeaderMounted}
                     onLayoutLock={this.handleLayoutLock}
                     onReordered={this.handleColumnsReordered}
                     onReordering={reorderingHandler}
@@ -899,6 +897,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
                     minRowHeight={minRowHeight!}
                     onFocusedCell={this.handleFocus}
                     onLayoutLock={this.handleLayoutLock}
+                    onMount={this.handleHeaderMounted}
                     onResizeGuide={resizeHandler}
                     onReordered={this.handleRowsReordered}
                     onReordering={reorderingHandler}
@@ -1081,6 +1080,23 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
                 />
             );
         });
+    }
+
+    private handleHeaderMounted = (whichHeader: "column" | "row") => {
+        const { didHeadersMount } = this.state;
+        if (didHeadersMount) {
+            return;
+        }
+
+        if (whichHeader === "column") {
+            this.didColumnHeaderMount = true;
+        } else {
+            this.didRowHeaderMount = true;
+        }
+
+        if (this.didColumnHeaderMount && this.didRowHeaderMount) {
+            this.setState({ didHeadersMount: true });
+        }
     }
 
     private handleCompleteRender = () => {

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -1104,7 +1104,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         // defined and the second after the viewportRect has been set. the cells
         // will only actually render once the viewportRect is defined though, so
         // we defer invoking onCompleteRender until that check passes.
-        if (this.state.viewportRect != null) {
+        if (this.state.viewportRect != null && this.state.didHeadersMount) {
             this.props.onCompleteRender?.();
             this.didCompletelyMount = true;
         }

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -1097,7 +1097,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         if (this.didColumnHeaderMount && this.didRowHeaderMount) {
             this.setState({ didHeadersMount: true });
         }
-    }
+    };
 
     private handleCompleteRender = () => {
         // the first onCompleteRender is triggered before the viewportRect is

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -457,6 +457,15 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
             className,
         );
 
+        // if (this.grid == null) {
+        //     return (
+        //         <div
+        //             className={classes}
+        //             ref={this.refHandlers.rootTable}
+        //         />
+        //     );
+        // }
+
         return (
             <div
                 className={classes}
@@ -519,6 +528,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
                     this.updateViewportRect(this.locator?.getViewportRect());
                 }
             });
+            this.forceUpdate();
         }
     }
 

--- a/packages/table/src/tableState.ts
+++ b/packages/table/src/tableState.ts
@@ -37,6 +37,13 @@ export interface TableState {
     horizontalGuides: number[];
 
     /**
+     * Flag indicating that both the column headers (if present)
+     * and row headers (if present) have been rendered and mounted, including any
+     * custom renderers which may affect quadrant layout measurements.
+     */
+    didHeadersMount: boolean;
+
+    /**
      * If `true`, will disable updates that will cause re-renders of children
      * components. This is used, for example, to disable layout updates while
      * the user is dragging a resize handle.

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -106,9 +106,7 @@ describe("TableQuadrantStack", () => {
             return <div />;
         };
 
-        mount(
-            <TableQuadrantStack grid={grid} bodyRenderer={sinon.spy()} rowHeaderRenderer={rowHeaderRenderer} />,
-        );
+        mount(<TableQuadrantStack grid={grid} bodyRenderer={sinon.spy()} rowHeaderRenderer={rowHeaderRenderer} />);
 
         const HORIZONTAL_GUIDES = [1, 2, 3];
         expect(() => resizeHandlerMain(HORIZONTAL_GUIDES)).not.to.throw();
@@ -221,13 +219,7 @@ describe("TableQuadrantStack", () => {
         it("invokes rowHeaderRenderer once for each quadrant on mount", () => {
             const bodyRenderer = sinon.spy();
             const rowHeaderRenderer = sinon.spy();
-            mount(
-                <TableQuadrantStack
-                    grid={grid}
-                    bodyRenderer={bodyRenderer}
-                    rowHeaderRenderer={rowHeaderRenderer}
-                />,
-            );
+            mount(<TableQuadrantStack grid={grid} bodyRenderer={bodyRenderer} rowHeaderRenderer={rowHeaderRenderer} />);
             expect(rowHeaderRenderer.callCount).to.equal(4);
         });
 

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -65,7 +65,7 @@ describe("TableQuadrantStack", () => {
         const columnHeaderRef = sinon.spy();
         const scrollContainerRef = sinon.spy();
 
-        const columnHeaderCellRenderer = (refHandler: IRef<HTMLDivElement>) => {
+        const columnHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
             return <div ref={refHandler} />;
         };
         const rendeRowHeader = (refHandler: IRef<HTMLDivElement>) => {
@@ -80,8 +80,8 @@ describe("TableQuadrantStack", () => {
                 rowHeaderRef={rowHeaderRef}
                 columnHeaderRef={columnHeaderRef}
                 scrollContainerRef={scrollContainerRef}
-                columnHeaderCellRenderer={columnHeaderCellRenderer}
-                rowHeaderCellRenderer={rendeRowHeader}
+                columnHeaderRenderer={columnHeaderRenderer}
+                rowHeaderRenderer={rendeRowHeader}
             />,
         );
 
@@ -101,13 +101,13 @@ describe("TableQuadrantStack", () => {
         type ResizeHandler = (verticalGuides: number[]) => void;
         let resizeHandlerMain: ResizeHandler;
 
-        const rowHeaderCellRenderer = (_a: any, resizeHandler: any) => {
+        const rowHeaderRenderer = (_a: any, resizeHandler: any) => {
             resizeHandlerMain = resizeHandler;
             return <div />;
         };
 
         mount(
-            <TableQuadrantStack grid={grid} bodyRenderer={sinon.spy()} rowHeaderCellRenderer={rowHeaderCellRenderer} />,
+            <TableQuadrantStack grid={grid} bodyRenderer={sinon.spy()} rowHeaderRenderer={rowHeaderRenderer} />,
         );
 
         const HORIZONTAL_GUIDES = [1, 2, 3];
@@ -205,30 +205,30 @@ describe("TableQuadrantStack", () => {
             expect(menuRenderer.callCount).to.equal(4);
         });
 
-        it("invokes columnHeaderCellRenderer once for each quadrant on mount", () => {
+        it("invokes columnHeaderRenderer once for each quadrant on mount", () => {
             const bodyRenderer = sinon.spy();
-            const columnHeaderCellRenderer = sinon.spy();
+            const columnHeaderRenderer = sinon.spy();
             mount(
                 <TableQuadrantStack
                     grid={grid}
                     bodyRenderer={bodyRenderer}
-                    columnHeaderCellRenderer={columnHeaderCellRenderer}
+                    columnHeaderRenderer={columnHeaderRenderer}
                 />,
             );
-            expect(columnHeaderCellRenderer.callCount).to.equal(4);
+            expect(columnHeaderRenderer.callCount).to.equal(4);
         });
 
-        it("invokes rowHeaderCellRenderer once for each quadrant on mount", () => {
+        it("invokes rowHeaderRenderer once for each quadrant on mount", () => {
             const bodyRenderer = sinon.spy();
-            const rowHeaderCellRenderer = sinon.spy();
+            const rowHeaderRenderer = sinon.spy();
             mount(
                 <TableQuadrantStack
                     grid={grid}
                     bodyRenderer={bodyRenderer}
-                    rowHeaderCellRenderer={rowHeaderCellRenderer}
+                    rowHeaderRenderer={rowHeaderRenderer}
                 />,
             );
-            expect(rowHeaderCellRenderer.callCount).to.equal(4);
+            expect(rowHeaderRenderer.callCount).to.equal(4);
         });
 
         it("does not render LEFT/TOP_LEFT quadrants if row header not shown and no frozen columns", () => {
@@ -256,7 +256,7 @@ describe("TableQuadrantStack", () => {
                     <TableQuadrantStack
                         grid={grid}
                         bodyRenderer={sinon.spy()}
-                        columnHeaderCellRenderer={renderRowOrColumnHeader}
+                        columnHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 expect(() => resizeHandler([])).not.to.throw();
@@ -269,7 +269,7 @@ describe("TableQuadrantStack", () => {
                         grid={grid}
                         handleColumnResizeGuide={handleColumnResizeGuide}
                         bodyRenderer={sinon.spy()}
-                        columnHeaderCellRenderer={renderRowOrColumnHeader}
+                        columnHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 resizeHandler([]);
@@ -283,7 +283,7 @@ describe("TableQuadrantStack", () => {
                     <TableQuadrantStack
                         grid={grid}
                         bodyRenderer={sinon.spy()}
-                        rowHeaderCellRenderer={renderRowOrColumnHeader}
+                        rowHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 expect(() => resizeHandler([])).not.to.throw();
@@ -296,7 +296,7 @@ describe("TableQuadrantStack", () => {
                         grid={grid}
                         handleRowResizeGuide={handleRowResizeGuide}
                         bodyRenderer={sinon.spy()}
-                        rowHeaderCellRenderer={renderRowOrColumnHeader}
+                        rowHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 resizeHandler([]);
@@ -321,7 +321,7 @@ describe("TableQuadrantStack", () => {
                     <TableQuadrantStack
                         grid={grid}
                         bodyRenderer={sinon.spy()}
-                        columnHeaderCellRenderer={renderRowOrColumnHeader}
+                        columnHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 expect(() => reorderingHandler(1, 2, 3)).not.to.throw();
@@ -334,7 +334,7 @@ describe("TableQuadrantStack", () => {
                         grid={grid}
                         handleColumnsReordering={handleColumnsReordering}
                         bodyRenderer={sinon.spy()}
-                        columnHeaderCellRenderer={renderRowOrColumnHeader}
+                        columnHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 reorderingHandler(1, 2, 3);
@@ -348,7 +348,7 @@ describe("TableQuadrantStack", () => {
                     <TableQuadrantStack
                         grid={grid}
                         bodyRenderer={sinon.spy()}
-                        rowHeaderCellRenderer={renderRowOrColumnHeader}
+                        rowHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 expect(() => reorderingHandler(1, 2, 3)).not.to.throw();
@@ -361,7 +361,7 @@ describe("TableQuadrantStack", () => {
                         grid={grid}
                         handleRowsReordering={handleRowsReordering}
                         bodyRenderer={sinon.spy()}
-                        rowHeaderCellRenderer={renderRowOrColumnHeader}
+                        rowHeaderRenderer={renderRowOrColumnHeader}
                     />,
                 );
                 reorderingHandler(1, 2, 3);
@@ -416,7 +416,7 @@ describe("TableQuadrantStack", () => {
         });
 
         function assertDefaultQuadrantSizesCorrect(numFrozenRows: number, numFrozenColumns: number) {
-            const rowHeaderCellRenderer = (refHandler: IRef<HTMLDivElement>) => {
+            const rowHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
                 // need to set the width on a child so the header maintains its size
                 // when the component measures the "desired" row-header width (by
                 // setting width:auto on the parent here).
@@ -426,7 +426,7 @@ describe("TableQuadrantStack", () => {
                     </div>
                 );
             };
-            const columnHeaderCellRenderer = (refHandler: IRef<HTMLDivElement>) => {
+            const columnHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
                 return <div ref={refHandler} style={{ height: COLUMN_HEADER_HEIGHT, width: "100%" }} />;
             };
 
@@ -436,8 +436,8 @@ describe("TableQuadrantStack", () => {
                     numFrozenColumns={numFrozenColumns}
                     numFrozenRows={numFrozenRows}
                     bodyRenderer={renderGridBody()}
-                    rowHeaderCellRenderer={rowHeaderCellRenderer}
-                    columnHeaderCellRenderer={columnHeaderCellRenderer}
+                    rowHeaderRenderer={rowHeaderRenderer}
+                    columnHeaderRenderer={columnHeaderRenderer}
                 />,
             );
 
@@ -453,7 +453,7 @@ describe("TableQuadrantStack", () => {
         }
 
         function assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows: number, numFrozenColumns: number) {
-            const columnHeaderCellRenderer = (refHandler: IRef<HTMLDivElement>) => {
+            const columnHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
                 return <div ref={refHandler} style={{ height: COLUMN_HEADER_HEIGHT, width: "100%" }} />;
             };
 
@@ -464,7 +464,7 @@ describe("TableQuadrantStack", () => {
                     numFrozenColumns={numFrozenColumns}
                     numFrozenRows={numFrozenRows}
                     bodyRenderer={renderGridBody()}
-                    columnHeaderCellRenderer={columnHeaderCellRenderer}
+                    columnHeaderRenderer={columnHeaderRenderer}
                 />,
             );
 


### PR DESCRIPTION
The table component rendering process has a particular order of operations which relies on DOM interactions and React lifecycle methods happening in a certain way for all its measurement calculations to be accurate. Before this PR, TableQuadrantStack was taking measurements of column/row headers before they had a chance to render their contents, and using those width/height values to set the size of the quadrants for the initial render. This turned out to be buggy and produced visual gaps in the table when there were custom column/row header renderers, or in the case of frozen cols/rows.

The code in this PR adds some logic to Table2 and TableQuadrantStack to keep track of when the ColumnHeader and RowHeader components are fully mounted, after which we trigger a resync of the quadrant views with updated width/height measurements of the header areas. This fixes a few bugs.

## Bug 1

Initial display of frozen cols/rows was wrong on initial render (before):

<img width="808" alt="Screen Shot 2022-02-25 at 10 17 39 AM" src="https://user-images.githubusercontent.com/723999/155751256-edd78900-4373-4cf6-a64d-a592577f71be.png">


After:

<img width="810" alt="Screen Shot 2022-02-25 at 10 17 43 AM" src="https://user-images.githubusercontent.com/723999/155751282-9769824a-e175-4c85-9756-56358743c5f7.png">


## Bug 2

Initial display of column headers with heights exceeding the minimum/default column header height was wrong on initial render(before):

<img width="405" alt="Screen Shot 2022-02-25 at 10 17 56 AM" src="https://user-images.githubusercontent.com/723999/155751303-0e2afa0f-7aaf-4c45-9b64-aad53b2e6694.png">

After:

<img width="818" alt="Screen Shot 2022-02-25 at 11 20 12 AM" src="https://user-images.githubusercontent.com/723999/155751333-a244ddb5-ba88-4c12-9865-5d87ecf8db7d.png">

