### PR TITLE
feat: allow React 18 peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,8 +59,8 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^3.0.3",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -41,8 +41,8 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/colors": "^4.0.2",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -38,8 +38,8 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^3.0.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -40,8 +40,8 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^3.0.3",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -41,8 +41,8 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/colors": "^4.0.2",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -43,8 +43,8 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^3.0.0",


### PR DESCRIPTION
#### Fixes #5205

#### Changes proposed in this pull request:

- Allow React 18 peer dependency for all packages that declare one in package.json

Note that I'm not adding a testing environment for React 17 or React 18 here. 17 is possible with an [unofficial adapter](https://github.com/wojtekmaj/enzyme-adapter-react-17), but [18 is probably not](https://dev.to/wojtekmaj/enzyme-is-dead-now-what-ekl). Until we switch our testing infrastructure, we'll have to rely on issue reports to deal with any problems Blueprint has in newer versions of React.