### PR TITLE
[table] fix(Table2): uncontrolled resizing of cols/rows

### DIFF
--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -573,14 +573,14 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
                 (dep, index) => dep !== (prevProps.cellRendererDependencies ?? [])[index],
             );
 
-        const didColumnWidthsChange =
-            this.props.columnWidths !== undefined
-                ? !Utils.compareSparseArrays(this.props.columnWidths, prevState.columnWidths)
-                : !Utils.compareSparseArrays(this.state.columnWidths, prevState.columnWidths);
-        const didRowHeightsChange =
-            this.props.rowHeights !== undefined
-                ? !Utils.compareSparseArrays(this.props.rowHeights, prevState.rowHeights)
-                : !Utils.compareSparseArrays(this.state.rowHeights, prevState.rowHeights);
+        const didColumnWidthsChange = !Utils.compareSparseArrays(
+            this.props.columnWidths ?? this.state.columnWidths,
+            prevState.columnWidths,
+        );
+        const didRowHeightsChange = !Utils.compareSparseArrays(
+            this.props.rowHeights ?? this.state.rowHeights,
+            prevState.rowHeights,
+        );
 
         const shouldInvalidateGrid =
             didChildrenChange ||

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -574,11 +574,13 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             );
 
         const didColumnWidthsChange =
-            this.props.columnWidths !== undefined &&
-            !Utils.compareSparseArrays(this.props.columnWidths, prevState.columnWidths);
+            this.props.columnWidths !== undefined
+                ? !Utils.compareSparseArrays(this.props.columnWidths, prevState.columnWidths)
+                : !Utils.compareSparseArrays(this.state.columnWidths, prevState.columnWidths);
         const didRowHeightsChange =
-            this.props.rowHeights !== undefined &&
-            !Utils.compareSparseArrays(this.props.rowHeights, prevState.rowHeights);
+            this.props.rowHeights !== undefined
+                ? !Utils.compareSparseArrays(this.props.rowHeights, prevState.rowHeights)
+                : !Utils.compareSparseArrays(this.state.rowHeights, prevState.rowHeights);
 
         const shouldInvalidateGrid =
             didChildrenChange ||


### PR DESCRIPTION
Fixes resizing rows/cols not visually updating for Tables that don't use the `columnWidths` / `rowHeights` prop.

I think this was introduced [here](https://github.com/palantir/blueprint/commit/e9e562060e6f2266b059ccc69bbe795f886e4422#diff-043a1f4cfcb847ca6d0d77077219b447e26786e280bbf7fe3428ddb0a9f7ef84L557) where before we were comparing `props.columnWidths` to `prevState.columnWidths` where `props.columnWidths` was  always `undefined` for Tables not using the prop. Now that there is an undefined check `didColumnWidthsChange` will always be false for Tables not using the prop.

Maybe a better spot for this update is in `handleColumnWidthChanged` ? We call `validateGrid` there, but that doesn't seem to visually update the table with the new sizes.
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added a check that prevState !== currentState for column widths and row heights when the prop is not set
<!-- Fill this out. -->

#### Screenshot

before:
![before](https://user-images.githubusercontent.com/13280642/160291059-61fc5bb3-d84e-4fbc-a094-80a02b091af7.gif)


after:
![after](https://user-images.githubusercontent.com/13280642/160291056-1c2a9b3f-28a3-49c2-be44-0743d1dfc32e.gif)



