### PR TITLE
[node-build-scripts] fix(sass-compile): source map file paths

### DIFF
--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -14,6 +14,7 @@
         "sass-lint": "./sass-lint.js"
     },
     "dependencies": {
+        "@types/fs-extra": "^9.0.13",
         "autoprefixer": "^10.4.4",
         "chokidar": "^3.5.3",
         "cross-spawn": "^7.0.3",
@@ -30,6 +31,7 @@
         "postcss-scss": "^4.0.3",
         "prettier": "~2.6.2",
         "sass": "^1.49.10",
+        "source-map": "^0.7.4",
         "strip-css-comments": "^4.1.0",
         "stylelint": "^14.6.1",
         "stylelint-junit-formatter": "^0.2.2",

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -13,13 +13,3 @@ ROOT_NM=../../node_modules
 
 # the `dart-sass` CLI doesn't support custom functions or importers, but the JS API does, so delegate to node
 $ROOT_NM/.bin/ts-node -O "{ \"esModuleInterop\": true }" ../node-build-scripts/sass-compile.ts --output $OUTPUT $@
-
-# in source maps, paths to blueprint packages should be direct, rather than
-# going through node_modules. https://github.com/palantir/blueprint/issues/3500
-if [[ -d $OUTPUT ]]; then
-  if [[ $OSTYPE == 'darwin'* ]]; then
-    sed -i '' 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
-  else
-    sed -i 's/..\/node_modules\/@blueprintjs\///' $OUTPUT/*.css.map
-  fi
-fi

--- a/packages/node-build-scripts/sass-compile.ts
+++ b/packages/node-build-scripts/sass-compile.ts
@@ -83,9 +83,9 @@ function fixSourcePathsInSourceMap({
 }): string {
     const parsedMap = JSON.parse(sourceMapBuffer.toString()) as RawSourceMap;
     parsedMap.sources = parsedMap.sources.map(source => {
-        const outputDirectory = path.dirname(outputMapFile)
+        const outputDirectory = path.dirname(outputMapFile);
         const pathToSourceWithoutProtocol = source.replace("file://", "");
         return path.relative(outputDirectory, pathToSourceWithoutProtocol);
-    })
+    });
     return JSON.stringify(parsedMap);
 }

--- a/packages/node-build-scripts/sass-compile.ts
+++ b/packages/node-build-scripts/sass-compile.ts
@@ -62,6 +62,7 @@ function compileFile(inputFile: string) {
         file: inputFile,
         importer: nodeSassPackageImporter(),
         sourceMap: true,
+        sourceMapContents: true,
         outFile,
         functions,
         charset: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10961,12 +10961,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-source-map@^0.7.4:
+source-map@^0.7.3, source-map@^0.7.4, source-map@~0.7.2:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,6 +1410,13 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/fuzzaldrin-plus@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@types/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.1.tgz#818d00303d3f83190cdcf9d4496eded40d05576f"
@@ -10958,6 +10965,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 source-map@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
#### Fixes #5416

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

When running a react app with the latest version of blueprint, I get errors like:

```
Failed to parse source map from '/home/circleci/project/packages/icons/src/generated/20px/blueprint-icons-20.css' file: Error: ENOENT: no such file or directory, open '/home/circleci/project/packages/icons/src/generated/20px/blueprint-icons-20.css'
```

Source maps are generated with _absolute paths_ to the source files (hence the `/home/circleci` paths). 

Blueprint is using `renderSync` to generate source maps. https://github.com/palantir/blueprint/blob/3c4daa757d63c37adcc4842cb28ab400f0b58b39/packages/node-build-scripts/sass-compile.ts#L60

Per https://github.com/sass/dart-sass/issues/1437, this right fix is to manually change the absolute paths to be relative.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
