### PR TITLE
[popover2] chore: fix react peer dep, allow v18

### DIFF
--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -44,7 +44,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8 || 17 || 18"
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^3.1.1",


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/5205#issuecomment-1095589509

Missed this in #5226 :(
