### PR TITLE
[core] fix: restore button loading prop precedence

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -65,8 +65,9 @@ export interface IButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = 
     large?: boolean;
 
     /**
-     * If set to `true`, the button will display a centered loading spinner instead of its contents, and the button will be disabled.
-     * The width of the button is not affected by the value of this prop.
+     * If set to `true`, the button will display a centered loading spinner instead of its contents
+     * and the button will be disabled (_even if_ `disabled={false}`). The width of the button is
+     * not affected by the value of this prop.
      *
      * @default false
      */
@@ -120,7 +121,17 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
     public abstract render(): JSX.Element;
 
     protected getCommonButtonProps() {
-        const { active, alignText, fill, large, loading, outlined, minimal, small, tabIndex } = this.props;
+        const {
+            active = false,
+            alignText,
+            fill,
+            large,
+            loading = false,
+            outlined,
+            minimal,
+            small,
+            tabIndex,
+        } = this.props;
         const disabled = this.props.disabled || loading;
 
         const className = classNames(

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -120,8 +120,8 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
     public abstract render(): JSX.Element;
 
     protected getCommonButtonProps() {
-        const { active, alignText, fill, large, loading = false, outlined, minimal, small, tabIndex } = this.props;
-        const disabled = this.props.disabled ?? loading;
+        const { active, alignText, fill, large, loading, outlined, minimal, small, tabIndex } = this.props;
+        const disabled = this.props.disabled || loading;
 
         const className = classNames(
             Classes.BUTTON,

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -79,6 +79,14 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             assert.isTrue(wrapper.hasClass(Classes.DISABLED));
         });
 
+        // This tests some subtle (potentialy unexpected) behavior, but it was an API decision we
+        // made a long time ago which we rely on and should not break.
+        // See https://github.com/palantir/blueprint/issues/3819#issuecomment-1189478596
+        it("button is disabled when the loading prop is true, even if disabled={false}", () => {
+            const wrapper = button({ disabled: false, loading: true });
+            assert.isTrue(wrapper.hasClass(Classes.DISABLED));
+        });
+
         it("clicking button triggers onClick prop", () => {
             const onClick = spy();
             button({ onClick }).simulate("click");


### PR DESCRIPTION
This reverts commit b6ea71e and updates the `loading` prop docs to mention that its value takes precedence over `disabled={false}`, which was the behavior before #5360. See https://github.com/palantir/blueprint/issues/3819#issuecomment-1189478596 for more rationale on this change.
