### PR TITLE
[core] feat(Portal): add support for new context API

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -85,6 +85,8 @@ export const POPOVER_WARN_PLACEMENT_AND_POSITION_MUTEX =
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 
 export const PORTAL_CONTEXT_CLASS_NAME_STRING = ns + ` <Portal> context blueprintPortalClassName must be string`;
+export const PORTAL_LEGACY_CONTEXT_API =
+    ns + ` setting blueprintPortalClassName via legacy React context API is deprecated, use <PortalProvider> instead.`;
 
 export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
     ns + ` <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -1,40 +1,46 @@
 @# Portal
 
-The `Portal` component renders its children into a new "subtree" outside of the current component
-hierarchy. It is an essential piece of [`Overlay`](#core/components/overlay), responsible for ensuring that
-the overlay contents cover the application below. In most cases you do not need to use a `Portal`
+The Portal component renders its children into a new "subtree" outside of the current component
+hierarchy. It is an essential piece of [Overlay](#core/components/overlay), responsible for ensuring that
+the overlay contents cover the application below. In most cases you do not need to use a Portal
 directly; this documentation is provided simply for reference.
 
-@## React 15
+For the most part, Portal is a thin wrapper around [`ReactDOM.createPortal`](https://reactjs.org/docs/portals.html).
 
-In a **React 15** environment, `Portal` will use `ReactDOM.unstable_renderSubtreeIntoContainer` to achieve the teleportation effect, which has a few caveats:
+@## React context (legacy)
 
-1. `Portal` `children` are wrapped in an extra `<div>` inside the portal container element.
-1. Test harnesses such as `enzyme` cannot trivially find elements "through" Portals as they're not in the same React tree.
-1. React `context` _is_ preserved (this one's a good thing).
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">
 
-In a **React 16+** environment, the `Portal` component will use [`ReactDOM.createPortal`](https://reactjs.org/docs/portals.html) which preserves the React tree perfectly and does not require any of the above caveats.
+Deprecated: use [PortalProvider](#core/context/portal-provider)
 
-@## React context
+</h4>
 
-`Portal` supports the following options on its [React context](https://facebook.github.io/react/docs/context.html).
-To use them, supply a child context to a subtree that contains the Portals you want to customize.
-
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-
-Blueprint uses the React 15-compatible `getChildContext()` API instead of the newer React 16.3 `React.createContext()` API.
+This API is **deprecated since @blueprintjs/core v4.8.0** in favor of
+[PortalProvider](#core/context/portal-provider), which uses the
+[newer React context API](https://reactjs.org/docs/context.html).
 
 </div>
 
-@interface IPortalContext
+Portal supports the following options on its [React (legacy) context](https://reactjs.org/docs/legacy-context.html).
+To use them, supply a child context to a subtree that contains the Portals you want to customize.
+
+@interface PortalLegacyContext
+
+@## React context
+
+Portal supports the following options on its [React context](https://reactjs.org/docs/context.html)
+via [PortalProvider](#core/context/portal-provider).
+
+@interface PortalContextOptions
 
 @## Props
 
-The `Portal` component functions like a declarative `appendChild()`, or jQuery's
+The Portal component functions like a declarative `appendChild()`, or jQuery's
 `$.fn.appendTo()`. The children of a `Portal` component are inserted into a new
 child of the `<body>`.
 
-`Portal` is used inside [`Overlay`](#core/components/overlay) to actually overlay the content on the
+Portal is used inside [Overlay](#core/components/overlay) to actually overlay the content on the
 application.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -21,7 +21,7 @@ import * as Classes from "../../common/classes";
 import { ValidationMap } from "../../common/context";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
-import { PortalContext, PortalContextOptions } from "../../context";
+import { PortalContext, PortalContextOptions } from "../../context/portal/portalProvider";
 
 // eslint-disable-next-line deprecation/deprecation
 export type PortalProps = IPortalProps;

--- a/packages/core/src/context/context.md
+++ b/packages/core/src/context/context.md
@@ -3,3 +3,4 @@
 <!-- Exact ordering of items in the navbar: -->
 
 @page hotkeys-provider
+@page portal-provider

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -20,3 +20,5 @@ export {
     HotkeysProvider,
     HotkeysProviderProps,
 } from "./hotkeys/hotkeysProvider";
+
+export { PortalContextOptions, PortalContext, PortalProvider } from "./portal/portalProvider";

--- a/packages/core/src/context/portal/portal-provider.md
+++ b/packages/core/src/context/portal/portal-provider.md
@@ -1,0 +1,29 @@
+---
+tag: new
+---
+
+@# PortalProvider
+
+PortalProvider generates a React context necessary for customizing global [Portal](#core/components/portal)
+options. It uses the [React context API](https://reactjs.org/docs/context.html).
+
+@## Usage
+
+```tsx
+import { PortalProvider, Dialog } from "@blueprintjs/core";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(
+    <PortalProvider portalClassName="my-portal">
+        <Dialog isOpen={true}>
+            <span>This dialog will have a custom class on its portal element.</span>
+        </Dialog>
+    </PortalProvider>,
+    document.querySelector("#app"),
+);
+```
+
+@## Props interface
+
+@interface PortalContextOptions

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+export interface PortalContextOptions {
+    /** Additional CSS classes to add to all `Portal` elements in this React context. */
+    portalClassName?: string;
+}
+
+/**
+ * A React context to set options for all portals in a given subtree.
+ * Do not use this PortalContext directly, instead use PortalProvider to set the options.
+ */
+export const PortalContext = React.createContext<PortalContextOptions>({});
+
+export const PortalProvider = ({ children, ...options }: React.PropsWithChildren<PortalContextOptions>) => {
+    return <PortalContext.Provider value={options}>{children}</PortalContext.Provider>;
+};

--- a/packages/core/src/hooks/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+export function usePrevious<T>(value: T) {
+    const ref = React.useRef<T>();
+    React.useEffect(() => {
+        ref.current = value; // assign the value of ref to the argument
+    }, [value]); // this code will run when the value of 'value' changes
+    return ref.current; // in the end, return the current ref value.
+}

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -18,10 +18,10 @@ import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 
-import { Classes, IPortalProps, Portal } from "../../src";
+import { Classes, Portal, PortalProps, PortalProvider } from "../../src";
 
 describe("<Portal>", () => {
-    let portal: ReactWrapper<IPortalProps>;
+    let portal: ReactWrapper<PortalProps>;
 
     afterEach(() => {
         portal?.unmount();
@@ -73,13 +73,27 @@ describe("<Portal>", () => {
         assert.exists(portal.find(".class-two"));
     });
 
-    it("respects blueprintPortalClassName on context", () => {
+    it("respects blueprintPortalClassName on legacy context", () => {
         const CLASS_TO_TEST = "bp-test-klass bp-other-class";
         portal = mount(
             <Portal>
                 <p>test</p>
             </Portal>,
             { context: { blueprintPortalClassName: CLASS_TO_TEST } },
+        );
+
+        const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);
+        assert.isTrue(portalElement?.classList.contains(Classes.PORTAL));
+    });
+
+    it("respects portalClassName on new context API", () => {
+        const CLASS_TO_TEST = "bp-test-klass bp-other-class";
+        portal = mount(
+            <PortalProvider portalClassName={CLASS_TO_TEST}>
+                <Portal>
+                    <p>test</p>
+                </Portal>
+            </PortalProvider>,
         );
 
         const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -21,10 +21,16 @@ import * as React from "react";
 import { Classes, Portal, PortalProps, PortalProvider } from "../../src";
 
 describe("<Portal>", () => {
+    let rootElement: HTMLElement | undefined;
     let portal: ReactWrapper<PortalProps>;
 
+    beforeEach(() => {
+        rootElement = document.createElement("div");
+        document.body.appendChild(rootElement);
+    });
     afterEach(() => {
         portal?.unmount();
+        rootElement?.remove();
     });
 
     it("attaches contents to document.body", () => {
@@ -33,6 +39,7 @@ describe("<Portal>", () => {
             <Portal>
                 <p className={CLASS_TO_TEST}>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
         assert.lengthOf(document.getElementsByClassName(CLASS_TO_TEST), 1);
     });
@@ -45,6 +52,7 @@ describe("<Portal>", () => {
             <Portal container={container}>
                 <p className={CLASS_TO_TEST}>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
         assert.lengthOf(container.getElementsByClassName(CLASS_TO_TEST), 1);
         document.body.removeChild(container);
@@ -56,6 +64,7 @@ describe("<Portal>", () => {
             <Portal className={CLASS_TO_TEST}>
                 <p>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
 
         const portalChild = document.querySelector(`.${Classes.PORTAL}.${CLASS_TO_TEST}`);
@@ -67,6 +76,7 @@ describe("<Portal>", () => {
             <Portal className="class-one">
                 <p>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
         assert.exists(portal.find(".class-one"));
         portal.setProps({ className: "class-two" });
@@ -79,7 +89,7 @@ describe("<Portal>", () => {
             <Portal>
                 <p>test</p>
             </Portal>,
-            { context: { blueprintPortalClassName: CLASS_TO_TEST } },
+            { attachTo: rootElement, context: { blueprintPortalClassName: CLASS_TO_TEST } },
         );
 
         const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);
@@ -94,6 +104,7 @@ describe("<Portal>", () => {
                     <p>test</p>
                 </Portal>
             </PortalProvider>,
+            { attachTo: rootElement },
         );
 
         const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);
@@ -105,6 +116,7 @@ describe("<Portal>", () => {
             <Portal className="class-one class-two">
                 <p>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
         portal.setProps({ className: undefined });
         // no assertion necessary - will crash on incorrect code
@@ -115,21 +127,23 @@ describe("<Portal>", () => {
             <Portal className="">
                 <p>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
         portal.setProps({ className: "class-one" });
         // no assertion necessary - will crash on incorrect code
     });
 
     it("children mount before onChildrenMount invoked", done => {
-        function spy() {
-            // can't use `portal` in here as `mount()` has not finished, so query DOM directly
+        function handleChildrenMount() {
+            // can't use `portal` in here as `mount()` has not finished, so we query DOM directly instead
             assert.exists(document.querySelector("p"));
             done();
         }
         portal = mount(
-            <Portal onChildrenMount={spy}>
+            <Portal onChildrenMount={handleChildrenMount}>
                 <p>test</p>
             </Portal>,
+            { attachTo: rootElement },
         );
     });
 });


### PR DESCRIPTION
#### This will eventually fix #5139, but for now we need to keep legacy context for backwards-compatibility, so the console warning will remain.

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Remove mentions of React 15 from Portal documentation
- Remove code which supported React 15 in Portal implementation (guarding against `React.createPortal` not being available)
- Create `PortalContext` and `PortalProvider` APIs which allow setting global options on Portals in a given React subtree using the newer React context API
- Refactor Portal into a React function component which uses `PortalContext` for forwards-compatibility with the new `PortalProvider` API, while retaining backwards-compatibility with the legacy context API (`legacyContext: PortalLegacyContext` passed in the constructor)

#### Reviewers should focus on:

No regressions
