### PR TITLE
[select] feat(Select2, Suggest2, MultiSelect2): menuProps allows forwarding props to Menu

### DIFF
--- a/packages/docs-app/src/common/filmSelect.tsx
+++ b/packages/docs-app/src/common/filmSelect.tsx
@@ -69,7 +69,7 @@ export default function ({ allowCreate = false, fill, ...restProps }: Props) {
             createNewItemFromQuery={maybeCreateNewItemFromQuery}
             createNewItemRenderer={maybeCreateNewItemRenderer}
             itemsEqual={areFilmsEqual}
-            menuLabel="films"
+            menuProps={{ "aria-label": "films" }}
             noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
             onItemSelect={handleItemSelect}
             items={items}

--- a/packages/docs-app/src/common/filmSelect.tsx
+++ b/packages/docs-app/src/common/filmSelect.tsx
@@ -69,6 +69,7 @@ export default function ({ allowCreate = false, fill, ...restProps }: Props) {
             createNewItemFromQuery={maybeCreateNewItemFromQuery}
             createNewItemRenderer={maybeCreateNewItemRenderer}
             itemsEqual={areFilmsEqual}
+            menuLabel="films"
             noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
             onItemSelect={handleItemSelect}
             items={items}

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -124,7 +124,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     // we may customize the default filmSelectProps.items by
                     // adding newly created items to the list, so pass our own
                     items={this.state.items}
-                    menuLabel="films"
+                    menuProps={{ "aria-label": "films" }}
                     noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
                     onClear={this.state.showClearButton ? this.handleClear : undefined}
                     onItemSelect={this.handleFilmSelect}

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -124,6 +124,7 @@ export class MultiSelectExample extends React.PureComponent<IExampleProps, IMult
                     // we may customize the default filmSelectProps.items by
                     // adding newly created items to the list, so pass our own
                     items={this.state.items}
+                    menuLabel="films"
                     noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
                     onClear={this.state.showClearButton ? this.handleClear : undefined}
                     onItemSelect={this.handleFilmSelect}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -172,12 +172,17 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { menuProps = {}, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+        const { menuProps, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ ...menuProps, "aria-multiselectable": true, id: this.listboxId }}
+                menuProps={{
+                    "aria-label": "selectable options",
+                    ...menuProps,
+                    "aria-multiselectable": true,
+                    id: this.listboxId,
+                }}
                 onItemSelect={this.handleItemSelect}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -51,6 +51,11 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     fill?: boolean;
 
     /**
+     * Applied to the `aria-label` prop of the `listbox` `ul`
+     */
+    menuLabel?: string;
+
+    /**
      * If provided, this component will render a "clear" button inside its TagInput.
      * Clicking that button will invoke this callback to clear all items from the current selection.
      */
@@ -166,12 +171,12 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+        const { menuLabel, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ "aria-multiselectable": true, id: this.listboxId }}
+                menuProps={{ "aria-label": menuLabel, "aria-multiselectable": true, id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -51,8 +51,7 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     fill?: boolean;
 
     /**
-     * Props that get spread to the menu popover's listbox `ul` element
-     * that contains the selectable options.
+     * Props to spread to the `Menu` listbox containing the selectable options.
      */
     menuProps?: React.HTMLProps<HTMLUListElement>;
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -51,9 +51,10 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     fill?: boolean;
 
     /**
-     * Applied to the `aria-label` prop of the `listbox` `ul`
+     * Props that get spread to the menu popover's listbox `ul` element
+     * that contains the selectable options.
      */
-    menuLabel?: string;
+    menuProps?: React.HTMLProps<HTMLUListElement>;
 
     /**
      * If provided, this component will render a "clear" button inside its TagInput.
@@ -171,12 +172,12 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { menuLabel, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
+        const { menuProps = {}, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ "aria-label": menuLabel, "aria-multiselectable": true, id: this.listboxId }}
+                menuProps={{ ...menuProps, "aria-multiselectable": true, id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 onQueryChange={this.handleQueryChange}
                 ref={this.refHandlers.queryList}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -76,6 +76,11 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     inputProps?: InputGroupProps2;
 
     /**
+     * Applied to the `aria-label` prop of the `listbox` `ul`
+     */
+    menuLabel?: string;
+
+    /**
      * Props to add to the popover target wrapper element.
      */
     popoverTargetProps?: React.HTMLAttributes<HTMLDivElement>;
@@ -118,12 +123,12 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, inputProps, popoverProps, ...restProps } = this.props;
+        const { filterable, inputProps, menuLabel, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ id: this.listboxId }}
+                menuProps={{ "aria-label": menuLabel, id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}
                 renderer={this.renderQueryList}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -76,9 +76,10 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     inputProps?: InputGroupProps2;
 
     /**
-     * Applied to the `aria-label` prop of the `listbox` `ul`
+     * Props that get spread to the menu popover's listbox `ul` element
+     * that contains the selectable options.
      */
-    menuLabel?: string;
+    menuProps?: React.HTMLProps<HTMLUListElement>;
 
     /**
      * Props to add to the popover target wrapper element.
@@ -123,12 +124,12 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, inputProps, menuLabel, popoverProps, ...restProps } = this.props;
+        const { filterable, inputProps, menuProps = {}, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ "aria-label": menuLabel, id: this.listboxId }}
+                menuProps={{ ...menuProps, id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}
                 renderer={this.renderQueryList}

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -76,8 +76,7 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     inputProps?: InputGroupProps2;
 
     /**
-     * Props that get spread to the menu popover's listbox `ul` element
-     * that contains the selectable options.
+     * Props to spread to the `Menu` listbox containing the selectable options.
      */
     menuProps?: React.HTMLProps<HTMLUListElement>;
 

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -124,12 +124,12 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { filterable, inputProps, menuProps = {}, popoverProps, ...restProps } = this.props;
+        const { filterable, inputProps, menuProps, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ ...menuProps, id: this.listboxId }}
+                menuProps={{ "aria-label": "selectable options", ...menuProps, id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}
                 renderer={this.renderQueryList}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -140,12 +140,12 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { disabled, inputProps, menuProps = {}, popoverProps, ...restProps } = this.props;
+        const { disabled, inputProps, menuProps, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ ...menuProps, id: this.listboxId }}
+                menuProps={{ "aria-label": "selectable options", ...menuProps, id: this.listboxId }}
                 initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -77,8 +77,7 @@ export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps
     selectedItem?: T | null;
 
     /**
-     * Props that get spread to the menu popover's listbox `ul` element
-     * that contains the selectable options.
+     * Props to spread to the `Menu` listbox containing the selectable options.
      */
     menuProps?: React.HTMLProps<HTMLUListElement>;
 

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -77,9 +77,10 @@ export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps
     selectedItem?: T | null;
 
     /**
-     * Applied to the `aria-label` prop of the `listbox` `ul`
+     * Props that get spread to the menu popover's listbox `ul` element
+     * that contains the selectable options.
      */
-    menuLabel?: string;
+    menuProps?: React.HTMLProps<HTMLUListElement>;
 
     /**
      * If true, the component waits until a keydown event in the TagInput
@@ -139,12 +140,12 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { disabled, inputProps, menuLabel, popoverProps, ...restProps } = this.props;
+        const { disabled, inputProps, menuProps = {}, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ "aria-label": menuLabel, id: this.listboxId }}
+                menuProps={{ ...menuProps, id: this.listboxId }}
                 initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -77,6 +77,11 @@ export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps
     selectedItem?: T | null;
 
     /**
+     * Applied to the `aria-label` prop of the `listbox` `ul`
+     */
+    menuLabel?: string;
+
+    /**
      * If true, the component waits until a keydown event in the TagInput
      * before opening its popover.
      *
@@ -134,12 +139,12 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     public render() {
         // omit props specific to this component, spread the rest.
-        const { disabled, inputProps, popoverProps, ...restProps } = this.props;
+        const { disabled, inputProps, menuLabel, popoverProps, ...restProps } = this.props;
 
         return (
             <this.TypedQueryList
                 {...restProps}
-                menuProps={{ id: this.listboxId }}
+                menuProps={{ "aria-label": menuLabel, id: this.listboxId }}
                 initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

in order to pass aXe a11y testing, we need to apply an `aria-label` to the `Menu` that is created by MultiSelect2/Select2/Suggest2
