### PR TITLE
[select] fix(Select2, Suggest2, MultiSelect2): html props type

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -53,7 +53,7 @@ export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverP
     /**
      * Props to spread to the `Menu` listbox containing the selectable options.
      */
-    menuProps?: React.HTMLProps<HTMLUListElement>;
+    menuProps?: React.HTMLAttributes<HTMLUListElement>;
 
     /**
      * If provided, this component will render a "clear" button inside its TagInput.

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -78,7 +78,7 @@ export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps 
     /**
      * Props to spread to the `Menu` listbox containing the selectable options.
      */
-    menuProps?: React.HTMLProps<HTMLUListElement>;
+    menuProps?: React.HTMLAttributes<HTMLUListElement>;
 
     /**
      * Props to add to the popover target wrapper element.

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -79,7 +79,7 @@ export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps
     /**
      * Props to spread to the `Menu` listbox containing the selectable options.
      */
-    menuProps?: React.HTMLProps<HTMLUListElement>;
+    menuProps?: React.HTMLAttributes<HTMLUListElement>;
 
     /**
      * If true, the component waits until a keydown event in the TagInput


### PR DESCRIPTION
Fixes type issue due to `Menu`'s `menuProps` being `React.HTMLAttributes` and Selct2/MultiSelect2/Suggest2 `menuProps` being `React.HTMLProps`