### PR TITLE
docs: scope down Blueprint v5.0 breaking changes

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeys-target2.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target2.md
@@ -13,7 +13,7 @@ Migrating from [HotkeysTarget](#core/components/hotkeys)?
 
 HotkeysTarget2 is a replacement for HotkeysTarget. You are encouraged to use this new API, or
 the `useHotkeys` hook directly in your function components, as they will become the standard
-APIs in Blueprint v5. See the full
+APIs in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration) on the wiki.
 
 </div>

--- a/packages/core/src/components/hotkeys/hotkeys.md
+++ b/packages/core/src/components/hotkeys/hotkeys.md
@@ -9,8 +9,8 @@ Deprecated: use [useHotkeys](#core/hooks/use-hotkeys)
 
 This API is **deprecated since @blueprintjs/core v3.39.0** in favor of the new
 [`useHotkeys` hook](#core/hooks/use-hotkeys) and
-[HotkeysTarget2 component](#core/components/hotkeys-target2) available to React 16.8+ users.
-You should migrate to one of these new APIs, as they will become the standard in Blueprint v5.
+[HotkeysTarget2 component](#core/components/hotkeys-target2). You should migrate to one of
+these new APIs, as they will become the standard in future major version of Blueprint.
 
 </div>
 

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -31,19 +31,6 @@ A `Menu` is a `<ul>` container for menu items and dividers.
 
 @## Menu item
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
-
-Deprecated: use [MenuItem2](#popover2-package/menu-item2)
-
-</h4>
-
-This component is **deprecated since @blueprintjs/core v4.7.0** in favor of the new
-MenuItem2 component, which uses Popover2 instead of Popover under the hood.
-You should migrate to the new API which will become the standard in Blueprint v5.
-
-</div>
-
 A `MenuItem` is a single interactive item in a `Menu`.
 
 This component renders an `<li>` containing an `<a>`. Make the `MenuItem`
@@ -99,11 +86,16 @@ there is not enough room to the right.
 </Menu>
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">JavaScript only</h4>
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">
 
-Submenus are only supported in the React components. They cannot be created with CSS alone because
-they rely on the [`Popover`](#core/components/popover) component for positioning and transitions.
+Deprecated prop `popoverProps`: use [MenuItem2](#popover2-package/menu-item2)
+
+</h4>
+
+Usage of `<MenuItem popoverProps={...}>` is **deprecated since @blueprintjs/core v4.7.0**
+in favor of the new MenuItem2 component, which uses Popover2 instead of Popover under the hood.
+You should migrate to the new API which will become the standard in Blueprint v5.
 
 </div>
 

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -7,7 +7,7 @@ Menus display lists of interactive items.
 The Menu API includes three React components:
 
 * [Menu](#core/components/menu.menu)
-* [MenuItem](#core/components/menu.menu-item) (DEPRECATED, use [MenuItem2](#popover2-package/menu-item2))
+* [MenuItem](#core/components/menu.menu-item)
 * [MenuDivider](#core/components/menu.menu-divider)
 
 ```tsx
@@ -95,7 +95,8 @@ Deprecated prop `popoverProps`: use [MenuItem2](#popover2-package/menu-item2)
 
 Usage of `<MenuItem popoverProps={...}>` is **deprecated since @blueprintjs/core v4.7.0**
 in favor of the new MenuItem2 component, which uses Popover2 instead of Popover under the hood.
-You should migrate to the new API which will become the standard in Blueprint v5.
+If you use customize the layout of submenus using this prop, you should migrate to the new API
+which will become the standard in Blueprint v5.
 
 </div>
 

--- a/packages/core/src/components/panel-stack/panel-stack.md
+++ b/packages/core/src/components/panel-stack/panel-stack.md
@@ -8,8 +8,8 @@ Deprecated: use [PanelStack2](#core/components/panel-stack2)
 </h4>
 
 This API is **deprecated since @blueprintjs/core v3.40.0** in favor of the new
-PanelStack2 component available to React 16.8+ users. You should migrate to the
-new API which will become the standard in Blueprint v5.
+PanelStack2 component. You should migrate to the new API which will become the
+standard in a future major version of Blueprint.
 
 </div>
 

--- a/packages/core/src/components/panel-stack2/panel-stack2.md
+++ b/packages/core/src/components/panel-stack2/panel-stack2.md
@@ -12,8 +12,8 @@ Migrating from [PanelStack](#core/components/panel-stack)?
 </h4>
 
 PanelStack2 is a replacement for PanelStack. It will become the standard
-API in Blueprint core v5. You are encouraged to use this new API now to ease the
-transition to the next major version of Blueprint. See the full
+API in a future major version of Blueprint. You are encouraged to use this
+new API now for forwards-compatibility. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/PanelStack2-migration) on the wiki.
 
 </div>

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -12,7 +12,7 @@ Migrating from [HotkeysTarget](#core/components/hotkeys)?
 </h4>
 
 HotkeysProvider and `useHotkeys`, used together, are a replacement for HotkeysTarget.
-You are encouraged to use this new API, as it will become the standard APIs in Blueprint v5.
+You are encouraged to use this new API, as it will become the standard APIs in a future major version of Blueprint.
 See the full [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration)
 on the wiki.
 

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -13,7 +13,7 @@ Migrating from [HotkeysTarget](#core/components/hotkeys)?
 
 `useHotkeys` is a replacement for HotkeysTarget. You are encouraged to use this new API in your function
 components, or the [HotkeysTarget2 component](#core/components/hotkeys-target2) in your component classes,
-as they will become the standard APIs in Blueprint v5. See the full
+as they will become the standard APIs in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration) on the wiki.
 
 </div>

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
@@ -9,8 +9,10 @@ export const coreComponentsMigrationMapping = {
     AbstractPureComponent: "AbstractPureComponent2",
     Breadcrumbs: "Breadcrumbs2",
     CollapsibleList: "OverflowList",
-    MenuItem: "MenuItem2",
-    PanelStack: "PanelStack2",
+    // TODO(@adidahiya): smarter lint rule which detects <MenuItem popoverProps> usage
+    // MenuItem: "MenuItem2",
+    // TODO(@adidahiya): Blueprint v6
+    // PanelStack: "PanelStack2",
     Popover: "Popover2",
     Tooltip: "Tooltip2",
 };

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-datetime-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-datetime-components.ts
@@ -7,7 +7,8 @@ import { createNoDeprecatedComponentsRule } from "./createNoDeprecatedComponents
 export const datetimeComponentsMigrationMapping = {
     DateInput: "DateInput2",
     DateRangeInput: "DateRangeInput2",
-    DateTimePicker: "DatePicker",
+    // TODO(@adidahiya): Blueprint v6
+    // DateTimePicker: "DatePicker",
 };
 
 /**

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-table-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-table-components.ts
@@ -5,12 +5,13 @@
 import { createNoDeprecatedComponentsRule } from "./createNoDeprecatedComponentsRule";
 
 export const tableComponentsMigrationMapping = {
-    ColumnHeaderCell: "ColumnHeaderCell2",
-    EditableCell: "EditableCell2",
     JSONFormat: "JSONFormat2",
-    RowHeaderCell: "RowHeaderCell2",
-    Table: "Table2",
     TruncatedFormat: "TruncatedFormat2",
+    // TODO(@adidahiya): Blueprint v6
+    // ColumnHeaderCell: "ColumnHeaderCell2",
+    // EditableCell: "EditableCell2",
+    // RowHeaderCell: "RowHeaderCell2",
+    // Table: "Table2",
 };
 
 /**

--- a/packages/popover2/src/menu-item2.md
+++ b/packages/popover2/src/menu-item2.md
@@ -11,10 +11,12 @@ Migrating from [MenuItem](#core/components/menu.menu-item)?
 
 </h4>
 
-MenuItem2 is a replacement for MenuItem and will replace it in Blueprint core v5.
-You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
-See the [migration guide](https://github.com/palantir/blueprint/wiki/Popover2-migration#menuitem2)
-on the wiki (the changes are minimal, it should be an easy drop-in replacement).
+MenuItem2 is a replacement for MenuItem. It uses Popover2 instead of Popover for its submenus.
+You are encouraged to migrate to MenuItem2 now in the rare case where you customize submenu layout
+using the `<MenuItem popoverProps>` API (see the
+[Popover2 migration guide](https://github.com/palantir/blueprint/wiki/Popover2-migration#menuitem2)
+on the wiki) &mdash; otherwise, you can leave MenuItem as-is and it will be seamlessly updated
+in Blueprint v5.
 
 </div>
 

--- a/packages/table/src/docs/table2.md
+++ b/packages/table/src/docs/table2.md
@@ -7,7 +7,7 @@ tag: new
 As of `@blueprintjs/table` v3.9.0, there are two versions of the table component API,
 [Table](#table/api.table) and [Table2](#table/table2). All of the documentation examples
 on this site demonstrate the newer Table2 API. You are encouraged to migrate to Table2
-for forwards-compatibility with [Blueprint v5.0](https://github.com/palantir/blueprint/wiki/Blueprint-5.0).
+for forwards-compatibility with future major versions of Blueprint.
 
 @## Migration from Table
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

We're reducing the scope of Blueprint v5.0 to focus on just the popover-related breaking changes and some low-hanging fruit. Some breaks will be punted to v6.0. This PR updates the docs to reflect that they are not coming in v5.0, in accordance with the same edits I just made to the [v5.0 wiki page](https://github.com/palantir/blueprint/wiki/Blueprint-5.0).

#### Reviewers should focus on:

Lint rule enforcement changes
