### PR TITLE
a11y tooltip role

### DIFF
--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -107,7 +107,7 @@ export class Tooltip extends AbstractPureComponent2<TooltipProps> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                {children}
+                <div role="tooltip">{children}</div>
             </Popover>
         );
     }

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -136,7 +136,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                {children}
+                <div role="tooltip">{children}</div>
             </Popover2>
         );
     };


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

add `role="tooltip"` to `tooltip` and `tooltip2` for a11y purposes. Wanted to see if the devs would support this change. If not, no worries, users of blueprint can always manually pass their children to these

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
