### PR TITLE
[stylelint-plugin] fix(no-prefix-literal): replace selectors correctly

### DIFF
--- a/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
@@ -101,8 +101,7 @@ export default stylelint.createPlugin(
                         if ((context as any).fix && !disableFix) {
                             assertBpVariablesImportExists(cssSyntax);
                             const fixed =
-                                BpPrefixVariableMap[cssSyntax] +
-                                selector.value.substring(bannedPrefix.length, selector.value.length - 1);
+                                BpPrefixVariableMap[cssSyntax] + selector.value.substring(bannedPrefix.length);
                             // Note - selector.value = "#{$var}" escapes special characters and produces "\#\{\$var\}",
                             // and to work around that we use selector.toString instead.
                             selector.toString = () => `.${fixed}`;

--- a/packages/stylelint-plugin/src/utils/checkImportExists.ts
+++ b/packages/stylelint-plugin/src/utils/checkImportExists.ts
@@ -36,7 +36,7 @@ export function checkImportExists(root: Root, importPath: string | string[]): bo
 function stripLessReference(str: string): string {
     const LESS_REFERENCE = "(reference)";
     if (str.startsWith(`${LESS_REFERENCE} `)) {
-        return str.substring(LESS_REFERENCE.length + 1, str.length);
+        return str.substring(LESS_REFERENCE.length + 1);
     }
     return str;
 }
@@ -46,6 +46,7 @@ function stripQuotes(str: string): string {
         (str.charAt(0) === '"' && str.charAt(str.length - 1) === '"') ||
         (str.charAt(0) === "'" && str.charAt(str.length - 1) === "'")
     ) {
+        // omit first and last character
         return str.substring(1, str.length - 1);
     }
     return str;

--- a/packages/stylelint-plugin/test/no-prefix-literal.test.js
+++ b/packages/stylelint-plugin/test/no-prefix-literal.test.js
@@ -15,6 +15,8 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { expect } = require("chai");
+const fs = require("fs");
+const path = require("path");
 const stylelint = require("stylelint");
 
 const config = {
@@ -165,5 +167,39 @@ describe("no-prefix-literal", () => {
         expect(result.errored).to.be.true;
         const warnings = result.results[0].warnings;
         expect(warnings).lengthOf(2);
+    });
+
+    describe("auto-fixer", () => {
+        const tmpDir = path.join(__dirname, "tmp");
+
+        before(() => {
+            fs.mkdirSync(tmpDir);
+        });
+        after(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it("Replaces selector text properly", async () => {
+            const fixtureFilename = "contains-bp3.scss";
+            // path to the fixture we want to test
+            const fixturePath = path.join(__dirname, "fixtures/no-prefix-literal", fixtureFilename);
+            // path to a copy of the fixture which we can allow stylelint to mutate
+            const mutableFixturePath = path.join(tmpDir, fixtureFilename);
+            fs.copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                files: mutableFixturePath,
+                config,
+                fix: true,
+            });
+            // there should be no warnings/errors since the fixer should succeed
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).lengthOf(0);
+
+            const fixedSourceContents = fs.readFileSync(mutableFixturePath, { encoding: "utf-8" });
+            expect(fixedSourceContents).to.contain(`@import "~@blueprintjs/core/lib/scss/variables";`);
+            expect(fixedSourceContents).to.contain(".#{$bp-ns}-tag {");
+        });
     });
 });


### PR DESCRIPTION
#### Fixes #5464

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Fix usage of `String::substring()` in custom stylelint rules
- Add a unit test for the regression identified in the linked issue

#### Reviewers should focus on:



#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
