### PR TITLE
[core] fix(Menu): add a11y roles and aria attributes

### DIFF
--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -41,7 +41,7 @@ export class Menu extends AbstractPureComponent2<MenuProps> {
         const { className, children, large, ulRef, role, ...htmlProps } = this.props;
         const classes = classNames(Classes.MENU, { [Classes.LARGE]: large }, className);
         return (
-            <ul {...htmlProps} className={classes} ref={ulRef} role={role ?? "menu"}>
+            <ul role="menu" {...htmlProps} className={classes} ref={ulRef}>
                 {children}
             </ul>
         );

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -38,7 +38,7 @@ export class Menu extends AbstractPureComponent2<MenuProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Menu`;
 
     public render() {
-        const { className, children, large, ulRef, role, ...htmlProps } = this.props;
+        const { className, children, large, ulRef, ...htmlProps } = this.props;
         const classes = classNames(Classes.MENU, { [Classes.LARGE]: large }, className);
         return (
             <ul role="menu" {...htmlProps} className={classes} ref={ulRef}>

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -41,7 +41,7 @@ export class Menu extends AbstractPureComponent2<MenuProps> {
         const { className, children, large, ulRef, role, ...htmlProps } = this.props;
         const classes = classNames(Classes.MENU, { [Classes.LARGE]: large }, className);
         return (
-            <ul role={role ?? "menu"} {...htmlProps} className={classes} ref={ulRef}>
+            <ul {...htmlProps} className={classes} ref={ulRef} role={role ?? "menu"}>
                 {children}
             </ul>
         );

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -38,10 +38,10 @@ export class Menu extends AbstractPureComponent2<MenuProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Menu`;
 
     public render() {
-        const { className, children, large, ulRef, ...htmlProps } = this.props;
+        const { className, children, large, ulRef, role, ...htmlProps } = this.props;
         const classes = classNames(Classes.MENU, { [Classes.LARGE]: large }, className);
         return (
-            <ul {...htmlProps} className={classes} ref={ulRef}>
+            <ul role={role ?? "menu"} {...htmlProps} className={classes} ref={ulRef}>
                 {children}
             </ul>
         );

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -39,11 +39,11 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
         const { className, title } = this.props;
         if (title == null) {
             // simple divider
-            return <li className={classNames(Classes.MENU_DIVIDER, className)} />;
+            return <li className={classNames(Classes.MENU_DIVIDER, className)} role="none" />;
         } else {
             // section header with title
             return (
-                <li className={classNames(Classes.MENU_HEADER, className)}>
+                <li className={classNames(Classes.MENU_HEADER, className)} role="none">
                     <H6>{title}</H6>
                 </li>
             );

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -177,7 +177,6 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
-                "aria-expanded": hasSubmenu,
                 role: "menuitem",
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -177,6 +177,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
+                role: "menuitem",
                 tabIndex: 0,
                 ...htmlProps,
                 ...(disabled ? DISABLED_PROPS : {}),

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -177,6 +177,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
+                "aria-expanded": hasSubmenu,
                 role: "menuitem",
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -199,7 +199,11 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         );
 
         const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });
-        return <li className={liClasses}>{this.maybeRenderPopover(target, children)}</li>;
+        return (
+            <li className={liClasses} role="none">
+                {this.maybeRenderPopover(target, children)}
+            </li>
+        );
     }
 
     private maybeRenderLabel(labelElement?: React.ReactNode) {


### PR DESCRIPTION
#### Fixes #5320

#### Checklist

- [N/A ] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix `Menu` and `MenuItem` a11y roles for a menu per this example: https://w3c.github.io/aria-practices/examples/menubar/menubar-navigation.html

#### Reviewers should focus on:

the above example aria menu