### PR TITLE
[core] fix: Set aria-hidden for purely decorative icons

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -185,10 +185,12 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
 
     protected renderChildren(): React.ReactNode {
         const { children, icon, loading, rightIcon, text } = this.props;
+        const maybeHasText = !Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children);
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={IconSize.LARGE} />,
-            <Icon key="leftIcon" icon={icon} />,
-            (!Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children)) && (
+            // The icon is purely decorative if text is provided
+            <Icon key="leftIcon" icon={icon} aria-hidden={maybeHasText} tabIndex={maybeHasText ? -1 : 0} />,
+            maybeHasText && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}
                     {children}

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -78,7 +78,7 @@ export class Callout extends AbstractPureComponent2<CalloutProps> {
 
         return (
             <div className={classes} {...htmlProps}>
-                {iconName && <Icon icon={iconName} size={IconSize.LARGE} />}
+                {iconName && <Icon icon={iconName} size={IconSize.LARGE} aria-hidden={true} tabIndex={-1} />}
                 {title && <H4>{title}</H4>}
                 {children}
             </div>

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -165,7 +165,7 @@ export class Dialog extends AbstractPureComponent2<DialogProps> {
         }
         return (
             <div className={Classes.DIALOG_HEADER}>
-                <Icon icon={icon} size={IconSize.LARGE} />
+                <Icon icon={icon} size={IconSize.LARGE} aria-hidden={true} tabIndex={-1} />
                 <H4 id={this.titleId}>{title}</H4>
                 {this.maybeRenderCloseButton()}
             </div>

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -269,7 +269,7 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
                 </span>
             );
         } else if (leftIcon != null) {
-            return <Icon icon={leftIcon} />;
+            return <Icon icon={leftIcon} aria-hidden={true} tabIndex={-1} />;
         }
 
         return undefined;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -166,7 +166,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
                 ...(disabled ? DISABLED_PROPS : {}),
                 className: anchorClasses,
             },
-            <Icon icon={icon} />,
+            <Icon icon={icon} aria-hidden={true} tabIndex={-1} />,
             <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>
                 {text}
             </Text>,

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -75,7 +75,7 @@ export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
         } else {
             return (
                 <div className={Classes.NON_IDEAL_STATE_VISUAL}>
-                    <Icon icon={icon} size={IconSize.LARGE * 3} />
+                    <Icon icon={icon} size={IconSize.LARGE * 3} aria-hidden={true} tabIndex={-1} />
                 </div>
             );
         }

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -141,7 +141,7 @@ export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>> {
             <li className={classes}>
                 <div className={contentClasses} ref={this.handleContentRef} {...eventHandlers}>
                     {this.maybeRenderCaret()}
-                    <Icon className={Classes.TREE_NODE_ICON} icon={icon} />
+                    <Icon className={Classes.TREE_NODE_ICON} icon={icon} aria-hidden={true} tabIndex={-1} />
                     <span className={Classes.TREE_NODE_LABEL}>{label}</span>
                     {this.maybeRenderSecondaryLabel()}
                 </div>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

For icons that are purely decorative because they have associated text, add `aria-hidden={true}` and `tabIndex={-1}` to the `Icon` props

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
