### PR TITLE
[core,colors] fix !default modifiers in Sass variables

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -8,7 +8,7 @@
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p src/",
         "compile:css": "sass-compile ./src",
-        "compile:css-colors": "generate-css-variables --outputFileName colors _colors.scss",
+        "compile:css-colors": "generate-css-variables --retainDefault true --outputFileName colors _colors.scss",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
         "lint": "npm-run-all -p lint:scss lint:es",
         "lint:scss": "sass-lint",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
         "dist": "run-s \"dist:*\"",
         "dist:bundle": "cross-env NODE_ENV=production webpack",
         "dist:css": "css-dist lib/css/*.css",
-        "dist:variables": "generate-css-variables ../../colors/src/_colors.scss common/_color-aliases.scss common/_variables.scss",
+        "dist:variables": "generate-css-variables --retainDefault true ../../colors/src/_colors.scss common/_color-aliases.scss common/_variables.scss",
         "dist:verify": "assert-package-layout",
         "lint": "run-p lint:scss lint:es",
         "lint:scss": "sass-lint",

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -6,8 +6,9 @@
 @import "mixins";
 
 // Namespace appended to the beginning of each CSS class: `.#{$ns}-button`.
-// Do not quote this value, for Less consumers.
-$ns: bp4 !default;
+// N.B. No quotes around this string value, for Less syntax compatibility. Also, this cannot be overriden
+// (the JS components have this class prefix hard-coded), so it does not have the `! default` modifier.
+$ns: bp4;
 // Alias for BP users outside this repo
 $bp-ns: $ns;
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

Fixes the Sass variables issues I described in https://github.com/palantir/blueprint/issues/5225#issuecomment-1098162039.

The `! default` modifier was accidentally removed from Sass variables in https://github.com/palantir/blueprint/pull/4941. Adding back the CLI argument brings those back, both for core and colors packages.

Also I've removed the ability to override `$ns`, as it is meaningless to do so.

