### PR TITLE
[datetime] fix(DatePicker): disable clear button

### DIFF
--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -35,6 +35,7 @@ export type DatePickerProps = IDatePickerProps;
 export interface IDatePickerProps extends IDatePickerBaseProps, Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
+     * If disabled, the "Clear" Button in the Actions Bar will also be disabled.
      *
      * @default true
      */
@@ -262,12 +263,17 @@ export class DatePicker extends AbstractPureComponent2<DatePickerProps, IDatePic
     );
 
     private renderOptionsBar() {
-        const { clearButtonText, todayButtonText } = this.props;
+        const { clearButtonText, todayButtonText, canClearSelection } = this.props;
         return [
             <Divider key="div" />,
             <div className={Classes.DATEPICKER_FOOTER} key="footer">
                 <Button minimal={true} onClick={this.handleTodayClick} text={todayButtonText} />
-                <Button minimal={true} onClick={this.handleClearClick} text={clearButtonText} />
+                <Button
+                    disabled={!canClearSelection}
+                    minimal={true}
+                    onClick={this.handleClearClick}
+                    text={clearButtonText}
+                />
             </div>,
         ];
     }

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -688,6 +688,16 @@ describe("<DatePicker>", () => {
         assert.isNull(onChange.secondCall.args[0]);
     });
 
+    it("Clear button disabled when canClearSelection is false", () => {
+        const { getClearButton } = wrap(<DatePicker canClearSelection={false} showActionsBar={true} />);
+        assert.isTrue(getClearButton().props().disabled);
+    });
+
+    it("Clear button enabled when canClearSelection is true", () => {
+        const { getClearButton } = wrap(<DatePicker canClearSelection={true} showActionsBar={true} />);
+        assert.isFalse(getClearButton().props().disabled);
+    });
+
     it("selects the current day when Today is clicked", () => {
         const { root } = wrap(<DatePicker showActionsBar={true} />);
         root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).first().simulate("click");
@@ -720,6 +730,7 @@ describe("<DatePicker>", () => {
             clickShortcut: (index = 0) => {
                 wrapper.find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`).hostNodes().find("a").at(index).simulate("click");
             },
+            getClearButton: () => wrapper.find(`.${Classes.DATEPICKER_FOOTER}`).find(Button).last(),
             getDay: (dayNumber = 1) =>
                 wrapper
                     .find(`.${Classes.DATEPICKER_DAY}`)


### PR DESCRIPTION
#### Fixes #5228 

#### Checklist

- [X] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

When `canClearSelection` is `false`, disable the Clear button on the Actions Bar of the Date Picker.

#### Screenshot
<img width="279" alt="Screen Shot 2022-04-09 at 5 24 00 pm" src="https://user-images.githubusercontent.com/52145084/162561523-56010bbe-4ee7-4a3d-9610-c019648010a5.png">

<img width="805" alt="Screen Shot 2022-04-09 at 5 24 27 pm" src="https://user-images.githubusercontent.com/52145084/162561543-7405d2e7-a121-468f-bc45-c41793522411.png">

