### PR TITLE
[table] fix column layout when columnWidths has sparse values

### DIFF
--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -21,4 +21,10 @@ import { FocusStyleManager } from "@blueprintjs/core";
 import { Examples } from "./examples/Examples";
 
 FocusStyleManager.onlyShowFocusOnTabs();
-ReactDOM.render(<Examples />, document.querySelector("#blueprint-demo-app"));
+
+(async () => {
+    // Wait until CSS is loaded before rendering components because some of them (like Table)
+    // rely on those styles to take accurate DOM measurements.
+    await import("./index.scss");
+    ReactDOM.render(<Examples />, document.querySelector("#blueprint-demo-app"));
+})();

--- a/packages/demo-app/src/styles.d.ts
+++ b/packages/demo-app/src/styles.d.ts
@@ -1,0 +1,8 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ */
+
+declare module "*.scss" {
+    const styles: any;
+    export = styles;
+}

--- a/packages/demo-app/src/tsconfig.json
+++ b/packages/demo-app/src/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "declaration": false,
         "lib": ["dom", "es5", "es6"],
+        "module": "es2020",
         "outDir": "../dist",
         "sourceMap": false,
         "strictNullChecks": false

--- a/packages/demo-app/webpack.config.js
+++ b/packages/demo-app/webpack.config.js
@@ -26,7 +26,6 @@ module.exports = Object.assign({}, baseConfig, {
             "./polyfill.js",
             // bundle entry points
             "./src/index.tsx",
-            "./src/index.scss",
         ],
     },
 

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -140,7 +140,10 @@ export const Utils = {
      * @param array - the `Array` to copy and adjust
      * @param length - the target length of the array
      * @param fillValue - the value to add to the array if it is too short
+     *
+     * @deprecated this function is no longer used in the table component, so it will be removed in a future major version
      */
+    // eslint-disable-next-line deprecation/deprecation
     arrayOfLength<T>(array: T[], length: number, fillValue: T): T[] {
         if (array.length > length) {
             return array.slice(0, length);

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -133,14 +133,14 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
             // Make sure the width/height arrays have the correct length, but keep
             // as many existing widths/heights as possible. Also, apply the
             // sparse width/heights from props.
-            newColumnWidths = Utils.arrayOfLength(newColumnWidths, numCols, defaultColumnWidth);
+            newColumnWidths = Array(numCols).fill(defaultColumnWidth);
             newColumnWidths = Utils.assignSparseValues(newColumnWidths, previousColumnWidths);
             newColumnWidths = Utils.assignSparseValues(newColumnWidths, columnWidths);
         }
 
         let newRowHeights = rowHeights;
         if (rowHeights !== state.rowHeights || numRows !== state.rowHeights.length) {
-            newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
+            newColumnWidths = Array(numRows).fill(defaultRowHeight);
             newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
         }
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -140,7 +140,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
 
         let newRowHeights = rowHeights;
         if (rowHeights !== state.rowHeights || numRows !== state.rowHeights.length) {
-            newColumnWidths = Array(numRows).fill(defaultRowHeight);
+            newRowHeights = Array(numRows).fill(defaultRowHeight);
             newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
         }
 

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -138,14 +138,14 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             // Make sure the width/height arrays have the correct length, but keep
             // as many existing widths/heights as possible. Also, apply the
             // sparse width/heights from props.
-            newColumnWidths = Utils.arrayOfLength(newColumnWidths, numCols, defaultColumnWidth);
+            newColumnWidths = Array(numCols).fill(defaultColumnWidth);
             newColumnWidths = Utils.assignSparseValues(newColumnWidths, previousColumnWidths);
             newColumnWidths = Utils.assignSparseValues(newColumnWidths, columnWidths);
         }
 
         let newRowHeights = rowHeights;
         if (rowHeights !== state.rowHeights || numRows !== state.rowHeights.length) {
-            newRowHeights = Utils.arrayOfLength(newRowHeights, numRows, defaultRowHeight);
+            newColumnWidths = Array(numRows).fill(defaultRowHeight);
             newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
         }
 

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -145,7 +145,7 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
 
         let newRowHeights = rowHeights;
         if (rowHeights !== state.rowHeights || numRows !== state.rowHeights.length) {
-            newColumnWidths = Array(numRows).fill(defaultRowHeight);
+            newRowHeights = Array(numRows).fill(defaultRowHeight);
             newRowHeights = Utils.assignSparseValues(newRowHeights, rowHeights);
         }
 

--- a/packages/table/test/utilsTests.ts
+++ b/packages/table/test/utilsTests.ts
@@ -115,6 +115,7 @@ describe("Utils", () => {
     });
 
     describe("arrayOfLength", () => {
+        /* eslint-disable deprecation/deprecation */
         it("truncates if too long", () => {
             const original = Utils.times(5, () => "A");
             const result = Utils.arrayOfLength(original, 2, "B");
@@ -139,6 +140,7 @@ describe("Utils", () => {
             expect(result).to.have.lengthOf(5);
             expect(result).to.deep.equal(["A", "A", "A", "A", "A"]);
         });
+        /* eslint-enable deprecation/deprecation */
     });
 
     describe("assignSparseValues", () => {


### PR DESCRIPTION
#### Fixes #5264

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix implementation of lifecycle method in Table and Table2 components so that it computes `state.columnWidths` correctly even when consumers provide a `props.columnWidths` with sparse (undefined) values for new columns.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

![2022-06-01 17 45 31](https://user-images.githubusercontent.com/723999/171507570-c671e5ea-813c-4ed9-a773-5d5a2e5d9356.gif)

