### PR TITLE
[datetime2] feat(DateInput2): use Popover2, port DateInput impl

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to DateInput2 in the datetime2
+ * package instead.
+ */
+
 import classNames from "classnames";
 import * as React from "react";
 import type { DayPickerProps } from "react-day-picker";
@@ -161,6 +167,7 @@ export interface IDateInputState {
     selectedShortcutIndex?: number;
 }
 
+/** @deprecated use { DateInput2 } from "@blueprintjs/datetime2" */
 export class DateInput extends AbstractPureComponent2<DateInputProps, IDateInputState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.DateInput`;
 

--- a/packages/datetime2/src/blueprint-datetime2.scss
+++ b/packages/datetime2/src/blueprint-datetime2.scss
@@ -12,6 +12,13 @@
   user-select: none;
 }
 
+.#{$ns}-date-input {
+  .#{$ns}-input-action {
+    // we need these elements to lay out next to each other if there are multiple
+    display: flex;
+  }
+}
+
 .#{$ns}-date-input-timezone-select {
   width: 100%;
 }

--- a/packages/datetime2/src/common/classes.ts
+++ b/packages/datetime2/src/common/classes.ts
@@ -18,6 +18,7 @@ import { Classes } from "@blueprintjs/core";
 
 const NS = Classes.getClassNamespace();
 
+export const DATE_INPUT = `${NS}-date-input`;
 export const DATE_INPUT_POPOVER = `${NS}-date-input-popover`;
 export const DATE_INPUT_TIMEZONE_SELECT = `${NS}-date-input-timezone-select`;
 

--- a/packages/datetime2/src/common/classes.ts
+++ b/packages/datetime2/src/common/classes.ts
@@ -18,6 +18,7 @@ import { Classes } from "@blueprintjs/core";
 
 const NS = Classes.getClassNamespace();
 
+export const DATE_INPUT_POPOVER = `${NS}-date-input-popover`;
 export const DATE_INPUT_TIMEZONE_SELECT = `${NS}-date-input-timezone-select`;
 
 export const TIMEZONE_SELECT = `${NS}-timezone-select`;

--- a/packages/datetime2/src/common/dateUtils.ts
+++ b/packages/datetime2/src/common/dateUtils.ts
@@ -22,6 +22,10 @@ export function clone(d: Date) {
     return new Date(d.getTime());
 }
 
+export function isDateValid(date: Date | false | null): date is Date {
+    return date instanceof Date && !isNaN(date.valueOf());
+}
+
 export function isSameTime(d1: Date | null, d2: Date | null) {
     // N.B. do not use date-fns helper fns here, since we don't want to return false when the month/day/year is different
     return (

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -24,7 +24,6 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     InputGroupProps2,
-    Intent,
     mergeRefs,
     Props,
     Tag,
@@ -554,7 +553,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
         >
             <InputGroup
                 autoComplete="off"
-                intent={isErrorState ? Intent.DANGER : Intent.NONE}
+                intent={isErrorState ? "danger" : "none"}
                 placeholder={placeholder}
                 rightElement={
                     <>

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -269,6 +269,10 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     const handleDateChange = React.useCallback(
         (newDate: Date | null, isUserChange: boolean, didSubmitWithEnter = false) => {
             if (newDate === null) {
+                if (!didSubmitWithEnter) {
+                    // user clicked on current day in the calendar, so we should clear the input
+                    setInputValue("");
+                }
                 props.onChange?.(null, isUserChange);
                 return;
             }

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import { isValid } from "date-fns";
 import * as React from "react";
 import type { DayPickerProps } from "react-day-picker";
 
@@ -374,7 +373,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     // we use today's date and shift it to the desired/current timezone
     const tzSelectDate = React.useMemo(
         () =>
-            valueAsDate != null && isValid(valueAsDate)
+            valueAsDate != null && isDateValid(valueAsDate)
                 ? valueAsDate
                 : convertLocalDateToTimezoneTime(new Date(), timezoneValue),
         [timezoneValue, valueAsDate],
@@ -532,7 +531,9 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                 inputRef.current?.blur();
             } else if (e.key === "Enter" && inputValue != null) {
                 const nextDate = parseDate(inputValue);
-                handleDateChange(nextDate, true, true);
+                if (isDateValid(nextDate)) {
+                    handleDateChange(nextDate, true, true);
+                }
             }
 
             props.inputProps?.onKeyDown?.(e);

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -186,6 +186,7 @@ const timezoneSelectButtonProps: Partial<ButtonProps> = {
     outlined: true,
 };
 
+const INVALID_DATE = new Date(undefined!);
 const DEFAULT_MAX_DATE = DatePickerUtils.getDefaultMaxDate();
 const DEFAULT_MIN_DATE = DatePickerUtils.getDefaultMinDate();
 
@@ -429,7 +430,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                 return null;
             }
             const newDate = props.parseDate(dateString, props.locale);
-            return newDate === false ? new Date() : newDate;
+            return newDate === false ? INVALID_DATE : newDate;
         },
         // HACKHACK: ESLint false positive
         // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -483,7 +484,16 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             }
             props.inputProps?.onBlur?.(e);
         },
-        [inputValue, valueAsDate, minDate, maxDate, props.onChange, props.onError, props.inputProps?.onBlur],
+        [
+            formattedDateString,
+            inputValue,
+            valueAsDate,
+            minDate,
+            maxDate,
+            props.onChange,
+            props.onError,
+            props.inputProps?.onBlur,
+        ],
     );
 
     const handleInputChange = React.useCallback(
@@ -507,6 +517,10 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             } else {
                 if (valueString.length === 0) {
                     props.onChange?.(null, true);
+                }
+                if (!isControlled) {
+                    // update this state when the date is invalid to update formattedDateString
+                    setValue(inputValueAsDate);
                 }
                 setInputValue(valueString);
             }

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -566,6 +566,9 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     // Main render
     // ------------------------------------------------------------------------
 
+    const shouldShowErrorStyling =
+        !isInputFocused || inputValue === props.outOfRangeMessage || inputValue === props.invalidDateMessage;
+
     return (
         <Popover2
             isOpen={isOpen && !props.disabled}
@@ -580,7 +583,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
         >
             <InputGroup
                 autoComplete="off"
-                intent={!isInputFocused && isErrorState ? "danger" : "none"}
+                intent={shouldShowErrorStyling && isErrorState ? "danger" : "none"}
                 placeholder={placeholder}
                 rightElement={
                     <>

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -188,14 +188,18 @@ const timezoneSelectButtonProps: Partial<ButtonProps> = {
     outlined: true,
 };
 
+const DEFAULT_MAX_DATE = DatePickerUtils.getDefaultMaxDate();
+const DEFAULT_MIN_DATE = DatePickerUtils.getDefaultMinDate();
+
 export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateInput2(props) {
     const {
         defaultTimezone,
         defaultValue,
         disableTimezoneSelect,
         inputProps = {},
-        minDate = null,
-        maxDate = null,
+        // defaults duplicated here for TypeScript convenience
+        maxDate = DEFAULT_MAX_DATE,
+        minDate = DEFAULT_MIN_DATE,
         placeholder,
         popoverProps = {},
         showTimezoneSelect,
@@ -280,7 +284,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                 !props.closeOnSelection ||
                 (prevDate != null &&
                     (hasMonthChanged(prevDate, newDate) ||
-                        (props.timePrecision !== undefined && hasTimeChanged(prevDate, newDate))));
+                        (timePrecision !== undefined && hasTimeChanged(prevDate, newDate))));
 
             // if selecting a date via click or Tab, the input will already be
             // blurred by now, so sync isInputFocused to false. if selecting via
@@ -348,10 +352,13 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             <DatePicker
                 {...datePickerProps}
                 dayPickerProps={dayPickerProps}
+                maxDate={maxDate}
+                minDate={minDate}
                 onChange={handleDateChange}
-                value={valueAsDate}
                 onShortcutChange={handleShortcutChange}
                 selectedShortcutIndex={selectedShortcutIndex}
+                timePrecision={timePrecision}
+                value={valueAsDate}
             />
             <div onFocus={handleEndFocusBoundaryFocusIn} tabIndex={0} />
         </div>
@@ -539,7 +546,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             fill={props.fill}
             {...popoverProps}
             autoFocus={false}
-            className={classNames(popoverProps.className, props.className)}
+            className={classNames(Classes.DATE_INPUT, popoverProps.className, props.className)}
             content={popoverContent}
             enforceFocus={false}
             onClose={handlePopoverClose}
@@ -552,7 +559,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                 rightElement={
                     <>
                         {maybeTimezonePicker}
-                        {props.inputProps?.rightElement}
+                        {props.rightElement}
                     </>
                 }
                 type="text"
@@ -574,8 +581,8 @@ DateInput2.defaultProps = {
     closeOnSelection: true,
     disabled: false,
     invalidDateMessage: "Invalid date",
-    maxDate: DatePickerUtils.getDefaultMaxDate(),
-    minDate: DatePickerUtils.getDefaultMinDate(),
+    maxDate: DEFAULT_MAX_DATE,
+    minDate: DEFAULT_MIN_DATE,
     outOfRangeMessage: "Out of range",
     reverseMonthAndYearMenus: false,
 };

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -14,13 +14,26 @@
  * limitations under the License.
  */
 
+import classNames from "classnames";
 import { isValid } from "date-fns";
 import * as React from "react";
+import type { DayPickerProps } from "react-day-picker";
 
-import { ButtonProps, DISPLAYNAME_PREFIX, Tag } from "@blueprintjs/core";
-import { DateInput, DateInputProps } from "@blueprintjs/datetime";
+import {
+    ButtonProps,
+    DISPLAYNAME_PREFIX,
+    InputGroup,
+    InputGroupProps2,
+    Intent,
+    mergeRefs,
+    Props,
+    Tag,
+} from "@blueprintjs/core";
+import { DateFormatProps, DatePicker, DatePickerBaseProps, DatePickerShortcut } from "@blueprintjs/datetime";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import * as Classes from "../../common/classes";
+import { isDateValid, isDayInRange } from "../../common/dateUtils";
 import { getCurrentTimezone } from "../../common/getTimezone";
 import { getTimezoneName } from "../../common/timezoneNameUtils";
 import {
@@ -30,14 +43,63 @@ import {
 } from "../../common/timezoneUtils";
 import { TimezoneSelect } from "../timezone-select/timezoneSelect";
 
-export interface DateInput2Props extends Omit<DateInputProps, "defaultValue" | "onChange" | "value" | "rightElement"> {
+export interface DateInput2Props extends DatePickerBaseProps, DateFormatProps, Props {
+    /**
+     * Allows the user to clear the selection by clicking the currently selected day.
+     * Passed to `DatePicker` component.
+     *
+     * @default true
+     */
+    canClearSelection?: boolean;
+
+    /**
+     * Text for the reset button in the date picker action bar.
+     * Passed to `DatePicker` component.
+     *
+     * @default "Clear"
+     */
+    clearButtonText?: string;
+
+    /**
+     * Whether the calendar popover should close when a date is selected.
+     *
+     * @default true
+     */
+    closeOnSelection?: boolean;
+
     /** The default timezone selected. Defaults to the user local timezone */
     defaultTimezone?: string;
+
+    /**
+     * Whether to disable the timezone select.
+     *
+     * @default false
+     */
+    disableTimezoneSelect?: boolean;
 
     /**
      * The default date to be used in the component when uncontrolled, represented as an ISO string.
      */
     defaultValue?: string;
+
+    /**
+     * Whether the date input is non-interactive.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether the component should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * Props to pass to the [input group](#core/components/text-inputs.input-group).
+     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
+     * `type` is fixed to "text".
+     */
+    inputProps?: Omit<InputGroupProps2, "disabled" | "type" | "value">;
 
     /**
      * Callback invoked whenever the date or timezone has changed.
@@ -48,8 +110,41 @@ export interface DateInput2Props extends Omit<DateInputProps, "defaultValue" | "
      */
     onChange?: (newDate: string | null, isUserChange?: boolean) => void;
 
-    /** An ISO string representing the selected time. */
-    value?: string | null;
+    /**
+     * Called when the user finishes typing in a new date and the date causes an error state.
+     * If the date is invalid, `new Date(undefined)` will be returned. If the date is out of range,
+     * the out of range date will be returned (`onChange` is not called in this case).
+     */
+    onError?: (errorDate: Date) => void;
+
+    /**
+     * The props to pass to the popover.
+     */
+    popoverProps?: Partial<
+        Omit<
+            Popover2Props,
+            | "autoFocus"
+            | "content"
+            | "defaultIsOpen"
+            | "disabled"
+            | "enforceFocus"
+            | "fill"
+            | "renderTarget"
+            | "targetTagName"
+        >
+    >;
+
+    /**
+     * Element to render on right side of input.
+     */
+    rightElement?: JSX.Element;
+
+    /**
+     * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown below the calendar.
+     *
+     * @default false
+     */
+    showActionsBar?: boolean;
 
     /**
      * Whether to show the timezone select dropdown on the right side of the input.
@@ -60,11 +155,25 @@ export interface DateInput2Props extends Omit<DateInputProps, "defaultValue" | "
     showTimezoneSelect?: boolean;
 
     /**
-     * Whether to disable the timezone select.
+     * Whether shortcuts to quickly select a date are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
      *
      * @default false
      */
-    disableTimezoneSelect?: boolean;
+    shortcuts?: boolean | DatePickerShortcut[];
+
+    /**
+     * Text for the today button in the date picker action bar.
+     * Passed to `DatePicker` component.
+     *
+     * @default "Today"
+     */
+    todayButtonText?: string;
+
+    /** An ISO string representing the selected time. */
+    value?: string | null;
 }
 
 const timezoneSelectButtonProps: Partial<ButtonProps> = {
@@ -77,58 +186,145 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     const {
         defaultTimezone,
         defaultValue,
-        disabled,
         disableTimezoneSelect,
-        onChange,
+        inputProps = {},
+        minDate = null,
+        maxDate = null,
+        placeholder,
+        popoverProps = {},
         showTimezoneSelect,
         timePrecision,
         value,
-        ...dateInputProps
+        ...datePickerProps
     } = props;
 
+    const [isOpen, setIsOpen] = React.useState(false);
     const [timezoneValue, setTimezoneValue] = React.useState(defaultTimezone ?? getCurrentTimezone());
-    const valueAsDate = React.useMemo(() => getDateObjectFromIsoString(value, timezoneValue), [timezoneValue, value]);
-    const defaultValueAsDate = React.useMemo(
+    const valueFromProps = React.useMemo(
+        () => getDateObjectFromIsoString(value, timezoneValue),
+        [timezoneValue, value],
+    );
+    const defaultValueFromProps = React.useMemo(
         () => getDateObjectFromIsoString(defaultValue, timezoneValue),
         [defaultValue, defaultTimezone],
     );
-    // when uncontrolled, we need to keep local state for the date value so that we can send it to the consumer when
-    // handling timezone changes
-    const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValueAsDate);
+    const [valueAsDate, setValue] = React.useState<Date | null>(
+        valueFromProps !== undefined ? valueFromProps : defaultValueFromProps!,
+    );
+    const [selectedShortcutIndex, setSelectedShortcutIndex] = React.useState<number | undefined>(undefined);
+    const [isInputFocused, setIsInputFocused] = React.useState(false);
+    const [inputValue, setInputValue] = React.useState(value ?? null);
+
+    const inputRef = React.useRef<HTMLInputElement | null>(null);
+    const popoverContentRef = React.useRef<HTMLDivElement | null>(null);
+
+    const handlePopoverClose = React.useCallback((e: React.SyntheticEvent<HTMLElement>) => {
+        popoverProps.onClose?.(e);
+        setIsOpen(false);
+    }, []);
 
     const handleTimezoneChange = React.useCallback(
         (newTimezone: string) => {
-            setTimezoneValue(newTimezone);
-            if (valueAsDate === undefined && uncontrolledValue !== undefined) {
-                // uncontrolled
-                const newDateString = getIsoEquivalentWithUpdatedTimezone(
-                    uncontrolledValue,
-                    newTimezone,
-                    timePrecision,
-                );
-                onChange?.(newDateString);
-            } else if (valueAsDate != null) {
+            if (valueAsDate !== null) {
+                setTimezoneValue(newTimezone);
                 const newDateString = getIsoEquivalentWithUpdatedTimezone(valueAsDate, newTimezone, timePrecision);
-                onChange?.(newDateString);
+                props.onChange?.(newDateString);
             }
         },
-        [onChange, valueAsDate, timePrecision, uncontrolledValue],
+        [props.onChange, valueAsDate, timePrecision],
     );
 
     const handleDateChange = React.useCallback(
-        (newDate: Date | null, isUserChange: boolean) => {
-            if (newDate == null) {
-                onChange?.(newDate, isUserChange);
+        (newDate: Date | null, isUserChange: boolean, didSubmitWithEnter = false) => {
+            if (newDate === null) {
+                props.onChange?.(null, isUserChange);
                 return;
             }
-            if (valueAsDate === undefined) {
-                // uncontrolled
-                setUncontrolledValue(newDate);
-            }
+
+            const prevDate = valueAsDate;
+
+            // this change handler was triggered by a change in month, day, or (if
+            // enabled) time. for UX purposes, we want to close the popover only if
+            // the user explicitly clicked a day within the current month.
+            const newIsOpen =
+                !isUserChange ||
+                !props.closeOnSelection ||
+                (prevDate != null &&
+                    (hasMonthChanged(prevDate, newDate) ||
+                        (props.timePrecision !== undefined && hasTimeChanged(prevDate, newDate))));
             const newDateString = getIsoEquivalentWithUpdatedTimezone(newDate, timezoneValue, timePrecision);
-            onChange?.(newDateString, isUserChange);
+
+            // if selecting a date via click or Tab, the input will already be
+            // blurred by now, so sync isInputFocused to false. if selecting via
+            // Enter, setting isInputFocused to false won't do anything by itself,
+            // plus we want the field to retain focus anyway.
+            // (note: spelling out the ternary explicitly reads more clearly.)
+            const newIsInputFocused = didSubmitWithEnter ? true : false;
+
+            if (valueFromProps === undefined) {
+                setIsInputFocused(newIsInputFocused);
+                setIsOpen(newIsOpen);
+                setValue(newDate);
+                setInputValue(newDateString);
+            } else {
+                setIsInputFocused(newIsInputFocused);
+                setIsOpen(newIsOpen);
+            }
+
+            props.onChange?.(newDateString, isUserChange);
         },
-        [onChange, timezoneValue, timePrecision],
+        [props.onChange, timezoneValue, timePrecision],
+    );
+
+    const dayPickerProps: DayPickerProps = {
+        ...props.dayPickerProps,
+        onDayKeyDown: (day, modifiers, e) => {
+            props.dayPickerProps?.onDayKeyDown?.(day, modifiers, e);
+        },
+        onMonthChange: (month: Date) => {
+            props.dayPickerProps?.onMonthChange?.(month);
+        },
+    };
+
+    const handleShortcutChange = React.useCallback((_: DatePickerShortcut, index: number) => {
+        setSelectedShortcutIndex(index);
+    }, []);
+
+    const handleStartFocusBoundaryFocusIn = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+        if (popoverContentRef.current?.contains(getRelatedTargetWithFallback(e))) {
+            // Not closing Popover to allow user to freely switch between manually entering a date
+            // string in the input and selecting one via the Popover
+            inputRef.current?.focus();
+        } else {
+            getKeyboardFocusableElements(popoverContentRef).shift()?.focus();
+        }
+    }, []);
+
+    const handleEndFocusBoundaryFocusIn = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+        if (popoverContentRef.current?.contains(getRelatedTargetWithFallback(e))) {
+            inputRef.current?.focus();
+            handlePopoverClose(e);
+        } else {
+            getKeyboardFocusableElements(popoverContentRef).pop()?.focus();
+        }
+    }, []);
+
+    // React's onFocus prop listens to the focusin browser event under the hood, so it's safe to
+    // provide it the focusIn event handlers instead of using a ref and manually adding the
+    // event listeners ourselves.
+    const popoverContent = (
+        <div ref={popoverContentRef}>
+            <div onFocus={handleStartFocusBoundaryFocusIn} tabIndex={0} />
+            <DatePicker
+                {...datePickerProps}
+                dayPickerProps={dayPickerProps}
+                onChange={handleDateChange}
+                value={valueAsDate}
+                onShortcutChange={handleShortcutChange}
+                selectedShortcutIndex={selectedShortcutIndex}
+            />
+            <div onFocus={handleEndFocusBoundaryFocusIn} tabIndex={0} />
+        </div>
     );
 
     // we need a date which is guaranteed to be non-null here; if necessary, we use today's date and shift
@@ -142,7 +338,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     );
 
     const isTimezoneSelectHidden = timePrecision === undefined || showTimezoneSelect === false;
-    const isTimezoneSelectDisabled = disabled || disableTimezoneSelect;
+    const isTimezoneSelectDisabled = props.disabled || disableTimezoneSelect;
 
     const maybeTimezonePicker = isTimezoneSelectHidden ? undefined : (
         <TimezoneSelect
@@ -163,16 +359,210 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
         </TimezoneSelect>
     );
 
+    const formattedDateValue = React.useMemo(
+        () =>
+            valueAsDate === null ? "" : getIsoEquivalentWithUpdatedTimezone(valueAsDate, timezoneValue, timePrecision),
+        [valueAsDate, timezoneValue, timePrecision],
+    );
+    const isErrorState =
+        valueAsDate != null && (!isDateValid(valueAsDate) || !isDayInRange(valueAsDate, [minDate, maxDate]));
+
+    const parseDate = React.useCallback(
+        (dateString: string) => {
+            if (dateString === props.outOfRangeMessage || dateString === props.invalidDateMessage) {
+                return null;
+            }
+            const newDate = props.parseDate(dateString, props.locale);
+            return newDate === false ? new Date() : newDate;
+        },
+        // HACKHACK: ESLint false positive
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        [props.outOfRangeMessage, props.invalidDateMessage, props.parseDate, props.locale],
+    );
+
+    const handleInputFocus = React.useCallback(
+        (e: React.FocusEvent<HTMLInputElement>) => {
+            setIsInputFocused(true);
+            setIsOpen(true);
+            setInputValue(formattedDateValue);
+            props.inputProps?.onFocus?.(e);
+        },
+        [formattedDateValue, props.inputProps?.onFocus],
+    );
+
+    const handleInputBlur = React.useCallback(
+        (e: React.FocusEvent<HTMLInputElement>) => {
+            if (inputValue == null || valueAsDate == null) {
+                return;
+            }
+
+            const date = parseDate(inputValue);
+
+            if (
+                inputValue.length > 0 &&
+                inputValue !== formattedDateValue &&
+                (!isDateValid(date) || !isDayInRange(date, [minDate, maxDate]))
+            ) {
+                if (value === undefined) {
+                    // uncontrolled
+                    setIsInputFocused(false);
+                    setValue(date);
+                    setInputValue(null);
+                } else {
+                    setIsInputFocused(false);
+                }
+
+                if (date === null) {
+                    props.onChange?.(null, true);
+                } else {
+                    props.onError?.(date);
+                }
+            } else {
+                if (inputValue.length === 0) {
+                    setIsInputFocused(false);
+                    setValue(null);
+                    setInputValue(null);
+                } else {
+                    setIsInputFocused(false);
+                }
+            }
+            props.inputProps?.onBlur?.(e);
+        },
+        [
+            inputValue,
+            valueAsDate,
+            formattedDateValue,
+            minDate,
+            maxDate,
+            props.onChange,
+            props.onError,
+            props.inputProps?.onBlur,
+        ],
+    );
+
+    const handleInputChange = React.useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const valueString = (e.target as HTMLInputElement).value;
+            const inputValueAsDate = parseDate(valueString);
+
+            if (isDateValid(inputValueAsDate) && isDayInRange(inputValueAsDate, [minDate, maxDate])) {
+                if (value === undefined) {
+                    // uncontrolled
+                    setValue(inputValueAsDate);
+                    setInputValue(valueString);
+                } else {
+                    setInputValue(valueString);
+                }
+                props.onChange?.(valueString, true);
+            } else {
+                if (valueString.length === 0) {
+                    props.onChange?.(null, true);
+                }
+                setInputValue(valueString);
+            }
+            props.inputProps?.onChange?.(e);
+        },
+        [minDate, maxDate, props.onChange, props.inputProps?.onChange],
+    );
+
+    const handleInputClick = React.useCallback(
+        (e: React.MouseEvent<HTMLInputElement>) => {
+            // stop propagation to the Popover's internal handleTargetClick handler;
+            // otherwise, the popover will flicker closed as soon as it opens.
+            e.stopPropagation();
+            props.inputProps?.onClick?.(e);
+        },
+        [props.inputProps?.onClick],
+    );
+
+    const handleInputKeyDown = React.useCallback(
+        (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === "Tab" && e.shiftKey) {
+                // close popover on SHIFT+TAB key press
+                handlePopoverClose(e);
+            } else if (e.key === "Tab" && isOpen) {
+                getKeyboardFocusableElements(popoverContentRef).shift()?.focus();
+                // necessary to prevent focusing the second focusable element
+                e.preventDefault();
+            } else if (e.key === "Escape") {
+                setIsOpen(false);
+                inputRef.current?.blur();
+            } else if (e.key === "Enter" && inputValue != null) {
+                const nextDate = parseDate(inputValue);
+                handleDateChange(nextDate, true, true);
+            }
+
+            props.inputProps?.onKeyDown?.(e);
+        },
+        [inputValue, props.inputProps?.onKeyDown],
+    );
+
     return (
-        <DateInput
-            {...dateInputProps}
-            defaultValue={defaultValueAsDate}
-            value={valueAsDate}
-            onChange={handleDateChange}
-            timePrecision={timePrecision}
-            rightElement={maybeTimezonePicker}
-            disabled={disabled}
-        />
+        <Popover2
+            isOpen={isOpen && !props.disabled}
+            fill={props.fill}
+            {...popoverProps}
+            autoFocus={false}
+            className={classNames(popoverProps.className, props.className)}
+            content={popoverContent}
+            enforceFocus={false}
+            onClose={handlePopoverClose}
+            popoverClassName={classNames(Classes.DATE_INPUT_POPOVER, popoverProps.popoverClassName)}
+        >
+            <InputGroup
+                autoComplete="off"
+                intent={isErrorState ? Intent.DANGER : Intent.NONE}
+                placeholder={placeholder}
+                rightElement={
+                    <>
+                        {maybeTimezonePicker}
+                        {props.inputProps?.rightElement}
+                    </>
+                }
+                type="text"
+                {...inputProps}
+                disabled={props.disabled}
+                inputRef={mergeRefs(inputRef, props.inputProps?.inputRef ?? null)}
+                onBlur={handleInputBlur}
+                onChange={handleInputChange}
+                onClick={handleInputClick}
+                onFocus={handleInputFocus}
+                onKeyDown={handleInputKeyDown}
+                value={isInputFocused ? inputValue ?? undefined : formattedDateValue}
+            />
+        </Popover2>
     );
 });
 DateInput2.displayName = `${DISPLAYNAME_PREFIX}.DateInput2`;
+
+function getRelatedTargetWithFallback(e: React.FocusEvent<HTMLElement>) {
+    return (e.relatedTarget ?? document.activeElement) as HTMLElement;
+}
+
+function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<HTMLDivElement | null>) {
+    if (popoverContentRef.current === null) {
+        return [];
+    }
+
+    const elements: HTMLElement[] = Array.from(
+        popoverContentRef.current.querySelectorAll("button:not([disabled]),input,[tabindex]:not([tabindex='-1'])"),
+    );
+    // Remove focus boundary div elements
+    elements.pop();
+    elements.shift();
+    return elements;
+}
+
+function hasMonthChanged(prevDate: Date | null, nextDate: Date | null) {
+    return (prevDate == null) !== (nextDate == null) || nextDate?.getMonth() !== prevDate?.getMonth();
+}
+
+function hasTimeChanged(prevDate: Date | null, nextDate: Date | null) {
+    return (
+        (prevDate == null) !== (nextDate == null) ||
+        nextDate?.getHours() !== prevDate?.getHours() ||
+        nextDate?.getMinutes() !== prevDate?.getMinutes() ||
+        nextDate?.getSeconds() !== prevDate?.getSeconds() ||
+        nextDate?.getMilliseconds() !== prevDate?.getMilliseconds()
+    );
+}

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -603,6 +603,27 @@ describe("<DateInput2>", () => {
             assert.strictEqual(onInputChange.args[0][0].type, "change", "inputProps.onChange expects change event");
         });
 
+        it("typing an invalid date updates the text input with the 'invalid date' message", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: containerElement,
+            });
+            focusInput(wrapper);
+            changeInput(wrapper, "4/77/2016");
+            blurInput(wrapper);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), DateInput2.defaultProps?.invalidDateMessage);
+        });
+
+        it("text input does not show error styling until user is done typing and blurs the input", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: containerElement,
+            });
+            focusInput(wrapper);
+            changeInput(wrapper, "4/77/201");
+            assert.notEqual(wrapper.find(InputGroup).prop("intent"), "danger");
+            blurInput(wrapper);
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), "danger");
+        });
+
         it("clearing the date in the input invokes onChange with null", () => {
             const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
                 attachTo: containerElement,
@@ -611,7 +632,7 @@ describe("<DateInput2>", () => {
             assert.isTrue(onChange.calledWith(null, true));
         });
 
-        it("Clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
+        it("clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
             const wrapper = mount(
                 <DateInput2
                     {...DEFAULT_PROPS_CONTROLLED}

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -180,53 +180,6 @@ describe("<DateInput2>", () => {
         });
     });
 
-    describe("controlled usage", () => {
-        const DEFAULT_PROPS_CONTROLLED = {
-            ...DEFAULT_PROPS,
-            onChange,
-            value: VALUE,
-        };
-
-        it("handles null inputs without crashing", () => {
-            assert.doesNotThrow(() => mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={null} />));
-        });
-
-        describe("when changing timezone", () => {
-            it("calls onChange with the updated ISO string", () => {
-                const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
-                clickTimezoneItem(wrapper, "Paris");
-                assert.isTrue(onChange.calledOnce);
-                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30:00.000+01:00"]);
-            });
-
-            it("formats the returned ISO string according to timePrecision", () => {
-                const wrapper = mount(
-                    <DateInput2 {...DEFAULT_PROPS_CONTROLLED} timePrecision={TimePrecision.MINUTE} />,
-                );
-                clickTimezoneItem(wrapper, "Paris");
-                assert.isTrue(onChange.calledOnce);
-                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30+01:00"]);
-            });
-        });
-
-        it("changing the time calls onChange with the updated ISO string", () => {
-            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />, { attachTo: containerElement });
-            focusInput(wrapper);
-            setTimeUnit(wrapper, TimeUnit.HOUR_24, 11);
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.firstCall.args, ["2021-11-29T11:30:00.000+00:00", true]);
-        });
-
-        it("clearing the input invokes onChange with null", () => {
-            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
-            wrapper
-                .find(InputGroup)
-                .find("input")
-                .simulate("change", { target: { value: "" } });
-            assert.isTrue(onChange.calledOnceWithExactly(null, true));
-        });
-    });
-
     describe("uncontrolled usage", () => {
         const DEFAULT_PROPS_UNCONTROLLED = {
             ...DEFAULT_PROPS,
@@ -501,6 +454,53 @@ describe("<DateInput2>", () => {
             clickCalendarDay(wrapper, DATE.getDate());
             assert.isTrue(onChange.calledOnce);
             assert.isTrue(isEqual(parseISO(onChange.firstCall.args[0]), DATE));
+        });
+    });
+
+    describe("controlled usage", () => {
+        const DEFAULT_PROPS_CONTROLLED = {
+            ...DEFAULT_PROPS,
+            onChange,
+            value: VALUE,
+        };
+
+        it("handles null inputs without crashing", () => {
+            assert.doesNotThrow(() => mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={null} />));
+        });
+
+        describe("when changing timezone", () => {
+            it("calls onChange with the updated ISO string", () => {
+                const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
+                clickTimezoneItem(wrapper, "Paris");
+                assert.isTrue(onChange.calledOnce);
+                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30:00.000+01:00"]);
+            });
+
+            it("formats the returned ISO string according to timePrecision", () => {
+                const wrapper = mount(
+                    <DateInput2 {...DEFAULT_PROPS_CONTROLLED} timePrecision={TimePrecision.MINUTE} />,
+                );
+                clickTimezoneItem(wrapper, "Paris");
+                assert.isTrue(onChange.calledOnce);
+                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30+01:00"]);
+            });
+        });
+
+        it("changing the time calls onChange with the updated ISO string", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            setTimeUnit(wrapper, TimeUnit.HOUR_24, 11);
+            assert.isTrue(onChange.calledOnce);
+            assert.deepEqual(onChange.firstCall.args, ["2021-11-29T11:30:00.000+00:00", true]);
+        });
+
+        it("clearing the input invokes onChange with null", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
+            wrapper
+                .find(InputGroup)
+                .find("input")
+                .simulate("change", { target: { value: "" } });
+            assert.isTrue(onChange.calledOnceWithExactly(null, true));
         });
     });
 

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -20,7 +20,8 @@ import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup } from "@blueprintjs/core";
-import { Classes as DatetimeClasses, TimePrecision, TimeUnit } from "@blueprintjs/datetime";
+import { DatePicker, Classes as DatetimeClasses, Months, TimePrecision, TimeUnit } from "@blueprintjs/datetime";
+import { Popover2, Classes as Popover2Classes } from "@blueprintjs/popover2";
 
 import { Classes, DateInput2, DateInput2Props, TimezoneSelect } from "../../src";
 
@@ -34,9 +35,9 @@ const DEFAULT_PROPS = {
     formatDate,
     parseDate,
     popoverProps: {
-        isOpen: true,
         usePortal: false,
     },
+    timePickerProps: { showArrowButtons: true },
     timePrecision: TimePrecision.MILLISECOND,
 };
 
@@ -53,6 +54,130 @@ describe("<DateInput2>", () => {
         onChange.resetHistory();
     });
 
+    describe("basic rendering", () => {
+        it("passes custom classNames to popover target", () => {
+            const CLASS_1 = "foo";
+            const CLASS_2 = "bar";
+
+            const wrapper = mount(
+                <DateInput2
+                    {...DEFAULT_PROPS}
+                    className={CLASS_1}
+                    popoverProps={{ ...DEFAULT_PROPS.popoverProps, className: CLASS_2 }}
+                />,
+            );
+
+            const popoverTarget = wrapper.find(`.${Classes.DATE_INPUT}.${Popover2Classes.POPOVER2_TARGET}`).hostNodes();
+            assert.isTrue(popoverTarget.hasClass(CLASS_1));
+            assert.isTrue(popoverTarget.hasClass(CLASS_2));
+        });
+
+        it("supports custom input props", () => {
+            const wrapper = mount(
+                <DateInput2 {...DEFAULT_PROPS} inputProps={{ style: { background: "yellow" }, tabIndex: 4 }} />,
+            );
+            const inputElement = wrapper.find("input").getDOMNode() as HTMLInputElement;
+            assert.equal(inputElement.style.background, "yellow");
+            assert.equal(inputElement.tabIndex, 4);
+        });
+
+        it("supports inputProps.inputRef", () => {
+            let input: HTMLInputElement | null = null;
+            mount(<DateInput2 {...DEFAULT_PROPS} inputProps={{ inputRef: ref => (input = ref) }} />);
+            assert.instanceOf(input, HTMLInputElement);
+        });
+
+        it("does not render a TimezoneSelect if timePrecision is undefined", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS} timePrecision={undefined} />);
+            assert.isFalse(wrapper.find(TimezoneSelect).exists());
+        });
+
+        it("correctly passes on defaultTimezone to TimezoneSelect", () => {
+            const defaultTimezone = "Europe/Paris";
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS} defaultTimezone={defaultTimezone} />);
+            const timezoneSelect = wrapper.find(TimezoneSelect);
+            assert.strictEqual(timezoneSelect.prop("value"), defaultTimezone);
+        });
+
+        it("passes datePickerProps to DatePicker correctly", () => {
+            const datePickerProps = {
+                clearButtonText: "clear",
+                todayButtonText: "today",
+            };
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS} {...datePickerProps} />);
+            focusInput(wrapper);
+            const datePicker = wrapper.find(DatePicker);
+            assert.equal(datePicker.prop("clearButtonText"), "clear");
+            assert.equal(datePicker.prop("todayButtonText"), "today");
+        });
+
+        it("passes inputProps to InputGroup", () => {
+            const inputRef = sinon.spy();
+            const onFocus = sinon.spy();
+            const wrapper = mount(
+                <DateInput2
+                    {...DEFAULT_PROPS}
+                    inputProps={{
+                        inputRef,
+                        leftIcon: "star",
+                        onFocus,
+                        required: true,
+                    }}
+                />,
+            );
+            focusInput(wrapper);
+
+            const input = wrapper.find(InputGroup);
+            assert.strictEqual(input.prop("leftIcon"), "star");
+            assert.isTrue(input.prop("required"));
+            assert.isTrue(inputRef.called, "inputRef not invoked");
+            assert.isTrue(onFocus.called, "onFocus not invoked");
+        });
+
+        it("passes fill and popoverProps to Popover2", () => {
+            const onOpening = sinon.spy();
+            const wrapper = mount(
+                <DateInput2
+                    {...DEFAULT_PROPS}
+                    fill={true}
+                    popoverProps={{
+                        onOpening,
+                        placement: "top",
+                        usePortal: false,
+                    }}
+                />,
+            );
+            focusInput(wrapper);
+
+            const popover = wrapper.find(Popover2).first();
+            assert.strictEqual(popover.prop("fill"), true);
+            assert.strictEqual(popover.prop("placement"), "top");
+            assert.strictEqual(popover.prop("usePortal"), false);
+            assert.isTrue(onOpening.calledOnce);
+        });
+    });
+
+    describe("popover interaction", () => {
+        it("opens the popover when focusing input", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("doesn't open the popover when disabled", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS} disabled={true} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            assertPopoverIsOpen(wrapper, false);
+        });
+
+        it("popover closes when ESC key pressed", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            wrapper.find(InputGroup).find("input").simulate("keydown", { key: "Escape" });
+            assertPopoverIsOpen(wrapper, false);
+        });
+    });
+
     describe("controlled usage", () => {
         const DEFAULT_PROPS_CONTROLLED = {
             ...DEFAULT_PROPS,
@@ -64,41 +189,32 @@ describe("<DateInput2>", () => {
             assert.doesNotThrow(() => mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={null} />));
         });
 
-        it("Correctly passes on the default selected timezone", () => {
-            const defaultTimezone = "Europe/Paris";
-            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} defaultTimezone={defaultTimezone} />);
-            const timezoneSelect = wrapper.find(TimezoneSelect);
+        describe("when changing timezone", () => {
+            it("calls onChange with the updated ISO string", () => {
+                const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
+                clickTimezoneItem(wrapper, "Paris");
+                assert.isTrue(onChange.calledOnce);
+                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30:00.000+01:00"]);
+            });
 
-            assert.strictEqual(timezoneSelect.prop("value"), defaultTimezone);
+            it("formats the returned ISO string according to timePrecision", () => {
+                const wrapper = mount(
+                    <DateInput2 {...DEFAULT_PROPS_CONTROLLED} timePrecision={TimePrecision.MINUTE} />,
+                );
+                clickTimezoneItem(wrapper, "Paris");
+                assert.isTrue(onChange.calledOnce);
+                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30+01:00"]);
+            });
         });
 
-        it("It updates the passed back string when timezone is changed", () => {
-            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
-            clickTimezoneItem(wrapper, "Paris");
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30:00.000+01:00"]);
-        });
-
-        it("It formats the string based on the time precision when timezone is changed", () => {
-            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} timePrecision={TimePrecision.MINUTE} />);
-            clickTimezoneItem(wrapper, "Paris");
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30+01:00"]);
-        });
-
-        it("It updates the passed back string when time is changed", () => {
+        it("changing the time calls onChange with the updated ISO string", () => {
             const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />, { attachTo: containerElement });
             setTimeUnit(wrapper, TimeUnit.HOUR_24, 11);
             assert.isTrue(onChange.calledOnce);
             assert.deepEqual(onChange.firstCall.args, ["2021-11-29T11:30:00.000+00:00", true]);
         });
 
-        it("Does not render a timezone select if timePrecision is undefined", () => {
-            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} timePrecision={undefined} />);
-            assert.isFalse(wrapper.find(TimezoneSelect).exists());
-        });
-
-        it("Clearing the input invokes onChange with null", () => {
+        it("clearing the input invokes onChange with null", () => {
             const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
             wrapper
                 .find(InputGroup)
@@ -117,6 +233,7 @@ describe("<DateInput2>", () => {
 
         it("calls onChange on date changes", () => {
             const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
             wrapper
                 .find(`.${DatetimeClasses.DATEPICKER_DAY}:not(.${DatetimeClasses.DATEPICKER_DAY_OUTSIDE})`)
                 .first()
@@ -125,7 +242,6 @@ describe("<DateInput2>", () => {
             assert.isTrue(onChange.calledOnce);
             // first non-outside day should be the November 1st
             assert.strictEqual(onChange.firstCall.args[0], "2021-11-01T10:30:00.000+00:00");
-            wrapper.unmount();
         });
 
         it("calls onChange on timezone changes", () => {
@@ -135,9 +251,92 @@ describe("<DateInput2>", () => {
             console.info(onChange.firstCall.args);
             // New York is UTC-5
             assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30:00.000-05:00");
-            wrapper.unmount();
+        });
+
+        // HACKHACK: this test ported from DateInput doesn't seem to match any real UX, since pressing Shift+Tab
+        // on the first focussable day in a calendar month doesn't move you to the previous month; instead it moves focus
+        // to the year dropdown. It might be worth testing behavior when pressing the left arrow key, since that _does_
+        // move focus to the last day of the previous month.
+        it.skip("popover should not close if focus moves to previous day (last day of prev month)", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            blurInput(wrapper);
+            const firstTabbable = wrapper.find(Popover2).find(".DayPicker-Day").filter({ tabIndex: 0 }).first();
+            const lastDayOfPrevMonth = wrapper
+                .find(Popover2)
+                .find(".DayPicker-Body > .DayPicker-Week .DayPicker-Day--outside")
+                .last();
+
+            firstTabbable.simulate("focus");
+            firstTabbable.simulate("blur", {
+                relatedTarget: lastDayOfPrevMonth.getDOMNode(),
+                target: firstTabbable.getDOMNode(),
+            });
+            wrapper.update();
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover should not close if focus moves to month select", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            blurInput(wrapper);
+            changeSelectDropdown(wrapper, DatetimeClasses.DATEPICKER_MONTH_SELECT, Months.NOVEMBER);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover should not close if focus moves to year select", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            blurInput(wrapper);
+            changeSelectDropdown(wrapper, DatetimeClasses.DATEPICKER_YEAR_SELECT, 2020);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover should not close when time picker arrows are clicked after selecting a month", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            changeSelectDropdown(wrapper, DatetimeClasses.DATEPICKER_MONTH_SELECT, Months.OCTOBER);
+            wrapper
+                .find(`.${DatetimeClasses.TIMEPICKER_ARROW_BUTTON}.${DatetimeClasses.TIMEPICKER_HOUR}`)
+                .first()
+                .simulate("click");
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("pressing Enter saves the inputted date and closes the popover", () => {
+            const IMPROPERLY_FORMATTED_DATE_STRING = "002/0015/2015";
+            const PROPERLY_FORMATTED_DATE_STRING = "2/15/2015";
+            const onKeyDown = sinon.spy();
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} inputProps={{ onKeyDown }} />, {
+                attachTo: containerElement,
+            });
+            focusInput(wrapper);
+            const input = wrapper.find(InputGroup).find("input");
+            input.simulate("change", { target: { value: IMPROPERLY_FORMATTED_DATE_STRING } });
+            input.simulate("keydown", { key: "Enter" });
+            assertPopoverIsOpen(wrapper, false);
+            assert.notStrictEqual(document.activeElement, input.getDOMNode(), "input should not be focused");
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), PROPERLY_FORMATTED_DATE_STRING);
+            assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
+        });
+
+        it("clicking a date puts it in the input box and closes the popover", () => {
+            const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
+            focusInput(wrapper);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "11/29/2021");
+            clickCalendarDay(wrapper, 12);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "11/12/2021");
+            assertPopoverIsOpen(wrapper, false);
         });
     });
+
+    function focusInput(wrapper: ReactWrapper<DateInput2Props>) {
+        wrapper.find(InputGroup).find("input").simulate("focus");
+    }
+
+    function blurInput(wrapper: ReactWrapper<DateInput2Props>) {
+        wrapper.find(InputGroup).find("input").simulate("blur");
+    }
 
     function clickTimezoneItem(wrapper: ReactWrapper<DateInput2Props>, searchQuery: string) {
         wrapper.find(`.${Classes.TIMEZONE_SELECT}`).hostNodes().simulate("click");
@@ -150,8 +349,15 @@ describe("<DateInput2>", () => {
             .simulate("click");
     }
 
+    function clickCalendarDay(wrapper: ReactWrapper<DateInput2Props>, dayNumber: number) {
+        wrapper
+            .find(`.${DatetimeClasses.DATEPICKER_DAY}`)
+            .filterWhere(day => day.text() === `${dayNumber}` && !day.hasClass(DatetimeClasses.DATEPICKER_DAY_OUTSIDE))
+            .simulate("click");
+    }
+
     function setTimeUnit(wrapper: ReactWrapper<DateInput2Props>, unit: TimeUnit, value: number) {
-        wrapper.find(`.${CoreClasses.INPUT_GROUP}`).hostNodes().simulate("focus");
+        focusInput(wrapper);
         let inputClass: string;
         switch (unit) {
             case TimeUnit.HOUR_12:
@@ -171,5 +377,27 @@ describe("<DateInput2>", () => {
         const input = wrapper.find(`.${inputClass}`).first();
         input.simulate("change", { target: { value } });
         input.simulate("blur");
+    }
+
+    function changeSelectDropdown(wrapper: ReactWrapper<DateInput2Props>, className: string, value: React.ReactText) {
+        wrapper
+            .find(`.${className}`)
+            .find("select")
+            .simulate("change", { target: { value: value.toString() } });
+    }
+
+    function assertPopoverIsOpen(wrapper: ReactWrapper<DateInput2Props>, expectedIsOpen: boolean = true) {
+        const openPopoverTarget = wrapper.find(`.${Popover2Classes.POPOVER2_OPEN}`);
+        if (expectedIsOpen) {
+            assert.isTrue(
+                openPopoverTarget.exists(),
+                `Expected .${Popover2Classes.POPOVER2_OPEN} to exist, indicating the popover is open`,
+            );
+        } else {
+            assert.isFalse(
+                openPopoverTarget.exists(),
+                `Expected .${Popover2Classes.POPOVER2_OPEN} NOT to exist, indicating the popover is closed`,
+            );
+        }
     }
 });

--- a/packages/docs-app/src/common/dateFormatSelector.tsx
+++ b/packages/docs-app/src/common/dateFormatSelector.tsx
@@ -39,7 +39,9 @@ export interface DateFormatSelectorProps {
 }
 
 export const DateFormatSelector: React.FC<DateFormatSelectorProps> = props => {
-    const handleChange = handleNumberChange(index => props.onChange(props.formatOptions[index]));
+    const handleChange = handleNumberChange(index => {
+        props.onChange(props.formatOptions[index]);
+    });
     const value = props.formatOptions.indexOf(props.format);
 
     return (

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -73,6 +73,7 @@ export class DateInputExample extends React.PureComponent<IExampleProps, IDateIn
         const { date, format, showTimeArrowButtons, timePrecision, ...spreadProps } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
+                {/* eslint-disable-next-line deprecation/deprecation */}
                 <DateInput
                     {...spreadProps}
                     {...format}

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { H5, Position, Switch } from "@blueprintjs/core";
+import { H5, Icon, Position, Switch } from "@blueprintjs/core";
 import { DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { DateInput2 } from "@blueprintjs/datetime2";
 import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
@@ -33,6 +33,9 @@ export interface DateInput2ExampleState {
     format: DateFormatProps;
     reverseMonthAndYearMenus: boolean;
     shortcuts: boolean;
+    showActionsBar: boolean;
+    showRightElement: boolean;
+    showTimePickerArrows: boolean;
     showTimezoneSelect: boolean;
     timePrecision: TimePrecision | undefined;
 }
@@ -47,9 +50,14 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
         format: DATE_FNS_FORMATS[0],
         reverseMonthAndYearMenus: false,
         shortcuts: false,
+        showActionsBar: false,
+        showRightElement: false,
+        showTimePickerArrows: false,
         showTimezoneSelect: true,
         timePrecision: TimePrecision.MINUTE,
     };
+
+    private toggleActionsBar = handleBooleanChange(showActionsBar => this.setState({ showActionsBar }));
 
     private toggleSelection = handleBooleanChange(closeOnSelection => this.setState({ closeOnSelection }));
 
@@ -67,12 +75,19 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
 
     private toggleReverseMenus = handleBooleanChange(reverse => this.setState({ reverseMonthAndYearMenus: reverse }));
 
+    private toggleRightElement = handleBooleanChange(showRightElement => this.setState({ showRightElement }));
+
+    private toggleTimePickerArrows = handleBooleanChange(showTimePickerArrows =>
+        this.setState({ showTimePickerArrows }),
+    );
+
     private handleTimePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
         this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
     );
 
     public render() {
-        const { date, format, timePrecision, ...spreadProps } = this.state;
+        const { date, format, showRightElement, showTimePickerArrows, ...spreadProps } = this.state;
+
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <DateInput2
@@ -80,7 +95,10 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
                     {...format}
                     onChange={this.handleDateChange}
                     popoverProps={{ position: Position.BOTTOM }}
-                    timePrecision={timePrecision}
+                    rightElement={showRightElement && <Icon icon="globe" />}
+                    timePickerProps={
+                        this.state.timePrecision === undefined ? undefined : { showArrowButtons: showTimePickerArrows }
+                    }
                     value={date}
                 />
                 {date}
@@ -92,19 +110,33 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
         const {
             closeOnSelection,
             disabled,
-            fill,
-            reverseMonthAndYearMenus: reverse,
-            format,
-            timePrecision,
-            shortcuts,
             disableTimezoneSelect,
+            fill,
+            format,
+            reverseMonthAndYearMenus: reverse,
+            shortcuts,
+            showActionsBar,
+            showRightElement,
+            showTimePickerArrows,
             showTimezoneSelect,
+            timePrecision,
         } = this.state;
         return (
             <>
                 <H5>Props</H5>
                 <Switch label="Close on selection" checked={closeOnSelection} onChange={this.toggleSelection} />
-                <Switch checked={shortcuts} label="Show shortcuts" onChange={this.toggleShortcuts} />
+                <Switch
+                    checked={shortcuts}
+                    disabled={showActionsBar}
+                    label="Show shortcuts"
+                    onChange={this.toggleShortcuts}
+                />
+                <Switch
+                    checked={showActionsBar}
+                    disabled={shortcuts}
+                    label="Show actions bar"
+                    onChange={this.toggleActionsBar}
+                />
                 <PrecisionSelect
                     allowNone={true}
                     label="Time precision"
@@ -116,6 +148,13 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
                 <Switch label="Disabled" checked={disabled} onChange={this.toggleDisabled} />
                 <Switch label="Fill" checked={fill} onChange={this.toggleFill} />
                 <Switch label="Reverse month and year menus" checked={reverse} onChange={this.toggleReverseMenus} />
+                <Switch
+                    label="Show time picker arrows"
+                    checked={showTimePickerArrows}
+                    disabled={timePrecision === undefined}
+                    onChange={this.toggleTimePickerArrows}
+                />
+                <Switch label="Show right element" checked={showRightElement} onChange={this.toggleRightElement} />
                 <DateFnsFormatSelector format={format} onChange={this.handleFormatChange} />
 
                 <H5>Timezone props</H5>

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -176,7 +176,10 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
         );
     }
 
-    private handleDateChange = (date: string | null) => this.setState({ date });
+    private handleDateChange = (date: string | null) => {
+        console.info(date);
+        this.setState({ date });
+    };
 
     private handleFormatChange = (format: DateFormatProps) => this.setState({ format });
 }

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { H5, Icon, Position, Switch } from "@blueprintjs/core";
+import { H5, Icon, Switch } from "@blueprintjs/core";
 import { DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { DateInput2 } from "@blueprintjs/datetime2";
 import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
@@ -94,7 +94,7 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
                     {...spreadProps}
                     {...format}
                     onChange={this.handleDateChange}
-                    popoverProps={{ position: Position.BOTTOM }}
+                    popoverProps={{ placement: "bottom" }}
                     rightElement={
                         showRightElement && (
                             <Icon icon="globe" intent="primary" style={{ padding: 7, marginLeft: -5 }} />
@@ -177,9 +177,10 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
     }
 
     private handleDateChange = (date: string | null) => {
-        console.info(date);
         this.setState({ date });
     };
 
-    private handleFormatChange = (format: DateFormatProps) => this.setState({ format });
+    private handleFormatChange = (format: DateFormatProps) => {
+        this.setState({ format });
+    };
 }

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -95,7 +95,11 @@ export class DateInput2Example extends React.PureComponent<IExampleProps, DateIn
                     {...format}
                     onChange={this.handleDateChange}
                     popoverProps={{ position: Position.BOTTOM }}
-                    rightElement={showRightElement && <Icon icon="globe" />}
+                    rightElement={
+                        showRightElement && (
+                            <Icon icon="globe" intent="primary" style={{ padding: 7, marginLeft: -5 }} />
+                        )
+                    }
                     timePickerProps={
                         this.state.timePrecision === undefined ? undefined : { showArrowButtons: showTimePickerArrows }
                     }


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Despite what the docs stated before this change, we were not using Popover2 properly in DateInput2. It was delegating to DateInput for the text input + popover implementation, which used Popover.

This PR ports over the remaining code from DateInput into DateInput2 and migrates to Popover2.

#### Reviewers should focus on:

- No regressions from DateInput
- Passing test suite

#### Screenshot

<img width="341" alt="image" src="https://user-images.githubusercontent.com/723999/178842562-c41211ed-1dda-4178-a27f-09a8204c09ed.png">

