### PR TITLE
[core] fix(MenuItem): remove errant markup

### DIFF
--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -4,7 +4,7 @@ Menus display lists of interactive items.
 
 @reactExample MenuExample
 
-The Men` API includes three React components:
+The Menu API includes three React components:
 
 * [`Menu`](#core/components/menu.menu)
 * [`MenuItem`](#core/components/menu.menu-item)

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -186,7 +186,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
                 // wrap icon in a <span> in case `icon` is a custom element rather than a built-in icon identifier,
                 // so that we always render this class
                 <span className={Classes.MENU_ITEM_ICON}>
-                    <Icon icon={icon} aria-hidden={true} tabIndex={-1} />,
+                    <Icon icon={icon} aria-hidden={true} tabIndex={-1} />
                 </span>
             ) : undefined,
             <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>


### PR DESCRIPTION

#### Changes proposed in this pull request:

Remove errant `,` which was inserted due to a semantic merge conflict 🤦🏽 

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

Before:

<img width="458" alt="Screen Shot 2022-03-21 at 3 37 33 PM" src="https://user-images.githubusercontent.com/723999/159351069-ceb17be7-1b64-4a68-97df-3a39b9b81f43.png">

After:

<img width="444" alt="Screen Shot 2022-03-21 at 3 37 39 PM" src="https://user-images.githubusercontent.com/723999/159351088-9eecb75e-d141-42e5-b24c-0bbb9d17962b.png">

