### PR TITLE
add `title` prop to button

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -85,6 +85,12 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     small?: boolean;
 
     /**
+     * String for the `title` attribute on the rendered element, which will appear
+     * on hover as a native browser tooltip.
+     */
+    title?: string;
+
+    /**
      * HTML `type` attribute of button. Accepted values are `"button"`, `"submit"`, and `"reset"`.
      * Note that this prop has no effect on `AnchorButton`; it only affects `Button`.
      *


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

Weird that `title` prop is not present on `HTMLButtonElement` when this prop is allowed, applicable, and common. Manually added it.