### PR TITLE
[core] fix(MultiSlider): loosen children validation

### DIFF
--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -218,7 +218,7 @@ export class MultiSlider extends AbstractPureComponent2<MultiSliderProps, ISlide
             throw new Error(Errors.SLIDER_ZERO_STEP);
         }
         if (props.labelStepSize !== undefined && props.labelValues !== undefined) {
-            throw new Error(Errors.MULTISLIDER_WARN_LABEL_STEP_SIZE_LABEL_VALUES_MUTEX);
+            console.error(Errors.MULTISLIDER_WARN_LABEL_STEP_SIZE_LABEL_VALUES_MUTEX);
         }
         if (props.labelStepSize !== undefined && props.labelStepSize! <= 0) {
             throw new Error(Errors.SLIDER_ZERO_LABEL_STEP);
@@ -232,7 +232,7 @@ export class MultiSlider extends AbstractPureComponent2<MultiSliderProps, ISlide
             }
         });
         if (anyInvalidChildren) {
-            throw new Error(Errors.MULTISLIDER_INVALID_CHILD);
+            console.error(Errors.MULTISLIDER_INVALID_CHILD);
         }
     }
 

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -22,7 +22,8 @@ import * as sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
-import { Classes, IMultiSliderProps, MultiSlider } from "../../src";
+import { Classes, MultiSlider, MultiSliderProps } from "../../src";
+import * as Errors from "../../src/common/errors";
 import { Handle } from "../../src/components/slider/handle";
 import { mouseUpHorizontal, simulateMovement } from "./sliderTestUtils";
 
@@ -319,24 +320,31 @@ describe("<MultiSlider>", () => {
     });
 
     describe("validation", () => {
-        it("throws an error if a child is not a slider handle", () => {
-            expectPropValidationError(MultiSlider, { children: (<span>Bad</span>) as any });
+        let errorSpy: sinon.SinonSpy | undefined;
+
+        before(() => (errorSpy = sinon.spy(console, "error")));
+        afterEach(() => errorSpy?.resetHistory());
+        after(() => errorSpy?.restore());
+
+        it("logs an error if a child is not a slider handle", () => {
+            mount(
+                <MultiSlider>
+                    <span>Bad</span>
+                </MultiSlider>,
+            );
+            assert.isTrue(errorSpy?.calledWith(Errors.MULTISLIDER_INVALID_CHILD));
         });
 
         it("throws error if stepSize <= 0", () => {
-            [0, -10].forEach(stepSize => {
-                expectPropValidationError(MultiSlider, { stepSize }, "greater than zero");
-            });
+            expectPropValidationError(MultiSlider, { stepSize: -5 }, "greater than zero");
         });
 
         it("throws error if labelStepSize <= 0", () => {
-            [0, -10].forEach(labelStepSize => {
-                expectPropValidationError(MultiSlider, { labelStepSize }, "greater than zero");
-            });
+            expectPropValidationError(MultiSlider, { labelStepSize: -5 }, "greater than zero");
         });
     });
 
-    function renderSlider(joinedProps: IMultiSliderProps & { values?: [number, number, number] } = {}) {
+    function renderSlider(joinedProps: MultiSliderProps & { values?: [number, number, number] } = {}) {
         const { values = [0, 5, 10], ...props } = joinedProps;
         return mount(
             <MultiSlider {...props}>


### PR DESCRIPTION
#### Fixes #4456

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Log a console error instead of throwing a hard error when MultiSlider children fail to validate as Handles. This allows users to use styled-components HOCs on Handle children elements.

