### PR TITLE
[core] docs: remove unnecessary </code> markup

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -100,7 +100,7 @@ Markup:
   </p>
   <ul>
     <li>Item the <code>first</code>.</li>
-    <li>Item the <strong>second</strong></code>.</li>
+    <li>Item the <strong>second</strong>.</li>
     <li>Item the <a href="#core/typography.running-text">third</a>.</li>
   </ul>
   <h3>Scale, Speed, Agility</h3>


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Removed unnecessary `</code>` from core typography documentation.

#### Reviewers should focus on:

Please verify example code in the documentation is still valid.

#### Screenshot

<img width="832" alt="Screen Shot 2022-05-13 at 9 30 31 PM" src="https://user-images.githubusercontent.com/1866934/168410696-c5282c81-925e-464e-b95f-b6e114c535e0.png">
