### PR TITLE
[core] fix: refactor typography colors into mixins

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -1,11 +1,13 @@
-@charset "utf-8"; // foreign characters ahead (in KSS markup)
 
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 @import "common/variables";
 @import "common/mixins";
+@import "common/typography-colors";
 @import "components/icon/icon";
+
+@include pt-typography-colors();
 
 /*
 Headings
@@ -83,22 +85,6 @@ Styleguide ui-text
 
 // NOTE: .#{$ns}-text-large defined below after .#{$ns}-running-text
 
-.#{$ns}-text-muted {
-  color: $pt-text-color-muted;
-
-  .#{$ns}-dark & {
-    color: $pt-dark-text-color-muted;
-  }
-}
-
-.#{$ns}-text-disabled {
-  color: $pt-text-color-disabled;
-
-  .#{$ns}-dark & {
-    color: $pt-dark-text-color-disabled;
-  }
-}
-
 .#{$ns}-text-overflow-ellipsis {
   @include overflow-ellipsis();
 }
@@ -147,10 +133,6 @@ Styleguide running-text
     border: none;
     border-bottom: 1px solid $pt-divider-black;
     margin: ($pt-grid-size * 2) 0;
-
-    .#{$ns}-dark & {
-      border-color: $pt-dark-divider-white;
-    }
   }
 
   p {
@@ -207,31 +189,11 @@ Styleguide typography.links
 */
 
 a {
-  color: $pt-link-color;
   text-decoration: none;
 
   &:hover {
-    color: $pt-link-color;
     cursor: pointer;
     text-decoration: underline;
-  }
-
-  #{$icon-classes} {
-    color: inherit;
-  }
-
-  code,
-  .#{$ns}-dark & code {
-    color: inherit;
-  }
-
-  .#{$ns}-dark &,
-  .#{$ns}-dark &:hover {
-    color: $pt-dark-link-color;
-
-    #{$icon-classes} {
-      color: inherit;
-    }
   }
 }
 
@@ -259,37 +221,14 @@ Styleguide preformatted
 
 %code {
   @include monospace-typography();
-  background: $pt-code-background-color;
-
   border-radius: $pt-border-radius;
-  box-shadow: inset border-shadow(0.2);
-  color: $pt-code-text-color;
   font-size: smaller;
   padding: 2px 5px;
-
-  .#{$ns}-dark & {
-    background: $pt-dark-code-background-color;
-    box-shadow: inset border-shadow(0.4);
-    color: $pt-dark-code-text-color;
-  }
-
-  a > & {
-    // <code> in links. markdown: [`code`](http://url)
-    // $pt-link-color does not have good contrast with non-link <code>'s in light theme, so we use a brighter hue
-    color: $pt-intent-primary;
-
-    .#{$ns}-dark & {
-      color: inherit;
-    }
-  }
 }
 
 %code-block {
   @include monospace-typography();
-  background: $pt-code-background-color;
   border-radius: $pt-border-radius;
-  box-shadow: inset 0 0 0 1px $pt-divider-black;
-  color: $pt-text-color;
 
   display: block;
   font-size: $pt-font-size - 1px;
@@ -299,16 +238,7 @@ Styleguide preformatted
   word-break: break-all;
   word-wrap: break-word;
 
-  .#{$ns}-dark & {
-    background: $pt-dark-code-background-color;
-    box-shadow: inset 0 0 0 1px $pt-dark-divider-black;
-    color: $pt-dark-text-color;
-  }
-
   > code {
-    background: none;
-    box-shadow: none;
-    color: inherit;
     font-size: inherit;
     padding: 0;
   }
@@ -324,10 +254,7 @@ Styleguide preformatted
 
 %keyboard {
   align-items: center;
-  background: $white;
   border-radius: $pt-border-radius;
-  box-shadow: $pt-elevation-shadow-1;
-  color: $pt-text-color-muted;
   display: inline-flex;
   font-family: inherit;
   font-size: $pt-font-size-small;
@@ -340,12 +267,6 @@ Styleguide preformatted
 
   #{$icon-classes} {
     margin-right: $pt-grid-size * 0.5;
-  }
-
-  .#{$ns}-dark & {
-    background: $dark-gray4;
-    box-shadow: $pt-dark-elevation-shadow-1;
-    color: $pt-dark-text-color-muted;
   }
 }
 
@@ -454,6 +375,11 @@ Styleguide rtl
   text-align: right;
 }
 
+
+/*
+Dark theme
+*/
+
 .#{$ns}-dark {
-  color: $pt-dark-text-color;
+  @include pt-dark-typography-colors();
 }

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "common/variables";
+@import "common/variables-extended";
 @import "common/mixins";
 @import "common/typography-colors";
 @import "components/icon/icon";

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -1,4 +1,3 @@
-
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
@@ -6,7 +5,6 @@
 @import "common/mixins";
 @import "common/typography-colors";
 @import "components/icon/icon";
-
 @include pt-typography-colors();
 
 /*

--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -8,6 +8,7 @@ Licensed under the Apache License, Version 2.0.
 // Import files in the same order that they are documented in the docs
 @import "~@blueprintjs/colors/lib/scss/colors";
 @import "common/variables";
+@import "common/variables-extended";
 @import "common/mixins";
 
 @import "reset";

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -5,12 +5,6 @@
 @import "~@blueprintjs/colors/lib/scss/colors";
 @import "flex";
 
-// Extended color pallete
-$blue6: #99c4ff;
-$green6: #7cd7a2;
-$orange6: #f5c186;
-$red6: #ffa1a4;
-
 $pt-intent-colors: (
   "primary": $pt-intent-primary,
   "success": $pt-intent-success,

--- a/packages/core/src/common/_typography-colors.scss
+++ b/packages/core/src/common/_typography-colors.scss
@@ -1,0 +1,154 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "variables";
+@import "mixins";
+
+@mixin pt-typography-colors() {
+  // N.B. we can't declare any global colors here because this mixin is @included at
+  // the root, outside of any selector, but _reset.scss sets the body text color for us.
+
+  .#{$ns}-text-muted {
+    color: $pt-text-color-muted;
+  }
+
+  .#{$ns}-text-disabled {
+    color: $pt-text-color-disabled;
+  }
+
+  .#{$ns}-running-text {
+    hr {
+      border-color: $pt-divider-black;
+    }
+  }
+
+  a {
+    color: $pt-link-color;
+
+    &:hover {
+      color: $pt-link-color;
+    }
+
+    #{$icon-classes} {
+      color: inherit;
+    }
+
+    code {
+      color: inherit;
+    }
+  }
+
+  .#{$ns}-code,
+  .#{$ns}-running-text code {
+    background: $pt-code-background-color;
+    box-shadow: inset border-shadow(0.2);
+    color: $pt-code-text-color;
+
+    a > & {
+      // <code> in links. markdown: [`code`](http://url)
+      // $pt-link-color does not have good contrast with non-link <code>'s in light theme, so we use a brighter hue
+      color: $pt-intent-primary;
+    }
+  }
+
+  .#{$ns}-code-block,
+  .#{$ns}-running-text pre {
+    background: $pt-code-background-color;
+    box-shadow: inset 0 0 0 1px $pt-divider-black;
+    color: $pt-text-color;
+
+    > code {
+      background: none;
+      box-shadow: none;
+      color: inherit;
+    }
+  }
+
+  .#{$ns}-key,
+  .#{$ns}-running-text kbd {
+    background: $white;
+    box-shadow: $pt-elevation-shadow-1;
+    color: $pt-text-color-muted;
+  }
+
+  #{$icon-classes} {
+    @each $intent, $color in $pt-intent-text-colors {
+      &.#{$ns}-intent-#{$intent} {
+        color: $color;
+      }
+    }
+  }
+}
+
+@mixin pt-dark-typography-colors() {
+  color: $pt-dark-text-color;
+
+  .#{$ns}-text-muted {
+    color: $pt-dark-text-color-muted;
+  }
+
+  .#{$ns}-text-disabled {
+    color: $pt-dark-text-color-disabled;
+  }
+
+  .#{$ns}-running-text {
+    hr {
+      border-color: $pt-dark-divider-white;
+    }
+  }
+
+  a {
+    color: $pt-dark-link-color;
+
+    &:hover {
+      color: $pt-dark-link-color;
+    }
+
+    #{$icon-classes} {
+      color: inherit;
+    }
+
+    code {
+      color: inherit;
+    }
+  }
+
+  .#{$ns}-code,
+  .#{$ns}-running-text code {
+    background: $pt-dark-code-background-color;
+    box-shadow: inset border-shadow(0.4);
+    color: $pt-dark-code-text-color;
+
+    a > & {
+      color: inherit;
+    }
+  }
+
+  .#{$ns}-code-block,
+  .#{$ns}-running-text pre {
+    background: $pt-dark-code-background-color;
+    box-shadow: inset 0 0 0 1px $pt-dark-divider-black;
+    color: $pt-dark-text-color;
+
+    > code {
+      background: none;
+      box-shadow: none;
+      color: inherit;
+    }
+  }
+
+  .#{$ns}-key,
+  .#{$ns}-running-text kbd {
+    background: $dark-gray4;
+    box-shadow: $pt-dark-elevation-shadow-1;
+    color: $pt-dark-text-color-muted;
+  }
+
+  #{$icon-classes} {
+    @each $intent, $color in $pt-dark-intent-text-colors {
+      &.#{$ns}-intent-#{$intent} {
+        color: $color;
+      }
+    }
+  }
+}

--- a/packages/core/src/common/_typography-colors.scss
+++ b/packages/core/src/common/_typography-colors.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "variables";
+@import "variables-extended";
 @import "mixins";
 
 @mixin pt-typography-colors() {

--- a/packages/core/src/common/_variables-extended.scss
+++ b/packages/core/src/common/_variables-extended.scss
@@ -1,0 +1,23 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "variables";
+
+// This file contains additional common variables which we do not want to export
+// in public API via variables.scss, or they contain syntax which does not play
+// well with our generate-css-variables script and thus cannot be easily
+// exported.
+
+$half-grid-size: $pt-grid-size * 0.5 !default;
+
+// Extended color pallete
+$blue6: #99c4ff;
+$green6: #7cd7a2;
+$orange6: #f5c186;
+$red6: #ffa1a4;
+
+$icon-classes: (
+  ".#{$ns}-icon",
+  ".#{$ns}-icon-standard",
+  ".#{$ns}-icon-large"
+) !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -20,6 +20,11 @@ $pt-grid-size: 10px !default;
 
 $icons16-family: "blueprint-icons-16" !default;
 $icons20-family: "blueprint-icons-20" !default;
+$icon-classes: (
+  ".#{$ns}-icon",
+  ".#{$ns}-icon-standard",
+  ".#{$ns}-icon-large"
+) !default;
 
 $pt-icon-size-standard: 16px !default;
 $pt-icon-size-large: 20px !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -7,7 +7,7 @@
 
 // Namespace appended to the beginning of each CSS class: `.#{$ns}-button`.
 // N.B. No quotes around this string value, for Less syntax compatibility. Also, this cannot be overriden
-// (the JS components have this class prefix hard-coded), so it does not have the `! default` modifier.
+// (the JS components have this class prefix hard-coded), so it does not have the `!default` modifier.
 $ns: bp4;
 // Alias for BP users outside this repo
 $bp-ns: $ns;
@@ -20,11 +20,6 @@ $pt-grid-size: 10px !default;
 
 $icons16-family: "blueprint-icons-16" !default;
 $icons20-family: "blueprint-icons-20" !default;
-$icon-classes: (
-  ".#{$ns}-icon",
-  ".#{$ns}-icon-standard",
-  ".#{$ns}-icon-large"
-) !default;
 
 $pt-icon-size-standard: 16px !default;
 $pt-icon-size-large: 20px !default;

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "../../common/variables";
+@import "../../common/variables-extended";
 @import "./common";
 
 /*

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -3,6 +3,7 @@
 
 @import "../../common/mixins";
 @import "../../common/variables";
+@import "../../common/variables-extended";
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "../../common/variables";
+@import "../../common/variables-extended";
 @import "../button/common";
 
 /*

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -2,13 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "~@blueprintjs/icons/lib/scss/variables";
+@import "../../common/variables";
 @import "icon-mixins";
-
-$icon-classes: (
-  ".#{$ns}-icon",
-  ".#{$ns}-icon-standard",
-  ".#{$ns}-icon-large"
-) !default;
 
 // the icon class which will contain an SVG icon
 .#{$ns}-icon {
@@ -39,18 +34,7 @@ $icon-classes: (
   }
 }
 
-// intent support for both SVG and font icons
-#{$icon-classes} {
-  @each $intent, $color in $pt-intent-text-colors {
-    &.#{$ns}-intent-#{$intent} {
-      color: $color;
-
-      .#{$ns}-dark & {
-        color: map-get($pt-dark-intent-text-colors, $intent);
-      }
-    }
-  }
-}
+// intent colors for both SVG and font icons are set in _typography-colors.scss
 
 //
 // Icon font styles

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -3,6 +3,7 @@
 
 @import "~@blueprintjs/icons/lib/scss/variables";
 @import "../../common/variables";
+@import "../../common/variables-extended";
 @import "icon-mixins";
 
 // the icon class which will contain an SVG icon

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -1,9 +1,11 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-$half-grid-size: $pt-grid-size * 0.5 !default;
+@import "../../common/mixins";
+@import "../../common/variables";
+@import "../../common/variables-extended";
 
-$menu-item-border-radius: $pt-border-radius - 1 !default;
+$menu-item-border-radius: $pt-border-radius !default;
 
 // Set line-height of menu items to be a multiple of the font size. This is
 // needed because if the line-height does not extend far enough past the font's

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -1,6 +1,9 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@import "../../common/variables";
+@import "../../common/variables-extended";
+
 $tag-default-color: $gray1 !default;
 $dark-tag-default-color: $gray5 !default;
 

--- a/packages/core/src/components/tag/_tag.scss
+++ b/packages/core/src/components/tag/_tag.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "../../common/variables";
+@import "../../common/variables-extended";
 @import "./common";
 
 /*

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "../../common/variables";
+@import "../../common/typography-colors";
 @import "../popover/common";
 @import "./common";
 
@@ -28,27 +29,11 @@ $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-op
     $duration: $pt-transition-duration,
     $after: "> &"
   );
+  // override typography & icon colors because we use a dark background
+  @include pt-dark-typography-colors();
 
   .#{$ns}-popover-content {
     padding: $tooltip-padding-vertical $tooltip-padding-horizontal;
-  }
-
-  // override typography because we use a dark background
-  a,
-  a:hover {
-    color: $pt-dark-link-color;
-  }
-
-  .#{$ns}-heading {
-    color: $pt-dark-heading-color;
-  }
-
-  .#{$ns}-text-muted {
-    color: $pt-dark-text-color-muted;
-  }
-
-  .#{$ns}-text-disabled {
-    color: $pt-dark-text-color-disabled;
   }
 
   &.#{$ns}-dark,
@@ -60,24 +45,8 @@ $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-op
       $dark-tooltip-arrow-box-shadow,
       $pt-dark-border-shadow-opacity
     );
-
     // override typography because we use a light background
-    a,
-    a:hover {
-      color: $pt-link-color;
-    }
-
-    .#{$ns}-heading {
-      color: $pt-heading-color;
-    }
-
-    .#{$ns}-text-muted {
-      color: $pt-text-color-muted;
-    }
-
-    .#{$ns}-text-disabled {
-      color: $pt-text-color-disabled;
-    }
+    @include pt-typography-colors();
   }
 
   @each $intent, $color in $pt-intent-colors {

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -1,9 +1,10 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@import "../../common/variables";
-@import "../../common/mixins";
 @import "~@blueprintjs/icons/lib/scss/variables";
+@import "../../common/variables";
+@import "../../common/variables-extended";
+@import "../../common/mixins";
 
 /*
 Trees

--- a/packages/demo-app/src/examples/TooltipExample.tsx
+++ b/packages/demo-app/src/examples/TooltipExample.tsx
@@ -29,7 +29,7 @@ export class TooltipExample extends React.PureComponent {
                     className={Classes.TOOLTIP2_INDICATOR}
                     content={
                         <span>
-                            <Icon icon="tick-circle" />
+                            <Icon icon="tick-circle" intent="success" style={{ marginRight: 7 }} />
                             Always open tooltip
                         </span>
                     }

--- a/packages/demo-app/src/examples/TooltipExample.tsx
+++ b/packages/demo-app/src/examples/TooltipExample.tsx
@@ -16,6 +16,7 @@
 
 import * as React from "react";
 
+import { Icon } from "@blueprintjs/core";
 import { Classes, Tooltip2 } from "@blueprintjs/popover2";
 
 import { ExampleCard } from "./ExampleCard";
@@ -26,7 +27,12 @@ export class TooltipExample extends React.PureComponent {
             <ExampleCard label="Tooltip" width={200}>
                 <Tooltip2
                     className={Classes.TOOLTIP2_INDICATOR}
-                    content={<span>Always open tooltip</span>}
+                    content={
+                        <span>
+                            <Icon icon="tick-circle" />
+                            Always open tooltip
+                        </span>
+                    }
                     isOpen={true}
                 >
                     Always open target

--- a/packages/popover2/src/_tooltip2.scss
+++ b/packages/popover2/src/_tooltip2.scss
@@ -1,6 +1,7 @@
 // Copyright 2021 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@import "~@blueprintjs/core/src/common/typography-colors";
 @import "./common";
 
 $tooltip2-background-color: $dark-gray5 !default;
@@ -35,6 +36,8 @@ $dark-tooltip2-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-o
     $duration: $pt-transition-duration,
     $after: "> &"
   );
+  // override typography because we use a dark background
+  @include pt-dark-typography-colors();
 
   .#{$ns}-popover2-content {
     padding: $tooltip2-padding-vertical $tooltip2-padding-horizontal;
@@ -46,24 +49,6 @@ $dark-tooltip2-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-o
   &.#{$ns}-popover2-placement-bottom .#{$ns}-popover2-arrow { transform: translateY(3px); }
   &.#{$ns}-popover2-placement-right .#{$ns}-popover2-arrow { transform: translateX(3px); }
 
-  // override typography because we use a dark background
-  a,
-  a:hover {
-    color: $pt-dark-link-color;
-  }
-
-  .#{$ns}-heading {
-    color: $pt-dark-heading-color;
-  }
-
-  .#{$ns}-text-muted {
-    color: $pt-dark-text-color-muted;
-  }
-
-  .#{$ns}-text-disabled {
-    color: $pt-dark-text-color-disabled;
-  }
-
   &.#{$ns}-dark,
   .#{$ns}-dark & {
     @include popover2-appearance(
@@ -73,24 +58,8 @@ $dark-tooltip2-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-o
       $dark-tooltip2-arrow-box-shadow,
       $pt-dark-border-shadow-opacity
     );
-
     // override typography because we use a light background
-    a,
-    a:hover {
-      color: $pt-link-color;
-    }
-
-    .#{$ns}-heading {
-      color: $pt-heading-color;
-    }
-
-    .#{$ns}-text-muted {
-      color: $pt-text-color-muted;
-    }
-
-    .#{$ns}-text-disabled {
-      color: $pt-text-color-disabled;
-    }
+    @include pt-typography-colors();
   }
 
   @each $intent, $color in $pt-intent-colors {


### PR DESCRIPTION
#### Fixes #5072

#### Changes proposed in this pull request:

- Refactor all typography color styles into `pt-typography-colors()` and `pt-dark-typography-colors()` mixins
- Use these mixins in Tooltip and Tooltip2 styles to override the default colors since we use inverted backgrounds

#### Reviewers should focus on:

No regressions

#### Screenshot

<img width="227" alt="image" src="https://user-images.githubusercontent.com/723999/166847433-5c6fd636-bfd1-43fa-925c-671c3e302df2.png">
<img width="239" alt="image" src="https://user-images.githubusercontent.com/723999/166847440-c3e3d78c-60a9-4c4d-a9f1-c6dc35c80bf7.png">
