### PR TITLE
[table] fix: vertical scroll bug when ghostCells enabled attempt 2

### DIFF
--- a/packages/table-dev-app/src/features.html
+++ b/packages/table-dev-app/src/features.html
@@ -144,6 +144,10 @@
   <div id="table-10"></div>
   <br /><br />
 
+  <h4>Scrollable Rows</h4>
+  <div id="table-11"></div>
+  <br /><br />
+
   <script src="features.bundle.js"></script>
 </body>
 </html>

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -695,8 +695,7 @@ ReactDOM.render(
 
 function renderName() {
     return (
-        <div style={{ lineHeight: "50px" }}>
-            <div className={Classes.TEXT_LARGE}>Large header Cell</div>
+        <div style={{ lineHeight: "100px" }}>
             <div className={Classes.TEXT_LARGE}>Large header Cell</div>
         </div>
     );

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -683,3 +683,21 @@ class ReorderableTableExample extends React.Component<{}, IReorderableTableExamp
 }
 
 ReactDOM.render(<ReorderableTableExample />, document.getElementById("table-10"));
+
+ReactDOM.render(
+    <div style={{ height: 335, width: 300 }}>
+        <Table2 numRows={10} defaultRowHeight={30} enableGhostCells={true}>
+            <Column columnHeaderCellRenderer={() => <ColumnHeaderCell nameRenderer={renderName} />} />
+        </Table2>
+    </div>,
+    document.getElementById("table-11"),
+);
+
+function renderName() {
+    return (
+        <div style={{ lineHeight: "50px" }}>
+            <div className={Classes.TEXT_LARGE}>Large header Cell</div>
+            <div className={Classes.TEXT_LARGE}>Large header Cell</div>
+        </div>
+    );
+}

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -264,7 +264,7 @@ export class Grid {
      * `Rect` argument.
      */
     public getRowIndicesInRect(options: GetRowIndicesInRectOptions): RowIndices {
-        const { rect, includeGhostCells = false, columnHeaderHeight = 0, limit = 0 } = options;
+        const { rect, includeGhostCells = false, columnHeaderHeight = 0, limit = Grid.DEFAULT_MAX_ROWS } = options;
         if (rect == null) {
             return { rowIndexEnd: 0, rowIndexStart: 0 };
         }

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -253,7 +253,12 @@ export class Grid {
      * Returns the start and end indices of rows that intersect with the given
      * `Rect` argument.
      */
-    public getRowIndicesInRect(rect: Rect, includeGhostCells = false, limit = Grid.DEFAULT_MAX_ROWS): RowIndices {
+    public getRowIndicesInRect(
+        rect: Rect,
+        includeGhostCells = false,
+        rectHeightCorrection = 0,
+        limit = Grid.DEFAULT_MAX_ROWS,
+    ): RowIndices {
         if (rect == null) {
             return { rowIndexEnd: 0, rowIndexStart: 0 };
         }
@@ -262,7 +267,7 @@ export class Grid {
         const { top = 0, height } = rect;
         const { start, end } = this.getIndicesInInterval(
             top,
-            top + height,
+            top + (height - rectHeightCorrection),
             searchEnd,
             !includeGhostCells,
             this.getCumulativeHeightAt,

--- a/packages/table/src/common/grid.ts
+++ b/packages/table/src/common/grid.ts
@@ -35,6 +35,16 @@ export interface ColumnIndices {
     columnIndexEnd: number;
 }
 
+interface GetRowIndicesInRectOptions {
+    rect: Rect;
+    /**
+     * height to subtract from the rect height, as rows hidden behind the columnHeader should not be returned.
+     */
+    columnHeaderHeight?: number;
+    limit?: number;
+    includeGhostCells?: boolean;
+}
+
 /**
  * This class manages the sizes of grid cells using arrays of individual row/column sizes.
  */
@@ -203,7 +213,7 @@ export class Grid {
             return results;
         }
 
-        const { rowIndexStart, rowIndexEnd } = this.getRowIndicesInRect(rect);
+        const { rowIndexStart, rowIndexEnd } = this.getRowIndicesInRect({ rect });
         const { columnIndexStart, columnIndexEnd } = this.getColumnIndicesInRect(rect);
         for (let rowIndex = rowIndexStart; rowIndex <= rowIndexEnd; rowIndex++) {
             for (let columnIndex = columnIndexStart; columnIndex <= columnIndexEnd; columnIndex++) {
@@ -224,7 +234,7 @@ export class Grid {
             return results;
         }
 
-        const { rowIndexStart, rowIndexEnd } = this.getRowIndicesInRect(rect);
+        const { rowIndexStart, rowIndexEnd } = this.getRowIndicesInRect({ rect });
         for (let rowIndex = rowIndexStart; rowIndex <= rowIndexEnd; rowIndex++) {
             results.push(callback(rowIndex));
         }
@@ -253,12 +263,8 @@ export class Grid {
      * Returns the start and end indices of rows that intersect with the given
      * `Rect` argument.
      */
-    public getRowIndicesInRect(
-        rect: Rect,
-        includeGhostCells = false,
-        rectHeightCorrection = 0,
-        limit = Grid.DEFAULT_MAX_ROWS,
-    ): RowIndices {
+    public getRowIndicesInRect(options: GetRowIndicesInRectOptions): RowIndices {
+        const { rect, includeGhostCells = false, columnHeaderHeight = 0, limit = 0 } = options;
         if (rect == null) {
             return { rowIndexEnd: 0, rowIndexStart: 0 };
         }
@@ -267,7 +273,7 @@ export class Grid {
         const { top = 0, height } = rect;
         const { start, end } = this.getIndicesInInterval(
             top,
-            top + (height - rectHeightCorrection),
+            top + (height - columnHeaderHeight),
             searchEnd,
             !includeGhostCells,
             this.getCumulativeHeightAt,

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -786,11 +786,15 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             return false;
         }
 
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect, enableGhostCells);
+        const rowIndices = this.grid.getRowIndicesInRect(
+            viewportRect,
+            enableGhostCells,
+            this.columnHeaderElement?.clientHeight ?? Grid.MIN_COLUMN_HEADER_HEIGHT,
+        );
 
         const isViewportUnscrolledVertically = viewportRect != null && viewportRect.top === 0;
         const areRowHeadersLoading = hasLoadingOption(this.props.loadingOptions, TableLoadingOption.ROW_HEADERS);
-        const areGhostRowsVisible = enableGhostCells && this.grid.isGhostIndex(rowIndices.rowIndexEnd - 1, 0);
+        const areGhostRowsVisible = enableGhostCells && this.grid.isGhostIndex(rowIndices.rowIndexEnd, 0);
 
         return areGhostRowsVisible && (isViewportUnscrolledVertically || areRowHeadersLoading);
     }

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -786,11 +786,11 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             return false;
         }
 
-        const rowIndices = this.grid.getRowIndicesInRect(
-            viewportRect,
-            enableGhostCells,
-            this.columnHeaderElement?.clientHeight ?? Grid.MIN_COLUMN_HEADER_HEIGHT,
-        );
+        const rowIndices = this.grid.getRowIndicesInRect({
+            columnHeaderHeight: this.columnHeaderElement?.clientHeight ?? Grid.MIN_COLUMN_HEADER_HEIGHT,
+            includeGhostCells: enableGhostCells,
+            rect: viewportRect,
+        });
 
         const isViewportUnscrolledVertically = viewportRect != null && viewportRect.top === 0;
         const areRowHeadersLoading = hasLoadingOption(this.props.loadingOptions, TableLoadingOption.ROW_HEADERS);
@@ -987,7 +987,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             ),
         });
 
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect, enableGhostCells);
+        const rowIndices = this.grid.getRowIndicesInRect({ rect: viewportRect, includeGhostCells: enableGhostCells });
         const rowIndexStart = showFrozenRowsOnly ? 0 : rowIndices.rowIndexStart;
         const rowIndexEnd = showFrozenRowsOnly ? this.getMaxFrozenRowIndex() : rowIndices.rowIndexEnd;
 
@@ -1078,7 +1078,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             return undefined;
         }
 
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect, enableGhostCells);
+        const rowIndices = this.grid.getRowIndicesInRect({ rect: viewportRect, includeGhostCells: enableGhostCells });
         const columnIndices = this.grid.getColumnIndicesInRect(viewportRect, enableGhostCells);
 
         // start beyond the frozen area if rendering unrelated quadrants, so we
@@ -1513,7 +1513,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             return;
         }
         const columnIndices = this.grid.getColumnIndicesInRect(viewportRect);
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect);
+        const rowIndices = this.grid.getRowIndicesInRect({ rect: viewportRect });
         this.props.onVisibleCellsChange?.(rowIndices, columnIndices);
     }
 

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -669,11 +669,15 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             return false;
         }
 
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect, enableGhostCells!);
+        const rowIndices = this.grid.getRowIndicesInRect(
+            viewportRect,
+            enableGhostCells!,
+            this.columnHeaderHeight || Grid.MIN_COLUMN_HEADER_HEIGHT,
+        );
 
         const isViewportUnscrolledVertically = viewportRect != null && viewportRect.top === 0;
         const areRowHeadersLoading = hasLoadingOption(this.props.loadingOptions, TableLoadingOption.ROW_HEADERS);
-        const areGhostRowsVisible = enableGhostCells! && this.grid.isGhostIndex(rowIndices.rowIndexEnd - 1, 0);
+        const areGhostRowsVisible = enableGhostCells! && this.grid.isGhostIndex(rowIndices.rowIndexEnd, 0);
 
         return areGhostRowsVisible && (isViewportUnscrolledVertically || areRowHeadersLoading);
     }

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -221,7 +221,7 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
         columnHeader: (ref: HTMLElement | null) => {
             this.columnHeaderElement = ref;
             if (ref != null) {
-                this.columnHeaderHeight = ref.clientHeight;
+                this.columnHeaderHeight = Math.max(ref.clientHeight, Grid.MIN_COLUMN_HEADER_HEIGHT);
             }
         },
         quadrantStack: (ref: TableQuadrantStack) => (this.quadrantStackInstance = ref),
@@ -669,11 +669,11 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             return false;
         }
 
-        const rowIndices = this.grid.getRowIndicesInRect(
-            viewportRect,
-            enableGhostCells!,
-            this.columnHeaderHeight || Grid.MIN_COLUMN_HEADER_HEIGHT,
-        );
+        const rowIndices = this.grid.getRowIndicesInRect({
+            columnHeaderHeight: this.columnHeaderHeight,
+            includeGhostCells: enableGhostCells!,
+            rect: viewportRect,
+        });
 
         const isViewportUnscrolledVertically = viewportRect != null && viewportRect.top === 0;
         const areRowHeadersLoading = hasLoadingOption(this.props.loadingOptions, TableLoadingOption.ROW_HEADERS);
@@ -884,7 +884,10 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
         // if we have vertical overflow, no need to render ghost rows
         // (this avoids problems like https://github.com/palantir/blueprint/issues/5027)
         const hasVerticalOverflow = this.locator.hasVerticalOverflow(this.columnHeaderHeight, viewportRect);
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect, hasVerticalOverflow ? false : enableGhostCells);
+        const rowIndices = this.grid.getRowIndicesInRect({
+            includeGhostCells: hasVerticalOverflow ? false : enableGhostCells,
+            rect: viewportRect,
+        });
 
         const rowIndexStart = showFrozenRowsOnly ? 0 : rowIndices.rowIndexStart;
         const rowIndexEnd = showFrozenRowsOnly ? this.getMaxFrozenRowIndex() : rowIndices.rowIndexEnd;
@@ -974,7 +977,10 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
         // (this avoids problems like https://github.com/palantir/blueprint/issues/5027)
         const hasVerticalOverflow = this.locator.hasVerticalOverflow(this.columnHeaderHeight, viewportRect);
         const hasHorizontalOverflow = this.locator.hasHorizontalOverflow(this.rowHeaderWidth, viewportRect);
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect, hasVerticalOverflow ? false : enableGhostCells);
+        const rowIndices = this.grid.getRowIndicesInRect({
+            includeGhostCells: hasVerticalOverflow ? false : enableGhostCells,
+            rect: viewportRect,
+        });
         const columnIndices = this.grid.getColumnIndicesInRect(
             viewportRect,
             hasHorizontalOverflow ? false : enableGhostCells,
@@ -1438,7 +1444,7 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             return;
         }
         const columnIndices = this.grid.getColumnIndicesInRect(viewportRect);
-        const rowIndices = this.grid.getRowIndicesInRect(viewportRect);
+        const rowIndices = this.grid.getRowIndicesInRect({ rect: viewportRect });
         this.props.onVisibleCellsChange?.(rowIndices, columnIndices);
     }
 

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -199,7 +199,7 @@ describe("Grid", () => {
         });
 
         it("unlimited rows", () => {
-            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect, false, 0);
+            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect, false, 0, 0);
             expect(rowIndexStart).to.equal(0);
             expect(rowIndexEnd).to.equal(5000 - 1);
         });

--- a/packages/table/test/gridTests.ts
+++ b/packages/table/test/gridTests.ts
@@ -48,7 +48,7 @@ describe("Grid", () => {
         expect(columnIndexStart).to.equal(2);
         expect(columnIndexEnd).to.equal(5);
 
-        const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect, true);
+        const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({ rect, includeGhostCells: true });
         expect(rowIndexStart).to.equal(1);
         expect(rowIndexEnd).to.equal(5);
     });
@@ -73,7 +73,7 @@ describe("Grid", () => {
     it("locates row indices of overlapping rect", () => {
         const grid = new Grid(test7s, test13s, 0);
         const rect = new Rect(0, 15, 0, 15);
-        const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect);
+        const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({ rect });
         expect(rowIndexStart).to.equal(2);
         expect(rowIndexEnd).to.equal(4);
 
@@ -116,7 +116,7 @@ describe("Grid", () => {
         it("row before border", () => {
             const grid = new Grid(test7s, test13s, 0);
             const rect = new Rect(0, 13, 0, 1);
-            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect);
+            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({ rect });
             expect(rowIndexStart).to.equal(1);
             expect(rowIndexEnd).to.equal(1);
         });
@@ -124,7 +124,7 @@ describe("Grid", () => {
         it("row overlapping border", () => {
             const grid = new Grid(test7s, test13s, 0);
             const rect = new Rect(0, 13, 0, 2);
-            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect);
+            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({ rect });
             expect(rowIndexStart).to.equal(1);
             expect(rowIndexEnd).to.equal(2);
         });
@@ -132,7 +132,7 @@ describe("Grid", () => {
         it("row after border", () => {
             const grid = new Grid(test7s, test13s, 0);
             const rect = new Rect(0, 14, 0, 7);
-            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect);
+            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({ rect });
             expect(rowIndexStart).to.equal(2);
             expect(rowIndexEnd).to.equal(2);
         });
@@ -193,13 +193,17 @@ describe("Grid", () => {
         const rect = new Rect(0, 0, 50000, 50000);
 
         it("limits rows", () => {
-            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect);
+            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({ rect });
             expect(rowIndexStart).to.equal(0);
             expect(rowIndexEnd).to.equal(Grid.DEFAULT_MAX_ROWS);
         });
 
         it("unlimited rows", () => {
-            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect(rect, false, 0, 0);
+            const { rowIndexStart, rowIndexEnd } = grid.getRowIndicesInRect({
+                includeGhostCells: false,
+                limit: 0,
+                rect,
+            });
             expect(rowIndexStart).to.equal(0);
             expect(rowIndexEnd).to.equal(5000 - 1);
         });


### PR DESCRIPTION
#### Fixes #4765 (again)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adds a parameter `rectHeightCorrection` to `getRowIndicesInRect`. This is utilized in `shouldDisableVerticalScroll` to account for the `columnHeaderHeight` when checking for which cells are visible to determine whether or not to disable vertical scrolling. 

Also reverts the table change made in https://github.com/palantir/blueprint/pull/5113 that attempted to fix this issue (which it did for the case when the table used the default column header) but didn't address the root cause of the problem - that header heights weren't being accounted for when determining which rows were currently visible.

Added a smoke test table in the table-app features
#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
before:
![scroll-before](https://user-images.githubusercontent.com/13280642/162647509-ec982d07-2cdb-4159-827e-9cdb65a4dc21.gif)
after:
![scroll-after](https://user-images.githubusercontent.com/13280642/162647511-64901f11-4a28-4a82-ba8a-386e14005513.gif)

