### PR TITLE
[table] feat(Table2, ColumnHeaderCell2): migrate away from legacy React context API

### DIFF
--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -26,7 +26,7 @@ import {
     Cell,
     Column,
     ColumnHeaderCell2,
-    ColumnHeaderCellProps,
+    ColumnHeaderCell2Props,
     CopyCellsMenuItem,
     EditableCell2,
     EditableName,
@@ -554,7 +554,7 @@ ReactDOM.render(
     document.getElementById("table-6"),
 );
 
-class CustomHeaderCell extends React.Component<ColumnHeaderCellProps> {
+class CustomHeaderCell extends React.Component<ColumnHeaderCell2Props> {
     public render() {
         return <ColumnHeaderCell2 {...this.props}>Hey dawg.</ColumnHeaderCell2>;
     }

--- a/packages/table/src/common/context.ts
+++ b/packages/table/src/common/context.ts
@@ -13,13 +13,17 @@
  * limitations under the License.
  */
 
+/* eslint-disable deprecation/deprecation */
+
 import * as PropTypes from "prop-types";
 import * as React from "react";
 
+/** @deprecated use newer React context API */
 export interface ColumnInteractionBarContextTypes {
     enableColumnInteractionBar: boolean | null | undefined;
 }
 
+/** @deprecated use newer React context API */
 export const columnInteractionBarContextTypes: React.ValidationMap<ColumnInteractionBarContextTypes> = {
     enableColumnInteractionBar: PropTypes.bool,
 };

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -26,11 +26,11 @@ import { IClientCoordinates } from "../interactions/dragTypes";
 import { IIndexedResizeCallback } from "../interactions/resizable";
 import { Orientation } from "../interactions/resizeHandle";
 import { RegionCardinality, Regions } from "../regions";
-import { ColumnHeaderCell2, ColumnHeaderCellProps } from "./columnHeaderCell2";
+import { ColumnHeaderCell2, ColumnHeaderCell2Props } from "./columnHeaderCell2";
 import { Header, IHeaderProps } from "./header";
 
 /** @deprecated use ColumnHeaderRenderer */
-export type IColumnHeaderRenderer = (columnIndex: number) => React.ReactElement<ColumnHeaderCellProps> | null;
+export type IColumnHeaderRenderer = (columnIndex: number) => React.ReactElement<ColumnHeaderCell2Props> | null;
 // eslint-disable-next-line deprecation/deprecation
 export type ColumnHeaderRenderer = IColumnHeaderRenderer;
 

--- a/packages/table/src/headers/columnHeaderCell2.tsx
+++ b/packages/table/src/headers/columnHeaderCell2.tsx
@@ -21,25 +21,30 @@ import { AbstractPureComponent2, Utils as CoreUtils, DISPLAYNAME_PREFIX, Icon } 
 import { Popover2 } from "@blueprintjs/popover2";
 
 import * as Classes from "../common/classes";
-import { columnInteractionBarContextTypes, ColumnInteractionBarContextTypes } from "../common/context";
 import { LoadableContent } from "../common/loadableContent";
 import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
 import { HorizontalCellDivider, IColumnHeaderCellProps, IColumnHeaderCellState } from "./columnHeaderCell";
 import { HeaderCell2 } from "./headerCell2";
 
 // eslint-disable-next-line deprecation/deprecation
-export type ColumnHeaderCellProps = IColumnHeaderCellProps;
+export interface ColumnHeaderCell2Props extends IColumnHeaderCellProps {
+    /**
+     * If `true`, adds an interaction bar on top of all column header cells, and
+     * moves interaction triggers into it.
+     *
+     * @default false
+     */
+    enableColumnInteractionBar?: boolean;
+}
 
-export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCellProps, IColumnHeaderCellState> {
+export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCell2Props, IColumnHeaderCellState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ColumnHeaderCell2`;
 
-    public static defaultProps: ColumnHeaderCellProps = {
+    public static defaultProps: ColumnHeaderCell2Props = {
+        enableColumnInteractionBar: false,
         isActive: false,
         menuIcon: "chevron-down",
     };
-
-    public static contextTypes: React.ValidationMap<ColumnInteractionBarContextTypes> =
-        columnInteractionBarContextTypes;
 
     /**
      * This method determines if a `MouseEvent` was triggered on a target that
@@ -57,38 +62,30 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCellPr
         );
     }
 
-    public context: ColumnInteractionBarContextTypes = {
-        enableColumnInteractionBar: false,
-    };
-
     public state = {
         isActive: false,
     };
 
     public render() {
         const {
-            // from IColumnHeaderCellProps
+            enableColumnInteractionBar,
             enableColumnReordering,
             isColumnSelected,
             menuIcon,
-
-            // from IColumnNameProps
             name,
             nameRenderer,
-
-            // from IHeaderProps
             ...spreadableProps
         } = this.props;
 
         const classes = classNames(spreadableProps.className, Classes.TABLE_COLUMN_HEADER_CELL, {
-            [Classes.TABLE_HAS_INTERACTION_BAR]: this.context.enableColumnInteractionBar,
+            [Classes.TABLE_HAS_INTERACTION_BAR]: enableColumnInteractionBar,
             [Classes.TABLE_HAS_REORDER_HANDLE]: this.props.reorderHandle != null,
         });
 
         return (
             <HeaderCell2
-                isReorderable={this.props.enableColumnReordering}
-                isSelected={this.props.isColumnSelected}
+                isReorderable={enableColumnReordering}
+                isSelected={isColumnSelected}
                 {...spreadableProps}
                 className={classes}
             >
@@ -100,7 +97,7 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCellPr
     }
 
     private renderName() {
-        const { index, loading, name, nameRenderer, reorderHandle } = this.props;
+        const { enableColumnInteractionBar, index, loading, name, nameRenderer, reorderHandle } = this.props;
 
         const dropdownMenu = this.maybeRenderDropdownMenu();
         const defaultName = <div className={Classes.TABLE_TRUNCATED_TEXT}>{name}</div>;
@@ -111,7 +108,7 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCellPr
             </LoadableContent>
         );
 
-        if (this.context.enableColumnInteractionBar) {
+        if (enableColumnInteractionBar) {
             return (
                 <div className={Classes.TABLE_COLUMN_NAME} title={name}>
                     <div className={Classes.TABLE_INTERACTION_BAR}>

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -71,7 +71,7 @@ export { RowHeaderRenderer } from "./headers/rowHeader";
 
 export { ColumnHeaderCell, IColumnHeaderCellProps, HorizontalCellDivider } from "./headers/columnHeaderCell";
 
-export { ColumnHeaderCell2, ColumnHeaderCellProps } from "./headers/columnHeaderCell2";
+export { ColumnHeaderCell2, ColumnHeaderCell2Props } from "./headers/columnHeaderCell2";
 
 export { IRowHeaderCellProps, RowHeaderCellProps, RowHeaderCell } from "./headers/rowHeaderCell";
 

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -31,7 +31,6 @@ import { CellRenderer } from "./cell/cell";
 import { Column, ColumnProps } from "./column";
 import type { FocusedCellCoordinates } from "./common/cellTypes";
 import * as Classes from "./common/classes";
-import { columnInteractionBarContextTypes, ColumnInteractionBarContextTypes } from "./common/context";
 import * as Errors from "./common/errors";
 import { Grid, ICellMapper } from "./common/grid";
 import * as FocusedCellUtils from "./common/internal/focusedCellUtils";
@@ -40,7 +39,7 @@ import { Rect } from "./common/rect";
 import { RenderMode } from "./common/renderMode";
 import { Utils } from "./common/utils";
 import { ColumnHeader } from "./headers/columnHeader";
-import { ColumnHeaderCell2, ColumnHeaderCellProps } from "./headers/columnHeaderCell2";
+import { ColumnHeaderCell2, ColumnHeaderCell2Props } from "./headers/columnHeaderCell2";
 import { renderDefaultRowHeader, RowHeader } from "./headers/rowHeader";
 import { ResizeSensor } from "./interactions/resizeSensor";
 import { GuideLayer } from "./layers/guides";
@@ -97,9 +96,6 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
         rowHeaderCellRenderer: renderDefaultRowHeader,
         selectionModes: SelectionModes.ALL,
     };
-
-    public static childContextTypes: React.ValidationMap<ColumnInteractionBarContextTypes> =
-        columnInteractionBarContextTypes;
 
     public static getDerivedStateFromProps(props: TablePropsWithDefaults, state: TableState) {
         const {
@@ -433,12 +429,6 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
     // React lifecycle
     // ===============
 
-    public getChildContext(): ColumnInteractionBarContextTypes {
-        return {
-            enableColumnInteractionBar: this.props.enableColumnInteractionBar!,
-        };
-    }
-
     public shouldComponentUpdate(nextProps: Table2Props, nextState: TableState) {
         const propKeysDenylist = { exclude: Table2.SHALLOW_COMPARE_PROP_KEYS_DENYLIST };
         const stateKeysDenylist = { exclude: Table2.SHALLOW_COMPARE_STATE_KEYS_DENYLIST };
@@ -763,12 +753,14 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
             const columnHeaderCell = columnHeaderCellRenderer(columnIndex);
             if (columnHeaderCell != null) {
                 return React.cloneElement(columnHeaderCell, {
+                    enableColumnInteractionBar: this.props.enableColumnInteractionBar,
                     loading: columnHeaderCell.props.loading ?? columnLoading,
                 });
             }
         }
 
-        const baseProps: ColumnHeaderCellProps = {
+        const baseProps: ColumnHeaderCell2Props = {
+            enableColumnInteractionBar: this.props.enableColumnInteractionBar,
             index: columnIndex,
             loading: columnLoading,
             ...spreadableProps,

--- a/packages/table/test/columnHeaderCell2Tests.tsx
+++ b/packages/table/test/columnHeaderCell2Tests.tsx
@@ -15,14 +15,14 @@
  */
 
 import { expect } from "chai";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
 import { H4, Menu } from "@blueprintjs/core";
 import { MenuItem2, Classes as Popover2Classes } from "@blueprintjs/popover2";
 
-import { ColumnHeaderCell2, ColumnHeaderCellProps } from "../src";
+import { ColumnHeaderCell2, ColumnHeaderCell2Props } from "../src";
 import * as Classes from "../src/common/classes";
 import { ElementHarness, ReactHarness } from "./harness";
 import { createTableOfSize } from "./mocks/table";
@@ -56,7 +56,7 @@ describe("<ColumnHeaderCell2>", () => {
         renderNameStub.returns("string");
         const NAME = "my-name";
         const INDEX = 17;
-        shallow(<ColumnHeaderCell2 index={INDEX} name={NAME} nameRenderer={renderNameStub} />);
+        mount(<ColumnHeaderCell2 index={INDEX} name={NAME} nameRenderer={renderNameStub} />);
         expect(renderNameStub.firstCall.args).to.deep.equal([NAME, INDEX]);
     });
 
@@ -136,30 +136,28 @@ describe("<ColumnHeaderCell2>", () => {
         }
     });
 
-    // TODO: re-enable these tests when we switch to enzyme's testing harness instead of our own,
-    // so that we can supply a react context with enableColumnInteractionBar: true
-    // see https://github.com/palantir/blueprint/issues/2076
-    describe.skip("Reorder handle", () => {
+    describe("Reorder handle", () => {
         const REORDER_HANDLE_CLASS = Classes.TABLE_REORDER_HANDLE_TARGET;
 
         it("shows reorder handle in interaction bar if reordering and interaction bar are enabled", () => {
-            const element = mount({ enableColumnReordering: true });
-            expect(element.find(`.${Classes.TABLE_INTERACTION_BAR} .${REORDER_HANDLE_CLASS}`)!.exists()).to.be.true;
+            const wrapper = mountHeaderCell();
+            expect(wrapper.find(`.${Classes.TABLE_INTERACTION_BAR} .${REORDER_HANDLE_CLASS}`)!.exists()).to.be.true;
         });
 
         it("shows reorder handle next to column name if reordering enabled but interaction bar disabled", () => {
-            const element = mount({ enableColumnReordering: true });
-            expect(element.find(`.${Classes.TABLE_COLUMN_NAME} .${REORDER_HANDLE_CLASS}`)!.exists()).to.be.true;
+            const wrapper = mountHeaderCell({ enableColumnInteractionBar: false });
+            expect(wrapper.find(`.${Classes.TABLE_COLUMN_NAME} .${REORDER_HANDLE_CLASS}`)!.exists()).to.be.true;
         });
 
-        function mount(props: Partial<ColumnHeaderCellProps>) {
-            const element = harness.mount(
+        function mountHeaderCell(props?: Partial<ColumnHeaderCell2Props>) {
+            return mount(
                 <ColumnHeaderCell2
-                    enableColumnReordering={props.enableColumnReordering}
+                    enableColumnInteractionBar={true}
                     reorderHandle={<div className={REORDER_HANDLE_CLASS} />}
+                    enableColumnReordering={true}
+                    {...props}
                 />,
             );
-            return element;
         }
     });
 });

--- a/packages/table/test/columnHeaderCell2Tests.tsx
+++ b/packages/table/test/columnHeaderCell2Tests.tsx
@@ -53,7 +53,7 @@ describe("<ColumnHeaderCell2>", () => {
 
     it("passes index prop to nameRenderer callback if index was provided", () => {
         const renderNameStub = sinon.stub();
-        renderNameStub.returns("string");
+        renderNameStub.returns(<span>name</span>);
         const NAME = "my-name";
         const INDEX = 17;
         mount(<ColumnHeaderCell2 index={INDEX} name={NAME} nameRenderer={renderNameStub} />);


### PR DESCRIPTION

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Remove `contextTypes` and `getChildContext()` from `<Table2>`
- Add `enableColumnInteractionBar` prop to `<ColumnHeaderCell2>`, plumb the prop through from `<Table2>` instead of using React context API (it was unnecessarily complex in the first place to use context)

