### PR TITLE
[core] fix(OverflowList): improve spacer width check

### DIFF
--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -151,7 +151,7 @@ export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOver
     /** A cache containing the widths of all elements being observed to detect growing/shrinking */
     private previousWidths = new Map<Element, number>();
 
-    private spacer: Element | null = null;
+    private spacer: HTMLElement | null = null;
 
     public componentDidMount() {
         this.repartition(false);
@@ -255,7 +255,7 @@ export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOver
                 overflow: [],
                 visible: this.props.items,
             }));
-        } else if (this.spacer.getBoundingClientRect().width < 0.9) {
+        } else if (this.spacer.offsetWidth < 0.9) {
             // spacer has flex-shrink and width 1px so if it's much smaller then we know to shrink
             this.setState(state => {
                 if (state.visible.length <= this.props.minVisibleItems!) {


### PR DESCRIPTION
#### Fixes #5167

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix the OverflowList spacer width check to account for css scaling

#### Reviewers should focus on:

Any risks to using `offsetWidth` instead of `getBoundingClientRect()`

#### Screenshot

No user facing change
