### PR TITLE
[select] fix(Select): matchTargetWidth regression

### DIFF
--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -27,7 +27,8 @@
     }
   }
 
-  &.#{$ns}-popover2-match-target-width {
+  &.#{$ns}-popover2-match-target-width,
+  &.#{$ns}-select-match-target-width { // deprecated: this class is only used by <Select>
     width: 100%;
 
     .#{$ns}-menu {

--- a/packages/select/test/index.ts
+++ b/packages/select/test/index.ts
@@ -4,6 +4,13 @@
 
 import "@blueprintjs/test-commons/bootstrap";
 
+// tslint:disable no-submodule-imports
+import "normalize.css/normalize.css";
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
+// tslint:enable no-submodule-imports
+import "../lib/css/blueprint-select.css";
+
 import "./listItemsPropsTests";
 import "./multiSelectTests";
 import "./multiSelect2Tests";

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -26,6 +26,7 @@ import { dispatchTestKeyboardEventWithCode } from "@blueprintjs/test-commons";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
 import { IItemRendererProps, MultiSelect2, MultiSelect2Props, MultiSelect2State } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
+import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
 describe("<MultiSelect2>", () => {
     const FilmMultiSelect = MultiSelect2.ofType<IFilm>();
@@ -41,6 +42,7 @@ describe("<MultiSelect2>", () => {
         itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
+    let testsContainerElement: HTMLElement | undefined;
 
     beforeEach(() => {
         handlers = {
@@ -48,6 +50,12 @@ describe("<MultiSelect2>", () => {
             itemRenderer: sinon.spy(renderFilm),
             onItemSelect: sinon.spy(),
         };
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        testsContainerElement?.remove();
     });
 
     selectComponentSuite<MultiSelect2Props<IFilm>, MultiSelect2State>(props =>
@@ -59,6 +67,12 @@ describe("<MultiSelect2>", () => {
                 tagRenderer={renderTag}
             />,
         ),
+    );
+
+    selectPopoverTestSuite<MultiSelect2Props<IFilm>, MultiSelect2State>(props =>
+        mount(<MultiSelect2 {...props} selectedItems={[]} tagRenderer={renderTag} />, {
+            attachTo: testsContainerElement,
+        }),
     );
 
     it("placeholder can be controlled with placeholder prop", () => {

--- a/packages/select/test/select2Tests.tsx
+++ b/packages/select/test/select2Tests.tsx
@@ -25,6 +25,7 @@ import { Popover2 } from "@blueprintjs/popover2";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
 import { IItemRendererProps, Select2, Select2Props, Select2State } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
+import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
 describe("<Select2>", () => {
     const FilmSelect = Select2.ofType<IFilm>();
@@ -38,6 +39,7 @@ describe("<Select2>", () => {
         itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
+    let testsContainerElement: HTMLElement | undefined;
 
     beforeEach(() => {
         handlers = {
@@ -45,16 +47,23 @@ describe("<Select2>", () => {
             itemRenderer: sinon.spy(renderFilm),
             onItemSelect: sinon.spy(),
         };
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
     });
 
     afterEach(() => {
         for (const spy of Object.values(handlers)) {
             spy.resetHistory();
         }
+        testsContainerElement?.remove();
     });
 
     selectComponentSuite<Select2Props<IFilm>, Select2State>(props =>
         mount(<Select2 {...props} popoverProps={{ isOpen: true, usePortal: false }} />),
+    );
+
+    selectPopoverTestSuite<Select2Props<IFilm>, Select2State>(props =>
+        mount(<Select2 {...props} />, { attachTo: testsContainerElement }),
     );
 
     it("renders a Popover2 around children that contains InputGroup and items", () => {

--- a/packages/select/test/selectPopoverTestSuite.tsx
+++ b/packages/select/test/selectPopoverTestSuite.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { ReactWrapper } from "enzyme";
+import * as sinon from "sinon";
+
+import { Classes as Popover2Classes } from "@blueprintjs/popover2";
+
+import { areFilmsEqual, filterFilm, IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
+import { IListItemsProps, SelectPopoverProps } from "../src";
+
+/**
+ * Common tests for popover functionality in select components which use Popover2.
+ *
+ * render() should ensure the component is attached to a DOM node so that we can get accurate DOM measurements.
+ */
+export function selectPopoverTestSuite<P extends IListItemsProps<IFilm>, S>(
+    render: (props: IListItemsProps<IFilm> & SelectPopoverProps) => ReactWrapper<P, S>,
+    findPopover: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper =>
+        wrapper.find(`.${Popover2Classes.POPOVER2}`),
+    findTarget: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper =>
+        wrapper.find(`.${Popover2Classes.POPOVER2_TARGET}`),
+) {
+    const defaultProps = {
+        itemPredicate: filterFilm,
+        itemRenderer: sinon.spy(renderFilm),
+        items: TOP_100_FILMS.slice(0, 20),
+        itemsEqual: areFilmsEqual,
+        onActiveItemChange: sinon.spy(),
+        onItemSelect: sinon.spy(),
+        onQueryChange: sinon.spy(),
+        query: "19",
+    };
+    const defaultPopoverProps = {
+        isOpen: true,
+        usePortal: false,
+    };
+
+    describe("popover", () => {
+        it("matchTargetWidth: true makes popover same width as target", () => {
+            const wrapper = render({
+                ...defaultProps,
+                popoverProps: { ...defaultPopoverProps, matchTargetWidth: true },
+            });
+            const popoverWidth = findPopover(wrapper).hostNodes().getDOMNode().clientWidth;
+            const targetWidth = findTarget(wrapper).hostNodes().getDOMNode().clientWidth;
+            assert.notEqual(popoverWidth, 0, "popover width should be > 0");
+            assert.notEqual(targetWidth, 0, "target width should be > 0");
+            assert.closeTo(targetWidth, popoverWidth, 1, "popover width should be close to target width");
+            wrapper.detach();
+        });
+    });
+}

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -25,7 +25,7 @@ import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/film
 import { IItemRendererProps, ISelectProps, ISelectState, Select } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 
-describe.only("<Select>", () => {
+describe("<Select>", () => {
     const FilmSelect = Select.ofType<IFilm>();
     const defaultProps = {
         items: TOP_100_FILMS,
@@ -115,14 +115,18 @@ describe.only("<Select>", () => {
         assert.strictEqual(wrapper.find(Popover).prop("isOpen"), true);
     });
 
-    it.only("matchTargetWidth={true} makes popover same width as target", () => {
+    it("matchTargetWidth={true} makes popover same width as target", done => {
         const wrapper = select({ matchTargetWidth: true });
-        const popoverWidth = wrapper.find(`.${Classes.POPOVER}`).hostNodes().getDOMNode().clientWidth;
-        const targetWidth = wrapper.find(`.${Classes.POPOVER_TARGET}`).hostNodes().getDOMNode().clientWidth;
-        assert.notEqual(popoverWidth, 0, "popover width should be > 0");
-        assert.notEqual(targetWidth, 0, "target width should be > 0");
-        assert.closeTo(targetWidth, popoverWidth, 1, "popover width should be close to target width");
-        wrapper.detach();
+        // wait one frame for popper.js v1 to position the popover and apply our custom modifier
+        setTimeout(() => {
+            const popoverWidth = wrapper.find(`.${Classes.POPOVER}`).hostNodes().getDOMNode().clientWidth;
+            const targetWidth = wrapper.find(`.${Classes.POPOVER_TARGET}`).hostNodes().getDOMNode().clientWidth;
+            assert.notEqual(popoverWidth, 0, "popover width should be > 0");
+            assert.notEqual(targetWidth, 0, "target width should be > 0");
+            assert.closeTo(targetWidth, popoverWidth, 1, "popover width should be close to target width");
+            wrapper.detach();
+            done();
+        });
     });
 
     function select(props: Partial<ISelectProps<IFilm>> = {}, query?: string) {

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -19,13 +19,13 @@ import { mount } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
-import { InputGroup, Keys, Popover } from "@blueprintjs/core";
+import { Classes, InputGroup, Keys, Popover } from "@blueprintjs/core";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
 import { IItemRendererProps, ISelectProps, ISelectState, Select } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 
-describe("<Select>", () => {
+describe.only("<Select>", () => {
     const FilmSelect = Select.ofType<IFilm>();
     const defaultProps = {
         items: TOP_100_FILMS,
@@ -37,6 +37,7 @@ describe("<Select>", () => {
         itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
+    let testsContainerElement: HTMLElement | undefined;
 
     beforeEach(() => {
         handlers = {
@@ -44,6 +45,12 @@ describe("<Select>", () => {
             itemRenderer: sinon.spy(renderFilm),
             onItemSelect: sinon.spy(),
         };
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        testsContainerElement?.remove();
     });
 
     selectComponentSuite<ISelectProps<IFilm>, ISelectState>(props =>
@@ -108,11 +115,22 @@ describe("<Select>", () => {
         assert.strictEqual(wrapper.find(Popover).prop("isOpen"), true);
     });
 
+    it.only("matchTargetWidth={true} makes popover same width as target", () => {
+        const wrapper = select({ matchTargetWidth: true });
+        const popoverWidth = wrapper.find(`.${Classes.POPOVER}`).hostNodes().getDOMNode().clientWidth;
+        const targetWidth = wrapper.find(`.${Classes.POPOVER_TARGET}`).hostNodes().getDOMNode().clientWidth;
+        assert.notEqual(popoverWidth, 0, "popover width should be > 0");
+        assert.notEqual(targetWidth, 0, "target width should be > 0");
+        assert.closeTo(targetWidth, popoverWidth, 1, "popover width should be close to target width");
+        wrapper.detach();
+    });
+
     function select(props: Partial<ISelectProps<IFilm>> = {}, query?: string) {
         const wrapper = mount(
             <FilmSelect {...defaultProps} {...handlers} {...props}>
                 <button data-testid="target-button">Target</button>
             </FilmSelect>,
+            { attachTo: testsContainerElement },
         );
         if (query !== undefined) {
             wrapper.setState({ query });

--- a/packages/select/test/suggest2Tests.tsx
+++ b/packages/select/test/suggest2Tests.tsx
@@ -26,6 +26,7 @@ import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/film
 import { IItemRendererProps, QueryList } from "../src";
 import { Suggest2, Suggest2Props, Suggest2State } from "../src/components/suggest/suggest2";
 import { selectComponentSuite } from "./selectComponentSuite";
+import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
 describe("Suggest2", () => {
     const FilmSuggest = Suggest2.ofType<IFilm>();
@@ -40,6 +41,7 @@ describe("Suggest2", () => {
         itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
+    let testsContainerElement: HTMLElement | undefined;
 
     beforeEach(() => {
         handlers = {
@@ -48,6 +50,12 @@ describe("Suggest2", () => {
             itemRenderer: sinon.spy(renderFilm),
             onItemSelect: sinon.spy(),
         };
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        testsContainerElement?.remove();
     });
 
     selectComponentSuite<Suggest2Props<IFilm>, Suggest2State<IFilm>>(props =>
@@ -58,6 +66,10 @@ describe("Suggest2", () => {
                 popoverProps={{ isOpen: true, usePortal: false }}
             />,
         ),
+    );
+
+    selectPopoverTestSuite<Suggest2Props<IFilm>, Suggest2State<IFilm>>(props =>
+        mount(<Suggest2 {...props} inputValueRenderer={inputValueRenderer} />, { attachTo: testsContainerElement }),
     );
 
     describe("Basic behavior", () => {


### PR DESCRIPTION
#### Fixes #5374

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Add unit test suite for Select2, Suggest2, and MultiSelect2 to validate popover behavior like `popoverProps.matchTargetWidth`
- Add unit test for Select to validate `matchTargetWidth` behavior
- Fix Select component's `matchTargetWidth` behavior, which regressed in style changes in #5354

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
