### PR TITLE
[core] fix(Sass API): allow extended color palette overrides

### DIFF
--- a/packages/core/src/common/_variables-extended.scss
+++ b/packages/core/src/common/_variables-extended.scss
@@ -11,10 +11,10 @@
 $half-grid-size: $pt-grid-size * 0.5 !default;
 
 // Extended color pallete
-$blue6: #99c4ff;
-$green6: #7cd7a2;
-$orange6: #f5c186;
-$red6: #ffa1a4;
+$blue6: #99c4ff !default;
+$green6: #7cd7a2 !default;
+$orange6: #f5c186 !default;
+$red6: #ffa1a4 !default;
 
 $icon-classes: (
   ".#{$ns}-icon",


### PR DESCRIPTION
#### Checklist

- [x] Includes tests (N/A)
- [x] Update documentation (N/A)

#### Changes proposed in this pull request:

Allow variables within the extended color pallete to be overridden by users of `blueprintjs`, similar to the pattern followed within `packages/colors/src/_colors.scss`. This is important for providing custom themes