### PR TITLE
[core] docs: remove deprecated Menu.Item usage in code sample

### DIFF
--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -18,7 +18,7 @@ The Menu API includes three React components:
     <MenuDivider />
     <MenuItem text="Settings..." icon="cog" intent="primary">
         <MenuItem icon="tick" text="Save on edit" />
-        <Menu.Item icon="blank" text="Compile on edit" />
+        <MenuItem icon="blank" text="Compile on edit" />
     </MenuItem>
 </Menu>
 ```


### PR DESCRIPTION
#### Checklist

- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

`Menu.Item` is deprecated since 3.38.0. It should not be used in code samples. Replaced it with `MenuItem`.
