### PR TITLE
[datetime] fix: clicking shortcuts no longer dismisses popovers

### DIFF
--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -95,10 +95,10 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
         const shortcutElements = shortcuts.map((shortcut, index) => (
             <MenuItem
                 active={this.props.selectedShortcutIndex === index}
-                className={Classes.POPOVER_DISMISS_OVERRIDE}
                 disabled={!this.isShortcutInRange(shortcut.dateRange)}
                 key={index}
                 onClick={this.getShorcutClickHandler(shortcut, index)}
+                shouldDismissPopover={false}
                 text={shortcut.label}
             />
         ));

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Classes, Menu, MenuItem } from "@blueprintjs/core";
+import { Menu, MenuItem } from "@blueprintjs/core";
 
 import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
 import { DateRange } from "./common/dateRange";


### PR DESCRIPTION
#### Fixes #3338
By default MenuItem has `Classes.POPOVER_DISMISS` added to the component, controlled by the `shouldDismissPopover` prop.

The `Shortcuts` component clearly intended to block this behavior through the use of `Classes.POPOVER_DISMISS_OVERRIDE`.

However, per the [`Popover`](https://github.com/palantir/blueprint/blob/28a400f08ecd18152304bb893e0a15bdd7d219aa/packages/core/src/components/popover/popover.tsx#L540) and [`Popover2`](https://github.com/palantir/blueprint/blob/develop/packages/popover2/src/popover2.tsx#L609) components, a dismiss inside an override still dismisses.

Luckily, `MenuItem` has a prop just for this!
<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Stop datepicker shortcuts from dismissing popovers

#### Reviewers should focus on:

If this correctly dismisses popovers and aligns with the author's original intent.

#### Screenshot

(Imagine a picture of a happy dev, not having to insert some hack to strip the dismiss class from the child menuitem)