### PR TITLE
[core,colors] fix !default flags on generated SCSS variables

### DIFF
--- a/packages/node-build-scripts/generate-css-variables.js
+++ b/packages/node-build-scripts/generate-css-variables.js
@@ -142,7 +142,7 @@ function generateScssVariables(parsedInput, outputFilename, retainDefault) {
         const variablesArray = Object.entries(parsedVars)
             .filter(([varName, _value]) => varsInBlock.has(varName))
             .map(([varName, value]) => {
-                const defaultFlag = varsWithDefaultFlag.has(varName) ? "!default" : "";
+                const defaultFlag = retainDefault && varsWithDefaultFlag.has(varName) ? "!default" : "";
                 return `${varName}: ${convertParsedValueToOutput(value, "scss")} ${defaultFlag};`;
             });
 

--- a/packages/node-build-scripts/generate-css-variables.js
+++ b/packages/node-build-scripts/generate-css-variables.js
@@ -33,8 +33,8 @@ function main() {
         }).argv;
 
     const outputFilename = args["outputFileName"];
-    const parsedInput = getParsedVars(args["_"], args["retainDefault"]);
-    generateScssVariables(parsedInput, outputFilename);
+    const parsedInput = getParsedVars(args["_"]);
+    generateScssVariables(parsedInput, outputFilename, args["retainDefault"]);
     generateLessVariables(parsedInput, outputFilename);
 }
 
@@ -43,10 +43,9 @@ function main() {
  * and gets compiled output from `get-sass-vars`.
  *
  * @param {string[]} inputSources
- * @param {boolean} retainDefault
- * @returns {{parsedVars: object, varsInBlocks: Set<string>[]}} output compiled variable values and grouped variable blocks
+ * @returns {{parsedVars: object, varsInBlocks: Set<string>[], varsWithDefaultFlag: Set<string>}} output compiled variable values and grouped variable blocks
  */
-function getParsedVars(inputSources, retainDefault) {
+function getParsedVars(inputSources) {
     // concatenate sources
     let cleanedInput = inputSources.reduce((str, currentFilename) => {
         return str + fs.readFileSync(`${SRC_DIR}/${currentFilename}`).toString();
@@ -58,9 +57,6 @@ function getParsedVars(inputSources, retainDefault) {
         .replace(/@use "sass:math";\n/g, "")
         .replace(/border-shadow\((.+)\)/g, "0 0 0 1px rgba($black, $1)")
         .replace(/\n{3,}/g, "\n\n");
-    if (!retainDefault) {
-        cleanedInput = cleanedInput.replace(/\ \!default/g, "");
-    }
     cleanedInput = [USE_MATH_RULE, cleanedInput].join("\n");
 
     // @ts-ignore, issues with types in `get-sass-vars`
@@ -77,7 +73,17 @@ function getParsedVars(inputSources, retainDefault) {
             block =>
                 new Set([...block.matchAll(/(?<varName>\$[-_a-zA-z0-9]+)(?::)/g)].map(match => match.groups.varName)),
         );
-    return { parsedVars, varsInBlocks };
+
+    // `getSassVarsSync` strips `!default` flags from the output, so we need to determine which
+    // variables had those flags set here and pass it on
+    const varsWithDefaultFlag = new Set(
+        [...cleanedInput.matchAll(/(?<varName>\$[-_a-zA-z0-9]+)(?::)(?<varValue>[\s\S]+?);/gm)]
+            .map(match => [match.groups.varName, match.groups.varValue.trim()])
+            .filter(([, varValue]) => varValue.endsWith("!default"))
+            .map(([varName]) => varName),
+    );
+
+    return { parsedVars, varsInBlocks, varsWithDefaultFlag };
 }
 
 function isPrimitive(value) {
@@ -123,20 +129,24 @@ function convertParsedValueToOutput(value, outputType) {
  * Pulls together variables from the specified Sass source files, sanitizes them for consumption,
  * and writes to an output file.
  *
- * @param {{parsedVars: object, varsInBlocks: Set<string>[]}} parsedInput
+ * @param {{parsedVars: object, varsInBlocks: Set<string>[], varsWithDefaultFlag: Set<string>}} parsedInput
  * @param {string} outputFilename
+ * @param {boolean} retainDefault whether to retain `!default` flags on variables
  * @returns {string} output Sass contents
  */
-function generateScssVariables(parsedInput, outputFilename) {
-    const { parsedVars, varsInBlocks } = parsedInput;
+function generateScssVariables(parsedInput, outputFilename, retainDefault) {
+    const { parsedVars, varsInBlocks, varsWithDefaultFlag } = parsedInput;
 
     let variablesScss = COPYRIGHT_HEADER + "\n";
     for (const varsInBlock of varsInBlocks) {
         const variablesArray = Object.entries(parsedVars)
             .filter(([varName, _value]) => varsInBlock.has(varName))
-            .map(([varName, value]) => `${varName}: ${convertParsedValueToOutput(value, "scss")};`);
+            .map(([varName, value]) => {
+                const defaultFlag = varsWithDefaultFlag.has(varName) ? "!default" : "";
+                return `${varName}: ${convertParsedValueToOutput(value, "scss")} ${defaultFlag};`;
+            });
 
-            variablesScss = `${variablesScss}${variablesArray.join("\n")}\n\n`;
+        variablesScss = `${variablesScss}${variablesArray.join("\n")}\n\n`;
     }
 
     const formattedVariablesScss = prettier.format(variablesScss, { parser: "less" });


### PR DESCRIPTION
#### Fixes the issue described in the comment: https://github.com/palantir/blueprint/pull/5260#issuecomment-1100586558

The previous fix (https://github.com/palantir/blueprint/pull/5260) partially fixed the issue with the `!default` flag being stripped from generated SCSS variable files, but didn't fully fix it due to another issue introduced just recently (described in my comment on that PR).

#### Changes proposed in this pull request:

This PR implements the idea I had for a fix mentioned in that comment. A regex is used to search for variables in the input SCSS and match whether each variable has a `!default` flag or not. The flags are then restored afterwards, when generating the new output (for SCSS only, since it is not applicable to LESS). While this is just a regex and therefore imperfect, it does seem to work reliably for every use case that currently exists (though I presume, for example, it would fail if it encountered a string value containing a semicolon). I've tested it on the variables files generated in both `colors` and `core` and they both appear to have the correct output now.

#### Reviewers should focus on:

- Whether the regex is reliable enough for production usage 😄 (However my thinking is that this should be fine - it improves on the previous situation significantly and the impact of a failed match is obviously very low; it wouldn't break anything around it, but it could be confusing and difficult to track down for anyone unlucky enough to encounter it)

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
