### PR TITLE
docs(ControlGroup, TimezoneSelect): minor fixes

### DIFF
--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -1,8 +1,8 @@
 @# Control group
 
-A control group renders several distinct form controls as one unit, squaring the
-borders between them. It supports any number of buttons, text inputs, input
-groups, and HTML selects as direct children.
+A control group renders multiple distinct form controls as one unit, with a small margin
+between elements. It supports any number of buttons, text inputs, input groups, numeric
+inputs, and HTML selects as direct children.
 
 <div class="@ns-callout @ns-intent-success @ns-icon-comparison">
     <h4 class="@ns-heading">Control group vs. input group</h4>
@@ -52,10 +52,6 @@ HTML `<div>` props, in addition to those listed below.
 @interface IControlGroupProps
 
 @## CSS
-
-A `.@ns-control-group` renders several distinct controls as one unit, squaring the borders between
-them. It supports any number of `.@ns-button`, `.@ns-input`, `.@ns-input-group`, and `.@ns-select`
-elements as direct children.
 
 Note that `.@ns-control-group` does not cascade any modifiers to its children. For example, each
 child must be marked individually as `.@ns-large` for uniform large appearance.

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -522,7 +522,7 @@
     justify-content: center;
   }
 
-  #{example("TimezonePickerV2Example")} .docs-example {
+  #{example("TimezoneSelectExample")} .docs-example {
     flex-direction: row;
   }
 }


### PR DESCRIPTION
#### Fixes #5373

#### Checklist

- ~Includes tests~
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Remove mentions of "squaring borders" in ControlGroup docs. Instead, mention a small gap between them to match the v4 visual style.
- Fix TimezoneSelect docs example styling so that `fill={true}` does not make it overflow the container

#### Reviewers should focus on:

N/A

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
