### PR TITLE
refactor: use IconNames constant

### DIFF
--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { AbstractPureComponent2, Classes, IRef } from "../../common";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, MaybeElement, Props } from "../../common/props";
@@ -154,7 +156,7 @@ export class Dialog extends AbstractPureComponent2<DialogProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<Icon icon="cross" size={IconSize.STANDARD} />}
+                    icon={<Icon icon={IconNames.CROSS} size={IconSize.STANDARD} />}
                     minimal={true}
                     onClick={this.props.onClose}
                 />

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
 import { getPositionIgnoreAngles, isPositionHorizontal, Position } from "../../common/position";
@@ -164,7 +166,7 @@ export class Drawer extends AbstractPureComponent2<DrawerProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<Icon icon="small-cross" size={IconSize.LARGE} />}
+                    icon={<Icon icon={IconNames.SMALL_CROSS} size={IconSize.LARGE} />}
                     minimal={true}
                     onClick={this.props.onClose}
                 />

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import {
     AbstractPureComponent2,
     Classes,
@@ -403,7 +405,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                     aria-label="increment"
                     aria-controls={this.numericInputId}
                     disabled={disabled || isIncrementDisabled}
-                    icon="chevron-up"
+                    icon={IconNames.CHEVRON_UP}
                     intent={intent}
                     {...this.incrementButtonHandlers}
                 />
@@ -411,7 +413,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                     aria-label="decrement"
                     aria-controls={this.numericInputId}
                     disabled={disabled || isDecrementDisabled}
-                    icon="chevron-down"
+                    icon={IconNames.CHEVRON_DOWN}
                     intent={intent}
                     {...this.decrementButtonHandlers}
                 />

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { AbstractPureComponent2 } from "../../common";
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
 import { IElementRefProps, OptionProps } from "../../common/props";
@@ -100,7 +102,7 @@ export class HTMLSelect extends AbstractPureComponent2<HTMLSelectProps> {
                     {optionChildren}
                     {htmlProps.children}
                 </select>
-                <Icon icon="double-caret-vertical" title="Open dropdown" {...iconProps} />
+                <Icon icon={IconNames.DOUBLE_CARET_VERTICAL} title="Open dropdown" {...iconProps} />
             </div>
         );
     }

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -18,6 +18,8 @@ import classNames from "classnames";
 import { Modifiers } from "popper.js";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { AbstractPureComponent2, Classes, Position } from "../../common";
 import { ActionProps, DISPLAYNAME_PREFIX, LinkProps } from "../../common/props";
 import { Icon } from "../icon/icon";
@@ -229,7 +231,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
                 {text}
             </Text>,
             this.maybeRenderLabel(labelElement),
-            hasSubmenu ? <Icon className={Classes.MENU_SUBMENU_ICON} icon="caret-right" /> : undefined,
+            hasSubmenu ? <Icon className={Classes.MENU_SUBMENU_ICON} icon={IconNames.CARET_RIGHT} /> : undefined,
         );
 
         const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -16,8 +16,11 @@
 
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { AbstractPureComponent2, Classes } from "../../common";
 import { Button } from "../button/buttons";
+import { Icon } from "../icon/icon";
 import { Text } from "../text/text";
 import { IPanel } from "./panelProps";
 
@@ -82,7 +85,7 @@ export class PanelView extends AbstractPureComponent2<IPanelViewProps> {
             <Button
                 aria-label="Back"
                 className={Classes.PANEL_STACK_HEADER_BACK}
-                icon="chevron-left"
+                icon={IconNames.CHEVERON_LEFT}
                 minimal={true}
                 onClick={this.handleClose}
                 small={true}

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -20,7 +20,6 @@ import { IconNames } from "@blueprintjs/icons";
 
 import { AbstractPureComponent2, Classes } from "../../common";
 import { Button } from "../button/buttons";
-import { Icon } from "../icon/icon";
 import { Text } from "../text/text";
 import { IPanel } from "./panelProps";
 

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -85,7 +85,7 @@ export class PanelView extends AbstractPureComponent2<IPanelViewProps> {
             <Button
                 aria-label="Back"
                 className={Classes.PANEL_STACK_HEADER_BACK}
-                icon={IconNames.CHEVERON_LEFT}
+                icon={IconNames.CHEVRON_LEFT}
                 minimal={true}
                 onClick={this.handleClose}
                 small={true}

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -62,7 +62,7 @@ export const PanelView2: PanelView2Component = <T extends Panel<object>>(props: 
             <Button
                 aria-label="Back"
                 className={Classes.PANEL_STACK_HEADER_BACK}
-                icon={IconNames.CHEVERON_LEFT}
+                icon={IconNames.CHEVRON_LEFT}
                 minimal={true}
                 onClick={handleClose}
                 small={true}

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -16,6 +16,8 @@
 
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Button } from "../button/buttons";
 import { Text } from "../text/text";
@@ -60,7 +62,7 @@ export const PanelView2: PanelView2Component = <T extends Panel<object>>(props: 
             <Button
                 aria-label="Back"
                 className={Classes.PANEL_STACK_HEADER_BACK}
-                icon="chevron-left"
+                icon={IconNames.CHEVERON_LEFT}
                 minimal={true}
                 onClick={handleClose}
                 small={true}

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import {
     AbstractPureComponent2,
     Classes,
@@ -169,7 +171,7 @@ export class Tag extends AbstractPureComponent2<TagProps> {
                 onClick={this.onRemoveClick}
                 tabIndex={interactive ? tabIndex : undefined}
             >
-                <Icon icon="small-cross" size={isLarge ? IconSize.LARGE : IconSize.STANDARD} />
+                <Icon icon={IconNames.SMALL_CROSS} size={isLarge ? IconSize.LARGE : IconSize.STANDARD} />
             </button>
         ) : null;
 

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { IconNames } from "@blueprintjs/icons";
+
 import { AbstractPureComponent2, Classes } from "../../common";
 import { ActionProps, DISPLAYNAME_PREFIX, IntentProps, LinkProps, MaybeElement, Props } from "../../common/props";
 import { ButtonGroup } from "../button/buttonGroup";
@@ -80,7 +82,7 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
                 </span>
                 <ButtonGroup minimal={true}>
                     {this.maybeRenderActionButton()}
-                    <Button aria-label="Close" icon="cross" onClick={this.handleCloseClick} />
+                    <Button aria-label="Close" icon={IconNames.CROSS} onClick={this.handleCloseClick} />
                 </ButtonGroup>
             </div>
         );

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -43,7 +43,7 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
                         aria-label="Go to previous month"
                         className={classes.navButtonPrev}
                         disabled={areSameMonth(month, minDate)}
-                        icon={IconNames.CHEVERON_LEFT}
+                        icon={IconNames.CHEVRON_LEFT}
                         minimal={true}
                         onClick={this.handlePreviousClick}
                     />

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { NavbarElementProps } from "react-day-picker";
 
 import { Button } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import * as Classes from "./common/classes";
 import { areSameMonth } from "./common/dateUtils";
@@ -42,7 +43,7 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
                         aria-label="Go to previous month"
                         className={classes.navButtonPrev}
                         disabled={areSameMonth(month, minDate)}
-                        icon="chevron-left"
+                        icon={IconNames.CHEVERON_LEFT}
                         minimal={true}
                         onClick={this.handlePreviousClick}
                     />
@@ -52,7 +53,7 @@ export class DatePickerNavbar extends React.PureComponent<IDatePickerNavbarProps
                         aria-label="Go to next month"
                         className={classes.navButtonNext}
                         disabled={areSameMonth(month, maxDate)}
-                        icon="chevron-right"
+                        icon={IconNames.CHEVRON_RIGHT}
                         minimal={true}
                         onClick={this.handleNextClick}
                     />

--- a/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
@@ -28,6 +28,7 @@ import {
     MenuItem,
     Props,
 } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { ItemListPredicate, ItemRenderer, Select2, SelectPopoverProps } from "@blueprintjs/select";
 
 import * as Classes from "../../common/classes";
@@ -197,7 +198,15 @@ export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, 
         ) : (
             <span className={CoreClasses.TEXT_MUTED}>{placeholder}</span>
         );
-        return <Button rightIcon="caret-down" disabled={disabled} text={buttonContent} fill={fill} {...buttonProps} />;
+        return (
+            <Button
+                rightIcon={IconNames.CARET_DOWN}
+                disabled={disabled}
+                text={buttonContent}
+                fill={fill}
+                {...buttonProps}
+            />
+        );
     }
 
     private filterItems: ItemListPredicate<TimezoneWithNames> = (query, items) => {

--- a/packages/docs-app/src/common/filmSelect.tsx
+++ b/packages/docs-app/src/common/filmSelect.tsx
@@ -17,6 +17,7 @@
 import * as React from "react";
 
 import { Button, MenuItem } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { Select2, Select2Props } from "@blueprintjs/select";
 
 import {
@@ -77,8 +78,8 @@ export default function ({ allowCreate = false, fill, ...restProps }: Props) {
             {...restProps}
         >
             <Button
-                icon="film"
-                rightIcon="caret-down"
+                icon={IconNames.FILM}
+                rightIcon={IconNames.CARET_DOWN}
                 text={film ? `${film.title} (${film.year})` : "(No selection)"}
                 disabled={restProps.disabled}
                 fill={fill}

--- a/packages/docs-app/src/common/films.tsx
+++ b/packages/docs-app/src/common/films.tsx
@@ -17,6 +17,7 @@
 import * as React from "react";
 
 import { MenuItem } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { ItemPredicate, ItemRenderer } from "@blueprintjs/select";
 
 export interface IFilm {
@@ -157,7 +158,7 @@ export const renderCreateFilmOption = (
     handleClick: React.MouseEventHandler<HTMLElement>,
 ) => (
     <MenuItem
-        icon="add"
+        icon={IconNames.ADD}
         text={`Create "${query}"`}
         roleStructure="listoption"
         active={active}

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -21,6 +21,7 @@ import * as React from "react";
 import { AnchorButton, Classes, HotkeysProvider, Tag } from "@blueprintjs/core";
 import { IDocsCompleteData } from "@blueprintjs/docs-data";
 import { Documentation, IDocumentationProps, NavMenuItem, NavMenuItemProps } from "@blueprintjs/docs-theme";
+import { IconNames } from "@blueprintjs/icons";
 
 import { NavHeader } from "./navHeader";
 import { NavIcon } from "./navIcons";
@@ -127,7 +128,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
         return (
             <AnchorButton
                 href={`${GITHUB_SOURCE_URL}/${page.sourcePath}`}
-                icon="edit"
+                icon={IconNames.EDIT}
                 minimal={true}
                 target="_blank"
                 text="Edit this page"

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 
 import { Classes, H3, InputGroup, NonIdealState } from "@blueprintjs/core";
 import { smartSearch } from "@blueprintjs/docs-theme";
+import { IconNames } from "@blueprintjs/icons";
 
 import { DocsIcon, IDocsIconProps as IIcon } from "./docsIcon";
 
@@ -58,7 +59,7 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
                     autoFocus={true}
                     className={Classes.FILL}
                     large={true}
-                    leftIcon="search"
+                    leftIcon={IconNames.SEARCH}
                     placeholder="Search for icons..."
                     onChange={this.handleFilterChange}
                     type="search"
@@ -89,7 +90,7 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
     };
 
     private renderZeroState() {
-        return <NonIdealState className={Classes.TEXT_MUTED} icon="zoom-out" description="No icons found" />;
+        return <NonIdealState className={Classes.TEXT_MUTED} icon={IconNames.ZOOM_OUT} description="No icons found" />;
     }
 
     private getFilteredIcons(groupName: string) {

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 
 import { Classes, HotkeysTarget2, Intent, Menu, MenuItem, NavbarHeading, Tag } from "@blueprintjs/core";
 import { NavButton } from "@blueprintjs/docs-theme";
+import { IconNames } from "@blueprintjs/icons";
 import { Popover2 } from "@blueprintjs/popover2";
 
 import { Logo } from "./logo";
@@ -103,7 +104,7 @@ export class NavHeader extends React.PureComponent<INavHeaderProps> {
             });
         return (
             <Popover2 content={<Menu className="docs-version-list">{releaseItems}</Menu>} placement="bottom">
-                <Tag interactive={true} minimal={true} round={true} rightIcon="caret-down">
+                <Tag interactive={true} minimal={true} round={true} rightIcon={IconNames.CARET_DOWN}>
                     v{major(currentVersion)}
                 </Tag>
             </Popover2>

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -17,21 +17,31 @@
 import * as React from "react";
 
 import { Card, H4, Icon, IconName } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 export class Welcome extends React.PureComponent {
     public render() {
         return (
             <div className="blueprint-welcome">
-                <WelcomeCard href="#blueprint/getting-started" icon="star" title="Getting started" sameTab={true} />
-                <WelcomeCard href="https://github.com/palantir/blueprint" icon="git-repo" title="Git repository" />
+                <WelcomeCard
+                    href="#blueprint/getting-started"
+                    icon={IconNames.STAR}
+                    title="Getting started"
+                    sameTab={true}
+                />
+                <WelcomeCard
+                    href="https://github.com/palantir/blueprint"
+                    icon={IconNames.GIT_REPO}
+                    title="Git repository"
+                />
                 <WelcomeCard
                     href="https://codesandbox.io/s/blueprint-sandbox-et9xy"
-                    icon="code-block"
+                    icon={IconNames.CODE_BLOCK}
                     title="Code Sandbox"
                 />
                 <WelcomeCard
                     href="https://github.com/palantir/blueprint#contributing"
-                    icon="git-merge"
+                    icon={IconNames.GIT_MERGE}
                     title="Contributing"
                 />
             </div>

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -19,6 +19,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Drawer, FocusStyleManager, HotkeysTarget2, Props } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import { DocumentationContextTypes, hasTypescriptData, IDocsData, IDocumentationContext } from "../common/context";
 import { eachLayoutNode } from "../common/utils";
@@ -207,7 +208,7 @@ export class Documentation extends React.PureComponent<IDocumentationProps, IDoc
                                 {this.props.header}
                                 <div className="docs-nav-divider" />
                                 <NavButton
-                                    icon="search"
+                                    icon={IconNames.SEARCH}
                                     hotkey="shift + s"
                                     text="Search..."
                                     onClick={this.handleOpenNavigator}

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -19,6 +19,7 @@ import { filter } from "fuzzaldrin-plus";
 import * as React from "react";
 
 import { Classes, Icon, InputGroupProps2, MenuItem } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { ItemListPredicate, ItemRenderer, Omnibar } from "@blueprintjs/select";
 
 import { eachLayoutNode } from "../common/utils";
@@ -100,7 +101,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
 
         // insert caret-right between each path element
         const pathElements = section.path.reduce<React.ReactChild[]>((elems, el) => {
-            elems.push(el, <Icon key={el} icon="caret-right" />);
+            elems.push(el, <Icon key={el} icon={IconNames.CARET_RIGHT} />);
             return elems;
         }, []);
         pathElements.pop();

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -19,6 +19,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Icon } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 export const Heading: React.FC<IHeadingTag> = ({ level, route, value }) =>
     // use createElement so we can dynamically choose tag based on depth
@@ -27,7 +28,7 @@ export const Heading: React.FC<IHeadingTag> = ({ level, route, value }) =>
         { className: classNames(Classes.HEADING, "docs-title") },
         <a className="docs-anchor" data-route={route} key="anchor" />,
         <a className="docs-anchor-link" href={"#" + route} key="link">
-            <Icon icon="link" />
+            <Icon icon={IconNames.LINK} />
         </a>,
         value,
     );

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -18,6 +18,7 @@ import { ITag } from "@documentalist/client";
 import * as React from "react";
 
 import { AnchorButton, Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import { IExampleProps } from "../components/example";
 
@@ -56,7 +57,7 @@ export class ReactExampleTagRenderer {
                     className="docs-example-view-source"
                     fill={true}
                     href={example.sourceUrl}
-                    icon="code"
+                    icon={IconNames.CODE}
                     intent={Intent.PRIMARY}
                     minimal={true}
                     target="_blank"

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -30,6 +30,7 @@ import {
     TagInputProps,
     Utils,
 } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
@@ -266,7 +267,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     <Button
                         aria-label="Clear selected items"
                         disabled={disabled}
-                        icon="cross"
+                        icon={IconNames.CROSS}
                         minimal={true}
                         onClick={this.handleClearButtonClick}
                         title="Clear selected items"

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, InputGroup, InputGroupProps2, Overlay, OverlayProps } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -89,7 +90,7 @@ export class Omnibar<T> extends React.PureComponent<OmnibarProps<T>> {
                     <InputGroup
                         autoFocus={true}
                         large={true}
-                        leftIcon="search"
+                        leftIcon={IconNames.SEARCH}
                         placeholder="Search..."
                         {...inputProps}
                         onChange={listProps.handleQueryChange}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -31,6 +31,7 @@ import {
     refHandler,
     setRef,
 } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import { Classes, IListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
@@ -184,7 +185,7 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
 
         const input = (
             <InputGroup
-                leftIcon="search"
+                leftIcon={IconNames.SEARCH}
                 placeholder="Filter..."
                 rightElement={this.maybeRenderClearButton(listProps.query)}
                 {...inputProps}
@@ -229,7 +230,9 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
     };
 
     private maybeRenderClearButton(query: string) {
-        return query.length > 0 ? <Button icon="cross" minimal={true} onClick={this.resetQuery} /> : undefined;
+        return query.length > 0 ? (
+            <Button icon={IconNames.CROSS} minimal={true} onClick={this.resetQuery} />
+        ) : undefined;
     }
 
     private handleTargetKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -32,6 +32,7 @@ import {
     setRef,
     Utils,
 } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
@@ -162,7 +163,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         const input = (
             <InputGroup
                 aria-autocomplete="list"
-                leftIcon="search"
+                leftIcon={IconNames.SEARCH}
                 placeholder="Filter..."
                 rightElement={this.maybeRenderClearButton(listProps.query)}
                 {...inputProps}
@@ -240,7 +241,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         return query.length > 0 ? (
             <Button
                 aria-label="Clear filter query"
-                icon="cross"
+                icon={IconNames.CROSS}
                 minimal={true}
                 onClick={this.resetQuery}
                 title="Clear filter query"

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -21,6 +21,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { Button, Classes, H4, Intent, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import {
     Cell,
     Column,
@@ -72,10 +73,18 @@ function getTableComponent(numCols: number, numRows: number, columnProps?: any, 
 const renderTestMenu = () => (
     /* eslint-disable no-console */
     <Menu>
-        <MenuItem icon="export" onClick={() => console.log("Beam me up!")} text="Teleport" />
-        <MenuItem icon="sort-alphabetical-desc" onClick={() => console.log("ZA is the worst")} text="Down with ZA!" />
+        <MenuItem icon={IconNames.EXPORT} onClick={() => console.log("Beam me up!")} text="Teleport" />
+        <MenuItem
+            icon={IconNames.SORT_ALPHABETICAL_DESC}
+            onClick={() => console.log("ZA is the worst")}
+            text="Down with ZA!"
+        />
         <MenuDivider />
-        <MenuItem icon="curved-range-chart" onClick={() => console.log("You clicked the trident!")} text="Psi" />
+        <MenuItem
+            icon={IconNames.CURVED_RANGE_CHART}
+            onClick={() => console.log("You clicked the trident!")}
+            text="Psi"
+        />
     </Menu>
 );
 

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -35,6 +35,7 @@ import {
     MenuItem,
     Switch,
 } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import {
     Cell,
     Column,
@@ -490,7 +491,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         const menu = (
             <Menu>
                 <MenuItem
-                    icon="insert"
+                    icon={IconNames.INSERT}
                     onClick={() => {
                         this.store.addColumnBefore(columnIndex);
                         this.setState({ numCols: this.state.numCols + 1 });
@@ -498,7 +499,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                     text="Insert column before"
                 />
                 <MenuItem
-                    icon="insert"
+                    icon={IconNames.INSERT}
                     onClick={() => {
                         this.store.addColumnAfter(columnIndex);
                         this.setState({ numCols: this.state.numCols + 1 });
@@ -506,7 +507,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                     text="Insert column after"
                 />
                 <MenuItem
-                    icon="remove"
+                    icon={IconNames.REMOVE}
                     onClick={() => {
                         this.store.removeColumn(columnIndex);
                         this.setState({ numCols: this.state.numCols - 1 });
@@ -527,7 +528,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         return (
             <Menu>
                 <MenuItem
-                    icon="insert"
+                    icon={IconNames.INSERT}
                     onClick={() => {
                         this.store.addRowBefore(rowIndex);
                         this.setState({ numRows: this.state.numRows + 1 });
@@ -535,7 +536,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                     text="Insert row before"
                 />
                 <MenuItem
-                    icon="insert"
+                    icon={IconNames.INSERT}
                     onClick={() => {
                         this.store.addRowAfter(rowIndex);
                         this.setState({ numRows: this.state.numRows + 1 });
@@ -543,7 +544,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
                     text="Insert row after"
                 />
                 <MenuItem
-                    icon="remove"
+                    icon={IconNames.REMOVE}
                     onClick={() => {
                         this.store.removeRow(rowIndex);
                         this.setState({ numRows: this.state.numRows - 1 });
@@ -1047,10 +1048,10 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
     private renderBodyContextMenu = () => {
         const menu = (
             <Menu>
-                <MenuItem icon="search-around" text="Item 1" />
-                <MenuItem icon="search" text="Item 2" />
-                <MenuItem icon="graph-remove" text="Item 3" />
-                <MenuItem icon="group-objects" text="Item 4" />
+                <MenuItem icon={IconNames.SEARCH_AROUND} text="Item 1" />
+                <MenuItem icon={IconNames.SEARCH} text="Item 2" />
+                <MenuItem icon={IconNames.GRAPH_REMOVE} text="Item 3" />
+                <MenuItem icon={IconNames.GROUP_OBJECTS} text="Item 4" />
                 <MenuDivider />
                 <MenuItem disabled={true} text="Disabled item" />
             </Menu>

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, Icon, Popover, Position, Props } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import * as Classes from "../../common/classes";
 import { Utils } from "../../common/utils";
@@ -236,7 +237,7 @@ export class TruncatedFormat extends React.PureComponent<ITruncatedFormatProps, 
                     isOpen={true}
                     onClose={this.handlePopoverClose}
                 >
-                    <Icon icon="more" />
+                    <Icon icon={IconNames.MORE} />
                     {/* eslint-disable-next-line deprecation/deprecation */}
                 </Popover>
             );
@@ -245,7 +246,7 @@ export class TruncatedFormat extends React.PureComponent<ITruncatedFormatProps, 
             // `<Popover>` changes, this must be updated.
             return (
                 <span className={Classes.TABLE_TRUNCATED_POPOVER_TARGET} onClick={this.handlePopoverOpen}>
-                    <Icon icon="more" />
+                    <Icon icon={IconNames.MORE} />
                 </span>
             );
         }

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Utils as CoreUtils, Icon } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 import { Grid } from "../common";
 import type { FocusedCellCoordinates } from "../common/cellTypes";
@@ -406,7 +407,7 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
                       <div
                           className={classNames(Classes.TABLE_REORDER_HANDLE, CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT)}
                       >
-                          <Icon icon="drag-handle-vertical" title="Press down to drag" />
+                          <Icon icon={IconNames.DRAG_HANDLE_VERTICAL} title="Press down to drag" />
                       </div>
                   </div>,
                   false,

--- a/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
+++ b/packages/timezone/src/components/timezone-picker/timezonePicker.tsx
@@ -28,6 +28,7 @@ import {
     MenuItem,
     Props,
 } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 import { ItemListPredicate, ItemRenderer, Select } from "@blueprintjs/select";
 
 import * as Classes from "../../common/classes";
@@ -208,7 +209,7 @@ export class TimezonePicker extends AbstractPureComponent2<TimezonePickerProps, 
         ) : (
             <span className={CoreClasses.TEXT_MUTED}>{placeholder}</span>
         );
-        return <Button rightIcon="caret-down" disabled={disabled} text={buttonContent} {...buttonProps} />;
+        return <Button rightIcon={IconNames.CARET_DOWN} disabled={disabled} text={buttonContent} {...buttonProps} />;
     }
 
     private filterItems: ItemListPredicate<TimezoneItem> = (query, items) => {


### PR DESCRIPTION
Style refactor, no functional change

Better to use consts than string literals, since there is a const for the IconNames available