### PR TITLE
chore: fix NPM publish script again

### DIFF
--- a/scripts/circle-publish-npm
+++ b/scripts/circle-publish-npm
@@ -20,14 +20,6 @@ if ! [[ "$branch" == "develop" || "$branch" == "next" || "$branch" == release/* 
     exit 1
 fi
 
-if [ -z "${NPM_AUTH_TOKEN}" ]; then
-    echo "No NPM auth token available. Check the \$NPM_AUTH_TOKEN environment variable."
-    exit 1
-fi
-
-# set the auth token for this user, not just the repo
-npm set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
-
 if [[ "$branch" == "next" ]]; then
     echo "Publishing with next tag because branch name is next"
     # must set public access for scoped packages

--- a/scripts/publish-npm-semver-tagged
+++ b/scripts/publish-npm-semver-tagged
@@ -8,6 +8,22 @@ git fetch --tags
 SCRIPTS_DIR="$( dirname "$(readlink -f "$0")" )"
 
 publishable_paths=$("$SCRIPTS_DIR/get-publishable-paths-from-semver-tags" | sed -E -e '/^ *$/d')
+
+if [ -z "$publishable_paths" ]; then
+    echo "Nothing to publish."
+    exit 0
+fi
+
+if [ -z "${NPM_AUTH_TOKEN}" ]; then
+    echo "No NPM auth token available. Check the \$NPM_AUTH_TOKEN environment variable."
+    exit 1
+fi
+
+# set the auth token for this user, not just the repo
+# N.B. `npm set` doesn't work here, it complains that it doesn't work for NPM workspaces
+echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+chmod 0600 ~/.npmrc
+
 for path in $publishable_paths; do
     pushd "$path"
     echo "Attempting to publish package at path '$path'"


### PR DESCRIPTION
The latest [publish job](https://app.circleci.com/pipelines/github/palantir/blueprint/2216/workflows/488e947b-8fd1-4468-848e-a45c808bf61a/jobs/53711) failed  on the `npm set` line due to:

```
#!/bin/bash -eo pipefail
./scripts/publish-npm-semver-tagged
~/project/packages/colors ~/project
Attempting to publish package at path 'packages/colors'
npm ERR! code ENOWORKSPACES
npm ERR! This command does not support workspaces.
```

... which is kind of silly.

This change switches back to manually writing the npmrc file, but in the home folder this time.