### PR TITLE
[datetime] fix: improve time picker & footer layout

### DIFF
--- a/packages/datetime/src/_datepicker.scss
+++ b/packages/datetime/src/_datepicker.scss
@@ -50,7 +50,7 @@ $header-margin: ($header-height - $pt-input-height) * 0.5 !default;
     border-collapse: collapse;
     border-spacing: 0;
     display: inline-table;
-    margin: 0 $datepicker-padding $datepicker-padding;
+    margin: 0 $datepicker-padding;
     user-select: none;
 
     // create space between months (selector matches all but first month)
@@ -203,11 +203,17 @@ $header-margin: ($header-height - $pt-input-height) * 0.5 !default;
   display: flex;
   flex-direction: column;
   gap: 5px;
+
+  > .#{$ns}-divider {
+    margin: 0; // margin is already applied via flex gap
+    width: calc(100% - #{$datepicker-padding * 2});
+  }
 }
 
 .#{$ns}-datepicker-footer {
   display: flex;
   justify-content: space-between;
+  width: 100%;
 }
 
 .#{$ns}-dark .#{$ns}-datepicker {
@@ -265,4 +271,9 @@ $header-margin: ($header-height - $pt-input-height) * 0.5 !default;
   align-items: center;
   display: flex;
   flex-direction: column;
+
+  .#{$ns}-timepicker-arrow-row:empty + .#{$ns}-timepicker-input-row {
+    // when timepicker arrows are not displayed in the datepicker, we need a bit of extra margin
+    margin: $datepicker-padding 0;
+  }
 }

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -17,6 +17,11 @@
   .#{$ns}-daterangepicker-timepickers {
     display: flex;
     justify-content: space-around;
+
+    .#{$ns}-timepicker-arrow-row:empty + .#{$ns}-timepicker-input-row {
+      // when timepicker arrows are not displayed in the daterangepicker, we need a bit of extra margin
+      margin: $datepicker-padding 0;
+    }
   }
 
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -120,13 +120,3 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     color: $pt-dark-text-color;
   }
 }
-
-.#{$ns}-datepicker .#{$ns}-timepicker {
-  margin-bottom: $datepicker-padding * 2;
-  margin-top: $datepicker-padding;
-
-  // adjust margin when actions bar is hidden
-  &:last-child {
-    margin-bottom: $datepicker-padding;
-  }
-}


### PR DESCRIPTION
I noticed these problems in https://github.com/palantir/blueprint/pull/5390. In this PR, I have:

- Reduced whitespace/padding around time pickers
- Fixed divider above the footer element
- Fixed layout/justification of footer buttons

#### Screenshot

| Before | After |
| - | - |
| <img width="269" alt="image" src="https://user-images.githubusercontent.com/723999/178355681-3f10ef34-0022-4a57-876d-ed92178c9fae.png"> | <img width="275" alt="image" src="https://user-images.githubusercontent.com/723999/178355642-7a7392da-dfe8-42e4-bb62-29b541db9642.png"> |
| <img width="271" alt="image" src="https://user-images.githubusercontent.com/723999/178355745-bace793a-a47e-49aa-a0d8-6fdfb755a797.png"> | <img width="266" alt="image" src="https://user-images.githubusercontent.com/723999/178355761-a9741b3d-2e9a-4fe6-a624-63e9d3ddc9fd.png"> |
| <img width="266" alt="image" src="https://user-images.githubusercontent.com/723999/178355862-b61ecaa0-7042-4199-9fec-a75a01d0ac62.png"> | <img width="268" alt="image" src="https://user-images.githubusercontent.com/723999/178355891-d74c3967-e519-4365-aa2d-a0c233d483e7.png"> |

