### PR TITLE
[popover2] docs: fix invalid ContextMenu2 closing tag

### DIFF
--- a/packages/popover2/src/context-menu2.md
+++ b/packages/popover2/src/context-menu2.md
@@ -87,7 +87,7 @@ export default function AdvancedContextMenu2Example() {
                     Right click me!
                 </div>
             )}
-        </ContextMenu>
+        </ContextMenu2>
     )
 }
 ```


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

One closing tag was not updated when introducing ContextMenu2. That is now fixed.
