### PR TITLE
[core] fix(ResizeSensor): compatibility with React 18

### DIFF
--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -62,7 +62,7 @@ export class ResizeSensor extends AbstractPureComponent2<ResizeSensorProps> {
 
     private observer = new ResizeObserver(entries => this.props.onResize?.(entries));
 
-    public render() {
+    public render(): React.ReactNode {
         // pass-through render of single child
         return React.Children.only(this.props.children);
     }
@@ -77,6 +77,7 @@ export class ResizeSensor extends AbstractPureComponent2<ResizeSensorProps> {
 
     public componentWillUnmount() {
         this.observer.disconnect();
+        this.element = null;
     }
 
     /**


### PR DESCRIPTION
#### Fixes #5313 & another bug

#### Checklist

- [ ] Includes tests: This is not testable easily without testing against React 18, which would be a pretty big change given that the build is currently hard-coded against React 16.
- [ ] Update documentation: I didn't touch the docs, as this doesn't change the user-facing API at all.

(If you think this needs tests or docs, I'll update the PR.)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Firstly, this fixes #5313 by defining an explicit return type for `render()`.

The difference between React 18 and 16 here seems to be that React 18 specifies `ReactFragment = Iterable<ReactNode>`, while React 16 specifies `{} | ReactNodeArray`. The definition of `only` drops the array, so the compiled type declaration is an union of what's left of `ReactNode`. That breaks when the newer `@types/react` doesn't allow `{}`. Specifying `ReactNode` should allow the union at compile time, and then the compiled `render(): ReactNode` is compatible with any version of React.

A quick grep for `React.Children.only` suggests that `packages/table/src/common/loadableContent.tsx` and `packages/table/src/interactions/draggable.tsx` are also affected, but I didn't have time to test them right now.

Secondly, this makes `ResizeSensor` work with React 18 StrictMode and its ["reusable state"](https://github.com/reactwg/react-18/discussions/19), which essentially runs effects twice - against their [own docs for `componentWillUnmount`](https://reactjs.org/docs/react-component.html#componentwillunmount). (The docs make this very enjoyable to debug.)

The current code assumes that the component is dumped after `componentWillUnmount` so it doesn't bother to clear `this.element`. This permanently disables the observer since `observeElement` will then think the element is already being observed. I added `this.element = null` to make it "reusable".

#### Reviewers should focus on:

If this breaks something subtle I didn't notice, I guess?
