### PR TITLE
[core] fix(Toast): add alert role to toast message for a11y

### DIFF
--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -72,11 +72,12 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
                 onFocus={this.clearTimeouts}
                 onMouseEnter={this.clearTimeouts}
                 onMouseLeave={this.startTimeout}
-                role="alert"
                 tabIndex={0}
             >
                 <Icon icon={icon} />
-                <span className={Classes.TOAST_MESSAGE}>{message}</span>
+                <span className={Classes.TOAST_MESSAGE} role="alert">
+                    {message}
+                </span>
                 <ButtonGroup minimal={true}>
                     {this.maybeRenderActionButton()}
                     <Button aria-label="Close" icon="cross" onClick={this.handleCloseClick} />

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -72,6 +72,7 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
                 onFocus={this.clearTimeouts}
                 onMouseEnter={this.clearTimeouts}
                 onMouseLeave={this.startTimeout}
+                role="alert"
                 tabIndex={0}
             >
                 <Icon icon={icon} />


### PR DESCRIPTION
#### Fixes #5324

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

add `role="alert"` to toast message for a11y purposes.
