### PR TITLE
[table] fix: scrolling bug when grid size == viewport size

### DIFF
--- a/packages/table-dev-app/src/features.html
+++ b/packages/table-dev-app/src/features.html
@@ -148,6 +148,10 @@
   <div id="table-11"></div>
   <br /><br />
 
+  <h4>Table with auto height and ghost cells enabled</h4>
+  <div id="table-12"></div>
+  <br /><br />
+
   <script src="features.bundle.js"></script>
 </body>
 </html>

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -699,3 +699,12 @@ function renderName() {
         </div>
     );
 }
+
+ReactDOM.render(
+    <div style={{ height: "auto", width: "180px" }}>
+        <Table2 numRows={5} defaultRowHeight={30} enableGhostCells={true}>
+            <Column name="Test" />
+        </Table2>
+    </div>,
+    document.getElementById("table-12"),
+);

--- a/packages/table/src/locator.ts
+++ b/packages/table/src/locator.ts
@@ -161,28 +161,31 @@ export class Locator implements ILocator {
     /**
      * Pass in an already-computed viewport rect here, if available, to reduce DOM reads.
      *
-     * @returns whether the rendered rows overflow the visible viewport vertically, helpful for scrolling calculations
+     * @returns whether the rendered rows overflow or exactly fit the visible viewport vertically, helpful for scrolling calculations
      */
-    public hasVerticalOverflow(
+    public hasVerticalOverflowOrExactFit(
         columnHeaderHeight = Grid.MIN_COLUMN_HEADER_HEIGHT,
         viewportRect = this.getViewportRect(),
     ) {
         if (this.grid === undefined) {
             return false;
         }
-        return this.grid.getHeight() > viewportRect.height - columnHeaderHeight;
+        return this.grid.getHeight() >= viewportRect.height - columnHeaderHeight;
     }
 
     /**
      * Pass in an already-computed viewport rect here, if available, to reduce DOM reads.
      *
-     * @returns whether the rendered columns overflow the visible viewport horizontally, helpful for scrolling calculations
+     * @returns whether the rendered columns overflow or exactly fit the visible viewport horizontally, helpful for scrolling calculations
      */
-    public hasHorizontalOverflow(rowHeaderWidth = Grid.MIN_ROW_HEADER_WIDTH, viewportRect = this.getViewportRect()) {
+    public hasHorizontalOverflowOrExactFit(
+        rowHeaderWidth = Grid.MIN_ROW_HEADER_WIDTH,
+        viewportRect = this.getViewportRect(),
+    ) {
         if (this.grid === undefined) {
             return false;
         }
-        return this.grid.getWidth() > viewportRect.width - rowHeaderWidth;
+        return this.grid.getWidth() >= viewportRect.width - rowHeaderWidth;
     }
 
     // Converters

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -814,15 +814,15 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             return <div className={classes} ref={refHandler} />;
         }
 
-        // if we have horizontal overflow, no need to render ghost columns
+        // if we have horizontal overflow or exact fit, no need to render ghost columns
         // (this avoids problems like https://github.com/palantir/blueprint/issues/5027)
-        const hasHorizontalOverflow = this.locator.hasHorizontalOverflow(
+        const hasHorizontalOverflowOrExactFit = this.locator.hasHorizontalOverflowOrExactFit(
             enableRowHeader ? this.rowHeaderWidth : 0,
             viewportRect,
         );
         const columnIndices = this.grid.getColumnIndicesInRect(
             viewportRect,
-            hasHorizontalOverflow ? false : enableGhostCells,
+            hasHorizontalOverflowOrExactFit ? false : enableGhostCells,
         );
 
         const columnIndexStart = showFrozenColumnsOnly ? 0 : columnIndices.columnIndexStart;
@@ -897,14 +897,14 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             return <div className={classes} ref={refHandler} />;
         }
 
-        // if we have vertical overflow, no need to render ghost rows
+        // if we have vertical overflow or exact fit, no need to render ghost rows
         // (this avoids problems like https://github.com/palantir/blueprint/issues/5027)
-        const hasVerticalOverflow = this.locator.hasVerticalOverflow(
+        const hasVerticalOverflowOrExactFit = this.locator.hasVerticalOverflowOrExactFit(
             enableColumnHeader ? this.columnHeaderHeight : 0,
             viewportRect,
         );
         const rowIndices = this.grid.getRowIndicesInRect({
-            includeGhostCells: hasVerticalOverflow ? false : enableGhostCells,
+            includeGhostCells: hasVerticalOverflowOrExactFit ? false : enableGhostCells,
             rect: viewportRect,
         });
 
@@ -994,23 +994,23 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             return undefined;
         }
 
-        // if we have vertical/horizontal overflow, no need to render ghost rows/columns (respectively)
+        // if we have vertical/horizontal overflow or exact fit, no need to render ghost rows/columns (respectively)
         // (this avoids problems like https://github.com/palantir/blueprint/issues/5027)
-        const hasVerticalOverflow = this.locator.hasVerticalOverflow(
+        const hasVerticalOverflowOrExactFit = this.locator.hasVerticalOverflowOrExactFit(
             enableColumnHeader ? this.columnHeaderHeight : 0,
             viewportRect,
         );
-        const hasHorizontalOverflow = this.locator.hasHorizontalOverflow(
+        const hasHorizontalOverflowOrExactFit = this.locator.hasHorizontalOverflowOrExactFit(
             enableRowHeader ? this.rowHeaderWidth : 0,
             viewportRect,
         );
         const rowIndices = this.grid.getRowIndicesInRect({
-            includeGhostCells: hasVerticalOverflow ? false : enableGhostCells,
+            includeGhostCells: hasVerticalOverflowOrExactFit ? false : enableGhostCells,
             rect: viewportRect,
         });
         const columnIndices = this.grid.getColumnIndicesInRect(
             viewportRect,
-            hasHorizontalOverflow ? false : enableGhostCells,
+            hasHorizontalOverflowOrExactFit ? false : enableGhostCells,
         );
 
         // start beyond the frozen area if rendering unrelated quadrants, so we

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -249,13 +249,22 @@ describe("<Table2>", function (this) {
         runTestToEnsureScrollingIsEnabled(false);
 
         it("does not render ghost rows when there is vertical overflow", () => {
+            // we need _some_ amount of vertical overflow to avoid the code path which disables vertical scroll
+            // in the table altogether. 200px leaves just enough space for the rows, but there is 30px taken up by
+            // the column header, which will overflow.
+            runTestToEnsureGhostCellsAreNotVisible(200);
+        });
+
+        it("does not render ghost rows when there is vertical exact fit", () => {
+            // 200px for row heights, 30px for row header
+            runTestToEnsureGhostCellsAreNotVisible(230);
+        });
+
+        function runTestToEnsureGhostCellsAreNotVisible(height: number) {
             const { containerElement } = mountTable(
                 { defaultRowHeight: 20, enableGhostCells: true },
                 {
-                    // we need _some_ amount of vertical overflow to avoid the code path which disables vertical scroll
-                    // in the table altogether. 200px leaves just enough space for the rows, but there is 30px taken up by
-                    // the column header, which will overflow.
-                    height: 200,
+                    height,
                     width: 300,
                 },
             );
@@ -266,7 +275,7 @@ describe("<Table2>", function (this) {
 
             // cleanup
             document.body.removeChild(containerElement);
-        });
+        }
 
         function runTestToEnsureScrollingIsEnabled(enableGhostCells: boolean) {
             it(`isn't disabled when there is half a row left to scroll to and enableGhostCells is set to ${enableGhostCells}`, () => {


### PR DESCRIPTION
Fixes a scrolling bug that is caused by unnecessarily rendering ghost cells when the grid height/width is equal to the viewports height/width (commonly happens if the container element has `height: "auto"`). Similar behavior in this past issue https://github.com/palantir/blueprint/issues/5027

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Changes `hasVerticalOverflow` to `hasVerticalOverflowOrExactFit` to account for the case where height/width is equal to the viewport where we don't need to render ghost cells.

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

before:
![beforeBPScroll](https://user-images.githubusercontent.com/13280642/180302591-7829b1da-ae4a-40dc-80f5-b10174c38873.gif)
after:
![afterBPScroll](https://user-images.githubusercontent.com/13280642/180302594-bbf61944-0240-4588-b1ef-2b5e70302b41.gif)
