### PR TITLE
[popover2] feat: Popover2 popupkind

### DIFF
--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -51,6 +51,20 @@ export const Popover2InteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Popover2InteractionKind = typeof Popover2InteractionKind[keyof typeof Popover2InteractionKind];
 
+/** Specifies the popup kind for aria-haspopup. */
+export enum Popover2PopupKind {
+    /** The popup is a menu. */
+    MENU = "menu",
+    /** The popup is a listbox. */
+    LISTBOX = "listbox",
+    /** The popup is a tree. */
+    TREE = "tree",
+    /** The popup is a grid. */
+    GRID = "grid",
+    /** The popup is a dialog. */
+    DIALOG = "dialog",
+}
+
 // eslint-disable-next-line deprecation/deprecation
 export type Popover2Props<TProps = React.HTMLProps<HTMLElement>> = IPopover2Props<TProps>;
 /** @deprecated use Popover2Props */
@@ -76,6 +90,17 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends P
      * @default "click"
      */
     interactionKind?: Popover2InteractionKind;
+
+    /**
+     * The kind of popup displayed by the popover. This property is ignored if
+     * `interactionKind` is a hover interaction. This controls the
+     * `aria-haspopup` attribute of the target element. The default is "menu"
+     * (technically, `aria-haspopup` will be set to "true", which is the same
+     * as "menu", for backwards compatibility).
+     *
+     * @default "menu" or undefined
+     */
+    popupKind?: Popover2PopupKind;
 
     /**
      * Enables an invisible overlay beneath the popover that captures clicks and
@@ -329,7 +354,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const targetProps = {
-            "aria-haspopup": "true",
+            "aria-haspopup": this.props.popupKind ?? (isHoverInteractionKind ? undefined : "true"),
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
             // applied to the generated target wrapper element.

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -37,6 +37,7 @@ import * as Errors from "./errors";
 import { Popover2Arrow, POPOVER_ARROW_SVG_SIZE } from "./popover2Arrow";
 import { positionToPlacement } from "./popover2PlacementUtils";
 import { Popover2SharedProps } from "./popover2SharedProps";
+import { PopupKind } from "./popupKind";
 import { ResizeSensor2 } from "./resizeSensor2";
 // eslint-disable-next-line import/no-cycle
 import { Tooltip2 } from "./tooltip2";
@@ -50,20 +51,6 @@ export const Popover2InteractionKind = {
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Popover2InteractionKind = typeof Popover2InteractionKind[keyof typeof Popover2InteractionKind];
-
-/** Specifies the popup kind for aria-haspopup. */
-export enum Popover2PopupKind {
-    /** The popup is a menu. */
-    MENU = "menu",
-    /** The popup is a listbox. */
-    LISTBOX = "listbox",
-    /** The popup is a tree. */
-    TREE = "tree",
-    /** The popup is a grid. */
-    GRID = "grid",
-    /** The popup is a dialog. */
-    DIALOG = "dialog",
-}
 
 // eslint-disable-next-line deprecation/deprecation
 export type Popover2Props<TProps = React.HTMLProps<HTMLElement>> = IPopover2Props<TProps>;
@@ -100,7 +87,7 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends P
      *
      * @default "menu" or undefined
      */
-    popupKind?: Popover2PopupKind;
+    popupKind?: PopupKind;
 
     /**
      * Enables an invisible overlay beneath the popover that captures clicks and

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -58,7 +58,7 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends P
     /**
      * Whether the popover/tooltip should acquire application focus when it first opens.
      *
-     * @default true for click interations, false for hover interactions
+     * @default true for click interactions, false for hover interactions
      */
     autoFocus?: boolean;
 
@@ -117,7 +117,7 @@ export interface IPopover2State {
 }
 
 /**
- * @template T target component props inteface
+ * @template T target component props interface
  */
 export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopover2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover2`;
@@ -273,15 +273,15 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         }
 
         const childrenCount = React.Children.count(props.children);
-        const hasRenderTargetPropp = props.renderTarget !== undefined;
+        const hasRenderTargetProp = props.renderTarget !== undefined;
 
-        if (childrenCount === 0 && !hasRenderTargetPropp) {
+        if (childrenCount === 0 && !hasRenderTargetProp) {
             console.warn(Errors.POPOVER2_REQUIRES_TARGET);
         }
         if (childrenCount > 1) {
             console.warn(Errors.POPOVER2_WARN_TOO_MANY_CHILDREN);
         }
-        if (childrenCount > 0 && hasRenderTargetPropp) {
+        if (childrenCount > 0 && hasRenderTargetProp) {
             console.warn(Errors.POPOVER2_WARN_DOUBLE_TARGET);
         }
     }
@@ -448,7 +448,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
                 usePortal={this.props.usePortal}
                 portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
-                // if hover interaciton, it doesn't make sense to take over focus control
+                // if hover interaction, it doesn't make sense to take over focus control
                 shouldReturnFocusOnClose={this.isHoverInteractionKind() ? false : shouldReturnFocusOnClose}
             >
                 <div className={Classes.POPOVER2_TRANSITION_CONTAINER} ref={popperProps.ref} style={popperProps.style}>
@@ -617,7 +617,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         const dismissElement = eventTarget.closest(
             `.${Classes.POPOVER2_DISMISS}, .${Classes.POPOVER2_DISMISS_OVERRIDE}`,
         );
-        // dismiss selectors from the "V1" version of Popover in the core pacakge
+        // dismiss selectors from the "V1" version of Popover in the core package
         // we expect these to be rendered by MenuItem, which at this point has no knowledge of Popover2
         // this can be removed once Popover2 is merged into core in v5.0
         const dismissElementV1 = eventTarget.closest(

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -80,10 +80,10 @@ export interface IPopover2Props<TProps = React.HTMLProps<HTMLElement>> extends P
 
     /**
      * The kind of popup displayed by the popover. This property is ignored if
-     * `interactionKind` is a hover interaction. This controls the
-     * `aria-haspopup` attribute of the target element. The default is "menu"
-     * (technically, `aria-haspopup` will be set to "true", which is the same
-     * as "menu", for backwards compatibility).
+     * `interactionKind` is {@link Popover2InteractionKind.HOVER_TARGET_ONLY}.
+     * This controls the `aria-haspopup` attribute of the target element. The
+     * default is "menu" (technically, `aria-haspopup` will be set to "true",
+     * which is the same as "menu", for backwards compatibility).
      *
      * @default "menu" or undefined
      */
@@ -341,7 +341,9 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const targetProps = {
-            "aria-haspopup": this.props.popupKind ?? (isHoverInteractionKind ? undefined : "true"),
+            "aria-haspopup":
+                this.props.popupKind ??
+                (this.props.interactionKind === Popover2InteractionKind.HOVER_TARGET_ONLY ? undefined : "true"),
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
             // applied to the generated target wrapper element.

--- a/packages/popover2/src/popupKind.ts
+++ b/packages/popover2/src/popupKind.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Specifies the popup kind for [aria-haspopup](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup).
+ */
+export enum PopupKind {
+    /** The popup is a menu. */
+    MENU = "menu",
+    /** The popup is a listbox. */
+    LISTBOX = "listbox",
+    /** The popup is a tree. */
+    TREE = "tree",
+    /** The popup is a grid. */
+    GRID = "grid",
+    /** The popup is a dialog. */
+    DIALOG = "dialog",
+}

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -200,7 +200,7 @@ describe("<Popover2>", () => {
         });
 
         it("renders without aria-haspopup attr for hover interaction", () => {
-            wrapper = renderPopover({ isOpen: true, interactionKind: Popover2InteractionKind.HOVER });
+            wrapper = renderPopover({ isOpen: true, interactionKind: Popover2InteractionKind.HOVER_TARGET_ONLY });
             assert.isFalse(wrapper.find("[aria-haspopup]").exists());
         });
     });

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -23,7 +23,7 @@ import { Classes as CoreClasses, Keys, Menu, MenuItem, Overlay, Portal } from "@
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 
 import { Classes, Errors } from "../src";
-import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind } from "../src/popover2";
+import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind, Popover2PopupKind } from "../src/popover2";
 import { Popover2Arrow } from "../src/popover2Arrow";
 import { Tooltip2 } from "../src/tooltip2";
 
@@ -191,6 +191,16 @@ describe("<Popover2>", () => {
         it("renders with aria-haspopup attr", () => {
             wrapper = renderPopover({ isOpen: true });
             assert.isTrue(wrapper.find("[aria-haspopup='true']").exists());
+        });
+
+        it("sets aria-haspopup attr base on popupKind", () => {
+            wrapper = renderPopover({ isOpen: true, popupKind: Popover2PopupKind.DIALOG });
+            assert.isTrue(wrapper.find("[aria-haspopup='dialog']").exists());
+        });
+
+        it("renders without aria-haspopup attr for hover interaction", () => {
+            wrapper = renderPopover({ isOpen: true, interactionKind: Popover2InteractionKind.HOVER });
+            assert.isFalse(wrapper.find("[aria-haspopup]").exists());
         });
     });
 

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -23,8 +23,9 @@ import { Classes as CoreClasses, Keys, Menu, MenuItem, Overlay, Portal } from "@
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 
 import { Classes, Errors } from "../src";
-import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind, Popover2PopupKind } from "../src/popover2";
+import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind } from "../src/popover2";
 import { Popover2Arrow } from "../src/popover2Arrow";
+import { PopupKind } from "../src/popupKind";
 import { Tooltip2 } from "../src/tooltip2";
 
 describe("<Popover2>", () => {
@@ -194,7 +195,7 @@ describe("<Popover2>", () => {
         });
 
         it("sets aria-haspopup attr base on popupKind", () => {
-            wrapper = renderPopover({ isOpen: true, popupKind: Popover2PopupKind.DIALOG });
+            wrapper = renderPopover({ isOpen: true, popupKind: PopupKind.DIALOG });
             assert.isTrue(wrapper.find("[aria-haspopup='dialog']").exists());
         });
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
This adds a new `popupKind` property to the `Popover2` component for controlling the `aria-haspopup` attribute of the target element.

The current implementation hard-codes `aria-haspopup` to "true" which means that the popup is a menu. However, this is not true in all cases. Furthermore, the `aria-haspopup` attribute should not be set for tooltips since they are not interactive elements. So if the interaction kind is a hover interaction, this new property is ignored.

Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->

Before:
![image](https://user-images.githubusercontent.com/963645/168376271-3c165826-1d50-4683-b6dc-a03027abd5bf.png)

After:
![image](https://user-images.githubusercontent.com/963645/168377299-67a73279-b205-463a-82b5-91588af39a1b.png)

