### PR TITLE
chore: Fix sass compile script for OS X

### DIFF
--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -20,5 +20,9 @@ $ROOT_NM/.bin/node-sass-chokidar \
 # in source maps, paths to blueprint packages should be direct, rather than
 # going through node_modules. https://github.com/palantir/blueprint/issues/3500
 if [[ -d $OUTPUT ]]; then
-  sed -i '' 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+  if [[ $OSTYPE == 'darwin'* ]]; then
+    sed -i '' 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+  else
+    sed -i 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+  fi
 fi

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -20,5 +20,5 @@ $ROOT_NM/.bin/node-sass-chokidar \
 # in source maps, paths to blueprint packages should be direct, rather than
 # going through node_modules. https://github.com/palantir/blueprint/issues/3500
 if [[ -d $OUTPUT ]]; then
-  sed -i 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
+  sed -i '' 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
 fi


### PR DESCRIPTION
Was running into `yarn compile` errors locally: `sed: 1: "lib/css//blueprint-icon ...": extra characters at the end of l command
error Command failed with exit code 1.` I think this was introduced with https://github.com/palantir/blueprint/pull/5146. 

Found this solution `Unlike Ubuntu, OS X requires the extension to be explicitly specified. The workaround is to set an empty string:` which fixed the issue


#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
