### PR TITLE
[select] feat: new MultiSelect2 component uses Popover2

### DIFF
--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-export type IRef<T extends HTMLElement = HTMLElement> = IRefObject<T> | IRefCallback<T>;
+export type IRef<T = HTMLElement> = IRefObject<T> | IRefCallback<T>;
 
 // compatible with React.Ref type in @types/react@^16
-export interface IRefObject<T extends HTMLElement = HTMLElement> {
+export interface IRefObject<T = HTMLElement> {
     current: T | null;
 }
 
-export function isRefObject<T extends HTMLElement>(value: IRef<T> | undefined | null): value is IRefObject<T> {
+export function isRefObject<T>(value: IRef<T> | undefined | null): value is IRefObject<T> {
     return value != null && typeof value !== "function";
 }
 
-export type IRefCallback<T extends HTMLElement = HTMLElement> = (ref: T | null) => any;
+export type IRefCallback<T = HTMLElement> = (ref: T | null) => any;
 
-export function isRefCallback<T extends HTMLElement>(value: IRef<T> | undefined | null): value is IRefCallback<T> {
+export function isRefCallback<T>(value: IRef<T> | undefined | null): value is IRefCallback<T> {
     return typeof value === "function";
 }
 
 /**
  * Assign the given ref to a target, either a React ref object or a callback which takes the ref as its first argument.
  */
-export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined | null, ref: T | null): void {
+export function setRef<T>(refTarget: IRef<T> | undefined | null, ref: T | null): void {
     if (isRefObject<T>(refTarget)) {
         refTarget.current = ref;
     } else if (isRefCallback(refTarget)) {
@@ -43,7 +43,7 @@ export function setRef<T extends HTMLElement>(refTarget: IRef<T> | undefined | n
 }
 
 /** @deprecated use mergeRefs() instead */
-export function combineRefs<T extends HTMLElement>(ref1: IRefCallback<T>, ref2: IRefCallback<T>) {
+export function combineRefs<T>(ref1: IRefCallback<T>, ref2: IRefCallback<T>) {
     return mergeRefs(ref1, ref2);
 }
 
@@ -51,7 +51,7 @@ export function combineRefs<T extends HTMLElement>(ref1: IRefCallback<T>, ref2: 
  * Utility for merging refs into one singular callback ref.
  * If using in a functional component, would recomend using `useMemo` to preserve function identity.
  */
-export function mergeRefs<T extends HTMLElement>(...refs: Array<IRef<T> | null>): IRefCallback<T> {
+export function mergeRefs<T>(...refs: Array<IRef<T> | null>): IRefCallback<T> {
     return value => {
         refs.forEach(ref => {
             setRef(ref, value);
@@ -59,7 +59,7 @@ export function mergeRefs<T extends HTMLElement>(...refs: Array<IRef<T> | null>)
     };
 }
 
-export function getRef<T extends HTMLElement>(ref: T | IRefObject<T> | null): T | null {
+export function getRef<T>(ref: T | IRefObject<T> | null): T | null {
     if (ref === null) {
         return null;
     }

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 
 import { Button, H5, Intent, MenuItem, Switch, TagProps } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Popover2 } from "@blueprintjs/popover2";
 import { ItemRenderer, MultiSelect2 } from "@blueprintjs/select";
 
 import {
@@ -64,6 +65,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         resetOnSelect: true,
         tagMinimal: false,
     };
+
+    private popoverRef: React.RefObject<Popover2<any>> = React.createRef();
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
 
@@ -114,7 +117,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     noResults={<MenuItem disabled={true} text="No results." />}
                     onItemSelect={this.handleFilmSelect}
                     onItemsPaste={this.handleFilmsPaste}
-                    popoverProps={{ minimal: popoverMinimal }}
+                    popoverProps={{ minimal: popoverMinimal, ref: this.popoverRef }}
                     tagRenderer={this.renderTag}
                     tagInputProps={{
                         onRemove: this.handleTagRemove,
@@ -272,5 +275,12 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         };
     }
 
-    private handleClear = () => this.setState({ films: [] });
+    private handleClear = () => {
+        this.setState({ films: [] });
+        // N.B. if MultiSelect had a "clear" button API provided out of the box, we wouldn't have to
+        // reach in to grab the Popover2 ref to reposition it... until then, we should do this to match
+        // the behavior which happens during TagInput's onRemove callback.
+        // see https://popper.js.org/docs/v2/modifiers/event-listeners/#when-the-reference-element-moves-or-changes-size
+        this.popoverRef.current?.reposition();
+    };
 }

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Button, H5, Intent, MenuItem, Switch, TagProps } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { ItemRenderer, MultiSelect } from "@blueprintjs/select";
+import { ItemRenderer, MultiSelect2 } from "@blueprintjs/select";
 
 import {
     areFilmsEqual,
@@ -32,7 +32,7 @@ import {
     TOP_100_FILMS,
 } from "../../common/films";
 
-const FilmMultiSelect = MultiSelect.ofType<IFilm>();
+const FilmMultiSelect = MultiSelect2.ofType<IFilm>();
 
 const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Intent.WARNING];
 

--- a/packages/select/src/components/index.ts
+++ b/packages/select/src/components/index.ts
@@ -17,6 +17,7 @@
 export * from "./omnibar/omnibar";
 export * from "./query-list/queryList";
 export * from "./select/multiSelect";
+export * from "./select/multiSelect2";
 export * from "./select/select";
 export * from "./select/select2";
 export * from "./select/suggest";

--- a/packages/select/src/components/select/multi-select.md
+++ b/packages/select/src/components/select/multi-select.md
@@ -1,17 +1,26 @@
 @# MultiSelect
 
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">
+
+Deprecated: use [MultiSelect2](#select/multi-select2)
+
+</h4>
+
+This component is **deprecated since @blueprintjs/select v4.3.0** in favor of the new
+MultiSelect2 component, which uses Popover2 instead of Popover under the hood.
+You should migrate to the new API which will become the standard in Blueprint v5.
+
+</div>
+
 Use `MultiSelect<T>` for choosing multiple items in a list. The component renders a [`TagInput`](#core/components/tag-input) wrapped in a `Popover`. Similarly to [`Select`](#select/select-component), you can pass in a predicate to customize the filtering algorithm.
 
 Selection state of a `MultiSelect<T>` is controlled with the `selectedItems` prop. React to user interactions with `onItemSelect` and `onRemove`.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Generic components and custom filtering</h4>
+The API for this component is nearly identical to that of MultiSelect2, except for a slight change in
+`popoverProps` and the wrapper element(s) rendered around its children.
+Refer to the [MultiSelect2 documentation](#select/select2) for full API details.
 
-For more information on controlled usage, generic components, creating new items, and custom filtering, visit the documentation for [`Select<T>`](#select/select-component).
-</div>
-
-@reactExample MultiSelectExample
+@## Props interface
 
 @interface IMultiSelectProps
-
-@interface ISelectItemRendererProps

--- a/packages/select/src/components/select/multi-select.md
+++ b/packages/select/src/components/select/multi-select.md
@@ -19,7 +19,7 @@ Selection state of a `MultiSelect<T>` is controlled with the `selectedItems` pro
 
 The API for this component is nearly identical to that of MultiSelect2, except for a slight change in
 `popoverProps` and the wrapper element(s) rendered around its children.
-Refer to the [MultiSelect2 documentation](#select/select2) for full API details.
+Refer to the [MultiSelect2 documentation](#select/multi-select2) for full API details.
 
 @## Props interface
 

--- a/packages/select/src/components/select/multi-select2.md
+++ b/packages/select/src/components/select/multi-select2.md
@@ -1,0 +1,35 @@
+---
+tag: new
+---
+
+@# MultiSelect2
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    <h4 class="@ns-heading">
+
+Migrating from [MultiSelect](#select/multi-select)?
+
+</h4>
+
+MultiSelect2 is a replacement for MultiSelect and will replace it in Blueprint core v5.
+You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
+See the [migration guide](https://github.com/palantir/blueprint/wiki/Select2,-Suggest2,-MultiSelect2-migration)
+on the wiki.
+
+</div>
+
+MultiSelect2 renders a UI to choose multiple items from a list. The component renders a [TagInput](#core/components/tag-input) wrapped in a [Popover2](#popover2/popover2). Just like with [Select2](#select/select2), you can pass in a predicate to customize the filtering algorithm.
+
+Selection state of a MultiSelect2 is controlled with the `selectedItems` prop. React to user interactions with `onItemSelect` and `onRemove`.
+
+@reactExample MultiSelectExample
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    <h4 class="@ns-heading">Generic components and custom filtering</h4>
+
+For more information on controlled usage, generic components, creating new items, and custom filtering, visit the documentation for [Select2](#select/select2).
+</div>
+
+@## Props interface
+
+@interface MultiSelect2Props

--- a/packages/select/src/components/select/multi-select2.md
+++ b/packages/select/src/components/select/multi-select2.md
@@ -18,7 +18,7 @@ on the wiki.
 
 </div>
 
-MultiSelect2 renders a UI to choose multiple items from a list. The component renders a [TagInput](#core/components/tag-input) wrapped in a [Popover2](#popover2/popover2). Just like with [Select2](#select/select2), you can pass in a predicate to customize the filtering algorithm.
+MultiSelect2 renders a UI to choose multiple items from a list. The component renders a [TagInput](#core/components/tag-input) wrapped in a [Popover2](#popover2-package/popover2). Just like with [Select2](#select/select2), you can pass in a predicate to customize the filtering algorithm.
 
 Selection state of a MultiSelect2 is controlled with the `selectedItems` prop. React to user interactions with `onItemSelect` and `onRemove`.
 

--- a/packages/select/src/components/select/multiSelect2.tsx
+++ b/packages/select/src/components/select/multiSelect2.tsx
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+
+import {
+    AbstractPureComponent2,
+    Classes as CoreClasses,
+    DISPLAYNAME_PREFIX,
+    Keys,
+    refHandler,
+    setRef,
+    TagInput,
+    TagInputAddMethod,
+    TagInputProps,
+} from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
+
+import { Classes, IListItemsProps } from "../../common";
+import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+
+// N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
+
+export interface MultiSelect2Props<T> extends IListItemsProps<T> {
+    /**
+     * Whether the component should take up the full width of its container.
+     * This overrides `popoverProps.fill` and `tagInputProps.fill`.
+     */
+    fill?: boolean;
+
+    /**
+     * Callback invoked when an item is removed from the selection by
+     * removing its tag in the TagInput. This is generally more useful than
+     * `tagInputProps.onRemove`  because it receives the removed value instead of
+     * the value's rendered `ReactNode` tag.
+     *
+     * It is not recommended to supply _both_ this prop and `tagInputProps.onRemove`.
+     */
+    onRemove?: (value: T, index: number) => void;
+
+    /**
+     * If true, the component waits until a keydown event in the TagInput
+     * before opening its popover.
+     *
+     * If false, the popover opens immediately after a mouse click focuses
+     * the component's TagInput.
+     *
+     * N.B. the behavior of this prop differs slightly from the same one
+     * in the Suggest component; see https://github.com/palantir/blueprint/issues/4152.
+     *
+     * @default false
+     */
+    openOnKeyDown?: boolean;
+
+    /**
+     * Input placeholder text. Shorthand for `tagInputProps.placeholder`.
+     *
+     * @default "Search..."
+     */
+    placeholder?: string;
+
+    /** Props to spread to `Popover2`. Note that `content` cannot be changed. */
+    popoverProps?: Partial<Omit<Popover2Props, "content">>;
+
+    /** Controlled selected values. */
+    selectedItems?: T[];
+
+    /** Props to spread to `TagInput`. Use `query` and `onQueryChange` to control the input. */
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    tagInputProps?: Partial<TagInputProps> & object;
+
+    /** Custom renderer to transform an item into tag content. */
+    tagRenderer: (item: T) => React.ReactNode;
+}
+
+export interface MultiSelect2State {
+    isOpen: boolean;
+}
+
+export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>, MultiSelect2State> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect2`;
+
+    public static defaultProps = {
+        fill: false,
+        placeholder: "Search...",
+    };
+
+    public static ofType<U>() {
+        return MultiSelect2 as new (props: MultiSelect2Props<U>) => MultiSelect2<U>;
+    }
+
+    public state: MultiSelect2State = {
+        isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
+    };
+
+    private TypedQueryList = QueryList.ofType<T>();
+
+    public input: HTMLInputElement | null = null;
+
+    public queryList: QueryList<T> | null = null;
+
+    private refHandlers: {
+        input: React.RefCallback<HTMLInputElement>;
+        queryList: React.RefCallback<QueryList<T>>;
+    } = {
+        input: refHandler(this, "input", this.props.tagInputProps?.inputRef),
+        queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
+    };
+
+    public componentDidUpdate(prevProps: MultiSelect2Props<T>) {
+        if (prevProps.tagInputProps?.inputRef !== this.props.tagInputProps?.inputRef) {
+            setRef(prevProps.tagInputProps?.inputRef, null);
+            this.refHandlers.input = refHandler(this, "input", this.props.tagInputProps?.inputRef);
+            setRef(this.props.tagInputProps?.inputRef, this.input);
+        }
+    }
+
+    public render() {
+        // omit props specific to this component, spread the rest.
+        const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+
+        return (
+            <this.TypedQueryList
+                {...restProps}
+                onItemSelect={this.handleItemSelect}
+                onQueryChange={this.handleQueryChange}
+                ref={this.refHandlers.queryList}
+                renderer={this.renderQueryList}
+            />
+        );
+    }
+
+    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+        const { fill, tagInputProps = {}, popoverProps = {}, selectedItems = [], placeholder } = this.props;
+        const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
+
+        if (fill) {
+            popoverProps.fill = true;
+            tagInputProps.fill = true;
+        }
+
+        // add our own inputProps.className so that we can reference it in event handlers
+        const inputProps = {
+            ...tagInputProps.inputProps,
+            className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT),
+        };
+
+        const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {
+            if (method === "paste") {
+                handlePaste(values);
+            }
+        };
+
+        return (
+            <Popover2
+                autoFocus={false}
+                canEscapeKeyClose={true}
+                enforceFocus={false}
+                isOpen={this.state.isOpen}
+                placement="bottom-start"
+                {...popoverProps}
+                className={classNames(listProps.className, popoverProps.className)}
+                content={
+                    <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+                        {listProps.itemList}
+                    </div>
+                }
+                interactionKind="click"
+                onInteraction={this.handlePopoverInteraction}
+                popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
+                onOpened={this.handlePopoverOpened}
+            >
+                <div
+                    onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}
+                    onKeyUp={this.getTagInputKeyUpHandler(handleKeyUp)}
+                >
+                    <TagInput
+                        placeholder={placeholder}
+                        {...tagInputProps}
+                        className={classNames(Classes.MULTISELECT, tagInputProps.className)}
+                        inputRef={this.refHandlers.input}
+                        inputProps={inputProps}
+                        inputValue={listProps.query}
+                        /* eslint-disable-next-line react/jsx-no-bind */
+                        onAdd={handleTagInputAdd}
+                        onInputChange={listProps.handleQueryChange}
+                        onRemove={this.handleTagRemove}
+                        values={selectedItems.map(this.props.tagRenderer)}
+                    />
+                </div>
+            </Popover2>
+        );
+    };
+
+    private handleItemSelect = (item: T, evt?: React.SyntheticEvent<HTMLElement>) => {
+        if (this.input != null) {
+            this.input.focus();
+        }
+        this.props.onItemSelect?.(item, evt);
+    };
+
+    private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ isOpen: query.length > 0 || !this.props.openOnKeyDown });
+        this.props.onQueryChange?.(query, evt);
+    };
+
+    // Popover interaction kind is CLICK, so this only handles click events.
+    // Note that we defer to the next animation frame in order to get the latest document.activeElement
+    private handlePopoverInteraction = (nextOpenState: boolean, evt?: React.SyntheticEvent<HTMLElement>) =>
+        this.requestAnimationFrame(() => {
+            const isInputFocused = this.input === document.activeElement;
+
+            if (this.input != null && !isInputFocused) {
+                // input is no longer focused, we should close the popover
+                this.setState({ isOpen: false });
+            } else if (!this.props.openOnKeyDown) {
+                // we should open immediately on click focus events
+                this.setState({ isOpen: true });
+            }
+
+            this.props.popoverProps?.onInteraction?.(nextOpenState, evt);
+        });
+
+    private handlePopoverOpened = (node: HTMLElement) => {
+        if (this.queryList != null) {
+            // scroll active item into view after popover transition completes and all dimensions are stable.
+            this.queryList.scrollActiveItemIntoView();
+        }
+        this.props.popoverProps?.onOpened?.(node);
+    };
+
+    private handleTagRemove = (tag: React.ReactNode, index: number) => {
+        const { selectedItems = [], onRemove, tagInputProps } = this.props;
+        onRemove?.(selectedItems[index], index);
+        tagInputProps?.onRemove?.(tag, index);
+    };
+
+    private getTagInputKeyDownHandler = (handleQueryListKeyDown: React.KeyboardEventHandler<HTMLElement>) => {
+        return (e: React.KeyboardEvent<HTMLElement>) => {
+            // HACKHACK: https://github.com/palantir/blueprint/issues/4165
+            // eslint-disable-next-line deprecation/deprecation
+            const { which } = e;
+
+            if (which === Keys.ESCAPE || which === Keys.TAB) {
+                // By default the escape key will not trigger a blur on the
+                // input element. It must be done explicitly.
+                if (this.input != null) {
+                    this.input.blur();
+                }
+                this.setState({ isOpen: false });
+            } else if (!(which === Keys.BACKSPACE || which === Keys.ARROW_LEFT || which === Keys.ARROW_RIGHT)) {
+                this.setState({ isOpen: true });
+            }
+
+            const isTargetingTagRemoveButton = (e.target as HTMLElement).closest(`.${CoreClasses.TAG_REMOVE}`) != null;
+
+            if (this.state.isOpen && !isTargetingTagRemoveButton) {
+                handleQueryListKeyDown?.(e);
+            }
+        };
+    };
+
+    private getTagInputKeyUpHandler = (handleQueryListKeyUp: React.KeyboardEventHandler<HTMLElement>) => {
+        return (e: React.KeyboardEvent<HTMLElement>) => {
+            const isTargetingInput = (e.target as HTMLElement).classList.contains(Classes.MULTISELECT_TAG_INPUT_INPUT);
+
+            // only handle events when the focus is on the actual <input> inside the TagInput, as that's
+            // what QueryList is designed to do
+            if (this.state.isOpen && isTargetingInput) {
+                handleQueryListKeyUp?.(e);
+            }
+        };
+    };
+}

--- a/packages/select/src/index.md
+++ b/packages/select/src/index.md
@@ -14,7 +14,9 @@ The **@blueprintjs/select** NPM package provides React components related to sel
 
 - [Suggest2](#select/suggest2) replacement for Suggest, uses Popover2 instead of Popover under the hood.
 
-- [MultiSelect](#select/multi-select) for selecting multiple items in a list.
+- [MultiSelect](#select/multi-select) for selecting multiple items in a list (DEPRECATED).
+
+- [MultiSelect2](#select/multi-select2) replacement for MultiSelect, uses Popover2 instead of Popover under the hood.
 
 - [Omnibar](#select/omnibar), a macOS spotlight-style typeahead component.
 
@@ -31,5 +33,6 @@ npm install --save @blueprintjs/select
 @page suggest
 @page suggest2
 @page multi-select
+@page multi-select2
 @page omnibar
 @page query-list

--- a/packages/select/test/index.ts
+++ b/packages/select/test/index.ts
@@ -6,6 +6,7 @@ import "@blueprintjs/test-commons/bootstrap";
 
 import "./listItemsPropsTests";
 import "./multiSelectTests";
+import "./multiSelect2Tests";
 import "./omnibarTests";
 import "./queryListTests";
 import "./renderFilteredItemsTests";

--- a/packages/select/test/isotest.js
+++ b/packages/select/test/isotest.js
@@ -25,6 +25,9 @@ describe("Select isomorphic rendering", () => {
         MultiSelect: {
             props: { items: [], query: "", selectedItems: [], tagRenderer: () => null },
         },
+        MultiSelect2: {
+            props: { items: [], query: "", selectedItems: [], tagRenderer: () => null },
+        },
         QueryList: {
             // needs at least one handler or it returns undefined
             props: { renderer: () => null },

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { mount } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+
+import { Classes as CoreClasses, Keys, Tag } from "@blueprintjs/core";
+import { dispatchTestKeyboardEventWithCode } from "@blueprintjs/test-commons";
+
+// this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
+import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
+import { IItemRendererProps, MultiSelect2, MultiSelect2Props, MultiSelect2State } from "../src";
+import { selectComponentSuite } from "./selectComponentSuite";
+
+describe("<MultiSelect2>", () => {
+    const FilmMultiSelect = MultiSelect2.ofType<IFilm>();
+    const defaultProps = {
+        items: TOP_100_FILMS,
+        popoverProps: { isOpen: true, usePortal: false },
+        query: "",
+        selectedItems: [] as IFilm[],
+        tagRenderer: renderTag,
+    };
+    let handlers: {
+        itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
+        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        onItemSelect: sinon.SinonSpy;
+    };
+
+    beforeEach(() => {
+        handlers = {
+            itemPredicate: sinon.spy(filterByYear),
+            itemRenderer: sinon.spy(renderFilm),
+            onItemSelect: sinon.spy(),
+        };
+    });
+
+    selectComponentSuite<MultiSelect2Props<IFilm>, MultiSelect2State>(props =>
+        mount(<MultiSelect2 {...props} popoverProps={{ isOpen: true, usePortal: false }} tagRenderer={renderTag} />),
+    );
+
+    it("placeholder can be controlled with placeholder prop", () => {
+        const placeholder = "look here";
+
+        const input = multiselect({ placeholder }).find("input");
+        assert.equal((input.getDOMNode() as HTMLInputElement).placeholder, placeholder);
+    });
+
+    it("placeholder can be controlled with TagInput's inputProps", () => {
+        const placeholder = "look here";
+
+        const input = multiselect({ tagInputProps: { placeholder } }).find("input");
+        assert.equal((input.getDOMNode() as HTMLInputElement).placeholder, placeholder);
+    });
+
+    it("tagRenderer can return JSX", () => {
+        const wrapper = multiselect({
+            selectedItems: [TOP_100_FILMS[0]],
+            tagRenderer: film => <strong>{film.title}</strong>,
+        });
+        assert.equal(wrapper.find(Tag).find("strong").length, 1);
+    });
+
+    // N.B. this is not good behavior, we shouldn't support this since the component is controlled.
+    // we keep it around for backcompat but expect that nobody actually uses the component this way.
+    it("selectedItems is optional", () => {
+        assert.doesNotThrow(() => multiselect({ selectedItems: undefined }));
+    });
+
+    it("only triggers QueryList key up events when focus is on TagInput's <input>", () => {
+        const itemSelectSpy = sinon.spy();
+        const wrapper = multiselect({
+            onItemSelect: itemSelectSpy,
+            selectedItems: [TOP_100_FILMS[1]],
+        });
+
+        const firstTagRemoveButton = wrapper.find(`.${CoreClasses.TAG_REMOVE}`).at(0).getDOMNode();
+        dispatchTestKeyboardEventWithCode(firstTagRemoveButton, "keyup", "Enter", Keys.ENTER);
+
+        // checks for the bug in https://github.com/palantir/blueprint/issues/3674
+        // where the first item in the dropdown list would get selected upon hitting Enter inside
+        // a TAG_REMOVE button
+        assert.isFalse(itemSelectSpy.calledWith(TOP_100_FILMS[0]));
+    });
+
+    it("triggers onRemove", () => {
+        const handleRemove = sinon.spy();
+        const wrapper = multiselect({
+            onRemove: handleRemove,
+            selectedItems: [TOP_100_FILMS[2], TOP_100_FILMS[3], TOP_100_FILMS[4]],
+        });
+        wrapper.find(`.${CoreClasses.TAG_REMOVE}`).at(1).simulate("click");
+        assert.isTrue(handleRemove.calledOnceWithExactly(TOP_100_FILMS[3], 1));
+    });
+
+    function multiselect(props: Partial<MultiSelect2Props<IFilm>> = {}, query?: string) {
+        const wrapper = mount(
+            <FilmMultiSelect {...defaultProps} {...handlers} {...props}>
+                <article />
+            </FilmMultiSelect>,
+        );
+        if (query !== undefined) {
+            wrapper.setState({ query });
+        }
+        return wrapper;
+    }
+});
+
+function renderTag(film: IFilm) {
+    return film.title;
+}
+
+function filterByYear(query: string, film: IFilm) {
+    return query === "" || film.year.toString() === query;
+}


### PR DESCRIPTION


#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Create a new MultiSelect2 component which uses Popover2 instead of Popover under the hood.

#### Reviewers should focus on:

Note the changes required to manually reposition the popover after adding or removing items from the selection. This was apparently not required with popper.js v1, but seems to be required with v2 due to its performance optimizations. [See the docs about this](https://popper.js.org/docs/v2/modifiers/event-listeners/#when-the-reference-element-moves-or-changes-size).

#### Screenshot

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/723999/170583970-101a7329-fc1c-4987-961c-282105f7fc80.png">

![2022-05-26 17 34 16](https://user-images.githubusercontent.com/723999/170583923-0b2c8361-6a95-48e1-8d4a-65193794e42e.gif)

