### PR TITLE
[core] allow MenuItem keyboard focus when disabled

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -257,5 +257,4 @@ const DISABLED_PROPS: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
     onMouseDown: undefined,
     onMouseEnter: undefined,
     onMouseLeave: undefined,
-    tabIndex: -1,
 };


### PR DESCRIPTION
According to the [aria spec](https://www.w3.org/TR/wai-aria-practices-1.2/#menu):

> Disabled menu items are focusable but cannot be activated.

In this context, "focusable" includes keyboard focusable.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
