### PR TITLE
[core] fix(NonIdealState): minor layout/visual bugs

### DIFF
--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -68,10 +68,8 @@ Styleguide non-ideal-state
 
 .#{$ns}-non-ideal-state-visual {
   color: $gray3;
-  // font-size set for CSS API only; the React component renders resized SVG.
-  font-size: $pt-icon-size-standard * 3;
 
-  svg {
+  .#{$ns}-icon svg {
     fill-opacity: 0.15;
     // need to show overflow for some strokes on paths that reach the edge of the icon bounding box
     overflow: visible;
@@ -84,7 +82,7 @@ Styleguide non-ideal-state
   }
 
   .#{$ns}-dark & {
-    svg {
+    .#{$ns}-icon svg {
       fill-opacity: 0.2;
     }
   }

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -9,7 +9,7 @@ Non-ideal state
 
 Markup:
 <div class="#{$ns}-non-ideal-state">
-  <div class="#{$ns}-non-ideal-state-visual">
+  <div class="#{$ns}-non-ideal-state-visual" style="font-size: 48px; line-height: 48px;">
     <span class="#{$ns}-icon #{$ns}-icon-folder-open"></span>
   </div>
   <div class="#{$ns}-non-ideal-state-text">

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -35,9 +35,22 @@ by adding a small stroke to the SVG paths.
 
 @## CSS
 
-Apply `.@ns-non-ideal-state` to the container and `.@ns-non-ideal-state-visual`
-to the icon element. The container should only have direct element children (all
-text should be wrapped in an enclosing element) for proper spacing between each
-child.
+Apply the `.@ns-non-ideal-state` class to the root container element and wrap the icon
+element with a `.@ns-non-ideal-state-visual` container.
+
+The root container should only have direct element children, no grandchildren (except
+for text, which is enclosed in a `.@ns-non-ideal-state-text` wrapper element). This
+constraint ensures proper spacing between each child.
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h4 class="@ns-heading">Limited CSS API support</h4>
+
+Note that you are required to set the `font-size` and `line-height` styles for
+the icon element to render it properly.
+
+Also, since the CSS API uses the icon font, Blueprint styles cannot adjust the icon visual
+design to have a muted appearance like it does with the React component API. This means
+NonIdealState elements rendered with this API will stand out visually within the design system.
+</div>
 
 @css non-ideal-state

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -79,14 +79,12 @@ export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
     };
 
     public render() {
-        const { action, children, className, description, layout, title } = this.props;
+        const { action, children, className, layout } = this.props;
+
         return (
             <div className={classNames(Classes.NON_IDEAL_STATE, `${Classes.NON_IDEAL_STATE}-${layout}`, className)}>
                 {this.maybeRenderVisual()}
-                <div className={Classes.NON_IDEAL_STATE_TEXT}>
-                    {title && <H4>{title}</H4>}
-                    {description && ensureElement(description, "div")}
-                </div>
+                {this.maybeRenderText()}
                 {action}
                 {children}
             </div>
@@ -96,11 +94,28 @@ export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
     private maybeRenderVisual() {
         const { icon, iconSize } = this.props;
         if (icon == null) {
-            return null;
+            return undefined;
         } else {
             return (
-                <div className={Classes.NON_IDEAL_STATE_VISUAL}>
+                <div
+                    className={Classes.NON_IDEAL_STATE_VISUAL}
+                    style={{ fontSize: `${iconSize}px`, lineHeight: `${iconSize}px` }}
+                >
                     <Icon icon={icon} size={iconSize} aria-hidden={true} tabIndex={-1} />
+                </div>
+            );
+        }
+    }
+
+    private maybeRenderText() {
+        const { description, title } = this.props;
+        if (title == null && description == null) {
+            return undefined;
+        } else {
+            return (
+                <div className={Classes.NON_IDEAL_STATE_TEXT}>
+                    {title && <H4>{title}</H4>}
+                    {description && ensureElement(description, "div")}
                 </div>
             );
         }

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -16,7 +16,16 @@
 
 import * as React from "react";
 
-import { Button, H5, NonIdealState, NonIdealStateIconSize, Switch } from "@blueprintjs/core";
+import {
+    Button,
+    ButtonGroup,
+    H5,
+    Label,
+    NonIdealState,
+    NonIdealStateIconSize,
+    Spinner,
+    Switch,
+} from "@blueprintjs/core";
 import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 
@@ -37,27 +46,31 @@ const nonIdealStateIconSizeToSize: Record<NonIdealStateIconSize, Size> = Object.
 const defaultIcon: IconName = "search";
 
 export interface INonIdealStateExampleState {
-    action: boolean;
-    description: boolean;
-    icon: IconName | null;
+    icon: IconName;
     iconSize: NonIdealStateIconSize;
     layout: Layout;
+    showAction: boolean;
+    showDescription: boolean;
+    showTitle: boolean;
+    visual: VisualKind;
 }
 
 export class NonIdealStateExample extends React.PureComponent<IExampleProps, INonIdealStateExampleState> {
     public state: INonIdealStateExampleState = {
-        action: true,
-        description: true,
         icon: defaultIcon,
         iconSize: NonIdealStateIconSize.STANDARD,
         layout: "vertical",
+        showAction: true,
+        showDescription: true,
+        showTitle: true,
+        visual: "icon",
     };
 
-    private toggleAction = handleBooleanChange(action => this.setState({ action }));
+    private toggleShowAction = handleBooleanChange(showAction => this.setState({ showAction }));
 
-    private toggleIcon = handleBooleanChange(icon => this.setState({ icon: icon ? defaultIcon : null }));
+    private toggleShowDescription = handleBooleanChange(showDescription => this.setState({ showDescription }));
 
-    private toggleDescription = handleBooleanChange(description => this.setState({ description }));
+    private toggleShowTitle = handleBooleanChange(showTitle => this.setState({ showTitle }));
 
     private handleIconNameChange = (icon: IconName) => this.setState({ icon });
 
@@ -65,28 +78,36 @@ export class NonIdealStateExample extends React.PureComponent<IExampleProps, INo
 
     private handleSizeChange = (size: Size) => this.setState({ iconSize: sizeToNonIdealStateIconSize[size] });
 
+    private handleVisualKindChange = (visual: VisualKind) => this.setState({ visual });
+
     public render() {
         const options = (
             <>
                 <H5>Props</H5>
                 <LayoutSelect layout={this.state.layout} onChange={this.handleLayoutChange} />
-                <Switch label="Show icon" checked={this.state.icon !== null} onChange={this.toggleIcon} />
+                <VisualSelect visual={this.state.visual} onChange={this.handleVisualKindChange} />
                 <IconSelect
-                    disabled={this.state.icon === null}
+                    disabled={this.state.visual !== "icon"}
                     iconName={this.state.icon}
                     onChange={this.handleIconNameChange}
                 />
                 <SizeSelect
-                    label="Icon size"
+                    label="Visual size"
                     optionLabels={["XS", "Small", "Standard"]}
                     size={nonIdealStateIconSizeToSize[this.state.iconSize]}
                     onChange={this.handleSizeChange}
                 />
-                <Switch label="Show description" checked={this.state.description} onChange={this.toggleDescription} />
-                <Switch label="Show action" checked={this.state.action} onChange={this.toggleAction} />
+                <Switch label="Show title" checked={this.state.showTitle} onChange={this.toggleShowTitle} />
+                <Switch
+                    label="Show description"
+                    checked={this.state.showDescription}
+                    onChange={this.toggleShowDescription}
+                />
+                <Switch label="Show action" checked={this.state.showAction} onChange={this.toggleShowAction} />
             </>
         );
 
+        const visual = this.state.visual === "icon" ? this.state.icon : <Spinner size={this.state.iconSize} />;
         const action = <Button outlined={true} text="New file" icon="plus" intent="primary" />;
         const description = (
             <div>
@@ -99,14 +120,35 @@ export class NonIdealStateExample extends React.PureComponent<IExampleProps, INo
         return (
             <Example options={options} {...this.props}>
                 <NonIdealState
-                    icon={this.state.icon === null ? undefined : this.state.icon}
+                    icon={visual}
                     iconSize={this.state.iconSize}
-                    title="No search results"
-                    description={this.state.description ? description : undefined}
-                    action={this.state.action ? action : undefined}
+                    title={this.state.showTitle ? "No search results" : undefined}
+                    description={this.state.showDescription ? description : undefined}
+                    action={this.state.showAction ? action : undefined}
                     layout={this.state.layout}
                 />
             </Example>
         );
     }
 }
+
+type VisualKind = "icon" | "spinner";
+
+/** Button radio group to switch between icon and spinner visuals. */
+const VisualSelect: React.FC<{ visual: VisualKind; onChange: (option: VisualKind) => void }> = ({
+    visual,
+    onChange,
+}) => {
+    const handleIcon = React.useCallback(() => onChange("icon"), []);
+    const handleSpinner = React.useCallback(() => onChange("spinner"), []);
+
+    return (
+        <Label>
+            Visual
+            <ButtonGroup fill={true} style={{ marginTop: 5 }}>
+                <Button active={visual === "icon"} text="Icon" onClick={handleIcon} />
+                <Button active={visual === "spinner"} text="Spinner" onClick={handleSpinner} />
+            </ButtonGroup>
+        </Label>
+    );
+};


### PR DESCRIPTION
#### Fixes #5292, fixes #5293

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Fix NonIdealState markup to omit empty element when _both_ title and description props are undefined
- Fix NonIdealState icon/visual styling to only target BP icon SVGs, not Spinner SVGs
- Fix NonIdealState icon/visual line height to make the height adjust for smaller sizes
- Add options to NonIdealState example in docs-app to demo the Spinner

#### Reviewers should focus on:

Fixes the linked issues

#### Screenshot

<img width="699" alt="image" src="https://user-images.githubusercontent.com/723999/168130681-d4813f73-3d09-4df4-9a67-30485eabfc2d.png">
<img width="706" alt="image" src="https://user-images.githubusercontent.com/723999/168130694-f6bac8aa-39b1-4a81-ab34-235c4cd1cdee.png">
