### PR TITLE
[core] fix: use solid focus outline style

### DIFF
--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -80,7 +80,7 @@ $pt-dark-intent-text-colors: (
 }
 
 @mixin focus-outline($offset: 2px) {
-  outline: $pt-outline-color auto 2px;
+  outline: $pt-outline-color solid 2px;
   outline-offset: $offset;
   -moz-outline-radius: 6px;
 }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -164,7 +164,7 @@ $control-indicator-spacing: $pt-grid-size !default;
 
   input:focus ~ .#{$ns}-control-indicator {
     @include focus-outline();
-    outline: $blue3 auto 2px;
+    outline: $blue3 solid 2px;
   }
 
   // right-aligned indicator is glued to the right side of the container
@@ -506,7 +506,7 @@ $control-indicator-spacing: $pt-grid-size !default;
     }
 
     input:focus ~ .#{$ns}-control-indicator {
-      outline: $blue5 auto 2px;
+      outline: $blue5 solid 2px;
     }
 
     input:not(:disabled):active ~ .#{$ns}-control-indicator {


### PR DESCRIPTION
Using `auto` for the outline style allows the user agent to override the outline style, leading to different results on different systems. This changes the style to solid so that all users will see the same style.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

Before:

![image](https://user-images.githubusercontent.com/963645/168637976-2b961da5-9d3d-4828-b3c2-99a5316f471d.png)


After:

![image](https://user-images.githubusercontent.com/963645/168638107-bd44780c-0f8f-47f8-aebe-7eadfec1f16a.png)

