### PR TITLE
[core] fix(EditableText): disabled and alwaysRenderInput intent styles

### DIFF
--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -31,14 +31,11 @@
     box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
   }
 
-  &.#{$ns}-disabled::before {
-    box-shadow: none;
-  }
-
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
+      .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
-      .#{$ns}-editable-text-content {
+      .#{$ns}-editable-text-input::placeholder {
         color: $color;
       }
 
@@ -70,7 +67,9 @@
 
     @each $intent, $color in $pt-dark-intent-text-colors {
       &.#{$ns}-intent-#{$intent} {
-        .#{$ns}-editable-text-content {
+        .#{$ns}-editable-text-content,
+        .#{$ns}-editable-text-input,
+        .#{$ns}-editable-text-input::placeholder {
           color: $color;
         }
 
@@ -83,6 +82,12 @@
         }
       }
     }
+  }
+
+  &.#{$ns}-disabled::before {
+    // override intent + dark theme selectors
+    /* stylelint-disable-next-line declaration-no-important */
+    box-shadow: none !important;
   }
 }
 


### PR DESCRIPTION
#### Fixes #5279

#### Changes proposed in this pull request:

Fixes all the linked issues so that intent text colors are applied consistently, and `disabled={true}` never makes the EditableText look interactive on hover.

