### PR TITLE
[select] feat(MultiSelect2): 'onClear' prop renders clear button

### DIFF
--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -16,9 +16,9 @@
 
 import * as React from "react";
 
-import { Button, H5, Intent, MenuItem, Switch, TagProps } from "@blueprintjs/core";
+import { Code, H5, Intent, MenuItem, Switch, TagProps } from "@blueprintjs/core";
 import { Example, IExampleProps } from "@blueprintjs/docs-theme";
-import { Popover2 } from "@blueprintjs/popover2";
+import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 import { ItemRenderer, MultiSelect2 } from "@blueprintjs/select";
 
 import {
@@ -50,6 +50,7 @@ export interface IMultiSelectExampleState {
     openOnKeyDown: boolean;
     popoverMinimal: boolean;
     resetOnSelect: boolean;
+    showClearButton: boolean;
     tagMinimal: boolean;
 }
 
@@ -67,6 +68,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         openOnKeyDown: false,
         popoverMinimal: true,
         resetOnSelect: true,
+        showClearButton: true,
         tagMinimal: false,
     };
 
@@ -90,6 +92,8 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
 
     private handleResetChange = this.handleSwitchChange("resetOnSelect");
 
+    private handleShowClearButtonChange = this.handleSwitchChange("showClearButton");
+
     private handleTagMinimalChange = this.handleSwitchChange("tagMinimal");
 
     public render() {
@@ -107,11 +111,6 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
         const maybeCreateNewItemFromQuery = allowCreate ? createFilm : undefined;
         const maybeCreateNewItemRenderer = allowCreate ? renderCreateFilmOption : null;
 
-        const clearButton =
-            films.length > 0 ? (
-                <Button disabled={flags.disabled} icon="cross" minimal={true} onClick={this.handleClear} />
-            ) : undefined;
-
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <FilmMultiSelect
@@ -126,6 +125,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     // adding newly created items to the list, so pass our own
                     items={this.state.items}
                     noResults={<MenuItem disabled={true} text="No results." />}
+                    onClear={this.state.showClearButton ? this.handleClear : undefined}
                     onItemSelect={this.handleFilmSelect}
                     onItemsPaste={this.handleFilmsPaste}
                     popoverProps={{ matchTargetWidth, minimal: popoverMinimal }}
@@ -133,7 +133,6 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     tagRenderer={this.renderTag}
                     tagInputProps={{
                         onRemove: this.handleTagRemove,
-                        rightElement: clearButton,
                         tagProps: getTagProps,
                     }}
                     selectedItems={this.state.films}
@@ -161,14 +160,42 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     checked={this.state.hasInitialContent}
                     onChange={this.handleInitialContentChange}
                 />
-                <Switch
-                    label="Allow creating new films"
-                    checked={this.state.allowCreate}
-                    onChange={this.handleAllowCreateChange}
-                />
+                <Tooltip2
+                    content={
+                        <>
+                            <Code>createNewItemFromQuery</Code> and <Code>createNewItemRenderer</Code> are{" "}
+                            {this.state.allowCreate ? "defined" : "undefined"}
+                        </>
+                    }
+                    placement="left"
+                >
+                    <Switch
+                        label="Allow creating new films"
+                        checked={this.state.allowCreate}
+                        onChange={this.handleAllowCreateChange}
+                    />
+                </Tooltip2>
+                <Tooltip2
+                    content={
+                        <>
+                            <Code>onClear</Code> is {this.state.showClearButton ? "defined" : "undefined"}
+                        </>
+                    }
+                    placement="left"
+                >
+                    <Switch
+                        label="Show clear button"
+                        checked={this.state.showClearButton}
+                        onChange={this.handleShowClearButtonChange}
+                    />
+                </Tooltip2>
                 <H5>Appearance props</H5>
-                <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
-                <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
+                <Tooltip2 content={<Code>disabled=&#123;{this.state.disabled.toString()}&#125;</Code>} placement="left">
+                    <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
+                </Tooltip2>
+                <Tooltip2 content={<Code>fill=&#123;{this.state.fill.toString()}&#125;</Code>} placement="left">
+                    <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
+                </Tooltip2>
                 <H5>Tag props</H5>
                 <Switch
                     label="Minimal tag style"
@@ -181,16 +208,35 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     onChange={this.handleIntentChange}
                 />
                 <H5>Popover props</H5>
-                <Switch
-                    label="Match target width"
-                    checked={this.state.matchTargetWidth}
-                    onChange={this.handleMatchTargetWidthChange}
-                />
-                <Switch
-                    label="Minimal popover style"
-                    checked={this.state.popoverMinimal}
-                    onChange={this.handlePopoverMinimalChange}
-                />
+                <Tooltip2
+                    content={
+                        <Code>
+                            popoverProps=&#123;&#123; matchTargetWidth: {this.state.matchTargetWidth.toString()}{" "}
+                            &#125;&#125;
+                        </Code>
+                    }
+                    placement="left"
+                >
+                    <Switch
+                        label="Match target width"
+                        checked={this.state.matchTargetWidth}
+                        onChange={this.handleMatchTargetWidthChange}
+                    />
+                </Tooltip2>
+                <Tooltip2
+                    content={
+                        <Code>
+                            popoverProps=&#123;&#123; minimal: {this.state.popoverMinimal.toString()} &#125;&#125;
+                        </Code>
+                    }
+                    placement="left"
+                >
+                    <Switch
+                        label="Minimal popover style"
+                        checked={this.state.popoverMinimal}
+                        onChange={this.handlePopoverMinimalChange}
+                    />
+                </Tooltip2>
             </>
         );
     }
@@ -296,10 +342,5 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
 
     private handleClear = () => {
         this.setState({ films: [] });
-        // N.B. if MultiSelect2 had a "clear" button API provided out of the box, we wouldn't have to
-        // reach in to grab the Popover2 ref to reposition it... until then, we should do this to match
-        // the behavior which happens during TagInput's onRemove callback.
-        // see https://popper.js.org/docs/v2/modifiers/event-listeners/#when-the-reference-element-moves-or-changes-size
-        this.popoverRef.current?.reposition();
     };
 }


### PR DESCRIPTION

#### Changes proposed in this pull request:

Before this change, we rendered a "clear" button in the MultiSelect2 example in the docs with a custom element supplied through `tagInputProps={ rightElement: ... }`.

This functionality should be provided out of the box, as it's a common use case. So I've added that here in this PR.

The clear button is enabled when an `onClear` callback prop is defined, and omitted when that prop is undefined. It doesn't make much sense to render a button when it's not hooked up to do anything.

#### Reviewers should focus on:

No regression from existing behavior in docs

