### PR TITLE
[v3] [datetime] fix: clicking shortcuts no longer dismisses popovers

### DIFF
--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Classes, Menu, MenuItem } from "@blueprintjs/core";
+import { Menu, MenuItem } from "@blueprintjs/core";
 
 import { DATERANGEPICKER_SHORTCUTS } from "./common/classes";
 import { DateRange } from "./common/dateRange";
@@ -95,10 +95,10 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
         const shortcutElements = shortcuts.map((shortcut, index) => (
             <MenuItem
                 active={this.props.selectedShortcutIndex === index}
-                className={Classes.POPOVER_DISMISS_OVERRIDE}
                 disabled={!this.isShortcutInRange(shortcut.dateRange)}
                 key={index}
                 onClick={this.getShorcutClickHandler(shortcut, index)}
+                shouldDismissPopover={false}
                 text={shortcut.label}
             />
         ));


### PR DESCRIPTION
Co-authored-by: Mason Cooper <mcooper@palantir.com>

Backports  #5219

#### Changes proposed in this pull request:

Stop datepicker shortcuts from dismissing popovers

#### Reviewers should focus on:

This is a cherry-pick from the 4.x branch, hopefully nothing special to review here.
