### PR TITLE
[select] fix(MultiSelect2): popoverProps placement prop warning

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -181,7 +181,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 canEscapeKeyClose={true}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
-                placement="bottom-start"
+                placement={popoverProps.position || popoverProps.placement ? undefined : "bottom-start"}
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [[N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Before this change, would get the warning `<Popover2> supports either placement or position prop, not both.` if specifying a `position` in the `popoverProps` of a `MultiSelect2`, due to the default `placement` being passed.
