### PR TITLE
[core] fix(Tag): improve a11y label

### DIFF
--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -124,6 +124,8 @@ export interface ITagProps
 export class Tag extends AbstractPureComponent2<TagProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tag`;
 
+    private tagId = Utils.uniqueId("tag");
+
     public render() {
         const {
             active,
@@ -172,10 +174,22 @@ export class Tag extends AbstractPureComponent2<TagProps> {
         ) : null;
 
         return (
-            <span {...htmlProps} className={tagClasses} tabIndex={interactive ? tabIndex : undefined} ref={elementRef}>
+            <span
+                {...htmlProps}
+                aria-labelledby={this.tagId}
+                className={tagClasses}
+                tabIndex={interactive ? tabIndex : undefined}
+                ref={elementRef}
+            >
                 <Icon icon={icon} />
                 {!isReactNodeEmpty(children) && (
-                    <Text className={Classes.FILL} ellipsize={!multiline} tagName="span" title={htmlTitle}>
+                    <Text
+                        className={Classes.FILL}
+                        ellipsize={!multiline}
+                        id={this.tagId}
+                        tagName="span"
+                        title={htmlTitle}
+                    >
                         {children}
                     </Text>
                 )}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Currently, a tag that has `tabIndex` > -1, when tabbed to in a screen reader, is also reading the remove button when reading the whole tag-- this should be excluded from reading the value of the tag-- the tag's remove button would be the next item being tabbed to.
