### PR TITLE
[eslint-plugin] feat(no-deprecated-components): more components

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components.ts
@@ -11,7 +11,10 @@ const DEPRECATED_TO_NEW_MAPPING: { [deprecated: string]: string } = {
     AbstractPureComponent: "AbstractPureComponent2",
     Breadcrumbs: "Breadcrumbs2",
     CollapsibleList: "OverflowList",
+    DateInput: "DateInput2",
     DateRangeInput: "DateRangeInput2",
+    DateTimePicker: "DatePicker",
+    MenuItem: "MenuItem2",
     MultiSelect: "MultiSelect2",
     PanelStack: "PanelStack2",
     Popover: "Popover2",
@@ -20,7 +23,12 @@ const DEPRECATED_TO_NEW_MAPPING: { [deprecated: string]: string } = {
     TimezonePicker: "TimezoneSelect",
     Tooltip: "Tooltip2",
 };
-const PACKAGES_WITH_DEPRECATED_IMPORTS = ["@blueprintjs/core", "@blueprintjs/select", "@blueprintjs/timezone"];
+const PACKAGES_WITH_DEPRECATED_IMPORTS = [
+    "@blueprintjs/core",
+    "@blueprintjs/datetime",
+    "@blueprintjs/select",
+    "@blueprintjs/timezone",
+];
 
 type MessageIds = "migration";
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Add `@blueprintjs/datetime` package to the list of packages which the rule checks for deprecated imports
- Add components to list of deprecations / disallowed imports:
  - DateInput
  - DateTimePicker
  - MenuItem

#### Reviewers should focus on:

Difficulty of rolling this out, as it's kind of a breaking change for the lint rule (builds with the rule set to "error" will start failing).

