### PR TITLE
[select] fix(QueryList): pass menuProps to itemListRenderer

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -57,7 +57,7 @@ export interface IItemListRendererProps<T> {
     itemsParentRef: IRef<HTMLUListElement>;
 
     /**
-     * Additional props to apply to the `Menu` that is created within the `QueryList`
+     * Props to apply to the `Menu` created within the `itemListRenderer`
      */
     menuProps?: React.HTMLAttributes<HTMLUListElement>;
 

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -57,6 +57,11 @@ export interface IItemListRendererProps<T> {
     itemsParentRef: IRef<HTMLUListElement>;
 
     /**
+     * Additional props to apply to the `Menu` that is created within the `QueryList`
+     */
+    menuProps?: React.HTMLAttributes<HTMLUListElement>;
+
+    /**
      * Call this function to render an item.
      * This retrieves the modifiers for the item and delegates actual rendering
      * to the owner component's `itemRenderer` prop.

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -211,7 +211,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
     }
 
     public render() {
-        const { className, items, renderer, itemListRenderer = this.renderItemList } = this.props;
+        const { className, items, renderer, itemListRenderer = this.renderItemList, menuProps } = this.props;
         const { createNewItem, ...spreadableState } = this.state;
         return renderer({
             ...spreadableState,
@@ -225,6 +225,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
                 ...spreadableState,
                 items,
                 itemsParentRef: this.refHandlers.itemsParent,
+                menuProps,
                 renderCreateItem: this.renderCreateItemMenuItem,
                 renderItem: this.renderItem,
             }),
@@ -348,7 +349,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
 
     /** default `itemListRenderer` implementation */
     private renderItemList = (listProps: IItemListRendererProps<T>) => {
-        const { initialContent, noResults, menuProps } = this.props;
+        const { initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
         const createItemView = listProps.renderCreateItem();
@@ -359,7 +360,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
         }
         const createFirst = this.isCreateItemFirst();
         return (
-            <Menu role="listbox" {...menuProps} ulRef={listProps.itemsParentRef}>
+            <Menu role="listbox" {...listProps.menuProps} ulRef={listProps.itemsParentRef}>
                 {createFirst && createItemView}
                 {menuContent}
                 {!createFirst && createItemView}

--- a/packages/select/src/components/select/select2.md
+++ b/packages/select/src/components/select/select2.md
@@ -279,10 +279,10 @@ If provided, the `itemListRenderer` prop will be called to render the contents o
 ```tsx
 import { ItemListRenderer } from "@blueprintjs/select";
 
-const renderMenu: ItemListRenderer<Film> = ({ items, itemsParentRef, query, renderItem }) => {
+const renderMenu: ItemListRenderer<Film> = ({ items, itemsParentRef, query, renderItem, menuProps }) => {
     const renderedItems = items.map(renderItem).filter(item => item != null);
     return (
-        <Menu ulRef={itemsParentRef}>
+        <Menu role="listbox" ulRef={itemsParentRef} {...menuProps}>
             <MenuItem
                 disabled={true}
                 text={`Found ${renderedItems.length} items matching "${query}"`}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

So basically, on a previous PR I submitted, we did not consider the case where a user passes a custom itemListRenderer, as they do in the `Select2` example-- in this case, a user needs access to the `menuProps` to get the generated `listboxId` so that they can assign `id={listboxId}` to their custom `Menu` item in their itemListRenderer-- currently, the `id={listboxId}` only gets applied to the _default_ itemListRenderer.

If this solution isn't approved, the alternative workaround to this would be for a user to create their own `id`, set `Menu id=${id}` in their custom itemListRenderer, then pass `popoverTargetProps={{aria-controls={id}`. If this isn't approved, I would like to add that example to the `Select2` example implementation
