### PR TITLE
[popover2] fix: declare children prop explicitly

### DIFF
--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -15,6 +15,7 @@
  */
 
 import { Boundary, Placement, placements, RootBoundary, StrictModifiers } from "@popperjs/core";
+import * as React from "react";
 import { StrictModifier } from "react-popper";
 
 import { OverlayableProps, Props, PopoverPosition, IRef } from "@blueprintjs/core";
@@ -45,6 +46,8 @@ export type Popover2SharedProps<T> = IPopover2SharedProps<T>;
  * @deprecated use Popover2SharedProps
  */
 export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
+    children?: React.ReactNode;
+
     /**
      * A boundary element supplied to the "flip" and "preventOverflow" modifiers.
      * This is a shorthand for overriding Popper.js modifier options with the `modifiers` prop.


### PR DESCRIPTION
#### Fixes #5250

#### Checklist

- [ ] ~Includes tests~ - no automated tests, but checked manually against a project of my own and confirmed it works as expected when used with React 18
- [ ] ~Update documentation~

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This PR defines the `children` prop explicitly for Popover2 and Tooltip2, which is a requirement in React 18.

It looks like https://github.com/palantir/blueprint/pull/5258 fixed all instances of this for function components but it didn't tackle class components.

Note that I haven't checked anything beyond Popover2/Tooltip2 - there may be other affected components, but we only use a few components from Blueprint in our project at the moment.
