### PR TITLE
chore: update Node version in README and engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ then [check out the "help wanted" label](https://github.com/palantir/blueprint/l
 [Lerna](https://lerna.js.org/) manages inter-package dependencies in this monorepo.
 Builds are orchestrated via `lerna run` and NPM scripts.
 
-**Prerequisites**: Node.js v12+, Yarn v1.22+
+**Prerequisites**: Node.js v16.x (see version specified in `.nvmrc`), Yarn v1.22+
 
 ### One-time setup
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "@types/react": "16.14.2"
     },
     "engines": {
-        "node": ">=12"
+        "node": ">=16"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Update README and package.json `"engines"` field to match what is suggested in `.nvmrc`.