### PR TITLE
[select] fix: use renderTarget API to fix fill prop

### DIFF
--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -108,7 +108,9 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 
         const clearButton =
-            films.length > 0 ? <Button icon="cross" minimal={true} onClick={this.handleClear} /> : undefined;
+            films.length > 0 ? (
+                <Button disabled={flags.disabled} icon="cross" minimal={true} onClick={this.handleClear} />
+            ) : undefined;
 
         return (
             <Example options={this.renderOptions()} {...this.props}>

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -40,11 +40,13 @@ const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Int
 export interface IMultiSelectExampleState {
     allowCreate: boolean;
     createdItems: IFilm[];
+    disabled: boolean;
     fill: boolean;
     films: IFilm[];
     hasInitialContent: boolean;
     intent: boolean;
     items: IFilm[];
+    matchTargetWidth: boolean;
     openOnKeyDown: boolean;
     popoverMinimal: boolean;
     resetOnSelect: boolean;
@@ -55,11 +57,13 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
     public state: IMultiSelectExampleState = {
         allowCreate: false,
         createdItems: [],
+        disabled: false,
         fill: false,
         films: [],
         hasInitialContent: false,
         intent: false,
         items: filmSelectProps.items,
+        matchTargetWidth: false,
         openOnKeyDown: false,
         popoverMinimal: true,
         resetOnSelect: true,
@@ -70,22 +74,27 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
 
-    private handleKeyDownChange = this.handleSwitchChange("openOnKeyDown");
-
-    private handleResetChange = this.handleSwitchChange("resetOnSelect");
-
-    private handlePopoverMinimalChange = this.handleSwitchChange("popoverMinimal");
-
-    private handleTagMinimalChange = this.handleSwitchChange("tagMinimal");
+    private handleDisabledChange = this.handleSwitchChange("disabled");
 
     private handleFillChange = this.handleSwitchChange("fill");
 
-    private handleIntentChange = this.handleSwitchChange("intent");
-
     private handleInitialContentChange = this.handleSwitchChange("hasInitialContent");
 
+    private handleIntentChange = this.handleSwitchChange("intent");
+
+    private handleKeyDownChange = this.handleSwitchChange("openOnKeyDown");
+
+    private handleMatchTargetWidthChange = this.handleSwitchChange("matchTargetWidth");
+
+    private handlePopoverMinimalChange = this.handleSwitchChange("popoverMinimal");
+
+    private handleResetChange = this.handleSwitchChange("resetOnSelect");
+
+    private handleTagMinimalChange = this.handleSwitchChange("tagMinimal");
+
     public render() {
-        const { allowCreate, films, hasInitialContent, tagMinimal, popoverMinimal, ...flags } = this.state;
+        const { allowCreate, films, hasInitialContent, tagMinimal, popoverMinimal, matchTargetWidth, ...flags } =
+            this.state;
         const getTagProps = (_value: React.ReactNode, index: number): TagProps => ({
             intent: this.state.intent ? INTENTS[index % INTENTS.length] : Intent.NONE,
             minimal: tagMinimal,
@@ -117,7 +126,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     noResults={<MenuItem disabled={true} text="No results." />}
                     onItemSelect={this.handleFilmSelect}
                     onItemsPaste={this.handleFilmsPaste}
-                    popoverProps={{ minimal: popoverMinimal }}
+                    popoverProps={{ matchTargetWidth, minimal: popoverMinimal }}
                     popoverRef={this.popoverRef}
                     tagRenderer={this.renderTag}
                     tagInputProps={{
@@ -155,6 +164,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     checked={this.state.allowCreate}
                     onChange={this.handleAllowCreateChange}
                 />
+                <H5>Appearance props</H5>
+                <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
                 <H5>Tag props</H5>
                 <Switch
@@ -168,6 +179,11 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     onChange={this.handleIntentChange}
                 />
                 <H5>Popover props</H5>
+                <Switch
+                    label="Match target width"
+                    checked={this.state.matchTargetWidth}
+                    onChange={this.handleMatchTargetWidthChange}
+                />
                 <Switch
                     label="Minimal popover style"
                     checked={this.state.popoverMinimal}

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -26,16 +26,16 @@ export interface ISelectExampleState {
     allowCreate: boolean;
     createFirst: boolean;
     createdItems: IFilm[];
+    disableItems: boolean;
+    disabled: boolean;
     fill: boolean;
     filterable: boolean;
     hasInitialContent: boolean;
+    matchTargetWidth: boolean;
     minimal: boolean;
     resetOnClose: boolean;
     resetOnQuery: boolean;
     resetOnSelect: boolean;
-    disableItems: boolean;
-    disabled: boolean;
-    matchTargetWidth: false;
 }
 
 /** Technically a Select2 example, since FilmSelect uses Select2. */
@@ -70,6 +70,8 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
 
     private handleItemDisabledChange = this.handleSwitchChange("disableItems");
 
+    private handleMatchTargetWidthChange = this.handleSwitchChange("matchTargetWidth");
+
     private handleMinimalChange = this.handleSwitchChange("minimal");
 
     private handleResetOnCloseChange = this.handleSwitchChange("resetOnClose");
@@ -78,10 +80,8 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
 
     private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
 
-    private handleMatchTargetWidthChange = this.handleSwitchChange("matchTargetWidth");
-
     public render() {
-        const { allowCreate, disabled, disableItems, minimal, ...flags } = this.state;
+        const { allowCreate, disabled, disableItems, matchTargetWidth, minimal, ...flags } = this.state;
 
         const initialContent = this.state.hasInitialContent ? (
             <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} />
@@ -96,7 +96,7 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     disabled={disabled}
                     itemDisabled={this.isItemDisabled}
                     initialContent={initialContent}
-                    popoverProps={{ minimal }}
+                    popoverProps={{ matchTargetWidth, minimal }}
                 />
             </Example>
         );
@@ -106,7 +106,6 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
         return (
             <>
                 <H5>Props</H5>
-                <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Filterable" checked={this.state.filterable} onChange={this.handleFilterableChange} />
                 <Switch
                     label="Reset on close"
@@ -123,7 +122,6 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     checked={this.state.resetOnSelect}
                     onChange={this.handleResetOnSelectChange}
                 />
-                <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
                 <Switch
                     label="Use initial content"
                     checked={this.state.hasInitialContent}
@@ -133,11 +131,6 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     label="Disable films before 2000"
                     checked={this.state.disableItems}
                     onChange={this.handleItemDisabledChange}
-                />
-                <Switch
-                    label="Match target width"
-                    checked={this.state.matchTargetWidth}
-                    onChange={this.handleMatchTargetWidthChange}
                 />
                 <Switch
                     label="Allow creating new items"
@@ -150,7 +143,15 @@ export class SelectExample extends React.PureComponent<IExampleProps, ISelectExa
                     checked={this.state.createFirst}
                     onChange={this.handleCreateFirstChange}
                 />
+                <H5>Appearance props</H5>
+                <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
+                <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
                 <H5>Popover props</H5>
+                <Switch
+                    label="Match target width"
+                    checked={this.state.matchTargetWidth}
+                    onChange={this.handleMatchTargetWidthChange}
+                />
                 <Switch
                     label="Minimal popover style"
                     checked={this.state.minimal}

--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -41,7 +41,7 @@ export interface ISuggestExampleState {
     fill: boolean;
     film: IFilm;
     items: IFilm[];
-    matchTargetWidth: false;
+    matchTargetWidth: boolean;
     minimal: boolean;
     openOnKeyDown: boolean;
     resetOnClose: boolean;

--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -37,9 +37,11 @@ export interface ISuggestExampleState {
     allowCreate: boolean;
     closeOnSelect: boolean;
     createdItems: IFilm[];
+    disabled: boolean;
     fill: boolean;
     film: IFilm;
     items: IFilm[];
+    matchTargetWidth: false;
     minimal: boolean;
     openOnKeyDown: boolean;
     resetOnClose: boolean;
@@ -52,9 +54,11 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
         allowCreate: false,
         closeOnSelect: true,
         createdItems: [],
+        disabled: false,
         fill: false,
         film: TOP_100_FILMS[0],
         items: filmSelectProps.items,
+        matchTargetWidth: false,
         minimal: true,
         openOnKeyDown: false,
         resetOnClose: false,
@@ -66,11 +70,15 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
 
     private handleCloseOnSelectChange = this.handleSwitchChange("closeOnSelect");
 
-    private handleOpenOnKeyDownChange = this.handleSwitchChange("openOnKeyDown");
+    private handleDisabledChange = this.handleSwitchChange("disabled");
+
+    private handleFillChange = this.handleSwitchChange("fill");
+
+    private handleMatchTargetWidthChange = this.handleSwitchChange("matchTargetWidth");
 
     private handleMinimalChange = this.handleSwitchChange("minimal");
 
-    private handleFillChange = this.handleSwitchChange("fill");
+    private handleOpenOnKeyDownChange = this.handleSwitchChange("openOnKeyDown");
 
     private handleResetOnCloseChange = this.handleSwitchChange("resetOnClose");
 
@@ -79,7 +87,7 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
     private handleResetOnSelectChange = this.handleSwitchChange("resetOnSelect");
 
     public render() {
-        const { allowCreate, film, minimal, ...flags } = this.state;
+        const { allowCreate, film, matchTargetWidth, minimal, ...flags } = this.state;
 
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
@@ -98,7 +106,7 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
                     items={this.state.items}
                     noResults={<MenuItem disabled={true} text="No results." />}
                     onItemSelect={this.handleValueChange}
-                    popoverProps={{ minimal }}
+                    popoverProps={{ matchTargetWidth, minimal }}
                 />
             </Example>
         );
@@ -138,8 +146,15 @@ export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestE
                     checked={this.state.allowCreate}
                     onChange={this.handleAllowCreateChange}
                 />
+                <H5>Appearance props</H5>
+                <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
                 <H5>Popover props</H5>
+                <Switch
+                    label="Match target width"
+                    checked={this.state.matchTargetWidth}
+                    onChange={this.handleMatchTargetWidthChange}
+                />
                 <Switch
                     label="Minimal popover style"
                     checked={this.state.minimal}

--- a/packages/popover2/src/_popover2.scss
+++ b/packages/popover2/src/_popover2.scss
@@ -51,9 +51,10 @@ $dark-popover2-arrow-box-shadow:
   }
 
   &.#{$ns}-minimal {
-    // popover2s with no obvious trigger will never have margin because the arrow
-    // is hidden so it is safe to remove in all cases always
-    margin: 0 !important; /* stylelint-disable-line declaration-no-important */
+    // Popover2 with no obvious trigger will never have margin because the arrow is hidden,
+    // so it is safe to remove. However, we give a 0.5px top margin to create a gap from
+    // the target to allow input focus borders to show.
+    margin: 0.5px 0 0 !important; /* stylelint-disable-line declaration-no-important */
 
     .#{$ns}-popover2-arrow {
       display: none;
@@ -130,4 +131,10 @@ span.#{$ns}-popover2-target {
 
   // this is important for span tag as default inline display height only includes text.
   // div tag can be used for display: block, which works fine.
+}
+
+.#{$ns}-popover2-target {
+  &.#{$ns}-fill {
+    width: 100%;
+  }
 }

--- a/packages/popover2/src/_popover2.scss
+++ b/packages/popover2/src/_popover2.scss
@@ -52,9 +52,8 @@ $dark-popover2-arrow-box-shadow:
 
   &.#{$ns}-minimal {
     // Popover2 with no obvious trigger will never have margin because the arrow is hidden,
-    // so it is safe to remove. However, we give a 0.5px top margin to create a gap from
-    // the target to allow input focus borders to show.
-    margin: 0.5px 0 0 !important; /* stylelint-disable-line declaration-no-important */
+    // so it is safe to remove.
+    margin: 0 !important; /* stylelint-disable-line declaration-no-important */
 
     .#{$ns}-popover2-arrow {
       display: none;

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -30,6 +30,7 @@ export type Popover2TargetProps = IPopover2TargetProps;
  * @deprecated use Popover2TargetProps
  */
 export interface IPopover2TargetProps {
+    /** Target ref. */
     ref: React.Ref<any>;
 
     /** Whether the popover or tooltip is currently open. */

--- a/packages/select/src/components/multi-select/_multi-select.scss
+++ b/packages/select/src/components/multi-select/_multi-select.scss
@@ -13,4 +13,13 @@
     max-width: $select-popover-max-width;
     overflow: auto;
   }
+
+  &.#{$ns}-popover2-match-target-width {
+    width: 100%;
+
+    .#{$ns}-menu {
+      max-width: none;
+      min-width: 0;
+    }
+  }
 }

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -181,9 +181,10 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     // the "fill" prop
     private getPopoverTargetRenderer =
         (listProps: IQueryListRendererProps<T>) =>
-        // N.B. pull out `isOpen` so that it's not forwarded to the DOM
+        // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
+        // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
-        ({ isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+        ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
             const { fill, tagInputProps = {}, selectedItems = [], placeholder } = this.props;
             const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -209,7 +209,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     className={classNames(targetProps.className, {
                         [CoreClasses.FILL]: fill,
                     })}
-                    // Normally, Popover2 would also need to attach its own `onKeyDown` handler,
+                    // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.
                     onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -37,6 +37,14 @@ import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
     /**
+     * Whether the component is non-interactive.
+     * If true, the list's item renderer will not be called.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
      * Whether the component should take up the full width of its container.
      * This overrides `popoverProps.fill` and `tagInputProps.fill`.
      */
@@ -76,9 +84,14 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     /** Controlled selected values. */
     selectedItems?: T[];
 
-    /** Props to spread to `TagInput`. Use `query` and `onQueryChange` to control the input. */
+    /**
+     * Props to spread to `TagInput`.
+     * If you wish to control the value of the input, use `query` and `onQueryChange` instead.
+     * Note that you are responsible for disabling any elements you may render in `tagInputProps.rightElement`
+     * when the overall `MultiSelect2` is disabled.
+     */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    tagInputProps?: Partial<TagInputProps> & object;
+    tagInputProps?: Partial<TagInputProps>;
 
     /** Custom renderer to transform an item into tag content. */
     tagRenderer: (item: T) => React.ReactNode;
@@ -92,6 +105,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSelect2`;
 
     public static defaultProps = {
+        disabled: false,
         fill: false,
         placeholder: "Search...",
     };
@@ -144,7 +158,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     }
 
     private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
-        const { popoverContentProps = {}, popoverProps = {} } = this.props;
+        const { disabled, popoverContentProps = {}, popoverProps = {} } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
 
         const popoverRef =
@@ -157,6 +171,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
             <Popover2
                 autoFocus={false}
                 canEscapeKeyClose={true}
+                disabled={disabled}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
                 placement={popoverProps.position || popoverProps.placement ? undefined : "bottom-start"}
@@ -185,9 +200,12 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
         ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
-            const { fill, tagInputProps = {}, selectedItems = [], placeholder } = this.props;
+            const { disabled, fill, tagInputProps = {}, selectedItems = [], placeholder } = this.props;
             const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 
+            if (disabled) {
+                tagInputProps.disabled = true;
+            }
             if (fill) {
                 tagInputProps.fill = true;
             }

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -197,15 +197,16 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 popoverClassName={classNames(Classes.MULTISELECT_POPOVER, popoverProps.popoverClassName)}
                 popupKind={PopupKind.LISTBOX}
                 ref={popoverRef}
-                renderTarget={this.getPopoverTargetRenderer(listProps)}
+                renderTarget={this.getPopoverTargetRenderer(listProps, this.state.isOpen)}
             />
         );
     };
 
-    // we use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
-    // the "fill" prop
+    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
+    // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
+    // again after that state changes.
     private getPopoverTargetRenderer =
-        (listProps: IQueryListRendererProps<T>) =>
+        (listProps: IQueryListRendererProps<T>, isOpen: boolean) =>
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
@@ -243,7 +244,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     aria-controls={this.listboxId}
                     {...popoverTargetProps}
                     {...targetProps}
-                    aria-expanded={this.state.isOpen}
+                    aria-expanded={isOpen}
                     // Note that we must set FILL here in addition to TagInput to get the wrapper element to full width
                     className={classNames(targetProps.className, popoverTargetProps.className, {
                         [CoreClasses.FILL]: fill,

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -4,15 +4,6 @@
 @import "../../common/variables";
 
 .#{$ns}-select-popover {
-  &.#{$ns}-select-match-target-width {
-    width: 100%;
-
-    .#{$ns}-menu {
-      max-width: none;
-      min-width: 0;
-    }
-  }
-
   .#{$ns}-popover-content,
   .#{$ns}-popover2-content {
     // use padding on container rather than margin on input group
@@ -33,6 +24,15 @@
     &:not(:first-child) {
       // adjust padding to account for that on .#{$ns}-popover-content above
       padding-top: $pt-grid-size * 0.5;
+    }
+  }
+
+  &.#{$ns}-popover2-match-target-width {
+    width: 100%;
+
+    .#{$ns}-menu {
+      max-width: none;
+      min-width: 0;
     }
   }
 }

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -190,9 +190,10 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
     // the "fill" prop
     private getPopoverTargetRenderer =
         (listProps: IQueryListRendererProps<T>) =>
-        // N.B. pull out `isOpen` so that it's not forwarded to the DOM
+        // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
+        // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
-        ({ isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+        ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
             const { handleKeyDown, handleKeyUp } = listProps;
             return (
                 <div

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -195,15 +195,16 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 popupKind={PopupKind.LISTBOX}
                 ref={popoverRef}
-                renderTarget={this.getPopoverTargetRenderer(listProps)}
+                renderTarget={this.getPopoverTargetRenderer(listProps, this.state.isOpen)}
             />
         );
     };
 
-    // we use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
-    // the "fill" prop
+    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
+    // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
+    // again after that state changes.
     private getPopoverTargetRenderer =
-        (listProps: IQueryListRendererProps<T>) =>
+        (listProps: IQueryListRendererProps<T>, isOpen: boolean) =>
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
@@ -215,7 +216,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                     aria-controls={this.listboxId}
                     {...popoverTargetProps}
                     {...targetProps}
-                    aria-expanded={this.state.isOpen}
+                    aria-expanded={isOpen}
                     // Note that we must set FILL here in addition to children to get the wrapper element to full width
                     className={classNames(targetProps.className, {
                         [CoreClasses.FILL]: this.props.fill,
@@ -223,8 +224,8 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.
-                    onKeyDown={this.state.isOpen ? handleKeyDown : this.handleTargetKeyDown}
-                    onKeyUp={this.state.isOpen ? handleKeyUp : undefined}
+                    onKeyDown={isOpen ? handleKeyDown : this.handleTargetKeyDown}
+                    onKeyUp={isOpen ? handleKeyUp : undefined}
                     ref={ref}
                     role="combobox"
                 >

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -38,7 +38,20 @@ import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+    /**
+     * Element which triggers the select popover. In most cases, you should display
+     * the name or label of the curently selected item here.
+     */
     children?: React.ReactNode;
+
+    /**
+     * Whether the component is non-interactive.
+     * If true, the list's item renderer will not be called.
+     * Note that you'll also need to disable the component's children, if appropriate.
+     *
+     * @default false
+     */
+    disabled?: boolean;
 
     /**
      * Whether the component should take up the full width of its container.
@@ -54,15 +67,6 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
      * @default true
      */
     filterable?: boolean;
-
-    /**
-     * Whether the component is non-interactive.
-     * If true, the list's item renderer will not be called.
-     * Note that you'll also need to disable the component's children, if appropriate.
-     *
-     * @default false
-     */
-    disabled?: boolean;
 
     /**
      * Props to spread to the query `InputGroup`. Use `query` and

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -230,7 +230,6 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
             // value shows query when open, and query remains when closed if nothing is selected.
             // if resetOnClose is enabled, then hide query when not open. (see handlePopoverOpening)
             const inputValue = isOpen ? listProps.query : selectedItemText ?? (resetOnClose ? "" : listProps.query);
-            console.info(`rendering InputGroup, isOpen: ${isOpen}, selectedItemText: ${selectedItemText}`);
 
             return (
                 <InputGroup
@@ -318,7 +317,6 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
             if (this.inputElement != null && !isInputFocused) {
                 // the input is no longer focused, we should close the popover
-                console.info("handlePopoverInteraction next frame");
                 this.setState({ isOpen: false });
             }
             this.props.popoverProps?.onInteraction?.(nextOpenState, event);

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -207,7 +207,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
     // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
-    // again after that state changes (it will produce a new renderTarget function).
+    // again after that state changes.
     private getPopoverTargetRenderer =
         (listProps: IQueryListRendererProps<T>, isOpen: boolean) =>
         // eslint-disable-next-line react/display-name

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -248,7 +248,6 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
                     onKeyUp={this.getTargetKeyUpHandler(handleKeyUp)}
                     placeholder={inputPlaceholder}
                     role="combobox"
-                    type="text"
                     value={inputValue}
                 />
             );

--- a/packages/select/test/suggest2Tests.tsx
+++ b/packages/select/test/suggest2Tests.tsx
@@ -202,12 +202,12 @@ describe("Suggest2", () => {
             const ITEM_INDEX = 4;
             const wrapper = suggest();
 
-            assert.isFalse(handlers.inputValueRenderer.called, "should not call inputValueRenderer before selection");
+            assert.isFalse(handlers.inputValueRenderer.called, "should not call inputValueRenderer before selection");
             selectItem(wrapper, ITEM_INDEX);
             const selectedItem = TOP_100_FILMS[ITEM_INDEX];
             const expectedValue = inputValueRenderer(selectedItem);
 
-            assert.isTrue(handlers.inputValueRenderer.called, "should call inputValueRenderer after selection");
+            assert.isTrue(handlers.inputValueRenderer.called, "should call inputValueRenderer after selection");
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), expectedValue);
         });
     });


### PR DESCRIPTION
#### Fixes #5353

#### Checklist

- [x] Includes tests - covered by existing test suite
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Select2, Suggest2, MultiSelect2:
- Fix `fill` prop, which did not work and was a regression from the V1 components
- This was done by migrating to the Popover2 `renderTarget` API, and has the added benefit of collapsing the DOM rendered by the components
  - :warning: This is a slightly breaking change, but we don't expect any real consumers using these component in production yet, so it's ok
- Also improved the docs examples for these components so that they clearly demonstrate `disabled`, `fill`, `matchTargetWidth` props

Select2, MultiSelect2:
- Fix `matchTargetWidth` styling so that the width of the popup menu is no longer constrained

MultiSelect2:
- Add support for `disabled?: boolean` prop

#### Reviewers should focus on:

No regressions, passing test suite

#### Screenshot

![2022-06-03 15 40 51](https://user-images.githubusercontent.com/723999/171938863-1a18e0e5-3708-4d7c-b191-add0da08ba85.gif)

<img width="521" alt="Screen Shot 2022-06-03 at 4 13 54 PM" src="https://user-images.githubusercontent.com/723999/171948195-c41e9482-be1a-48fb-b305-11fee160748b.png">

