### PR TITLE
[core] fix: remove invalid CSS selector (again)

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -27,7 +27,7 @@ Markup:
 Styleguide button
 */
 .#{$ns}-button {
-  @include pt-button-base();
+  @include pt-button-layout();
   @include pt-button-height($pt-button-height);
 
   &:empty {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -95,7 +95,7 @@ $button-intents: (
   "danger": ($pt-intent-danger, $red2, $red1)
 ) !default;
 
-@mixin pt-button-base() {
+@mixin pt-button-layout() {
   @include pt-flex-container(row, $button-icon-spacing, $inline: inline);
   align-items: center;
 
@@ -131,11 +131,9 @@ $button-intents: (
   padding: $button-padding-small;
 }
 
+// N.B. this mixin cannot be used on pseudo element selectors because it will produce invalid CSS
 @mixin pt-button() {
-  background-color: $button-background-color;
-  background-image: $button-gradient;
-  box-shadow: $button-box-shadow;
-  color: $pt-text-color;
+  @include pt-button-default-colors();
 
   &:hover {
     @include pt-button-hover();
@@ -155,6 +153,13 @@ $button-intents: (
       background: $button-background-color-active-disabled;
     }
   }
+}
+
+@mixin pt-button-default-colors() {
+  background-color: $button-background-color;
+  background-image: $button-gradient;
+  box-shadow: $button-box-shadow;
+  color: $pt-text-color;
 }
 
 @mixin pt-button-hover() {
@@ -216,11 +221,9 @@ $button-intents: (
   color: $button-intent-color-disabled;
 }
 
+// N.B. this mixin cannot be used on pseudo element selectors because it will produce invalid CSS
 @mixin pt-dark-button() {
-  background-color: $dark-button-background-color;
-  background-image: $dark-button-gradient;
-  box-shadow: $dark-button-box-shadow;
-  color: $pt-dark-text-color;
+  @include pt-dark-button-default-colors();
 
   &:hover,
   &:active,
@@ -250,6 +253,13 @@ $button-intents: (
     background: $dark-progress-track-color;
     stroke: $dark-progress-head-color;
   }
+}
+
+@mixin pt-dark-button-default-colors() {
+  background-color: $dark-button-background-color;
+  background-image: $dark-button-gradient;
+  box-shadow: $dark-button-box-shadow;
+  color: $pt-dark-text-color;
 }
 
 @mixin pt-dark-button-hover() {

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -97,7 +97,7 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) *
   user-select: none;
 
   &::after {
-    @include pt-button();
+    @include pt-button-default-colors();
     @include pt-button-height($pt-button-height-small);
     @include overflow-ellipsis();
     border-radius: $pt-border-radius;
@@ -119,6 +119,8 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) *
     @include pt-button-active();
   }
 
+  // N.B. disabled state is handled above, inside .#{$ns}-file-input block
+
   .#{$ns}-large & {
     @include pt-input-large();
     padding-right: $file-input-button-width-large + $input-padding-horizontal;
@@ -136,7 +138,7 @@ $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) *
     color: $pt-dark-text-color-disabled;
 
     &::after {
-      @include pt-dark-button();
+      @include pt-dark-button-default-colors();
     }
 
     &:hover::after {

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -4,7 +4,7 @@
 @import "../forms/common";
 
 %pt-select {
-  @include pt-button-base();
+  @include pt-button-layout();
   @include pt-button();
 
   /* stylelint-disable property-no-vendor-prefix */


### PR DESCRIPTION
#### Fixes #5256

It wasn't just the "active" modifier styles which were problematic as I thought in #5259, it's actually the `pt-button()` and `pt-dark-button()` mixins. I've refactored them here to fix the invalid selectors.
