### PR TITLE
fix: node_modules relative paths in sourcemaps

### DIFF
--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -19,4 +19,4 @@ $ROOT_NM/.bin/node-sass-chokidar \
 
 # in source maps, paths to blueprint packages should be direct, rather than
 # going through node_modules. https://github.com/palantir/blueprint/issues/3500
-sed -i '' 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+sed -i 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -19,4 +19,6 @@ $ROOT_NM/.bin/node-sass-chokidar \
 
 # in source maps, paths to blueprint packages should be direct, rather than
 # going through node_modules. https://github.com/palantir/blueprint/issues/3500
-sed -i 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+if [[ -d $OUTPUT ]]; then
+  sed -i 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+fi

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -16,3 +16,7 @@ $ROOT_NM/.bin/node-sass-chokidar \
   --output $OUTPUT \
   --source-map true \
   $@
+
+# in source maps, paths to blueprint packages should be direct, rather than
+# going through node_modules. https://github.com/palantir/blueprint/issues/3500
+sed -i '' 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map


### PR DESCRIPTION
#### Fixes #3500

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Taking a stab at fixing #3500.

The source maps published with blueprint are incorrect. For example:
```json
app/node_modules/@blueprintjs/select/lib/css/blueprint-select.css.map
{
    "version":3,
    "sources":[
        "../../src/components/omnibar/_omnibar.scss",
        "../../../../node_modules/@blueprintjs/core/src/common/_react-transition.scss",
        ...
```

The resolved path of that second source is `app/node_modules/node_modules/@blueprintjs/core/src/common/_react-transition.scss` (notice the double `node_modules`). This leads to webpack errors like:
```
Failed to parse source map from '/Users/zachkirsch/Dropbox/Mac/Documents/trace-app/node_modules/node_modules/@blueprintjs/core/src/common/_react-transition.scss' file: Error: ENOENT: no such file or directory, open '/Users/zachkirsch/Dropbox/Mac/Documents/trace-app/node_modules/node_modules/@blueprintjs/core/src/common/_react-transition.scss'
```

**Where does `"../../../../node_modules` come from?**

When the sass is compiled, the path `"~@blueprintjs/core/src/common/react-transition"` is resolved to `"node_modules/@blueprintjs/core/src/common/_react-transition.scss"`, and `node_modules` is 4 directories up, hence the final result of `../../../../node_modules/@blueprintjs/core/src/common/_react-transition.scss`. Ideally node-sass-chokidar could resolve/follow the symlink to figure out that there's a more direct route to that file (`../../../core/src/common/_react-transition.scss`), but it doesn't seem like that's possible.

I tried moving to `dart-sass` since `node-sass-chokidar` is [deprecated](https://github.com/michaelwayman/node-sass-chokidar), but it looks like the source maps have the same issue (paths going through node_modules).

So this PR is a "cheap" solution - after writing the source maps files, convert the "roundabout" `node_modules` paths to more direct paths:

```json
{
	"version": 3,
	"sources": [
		"../../src/components/omnibar/_omnibar.scss",
		"../../../core/src/common/_react-transition.scss",
``` 

#### Reviewers should focus on:

Is there a place I can add tests?

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
