### PR TITLE
chore(deps): update first-mate to use oniguruma@7.2.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5247,15 +5247,15 @@ first-mate-select-grammar@^1.0.3:
     lodash "^4.17.11"
 
 first-mate@^7.0.2:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/first-mate/-/first-mate-7.4.1.tgz#1acd6c9d857c9384c25145f068c1e164db1573e3"
-  integrity sha512-SEG5W0aajCvK/Ngoo3he3Ib4DsT+CRPhBAgSju5hksBLvvUfRWP7Jf3+HQ+CNTD4GZZqbDNOEJNOxbf35EblrQ==
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/first-mate/-/first-mate-7.4.3.tgz#058b9b6d2f43e38a5f0952669338cff2c46ae2dd"
+  integrity sha512-PtZUpaPmcV5KV4Rw5TfwczEnExN+X1o3Q/G82E4iRJ0tW91fm3Yi7pa5t4cBH8r3D6EyoBKvfpG2jKE+TZ0/nw==
   dependencies:
     emissary "^1"
     event-kit "^2.2.0"
     fs-plus "^3.0.0"
     grim "^2.0.1"
-    oniguruma "7.2.1"
+    oniguruma "^7.2.3"
     season "^6.0.2"
     underscore-plus "^1"
 
@@ -8753,10 +8753,10 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-oniguruma@7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
-  integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
+oniguruma@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.3.tgz#e0b0b415302de8cdd6564e57a1a822ac0ab57012"
+  integrity sha512-PZZcE0yfg8Q1IvaJImh21RUTHl8ep0zwwyoE912KqlWVrsGByjjj29sdACcD1BFyX2bLkfuOJeP+POzAGVWtbA==
   dependencies:
     nan "^2.14.0"
 


### PR DESCRIPTION
Fixes the build on macOS when using Node 16.14+ on macOS. Previously,
the build would fail with the following error:

error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'

It required contributors to downgrade to 14.17.x.

This bug was fixed in oniguruma@7.2.3. See
https://github.com/atom/node-oniguruma/pull/112. first-mate@7.4.3 is
the first version to require oniguruma@7.2.3.