### PR TITLE
[select] fix(a11y): update active item on focus changes

### DIFF
--- a/packages/docs-app/src/common/films.tsx
+++ b/packages/docs-app/src/common/films.tsx
@@ -132,7 +132,7 @@ export const TOP_100_FILMS: IFilm[] = [
     { title: "Monty Python and the Holy Grail", year: 1975 },
 ].map((m, index) => ({ ...m, rank: index + 1 }));
 
-export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, modifiers, query }) => {
+export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, handleFocus, modifiers, query }) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }
@@ -144,6 +144,7 @@ export const renderFilm: ItemRenderer<IFilm> = (film, { handleClick, modifiers, 
             label={film.year.toString()}
             key={film.rank}
             onClick={handleClick}
+            onFocus={handleFocus}
             text={highlightText(text, query)}
         />
     );

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -58,7 +58,7 @@ export class IconSelect extends React.PureComponent<IIconSelectProps> {
         );
     }
 
-    private renderIconItem: ItemRenderer<IconName | typeof NONE> = (icon, { handleClick, modifiers }) => {
+    private renderIconItem: ItemRenderer<IconName | typeof NONE> = (icon, { handleClick, handleFocus, modifiers }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
@@ -68,6 +68,7 @@ export class IconSelect extends React.PureComponent<IIconSelectProps> {
                 icon={icon === NONE ? undefined : icon}
                 key={icon}
                 onClick={handleClick}
+                onFocus={handleFocus}
                 text={icon}
             />
         );

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -118,6 +118,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
                 key={section.route}
                 multiline={true}
                 onClick={props.handleClick}
+                onFocus={props.handleFocus}
                 text={text}
             />
         );

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -35,6 +35,9 @@ export interface IItemRendererProps {
     /** Click event handler to select this item. */
     handleClick: MouseEventHandler<HTMLElement>;
 
+    /** Focus event handler to set this as the "active" item */
+    handleFocus: () => void;
+
     index?: number;
 
     /** Modifiers that describe how to render this item, such as `active` or `disabled`. */

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -374,6 +374,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
             };
             return this.props.itemRenderer(item, {
                 handleClick: e => this.handleItemSelect(item, e),
+                handleFocus: () => this.setActiveItem(item),
                 index,
                 modifiers,
                 query,

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -223,7 +223,7 @@ const filterFilm: ItemPredicate<IFilm> = (query, film) => {
     return film.title.toLowerCase().indexOf(query.toLowerCase()) >= 0;
 };
 
-const renderFilm: ItemRenderer<Film> = (film, { handleClick, modifiers }) => {
+const renderFilm: ItemRenderer<Film> = (film, { handleClick, handleFocus, modifiers }) => {
     if (!modifiers.matchesPredicate) {
         return null;
     }
@@ -233,6 +233,7 @@ const renderFilm: ItemRenderer<Film> = (film, { handleClick, modifiers }) => {
             key={film.title}
             label={film.year}
             onClick={handleClick}
+            onFocus={handleFocus}
             text={film.title}
         />
     );

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -211,7 +211,7 @@ export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, 
         return items.filter(item => expr.test(item.text + item.label));
     };
 
-    private renderItem: ItemRenderer<TimezoneItem> = (item, { handleClick, modifiers }) => {
+    private renderItem: ItemRenderer<TimezoneItem> = (item, { handleClick, handleFocus, modifiers }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
@@ -223,6 +223,7 @@ export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, 
                 text={item.text}
                 label={item.label}
                 onClick={handleClick}
+                onFocus={handleFocus}
                 shouldDismissPopover={false}
             />
         );


### PR DESCRIPTION
Pass handleFocus to itemRenderer to make select & query list components more accessible

#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Pass `handleFocus` to itemRenderer to make `Select` & `QueryList` components more accessible. Previously, tabbing through a query list would not update the `activeItem`, this caused unexpected behavior when selecting the actively focused item as it would actually select whatever was in `activeItem`.

These changes don't completely solve the problem as the up/down key driven state can still get out of sync with the focused item, but tabbing again will resume and we'll never select an _unexpected_ item. I think the fully-baked solution here would go both ways focus <-> active, but this would be much greater lift.

#### Reviewers should focus on:

The focus here should be whether or not we consider this a viable intermediary state, and if it makes sense to update the active item "on focus" in this way. Another note is that this isn't relevant for `Suggest`/`Multiselect` components as the input is outside of the popover in those - tabbing in general is just completely broken there.

#### Screenshot

Before:
![bp-bug-before](https://user-images.githubusercontent.com/36425972/162827004-296b7dc7-7194-4c3c-9bd9-76dfab9114e1.gif)

After:
![bp-bug-after](https://user-images.githubusercontent.com/36425972/162827212-0026839e-c41c-4aeb-9832-552c2530c7b9.gif)

