### PR TITLE
chore: fix NPM publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "stylelint-config-palantir": "^6.0.1",
         "stylelint-scss": "^4.2.0",
         "typescript": "~4.6.2",
+        "yargs": "^17.4.0",
         "yarn-deduplicate": "^4.0.0"
     },
     "resolutions": {

--- a/scripts/circle-publish-npm
+++ b/scripts/circle-publish-npm
@@ -20,8 +20,13 @@ if ! [[ "$branch" == "develop" || "$branch" == "next" || "$branch" == release/* 
     exit 1
 fi
 
-echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
-chmod 0600 .npmrc
+if [ -z "${NPM_AUTH_TOKEN}" ]; then
+    echo "No NPM auth token available. Check the \$NPM_AUTH_TOKEN environment variable."
+    exit 1
+fi
+
+# set the auth token for this user, not just the repo
+npm set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
 
 if [[ "$branch" == "next" ]]; then
     echo "Publishing with next tag because branch name is next"

--- a/scripts/get-publishable-paths-from-semver-tags
+++ b/scripts/get-publishable-paths-from-semver-tags
@@ -6,6 +6,8 @@
 
 "use strict";
 
+// @ts-check
+
 const cp = require("child_process");
 const path = require("path");
 const yargs = require("yargs").usage("$0 <commitish>").help();
@@ -47,5 +49,5 @@ cp.exec(`git tag --points-at ${commitish}`, (err, stdout) => {
         .filter(({ packageJson }) => !packageJson.private)
         .map(pkg => pkg.path);
 
-    publishablePackagePaths.forEach(pkgPath => console.log(pkgPath));
+    publishablePackagePaths.forEach(pkgPath => console.info(pkgPath));
 });


### PR DESCRIPTION
Seems like Node 16 / NPM 8 is not happy with an auth token simply living in the repo or package `.npmrc`, it needs to be set in the user's `~/.npmrc`. This change should fix that 🤞🏽 