### PR TITLE
[eslint-plugin] feat: only lint MenuItem with popoverProps attr

### DIFF
--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to MenuItem2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable deprecation/deprecation @blueprintjs/no-deprecated-components */
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to MenuItem2 instead.
  */
 
-/* eslint-disable deprecation/deprecation @blueprintjs/no-deprecated-components */
+/* eslint-disable deprecation/deprecation */
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
@@ -149,6 +149,7 @@ describe("MenuItem", () => {
             popoverClassName: "CUSTOM_POPOVER_CLASS_NAME",
         };
         const wrapper = shallow(
+            // eslint-disable-next-line @blueprintjs/no-deprecated-components
             <MenuItem icon="style" text="Style" popoverProps={popoverProps}>
                 <MenuItem text="one" />
                 <MenuItem text="two" />

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
@@ -9,7 +9,7 @@ export const coreComponentsMigrationMapping = {
     AbstractPureComponent: "AbstractPureComponent2",
     Breadcrumbs: "Breadcrumbs2",
     CollapsibleList: "OverflowList",
-    MenuItem: "MenuItem2",
+    "MenuItem.popoverProps": "MenuItem2",
     // TODO(@adidahiya): Blueprint v6
     // PanelStack: "PanelStack2",
     Popover: "Popover2",

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
@@ -9,7 +9,7 @@ export const coreComponentsMigrationMapping = {
     AbstractPureComponent: "AbstractPureComponent2",
     Breadcrumbs: "Breadcrumbs2",
     CollapsibleList: "OverflowList",
-    MenuItem: "MenuItem2",
+    "MenuItem.popoverProps": "MenuItem2",
     PanelStack: "PanelStack2",
     Popover: "Popover2",
     Tooltip: "Tooltip2",

--- a/packages/eslint-plugin/test/index.ts
+++ b/packages/eslint-plugin/test/index.ts
@@ -18,3 +18,4 @@ import "./classes-constants.test";
 import "./html-components.test";
 import "./icon-components.test";
 import "./no-deprecated-components.test";
+import "./no-deprecated-core-components.test";

--- a/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tslint:disable object-literal-sort-keys
+/* eslint-disable no-template-curly-in-string */
+
+import { TSESLint } from "@typescript-eslint/utils";
+import dedent from "dedent";
+
+import { noDeprecatedCoreComponentsRule } from "../src/rules/no-deprecated-components";
+
+const ruleTester = new TSESLint.RuleTester({
+    parser: require.resolve("@typescript-eslint/parser"),
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
+        },
+        sourceType: "module",
+    },
+});
+
+console.info("Testing no-deprecated-core-components rule...");
+ruleTester.run("no-deprecated-core-components", noDeprecatedCoreComponentsRule, {
+    // N.B. most other deprecated components are tested by no-deprecated-components.test.ts, this suite just tests
+    // for more specific violations which involve certain deprecated props
+    invalid: [
+        {
+            code: dedent`
+                import { MenuItem } from "@blueprintjs/core";
+
+                return <MenuItem popoverProps={{ boundary: "window" }} />
+            `,
+            errors: [
+                {
+                    messageId: "migrationWithPropUsage",
+                    data: {
+                        deprecatedComponentName: "MenuItem",
+                        deprecatedPropName: "popoverProps",
+                        newComponentName: "MenuItem2",
+                    },
+                },
+            ],
+        },
+        {
+            code: dedent`
+                import * as Blueprint from "@blueprintjs/core";
+
+                return <Blueprint.MenuItem popoverProps={{ boundary: "window" }} />
+            `,
+            errors: [
+                {
+                    messageId: "migrationWithPropUsage",
+                    data: {
+                        deprecatedComponentName: "MenuItem",
+                        deprecatedPropName: "popoverProps",
+                        newComponentName: "MenuItem2",
+                    },
+                },
+            ],
+        },
+    ],
+    valid: [
+        {
+            code: dedent`
+                import { MenuItem } from "@blueprintjs/core";
+
+                return <MenuItem text="Open in new tab" icon="share" />
+            `,
+        },
+        {
+            code: dedent`
+                import * as Blueprint from "@blueprintjs/core";
+
+                return <Blueprint.MenuItem text="Open in new tab" icon="share" />
+            `,
+        },
+    ],
+});


### PR DESCRIPTION


#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Improve `@blueprintjs/no-deprecated-core-components` & `@blueprintjs/no-deprecated-components` lint rule to understand components usage which is deprecated iff a specific prop is used. This is particularly useful for `<MenuItem>`, where we don't want to force consumers to unnecessarily migrate to `<MenuItem2>` in the overwhelming majority use case... we only need them to migrate when `popoverProps` is used. This will greatly reduce the code diff required in migrations.

#### Reviewers should focus on:

Implementation & test cases


