### PR TITLE
[node-build-scripts] fix(css-variables): string quotes for all values

### DIFF
--- a/packages/node-build-scripts/node-sass-json-functions.js
+++ b/packages/node-build-scripts/node-sass-json-functions.js
@@ -88,6 +88,11 @@ function getJsonValueFromSassValue(value, options) {
         try {
             if (typeof value !== "undefined" && "getValue" in value) {
                 resolvedValue = value.getValue();
+                if (value instanceof sass.types.String && stringHasWrappingQuotes(value)) {
+                    // We want to preserve quotes around string elements - if we don't do this,
+                    // we lose those quotes during the JSON conversion process.
+                    resolvedValue = `"${resolvedValue}"`;
+                }
             } else {
                 resolvedValue = null;
             }
@@ -96,6 +101,20 @@ function getJsonValueFromSassValue(value, options) {
         }
     }
     return resolvedValue;
+}
+
+/**
+ * HACKHACK: the legacy Sass value API has no way of distinguishing between quoted and unquoted strings
+ * (see documentation of types.String from the "sass" package), but there's a hacky way to parse that out
+ * from the string output by the value's .toString() method. A better solution would involve migrating to
+ * the async API.
+ *
+ * @param {sass.type.String} value dart-sass legacy String value
+ * @returns {boolean} true if the string contains quotes as the first and last characters
+ */
+function stringHasWrappingQuotes(value) {
+    const strValue = value.dartValue.toString();
+    return strValue.charAt(0) === '"' && strValue.charAt(strValue.length - 1) === '"';
 }
 
 /**
@@ -108,31 +127,10 @@ function listToArray(list, options) {
     const data = [];
     const hasSeparator = list.getSeparator();
     for (const index of Array.from({ length }).keys()) {
-        const sassValue = list.getValue(index);
-        let value = getJsonValueFromSassValue(sassValue, options);
-        if (hasSeparator) {
-            // for lists with comma separators (true lists), we want to preserve quotes around string elements
-            // if we don't do this, we lose those quotes during the JSON conversion process
-            if (sassValue instanceof sass.types.String && hasWrappingQuotes(sassValue)) {
-                value = `"${value}"`;
-            }
-        }
+        const value = getJsonValueFromSassValue(list.getValue(index), options);
         data.push(value);
     }
     return hasSeparator ? data : data.join(" ");
-}
-
-/**
- * @param {sass.type.String} value dart-sass legacy String value
- * @returns {boolean} true if the string contains quotes as the first and last characters
- */
-function hasWrappingQuotes(value) {
-    // HACKHACK: the legacy Sass value API has no way of distinguishing between quoted and unquoted strings
-    // (see documentation of types.String from the "sass" package), but there's a hacky way to parse that out
-    // from the string output by the dart-sass value's .toString() method. A better solution would involve
-    // migrating to the async API.
-    const strValue = value.dartValue.toString();
-    return strValue.charAt(0) === '"' && strValue.charAt(strValue.length - 1) === '"';
 }
 
 /**


### PR DESCRIPTION

#### Changes proposed in this pull request:

https://github.com/palantir/blueprint/pull/5303 fixed `generate-css-variables` to preserve string quotes for values inside lists, but after merging that I realized it doesn't actually target the broken use case I needed it to, which is a simple Sass variable value of a single string, like this:

```scss
// src/common/_variables.scss
$resources-path: "../../resources" !default;
```

Turns out we can simplify the change made in #5303 and apply it to all values which are not (List, Map, Color, or Number) in the JSON encoder.

So now we expect the above variable to be preserved exactly as-is in the output:

```scss
// lib/scss/variables.scss
$resources-path: "../../resources" !default;
```

#### Reviewers should focus on:

No regressions w/r/t #5303 

