### PR TITLE
[core] fix(MultiStepDialog): dark theme border styles

### DIFF
--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -105,6 +105,9 @@ $step-radius: $pt-border-radius * 2 !default;
 
   .#{$ns}-dark & {
     background: $dark-gray2;
+    border-bottom: 1px solid $pt-dark-divider-white;
+    border-bottom-left-radius: $dialog-border-radius;
+    border-left: 1px solid $pt-dark-divider-white;
   }
 }
 
@@ -117,7 +120,10 @@ $step-radius: $pt-border-radius * 2 !default;
 
   .#{$ns}-dark & {
     background-color: $dark-gray3;
-    border-left: 1px solid $pt-dark-divider-black;
+    border-bottom: 1px solid $pt-dark-divider-white;
+    border-bottom-right-radius: $dialog-border-radius;
+    border-left: 1px solid $pt-dark-divider-white;
+    border-right: 1px solid $pt-dark-divider-white;
   }
 }
 
@@ -131,7 +137,7 @@ $step-radius: $pt-border-radius * 2 !default;
 
   .#{$ns}-dark & {
     background: $dark-gray4;
-    border-top: 1px solid $pt-dark-divider-black;
+    border-top: 1px solid $pt-dark-divider-white;
   }
 
   .#{$ns}-dialog-footer-actions {
@@ -145,7 +151,7 @@ $step-radius: $pt-border-radius * 2 !default;
 
   .#{$ns}-dark & {
     background: $dark-gray3;
-    border-bottom: 1px solid $pt-dark-divider-black;
+    border-bottom: 1px solid $pt-dark-divider-white;
   }
 
   &.#{$ns}-dialog-step-viewed {


### PR DESCRIPTION
#### Fixes #5345

#### Changes proposed in this pull request:

Fix MultiStepDialog dark theme styles to use white borders.

#### Reviewers should focus on:

N/A

#### Screenshot

Before:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/723999/171661609-ff1e1b1f-b68f-441b-b010-db712840bf87.png">

After:

<img width="847" alt="Screen Shot 2022-06-03 at 11 07 53 AM" src="https://user-images.githubusercontent.com/723999/171881579-f0d6e77e-5b19-4bb8-ba24-c716d558d596.png">

