### PR TITLE
[v4] [table] fix(Table2): more column resizing issues

### DIFF
--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -347,6 +347,23 @@ export const Utils = {
         const approxCellHeight = approxNumLinesDesired * approxLineHeight;
         return approxCellHeight;
     },
+
+    /**
+     * Shallow comparison of potentially sparse arrays.
+     *
+     * @returns true if the array values are equal
+     */
+    compareSparseArrays(
+        a: Array<number | null | undefined> | undefined,
+        b: Array<number | null | undefined> | undefined,
+    ): boolean {
+        return (
+            a !== undefined &&
+            b !== undefined &&
+            a.length === b.length &&
+            a.every((aValue, index) => aValue === b[index])
+        );
+    },
 };
 
 // table is nearly deprecated, let's not block on code coverage

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -258,6 +258,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
             columnWidths,
             defaultRowHeight,
             defaultColumnWidth,
+            enableRowHeader,
             numRows,
             rowHeights,
             selectedRegions = [] as Region[],
@@ -308,6 +309,10 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
             syncViewportPosition: this.syncViewportPosition,
         });
         this.hotkeys = getHotkeysFromProps(props, this.hotkeysImpl);
+
+        if (enableRowHeader === false) {
+            this.didRowHeaderMount = true;
+        }
     }
 
     // Instance methods
@@ -549,8 +554,8 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
 
         const shouldInvalidateGrid =
             didChildrenChange ||
-            this.props.columnWidths !== prevState.columnWidths ||
-            this.props.rowHeights !== prevState.rowHeights ||
+            !Utils.compareSparseArrays(this.props.columnWidths, prevState.columnWidths) ||
+            !Utils.compareSparseArrays(this.props.rowHeights, prevState.rowHeights) ||
             this.props.numRows !== prevProps.numRows ||
             (this.props.forceRerenderOnSelectionChange && this.props.selectedRegions !== prevProps.selectedRegions);
 
@@ -1210,11 +1215,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
 
         this.invalidateGrid();
         this.setState({ columnWidths });
-
-        const { onColumnWidthChanged } = this.props;
-        if (onColumnWidthChanged != null) {
-            onColumnWidthChanged(columnIndex, width);
-        }
+        this.props.onColumnWidthChanged?.(columnIndex, width);
     };
 
     private handleRowHeightChanged = (rowIndex: number, height: number) => {
@@ -1236,11 +1237,7 @@ export class Table2 extends AbstractComponent2<TableProps, TableState, TableSnap
 
         this.invalidateGrid();
         this.setState({ rowHeights });
-
-        const { onRowHeightChanged } = this.props;
-        if (onRowHeightChanged != null) {
-            onRowHeightChanged(rowIndex, height);
-        }
+        this.props.onRowHeightChanged?.(rowIndex, height);
     };
 
     private handleRootScroll = (_event: React.UIEvent<HTMLElement>) => {


### PR DESCRIPTION
#### Changes proposed in this pull request:

Use `forceUpdate` after grid changes in componentDidUpdate to make the body cells re-render.

Prior to this change, the body cells would retain their old widths until the user moused over the main quadrant.