### PR TITLE
[table] deprecation(EditableCell), docs(EditableCell2)

### DIFF
--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -13,6 +13,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to EditableCell2 instead.
+ */
+
 import classNames from "classnames";
 import * as React from "react";
 
@@ -80,7 +85,7 @@ export interface IEditableCellState {
     dirtyValue?: string;
 }
 
-// HACKHACK(adahiya): fix for Blueprint 4.0
+/** @deprecated use { EditableCell2, Table2 } from "@blueprintjs/table" */
 // eslint-disable-next-line deprecation/deprecation
 @HotkeysTarget
 export class EditableCell extends React.Component<IEditableCellProps, IEditableCellState> {

--- a/packages/table/src/cell/editableCell2.tsx
+++ b/packages/table/src/cell/editableCell2.tsx
@@ -28,9 +28,9 @@ import {
 
 import * as Classes from "../common/classes";
 import { Draggable } from "../interactions/draggable";
-import { Cell, ICellProps } from "./cell";
+import { Cell, CellProps } from "./cell";
 
-export interface EditableCell2Props extends Omit<ICellProps, "onKeyDown" | "onKeyUp"> {
+export interface EditableCell2Props extends Omit<CellProps, "onKeyDown" | "onKeyUp"> {
     /**
      * Whether the given cell is the current active/focused cell.
      */

--- a/packages/table/src/docs/table-features.md
+++ b/packages/table/src/docs/table-features.md
@@ -43,7 +43,7 @@ will reference the up-to-date `sortedIndexMap` value.
 
 @## Editing
 
-To make your table editable, use the `EditableCell` and
+To make your table editable, use the [`EditableCell2`](#table/table2.editablecell2) and
 `EditableName` components to create editable table cells and column names.
 
 To further extend the interactivity of the column headers, you can

--- a/packages/table/src/docs/table2.md
+++ b/packages/table/src/docs/table2.md
@@ -4,12 +4,17 @@ tag: new
 
 @# Table2
 
-As of `@blueprintjs/table` v3.9.0, there are two versions of the table component API, exported as `Table` and `Table2`.
-All the documentation examples here use the newer Table2 API.
+As of `@blueprintjs/table` v3.9.0, there are two versions of the table component API,
+[Table](#table/api.table) and [Table2](#table/table2). All of the documentation examples
+on this site demonstrate the newer Table2 API.
 
-These two are functionally the same except for the fact that Table2 uses the new hotkeys API via
+@## Migration from Table
+
+The two APIs are functionally identical except for the fact that Table2 uses the new hotkeys API via
 [HotkeysTarget2](#core/components/hotkeys-target2). This means that you must configure a
-[HotkeysProvider](#core/context/hotkeys-provider) in your application in order to use Table2.
+[HotkeysProvider](#core/context/hotkeys-provider) in your application in order to use Table2
+(for more information, see the
+[hotkeys migration guide on the wiki](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration)).
 
 ```tsx
 import { HotkeysProvider } from "@blueprintjs/core";
@@ -29,5 +34,10 @@ ReactDOM.render(
 );
 ```
 
-`EditableCell` also binds its own hotkeys, so we have provided a new component `EditableCell2` which uses the new
-hotkeys API.
+@## EditableCell2
+
+If you render [EditableCell](#table/api.editablecell) within your table, you will also need to migrate to its
+successor, `EditableCell2`, in order to be compatible with the new hotkeys API, as this component binds some
+of its own hotkeys.
+
+@interface EditableCell2Props

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to EditableCell2 instead.
+ */
+
 import { expect } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";
+
+/* eslint-disable deprecation/deprecation */
 
 import { Cell, EditableCell } from "../src";
 import * as TableClasses from "../src/common/classes";


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Deprecate `EditableCell`
- Add `EditableCell2Props` documentation to the Table2 section, so that new props added in PRs like #5421 will get shown in the docs

