### PR TITLE
[select] fix(Suggest2): get root node correctly in Shadow DOM

### DIFF
--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -316,7 +316,8 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
     // Note that we defer to the next animation frame in order to get the latest document.activeElement
     private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
-            const isInputFocused = this.inputElement === document.activeElement;
+            const root = (this.inputElement?.getRootNode?.() ?? document) as DocumentOrShadowRoot & Node;
+            const isInputFocused = this.inputElement === root.activeElement;
 
             if (this.inputElement != null && !isInputFocused) {
                 // the input is no longer focused, we should close the popover

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -316,8 +316,8 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
     // Note that we defer to the next animation frame in order to get the latest document.activeElement
     private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
-            const root = (this.inputElement?.getRootNode?.() ?? document) as DocumentOrShadowRoot & Node;
-            const isInputFocused = this.inputElement === root.activeElement;
+            const rootNode = (this.inputElement?.getRootNode?.() ?? document) as DocumentOrShadowRoot & Node;
+            const isInputFocused = this.inputElement === rootNode.activeElement;
 
             if (this.inputElement != null && !isInputFocused) {
                 // the input is no longer focused, we should close the popover


### PR DESCRIPTION
#### Fixes #5461

#### Changes proposed in this pull request:

Changed detecting is input focused by comparing with input's rootNode rather than with window
