### PR TITLE
[v4] [table] fix lifecycle bugs scrolling + resizing

### DIFF
--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -52,7 +52,7 @@ import {
     resizeRowsByApproximateHeight,
     resizeRowsByTallestCell,
 } from "./resizeRows";
-import { getHotkeysFromProps, isSelectionModeEnabled } from "./table2Utils";
+import { compareChildren, getHotkeysFromProps, isSelectionModeEnabled } from "./table2Utils";
 import { TableBody } from "./tableBody";
 import { TableHotkeys } from "./tableHotkeys";
 import type { TableProps, TablePropsDefaults, TablePropsWithDefaults } from "./tableProps";
@@ -108,9 +108,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
 
         const newChildrenArray = React.Children.toArray(children) as Array<React.ReactElement<ColumnProps>>;
-        const didChildrenChange = !newChildrenArray.every(
-            (child, index) => child.key === state.childrenArray[index].key,
-        );
+        const didChildrenChange = !compareChildren(newChildrenArray, state.childrenArray);
         const numCols = newChildrenArray.length;
 
         let newColumnWidths = columnWidths;
@@ -544,9 +542,9 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         this.hotkeysImpl.setState(this.state);
         this.hotkeysImpl.setProps(this.props);
 
-        const newChildrenArray = React.Children.toArray(this.props.children) as Array<React.ReactElement<ColumnProps>>;
-        const didChildrenChange = !newChildrenArray.every(
-            (child, index) => child.key === this.state.childrenArray[index].key,
+        const didChildrenChange = !compareChildren(
+            React.Children.toArray(this.props.children) as Array<React.ReactElement<ColumnProps>>,
+            this.state.childrenArray,
         );
 
         const shouldInvalidateGrid =

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -108,7 +108,9 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         }
 
         const newChildrenArray = React.Children.toArray(children) as Array<React.ReactElement<ColumnProps>>;
-        const didChildrenChange = newChildrenArray !== state.childrenArray;
+        const didChildrenChange = !newChildrenArray.every(
+            (child, index) => child.key === state.childrenArray[index].key,
+        );
         const numCols = newChildrenArray.length;
 
         let newColumnWidths = columnWidths;
@@ -537,41 +539,15 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         this.didCompletelyMount = false;
     }
 
-    public getSnapshotBeforeUpdate() {
-        const { viewportRect } = this.state;
-
-        if (viewportRect === undefined) {
-            return {};
-        }
-
-        const grid = this.validateGrid();
-        const tableBottom = grid.getCumulativeHeightAt(grid.numRows - 1);
-        const tableRight = grid.getCumulativeWidthAt(grid.numCols - 1);
-
-        const nextScrollTop =
-            tableBottom < viewportRect.top + viewportRect.height
-                ? // scroll the last row into view
-                  Math.max(0, tableBottom - viewportRect.height)
-                : undefined;
-
-        const nextScrollLeft =
-            tableRight < viewportRect.left + viewportRect.width
-                ? // scroll the last column into view
-                  Math.max(0, tableRight - viewportRect.width)
-                : undefined;
-
-        // these will only be defined if they differ from viewportRect
-        return { nextScrollLeft, nextScrollTop };
-    }
-
-    public componentDidUpdate(prevProps: TableProps, prevState: TableState, snapshot: TableSnapshot) {
-        super.componentDidUpdate(prevProps, prevState, snapshot);
+    public componentDidUpdate(prevProps: TableProps, prevState: TableState) {
+        super.componentDidUpdate(prevProps, prevState);
         this.hotkeysImpl.setState(this.state);
         this.hotkeysImpl.setProps(this.props);
 
-        const didChildrenChange =
-            (React.Children.toArray(this.props.children) as Array<React.ReactElement<ColumnProps>>) !==
-            this.state.childrenArray;
+        const newChildrenArray = React.Children.toArray(this.props.children) as Array<React.ReactElement<ColumnProps>>;
+        const didChildrenChange = !newChildrenArray.every(
+            (child, index) => child.key === this.state.childrenArray[index].key,
+        );
 
         const shouldInvalidateGrid =
             didChildrenChange ||
@@ -587,18 +563,6 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
         if (this.locator != null) {
             this.validateGrid();
             this.updateLocator();
-        }
-
-        // When true, we'll need to imperatively synchronize quadrant views after
-        // the update. This check lets us avoid expensively diff'ing columnWidths
-        // and rowHeights in <TableQuadrantStack> on each update.
-        const didUpdateColumnOrRowSizes =
-            !CoreUtils.arraysEqual(this.state.columnWidths, prevState.columnWidths) ||
-            !CoreUtils.arraysEqual(this.state.rowHeights, prevState.rowHeights);
-
-        if (didUpdateColumnOrRowSizes) {
-            this.quadrantStackInstance?.synchronizeQuadrantViews();
-            this.syncViewportPosition(snapshot);
         }
 
         const shouldInvalidateHotkeys =

--- a/packages/table/src/table2Utils.ts
+++ b/packages/table/src/table2Utils.ts
@@ -17,9 +17,10 @@ import * as React from "react";
 
 import { HotkeyConfig } from "@blueprintjs/core";
 
+import type { ColumnProps } from "./column";
 import { RegionCardinality } from "./regions";
 import type { TableHotkeys } from "./tableHotkeys";
-import { TablePropsWithDefaults } from "./tableProps";
+import type { TablePropsWithDefaults } from "./tableProps";
 
 export function isSelectionModeEnabled(
     props: TablePropsWithDefaults,
@@ -141,4 +142,17 @@ export function getHotkeysFromProps(props: TablePropsWithDefaults, hotkeysImpl: 
     }
 
     return hotkeys;
+}
+
+/**
+ * @returns true if new and old children arrays are the same
+ */
+export function compareChildren(
+    newChildren: Array<React.ReactElement<ColumnProps>>,
+    oldChildren: Array<React.ReactElement<ColumnProps>>,
+): boolean {
+    return (
+        newChildren.length === oldChildren.length &&
+        newChildren.every((child, index) => child.key === oldChildren[index].key)
+    );
 }


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Fix children diffing code to accurately determine when Table2's children change (previously, this would be triggered too often)
- Remove buggy calls in componentDidUpdate which turned out to be unnecessary to sync viewport / quadrant stack position. These were causing a bug where rows were rendered blank after resizing columns when the table body was scrolled down any amount.

#### Reviewers should focus on:

No regressions

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
