### PR TITLE
[core] fix(AsyncControllableInput): handle compound composition events

### DIFF
--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -146,6 +146,9 @@ export class AsyncControllableInput extends React.PureComponent<
     };
 
     private handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+        // In some non-latin languages, a keystroke can end a composition event and immediately afterwards open another.
+        // This timeout unlocks nextValue to be overwritten by the `value` prop, if and only if a delay (10ms) has
+        // passed without a new composition event starting.
         this.compositionStatusTimeoutID = window.setTimeout(() => this.setState({ isComposing: false }), 10);
         this.props.onCompositionEnd?.(e);
     };

--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 import { polyfill } from "react-lifecycles-compat";
 
-import { DISPLAYNAME_PREFIX } from "../../common/props";
+import { AbstractPureComponent2, DISPLAYNAME_PREFIX } from "../../common";
 
 export interface IAsyncControllableInputProps
     extends React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> {
@@ -65,11 +65,17 @@ export interface IAsyncControllableInputState {
  * Note: this component does not apply any Blueprint-specific styling.
  */
 @polyfill
-export class AsyncControllableInput extends React.PureComponent<
+export class AsyncControllableInput extends AbstractPureComponent2<
     IAsyncControllableInputProps,
     IAsyncControllableInputState
 > {
     public static displayName = `${DISPLAYNAME_PREFIX}.AsyncControllableInput`;
+
+    /**
+     * The amount of time (in milliseconds) which the input will wait after a compositionEnd event before
+     * unlocking its state value for external updates via props. See `handleCompositionEnd` for more details.
+     */
+    public static COMPOSITION_END_DELAY = 10;
 
     public state: IAsyncControllableInputState = {
         hasPendingUpdate: false,
@@ -78,7 +84,7 @@ export class AsyncControllableInput extends React.PureComponent<
         value: this.props.value,
     };
 
-    private compositionStatusTimeoutID: number | null = null;
+    private cancelPendingCompositionEnd: (() => void) | null = null;
 
     public static getDerivedStateFromProps(
         nextProps: IAsyncControllableInputProps,
@@ -136,20 +142,21 @@ export class AsyncControllableInput extends React.PureComponent<
     }
 
     private handleCompositionStart = (e: React.CompositionEvent<HTMLInputElement>) => {
-        if (this.compositionStatusTimeoutID !== null) {
-            window.clearTimeout(this.compositionStatusTimeoutID);
-            this.compositionStatusTimeoutID = null;
-        }
-
+        this.cancelPendingCompositionEnd?.();
         this.setState({ isComposing: true });
         this.props.onCompositionStart?.(e);
     };
 
     private handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
-        // In some non-latin languages, a keystroke can end a composition event and immediately afterwards open another.
-        // This timeout unlocks nextValue to be overwritten by the `value` prop, if and only if a delay (10ms) has
+        // In some non-latin languages, a keystroke can end a composition event and immediately afterwards start another.
+        // This can lead to unexpected characters showing up in the text input. In order to circumvent this problem, we
+        // use a timeout which creates a delay which merges the two composition events, creating a more natural and predictable UX.
+        // `this.state.nextValue` will become "locked" (it cannot be overwritten by the `value` prop) until a delay (10ms) has
         // passed without a new composition event starting.
-        this.compositionStatusTimeoutID = window.setTimeout(() => this.setState({ isComposing: false }), 10);
+        this.cancelPendingCompositionEnd = this.setTimeout(
+            () => this.setState({ isComposing: false }),
+            AsyncControllableInput.COMPOSITION_END_DELAY,
+        );
         this.props.onCompositionEnd?.(e);
     };
 

--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -78,6 +78,8 @@ export class AsyncControllableInput extends React.PureComponent<
         value: this.props.value,
     };
 
+    private compositionStatusTimeoutID: number | null = null;
+
     public static getDerivedStateFromProps(
         nextProps: IAsyncControllableInputProps,
         nextState: IAsyncControllableInputState,
@@ -134,17 +136,17 @@ export class AsyncControllableInput extends React.PureComponent<
     }
 
     private handleCompositionStart = (e: React.CompositionEvent<HTMLInputElement>) => {
-        this.setState({
-            isComposing: true,
-            // Make sure that localValue matches externalValue, in case externalValue
-            // has changed since the last onChange event.
-            nextValue: this.state.value,
-        });
+        if (this.compositionStatusTimeoutID !== null) {
+            window.clearTimeout(this.compositionStatusTimeoutID);
+            this.compositionStatusTimeoutID = null;
+        }
+
+        this.setState({ isComposing: true });
         this.props.onCompositionStart?.(e);
     };
 
     private handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
-        this.setState({ isComposing: false });
+        this.compositionStatusTimeoutID = window.setTimeout(() => this.setState({ isComposing: false }), 10);
         this.props.onCompositionEnd?.(e);
     };
 

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -86,6 +86,25 @@ describe("<AsyncControllableInput>", () => {
             assert.strictEqual(wrapper.find("input").prop("value"), "hi ");
         });
 
+        it("external updates DO NOT flush with immediately ongoing compositions", async () => {
+            const wrapper = mount(<AsyncControllableInput type="text" value="hi" />);
+            const input = wrapper.find("input");
+
+            input.simulate("compositionstart", { data: "" });
+            input.simulate("compositionupdate", { data: " " });
+            input.simulate("change", { target: { value: "hi " } });
+
+            wrapper.setProps({ value: "bye" }).update();
+
+            input.simulate("compositionend", { data: " " });
+            input.simulate("compositionstart", { data: "" });
+
+            // Wait for the composition ending delay (10ms) to pass
+            await new Promise(resolve => setTimeout(() => resolve(null), 15));
+
+            assert.strictEqual(wrapper.find("input").prop("value"), "hi ");
+        });
+
         it("external updates flush after composition ends", async () => {
             const wrapper = mount(<AsyncControllableInput type="text" value="hi" />);
             const input = wrapper.find("input");
@@ -95,7 +114,9 @@ describe("<AsyncControllableInput>", () => {
             input.simulate("change", { target: { value: "hi " } });
             input.simulate("compositionend", { data: " " });
 
-            await Promise.resolve();
+            // Wait for the composition ending delay (10ms) to pass
+            await new Promise(resolve => setTimeout(() => resolve(null), 15));
+
             // we are "rejecting" the composition here by supplying a different controlled value
             wrapper.setProps({ value: "bye" }).update();
 

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -99,8 +99,10 @@ describe("<AsyncControllableInput>", () => {
             input.simulate("compositionend", { data: " " });
             input.simulate("compositionstart", { data: "" });
 
-            // Wait for the composition ending delay (10ms) to pass
-            await new Promise(resolve => setTimeout(() => resolve(null), 15));
+            // Wait for the composition ending delay to pass
+            await new Promise(resolve =>
+                setTimeout(() => resolve(null), AsyncControllableInput.COMPOSITION_END_DELAY + 5),
+            );
 
             assert.strictEqual(wrapper.find("input").prop("value"), "hi ");
         });
@@ -114,8 +116,10 @@ describe("<AsyncControllableInput>", () => {
             input.simulate("change", { target: { value: "hi " } });
             input.simulate("compositionend", { data: " " });
 
-            // Wait for the composition ending delay (10ms) to pass
-            await new Promise(resolve => setTimeout(() => resolve(null), 15));
+            // Wait for the composition ending delay to pass
+            await new Promise(resolve =>
+                setTimeout(() => resolve(null), AsyncControllableInput.COMPOSITION_END_DELAY + 5),
+            );
 
             // we are "rejecting" the composition here by supplying a different controlled value
             wrapper.setProps({ value: "bye" }).update();


### PR DESCRIPTION
There's an issue with the AsyncControllableInput, where Korean input can lead to incorrect values being stored.

#### The Bug

The cause is the way that Korean handles keyboard events: letters in the Korean language are combined into symbols, which are bubbled up as [CompositionEvents](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent). For instance, when typing the characters `ㄷ` -> `ㅣ` -> `ㄱ` -> `ㅏ`, they would successively render as `ㄷ`, `디`, `딕`, `디가` - note that with the last input the value splits out into two characters, which manifests as one CompositionEvent (`디`) ending and then a new one (`가`) immediately starting. I put together some logging to show the flow (times in seconds, logging code [here](https://github.com/Athenodoros/blueprint/blob/hms/composition-logging/packages/core/src/components/forms/asyncControllableInput.tsx)):

<img width="195" alt="Screen Shot 2022-03-14 at 11 49 44 AM" src="https://user-images.githubusercontent.com/23125102/158106824-e4166d89-2aa5-4648-9e4f-130a76b56a8a.png">

Currently, this gives incorrect results with AsyncControllableInput: because the `value` prop can be updated on a delay (eg. [example from the docs](https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx)), when the first composition ends the stored value (`디`) is blown away by the old state (`딕`), which results in the incorrect final result `닥가` (note the extra `ㄱ` in the first character).

#### The solution

As far as I can tell, there's no way in the onCompositionEnd callback to determine whether another CompositionEvent is about to start. If that's the case, the best solution I can think of is to manually wait to unlock the component for edits after some time delay - I've chosen 10ms, because in my experimentation it was always <=1ms before the next event started.

#### Checklist

- [x] Includes tests
- [ ] Update documentation

Is there documentation I should add?