### PR TITLE
[core] fix(OverflowList): improve performance, allow more items

### DIFF
--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { ResizeObserverEntry } from "@juggle/resize-observer";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -24,13 +23,6 @@ import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { shallowCompareKeys } from "../../common/utils";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
-
-/** @internal - do not expose this type */
-export enum OverflowDirection {
-    NONE,
-    GROW,
-    SHRINK,
-}
 
 // eslint-disable-next-line deprecation/deprecation
 export type OverflowListProps<T> = IOverflowListProps<T>;
@@ -116,16 +108,15 @@ export interface IOverflowListProps<T> extends Props {
 }
 
 export interface IOverflowListState<T> {
-    /**
-     * Direction of current overflow operation. An overflow can take several frames to settle.
-     *
-     * @internal don't expose the type
-     */
-    direction: OverflowDirection;
+    /** Whether repartitioning is still active. An overflow can take several frames to settle. */
+    repartitioning: boolean;
     /** Length of last overflow to dedupe `onOverflow` calls during smooth resizing. */
     lastOverflowCount: number;
     overflow: readonly T[];
     visible: readonly T[];
+    /** Pointer for the binary search algorithm used to find the finished non-overflowing state */
+    chopSize: number;
+    lastChopSize: number | null;
 }
 
 export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOverflowListState<T>> {
@@ -142,19 +133,18 @@ export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOver
     }
 
     public state: IOverflowListState<T> = {
-        direction: OverflowDirection.NONE,
+        chopSize: this.defaultChopSize(),
+        lastChopSize: null,
         lastOverflowCount: 0,
         overflow: [],
+        repartitioning: false,
         visible: this.props.items,
     };
-
-    /** A cache containing the widths of all elements being observed to detect growing/shrinking */
-    private previousWidths = new Map<Element, number>();
 
     private spacer: HTMLElement | null = null;
 
     public componentDidMount() {
-        this.repartition(false);
+        this.repartition();
     }
 
     public shouldComponentUpdate(_nextProps: OverflowListProps<T>, nextState: IOverflowListState<T>) {
@@ -181,24 +171,28 @@ export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOver
         ) {
             // reset visible state if the above props change.
             this.setState({
-                direction: OverflowDirection.GROW,
+                chopSize: this.defaultChopSize(),
+                lastChopSize: null,
                 lastOverflowCount: 0,
                 overflow: [],
+                repartitioning: true,
                 visible: this.props.items,
             });
         }
 
-        if (!shallowCompareKeys(prevState, this.state)) {
-            this.repartition(false);
-        }
-        const { direction, overflow, lastOverflowCount } = this.state;
+        const { repartitioning, overflow, lastOverflowCount } = this.state;
+
         if (
-            // if a resize operation has just completed (transition to NONE)
-            direction === OverflowDirection.NONE &&
-            direction !== prevState.direction &&
-            overflow.length !== lastOverflowCount
+            // if a resize operation has just completed
+            repartitioning === false &&
+            prevState.repartitioning === true
         ) {
-            this.props.onOverflow?.(overflow.slice());
+            // only invoke the callback if the UI has actually changed
+            if (overflow.length !== lastOverflowCount) {
+                this.props.onOverflow?.(overflow.slice());
+            }
+        } else if (!shallowCompareKeys(prevState, this.state)) {
+            this.repartition();
         }
     }
 
@@ -232,54 +226,97 @@ export class OverflowList<T> extends React.Component<OverflowListProps<T>, IOver
         return this.props.overflowRenderer(overflow.slice());
     }
 
-    private resize = (entries: readonly ResizeObserverEntry[]) => {
-        // if any parent is growing, assume we have more room than before
-        const growing = entries.some(entry => {
-            const previousWidth = this.previousWidths.get(entry.target) || 0;
-            return entry.contentRect.width > previousWidth;
-        });
-        this.repartition(growing);
-        entries.forEach(entry => this.previousWidths.set(entry.target, entry.contentRect.width));
+    private resize = () => {
+        this.repartition();
     };
 
-    private repartition(growing: boolean) {
+    private repartition() {
         if (this.spacer == null) {
             return;
         }
-        if (growing) {
-            this.setState(state => ({
-                direction: OverflowDirection.GROW,
-                // store last overflow if this is the beginning of a resize (for check in componentDidUpdate).
-                lastOverflowCount:
-                    state.direction === OverflowDirection.NONE ? state.overflow.length : state.lastOverflowCount,
-                overflow: [],
-                visible: this.props.items,
-            }));
-        } else if (this.spacer.offsetWidth < 0.9) {
-            // spacer has flex-shrink and width 1px so if it's much smaller then we know to shrink
+
+        // if lastChopSize was 1, then our binary search has exhausted.
+        const partitionExhausted = this.state.lastChopSize === 1;
+        const minVisible = this.props.minVisibleItems ?? 0;
+
+        // spacer has flex-shrink and width 1px so if it's much smaller then we know to shrink
+        const shouldShrink = this.spacer.offsetWidth < 0.9 && this.state.visible.length > minVisible;
+
+        // we only check partitionExhausted for shouldGrow to ensure shrinking is the final operation.
+        const shouldGrow =
+            (this.spacer.offsetWidth >= 1 || this.state.visible.length < minVisible) &&
+            this.state.overflow.length > 0 &&
+            !partitionExhausted;
+
+        if (shouldShrink || shouldGrow) {
             this.setState(state => {
-                if (state.visible.length <= this.props.minVisibleItems!) {
-                    return null;
+                let visible;
+                let overflow;
+                if (this.props.collapseFrom === Boundary.END) {
+                    const result = shiftElements(
+                        state.visible,
+                        state.overflow,
+                        this.state.chopSize * (shouldShrink ? 1 : -1),
+                    );
+                    visible = result[0];
+                    overflow = result[1];
+                } else {
+                    const result = shiftElements(
+                        state.overflow,
+                        state.visible,
+                        this.state.chopSize * (shouldShrink ? -1 : 1),
+                    );
+                    overflow = result[0];
+                    visible = result[1];
                 }
-                const collapseFromStart = this.props.collapseFrom === Boundary.START;
-                const visible = state.visible.slice();
-                const next = collapseFromStart ? visible.shift() : visible.pop();
-                if (next === undefined) {
-                    return null;
-                }
-                const overflow = collapseFromStart ? [...state.overflow, next] : [next, ...state.overflow];
+
                 return {
-                    // set SHRINK mode unless a GROW is already in progress.
-                    // GROW shows all items then shrinks until it settles, so we
-                    // preserve the fact that the original trigger was a GROW.
-                    direction: state.direction === OverflowDirection.NONE ? OverflowDirection.SHRINK : state.direction,
+                    chopSize: halve(state.chopSize),
+                    lastChopSize: state.chopSize,
+                    // if we're starting a new partition cycle, record the last overflow count so we can track whether the UI changes after the new overflow is calculated
+                    lastOverflowCount: this.isFirstPartitionCycle(state.chopSize)
+                        ? state.overflow.length
+                        : state.lastOverflowCount,
                     overflow,
+                    repartitioning: true,
                     visible,
                 };
             });
         } else {
             // repartition complete!
-            this.setState({ direction: OverflowDirection.NONE });
+            this.setState({
+                chopSize: this.defaultChopSize(),
+                lastChopSize: null,
+                repartitioning: false,
+            });
         }
     }
+
+    private defaultChopSize(): number {
+        return halve(this.props.items.length);
+    }
+
+    private isFirstPartitionCycle(currentChopSize: number): boolean {
+        return currentChopSize === this.defaultChopSize();
+    }
+}
+
+function halve(num: number): number {
+    return Math.ceil(num / 2);
+}
+
+function shiftElements<T>(leftArray: readonly T[], rightArray: readonly T[], num: number): [newFrom: T[], newTo: T[]] {
+    // if num is positive then elements are shifted from left-to-right, if negative then right-to-left
+    const allElements = leftArray.concat(rightArray);
+    const newLeftLength = leftArray.length - num;
+
+    if (newLeftLength <= 0) {
+        return [[], allElements];
+    } else if (newLeftLength >= allElements.length) {
+        return [allElements, []];
+    }
+
+    const sliceIndex = allElements.length - newLeftLength;
+
+    return [allElements.slice(0, -sliceIndex), allElements.slice(-sliceIndex)];
 }

--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -33,7 +33,7 @@ const ITEMS: ITestItem[] = IDS.map(id => ({ id }));
 const TestItem: React.FC<ITestItem> = () => <div style={{ width: 10, flex: "0 0 auto" }} />;
 const TestOverflow: React.FC<{ items: ITestItem[] }> = () => <div />;
 
-describe.skip("<OverflowList>", function (this) {
+describe("<OverflowList>", function (this) {
     // these tests rely on DOM measurement which can be flaky, so we allow some retries
     this.retries(3);
 
@@ -64,6 +64,10 @@ describe.skip("<OverflowList>", function (this) {
 
     it("overflows correctly on initial mount", () => {
         overflowList().assertVisibleItemSplit(4);
+    });
+
+    it("overflows correctly on initial mount with large number of items", () => {
+        overflowList(45, { items: new Array(10000).fill(0).map((_, i) => ({ id: i })) }).assertVisibleItemSplit(4);
     });
 
     it("shows more after growing", async () => {
@@ -221,9 +225,10 @@ describe.skip("<OverflowList>", function (this) {
          * overflow IDs assuming `collapseFrom="start"`.
          */
         wrapper.assertVisibleItemSplit = (visibleCount: number) => {
+            const ids = (props.items ?? ITEMS).map(it => it.id);
             return wrapper
-                .assertOverflowItems(...IDS.slice(0, -visibleCount))
-                .assertVisibleItems(...IDS.slice(-visibleCount));
+                .assertOverflowItems(...ids.slice(0, -visibleCount))
+                .assertVisibleItems(...ids.slice(-visibleCount));
         };
 
         /** Assert ordered IDs of overflow items. */


### PR DESCRIPTION
Use binary search instead of sequential search in the OverflowList repartition cycle to increase collapsible elements from 50 to 2^50.

#### Fixes #3792

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This pull request changes the algorithm used to repartition the OverflowList so that it can support a much higher number of items. The previous overflow list would break if there were 50 or more items collapsed into the Overflow element as described in issue #3792.

#### Reviewers should focus on:

The new OverflowList partitioning logic. 
