### PR TITLE
[core] fix(Menu): remove extraneous submenu icon title

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -200,9 +200,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
                 {text}
             </Text>,
             this.maybeRenderLabel(labelElement),
-            hasSubmenu ? (
-                <Icon className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" icon="caret-right" />
-            ) : undefined,
+            hasSubmenu ? <Icon className={Classes.MENU_SUBMENU_ICON} icon="caret-right" /> : undefined,
         );
 
         const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Remove icon title because not necessary/ doesn't provide any good info for the icon.
Reason 1) Expanding the sub-menu is not only performed by hovering over the icon, but can be performed by hovering over the whole button-- so, having "Open sub menu" on the icon is misleading because it can be opened by hovering over any part of the button, not just the icon.
Reason 2) The icon pretty much already has its own label given by the fact that it is part of the button, which contains text that describes the sub-menu-- having this additional title adds no value.