### PR TITLE
[docs-app] fix numeric input locale bug

### DIFF
--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -154,7 +154,7 @@ export class NumericInputBasicExample extends React.PureComponent<IExampleProps,
                 {this.renderSelectMenu(
                     "Locale",
                     locale,
-                    [{ label: "Default", value: "" }, ...LOCALES],
+                    [{ label: "Default", value: undefined }, ...LOCALES],
                     this.handleLocaleChange,
                 )}
             </>


### PR DESCRIPTION
Fixes a bug where setting the NumericInput locale to `""` (which is `Default`s select value)  results in a `Incorrect locale information provided` error and blank page.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

changes `Default`'s select value from `""` to `undefined`

#### Screenshots

before:
![before](https://user-images.githubusercontent.com/13280642/160287490-764fb899-323a-48e0-8a14-3210fdedcd57.gif)
after:
![after](https://user-images.githubusercontent.com/13280642/160287485-7434b934-788c-429d-9e4e-d85a70d88d51.gif)
