### PR TITLE
[webpack-build-scripts] fix: file-loader -> asset modules

### DIFF
--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {
@@ -28,6 +29,6 @@ module.exports = Object.assign({}, baseConfig, {
         filename: "[name].bundle.js",
         library: ["Blueprint", "Core"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist")
+        path: path.resolve(__dirname, "./dist"),
     },
 });

--- a/packages/datetime/webpack.config.js
+++ b/packages/datetime/webpack.config.js
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {
-        datetime: [
-            "./src/index.ts"
-        ],
+        datetime: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
@@ -29,6 +28,6 @@ module.exports = Object.assign({}, baseConfig, {
         filename: "[name].bundle.js",
         library: ["Blueprint", "Datetime"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist")
+        path: path.resolve(__dirname, "./dist"),
     },
 });

--- a/packages/docs-theme/webpack.config.js
+++ b/packages/docs-theme/webpack.config.js
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {
-        "docs-theme": [
-            "./src/index.ts"
-        ],
+        "docs-theme": ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
@@ -29,6 +28,6 @@ module.exports = Object.assign({}, baseConfig, {
         filename: "[name].bundle.js",
         library: ["Blueprint", "DocsTheme"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist")
+        path: path.resolve(__dirname, "./dist"),
     },
 });

--- a/packages/icons/webpack.config.js
+++ b/packages/icons/webpack.config.js
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {

--- a/packages/landing-app/webpack.config.js
+++ b/packages/landing-app/webpack.config.js
@@ -28,7 +28,10 @@ module.exports = Object.assign({}, baseConfig, {
         rules: baseConfig.module.rules.slice(0, 3).concat([
             {
                 test: /^((?!svgs).)*\.(eot|ttf|woff|woff2|svg|png)$/,
-                loader: require.resolve("file-loader"),
+                type: "asset/resource",
+                generator: {
+                    filename: "assets/[hash][ext][query]",
+                },
             },
         ]),
     },

--- a/packages/popover2/webpack.config.js
+++ b/packages/popover2/webpack.config.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {

--- a/packages/select/webpack.config.js
+++ b/packages/select/webpack.config.js
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {
-        select: [
-            "./src/index.ts"
-        ],
+        select: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
@@ -29,6 +28,6 @@ module.exports = Object.assign({}, baseConfig, {
         filename: "[name].bundle.js",
         library: ["Blueprint", "Select"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist")
+        path: path.resolve(__dirname, "./dist"),
     },
 });

--- a/packages/table/webpack.config.js
+++ b/packages/table/webpack.config.js
@@ -1,4 +1,4 @@
-/*\
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {
-        table: [
-            "./src/index.ts"
-        ],
+        table: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
@@ -29,6 +28,6 @@ module.exports = Object.assign({}, baseConfig, {
         filename: "[name].bundle.js",
         library: ["Blueprint", "Table"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist")
+        path: path.resolve(__dirname, "./dist"),
     },
 });

--- a/packages/timezone/webpack.config.js
+++ b/packages/timezone/webpack.config.js
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 const path = require("path");
+
+const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
 
 module.exports = Object.assign({}, baseConfig, {
     entry: {
-        timezone: [
-            "./src/index.ts"
-        ],
+        timezone: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
@@ -29,6 +28,6 @@ module.exports = Object.assign({}, baseConfig, {
         filename: "[name].bundle.js",
         library: ["Blueprint", "Timezone"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist")
+        path: path.resolve(__dirname, "./dist"),
     },
 });

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -11,7 +11,6 @@
         "autoprefixer": "^10.4.4",
         "css-loader": "^6.7.1",
         "cssnano": "^5.1.5",
-        "file-loader": "^6.2.0",
         "fork-ts-checker-notifier-webpack-plugin": "^6.0.0",
         "fork-ts-checker-webpack-plugin": "^7.2.1",
         "mini-css-extract-plugin": "^2.6.0",

--- a/packages/webpack-build-scripts/webpack.config.base.js
+++ b/packages/webpack-build-scripts/webpack.config.base.js
@@ -141,10 +141,9 @@ module.exports = {
             },
             {
                 test: /\.(eot|ttf|woff|woff2|svg|png|gif|jpe?g)$/,
-                loader: require.resolve("file-loader"),
-                options: {
-                    name: "[name].[ext]?[hash]",
-                    outputPath: "assets/",
+                type: "asset/resource",
+                generator: {
+                    filename: "assets/[hash][ext][query]",
                 },
             },
         ],

--- a/packages/webpack-build-scripts/webpack.config.karma.js
+++ b/packages/webpack-build-scripts/webpack.config.karma.js
@@ -51,7 +51,10 @@ module.exports = {
             },
             {
                 test: /\.(eot|ttf|woff|woff2|svg|png)$/,
-                loader: require.resolve("file-loader"),
+                type: "asset/resource",
+                generator: {
+                    filename: "assets/[hash][ext][query]",
+                },
             },
         ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5341,14 +5341,6 @@ file-entry-cache@^6.0.0:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"


### PR DESCRIPTION
file-loader is deprecated, long live [webpack asset modules](https://webpack.js.org/guides/asset-modules/)

this fixes font file loading in webpack-build-scripts 🔧 