### PR TITLE
[select] fix(QueryList): index is always defined in itemRenderer

### DIFF
--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -42,7 +42,8 @@ export interface IItemRendererProps {
      */
     handleFocus?: () => void;
 
-    index?: number;
+    /** Index of the item in the QueryList items array. */
+    index: number;
 
     /** Modifiers that describe how to render this item, such as `active` or `disabled`. */
     modifiers: IItemModifiers;


### PR DESCRIPTION

#### Changes proposed in this pull request:

Fix type of `index` property in `itemRenderer` so that it is always defined, to better reflect the runtime behavior and improve developer experience of this API.