### PR TITLE
[select] fix: ARIA listbox popup type and combobox list role

### DIFF
--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -36,5 +36,6 @@ export {
     StrictModifierNames,
 } from "./popover2SharedProps";
 export { IPopover2Props, Popover2Props, Popover2, Popover2InteractionKind } from "./popover2";
+export { PopupKind } from "./popupKind";
 export { ResizeSensor2, ResizeSensor2Props } from "./resizeSensor2";
 export { ITooltip2Props, Tooltip2Props, Tooltip2 } from "./tooltip2";

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -29,7 +29,7 @@ import {
     TagInputProps,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
-import { PopupKind } from "@blueprintjs/popover2/popupKind";
+import { PopupKind } from "@blueprintjs/popover2/src/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -204,7 +204,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 }
             >
                 <div
-                    {...wrapperProps}
+                    {...popoverTargetProps}
                     aria-expanded={this.state.isOpen}
                     onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTagInputKeyUpHandler(handleKeyUp)}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -83,6 +83,11 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
 
     /** Custom renderer to transform an item into tag content. */
     tagRenderer: (item: T) => React.ReactNode;
+
+    /**
+     * Props to add to the `div` that wraps the TagInput
+     */
+    wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export interface MultiSelect2State {
@@ -153,6 +158,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
             popoverRef,
             selectedItems = [],
             placeholder,
+            wrapperProps = {},
         } = this.props;
         const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 
@@ -199,13 +205,15 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 }
             >
                 <div
+                    {...wrapperProps}
+                    aria-expanded={this.state.isOpen}
                     onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTagInputKeyUpHandler(handleKeyUp)}
+                    role="combobox"
                 >
                     <TagInput
                         placeholder={placeholder}
                         {...tagInputProps}
-                        aria-expanded={this.state.isOpen}
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         inputRef={this.refHandlers.input}
                         inputProps={inputProps}
@@ -214,7 +222,6 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                         onAdd={handleTagInputAdd}
                         onInputChange={listProps.handleQueryChange}
                         onRemove={this.handleTagRemove}
-                        role="combobox"
                         values={selectedItems.map(this.props.tagRenderer)}
                     />
                 </div>

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -145,7 +145,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
         const queryListMenuProps = {
             id: listboxId,
-            ...restProps.menuProps,
+            ...(restProps.menuProps ?? {}),
         };
 
         return (

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -32,14 +32,11 @@ import {
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
+import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
-export interface MultiSelect2Props<T>
-    extends IListItemsProps<T>,
-        Pick<QueryListProps<T>, "menuProps">,
-        SelectPopoverProps {
+export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
     /**
      * Whether the component should take up the full width of its container.
      * This overrides `popoverProps.fill` and `tagInputProps.fill`.
@@ -143,15 +140,10 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         // omit props specific to this component, spread the rest.
         const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
-        const queryListMenuProps = {
-            id: this.listboxId,
-            ...(restProps.menuProps ?? {}),
-        };
-
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={queryListMenuProps}
+                menuProps={{ id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -190,6 +190,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 onInteraction={this.handlePopoverInteraction}
                 onOpened={this.handlePopoverOpened}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
+                popoverKind="listbox"
                 ref={
                     popoverRef === undefined
                         ? this.refHandlers.popover
@@ -204,7 +205,6 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                         placeholder={placeholder}
                         {...tagInputProps}
                         aria-expanded={this.state.isOpen}
-                        aria-haspopup="listbox"
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         inputRef={this.refHandlers.input}
                         inputProps={inputProps}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -30,12 +30,12 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { Classes, SelectPopoverProps } from "../../common";
+import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
-export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+export interface MultiSelect2Props<T> extends QueryListProps<T>, SelectPopoverProps {
     /**
      * Whether the component should take up the full width of its container.
      * This overrides `popoverProps.fill` and `tagInputProps.fill`.

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -166,10 +166,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         // add our own inputProps.className so that we can reference it in event handlers
         const inputProps = {
             ...tagInputProps.inputProps,
-            "aria-expanded": this.state.isOpen,
-            "aria-haspopup": "listbox",
             className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT),
-            role: "combobox",
         };
 
         const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {
@@ -209,6 +206,8 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     <TagInput
                         placeholder={placeholder}
                         {...tagInputProps}
+                        aria-expanded={this.state.isOpen}
+                        aria-haspopup="listbox"
                         className={classNames(Classes.MULTISELECT, tagInputProps.className)}
                         inputRef={this.refHandlers.input}
                         inputProps={inputProps}
@@ -217,6 +216,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                         onAdd={handleTagInputAdd}
                         onInputChange={listProps.handleQueryChange}
                         onRemove={this.handleTagRemove}
+                        role="combobox"
                         values={selectedItems.map(this.props.tagRenderer)}
                     />
                 </div>

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -28,8 +28,7 @@ import {
     TagInputAddMethod,
     TagInputProps,
 } from "@blueprintjs/core";
-import { Popover2 } from "@blueprintjs/popover2";
-import { PopupKind } from "@blueprintjs/popover2/src/popupKind";
+import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -27,9 +27,8 @@ import {
     TagInput,
     TagInputAddMethod,
     TagInputProps,
+    uniqueId,
 } from "@blueprintjs/core";
-// tslint:disable-next-line:no-submodule-imports
-import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -29,6 +29,7 @@ import {
     TagInputProps,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
+import type { PopupKind } from "@blueprintjs/popover2/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -190,7 +191,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 onInteraction={this.handlePopoverInteraction}
                 onOpened={this.handlePopoverOpened}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
-                popupKind="listbox"
+                popupKind={PopupKind.LISTBOX}
                 ref={
                     popoverRef === undefined
                         ? this.refHandlers.popover

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -28,6 +28,7 @@ import {
     TagInputAddMethod,
     TagInputProps,
 } from "@blueprintjs/core";
+// tslint:disable-next-line:no-submodule-imports
 import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -73,6 +73,11 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
      */
     placeholder?: string;
 
+    /**
+     * Props to add to the `div` that wraps the TagInput
+     */
+    popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
+
     /** Controlled selected values. */
     selectedItems?: T[];
 
@@ -82,11 +87,6 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
 
     /** Custom renderer to transform an item into tag content. */
     tagRenderer: (item: T) => React.ReactNode;
-
-    /**
-     * Props to add to the `div` that wraps the TagInput
-     */
-    popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export interface MultiSelect2State {

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -190,7 +190,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 onInteraction={this.handlePopoverInteraction}
                 onOpened={this.handlePopoverOpened}
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
-                popoverKind="listbox"
+                popupKind="listbox"
                 ref={
                     popoverRef === undefined
                         ? this.refHandlers.popover

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -29,7 +29,7 @@ import {
     TagInputProps,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
-import type { PopupKind } from "@blueprintjs/popover2/popupKind";
+import { PopupKind } from "@blueprintjs/popover2/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -166,6 +166,8 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         // add our own inputProps.className so that we can reference it in event handlers
         const inputProps = {
             ...tagInputProps.inputProps,
+            "aria-expanded": this.state.isOpen,
+            "aria-haspopup": "listbox",
             className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT),
             role: "combobox",
         };

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -43,6 +43,12 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     fill?: boolean;
 
     /**
+     * Adds `id={listboxId}` to the list Menu and `aria-controls={listboxId}` to the
+     * combobox element that opens it
+     */
+    listboxId?: string;
+
+    /**
      * Callback invoked when an item is removed from the selection by
      * removing its tag in the TagInput. This is generally more useful than
      * `tagInputProps.onRemove`  because it receives the removed value instead of
@@ -135,11 +141,17 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+        const { listboxId, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+
+        const queryListMenuProps = {
+            id: listboxId,
+            ...restProps.menuProps,
+        };
 
         return (
             <this.TypedQueryList
                 {...restProps}
+                menuProps={queryListMenuProps}
                 onItemSelect={this.handleItemSelect}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}
@@ -151,6 +163,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const {
             fill,
+            listboxId,
             tagInputProps = {},
             popoverContentProps = {},
             popoverProps = {},
@@ -204,6 +217,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 }
             >
                 <div
+                    aria-controls={listboxId}
                     {...popoverTargetProps}
                     aria-expanded={this.state.isOpen}
                     onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -30,12 +30,17 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, SelectPopoverProps } from "../../common";
+import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
-export interface MultiSelect2Props<T> extends QueryListProps<T>, SelectPopoverProps {
+export interface MultiSelect2Props<T>
+    extends IListItemsProps<T>,
+        Partial<
+            Omit<QueryListProps<T>, "items" | "onItemSelect" | "onQueryChange" | "ref" | "itemRenderer" | "renderer">
+        >,
+        SelectPopoverProps {
     /**
      * Whether the component should take up the full width of its container.
      * This overrides `popoverProps.fill` and `tagInputProps.fill`.

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -145,7 +145,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
         const queryListMenuProps = {
             id: listboxId,
-            ...(restProps.menuProps ?? {}),
+            ...(restProps.hasOwnProperty("menuProps") ? restProps.menuProps : {}),
         };
 
         return (

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -167,6 +167,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         const inputProps = {
             ...tagInputProps.inputProps,
             className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT),
+            role: "combobox",
         };
 
         const handleTagInputAdd = (values: any[], method: TagInputAddMethod) => {

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -28,6 +28,7 @@ import {
     TagInputAddMethod,
     TagInputProps,
 } from "@blueprintjs/core";
+import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
@@ -44,12 +45,6 @@ export interface MultiSelect2Props<T>
      * This overrides `popoverProps.fill` and `tagInputProps.fill`.
      */
     fill?: boolean;
-
-    /**
-     * Adds `id={listboxId}` to the list Menu and `aria-controls={listboxId}` to the
-     * combobox element that opens it
-     */
-    listboxId?: string;
 
     /**
      * Callback invoked when an item is removed from the selection by
@@ -105,6 +100,8 @@ export interface MultiSelect2State {
 export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>, MultiSelect2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect2`;
 
+    private listboxId = uniqueId("listbox");
+
     public static defaultProps = {
         fill: false,
         placeholder: "Search...",
@@ -144,10 +141,10 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { listboxId, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+        const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         const queryListMenuProps = {
-            id: listboxId,
+            id: this.listboxId,
             ...(restProps.menuProps ?? {}),
         };
 
@@ -166,7 +163,6 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         const {
             fill,
-            listboxId,
             tagInputProps = {},
             popoverContentProps = {},
             popoverProps = {},
@@ -220,7 +216,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 }
             >
                 <div
-                    aria-controls={listboxId}
+                    aria-controls={this.listboxId}
                     {...popoverTargetProps}
                     aria-expanded={this.state.isOpen}
                     onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -86,7 +86,7 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     /**
      * Props to add to the `div` that wraps the TagInput
      */
-    wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
+    popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export interface MultiSelect2State {

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -27,7 +27,7 @@ import {
     TagInput,
     TagInputAddMethod,
     TagInputProps,
-    uniqueId,
+    Utils,
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
@@ -100,7 +100,7 @@ export interface MultiSelect2State {
 export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>, MultiSelect2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect2`;
 
-    private listboxId = uniqueId("listbox");
+    private listboxId = Utils.uniqueId("listbox");
 
     public static defaultProps = {
         fill: false,

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -150,7 +150,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
         const queryListMenuProps = {
             id: listboxId,
-            ...(restProps.hasOwnProperty("menuProps") ? restProps.menuProps : {}),
+            ...(restProps.menuProps ?? {}),
         };
 
         return (

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -157,7 +157,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
             popoverRef,
             selectedItems = [],
             placeholder,
-            wrapperProps = {},
+            popoverTargetProps = {},
         } = this.props;
         const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -37,9 +37,7 @@ import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-lis
 
 export interface MultiSelect2Props<T>
     extends IListItemsProps<T>,
-        Partial<
-            Omit<QueryListProps<T>, "items" | "onItemSelect" | "onQueryChange" | "ref" | "itemRenderer" | "renderer">
-        >,
+        Pick<QueryListProps<T>, "menuProps">,
         SelectPopoverProps {
     /**
      * Whether the component should take up the full width of its container.

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -354,7 +354,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
         }
         const createFirst = this.isCreateItemFirst();
         return (
-            <Menu ulRef={listProps.itemsParentRef}>
+            <Menu role="listbox" ulRef={listProps.itemsParentRef}>
                 {createFirst && createItemView}
                 {menuContent}
                 {!createFirst && createItemView}

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -41,6 +41,11 @@ export interface IQueryListProps<T> extends IListItemsProps<T> {
     initialActiveItem?: T;
 
     /**
+     * Additional props to apply to the `Menu` that is created within the `QueryList`
+     */
+    menuProps?: React.HTMLAttributes<HTMLUListElement>;
+
+    /**
      * Callback invoked when user presses a key, after processing `QueryList`'s own key events
      * (up/down to navigate active item). This callback is passed to `renderer` and (along with
      * `onKeyUp`) can be attached to arbitrary content elements to support keyboard selection.
@@ -343,7 +348,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
 
     /** default `itemListRenderer` implementation */
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
-        const { initialContent, noResults } = this.props;
+        const { initialContent, noResults, menuProps } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
         const createItemView = listProps.renderCreateItem();
@@ -354,7 +359,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
         }
         const createFirst = this.isCreateItemFirst();
         return (
-            <Menu role="listbox" ulRef={listProps.itemsParentRef}>
+            <Menu role="listbox" {...menuProps} ulRef={listProps.itemsParentRef}>
                 {createFirst && createItemView}
                 {menuContent}
                 {!createFirst && createItemView}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -178,6 +178,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 <div
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
+                    role="combobox"
                 >
                     {this.props.children}
                 </div>

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -121,7 +121,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
         const queryListMenuProps = {
             id: listboxId,
-            ...restProps.menuProps,
+            ...(restProps.menuProps ?? {}),
         };
 
         return (

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -33,10 +33,10 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { Classes, SelectPopoverProps } from "../../common";
+import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
-export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+export interface Select2Props<T> extends QueryListProps<T>, SelectPopoverProps {
     children?: React.ReactNode;
 
     /**

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -71,17 +71,17 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     inputProps?: InputGroupProps2;
 
     /**
+     * Props to add to the popover target wrapper element.
+     */
+    popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
+
+    /**
      * Whether the active item should be reset to the first matching item _when
      * the popover closes_. The query will also be reset to the empty string.
      *
      * @default false
      */
     resetOnClose?: boolean;
-
-    /**
-     * Props to add to the popover target wrapper element.
-     */
-    popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export interface Select2State {

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -80,6 +80,12 @@ export interface Select2Props<T> extends IListItemsProps<T> {
      * @default false
      */
     resetOnClose?: boolean;
+
+    /**
+     * Props to add to the `div` that wraps the element that is clicked to display
+     * the select popover
+     */
+    wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export interface Select2State {
@@ -135,7 +141,14 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
-        const { fill, filterable = true, disabled = false, inputProps = {}, popoverProps = {} } = this.props;
+        const {
+            fill,
+            filterable = true,
+            disabled = false,
+            inputProps = {},
+            popoverProps = {},
+            wrapperProps = {},
+        } = this.props;
 
         if (fill) {
             popoverProps.fill = true;
@@ -176,6 +189,9 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 onClosing={this.handlePopoverClosing}
             >
                 <div
+                    {...wrapperProps}
+                    aria-expanded={this.state.isOpen}
+                    aria-haspopup="listbox"
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                     role="combobox"

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -82,7 +82,7 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
      * Props to add to the `div` that wraps the element that is clicked to display
      * the select popover
      */
-    wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
+    popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export interface Select2State {

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -31,8 +31,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
-import { Popover2 } from "@blueprintjs/popover2";
-import { PopupKind } from "@blueprintjs/popover2/src/popupKind";
+import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -126,7 +126,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
         const queryListMenuProps = {
             id: listboxId,
-            ...(restProps.hasOwnProperty("menuProps") ? restProps.menuProps : {}),
+            ...(restProps.menuProps ?? {}),
         };
 
         return (

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -79,8 +79,7 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     resetOnClose?: boolean;
 
     /**
-     * Props to add to the `div` that wraps the element that is clicked to display
-     * the select popover
+     * Props to add to the popover target wrapper element.
      */
     popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
 }

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -35,9 +35,9 @@ import {
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
+import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
-export interface Select2Props<T> extends IListItemsProps<T>, Pick<QueryListProps<T>, "menuProps">, SelectPopoverProps {
+export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
     children?: React.ReactNode;
 
     /**
@@ -116,15 +116,10 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         // omit props specific to this component, spread the rest.
         const { filterable, inputProps, popoverProps, ...restProps } = this.props;
 
-        const queryListMenuProps = {
-            id: this.listboxId,
-            ...(restProps.menuProps ?? {}),
-        };
-
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={queryListMenuProps}
+                menuProps={{ id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}
                 renderer={this.renderQueryList}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -33,10 +33,15 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, SelectPopoverProps } from "../../common";
+import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
-export interface Select2Props<T> extends QueryListProps<T>, SelectPopoverProps {
+export interface Select2Props<T>
+    extends IListItemsProps<T>,
+        Partial<
+            Omit<QueryListProps<T>, "items" | "onItemSelect" | "onQueryChange" | "ref" | "itemRenderer" | "renderer">
+        >,
+        SelectPopoverProps {
     children?: React.ReactNode;
 
     /**

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -32,7 +32,7 @@ import {
     setRef,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
-import { PopupKind } from "@blueprintjs/popover2/popupKind";
+import { PopupKind } from "@blueprintjs/popover2/src/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -186,12 +186,12 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 onOpened={this.handlePopoverOpened}
                 onOpening={this.handlePopoverOpening}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
+                popoverKind="listbox"
                 ref={popoverRef}
             >
                 <div
                     {...wrapperProps}
                     aria-expanded={this.state.isOpen}
-                    aria-haspopup="listbox"
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
                     role="combobox"

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -145,8 +145,8 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
             inputProps = {},
             popoverContentProps = {},
             popoverProps = {},
+            popoverTargetProps = {},
             popoverRef,
-            wrapperProps = {},
         } = this.props;
 
         if (fill) {

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -32,6 +32,7 @@ import {
     setRef,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
+import type { PopupKind } from "@blueprintjs/popover2/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -186,7 +187,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 onOpened={this.handlePopoverOpened}
                 onOpening={this.handlePopoverOpening}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
-                popupKind="listbox"
+                popupKind={PopupKind.LISTBOX}
                 ref={popoverRef}
             >
                 <div

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -31,6 +31,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
+import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
@@ -71,12 +72,6 @@ export interface Select2Props<T> extends IListItemsProps<T>, Pick<QueryListProps
     inputProps?: InputGroupProps2;
 
     /**
-     * Adds `id={listboxId}` to the list Menu and `aria-controls={listboxId}` to the
-     * combobox element that opens it
-     */
-    listboxId?: string;
-
-    /**
      * Props to add to the popover target wrapper element.
      */
     popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
@@ -96,6 +91,8 @@ export interface Select2State {
 
 export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Select2`;
+
+    private listboxId = uniqueId("listbox");
 
     public static ofType<U>() {
         return Select2 as new (props: Select2Props<U>) => Select2<U>;
@@ -117,10 +114,10 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, inputProps, listboxId, popoverProps, ...restProps } = this.props;
+        const { filterable, inputProps, popoverProps, ...restProps } = this.props;
 
         const queryListMenuProps = {
-            id: listboxId,
+            id: this.listboxId,
             ...(restProps.menuProps ?? {}),
         };
 
@@ -154,7 +151,6 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
             filterable = true,
             disabled = false,
             inputProps = {},
-            listboxId,
             popoverContentProps = {},
             popoverProps = {},
             popoverTargetProps = {},
@@ -202,7 +198,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 ref={popoverRef}
             >
                 <div
-                    aria-controls={listboxId}
+                    aria-controls={this.listboxId}
                     {...popoverTargetProps}
                     aria-expanded={this.state.isOpen}
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -32,7 +32,7 @@ import {
     setRef,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
-import type { PopupKind } from "@blueprintjs/popover2/popupKind";
+import { PopupKind } from "@blueprintjs/popover2/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -121,7 +121,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
         const queryListMenuProps = {
             id: listboxId,
-            ...(restProps.menuProps ?? {}),
+            ...(restProps.hasOwnProperty("menuProps") ? restProps.menuProps : {}),
         };
 
         return (

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -31,6 +31,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
+// tslint:disable-next-line:no-submodule-imports
 import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -190,7 +190,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 ref={popoverRef}
             >
                 <div
-                    {...wrapperProps}
+                    {...popoverTargetProps}
                     aria-expanded={this.state.isOpen}
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}
                     onKeyUp={this.state.isOpen ? handleKeyUp : undefined}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -30,7 +30,7 @@ import {
     Position,
     refHandler,
     setRef,
-    uniqueId,
+    Utils,
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
@@ -92,7 +92,7 @@ export interface Select2State {
 export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Select2`;
 
-    private listboxId = uniqueId("listbox");
+    private listboxId = Utils.uniqueId("listbox");
 
     public static ofType<U>() {
         return Select2 as new (props: Select2Props<U>) => Select2<U>;

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -36,12 +36,7 @@ import { Popover2, PopupKind } from "@blueprintjs/popover2";
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
-export interface Select2Props<T>
-    extends IListItemsProps<T>,
-        Partial<
-            Omit<QueryListProps<T>, "items" | "onItemSelect" | "onQueryChange" | "ref" | "itemRenderer" | "renderer">
-        >,
-        SelectPopoverProps {
+export interface Select2Props<T> extends IListItemsProps<T>, Pick<QueryListProps<T>, "menuProps">, SelectPopoverProps {
     children?: React.ReactNode;
 
     /**

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -71,6 +71,12 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     inputProps?: InputGroupProps2;
 
     /**
+     * Adds `id={listboxId}` to the list Menu and `aria-controls={listboxId}` to the
+     * combobox element that opens it
+     */
+    listboxId?: string;
+
+    /**
      * Props to add to the popover target wrapper element.
      */
     popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
@@ -111,11 +117,17 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, inputProps, popoverProps, ...restProps } = this.props;
+        const { filterable, inputProps, listboxId, popoverProps, ...restProps } = this.props;
+
+        const queryListMenuProps = {
+            id: listboxId,
+            ...restProps.menuProps,
+        };
 
         return (
             <this.TypedQueryList
                 {...restProps}
+                menuProps={queryListMenuProps}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}
                 renderer={this.renderQueryList}
@@ -142,6 +154,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
             filterable = true,
             disabled = false,
             inputProps = {},
+            listboxId,
             popoverContentProps = {},
             popoverProps = {},
             popoverTargetProps = {},
@@ -189,6 +202,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 ref={popoverRef}
             >
                 <div
+                    aria-controls={listboxId}
                     {...popoverTargetProps}
                     aria-expanded={this.state.isOpen}
                     onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -186,7 +186,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 onOpened={this.handlePopoverOpened}
                 onOpening={this.handlePopoverOpening}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
-                popoverKind="listbox"
+                popupKind="listbox"
                 ref={popoverRef}
             >
                 <div

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -30,9 +30,8 @@ import {
     Position,
     refHandler,
     setRef,
+    uniqueId,
 } from "@blueprintjs/core";
-// tslint:disable-next-line:no-submodule-imports
-import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -29,7 +29,7 @@ import {
     Position,
     refHandler,
     setRef,
-    uniqueId,
+    Utils,
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
@@ -104,7 +104,7 @@ export interface Suggest2State<T> {
 export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Suggest2State<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Suggest2`;
 
-    private listboxId = uniqueId("listbox");
+    private listboxId = Utils.uniqueId("listbox");
 
     public static defaultProps: Partial<Suggest2Props<any>> = {
         closeOnSelect: true,

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -141,7 +141,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
         const queryListMenuProps = {
             id: listboxId,
-            ...restProps.menuProps,
+            ...(restProps.menuProps ?? {}),
         };
 
         return (

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -31,7 +31,7 @@ import {
     setRef,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
-import { PopupKind } from "@blueprintjs/popover2/popupKind";
+import { PopupKind } from "@blueprintjs/popover2/src/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -146,7 +146,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
         const queryListMenuProps = {
             id: listboxId,
-            ...(restProps.hasOwnProperty("menuProps") ? restProps.menuProps : {}),
+            ...(restProps.menuProps ?? {}),
         };
 
         return (

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -32,10 +32,15 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, SelectPopoverProps } from "../../common";
+import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
-export interface Suggest2Props<T> extends QueryListProps<T>, SelectPopoverProps {
+export interface Suggest2Props<T>
+    extends IListItemsProps<T>,
+        Partial<
+            Omit<QueryListProps<T>, "items" | "onItemSelect" | "onQueryChange" | "ref" | "itemRenderer" | "renderer">
+        >,
+        SelectPopoverProps {
     /**
      * Whether the popover should close after selecting an item.
      *

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -30,6 +30,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
+// tslint:disable-next-line:no-submodule-imports
 import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -214,7 +214,6 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                     {...inputProps}
                     aria-autocomplete="list"
                     aria-expanded={this.state.isOpen}
-                    aria-haspopup="listbox"
                     inputRef={this.handleInputRef}
                     onChange={listProps.handleQueryChange}
                     onFocus={this.handleInputFocus}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -141,7 +141,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
         const queryListMenuProps = {
             id: listboxId,
-            ...(restProps.menuProps ?? {}),
+            ...(restProps.hasOwnProperty("menuProps") ? restProps.menuProps : {}),
         };
 
         return (

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -214,12 +214,17 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                     autoComplete={autoComplete}
                     disabled={this.props.disabled}
                     {...inputProps}
+                    aria-autocomplete="list"
+                    aria-expanded={this.state.isOpen}
+                    aria-haspopup="listbox"
                     inputRef={this.handleInputRef}
                     onChange={listProps.handleQueryChange}
                     onFocus={this.handleInputFocus}
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTargetKeyUpHandler(handleKeyUp)}
                     placeholder={inputPlaceholder}
+                    role="combobox"
+                    type="text"
                     value={inputValue}
                 />
             </Popover2>

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -32,10 +32,10 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { Classes, SelectPopoverProps } from "../../common";
+import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
-export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+export interface Suggest2Props<T> extends QueryListProps<T>, SelectPopoverProps {
     /**
      * Whether the popover should close after selecting an item.
      *

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -69,6 +69,12 @@ export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps
     defaultSelectedItem?: T;
 
     /**
+     * Adds `id={listboxId}` to the list Menu and `aria-controls={listboxId}` to the
+     * combobox element that opens it
+     */
+    listboxId?: string;
+
+    /**
      * The currently selected item, or `null` to indicate that no item is selected.
      * If omitted or `undefined`, this prop will be uncontrolled (managed by the component's state).
      * Use `onItemSelect` to listen for updates.
@@ -131,10 +137,17 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { disabled, inputProps, popoverProps, ...restProps } = this.props;
+        const { disabled, inputProps, listboxId, popoverProps, ...restProps } = this.props;
+
+        const queryListMenuProps = {
+            id: listboxId,
+            ...restProps.menuProps,
+        };
+
         return (
             <this.TypedQueryList
                 {...restProps}
+                menuProps={queryListMenuProps}
                 initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}
@@ -169,7 +182,14 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { fill, inputProps = {}, popoverContentProps = {}, popoverProps = {}, popoverRef } = this.props;
+        const {
+            fill,
+            inputProps = {},
+            listboxId,
+            popoverContentProps = {},
+            popoverProps = {},
+            popoverRef,
+        } = this.props;
         const { isOpen, selectedItem } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
         const { autoComplete = "off", placeholder = "Search..." } = inputProps;
@@ -212,6 +232,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                 <InputGroup
                     autoComplete={autoComplete}
                     disabled={this.props.disabled}
+                    aria-controls={listboxId}
                     {...inputProps}
                     aria-autocomplete="list"
                     aria-expanded={this.state.isOpen}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -35,12 +35,7 @@ import { Popover2, PopupKind } from "@blueprintjs/popover2";
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
 
-export interface Suggest2Props<T>
-    extends IListItemsProps<T>,
-        Partial<
-            Omit<QueryListProps<T>, "items" | "onItemSelect" | "onQueryChange" | "ref" | "itemRenderer" | "renderer">
-        >,
-        SelectPopoverProps {
+export interface Suggest2Props<T> extends IListItemsProps<T>, Pick<QueryListProps<T>, "menuProps">, SelectPopoverProps {
     /**
      * Whether the popover should close after selecting an item.
      *

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -31,6 +31,7 @@ import {
     setRef,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
+import type { PopupKind } from "@blueprintjs/popover2/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -206,7 +207,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                 onOpened={this.handlePopoverOpened}
                 onOpening={this.handlePopoverOpening}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
-                popupKind="listbox"
+                popupKind={PopupKind.LISTBOX}
                 ref={popoverRef}
             >
                 <InputGroup

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -34,9 +34,9 @@ import {
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList, QueryListProps } from "../query-list/queryList";
+import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
-export interface Suggest2Props<T> extends IListItemsProps<T>, Pick<QueryListProps<T>, "menuProps">, SelectPopoverProps {
+export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
     /**
      * Whether the popover should close after selecting an item.
      *
@@ -136,15 +136,10 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
         // omit props specific to this component, spread the rest.
         const { disabled, inputProps, popoverProps, ...restProps } = this.props;
 
-        const queryListMenuProps = {
-            id: this.listboxId,
-            ...(restProps.menuProps ?? {}),
-        };
-
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={queryListMenuProps}
+                menuProps={{ id: this.listboxId }}
                 initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -30,6 +30,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
+import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
@@ -69,12 +70,6 @@ export interface Suggest2Props<T> extends IListItemsProps<T>, Pick<QueryListProp
     defaultSelectedItem?: T;
 
     /**
-     * Adds `id={listboxId}` to the list Menu and `aria-controls={listboxId}` to the
-     * combobox element that opens it
-     */
-    listboxId?: string;
-
-    /**
      * The currently selected item, or `null` to indicate that no item is selected.
      * If omitted or `undefined`, this prop will be uncontrolled (managed by the component's state).
      * Use `onItemSelect` to listen for updates.
@@ -109,6 +104,8 @@ export interface Suggest2State<T> {
 export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Suggest2State<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Suggest2`;
 
+    private listboxId = uniqueId("listbox");
+
     public static defaultProps: Partial<Suggest2Props<any>> = {
         closeOnSelect: true,
         fill: false,
@@ -137,10 +134,10 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { disabled, inputProps, listboxId, popoverProps, ...restProps } = this.props;
+        const { disabled, inputProps, popoverProps, ...restProps } = this.props;
 
         const queryListMenuProps = {
-            id: listboxId,
+            id: this.listboxId,
             ...(restProps.menuProps ?? {}),
         };
 
@@ -182,14 +179,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const {
-            fill,
-            inputProps = {},
-            listboxId,
-            popoverContentProps = {},
-            popoverProps = {},
-            popoverRef,
-        } = this.props;
+        const { fill, inputProps = {}, popoverContentProps = {}, popoverProps = {}, popoverRef } = this.props;
         const { isOpen, selectedItem } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
         const { autoComplete = "off", placeholder = "Search..." } = inputProps;
@@ -232,7 +222,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                 <InputGroup
                     autoComplete={autoComplete}
                     disabled={this.props.disabled}
-                    aria-controls={listboxId}
+                    aria-controls={this.listboxId}
                     {...inputProps}
                     aria-autocomplete="list"
                     aria-expanded={this.state.isOpen}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -31,7 +31,7 @@ import {
     setRef,
 } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
-import type { PopupKind } from "@blueprintjs/popover2/popupKind";
+import { PopupKind } from "@blueprintjs/popover2/popupKind";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -29,9 +29,8 @@ import {
     Position,
     refHandler,
     setRef,
+    uniqueId,
 } from "@blueprintjs/core";
-// tslint:disable-next-line:no-submodule-imports
-import { uniqueId } from "@blueprintjs/core/src/common/utils";
 import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -30,8 +30,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
-import { Popover2 } from "@blueprintjs/popover2";
-import { PopupKind } from "@blueprintjs/popover2/src/popupKind";
+import { Popover2, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -206,6 +206,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                 onOpened={this.handlePopoverOpened}
                 onOpening={this.handlePopoverOpening}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
+                popupKind="listbox"
                 ref={popoverRef}
             >
                 <InputGroup


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Apply `role="listbox"` for the `Menu` created by `QueryList`-- `Menu` has `role="menu"` by default, and `listbox` is more applicable here. Also apply `role="combobox"` to the item that creates the `listbox` popover

Trying to model after https://www.digitala11y.com/combobox-role/ for Select2 and MultiSelect2, https://www.w3.org/TR/2021/NOTE-wai-aria-practices-1.2-20211129/examples/combobox/combobox-autocomplete-list.html for Suggest2.

with `menuProps`, user can pass a custom `id` (or other props) to the `Menu` created within the Select/Multiselect popover.