### PR TITLE
[datetime2] feat(DateInput2): remove target wrapper, fix fill prop

### DIFF
--- a/packages/datetime2/src/blueprint-datetime2.scss
+++ b/packages/datetime2/src/blueprint-datetime2.scss
@@ -4,6 +4,13 @@
 @import "~@blueprintjs/colors/lib/scss/colors";
 @import "~@blueprintjs/core/src/common/variables";
 
+.#{$bp}-datepicker-timepicker-wrapper {
+  // Ensure some padding around the timepicker elements. We need this when precision="millisecond" and
+  // useAmPm={true} - all four inputs and an HTMLSelect are rendered, which results in the timepicker
+  // being slightly wider than the datepicker. Without this padding, things look a bit too cramped.
+  padding: 0 2px;
+}
+
 .#{$ns}-timezone-select-popover {
   min-width: 370px;
 }

--- a/packages/datetime2/src/blueprint-datetime2.scss
+++ b/packages/datetime2/src/blueprint-datetime2.scss
@@ -4,7 +4,7 @@
 @import "~@blueprintjs/colors/lib/scss/colors";
 @import "~@blueprintjs/core/src/common/variables";
 
-.#{$bp}-datepicker-timepicker-wrapper {
+.#{$ns}-datepicker-timepicker-wrapper {
   // Ensure some padding around the timepicker elements. We need this when precision="millisecond" and
   // useAmPm={true} - all four inputs and an HTMLSelect are rendered, which results in the timepicker
   // being slightly wider than the datepicker. Without this padding, things look a bit too cramped.

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -35,7 +35,7 @@ import {
     DatePickerShortcut,
     DatePickerUtils,
 } from "@blueprintjs/datetime";
-import { Popover2, Popover2Props } from "@blueprintjs/popover2";
+import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import * as Classes from "../../common/classes";
 import { isDateValid, isDayInRange } from "../../common/dateUtils";
@@ -196,6 +196,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
         defaultTimezone,
         defaultValue,
         disableTimezoneSelect,
+        fill,
         inputProps = {},
         // defaults duplicated here for TypeScript convenience
         maxDate = DEFAULT_MAX_DATE,
@@ -570,10 +571,62 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     const shouldShowErrorStyling =
         !isInputFocused || inputValue === props.outOfRangeMessage || inputValue === props.invalidDateMessage;
 
+    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
+    // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
+    // again after that state changes.
+    const renderTarget = React.useCallback(
+        // N.B. pull out `defaultValue` & `isOpen` so that they're not forwarded to the DOM, but remember not to use
+        // `isOpen` directly since it may be stale (`renderTarget` is not re-invoked on state changes).
+        ({
+            defaultValue: _defaultValue,
+            isOpen: _isOpen,
+            ref,
+            ...targetProps
+        }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+            return (
+                <InputGroup
+                    autoComplete="off"
+                    className={classNames(targetProps.className, inputProps.className)}
+                    intent={shouldShowErrorStyling && isErrorState ? "danger" : "none"}
+                    placeholder={placeholder}
+                    rightElement={
+                        <>
+                            {maybeTimezonePicker}
+                            {props.rightElement}
+                        </>
+                    }
+                    type="text"
+                    {...targetProps}
+                    {...inputProps}
+                    aria-expanded={isOpen}
+                    disabled={props.disabled}
+                    fill={fill}
+                    inputRef={mergeRefs(ref, inputRef, props.inputProps?.inputRef ?? null)}
+                    onBlur={handleInputBlur}
+                    onChange={handleInputChange}
+                    onClick={handleInputClick}
+                    onFocus={handleInputFocus}
+                    onKeyDown={handleInputKeyDown}
+                    value={(isInputFocused ? inputValue : formattedDateString) ?? ""}
+                />
+            );
+        },
+        [
+            isOpen,
+            fill,
+            placeholder,
+            props.rightElement,
+            props.disabled,
+            props.inputProps,
+            inputValue,
+            formattedDateString,
+        ],
+    );
+
+    // N.B. no need to set `fill` since that is unused with the `renderTarget` API
     return (
         <Popover2
             isOpen={isOpen && !props.disabled}
-            fill={props.fill}
             {...popoverProps}
             autoFocus={false}
             className={classNames(Classes.DATE_INPUT, popoverProps.className, props.className)}
@@ -581,29 +634,8 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             enforceFocus={false}
             onClose={handlePopoverClose}
             popoverClassName={classNames(Classes.DATE_INPUT_POPOVER, popoverProps.popoverClassName)}
-        >
-            <InputGroup
-                autoComplete="off"
-                intent={shouldShowErrorStyling && isErrorState ? "danger" : "none"}
-                placeholder={placeholder}
-                rightElement={
-                    <>
-                        {maybeTimezonePicker}
-                        {props.rightElement}
-                    </>
-                }
-                type="text"
-                {...inputProps}
-                disabled={props.disabled}
-                inputRef={mergeRefs(inputRef, props.inputProps?.inputRef ?? null)}
-                onBlur={handleInputBlur}
-                onChange={handleInputChange}
-                onClick={handleInputClick}
-                onFocus={handleInputFocus}
-                onKeyDown={handleInputKeyDown}
-                value={(isInputFocused ? inputValue : formattedDateString) ?? ""}
-            />
-        </Popover2>
+            renderTarget={renderTarget}
+        />
     );
 });
 DateInput2.displayName = `${DISPLAYNAME_PREFIX}.DateInput2`;

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -612,14 +612,18 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             );
         },
         [
-            isOpen,
             fill,
+            formattedDateString,
+            inputValue,
+            isInputFocused,
+            isOpen,
+            isTimezoneSelectDisabled,
+            isTimezoneSelectHidden,
             placeholder,
-            props.rightElement,
+            shouldShowErrorStyling,
             props.disabled,
             props.inputProps,
-            inputValue,
-            formattedDateString,
+            props.rightElement,
         ],
     );
 

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -571,15 +571,12 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     const shouldShowErrorStyling =
         !isInputFocused || inputValue === props.outOfRangeMessage || inputValue === props.invalidDateMessage;
 
-    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
-    // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
-    // again after that state changes.
+    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like the "fill" prop.
     const renderTarget = React.useCallback(
-        // N.B. pull out `defaultValue` & `isOpen` so that they're not forwarded to the DOM, but remember not to use
-        // `isOpen` directly since it may be stale (`renderTarget` is not re-invoked on state changes).
+        // N.B. pull out `defaultValue` so that it's not forwarded to the DOM.
         ({
             defaultValue: _defaultValue,
-            isOpen: _isOpen,
+            isOpen: targetIsOpen,
             ref,
             ...targetProps
         }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
@@ -598,7 +595,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                     type="text"
                     {...targetProps}
                     {...inputProps}
-                    aria-expanded={isOpen}
+                    aria-expanded={targetIsOpen}
                     disabled={props.disabled}
                     fill={fill}
                     inputRef={mergeRefs(ref, inputRef, props.inputProps?.inputRef ?? null)}
@@ -616,7 +613,6 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             formattedDateString,
             inputValue,
             isInputFocused,
-            isOpen,
             isTimezoneSelectDisabled,
             isTimezoneSelectHidden,
             placeholder,

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -126,12 +126,13 @@ describe("<DateInput2>", () => {
             assert.equal(datePicker.prop("todayButtonText"), "today");
         });
 
-        it("passes inputProps to InputGroup", () => {
+        it("passes fill and inputProps to InputGroup", () => {
             const inputRef = sinon.spy();
             const onFocus = sinon.spy();
             const wrapper = mount(
                 <DateInput2
                     {...DEFAULT_PROPS}
+                    fill={true}
                     inputProps={{
                         inputRef,
                         leftIcon: "star",
@@ -143,18 +144,18 @@ describe("<DateInput2>", () => {
             focusInput(wrapper);
 
             const input = wrapper.find(InputGroup);
+            assert.strictEqual(input.prop("fill"), true);
             assert.strictEqual(input.prop("leftIcon"), "star");
             assert.isTrue(input.prop("required"));
             assert.isTrue(inputRef.called, "inputRef not invoked");
             assert.isTrue(onFocus.called, "onFocus not invoked");
         });
 
-        it("passes fill and popoverProps to Popover2", () => {
+        it("passes popoverProps to Popover2", () => {
             const onOpening = sinon.spy();
             const wrapper = mount(
                 <DateInput2
                     {...DEFAULT_PROPS}
-                    fill={true}
                     popoverProps={{
                         onOpening,
                         placement: "top",
@@ -165,7 +166,6 @@ describe("<DateInput2>", () => {
             focusInput(wrapper);
 
             const popover = wrapper.find(Popover2).first();
-            assert.strictEqual(popover.prop("fill"), true);
             assert.strictEqual(popover.prop("placement"), "top");
             assert.strictEqual(popover.prop("usePortal"), false);
             assert.isTrue(onOpening.calledOnce);

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -520,6 +520,7 @@
   .docs-example {
     flex-direction: column;
     justify-content: center;
+    gap: $pt-grid-size;
   }
 
   #{example("TimezoneSelectExample")} .docs-example {
@@ -543,8 +544,11 @@
 //
 
 #{example("DateInput2Example")} {
-  .#{$ns}-input-group {
+  .#{$ns}-date-input {
+    margin: 0;
     min-width: 300px;
+    // should not grow in vertical direction when fill={true}
+    flex-grow: 0;
   }
 }
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -519,8 +519,8 @@
 #{page("datetime", "^=")} {
   .docs-example {
     flex-direction: column;
-    justify-content: center;
     gap: $pt-grid-size;
+    justify-content: center;
   }
 
   #{example("TimezoneSelectExample")} .docs-example {
@@ -545,10 +545,10 @@
 
 #{example("DateInput2Example")} {
   .#{$ns}-date-input {
-    margin: 0;
-    min-width: 300px;
     // should not grow in vertical direction when fill={true}
     flex-grow: 0;
+    margin: 0;
+    min-width: 300px;
   }
 }
 


### PR DESCRIPTION
#### Fixes #5472

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Refactor DateInput2 to use Popover2's `renderTarget` API, like we do in Select2, Suggest2, and MultiSelect2. Note that this is a breaking change to the DOM layout, as we have combined the popover target and input group elements into one:
```diff
- <span aria-haspopup="true" class="bp4-date-input bp4-popover2-target">
-   <div class="bp4-input-group">
-     <input>
- </span>
+ <div class="bp4-input-group bp4-date-input bp4-popover2-target">
+   <input aria-haspopup="true">
+ </div>
```
- Fix `fill` prop so it now works as expected

#### Reviewers should focus on:

N/A

#### Screenshot

<img width="794" alt="image" src="https://user-images.githubusercontent.com/723999/182201221-6fd1a4e3-ae0c-45a3-83c1-231858426c33.png">
