### PR TITLE
[popover2] feat: Breadcrumbs2 component

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -1,5 +1,18 @@
 @# Breadcrumbs
 
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">
+
+Deprecated: use [Breadcrumbs2](#popover2-package/breadcrumbs2)
+
+</h4>
+
+This component is **deprecated since @blueprintjs/core v4.7.0** in favor of the new
+Breadcrumbs2 component, which uses Popover2 instead of Popover under the hood.
+You should migrate to the new API which will become the standard in Blueprint v5.
+
+</div>
+
 Breadcrumbs identify the path to the current resource in an application.
 
 @reactExample BreadcrumbsExample

--- a/packages/demo-app/src/examples/BreadcrumbExample.tsx
+++ b/packages/demo-app/src/examples/BreadcrumbExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { BreadcrumbProps, Breadcrumbs } from "@blueprintjs/core";
+import { BreadcrumbProps, Breadcrumbs2 } from "@blueprintjs/popover2";
 
 import { ExampleCard } from "./ExampleCard";
 
@@ -33,7 +33,7 @@ export class BreadcrumbExample extends React.PureComponent {
     public render() {
         return (
             <ExampleCard label="Breadcrumbs">
-                <Breadcrumbs items={ITEMS} />
+                <Breadcrumbs2 items={ITEMS} />
             </ExampleCard>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -114,6 +114,7 @@ export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBrea
         return (
             <Example options={options} {...this.props}>
                 <Card elevation={0} style={{ width: `${width}%` }}>
+                    {/* eslint-disable-next-line deprecation/deprecation */}
                     <Breadcrumbs
                         collapseFrom={collapseFrom}
                         items={alwaysRenderOverflow ? ITEMS_FOR_ALWAYS_RENDER : ITEMS}

--- a/packages/docs-app/src/examples/popover2-examples/breadcrumbs2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/breadcrumbs2Example.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import {
+    Boundary,
+    BreadcrumbProps,
+    Card,
+    Checkbox,
+    H5,
+    InputGroup,
+    Label,
+    RadioGroup,
+    Slider,
+} from "@blueprintjs/core";
+import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Breadcrumbs2 } from "@blueprintjs/popover2";
+
+export interface Breadcrumbs2ExampleState {
+    collapseFrom: Boundary;
+    renderCurrentAsInput: boolean;
+    alwaysRenderOverflow: boolean;
+    width: number;
+}
+
+const COLLAPSE_FROM_RADIOS = [
+    { label: "Start", value: Boundary.START.toString() },
+    { label: "End", value: Boundary.END.toString() },
+];
+
+const ITEMS: BreadcrumbProps[] = [
+    { icon: "folder-close", text: "All files" },
+    { icon: "folder-close", text: "Users" },
+    { icon: "folder-close", text: "Janet" },
+    { href: "#", icon: "folder-close", text: "Photos" },
+    { href: "#", icon: "folder-close", text: "Wednesday" },
+    { icon: "document", text: "image.jpg", current: true },
+];
+// Show less items for always redner example so we can see when everything fits
+const ITEMS_FOR_ALWAYS_RENDER: BreadcrumbProps[] = [
+    { href: "#", icon: "folder-close", text: "Root" },
+    { icon: "document", text: "image.jpg", current: true },
+];
+
+export class Breadcrumbs2Example extends React.PureComponent<IExampleProps, Breadcrumbs2ExampleState> {
+    public state: Breadcrumbs2ExampleState = {
+        alwaysRenderOverflow: false,
+        collapseFrom: Boundary.START,
+        renderCurrentAsInput: false,
+        width: 50,
+    };
+
+    private handleChangeCollapse = handleStringChange(collapseFrom =>
+        this.setState({ collapseFrom: collapseFrom as Boundary }),
+    );
+
+    private breadcrumbWidthLabelId = "num-visible-items-label";
+
+    public render() {
+        const options = (
+            <>
+                <H5>Props</H5>
+                <RadioGroup
+                    name="collapseFrom"
+                    inline={true}
+                    label="Collapse from"
+                    onChange={this.handleChangeCollapse}
+                    options={COLLAPSE_FROM_RADIOS}
+                    selectedValue={this.state.collapseFrom.toString()}
+                />
+                <Checkbox
+                    name="alwaysRenderOverflow"
+                    label="Always render overflow"
+                    onChange={this.handleChangeAlwaysRenderOverflow}
+                    checked={this.state.alwaysRenderOverflow}
+                />
+                <Checkbox
+                    name="renderCurrent"
+                    label="Render current breadcrumb as input"
+                    onChange={this.handleChangeRenderCurrentAsInput}
+                    checked={this.state.renderCurrentAsInput}
+                />
+                <H5>Example</H5>
+                <Label id={this.breadcrumbWidthLabelId}>Width</Label>
+                <Slider
+                    labelRenderer={this.renderLabel}
+                    labelStepSize={50}
+                    max={100}
+                    onChange={this.handleChangeWidth}
+                    showTrackFill={false}
+                    value={this.state.width}
+                    handleHtmlProps={{ "aria-labelledby": this.breadcrumbWidthLabelId }}
+                />
+            </>
+        );
+
+        const { collapseFrom, renderCurrentAsInput, width, alwaysRenderOverflow } = this.state;
+        return (
+            <Example options={options} {...this.props}>
+                <Card elevation={0} style={{ width: `${width}%` }}>
+                    <Breadcrumbs2
+                        collapseFrom={collapseFrom}
+                        items={alwaysRenderOverflow ? ITEMS_FOR_ALWAYS_RENDER : ITEMS}
+                        currentBreadcrumbRenderer={renderCurrentAsInput ? this.renderBreadcrumbInput : undefined}
+                        overflowListProps={{ alwaysRenderOverflow }}
+                    />
+                </Card>
+            </Example>
+        );
+    }
+
+    private renderLabel = (value: number) => {
+        return `${value}%`;
+    };
+
+    private handleChangeWidth = (width: number) => this.setState({ width });
+
+    private handleChangeRenderCurrentAsInput = () =>
+        this.setState({ renderCurrentAsInput: !this.state.renderCurrentAsInput });
+
+    private handleChangeAlwaysRenderOverflow = () =>
+        this.setState({ alwaysRenderOverflow: !this.state.alwaysRenderOverflow });
+
+    private renderBreadcrumbInput = ({ text }: BreadcrumbProps) => {
+        return <BreadcrumbInput defaultValue={typeof text === "string" ? text : undefined} />;
+    };
+}
+
+const BreadcrumbInput: React.FC<BreadcrumbProps & { defaultValue: string | undefined }> = props => {
+    const [text, setText] = React.useState(props.defaultValue ?? "");
+    const handleChange = React.useCallback((event: React.FormEvent<HTMLInputElement>) => {
+        setText((event.target as HTMLInputElement).value);
+    }, []);
+    return <InputGroup placeholder="rename me" value={text} onChange={handleChange} />;
+};

--- a/packages/docs-app/src/examples/popover2-examples/index.ts
+++ b/packages/docs-app/src/examples/popover2-examples/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { Breadcrumbs2Example } from "./breadcrumbs2Example";
 export * from "./popover2DismissExample";
 export * from "./popover2Example";
 export * from "./popover2InteractionKindExample";

--- a/packages/eslint-plugin/src/rules/no-deprecated-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components.ts
@@ -9,6 +9,7 @@ import { createRule } from "./utils/createRule";
 const DEPRECATED_TO_NEW_MAPPING: { [deprecated: string]: string } = {
     AbstractComponent: "AbstractComponent2",
     AbstractPureComponent: "AbstractPureComponent2",
+    Breadcrumbs: "Breadcrumbs2",
     CollapsibleList: "OverflowList",
     DateRangeInput: "DateRangeInput2",
     MultiSelect: "MultiSelect2",

--- a/packages/popover2/src/breadcrumbs2.md
+++ b/packages/popover2/src/breadcrumbs2.md
@@ -1,0 +1,71 @@
+---
+tag: new
+---
+
+@# Breadcrumbs2
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    <h4 class="@ns-heading">
+
+Migrating from [Breadcrumbs](#core/components/breadcrumbs)?
+
+</h4>
+
+Breadcrumbs2 is a replacement for Breadcrumbs and will replace it in Blueprint core v5.
+You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
+See the [migration guide](https://github.com/palantir/blueprint/wiki/Popover2-migration#breadcrumbs2)
+on the wiki (the changes are minimal, it should be an easy drop-in replacement).
+
+</div>
+
+Breadcrumbs identify the path to the current resource in an application.
+
+@reactExample Breadcrumbs2Example
+
+@## Props
+
+@### Breadcrumbs2
+
+The Breadcrumbs2 component requires an `items` array of
+[breadcrumb props](#core/components/breadcrumbs.breadcrumb) and renders them in
+an [OverflowList](#core/components/overflow-list) to automatically collapse
+breadcrumbs that do not fit in the available space.
+
+```tsx
+import { BreadcrumbProps, Icon } from "@blueprintjs/core";
+import { Breadcrumbs2 } from "@blueprintjs/popover2";
+import * as React from "react";
+
+const BREADCRUMBS: BreadcrumbProps[] = [
+    { href: "/users", icon: "folder-close", text: "Users" },
+    { href: "/users/janet", icon: "folder-close", text: "Janet" },
+    { icon: "document", text: "image.jpg" },
+];
+
+export class BreadcrumbsExample extends React.PureComponent {
+    public render() {
+        return (
+            <Breadcrumbs2
+                currentBreadcrumbRenderer={this.renderCurrentBreadcrumb}
+                items={BREADCRUMBS}
+             />
+        );
+    }
+
+    private renderCurrentBreadcrumb = ({ text, ...restProps }: BreadcrumbProps) => {
+        // customize rendering of last breadcrumb
+        return <Breadcrumb {...restProps}>{text} <Icon icon="star" /></Breadcrumb>;
+    };
+}
+```
+
+@interface Breadcrumbs2Props
+
+@### Breadcrumb
+
+The Breadcrumb component renders an `a.@ns-breadcrumb` if given an `href` or
+`onClick` and a `span.@ns-breadcrumb` otherwise. Typically you will supply an
+array of `BreadcrumbProps` to the `<Breadcrumbs items>` prop and only need to
+render this component directly when defining a custom `breadcrumbRenderer`.
+
+@interface IBreadcrumbProps

--- a/packages/popover2/src/breadcrumbs2.tsx
+++ b/packages/popover2/src/breadcrumbs2.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,23 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Boundary, Classes, Position, Props, removeNonHTMLProps } from "../../common";
-import { Menu } from "../menu/menu";
-import { MenuItem } from "../menu/menuItem";
-import { OverflowList, OverflowListProps } from "../overflow-list/overflowList";
-import { IPopoverProps, Popover } from "../popover/popover";
-import { Breadcrumb, BreadcrumbProps } from "./breadcrumb";
+import {
+    AbstractPureComponent2,
+    Boundary,
+    Breadcrumb,
+    BreadcrumbProps,
+    Classes as CoreClasses,
+    Menu,
+    MenuItem,
+    OverflowList,
+    OverflowListProps,
+    Props,
+    removeNonHTMLProps,
+} from "@blueprintjs/core";
 
-// eslint-disable-next-line deprecation/deprecation
-export type BreadcrumbsProps = IBreadcrumbsProps;
-/** @deprecated use BreadcrumbsProps */
-export interface IBreadcrumbsProps extends Props {
+import { Popover2, Popover2Props } from "./popover2";
+
+export interface Breadcrumbs2Props extends Props {
     /**
      * Callback invoked to render visible breadcrumbs. Best practice is to
      * render a `<Breadcrumb>` element. If `currentBreadcrumbRenderer` is also
@@ -71,18 +77,20 @@ export interface IBreadcrumbsProps extends Props {
      * Props to spread to `OverflowList`. Note that `items`,
      * `overflowRenderer`, and `visibleItemRenderer` cannot be changed.
      */
-    overflowListProps?: Partial<OverflowListProps<BreadcrumbProps>>;
+    overflowListProps?: Partial<
+        Omit<OverflowListProps<BreadcrumbProps>, "items" | "overflowRenderer" | "visibleItemRenderer">
+    >;
 
     /**
-     * Props to spread to the `Popover` showing the overflow menu.
+     * Props to spread to the popover showing the overflow menu.
      */
-    // eslint-disable-next-line deprecation/deprecation
-    popoverProps?: IPopoverProps;
+    popoverProps?: Partial<
+        Omit<Popover2Props, "content" | "defaultIsOpen" | "disabled" | "fill" | "renderTarget" | "targetTagName">
+    >;
 }
 
-/** @deprecated use { Breadcrumbs2 } from "@blueprintjs/popover2" */
-export class Breadcrumbs extends AbstractPureComponent2<BreadcrumbsProps> {
-    public static defaultProps: Partial<BreadcrumbsProps> = {
+export class Breadcrumbs2 extends AbstractPureComponent2<Breadcrumbs2Props> {
+    public static defaultProps: Partial<Breadcrumbs2Props> = {
         collapseFrom: Boundary.START,
     };
 
@@ -94,7 +102,7 @@ export class Breadcrumbs extends AbstractPureComponent2<BreadcrumbsProps> {
                 minVisibleItems={minVisibleItems}
                 tagName="ul"
                 {...overflowListProps}
-                className={classNames(Classes.BREADCRUMBS, overflowListProps.className, className)}
+                className={classNames(CoreClasses.BREADCRUMBS, overflowListProps.className, className)}
                 items={items}
                 overflowRenderer={this.renderOverflow}
                 visibleItemRenderer={this.renderBreadcrumbWrapper}
@@ -103,8 +111,8 @@ export class Breadcrumbs extends AbstractPureComponent2<BreadcrumbsProps> {
     }
 
     private renderOverflow = (items: readonly BreadcrumbProps[]) => {
-        const { collapseFrom } = this.props;
-        const position = collapseFrom === Boundary.END ? Position.BOTTOM_RIGHT : Position.BOTTOM_LEFT;
+        const { collapseFrom, popoverProps } = this.props;
+
         let orderedItems = items;
         if (collapseFrom === Boundary.START) {
             // If we're collapsing from the start, the menu should be read from the bottom to the
@@ -114,20 +122,18 @@ export class Breadcrumbs extends AbstractPureComponent2<BreadcrumbsProps> {
             orderedItems = items.slice().reverse();
         }
 
-        /* eslint-disable deprecation/deprecation */
         return (
             <li>
-                <Popover
-                    position={position}
+                <Popover2
+                    placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
                     disabled={orderedItems.length === 0}
                     content={<Menu>{orderedItems.map(this.renderOverflowBreadcrumb)}</Menu>}
-                    {...this.props.popoverProps}
+                    {...popoverProps}
                 >
-                    <span className={Classes.BREADCRUMBS_COLLAPSED} />
-                </Popover>
+                    <span className={CoreClasses.BREADCRUMBS_COLLAPSED} />
+                </Popover2>
             </li>
         );
-        /* eslint-enable deprecation/deprecation */
     };
 
     private renderOverflowBreadcrumb = (props: BreadcrumbProps, index: number) => {

--- a/packages/popover2/src/breadcrumbs2.tsx
+++ b/packages/popover2/src/breadcrumbs2.tsx
@@ -33,6 +33,7 @@ import {
 
 import { Popover2, Popover2Props } from "./popover2";
 
+export { BreadcrumbProps };
 export interface Breadcrumbs2Props extends Props {
     /**
      * Callback invoked to render visible breadcrumbs. Best practice is to

--- a/packages/popover2/src/index.md
+++ b/packages/popover2/src/index.md
@@ -5,12 +5,14 @@ reference: popover2-package
 @# Popover2
 
 The [**@blueprintjs/popover2** NPM package](https://www.npmjs.com/package/@blueprintjs/popover2)
-provides successors to Popover and Tooltip in `@blueprintjs/core`:
+provides updated APIs for popovers & tooltips from `@blueprintjs/core`, as well as some components
+which depend on them:
 
--   [`Popover2`](#popover2-package/popover2)
--   [`Tooltip2`](#popover2-package/tooltip2)
--   [`ContextMenu2`](#popover2-package/context-menu2)
--   [`ResizeSensor2`](#popover2-package/resize-sensor2)
+-   [Popover2](#popover2-package/popover2)
+-   [Tooltip2](#popover2-package/tooltip2)
+-   [ContextMenu2](#popover2-package/context-menu2)
+-   [ResizeSensor2](#popover2-package/resize-sensor2)
+-   [Breadcrumbs2](#popover2-package/breadcrumbs2)
 
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
 
@@ -34,3 +36,4 @@ Import the package stylesheet in Sass:
 @page tooltip2
 @page context-menu2
 @page resize-sensor2
+@page breadcrumbs2

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -18,6 +18,7 @@
 
 export * as Classes from "./classes";
 export * as Errors from "./errors";
+export { Breadcrumbs2, Breadcrumbs2Props } from "./breadcrumbs2";
 export {
     ContextMenu2,
     ContextMenu2Props,

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -18,7 +18,7 @@
 
 export * as Classes from "./classes";
 export * as Errors from "./errors";
-export { Breadcrumbs2, Breadcrumbs2Props } from "./breadcrumbs2";
+export { Breadcrumbs2, Breadcrumbs2Props, BreadcrumbProps } from "./breadcrumbs2";
 export {
     ContextMenu2,
     ContextMenu2Props,

--- a/packages/popover2/test/breadcrumbs2Tests.tsx
+++ b/packages/popover2/test/breadcrumbs2Tests.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { mount } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+
+import {
+    Boundary,
+    Breadcrumb,
+    BreadcrumbProps,
+    Classes as CoreClasses,
+    MenuItem,
+    OverflowList,
+    OverflowListProps,
+} from "@blueprintjs/core";
+
+import { Breadcrumbs2 } from "../src/breadcrumbs2";
+
+const ITEMS: BreadcrumbProps[] = [{ text: "1" }, { text: "2" }, { text: "3" }];
+
+describe("Breadcrumbs2", () => {
+    let containerElement: HTMLElement | undefined;
+
+    beforeEach(() => {
+        containerElement = document.createElement("div");
+        document.body.appendChild(containerElement);
+    });
+    afterEach(() => {
+        containerElement?.remove();
+    });
+
+    it("passes through props to the OverflowList", () => {
+        const wrapper = mount(
+            <Breadcrumbs2
+                className="breadcrumbs-class"
+                collapseFrom={Boundary.END}
+                items={[]}
+                minVisibleItems={7}
+                overflowListProps={{ className: "overflow-list-class", tagName: "article" }}
+            />,
+            { attachTo: containerElement },
+        );
+        const overflowListProps = wrapper.find<OverflowListProps<BreadcrumbProps>>(OverflowList).props();
+        assert.equal(overflowListProps.className, `${CoreClasses.BREADCRUMBS} overflow-list-class breadcrumbs-class`);
+        assert.equal(overflowListProps.collapseFrom, Boundary.END);
+        assert.equal(overflowListProps.minVisibleItems, 7);
+        assert.equal(overflowListProps.tagName, "article");
+    });
+
+    it("makes the last breadcrumb current", () => {
+        const wrapper = mount(<Breadcrumbs2 items={ITEMS} minVisibleItems={ITEMS.length} />, {
+            attachTo: containerElement,
+        });
+        const breadcrumbs = wrapper.find(Breadcrumb);
+        assert.lengthOf(breadcrumbs, ITEMS.length);
+        assert.isFalse(breadcrumbs.get(0).props.current);
+        assert.isTrue(breadcrumbs.get(ITEMS.length - 1).props.current);
+    });
+
+    it("renders overflow/collapsed indicator when items don't fit", () => {
+        const wrapper = mount(
+            // 70px is just enough to show one item
+            <div style={{ width: 70 }}>
+                <Breadcrumbs2 items={ITEMS} />
+            </div>,
+            { attachTo: containerElement },
+        );
+        assert.lengthOf(wrapper.find(`.${CoreClasses.BREADCRUMBS_COLLAPSED}`), 1);
+    });
+
+    it("renders the correct overflow menu items", () => {
+        const wrapper = mount(
+            // 70px is just enough to show one item
+            <div style={{ width: 70 }}>
+                <Breadcrumbs2 items={ITEMS} popoverProps={{ isOpen: true, usePortal: false }} />
+            </div>,
+            { attachTo: containerElement },
+        );
+        const menuItems = wrapper.find(MenuItem);
+        assert.lengthOf(menuItems, ITEMS.length - 1);
+        assert.equal(menuItems.get(0).props.text, "2");
+        assert.equal(menuItems.get(1).props.text, "1");
+    });
+
+    it("renders the correct overflow menu items when collapsing from END", () => {
+        const wrapper = mount(
+            // 70px is just enough to show one item
+            <div style={{ width: 70 }}>
+                <Breadcrumbs2
+                    collapseFrom={Boundary.END}
+                    items={ITEMS}
+                    popoverProps={{ isOpen: true, usePortal: false }}
+                />
+            </div>,
+            { attachTo: containerElement },
+        );
+        const menuItems = wrapper.find(MenuItem);
+        assert.lengthOf(menuItems, ITEMS.length - 1);
+        assert.equal(menuItems.get(0).props.text, "2");
+        assert.equal(menuItems.get(1).props.text, "3");
+    });
+
+    it("disables menu item when it is not clickable", () => {
+        const wrapper = mount(
+            // 10px is too small to show any items
+            <div style={{ width: 10 }}>
+                <Breadcrumbs2 items={ITEMS} popoverProps={{ isOpen: true, usePortal: false }} />
+            </div>,
+            { attachTo: containerElement },
+        );
+        const menuItems = wrapper.find(MenuItem);
+        assert.lengthOf(menuItems, ITEMS.length);
+        assert.isTrue(menuItems.get(0).props.disabled);
+    });
+
+    it("calls currentBreadcrumbRenderer (only) for the current breadcrumb", () => {
+        const spy = sinon.spy();
+        mount(<Breadcrumbs2 currentBreadcrumbRenderer={spy} items={ITEMS} minVisibleItems={ITEMS.length} />, {
+            attachTo: containerElement,
+        });
+        assert.isTrue(spy.calledOnce);
+        assert.isTrue(spy.calledWith(ITEMS[ITEMS.length - 1]));
+    });
+
+    it("does not call breadcrumbRenderer for the current breadcrumb when there is a currentBreadcrumbRenderer", () => {
+        const spy = sinon.spy();
+        mount(
+            <Breadcrumbs2
+                breadcrumbRenderer={spy}
+                currentBreadcrumbRenderer={() => <div />}
+                items={ITEMS}
+                minVisibleItems={ITEMS.length}
+            />,
+            { attachTo: containerElement },
+        );
+        assert.equal(spy.callCount, ITEMS.length - 1);
+        assert.isTrue(spy.neverCalledWith(ITEMS[ITEMS.length - 1]));
+    });
+
+    it("calls breadcrumbRenderer", () => {
+        const spy = sinon.spy();
+        mount(<Breadcrumbs2 breadcrumbRenderer={spy} items={ITEMS} minVisibleItems={ITEMS.length} />, {
+            attachTo: containerElement,
+        });
+        assert.equal(spy.callCount, ITEMS.length);
+    });
+});

--- a/packages/popover2/test/index.ts
+++ b/packages/popover2/test/index.ts
@@ -15,6 +15,7 @@
 
 import "@blueprintjs/test-commons/bootstrap";
 
+import "./breadcrumbs2Tests";
 import "./contextMenu2Tests";
 import "./popover2Tests";
 import "./resizeSensor2Tests";

--- a/packages/popover2/test/isotest.js
+++ b/packages/popover2/test/isotest.js
@@ -24,8 +24,11 @@ const Popover2Package = require("../lib/cjs");
 
 const requiredChild = React.createElement("button");
 
-describe("Core isomorphic rendering", () => {
+describe("Popover2 isomorphic rendering", () => {
     generateIsomorphicTests(Popover2Package, {
+        Breadcrumbs2: {
+            props: { items: [] },
+        },
         Popover2: {
             children: requiredChild,
         },


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

Create a new Breadcrumbs2 component which uses Popover2 instead of Popover. The rest of the implementation is identical, copied from Breadcrumbs.

While copying over the test suite, I adjusted the tests so that we actually render the component into a real DOM to better reflect real usage.

#### Reviewers should focus on:

No regressions compared to Breadcrumbs component, documentation looks good, and the `no-deprecated-components` lint rule is updated.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
<img width="394" alt="image" src="https://user-images.githubusercontent.com/723999/180577262-bdc56dc0-2694-4391-8ef5-e3ce8dc7b0d3.png">
