### PR TITLE
[core] feat(Spinner): add more a11y markup, support HTML attrs

### DIFF
--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -85,7 +85,7 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
     }
 
     public render() {
-        const { className, intent, value, tagName = "div" } = this.props;
+        const { className, intent, value, tagName = "div", ...htmlProps } = this.props;
         const size = this.getSize();
 
         const classes = classNames(
@@ -107,6 +107,7 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
             {
                 className: classes,
                 role: "progressbar",
+                ...htmlProps,
             },
             React.createElement(
                 tagName,

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -107,7 +107,7 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
             {
                 "aria-valuemax": 100,
                 "aria-valuemin": 0,
-                "aria-valuenow": value === undefined ? "indeterminate" : value * 100,
+                "aria-valuenow": value === undefined ? undefined : value * 100,
                 className: classes,
                 role: "progressbar",
                 ...htmlProps,

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -42,7 +42,7 @@ const STROKE_WIDTH = 4;
 const MIN_STROKE_WIDTH = 16;
 
 // eslint-disable-next-line deprecation/deprecation
-export type SpinnerProps = ISpinnerProps;
+export type SpinnerProps = (ISpinnerProps & React.HTMLAttributes<any>) | (ISpinnerProps & React.SVGAttributes<any>);
 /** @deprecated use SpinnerProps */
 export interface ISpinnerProps extends Props, IntentProps {
     /**
@@ -105,6 +105,9 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
         return React.createElement(
             tagName,
             {
+                "aria-valuemax": 100,
+                "aria-valuemin": 0,
+                "aria-valuenow": value === undefined ? "indeterminate" : value * 100,
                 className: classes,
                 role: "progressbar",
                 ...htmlProps,

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -29,10 +29,18 @@ describe("Spinner", () => {
         assert.lengthOf(root.find("path"), 2);
     });
 
-    it("supports HTML props", () => {
-        const LABEL = "widget loading";
-        const spinner = shallow(<Spinner aria-label={LABEL} />);
-        assert.strictEqual(spinner.prop("aria-label"), LABEL);
+    describe("accessibility", () => {
+        it("sets 'aria-valuenow' attribute", () => {
+            const VALUE = 0.4;
+            const spinner = shallow(<Spinner value={VALUE} />);
+            assert.strictEqual(spinner.prop("aria-valuenow"), VALUE * 100);
+        });
+
+        it("supports arbitrary ARIA HTML attributes", () => {
+            const LABEL = "widget loading";
+            const spinner = shallow(<Spinner aria-label={LABEL} />);
+            assert.strictEqual(spinner.prop("aria-label"), LABEL);
+        });
     });
 
     it("tagName determines both container elements", () => {

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import { mount, ReactWrapper } from "enzyme";
+import { mount, ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
 import { stub } from "sinon";
 
@@ -27,6 +27,12 @@ describe("Spinner", () => {
         const root = mount(<Spinner />);
         assert.lengthOf(root.find(`.${Classes.SPINNER}`), 1);
         assert.lengthOf(root.find("path"), 2);
+    });
+
+    it("supports HTML props", () => {
+        const LABEL = "widget loading";
+        const spinner = shallow(<Spinner aria-label={LABEL} />);
+        assert.strictEqual(spinner.prop("aria-label"), LABEL);
     });
 
     it("tagName determines both container elements", () => {

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -43,7 +43,12 @@ export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerE
         const { size, hasValue, intent, value } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
-                <Spinner intent={intent} size={size} value={hasValue ? value : null} />
+                <Spinner
+                    aria-label={hasValue ? `Loading ${value * 100}% complete` : "Loading..."}
+                    intent={intent}
+                    size={size}
+                    value={hasValue ? value : null}
+                />
             </Example>
         );
     }


### PR DESCRIPTION
#### Fixes #5317 

#### Checklist

- [X] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Allow custom html props to be passed to `Spinner`
