### PR TITLE
[core,table] fix: make some props.children optional again

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -25,7 +25,7 @@ export type CollapseProps = ICollapseProps;
 /** @deprecated use CollapseProps */
 export interface ICollapseProps extends Props {
     /** Contents to collapse. */
-    children: React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Component to render as the root element.

--- a/packages/core/src/components/collapsible-list/collapsibleList.tsx
+++ b/packages/core/src/components/collapsible-list/collapsibleList.tsx
@@ -34,7 +34,7 @@ export type CollapsibleListProps = ICollapsibleListProps;
 /** @deprecated use CollapsibleListProps */
 export interface ICollapsibleListProps extends Props {
     /** Contents to collapse. */
-    children: React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Element to render as dropdown target with `CLICK` interaction to show collapsed menu.

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -37,7 +37,7 @@ export interface IMultistepDialogProps extends DialogProps {
     backButtonProps?: DialogStepButtonProps;
 
     /** Dialog steps. */
-    children: React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Props for the close button that appears in the footer when there is no

--- a/packages/table/src/common/contextMenuTargetWrapper.tsx
+++ b/packages/table/src/common/contextMenuTargetWrapper.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 import { ContextMenuTarget, IProps } from "@blueprintjs/core";
 
 export interface IContextMenuTargetWrapper extends IProps {
-    children: React.ReactNode;
+    children?: React.ReactNode;
     renderContextMenu: (e: React.MouseEvent<HTMLElement>) => JSX.Element | undefined;
     style: React.CSSProperties;
 }

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -66,7 +66,7 @@ export interface IReorderableProps {
 
 export interface IDragReorderable extends IReorderableProps {
     /** Element to drag & reorder. */
-    children: React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Whether the reordering behavior is disabled.

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -90,7 +90,7 @@ export interface ISelectableProps {
 
 export interface IDragSelectableProps extends ISelectableProps {
     /** Element to make interactive. */
-    children: React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * A list of CSS selectors that should _not_ trigger selection when a `mousedown` occurs inside of them.


### PR DESCRIPTION
Fixes #5387 by reverting some of the stricter props.children type defs added in #5266
