### PR TITLE
[select] feat(Select2, MultiSelect2): popoverContentProps

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -73,12 +73,15 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T> {
      */
     placeholder?: string;
 
+    /** Props to spread to `Popover2` popover content. */
+    popoverContentProps?: React.HTMLAttributes<HTMLDivElement>;
+
     /**
      * Props to spread to `Popover2`.
      *
-     * Note that `content` cannot be changed, but we do support attaching a ref to the Popover2 component
-     * instance (sometimes useful to reposition the popover after updating `selectedItems` in reaction to
-     * a change external to this component).
+     * Note that `content` cannot be changed aside from utilizing `popoverContentProps`, but we do support
+     * attaching a ref to the Popover2 component instance (sometimes useful to reposition the popover after
+     * updating `selectedItems` in reaction to a change external to this component).
      */
     popoverProps?: Partial<
         Omit<Popover2Props, "content"> & { ref: React.RefObject<Popover2<React.HTMLProps<HTMLDivElement>>> }
@@ -155,7 +158,14 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { fill, tagInputProps = {}, popoverProps = {}, selectedItems = [], placeholder } = this.props;
+        const {
+            fill,
+            tagInputProps = {},
+            popoverContentProps = {},
+            popoverProps = {},
+            selectedItems = [],
+            placeholder,
+        } = this.props;
         const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 
         if (fill) {
@@ -185,7 +195,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
-                    <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+                    <div {...popoverContentProps} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                         {listProps.itemList}
                     </div>
                 }

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -70,7 +70,10 @@ export interface Select2Props<T> extends IListItemsProps<T> {
      */
     inputProps?: InputGroupProps2;
 
-    /** Props to spread to `Popover2`. Note that `content` cannot be changed. */
+    /** Props to spread to `Popover2` popover content. */
+    popoverContentProps?: React.HTMLAttributes<HTMLDivElement>;
+
+    /** Props to spread to `Popover2`. Note that `content` cannot be changed aside from utilizing `popoverContentProps`. */
     popoverProps?: Partial<Omit<Popover2Props, "content">>;
 
     /**
@@ -135,7 +138,14 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
-        const { fill, filterable = true, disabled = false, inputProps = {}, popoverProps = {} } = this.props;
+        const {
+            fill,
+            filterable = true,
+            disabled = false,
+            inputProps = {},
+            popoverContentProps = {},
+            popoverProps = {},
+        } = this.props;
 
         if (fill) {
             popoverProps.fill = true;
@@ -164,7 +174,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 {...popoverProps}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
-                    <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+                    <div {...popoverContentProps} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                         {filterable ? input : undefined}
                         {listProps.itemList}
                     </div>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

allow `popoverContentProps` to be passed to `MultiSelect2` and `Select2`. Allows user to apply props such as `aria-label` or `data-testid` to the popover that is created by these elements.

