### PR TITLE
[core] fix: left icon in buttons no longer get tab focus

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -189,7 +189,7 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={IconSize.LARGE} />,
             // The icon is purely decorative if text is provided
-            <Icon key="leftIcon" icon={icon} aria-hidden={maybeHasText} tabIndex={maybeHasText ? -1 : 0} />,
+            <Icon key="leftIcon" icon={icon} aria-hidden={maybeHasText} tabIndex={maybeHasText ? -1 : undefined} />,
             maybeHasText && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}


### PR DESCRIPTION
#### Fixes #5203

#### Changes proposed in this pull request:

This restores the `tabIndex` for left icons inside Button and AnchorButton to `undefined`, as it was before #5158.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
