### PR TITLE
[core] docs(TagInput): remove comment about typed usage

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -177,10 +177,6 @@ export interface ITagInputProps extends IntentProps, Props {
      * Controlled tag values. Each value will be rendered inside a `Tag`, which can be customized
      * using `tagProps`. Therefore, any valid React node can be used as a `TagInput` value; falsy
      * values will not be rendered.
-     *
-     * __Note about typed usage:__ If you know your `values` will always be of a certain `ReactNode`
-     * subtype, such as `string` or `ReactChild`, you can use that type on all your handlers
-     * to simplify type logic.
      */
     values: readonly React.ReactNode[];
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Original comment:
> Note about typed usage: If you know your values will always be of a certain ReactNode subtype, such as string or ReactChild, you can use that type on all your handlers to simplify type logic.

Not sure that this was ever true, but I only went back 5 years. 
Alternately instead of removing this comment the props could be typed to make it true, which would certainly be an improvement.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
