### PR TITLE
[datetime2] feat(DateRangeInput2): remove target wrapper element

### DIFF
--- a/packages/datetime2/src/common/classes.ts
+++ b/packages/datetime2/src/common/classes.ts
@@ -22,5 +22,8 @@ export const DATE_INPUT = `${NS}-date-input`;
 export const DATE_INPUT_POPOVER = `${NS}-date-input-popover`;
 export const DATE_INPUT_TIMEZONE_SELECT = `${NS}-date-input-timezone-select`;
 
+export const DATE_RANGE_INPUT = `${NS}-date-range-input`;
+export const DATE_RANGE_INPUT_POPOVER = `${NS}-date-range-input-popover`;
+
 export const TIMEZONE_SELECT = `${NS}-timezone-select`;
 export const TIMEZONE_SELECT_POPOVER = `${TIMEZONE_SELECT}-popover`;

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -380,8 +380,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
         }
     }
 
-    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
-    // the "fill" prop.
+    // We use the renderTarget API to flatten the rendered DOM.
     private renderTarget =
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
         ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 import {
     AbstractPureComponent2,
     Boundary,
-    Classes,
+    Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
     InputGroup,
     InputGroupProps2,
@@ -41,7 +41,7 @@ import {
 } from "@blueprintjs/datetime";
 import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popover2";
 
-import { DateRange, NonNullDateRange } from "../../common/dateRange";
+import { Classes, DateRange, NonNullDateRange } from "../../common";
 import { isDayInRange, isSameTime } from "../../common/dateUtils";
 import * as Errors from "../../common/errors";
 
@@ -354,20 +354,19 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
             />
         );
 
-        const popoverClassName = classNames(popoverProps.className, this.props.className);
-
         // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
             <Popover2
                 isOpen={this.state.isOpen}
                 placement="bottom-start"
-                {...this.props.popoverProps}
+                {...popoverProps}
                 autoFocus={false}
-                className={popoverClassName}
+                className={classNames(Classes.DATE_RANGE_INPUT, popoverProps.className, this.props.className)}
                 content={popoverContent}
                 enforceFocus={false}
                 onClose={this.handlePopoverClose}
+                popoverClassName={classNames(Classes.DATE_RANGE_INPUT_POPOVER, popoverProps.popoverClassName)}
                 renderTarget={this.renderTarget}
             />
         );
@@ -387,7 +386,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
         ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
             return (
-                <div {...targetProps} className={classNames(Classes.CONTROL_GROUP, targetProps.className)}>
+                <div {...targetProps} className={classNames(CoreClasses.CONTROL_GROUP, targetProps.className)}>
                     {this.renderInputGroup(Boundary.START)}
                     {this.renderInputGroup(Boundary.END)}
                 </div>

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -39,7 +39,7 @@ import {
     DateRangePicker,
     DateRangeShortcut,
 } from "@blueprintjs/datetime";
-import { Popover2, Popover2Props } from "@blueprintjs/popover2";
+import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import { DateRange, NonNullDateRange } from "../../common/dateRange";
 import { isDayInRange, isSameTime } from "../../common/dateUtils";
@@ -368,12 +368,8 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
                 content={popoverContent}
                 enforceFocus={false}
                 onClose={this.handlePopoverClose}
-            >
-                <div className={Classes.CONTROL_GROUP}>
-                    {this.renderInputGroup(Boundary.START)}
-                    {this.renderInputGroup(Boundary.END)}
-                </div>
-            </Popover2>
+                renderTarget={this.renderTarget}
+            />
         );
     }
 
@@ -384,6 +380,19 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
         }
     }
+
+    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like
+    // the "fill" prop.
+    private renderTarget =
+        // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
+        ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+            return (
+                <div {...targetProps} className={classNames(Classes.CONTROL_GROUP, targetProps.className)}>
+                    {this.renderInputGroup(Boundary.START)}
+                    {this.renderInputGroup(Boundary.END)}
+                </div>
+            );
+        };
 
     private renderInputGroup = (boundary: Boundary) => {
         const inputProps = this.getInputProps(boundary);


### PR DESCRIPTION
#### Changes proposed in this pull request:

Similar to #5473, this PR refactors DateRangeInput2 to use Popover2's `renderTarget` API, which allows us to flatten the rendered DOM by one level and combine the ControlGroup element w/ the Popover2 target element. Also added `.bp4-date-range-input` and `.bp4-date-range-input-popover` classes (surprised they weren't there before in `<DateRangeInput>`):

```diff
- <span aria-haspopup="true" class="bp4-popover2-target">
-     <div class="bp4-control-group">
-         <div class="bp4-input-group">...</div>
-         <div class="bp4-input-group">...</div>
-     </div>
- </span>
+ <div aria-haspopup="true" class="bp4-control-group bp4-date-range-input bp4-popover2-target">
+     <div class="bp4-input-group">...</div>
+     <div class="bp4-input-group">...</div>
+ </div>
```

#### Reviewers should focus on:

No regressions in behavior (should be covered by test suite)

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
