### PR TITLE
[core] feat(useHotkeys): warn when used outside of HotkeysProvider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,8 @@ jobs:
   dist:
     docker: *docker-node-image
     resource_class: large
+    environment:
+      NODE_ENV: test
     steps:
       - checkout
       - restore_cache: *restore-node-modules-cache
@@ -135,6 +137,7 @@ jobs:
     docker: *docker-node-browsers-image
     environment:
       JUNIT_REPORT_PATH: reports
+      NODE_ENV: test
     parallelism: 7
     steps:
       - checkout

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -36,6 +36,9 @@ export const HOTKEYS_WARN_DECORATOR_NO_METHOD = ns + ` @HotkeysTarget-decorated 
 export const HOTKEYS_WARN_DECORATOR_NEEDS_REACT_ELEMENT =
     ns + ` "@HotkeysTarget-decorated components must return a single JSX.Element or an empty render.`;
 
+export const HOTKEYS_PROVIDER_NOT_FOUND =
+    ns +
+    ` useHotkeys() was used outside of a <HotkeysProvider> context. These hotkeys will not be shown in the hotkeys help dialog.`;
 export const HOTKEYS_TARGET2_CHILDREN_LOCAL_HOTKEYS =
     ns +
     ` <HotkeysTarget2> was configured with local hotkeys, but you did not use the generated event handlers to bind their event handlers. Try using a render function as the child of this component.`;

--- a/packages/core/src/components/hotkeys/hotkeys-target2.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target2.md
@@ -4,10 +4,6 @@ tag: new
 
 @# HotkeysTarget2
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">This API requires React 16.8+</h4>
-</div>
-
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">
 

--- a/packages/core/src/components/panel-stack2/panel-stack2.md
+++ b/packages/core/src/components/panel-stack2/panel-stack2.md
@@ -4,10 +4,6 @@ tag: new
 
 @# Panel stack (v2)
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">This API requires React 16.8+</h4>
-</div>
-
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">
 

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -4,10 +4,6 @@ tag: new
 
 @# HotkeysProvider
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">This API requires React 16.8+</h4>
-</div>
-
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">
 

--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -21,6 +21,13 @@ import { HotkeysDialog2, HotkeysDialog2Props } from "../../components/hotkeys/ho
 import { HotkeyConfig } from "../../hooks";
 
 interface HotkeysContextState {
+    /**
+     * Whether the context instance is being used within a tree which has a <HotkeysProvider>.
+     * It's technically ok if this is false, but not recommended, since that means any hotkeys
+     * bound with that context instance will not show up in the hotkeys help dialog.
+     */
+    hasProvider: boolean;
+
     /** List of hotkeys accessible in the current scope, registered by currently mounted components, can be global or local. */
     hotkeys: HotkeyConfig[];
 
@@ -34,21 +41,20 @@ type HotkeysAction =
 
 export type HotkeysContextInstance = [HotkeysContextState, React.Dispatch<HotkeysAction>];
 
-const initialHotkeysState: HotkeysContextState = { hotkeys: [], isDialogOpen: false };
+const initialHotkeysState: HotkeysContextState = { hasProvider: false, hotkeys: [], isDialogOpen: false };
 const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
 
-// N.B. we can remove this optional call guard once Blueprint depends on React 16
 /**
  * A React context used to register and deregister hotkeys as components are mounted and unmounted in an application.
  * Users should take care to make sure that only _one_ of these is instantiated and used within an application, especially
  * if using global hotkeys.
  *
  * You will likely not be using this HotkeysContext directly, except in cases where you need to get a direct handle on an
- * exisitng context instance for advanced use cases involving nested HotkeysProviders.
+ * existing context instance for advanced use cases involving nested HotkeysProviders.
  *
  * For more information, see the [HotkeysProvider documentation](https://blueprintjs.com/docs/#core/context/hotkeys-provider).
  */
-export const HotkeysContext = React.createContext?.<HotkeysContextInstance>([initialHotkeysState, noOpDispatch]);
+export const HotkeysContext = React.createContext<HotkeysContextInstance>([initialHotkeysState, noOpDispatch]);
 
 const hotkeysReducer = (state: HotkeysContextState, action: HotkeysAction) => {
     switch (action.type) {
@@ -101,7 +107,7 @@ export interface HotkeysProviderProps {
  */
 export const HotkeysProvider = ({ children, dialogProps, renderDialog, value }: HotkeysProviderProps) => {
     const hasExistingContext = value != null;
-    const [state, dispatch] = value ?? React.useReducer(hotkeysReducer, initialHotkeysState);
+    const [state, dispatch] = value ?? React.useReducer(hotkeysReducer, { ...initialHotkeysState, hasProvider: true });
     const handleDialogClose = React.useCallback(() => dispatch({ type: "CLOSE_DIALOG" }), []);
 
     const dialog = renderDialog?.(state, { handleDialogClose }) ?? (

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -4,10 +4,6 @@ tag: new
 
 @# useHotkeys
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">This API requires React 16.8+</h4>
-</div>
-
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
     <h4 class="@ns-heading">
 

--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -16,6 +16,7 @@
 
 import * as React from "react";
 
+import { HOTKEYS_PROVIDER_NOT_FOUND } from "../../common/errors";
 import { comboMatches, getKeyCombo, IKeyCombo, parseKeyCombo } from "../../components/hotkeys/hotkeyParser";
 import { HotkeysContext } from "../../context";
 import { HotkeyConfig } from "./hotkeyConfig";
@@ -72,7 +73,13 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
     );
 
     // register keys with global context
-    const [, dispatch] = React.useContext(HotkeysContext);
+    const [state, dispatch] = React.useContext(HotkeysContext);
+
+    if (!state.hasProvider) {
+        React.useEffect(() => console.warn(HOTKEYS_PROVIDER_NOT_FOUND), []);
+    }
+
+    // we can still bind the hotkeys if there is no HotkeysProvider, they just won't show up in the dialog
     React.useEffect(() => {
         const payload = [...globalKeys.map(k => k.config), ...localKeys.map(k => k.config)];
         dispatch({ type: "ADD_HOTKEYS", payload });

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -127,51 +127,46 @@ describe("<AsyncControllableInput>", () => {
             assert.strictEqual(wrapper.find("input").prop("value"), "bye");
         });
 
-        // this test only seems to work in React 16, where we don't rely on the react-lifecycles-compat polyfill
-        if (React.version.startsWith("16")) {
-            it("accepts async controlled update, optimistically rendering new value while waiting for update", async () => {
-                class TestComponent extends React.PureComponent<{ initialValue: string }, { value: string }> {
-                    public state = { value: this.props.initialValue };
+        it("accepts async controlled update, optimistically rendering new value while waiting for update", async () => {
+            class TestComponent extends React.PureComponent<{ initialValue: string }, { value: string }> {
+                public state = { value: this.props.initialValue };
 
-                    public render() {
-                        return (
-                            <AsyncControllableInput type="text" value={this.state.value} onChange={this.handleChange} />
-                        );
-                    }
-
-                    private handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-                        const newValue = e.target.value;
-                        window.setTimeout(() => this.setState({ value: newValue }), 10);
-                    };
+                public render() {
+                    return <AsyncControllableInput type="text" value={this.state.value} onChange={this.handleChange} />;
                 }
 
-                const wrapper = mount(<TestComponent initialValue="hi" />);
-                assert.strictEqual(wrapper.find("input").prop("value"), "hi");
+                private handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+                    const newValue = e.target.value;
+                    window.setTimeout(() => this.setState({ value: newValue }), 10);
+                };
+            }
 
-                wrapper.find("input").simulate("change", { target: { value: "hi " } });
-                wrapper.update();
+            const wrapper = mount(<TestComponent initialValue="hi" />);
+            assert.strictEqual(wrapper.find("input").prop("value"), "hi");
 
-                assert.strictEqual(
-                    wrapper.find(AsyncControllableInput).prop("value"),
-                    "hi",
-                    "local state should still have initial value",
-                );
-                // but rendered input should optimistically show new value
-                assert.strictEqual(
-                    wrapper.find("input").prop("value"),
-                    "hi ",
-                    "rendered <input> should optimistically show new value",
-                );
+            wrapper.find("input").simulate("change", { target: { value: "hi " } });
+            wrapper.update();
 
-                // after async delay, confirm the update
-                await sleep(20);
-                assert.strictEqual(
-                    wrapper.find("input").prop("value"),
-                    "hi ",
-                    "rendered <input> should still show new value",
-                );
-                return;
-            });
-        }
+            assert.strictEqual(
+                wrapper.find(AsyncControllableInput).prop("value"),
+                "hi",
+                "local state should still have initial value",
+            );
+            // but rendered input should optimistically show new value
+            assert.strictEqual(
+                wrapper.find("input").prop("value"),
+                "hi ",
+                "rendered <input> should optimistically show new value",
+            );
+
+            // after async delay, confirm the update
+            await sleep(20);
+            assert.strictEqual(
+                wrapper.find("input").prop("value"),
+                "hi ",
+                "rendered <input> should still show new value",
+            );
+            return;
+        });
     });
 });

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -163,7 +163,7 @@ describe("useHotkeys", () => {
 
         before(() => (warnSpy = stub(console, "warn")));
         afterEach(() => warnSpy?.resetHistory());
-        after(() => warnSpy?.restore());
+        after(() => (console.warn as SinonStub).restore());
 
         it("logs a warning when used outside of HotkeysProvider context", () => {
             render(<TestComponentContainer />);

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -17,7 +17,7 @@
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
 import * as React from "react";
-import { spy, SinonSpy } from "sinon";
+import { spy, stub, SinonStub } from "sinon";
 
 import { InputGroup } from "@blueprintjs/core";
 // N.B. { fireEvent } from "@testing-library/react" does not generate "real" enough events which
@@ -159,15 +159,11 @@ describe("useHotkeys", () => {
     });
 
     describe("working with HotkeysProvider", () => {
-        let warnSpy: SinonSpy | undefined;
+        let warnSpy: SinonStub | undefined;
 
-        beforeEach(() => {
-            warnSpy = spy(console, "warn");
-        });
-
-        afterEach(() => {
-            warnSpy?.restore();
-        });
+        before(() => (warnSpy = stub(console, "warn")));
+        afterEach(() => warnSpy?.resetHistory());
+        after(() => warnSpy?.restore());
 
         it("logs a warning when used outside of HotkeysProvider context", () => {
             render(<TestComponentContainer />);

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -17,13 +17,14 @@
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
 import * as React from "react";
-import { spy } from "sinon";
+import { spy, SinonSpy } from "sinon";
 
 import { InputGroup } from "@blueprintjs/core";
 // N.B. { fireEvent } from "@testing-library/react" does not generate "real" enough events which
 // work with our hotkey parser implementation (worth investigating...)
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
+import { HotkeysProvider } from "../../src/context";
 import { useHotkeys } from "../../src/hooks";
 
 interface TestComponentProps extends TestComponentContainerProps {
@@ -155,5 +156,31 @@ describe("useHotkeys", () => {
         const target = screen.getByTestId("input-target");
         dispatchTestKeyboardEvent(target, "keydown", "A");
         expect(onKeyASpy.calledOnce).to.be.true;
+    });
+
+    describe("working with HotkeysProvider", () => {
+        let warnSpy: SinonSpy | undefined;
+
+        beforeEach(() => {
+            warnSpy = spy(console, "warn");
+        });
+
+        afterEach(() => {
+            warnSpy?.restore();
+        });
+
+        it("logs a warning when used outside of HotkeysProvider context", () => {
+            render(<TestComponentContainer />);
+            expect(warnSpy?.calledOnce).to.be.true;
+        });
+
+        it("does NOT log a warning when used inside a HotkeysProvider context", () => {
+            render(
+                <HotkeysProvider>
+                    <TestComponentContainer />
+                </HotkeysProvider>,
+            );
+            expect(warnSpy?.notCalled).to.be.true;
+        });
     });
 });

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -163,7 +163,7 @@ describe("useHotkeys", () => {
 
         before(() => (warnSpy = stub(console, "warn")));
         afterEach(() => warnSpy?.resetHistory());
-        after(() => (console.warn as SinonStub).restore());
+        after(() => warnSpy?.restore());
 
         it("logs a warning when used outside of HotkeysProvider context", () => {
             render(<TestComponentContainer />);

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -80,11 +80,6 @@ const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputRea
 };
 
 describe("useHotkeys", () => {
-    if (React.version.startsWith("15")) {
-        it("skipped tests for backwards-incompatible component", () => expect(true).to.be.true);
-        return;
-    }
-
     const onKeyASpy = spy();
     const onKeyBSpy = spy();
 

--- a/packages/core/test/panel-stack2/panelStack2Tests.tsx
+++ b/packages/core/test/panel-stack2/panelStack2Tests.tsx
@@ -41,11 +41,6 @@ const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
 };
 
 describe("<PanelStack2>", () => {
-    if (React.version.startsWith("15")) {
-        it("skipped tests for backwards-incompatible component", () => assert(true));
-        return;
-    }
-
     let testsContainerElement: HTMLElement;
     let panelStackWrapper: PanelStack2Wrapper<TestPanelType>;
 

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -25,6 +25,7 @@ import {
     FocusStyleManager,
     H4,
     H6,
+    HotkeysProvider,
     HTMLSelect,
     ButtonProps,
     Intent,
@@ -336,19 +337,21 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
     public render() {
         const layoutBoundary = this.state.enableLayoutBoundary;
         return (
-            <div className="container">
-                <SlowLayoutStack
-                    depth={SLOW_LAYOUT_STACK_DEPTH}
-                    enabled={this.state.enableSlowLayout}
-                    rootClassName={classNames("table", { "is-inline": this.state.showInline })}
-                    branchClassName={"layout-passthrough-fill"}
-                >
-                    <div className={layoutBoundary ? "layout-boundary" : "layout-passthrough-fill"}>
-                        {this.renderTable()}
-                    </div>
-                </SlowLayoutStack>
-                {this.renderSidebar()}
-            </div>
+            <HotkeysProvider>
+                <div className="container">
+                    <SlowLayoutStack
+                        depth={SLOW_LAYOUT_STACK_DEPTH}
+                        enabled={this.state.enableSlowLayout}
+                        rootClassName={classNames("table", { "is-inline": this.state.showInline })}
+                        branchClassName="layout-passthrough-fill"
+                    >
+                        <div className={layoutBoundary ? "layout-boundary" : "layout-passthrough-fill"}>
+                            {this.renderTable()}
+                        </div>
+                    </SlowLayoutStack>
+                    {this.renderSidebar()}
+                </div>
+            </HotkeysProvider>
         );
     }
 

--- a/packages/table/test/editableCell2Tests.tsx
+++ b/packages/table/test/editableCell2Tests.tsx
@@ -26,11 +26,6 @@ import * as TableClasses from "../src/common/classes";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 
 describe("<EditableCell2>", () => {
-    if (React.version.startsWith("15")) {
-        it("skipped tests for backwards-incompatible component", () => assert(true));
-        return;
-    }
-
     it("renders", () => {
         const elem = mount(<EditableCell2 value="test-value-5000" />);
         expect(elem.find(`.${TableClasses.TABLE_TRUNCATED_TEXT}`).text()).to.equal("test-value-5000");

--- a/packages/table/test/editableCell2Tests.tsx
+++ b/packages/table/test/editableCell2Tests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert, expect } from "chai";
+import { expect } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as sinon from "sinon";
 
-import { HotkeysProvider, Keys, Utils as CoreUtils } from "@blueprintjs/core";
+import { Keys, Utils as CoreUtils } from "@blueprintjs/core";
 import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test-commons";
 
 import { Cell, Column, TableProps, RegionCardinality, Table2, TableLoadingOption } from "../src";
@@ -727,19 +727,19 @@ describe("<Table2>", function (this) {
 
         describe("columns validation", () => {
             it("doesn't print a warning with default (0) frozen", () => {
-                const table = mountWithHotkeys(<Table2 />);
+                const table = mount(<Table2 />);
                 expect(table.state("numFrozenColumnsClamped")).to.equal(0, "clamped state");
-                expect(consoleWarn?.callCount).to.equal(0, "console.warn calls");
+                expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.false;
             });
 
             it("prints a warning and clamps numFrozenColumns with 0 columns, 1 frozen", () => {
-                const table = mountWithHotkeys(<Table2 numFrozenColumns={1} />);
+                const table = mount(<Table2 numFrozenColumns={1} />);
                 expect(table.state("numFrozenColumnsClamped")).to.equal(0, "clamped state");
                 expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
             });
 
             it("prints a warning and clamps numFrozenColumns with 1 column, 2 frozen", () => {
-                const table = mountWithHotkeys(
+                const table = mount(
                     <Table2 numFrozenColumns={2}>
                         <Column />
                     </Table2>,
@@ -751,19 +751,20 @@ describe("<Table2>", function (this) {
 
         describe("rows validation", () => {
             it("doesn't print a warning with default (0) frozen", () => {
-                const table = mountWithHotkeys(<Table2 />);
+                const table = mount(<Table2 />);
                 expect(table.state("numFrozenRowsClamped")).to.equal(0, "clamped state");
                 expect(consoleWarn?.callCount).to.equal(0, "console.warn calls");
+                expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.false;
             });
 
             it("prints a warning and clamps numFrozenRows with 0 rows, 1 frozen", () => {
-                const table = mountWithHotkeys(<Table2 numFrozenRows={1} numRows={0} />);
+                const table = mount(<Table2 numFrozenRows={1} numRows={0} />);
                 expect(table.state("numFrozenRowsClamped")).to.equal(0, "clamped state");
                 expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
             });
 
             it("prints a warning and clamps numFrozenRows with 1 row, 2 frozen", () => {
-                const table = mountWithHotkeys(
+                const table = mount(
                     <Table2 numFrozenRows={2} numRows={1}>
                         <Column />
                     </Table2>,
@@ -772,14 +773,6 @@ describe("<Table2>", function (this) {
                 expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
             });
         });
-
-        /**
-         * `console.warn` will be called if we don't wrap the table in a hotkeys provider,
-         * so we must ensure that we do this to get a clean console before testing console warnings.
-         */
-        function mountWithHotkeys(table: JSX.Element) {
-            return mount(<HotkeysProvider>{table}</HotkeysProvider>);
-        }
 
         const NUM_ROWS = 4;
         const NUM_COLUMNS = 3;

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert, expect } from "chai";
+import { expect } from "chai";
 import { mount as untypedMount, MountRendererProps, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -32,7 +32,7 @@ import { Rect } from "../src/common/rect";
 import { RenderMode } from "../src/common/renderMode";
 import { TableQuadrant } from "../src/quadrants/tableQuadrant";
 import { TableQuadrantStack } from "../src/quadrants/tableQuadrantStack";
-import { IRegion, Regions } from "../src/regions";
+import { Region, Regions } from "../src/regions";
 import { TableState } from "../src/tableState";
 import { CellType, expectCellLoading } from "./cellTestUtils";
 import { ElementHarness, ReactHarness } from "./harness";
@@ -490,7 +490,7 @@ describe("<Table2>", function (this) {
                 checkInstanceMethod(Regions.table(), 0, 0);
             });
 
-            function checkInstanceMethod(region: IRegion, expectedScrollLeft: number, expectedScrollTop: number) {
+            function checkInstanceMethod(region: Region, expectedScrollLeft: number, expectedScrollTop: number) {
                 // cast as `any` to access private members
                 const spy = sinon.spy((tableInstance as any).quadrantStackInstance, "scrollToPosition");
                 tableInstance.scrollToRegion(region);
@@ -1248,7 +1248,7 @@ describe("<Table2>", function (this) {
                 expectedCoords: IFocusedCellCoordinates,
             ) {
                 it(name, () => {
-                    const selectedRegions: IRegion[] = [
+                    const selectedRegions: Region[] = [
                         { cols: [0, 1], rows: [0, 1] },
                         { cols: [2, 2], rows: [2, 2] },
                     ];

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -45,11 +45,6 @@ import { createStringOfLength, createTableOfSize } from "./mocks/table";
 const mount = (el: React.ReactElement<TableProps>, options?: MountRendererProps) => untypedMount<Table2>(el, options);
 
 describe("<Table2>", function (this) {
-    if (React.version.startsWith("15")) {
-        it("skipped tests for backwards-incompatible component", () => assert(true));
-        return;
-    }
-
     // allow retrying failed tests here to reduce flakes.
     this.retries(2);
 

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -719,47 +719,58 @@ describe("<Table2>", function (this) {
     });
 
     describe("Freezing", () => {
-        let consoleWarn: sinon.SinonSpy;
+        let consoleWarn: sinon.SinonStub;
 
         before(() => (consoleWarn = sinon.stub(console, "warn")));
         afterEach(() => consoleWarn.resetHistory());
-        after(() => consoleWarn.restore());
+        after(() => (console.warn as sinon.SinonStub).restore());
 
-        // HACKHACK(https://github.com/palantir/blueprint/issues/3755): skip assertions for console warnings
-        it("prints a warning and clamps out-of-bounds numFrozenColumns if > number of columns", () => {
-            const table1 = mount(<Table2 />);
-            expect(table1.state("numFrozenColumnsClamped")).to.equal(0);
-            expect(consoleWarn.callCount).to.equal(0);
+        describe("columns validation", () => {
+            it("doesn't print a warning with default (0) frozen", () => {
+                const table = mount(<Table2 />);
+                expect(table.state("numFrozenColumnsClamped")).to.equal(0);
+                expect(consoleWarn.callCount).to.equal(0);
+            });
 
-            const table2 = mount(<Table2 numFrozenColumns={1} />);
-            expect(table2.state("numFrozenColumnsClamped")).to.equal(0);
-            // expect(consoleWarn.callCount).to.equal(1, "warned 1");
+            it("prints a warning and clamps numFrozenColumns with 0 columns, 1 frozen", () => {
+                const table = mount(<Table2 numFrozenColumns={1} />);
+                expect(table.state("numFrozenColumnsClamped")).to.equal(0);
+                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
+            });
 
-            const table3 = mount(
-                <Table2 numFrozenColumns={2}>
-                    <Column />
-                </Table2>,
-            );
-            expect(table3.state("numFrozenColumnsClamped")).to.equal(1, "clamped");
-            // expect(consoleWarn.callCount).to.equal(2, "warned 2");
+            it("prints a warning and clamps numFrozenColumns with 1 column, 2 frozen", () => {
+                const table = mount(
+                    <Table2 numFrozenColumns={2}>
+                        <Column />
+                    </Table2>,
+                );
+                expect(table.state("numFrozenColumnsClamped")).to.equal(1, "third table numFrozenColumnsClamped state");
+                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
+            });
         });
 
-        it("prints a warning and clamps out-of-bounds numFrozenRows if > numRows", () => {
-            const table1 = mount(<Table2 />);
-            expect(table1.state("numFrozenRowsClamped")).to.equal(0);
-            expect(consoleWarn.callCount).to.equal(0);
+        describe("rows validation", () => {
+            it("doesn't print a warning with default (0) frozen", () => {
+                const table = mount(<Table2 />);
+                expect(table.state("numFrozenRowsClamped")).to.equal(0);
+                expect(consoleWarn.callCount).to.equal(0);
+            });
 
-            const table2 = mount(<Table2 numFrozenRows={1} numRows={0} />);
-            expect(table2.state("numFrozenRowsClamped")).to.equal(0);
-            // expect(consoleWarn.callCount).to.equal(1, "warned 1");
+            it("prints a warning and clamps numFrozenRows with 0 rows, 1 frozen", () => {
+                const table = mount(<Table2 numFrozenRows={1} numRows={0} />);
+                expect(table.state("numFrozenRowsClamped")).to.equal(0, "second table numFrozenColumnsClamped state");
+                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
+            });
 
-            const table3 = mount(
-                <Table2 numFrozenRows={2} numRows={1}>
-                    <Column />
-                </Table2>,
-            );
-            expect(table3.state("numFrozenRowsClamped")).to.equal(1, "clamped");
-            // expect(consoleWarn.callCount).to.equal(2, "warned 3");
+            it("prints a warning and clamps numFrozenRows with 1 row, 2 frozen", () => {
+                const table = mount(
+                    <Table2 numFrozenRows={2} numRows={1}>
+                        <Column />
+                    </Table2>,
+                );
+                expect(table.state("numFrozenRowsClamped")).to.equal(1, "clamped");
+                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
+            });
         });
 
         const NUM_ROWS = 4;

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as sinon from "sinon";
 
-import { Keys, Utils as CoreUtils } from "@blueprintjs/core";
+import { HotkeysProvider, Keys, Utils as CoreUtils } from "@blueprintjs/core";
 import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test-commons";
 
 import { Cell, Column, TableProps, RegionCardinality, Table2, TableLoadingOption } from "../src";
@@ -719,59 +719,67 @@ describe("<Table2>", function (this) {
     });
 
     describe("Freezing", () => {
-        let consoleWarn: sinon.SinonStub;
+        let consoleWarn: sinon.SinonStub | undefined;
 
         before(() => (consoleWarn = sinon.stub(console, "warn")));
-        afterEach(() => consoleWarn.resetHistory());
-        after(() => (console.warn as sinon.SinonStub).restore());
+        afterEach(() => consoleWarn?.resetHistory());
+        after(() => consoleWarn?.restore());
 
         describe("columns validation", () => {
             it("doesn't print a warning with default (0) frozen", () => {
-                const table = mount(<Table2 />);
-                expect(table.state("numFrozenColumnsClamped")).to.equal(0);
-                expect(consoleWarn.callCount).to.equal(0);
+                const table = mountWithHotkeys(<Table2 />);
+                expect(table.state("numFrozenColumnsClamped")).to.equal(0, "clamped state");
+                expect(consoleWarn?.callCount).to.equal(0, "console.warn calls");
             });
 
             it("prints a warning and clamps numFrozenColumns with 0 columns, 1 frozen", () => {
-                const table = mount(<Table2 numFrozenColumns={1} />);
-                expect(table.state("numFrozenColumnsClamped")).to.equal(0);
-                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
+                const table = mountWithHotkeys(<Table2 numFrozenColumns={1} />);
+                expect(table.state("numFrozenColumnsClamped")).to.equal(0, "clamped state");
+                expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
             });
 
             it("prints a warning and clamps numFrozenColumns with 1 column, 2 frozen", () => {
-                const table = mount(
+                const table = mountWithHotkeys(
                     <Table2 numFrozenColumns={2}>
                         <Column />
                     </Table2>,
                 );
-                expect(table.state("numFrozenColumnsClamped")).to.equal(1, "third table numFrozenColumnsClamped state");
-                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
+                expect(table.state("numFrozenColumnsClamped")).to.equal(1, "clamped state");
+                expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_COLUMNS_BOUND_WARNING)).to.be.true;
             });
         });
 
         describe("rows validation", () => {
             it("doesn't print a warning with default (0) frozen", () => {
-                const table = mount(<Table2 />);
-                expect(table.state("numFrozenRowsClamped")).to.equal(0);
-                expect(consoleWarn.callCount).to.equal(0);
+                const table = mountWithHotkeys(<Table2 />);
+                expect(table.state("numFrozenRowsClamped")).to.equal(0, "clamped state");
+                expect(consoleWarn?.callCount).to.equal(0, "console.warn calls");
             });
 
             it("prints a warning and clamps numFrozenRows with 0 rows, 1 frozen", () => {
-                const table = mount(<Table2 numFrozenRows={1} numRows={0} />);
-                expect(table.state("numFrozenRowsClamped")).to.equal(0, "second table numFrozenColumnsClamped state");
-                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
+                const table = mountWithHotkeys(<Table2 numFrozenRows={1} numRows={0} />);
+                expect(table.state("numFrozenRowsClamped")).to.equal(0, "clamped state");
+                expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
             });
 
             it("prints a warning and clamps numFrozenRows with 1 row, 2 frozen", () => {
-                const table = mount(
+                const table = mountWithHotkeys(
                     <Table2 numFrozenRows={2} numRows={1}>
                         <Column />
                     </Table2>,
                 );
-                expect(table.state("numFrozenRowsClamped")).to.equal(1, "clamped");
-                expect(consoleWarn.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
+                expect(table.state("numFrozenRowsClamped")).to.equal(1, "clamped state");
+                expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.true;
             });
         });
+
+        /**
+         * `console.warn` will be called if we don't wrap the table in a hotkeys provider,
+         * so we must ensure that we do this to get a clean console before testing console warnings.
+         */
+        function mountWithHotkeys(table: JSX.Element) {
+            return mount(<HotkeysProvider>{table}</HotkeysProvider>);
+        }
 
         const NUM_ROWS = 4;
         const NUM_COLUMNS = 3;

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -753,7 +753,6 @@ describe("<Table2>", function (this) {
             it("doesn't print a warning with default (0) frozen", () => {
                 const table = mount(<Table2 />);
                 expect(table.state("numFrozenRowsClamped")).to.equal(0, "clamped state");
-                expect(consoleWarn?.callCount).to.equal(0, "console.warn calls");
                 expect(consoleWarn?.calledWith(Errors.TABLE_NUM_FROZEN_ROWS_BOUND_WARNING)).to.be.false;
             });
 


### PR DESCRIPTION
Fixes #3755 (for Table2, not touching Table since it's deprecated)

#### Changes proposed in this pull request:

- Log a console warning when `useHotkeys()` is used outside of a `<HotkeysProvider>` tree.
- Clean up some docs and tests which still referenced the possibility of React 15 (which was dropped in v4.0)

