### PR TITLE
[core] chore: DRY code with InputSharedProps interface

### DIFF
--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -82,7 +82,7 @@ export interface IFileInputProps extends React.LabelHTMLAttributes<HTMLLabelElem
     buttonText?: string;
 }
 
-// TODO: write tests (ignoring for now to get a build passing quickly)
+// this is a simple component, unit tests would be mostly tautological
 /* istanbul ignore next */
 export class FileInput extends AbstractPureComponent2<FileInputProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.FileInput`;

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../common/props";
 import { Icon, IconName } from "../icon/icon";
 import { AsyncControllableInput } from "./asyncControllableInput";
+import type { InputSharedProps } from "./inputSharedProps";
 
 // eslint-disable-next-line deprecation/deprecation
 export type InputGroupProps = IInputGroupProps;
@@ -116,8 +117,7 @@ export type InputGroupProps2 = IInputGroupProps2;
 export interface IInputGroupProps2
     extends Omit<HTMLInputProps, keyof ControlledProps2>,
         ControlledProps2,
-        IntentProps,
-        Props {
+        InputSharedProps {
     /**
      * Set this to `true` if you will be controlling the `value` of this input with asynchronous updates.
      * These may occur if you do not immediately call setState in a parent component with the value from
@@ -127,49 +127,11 @@ export interface IInputGroupProps2
      */
     asyncControl?: boolean;
 
-    /**
-     * Whether the input is non-interactive.
-     * Note that `rightElement` must be disabled separately; this prop will not affect it.
-     *
-     * @default false
-     */
-    disabled?: boolean;
-
-    /**
-     * Whether the component should take up the full width of its container.
-     */
-    fill?: boolean;
-
-    /** Ref handler or a ref object that receives HTML `<input>` element backing this component. */
-    inputRef?: IRef<HTMLInputElement>;
-
-    /**
-     * Element to render on the left side of input.  This prop is mutually exclusive
-     * with `leftIcon`.
-     */
-    leftElement?: JSX.Element;
-
-    /**
-     * Name of a Blueprint UI icon to render on the left side of the input group,
-     * before the user's cursor.  This prop is mutually exclusive with `leftElement`.
-     * Usage with content is deprecated.  Use `leftElement` for elements.
-     */
-    leftIcon?: IconName | MaybeElement;
-
     /** Whether this input should use large styles. */
     large?: boolean;
 
     /** Whether this input should use small styles. */
     small?: boolean;
-
-    /** Placeholder text in the absence of any value. */
-    placeholder?: string;
-
-    /**
-     * Element to render on right side of input.
-     * For best results, use a minimal button, tag, or small spinner.
-     */
-    rightElement?: JSX.Element;
 
     /** Whether the input (and any buttons) should appear with rounded caps. */
     round?: boolean;

--- a/packages/core/src/components/forms/inputSharedProps.ts
+++ b/packages/core/src/components/forms/inputSharedProps.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IRef } from "../../common";
+import type { IntentProps, MaybeElement, Props } from "../../common/props";
+import type { IconName } from "../icon/icon";
+
+/**
+ * Shared props interface for text & numeric inputs.
+ */
+export interface InputSharedProps extends IntentProps, Props {
+    /**
+     * Whether the input is non-interactive.
+     *
+     * Note that the content in `rightElement` must be disabled separately if defined;
+     * this prop will not affect it.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether the component should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * Ref attached to the HTML `<input>` element backing this component.
+     */
+    inputRef?: IRef<HTMLInputElement>;
+
+    /**
+     * Element to render on the left side of input.
+     * This prop is mutually exclusive with `leftIcon`.
+     */
+    leftElement?: JSX.Element;
+
+    /**
+     * Name of a Blueprint UI icon to render on the left side of the input group,
+     * before the user's cursor.
+     *
+     * This prop is mutually exclusive with `leftElement`.
+     *
+     * Note: setting a JSX.Element here is deprecated; use the `leftElement` prop instead.
+     */
+    leftIcon?: IconName | MaybeElement;
+
+    /**
+     * Placeholder text in the absence of any value.
+     */
+    placeholder?: string;
+
+    /**
+     * Element to render on right side of input.
+     * For best results, use a minimal button, tag, or small spinner.
+     */
+    rightElement?: JSX.Element;
+}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -17,20 +17,15 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import type { IconName } from "@blueprintjs/icons";
-
 import {
     AbstractPureComponent2,
     Classes,
     DISPLAYNAME_PREFIX,
     HTMLInputProps,
     Intent,
-    IntentProps,
     IRef,
     Keys,
-    MaybeElement,
     Position,
-    Props,
     refHandler,
     removeNonHTMLProps,
     setRef,
@@ -41,6 +36,7 @@ import { ButtonGroup } from "../button/buttonGroup";
 import { Button } from "../button/buttons";
 import { ControlGroup } from "./controlGroup";
 import { InputGroup } from "./inputGroup";
+import type { InputSharedProps } from "./inputSharedProps";
 import {
     clampValue,
     getValueOrEmptyValue,
@@ -55,7 +51,7 @@ import {
 // eslint-disable-next-line deprecation/deprecation
 export type NumericInputProps = INumericInputProps;
 /** @deprecated use NumericInputProps */
-export interface INumericInputProps extends IntentProps, Props {
+export interface INumericInputProps extends InputSharedProps {
     /**
      * Whether to allow only floating-point number characters in the field,
      * mimicking the native `input[type="number"]`.
@@ -97,21 +93,6 @@ export interface INumericInputProps extends IntentProps, Props {
     defaultValue?: number | string;
 
     /**
-     * Whether the input is non-interactive.
-     *
-     * @default false
-     */
-    disabled?: boolean;
-
-    /** Whether the numeric input should take up the full width of its container. */
-    fill?: boolean;
-
-    /**
-     * Ref handler that receives HTML `<input>` element backing this component.
-     */
-    inputRef?: IRef<HTMLInputElement>;
-
-    /**
      * If set to `true`, the input will display with larger styling.
      * This is equivalent to setting `Classes.LARGE` via className on the
      * parent control group and on the child input group.
@@ -119,18 +100,6 @@ export interface INumericInputProps extends IntentProps, Props {
      * @default false
      */
     large?: boolean;
-
-    /**
-     * Element to render on the left side of input. This prop is mutually exclusive
-     * with `leftIcon`.
-     */
-    leftElement?: JSX.Element;
-
-    /**
-     * Name of a Blueprint UI icon (or an icon element) to render on the left side of input. This prop is mutually exclusive with `leftElement`.
-     * Usage with content is deprecated.  Use `leftElement` for elements.
-     */
-    leftIcon?: IconName | MaybeElement;
 
     /**
      * The locale name, which is passed to the component to format the number and allowing to type the number in the specific locale.
@@ -161,15 +130,6 @@ export interface INumericInputProps extends IntentProps, Props {
      * @default 0.1
      */
     minorStepSize?: number | null;
-
-    /** The placeholder text in the absence of any value. */
-    placeholder?: string;
-
-    /**
-     * Element to render on right side of input.
-     * For best results, use a minimal button, tag, or small spinner.
-     */
-    rightElement?: JSX.Element;
 
     /**
      * Whether the entire text field should be selected on focus.


### PR DESCRIPTION
Creates a shared props interface which contains a handful of props shared between NumericInput and InputGroup.