### PR TITLE
[core] fix: allow $pt-outline-color to be overridden

### DIFF
--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -9,7 +9,7 @@ $pt-intent-danger: $red3 !default;
 $pt-app-background-color: $light-gray5 !default;
 $pt-dark-app-background-color: $dark-gray2 !default;
 
-$pt-outline-color: rgba($blue3, 0.6);
+$pt-outline-color: rgba($blue3, 0.6) !default;
 
 $pt-text-color: $dark-gray1 !default;
 $pt-text-color-muted: $gray1 !default;


### PR DESCRIPTION
$pt-outline-color is the only variable that can't be overridded. This add `!default` so that it can be customized like everything else.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
