### PR TITLE
[docs-app] fix: display icon correctly after copy to clipboard

### DIFF
--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -40,8 +40,8 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
   // override more specific selector above
   /* stylelint-disable declaration-no-important */
   &.docs-clipboard-copied .docs-clipboard-message::after {
-    font-family: $blueprint-icons-16-font;
     content: $swatch-copied-message !important;
+    font-family: $blueprint-icons-16-font, $pt-font-family-monospace, sans-serif;
   }
 
   &.docs-clipboard-copied .docs-clipboard-message[data-copied-message]::after {

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -40,6 +40,7 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
   // override more specific selector above
   /* stylelint-disable declaration-no-important */
   &.docs-clipboard-copied .docs-clipboard-message::after {
+    font-family: $blueprint-icons-16-font;
     content: $swatch-copied-message !important;
   }
 

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -41,7 +41,6 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
   /* stylelint-disable declaration-no-important */
   &.docs-clipboard-copied .docs-clipboard-message::after {
     content: $swatch-copied-message !important;
-    font-family: $pt-font-family-monospace, "Icons16", sans-serif;
   }
 
   &.docs-clipboard-copied .docs-clipboard-message[data-copied-message]::after {


### PR DESCRIPTION
#### Fixes #5209

#### Checklist

- [x] Fix on icons page
- [x] Fix on colors page

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Remove `font-family: $pt-font-family-monospace, "Icons16", sans-serif;` from `&.docs-clipboard-copied .docs-clipboard-message::after` and replace with `font-family: $blueprint-icons-16-font, $pt-font-family-monospace, sans-serif;` I believe this was loading the wrong fonts in the wrong order for the icons which is why "[]" was being outputted. 

#### Screenshot
**Old**
![Screen Shot 2022-04-04 at 7 16 01 pm](https://user-images.githubusercontent.com/52145084/161513477-f68e5a91-eafd-47ee-a543-824f0020e8b1.png)
![Screen Shot 2022-04-04 at 7 15 25 pm](https://user-images.githubusercontent.com/52145084/161513540-d397c0ec-24bc-40eb-ba01-e8d214ca31a5.png)
**New**
![Screen Shot 2022-04-04 at 7 16 08 pm](https://user-images.githubusercontent.com/52145084/161513568-dee4c3b7-8c94-4a7a-9855-452aa9b6bac9.png)
![Screen Shot 2022-04-04 at 7 15 09 pm](https://user-images.githubusercontent.com/52145084/161513593-f8b39065-95e9-45c1-bdca-43eb8ef48c72.png)

