### PR TITLE
[core] fix(NumericInput): improve a11y markup, add spinbutton role

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -202,6 +202,8 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     public static VALUE_ZERO = "0";
 
+    private numericInputId = Utils.uniqueId("numericInput");
+
     public static defaultProps: NumericInputProps = {
         allowNumericCharactersOnly: true,
         buttonPosition: Position.RIGHT,
@@ -397,6 +399,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
             <ButtonGroup className={Classes.FIXED} key="button-group" vertical={true}>
                 <Button
                     aria-label="increment"
+                    aria-controls={this.numericInputId}
                     disabled={disabled || isIncrementDisabled}
                     icon="chevron-up"
                     intent={intent}
@@ -404,6 +407,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 />
                 <Button
                     aria-label="decrement"
+                    aria-controls={this.numericInputId}
                     disabled={disabled || isDecrementDisabled}
                     icon="chevron-down"
                     intent={intent}
@@ -419,6 +423,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
             <InputGroup
                 asyncControl={this.props.asyncControl}
                 autoComplete="off"
+                id={this.numericInputId}
                 {...inputGroupHtmlProps}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputRef={this.inputRef}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -419,12 +419,20 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     private renderInput() {
         const inputGroupHtmlProps = removeNonHTMLProps(this.props, NON_HTML_PROPS, true);
+        const valueAsNumber = Number(parseStringToStringNumber(this.state.value, this.props.locale));
+        const hasSpinButtons = this.props.buttonPosition !== undefined && this.props.buttonPosition !== "none";
+
         return (
             <InputGroup
                 asyncControl={this.props.asyncControl}
                 autoComplete="off"
                 id={this.numericInputId}
+                role={hasSpinButtons ? "spinbutton" : "textbox"}
+                type="number"
                 {...inputGroupHtmlProps}
+                aria-valuemax={this.props.max}
+                aria-valuemin={this.props.min}
+                aria-valuenow={valueAsNumber}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputRef={this.inputRef}
                 large={this.props.large}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -428,7 +428,6 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 autoComplete="off"
                 id={this.numericInputId}
                 role={hasSpinButtons ? "spinbutton" : "textbox"}
-                type="number"
                 {...inputGroupHtmlProps}
                 aria-valuemax={this.props.max}
                 aria-valuemin={this.props.min}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -298,6 +298,8 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     private decrementButtonHandlers = this.getButtonEventHandlers(IncrementDirection.DOWN);
 
+    private getCurrentValueAsNumber = () => Number(parseStringToStringNumber(this.state.value, this.props.locale));
+
     public render() {
         const { buttonPosition, className, fill, large } = this.props;
         const containerClasses = classNames(Classes.NUMERIC_INPUT, { [Classes.LARGE]: large }, className);
@@ -419,7 +421,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     private renderInput() {
         const inputGroupHtmlProps = removeNonHTMLProps(this.props, NON_HTML_PROPS, true);
-        const valueAsNumber = Number(parseStringToStringNumber(this.state.value, this.props.locale));
+        const valueAsNumber = this.getCurrentValueAsNumber();
         const hasSpinButtons = this.props.buttonPosition !== undefined && this.props.buttonPosition !== "none";
 
         return (
@@ -505,7 +507,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
         if (this.props.min !== undefined || this.props.max !== undefined) {
             const min = this.props.min ?? -Infinity;
             const max = this.props.max ?? Infinity;
-            const valueAsNumber = Number(parseStringToStringNumber(this.state.value, this.props.locale));
+            const valueAsNumber = this.getCurrentValueAsNumber();
             if (valueAsNumber <= min || valueAsNumber >= max) {
                 this.stopContinuousChange();
                 return;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `aria-controls` prop for the increment/decrement buttons of the numericInput.

Add other aria props to make a proper spinbox a11y-wise-- see example https://w3c.github.io/aria-practices/examples/spinbutton/datepicker-spinbuttons.html