### PR TITLE
[core] fix: remove invalid CSS selector

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -149,6 +149,11 @@ $button-intents: (
   &:disabled,
   &.#{$ns}-disabled {
     @include pt-button-disabled();
+
+    &.#{$ns}-active,
+    &.#{$ns}-active:hover {
+      background: $button-background-color-active-disabled;
+    }
   }
 }
 
@@ -171,11 +176,6 @@ $button-intents: (
   color: $button-color-disabled;
   cursor: not-allowed;
   outline: none;
-
-  &.#{$ns}-active,
-  &.#{$ns}-active:hover {
-    background: $button-background-color-active-disabled;
-  }
 }
 
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
@@ -240,6 +240,10 @@ $button-intents: (
   &:disabled,
   &.#{$ns}-disabled {
     @include pt-dark-button-disabled();
+
+    &.#{$ns}-active {
+      background: $dark-button-background-color-active-disabled;
+    }
   }
 
   .#{$ns}-button-spinner .#{$ns}-spinner-head {
@@ -264,10 +268,6 @@ $button-intents: (
   background-image: none;
   box-shadow: none;
   color: $dark-button-color-disabled;
-
-  &.#{$ns}-active {
-    background: $dark-button-background-color-active-disabled;
-  }
 }
 
 @mixin pt-dark-button-intent() {


### PR DESCRIPTION
#### Fixes #5256

#### Changes proposed in this pull request:

Audit all `&::before` and `&::after` Sass blocks for use of problematic mixins which add on extra class names, producing the invalid CSS described in the linked issue. It looks like just FileInput had the problem.

#### Reviewers should focus on:

No regressions in buttons + file input styles.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
