### PR TITLE
[popover2] fix: hide Popover2 arrow from a11y API

### DIFF
--- a/packages/popover2/src/popover2Arrow.tsx
+++ b/packages/popover2/src/popover2Arrow.tsx
@@ -81,7 +81,7 @@ export interface IPopoverArrowProps {
 export const Popover2Arrow: React.FC<IPopoverArrowProps> = ({ arrowProps: { ref, style }, placement }) => (
     // data attribute allows popper.js to position the arrow
     <div
-        aria-hidden
+        aria-hidden={true}
         className={Classes.POPOVER2_ARROW}
         data-popper-arrow={true}
         ref={ref}

--- a/packages/popover2/src/popover2Arrow.tsx
+++ b/packages/popover2/src/popover2Arrow.tsx
@@ -81,6 +81,7 @@ export interface IPopoverArrowProps {
 export const Popover2Arrow: React.FC<IPopoverArrowProps> = ({ arrowProps: { ref, style }, placement }) => (
     // data attribute allows popper.js to position the arrow
     <div
+        aria-hidden
         className={Classes.POPOVER2_ARROW}
         data-popper-arrow={true}
         ref={ref}


### PR DESCRIPTION
The popover arrow is purely decorative and should be hidden from the accessibility DOM.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
