### PR TITLE
[popover2] feat(Tooltip2): add popoverRef to shared props

### DIFF
--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -29,7 +29,6 @@ import {
     mergeRefs,
     Overlay,
     Utils,
-    IRef,
 } from "@blueprintjs/core";
 
 import * as Classes from "./classes";
@@ -101,11 +100,6 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends P
      * @default false
      */
     shouldReturnFocusOnClose?: boolean;
-
-    /**
-     * Ref supplied to the `Classes.POPOVER` element.
-     */
-    popoverRef?: IRef<HTMLElement>;
 
     /**
      * Popper.js positioning strategy.

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -17,7 +17,7 @@
 import { Boundary, Placement, placements, RootBoundary, StrictModifiers } from "@popperjs/core";
 import { StrictModifier } from "react-popper";
 
-import { OverlayableProps, Props, PopoverPosition } from "@blueprintjs/core";
+import { OverlayableProps, Props, PopoverPosition, IRef } from "@blueprintjs/core";
 
 export { Boundary as PopperBoundary, Placement, placements as PlacementOptions };
 // copied from @popperjs/core, where it is not exported as public
@@ -162,6 +162,11 @@ export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
      * @default true
      */
     openOnTargetFocus?: boolean;
+
+    /**
+     * Ref supplied to the `Classes.POPOVER` element.
+     */
+    popoverRef?: IRef<HTMLElement>;
 
     /**
      * Target renderer which receives props injected by Popover2 which should be spread onto


### PR DESCRIPTION
#### Fixes #5218

#### Changes proposed in this pull request:

Move `popoverRef` to the set of props shared between Popover2 and Tooltip2, allowing it to be used in the latter component.

