### PR TITLE
[core] fix(NumericInput): don't apply textbox role

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -427,7 +427,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 asyncControl={this.props.asyncControl}
                 autoComplete="off"
                 id={this.numericInputId}
-                type={this.props.allowNumericCharactersOnly ? "number" : "text"}
+                role={this.props.allowNumericCharactersOnly ? "spinbutton" : "textbox"}
                 {...inputGroupHtmlProps}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputRef={this.inputRef}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -421,7 +421,6 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     private renderInput() {
         const inputGroupHtmlProps = removeNonHTMLProps(this.props, NON_HTML_PROPS, true);
-        const valueAsNumber = this.getCurrentValueAsNumber();
 
         return (
             <InputGroup
@@ -431,9 +430,6 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 role={this.props.allowNumericCharactersOnly ? "spinbutton" : "textbox"}
                 type={this.props.allowNumericCharactersOnly ? "number" : "text"}
                 {...inputGroupHtmlProps}
-                aria-valuemax={this.props.max}
-                aria-valuemin={this.props.min}
-                aria-valuenow={valueAsNumber}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputRef={this.inputRef}
                 large={this.props.large}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -427,7 +427,6 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 asyncControl={this.props.asyncControl}
                 autoComplete="off"
                 id={this.numericInputId}
-                role={this.props.allowNumericCharactersOnly ? "spinbutton" : "textbox"}
                 type={this.props.allowNumericCharactersOnly ? "number" : "text"}
                 {...inputGroupHtmlProps}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -421,6 +421,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     private renderInput() {
         const inputGroupHtmlProps = removeNonHTMLProps(this.props, NON_HTML_PROPS, true);
+        const valueAsNumber = this.getCurrentValueAsNumber();
 
         return (
             <InputGroup
@@ -429,6 +430,9 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 id={this.numericInputId}
                 role={this.props.allowNumericCharactersOnly ? "spinbutton" : undefined}
                 {...inputGroupHtmlProps}
+                aria-valuemax={this.props.max}
+                aria-valuemin={this.props.min}
+                aria-valuenow={valueAsNumber}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputRef={this.inputRef}
                 large={this.props.large}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -427,7 +427,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 asyncControl={this.props.asyncControl}
                 autoComplete="off"
                 id={this.numericInputId}
-                role={this.props.allowNumericCharactersOnly ? "spinbutton" : "textbox"}
+                role={this.props.allowNumericCharactersOnly ? "spinbutton" : undefined}
                 {...inputGroupHtmlProps}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputRef={this.inputRef}

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -422,14 +422,14 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
     private renderInput() {
         const inputGroupHtmlProps = removeNonHTMLProps(this.props, NON_HTML_PROPS, true);
         const valueAsNumber = this.getCurrentValueAsNumber();
-        const hasSpinButtons = this.props.buttonPosition !== undefined && this.props.buttonPosition !== "none";
 
         return (
             <InputGroup
                 asyncControl={this.props.asyncControl}
                 autoComplete="off"
                 id={this.numericInputId}
-                role={hasSpinButtons ? "spinbutton" : "textbox"}
+                role={this.props.allowNumericCharactersOnly ? "spinbutton" : "textbox"}
+                type={this.props.allowNumericCharactersOnly ? "number" : "text"}
                 {...inputGroupHtmlProps}
                 aria-valuemax={this.props.max}
                 aria-valuemin={this.props.min}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

update the `type` prop for the `<input>` element created in a `numericInput`. `role` prop no longer needed due to given `type`
