### PR TITLE
allow for additional props on nonIdealState

### DIFF
--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2 } from "../../common";
+import { AbstractPureComponent2, removeNonHTMLProps } from "../../common";
 import * as Classes from "../../common/classes";
 import { DISPLAYNAME_PREFIX, MaybeElement, Props } from "../../common/props";
 import { ensureElement } from "../../common/utils";
@@ -79,10 +79,15 @@ export class NonIdealState extends AbstractPureComponent2<NonIdealStateProps> {
     };
 
     public render() {
-        const { action, children, className, layout } = this.props;
+        const { action, children, className, layout, ...restProps } = this.props;
+
+        const htmlProps = removeNonHTMLProps(restProps);
 
         return (
-            <div className={classNames(Classes.NON_IDEAL_STATE, `${Classes.NON_IDEAL_STATE}-${layout}`, className)}>
+            <div
+                {...htmlProps}
+                className={classNames(Classes.NON_IDEAL_STATE, `${Classes.NON_IDEAL_STATE}-${layout}`, className)}
+            >
                 {this.maybeRenderVisual()}
                 {this.maybeRenderText()}
                 {action}

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -33,7 +33,7 @@ export enum NonIdealStateIconSize {
 // eslint-disable-next-line deprecation/deprecation
 export type NonIdealStateProps = INonIdealStateProps;
 /** @deprecated use NonIdealStateProps */
-export interface INonIdealStateProps extends Props {
+export interface INonIdealStateProps extends Props, Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
     /** An action to resolve the non-ideal state which appears after `description`. */
     action?: JSX.Element;
 

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -126,6 +126,7 @@ export class NonIdealStateExample extends React.PureComponent<IExampleProps, INo
                     description={this.state.showDescription ? description : undefined}
                     action={this.state.showAction ? action : undefined}
                     layout={this.state.layout}
+                    role="alert"
                 />
             </Example>
         );


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Allow additional html props to be passed to nonIdealState. Allows user to set `role`, or other props.

