### PR TITLE
[core] feat(FocusStyleManager): add escape hatch

### DIFF
--- a/packages/core/src/accessibility/_focus-states.scss
+++ b/packages/core/src/accessibility/_focus-states.scss
@@ -5,8 +5,8 @@
   @include focus-outline();
 }
 
-// override any focus outline anywhere
-.#{$ns}-focus-disabled :focus {
+// override any focus outline anywhere unless specifically ignored
+.#{$ns}-focus-disabled :focus:not(.#{$ns}-focus-manager-ignore *) {
   /* stylelint-disable declaration-no-important */
   outline: none !important;
 

--- a/packages/core/src/accessibility/_focus-states.scss
+++ b/packages/core/src/accessibility/_focus-states.scss
@@ -6,7 +6,7 @@
 }
 
 // override any focus outline anywhere unless specifically ignored
-.#{$ns}-focus-disabled :focus:not(.#{$ns}-focus-manager-ignore *) {
+.#{$ns}-focus-disabled :focus:not(.#{$ns}-focus-style-manager-ignore *) {
   /* stylelint-disable declaration-no-important */
   outline: none !important;
 

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -61,6 +61,7 @@ export const INTENT_WARNING = intentClass(Intent.WARNING)!;
 export const INTENT_DANGER = intentClass(Intent.DANGER)!;
 
 export const FOCUS_DISABLED = `${NS}-focus-disabled`;
+export const FOCUS_MANAGER_IGNORE = `${NS}-focus-manager-ignore`;
 
 // text utilities
 export const UI_TEXT = `${NS}-ui-text`;

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -61,7 +61,7 @@ export const INTENT_WARNING = intentClass(Intent.WARNING)!;
 export const INTENT_DANGER = intentClass(Intent.DANGER)!;
 
 export const FOCUS_DISABLED = `${NS}-focus-disabled`;
-export const FOCUS_MANAGER_IGNORE = `${NS}-focus-manager-ignore`;
+export const FOCUS_STYLE_MANAGER_IGNORE = `${NS}-focus-style-manager-ignore`;
 
 // text utilities
 export const UI_TEXT = `${NS}-ui-text`;

--- a/packages/core/src/docs/accessibility.md
+++ b/packages/core/src/docs/accessibility.md
@@ -37,6 +37,25 @@ __@blueprintjs/core__ package. It supports the following public methods:
 - `FocusStyleManager.onlyShowFocusOnTabs(): void`: Enable behavior which hides focus styles during mouse interaction.
 - `FocusStyleManager.alwaysShowFocus(): void`: Stop this behavior (focus styles are always visible).
 
+@### Selectivly ignoring the focus manager
+
+There is an escape hatch to allow components to ignore the focus manager. This
+can be useful when you do want to always show the focus outline, but only for certain
+components, like a tree. This is done by applying `Classes.FOCUS_MANAGER_IGNORE`
+to a container.
+
+```tsx
+import { Classes } from "@blueprintjs/core";
+
+
+const MyComponent = () => ({
+    <div classname={Classes.FOCUS_MANAGER_IGNORE}>
+        // Any components here will always show the focus outline when clicked.
+    </div>
+})
+```
+
+
 @## Color contrast
 
 Colors have been designed to be accessible to as many people as possible, even those who are

--- a/packages/core/src/docs/accessibility.md
+++ b/packages/core/src/docs/accessibility.md
@@ -37,19 +37,19 @@ __@blueprintjs/core__ package. It supports the following public methods:
 - `FocusStyleManager.onlyShowFocusOnTabs(): void`: Enable behavior which hides focus styles during mouse interaction.
 - `FocusStyleManager.alwaysShowFocus(): void`: Stop this behavior (focus styles are always visible).
 
-@### Selectivly ignoring the focus manager
+@### Selectively ignoring the focus style manager
 
-There is an escape hatch to allow components to ignore the focus manager. This
+There is an escape hatch to allow components to ignore the focus style manager. This
 can be useful when you do want to always show the focus outline, but only for certain
-components, like a tree. This is done by applying `Classes.FOCUS_MANAGER_IGNORE`
-to a container.
+components, like a tree. This is done by applying `Classes.FOCUS_STYLE_MANAGER_IGNORE`
+to a container element.
 
 ```tsx
 import { Classes } from "@blueprintjs/core";
 
 
 const MyComponent = () => ({
-    <div classname={Classes.FOCUS_MANAGER_IGNORE}>
+    <div classname={Classes.FOCUS_STYLE_MANAGER_IGNORE}>
         // Any components here will always show the focus outline when clicked.
     </div>
 })


### PR DESCRIPTION
#### Fixes #5229

#### Checklist

- [ ] Includes tests
- [x] Update documentation

Not sure how to do tests for css.

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This adds a new `Classes.FOCUS_MANAGER_IGNORE` for allowing individual components to chose to ignore the focus manager and always show the focus outline, even when clicked.


#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
