### PR TITLE
chore: use helper fn to get active DOM element

### DIFF
--- a/packages/core/src/common/utils/domUtils.ts
+++ b/packages/core/src/common/utils/domUtils.ts
@@ -19,6 +19,18 @@ export function elementIsOrContains(element: HTMLElement, testElement: HTMLEleme
 }
 
 /**
+ * Gets the active element in the document or shadow root (if an element is provided, and it's in the shadow DOM).
+ */
+export function getActiveElement(element?: HTMLElement | null, options?: GetRootNodeOptions) {
+    if (element == null) {
+        return document.activeElement;
+    }
+
+    const rootNode = (element.getRootNode(options) ?? document) as DocumentOrShadowRoot & Node;
+    return rootNode.activeElement;
+}
+
+/**
  * Throttle an event on an EventTarget by wrapping it in a
  * `requestAnimationFrame` call. Returns the event handler that was bound to
  * given eventName so you can clean up after yourself.

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -21,7 +21,7 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { AbstractPureComponent2, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
-import { isFunction } from "../../common/utils";
+import { getActiveElement, isFunction } from "../../common/utils";
 import { Portal } from "../portal/portal";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -349,11 +349,13 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         return this.requestAnimationFrame(() => {
             // container ref may be undefined between component mounting and Portal rendering
             // activeElement may be undefined in some rare cases in IE
-            if (this.containerElement == null || document.activeElement == null || !this.props.isOpen) {
+            const activeElement = getActiveElement(this.containerElement);
+
+            if (this.containerElement == null || activeElement == null || !this.props.isOpen) {
                 return;
             }
 
-            const isFocusOutsideModal = !this.containerElement.contains(document.activeElement);
+            const isFocusOutsideModal = !this.containerElement.contains(activeElement);
             if (isFocusOutsideModal) {
                 this.startFocusTrapElement?.focus({ preventScroll: true });
                 this.isAutoFocusing = false;
@@ -594,7 +596,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
             document.body.classList.add(Classes.OVERLAY_OPEN);
         }
 
-        this.lastActiveElementBeforeOpened = document.activeElement;
+        this.lastActiveElementBeforeOpened = getActiveElement(this.containerElement);
     }
 
     private handleTransitionExited = (node: HTMLElement) => {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -234,7 +234,7 @@ export class Tabs extends AbstractPureComponent2<TabsProps, ITabsState> {
     }
 
     private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-        const focusedElement = document.activeElement?.closest(TAB_SELECTOR);
+        const focusedElement = Utils.getActiveElement(this.tablistElement)?.closest(TAB_SELECTOR);
         // rest of this is potentially expensive and futile, so bail if no tab is focused
         if (focusedElement == null) {
             return;

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 
 import { AbstractPureComponent2, Classes, IRef, Keys, refHandler, setRef, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IntentProps, MaybeElement, Props } from "../../common/props";
+import { getActiveElement } from "../../common/utils";
 import { Icon, IconName, IconSize } from "../icon/icon";
 import { Tag, TagProps } from "../tag/tag";
 
@@ -361,7 +362,8 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
         this.requestAnimationFrame(() => {
             // we only care if the blur event is leaving the container.
             // defer this check using rAF so activeElement will have updated.
-            if (!currentTarget.contains(document.activeElement)) {
+            const isFocusInsideContainer = currentTarget.contains(getActiveElement(this.inputElement));
+            if (!isFocusInsideContainer) {
                 if (this.props.addOnBlur && this.state.inputValue !== undefined && this.state.inputValue.length > 0) {
                     this.addTags(this.state.inputValue, "blur");
                 }

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -26,6 +26,7 @@ import {
     mergeRefs,
     Props,
     Tag,
+    Utils,
 } from "@blueprintjs/core";
 import {
     DateFormatProps,
@@ -617,7 +618,7 @@ DateInput2.defaultProps = {
 };
 
 function getRelatedTargetWithFallback(e: React.FocusEvent<HTMLElement>) {
-    return (e.relatedTarget ?? document.activeElement) as HTMLElement;
+    return (e.relatedTarget ?? Utils.getActiveElement(e.currentTarget)) as HTMLElement;
 }
 
 function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<HTMLDivElement | null>) {

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -30,6 +30,7 @@ import {
     Props,
     refHandler,
     setRef,
+    Utils,
 } from "@blueprintjs/core";
 import {
     DateFormatProps,
@@ -792,7 +793,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
     // =======
 
     private shouldFocusInputRef(isFocused: boolean, inputRef: HTMLInputElement | null) {
-        return isFocused && inputRef != null && document.activeElement !== inputRef;
+        return isFocused && inputRef != null && Utils.getActiveElement(this.startInputElement) !== inputRef;
     }
 
     private getIsOpenValueWhenDateChanges = (nextSelectedStart: Date, nextSelectedEnd: Date): boolean => {

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -13,6 +13,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to MultiSelect2 instead.
+ */
+
 import classNames from "classnames";
 import * as React from "react";
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -323,10 +323,10 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     };
 
     // Popover interaction kind is CLICK, so this only handles click events.
-    // Note that we defer to the next animation frame in order to get the latest document.activeElement
+    // Note that we defer to the next animation frame in order to get the latest activeElement
     private handlePopoverInteraction = (nextOpenState: boolean, evt?: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
-            const isInputFocused = this.input === document.activeElement;
+            const isInputFocused = this.input === Utils.getActiveElement(this.input);
 
             if (this.input != null && !isInputFocused) {
                 // input is no longer focused, we should close the popover

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to Select2 instead.
+ */
+
 import classNames from "classnames";
 import * as React from "react";
 

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -276,7 +276,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     private handlePopoverOpening = (node: HTMLElement) => {
         // save currently focused element before popover steals focus, so we can restore it when closing.
-        this.previousFocusedElement = document.activeElement as HTMLElement;
+        this.previousFocusedElement = (Utils.getActiveElement(this.inputElement) as HTMLElement | null) ?? undefined;
 
         if (this.props.resetOnClose) {
             this.resetQuery();

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to Suggest2 instead.
+ */
+
 import classNames from "classnames";
 import * as React from "react";
 

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -313,12 +313,10 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
     }
 
     // Popover2 interaction kind is CLICK, so this only handles click events.
-    // Note that we defer to the next animation frame in order to get the latest document.activeElement
+    // Note that we defer to the next animation frame in order to get the latest activeElement
     private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
-            const rootNode = (this.inputElement?.getRootNode?.() ?? document) as DocumentOrShadowRoot & Node;
-            const isInputFocused = this.inputElement === rootNode.activeElement;
-
+            const isInputFocused = this.inputElement === Utils.getActiveElement(this.inputElement);
             if (this.inputElement != null && !isInputFocused) {
                 // the input is no longer focused, we should close the popover
                 this.setState({ isOpen: false });


### PR DESCRIPTION
#### Follow-up refactor after #5462

#### Changes proposed in this pull request:

- Create a utility helper function in @blueprintjs/core to grab the document (or shadow root) active element
- Use this new function across @blueprintjs/core and @blueprintjs/select components for consistent behavior in the shadow DOM

#### Reviewers should focus on:

No regressions, test suites should cover this behavior

#### Screenshot

N/A
