### PR TITLE
Bv/tooltip role

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -183,10 +183,10 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
             wrapperTagName = "div";
         }
 
-        const isContentEmpty = Utils.ensureElement(this.understandChildren().content) == null;
+        const contentEmpty = isContentEmpty(this.understandChildren().content);
         // need to do this check in render(), because `isOpen` is derived from
         // state, and state can't necessarily be accessed in validateProps.
-        if (isContentEmpty && !disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
+        if (contentEmpty && !disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
             console.warn(Errors.POPOVER_WARN_EMPTY_CONTENT);
         }
 
@@ -209,7 +209,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
                 className={this.props.portalClassName}
                 enforceFocus={this.props.enforceFocus}
                 hasBackdrop={this.props.hasBackdrop}
-                isOpen={isOpen && !isContentEmpty}
+                isOpen={isOpen && !contentEmpty}
                 onClose={this.handleOverlayClose}
                 onClosed={this.props.onClosed}
                 onClosing={this.props.onClosing}
@@ -613,4 +613,8 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         this.setState({ transformOrigin: getTransformOrigin(data) });
         return data;
     };
+}
+
+export function isContentEmpty(content: React.ReactNode) {
+    return Utils.ensureElement(content) == null;
 }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -108,7 +108,7 @@ export class Tooltip extends AbstractPureComponent2<TooltipProps> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                children
+                {children}
             </Popover>
         );
     }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -85,7 +85,7 @@ export class Tooltip extends AbstractPureComponent2<TooltipProps> {
     private popover: Popover | null = null;
 
     public render() {
-        const { children, intent, popoverClassName, ...restProps } = this.props;
+        const { children, content, intent, popoverClassName, ...restProps } = this.props;
         const classes = classNames(
             Classes.TOOLTIP,
             { [Classes.MINIMAL]: this.props.minimal },
@@ -101,13 +101,14 @@ export class Tooltip extends AbstractPureComponent2<TooltipProps> {
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}
+                content={<div role="tooltip">{content}</div>}
                 enforceFocus={false}
                 lazy={true}
                 popoverClassName={classes}
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                <div role="tooltip">{children}</div>
+                children
             </Popover>
         );
     }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -107,7 +107,7 @@ export class Tooltip extends AbstractPureComponent2<TooltipProps> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                {children}
+                <div role="tooltip">{children}</div>
             </Popover>
         );
     }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps } from "../../common/props";
 // eslint-disable-next-line import/no-cycle
-import { Popover, PopoverInteractionKind } from "../popover/popover";
+import { isContentEmpty, Popover, PopoverInteractionKind } from "../popover/popover";
 import { IPopoverSharedProps } from "../popover/popoverSharedProps";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -101,7 +101,7 @@ export class Tooltip extends AbstractPureComponent2<TooltipProps> {
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}
-                content={<div role="tooltip">{content}</div>}
+                content={isContentEmpty(content) ? content : <div role="tooltip">{content}</div>}
                 enforceFocus={false}
                 lazy={true}
                 popoverClassName={classes}

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -211,8 +211,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         const { disabled, content, placement, position = "auto", positioningStrategy } = this.props;
         const { isOpen } = this.state;
 
-        const isContentEmpty = content == null || (typeof content === "string" && content.trim() === "");
-        if (isContentEmpty) {
+        if (isContentEmpty(content)) {
             // need to do this check in render(), because `isOpen` is derived from
             // state, and state can't necessarily be accessed in validateProps.
             if (!disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
@@ -695,4 +694,8 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
 
 function noop() {
     // no-op
+}
+
+export function isContentEmpty(content: string | JSX.Element) {
+    return content == null || (typeof content === "string" && content.trim() === "");
 }

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -696,6 +696,6 @@ function noop() {
     // no-op
 }
 
-export function isContentEmpty(content: string | JSX.Element) {
+export function isContentEmpty(content: string | null | undefined | JSX.Element) {
     return content == null || (typeof content === "string" && content.trim() === "");
 }

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -105,7 +105,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
 
     // any descendant ContextMenu2s may update this ctxState
     private renderPopover = (ctxState: Tooltip2ContextState) => {
-        const { children, disabled, intent, popoverClassName, ...restProps } = this.props;
+        const { children, content, disabled, intent, popoverClassName, ...restProps } = this.props;
         const classes = classNames(
             Classes.TOOLTIP2,
             { [CoreClasses.MINIMAL]: this.props.minimal },
@@ -129,6 +129,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}
+                content={<div role="tooltip">{content}</div>}
                 disabled={ctxState.forceDisabled ?? disabled}
                 enforceFocus={false}
                 lazy={true}
@@ -136,7 +137,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                <div role="tooltip">{children}</div>
+                children
             </Popover2>
         );
     };

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -21,7 +21,7 @@ import { Classes as CoreClasses, DISPLAYNAME_PREFIX, IntentProps } from "@bluepr
 
 import * as Classes from "./classes";
 // eslint-disable-next-line import/no-cycle
-import { Popover2, Popover2InteractionKind } from "./popover2";
+import { isContentEmpty, Popover2, Popover2InteractionKind } from "./popover2";
 import { TOOLTIP_ARROW_SVG_SIZE } from "./popover2Arrow";
 import { Popover2SharedProps } from "./popover2SharedProps";
 import { Tooltip2Context, Tooltip2ContextState, Tooltip2Provider } from "./tooltip2Context";
@@ -129,7 +129,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
                 {...restProps}
                 autoFocus={false}
                 canEscapeKeyClose={false}
-                content={<div role="tooltip">{content}</div>}
+                content={isContentEmpty(content) ? content : <div role="tooltip">{content}</div>}
                 disabled={ctxState.forceDisabled ?? disabled}
                 enforceFocus={false}
                 lazy={true}

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -137,7 +137,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                children
+                {children}
             </Popover2>
         );
     };

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -136,7 +136,7 @@ export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
                 portalContainer={this.props.portalContainer}
                 ref={ref => (this.popover = ref)}
             >
-                {children}
+                <div role="tooltip">{children}</div>
             </Popover2>
         );
     };


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

add `role="tooltip"` to tooltip and tooltip2 for a11y purposes. Wanted to see if the devs would agree with / support this change. If not, no worries, BP users can always manually include this role in the tooltip contents they pass.
