### PR TITLE
[core] deprecate IPopoverProps, TooltipProps

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -76,6 +76,7 @@ export interface IBreadcrumbsProps extends Props {
     /**
      * Props to spread to the `Popover` showing the overflow menu.
      */
+    // eslint-disable-next-line deprecation/deprecation
     popoverProps?: IPopoverProps;
 }
 

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -44,6 +44,7 @@ export interface ICollapsibleListProps extends Props {
     /**
      * Props to pass to the dropdown.
      */
+    // eslint-disable-next-line deprecation/deprecation
     dropdownProps?: IPopoverProps;
 
     /**

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -112,6 +112,7 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
      * changed and `usePortal` defaults to `false` so all submenus will live in
      * the same container.
      */
+    // eslint-disable-next-line deprecation/deprecation
     popoverProps?: Partial<IPopoverProps>;
 
     /**

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -41,6 +41,7 @@ export const PopoverInteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PopoverInteractionKind = typeof PopoverInteractionKind[keyof typeof PopoverInteractionKind];
 
+/** @deprecated migrate to Popover2, use Popover2Props */
 export interface IPopoverProps extends IPopoverSharedProps {
     /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
     backdropProps?: React.HTMLProps<HTMLDivElement>;
@@ -109,12 +110,13 @@ export interface IPopoverState {
 }
 
 /** @deprecated use { Popover2 } from "@blueprintjs/popover2" */
+// eslint-disable-next-line deprecation/deprecation
 export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover`;
 
-    // eslint-disable-next-line deprecation/deprecation
     private popoverRef = React.createRef<HTMLDivElement>();
 
+    // eslint-disable-next-line deprecation/deprecation
     public static defaultProps: IPopoverProps = {
         boundary: "scrollParent",
         captureDismiss: false,
@@ -239,6 +241,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
         this.updateDarkParent();
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     public componentDidUpdate(prevProps: IPopoverProps, prevState: IPopoverState) {
         super.componentDidUpdate(prevProps, prevState);
 
@@ -273,6 +276,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
      */
     public reposition = () => this.popperScheduleUpdate?.();
 
+    // eslint-disable-next-line deprecation/deprecation
     protected validateProps(props: IPopoverProps & { children?: React.ReactNode }) {
         if (props.isOpen == null && props.onInteraction != null) {
             console.warn(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
@@ -438,6 +442,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
 
     private isControlled = () => this.props.isOpen !== undefined;
 
+    // eslint-disable-next-line deprecation/deprecation
     private getIsOpen(props: IPopoverProps) {
         // disabled popovers should never be allowed to open.
         if (props.disabled) {

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -23,9 +23,9 @@ import { DISPLAYNAME_PREFIX, IntentProps } from "../../common/props";
 import { Popover, PopoverInteractionKind } from "../popover/popover";
 import { IPopoverSharedProps } from "../popover/popoverSharedProps";
 
-// eslint-disable-next-line deprecation/deprecation
-export type TooltipProps = ITooltipProps;
-/** @deprecated use TooltipProps */
+/** @deprecated migrate to Tooltip2, use Tooltip2Props */
+export type TooltipProps = ITooltipProps; // eslint-disable-line deprecation/deprecation
+/** @deprecated migrate to Tooltip2, use Tooltip2Props */
 export interface ITooltipProps extends IPopoverSharedProps, IntentProps {
     /**
      * The content that will be displayed inside of the tooltip.
@@ -71,9 +71,11 @@ export interface ITooltipProps extends IPopoverSharedProps, IntentProps {
 }
 
 /** @deprecated use { Tooltip2 } from "@blueprintjs/popover2" */
+// eslint-disable-next-line deprecation/deprecation
 export class Tooltip extends AbstractPureComponent2<TooltipProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tooltip`;
 
+    // eslint-disable-next-line deprecation/deprecation
     public static defaultProps: Partial<TooltipProps> = {
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -112,7 +112,7 @@ export interface IDateInputProps extends DatePickerBaseProps, DateFormatProps, P
      * Props to pass to the `Popover`.
      * Note that `content`, `autoFocus`, and `enforceFocus` cannot be changed.
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/ban-types, deprecation/deprecation
     popoverProps?: Partial<IPopoverProps> & object;
 
     /**

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -133,6 +133,7 @@ export interface IDateRangeInputProps extends DatePickerBaseProps, DateFormatPro
      * The props to pass to the popover.
      * `autoFocus`, `content`, and `enforceFocus` will be ignored to avoid compromising usability.
      */
+    // eslint-disable-next-line deprecation/deprecation
     popoverProps?: Partial<IPopoverProps>;
 
     /**

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -23,9 +23,9 @@ import { FileMenu } from "./common/fileMenu";
 
 export class PopoverMinimalExample extends React.PureComponent<IExampleProps> {
     public render() {
+        /* eslint-disable deprecation/deprecation */
         const baseProps: IPopoverProps = { content: <FileMenu />, position: Position.BOTTOM_LEFT };
 
-        /* eslint-disable deprecation/deprecation */
         return (
             <Example options={false} {...this.props}>
                 <Popover {...baseProps} minimal={true}>

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -121,6 +121,7 @@ export class PopoverPortalExample extends React.PureComponent<IExampleProps, IPo
     }
 }
 
+// eslint-disable-next-line deprecation/deprecation
 const POPOVER_PROPS: IPopoverProps = {
     autoFocus: false,
     boundary: "window",

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -79,7 +79,7 @@ export interface IMultiSelectProps<T> extends IListItemsProps<T> {
     placeholder?: string;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/ban-types, deprecation/deprecation
     popoverProps?: Partial<IPopoverProps> & object;
 
     /** Controlled selected values. */

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -83,7 +83,7 @@ export interface ISelectProps<T> extends IListItemsProps<T> {
     matchTargetWidth?: boolean;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/ban-types, deprecation/deprecation
     popoverProps?: Partial<IPopoverProps> & object;
 
     /**

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -90,7 +90,7 @@ export interface ISuggestProps<T> extends IListItemsProps<T> {
     openOnKeyDown?: boolean;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/ban-types, deprecation/deprecation
     popoverProps?: Partial<IPopoverProps> & object;
 
     /**

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -246,6 +246,7 @@ describe("Suggest", () => {
             assert.isTrue(onOpening.calledOnce);
         });
 
+        // eslint-disable-next-line deprecation/deprecation
         function getPopoverProps(isOpen: boolean, modifiers: any): Partial<IPopoverProps> {
             return {
                 ...defaultProps.popoverProps,

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -109,6 +109,7 @@ export interface ITimezonePickerProps extends Props {
     inputProps?: InputGroupProps2;
 
     /** Props to spread to `Popover`. Note that `content` cannot be changed. */
+    // eslint-disable-next-line deprecation/deprecation
     popoverProps?: Partial<IPopoverProps>;
 }
 
@@ -155,6 +156,7 @@ export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, 
             placeholder: "Search for timezones...",
             ...inputProps,
         };
+        // eslint-disable-next-line deprecation/deprecation
         const finalPopoverProps: Partial<IPopoverProps> = {
             ...popoverProps,
             popoverClassName: classNames(Classes.TIMEZONE_PICKER_POPOVER, popoverProps.popoverClassName),
@@ -192,7 +194,7 @@ export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, 
         }
     }
 
-    protected validateProps(props: IPopoverProps & { children?: React.ReactNode }) {
+    protected validateProps(props: TimezonePickerProps & { children?: React.ReactNode }) {
         const childrenCount = React.Children.count(props.children);
         if (childrenCount > 1) {
             console.warn(Errors.TIMEZONE_PICKER_WARN_TOO_MANY_CHILDREN);


### PR DESCRIPTION
I noticed these types used downstream. These components are deprecated, so their prop types should be too.