### PR TITLE
[docs-app] fix(DocsIcon): migrate to ContextMenu2

### DIFF
--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -18,11 +18,12 @@ import classNames from "classnames";
 import download from "downloadjs";
 import * as React from "react";
 
-import { Classes, ContextMenuTarget, Icon, IconName, IconSize, Menu, MenuItem } from "@blueprintjs/core";
+import { Classes, Icon, IconName, IconSize, Menu, MenuItem } from "@blueprintjs/core";
+import { ContextMenu2 } from "@blueprintjs/popover2";
 
 import { ClickToCopy } from "./clickToCopy";
 
-export interface IDocsIconProps {
+export interface DocsIconProps {
     displayName: string;
     group: string;
     iconName: IconName;
@@ -35,24 +36,24 @@ function downloadIconFile(iconName: IconName, iconSize: 16 | 20) {
     download(`${GITHUB_RAW_PATH}/${iconSize}px/${iconName}.svg`);
 }
 
-// eslint-disable-next-line deprecation/deprecation
-@ContextMenuTarget
-export class DocsIcon extends React.PureComponent<IDocsIconProps> {
+export class DocsIcon extends React.PureComponent<DocsIconProps> {
     public render() {
         const { iconName, displayName, tags } = this.props;
         return (
-            <ClickToCopy className="docs-icon" data-tags={tags} value={iconName}>
-                <Icon icon={iconName} size={IconSize.LARGE} />
-                <div className="docs-icon-name">{displayName}</div>
-                <div className="docs-icon-detail">
-                    <p className="docs-code">{iconName}</p>
-                    <div className={Classes.TEXT_MUTED}>Right-click to download</div>
-                    <div
-                        className={classNames("docs-clipboard-message", Classes.TEXT_MUTED)}
-                        data-hover-message="Click to copy name"
-                    />
-                </div>
-            </ClickToCopy>
+            <ContextMenu2 className="docs-icon-container" content={this.renderContextMenu()}>
+                <ClickToCopy className="docs-icon" data-tags={tags} value={iconName}>
+                    <Icon icon={iconName} size={IconSize.LARGE} />
+                    <div className="docs-icon-name">{displayName}</div>
+                    <div className="docs-icon-detail">
+                        <p className="docs-code">{iconName}</p>
+                        <div className={Classes.TEXT_MUTED}>Right-click to download</div>
+                        <div
+                            className={classNames("docs-clipboard-message", Classes.TEXT_MUTED)}
+                            data-hover-message="Click to copy name"
+                        />
+                    </div>
+                </ClickToCopy>
+            </ContextMenu2>
         );
     }
 

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -19,29 +19,29 @@ import * as React from "react";
 import { Classes, H3, InputGroup, NonIdealState } from "@blueprintjs/core";
 import { smartSearch } from "@blueprintjs/docs-theme";
 
-import { DocsIcon, IDocsIconProps as IIcon } from "./docsIcon";
+import { DocsIcon, DocsIconProps as Icon } from "./docsIcon";
 
 const ICONS_PER_ROW = 5;
 
-export interface IIconsState {
+export interface IconsState {
     filter: string;
 }
 
-export interface IIconsProps {
-    iconFilter?: (query: string, icon: IIcon) => boolean;
-    iconRenderer?: (icon: IIcon, index: number) => JSX.Element;
-    icons?: IIcon[];
+export interface IconsProps {
+    iconFilter?: (query: string, icon: Icon) => boolean;
+    iconRenderer?: (icon: Icon, index: number) => JSX.Element;
+    icons?: Icon[];
 }
 
-export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
-    public static defaultProps: IIconsProps = {
+export class Icons extends React.PureComponent<IconsProps, IconsState> {
+    public static defaultProps: IconsProps = {
         iconFilter: isIconFiltered,
         iconRenderer: renderIcon,
         // tslint:disable-next-line:no-submodule-imports
         icons: require("@blueprintjs/icons/icons.json"),
     };
 
-    public state: IIconsState = {
+    public state: IconsState = {
         filter: "",
     };
 
@@ -78,7 +78,7 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
 
         let padIndex = iconElements.length;
         while (iconElements.length % ICONS_PER_ROW > 0) {
-            iconElements.push(<div className="docs-placeholder" key={`pad-${padIndex++}`} />);
+            iconElements.push(<div className="docs-icon-spacer" key={`pad-${padIndex++}`} />);
         }
         return (
             <div className="docs-icon-group" key={index}>
@@ -107,16 +107,16 @@ export class Icons extends React.PureComponent<IIconsProps, IIconsState> {
     };
 }
 
-function isIconFiltered(query: string, icon: IIcon) {
+function isIconFiltered(query: string, icon: Icon) {
     return smartSearch(query, icon.displayName, icon.iconName, icon.tags, icon.group);
 }
 
-function renderIcon(icon: IIcon, index: number) {
+function renderIcon(icon: Icon, index: number) {
     return <DocsIcon {...icon} key={index} />;
 }
 
-function initIconGroups(icons: IIcon[]) {
-    const groups: Record<string, IIcon[]> = {};
+function initIconGroups(icons: Icon[]) {
+    const groups: Record<string, Icon[]> = {};
     // group icons by group name
     for (const icon of icons) {
         if (groups[icon.group] == null) {

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -96,9 +96,9 @@ $icons-per-row: 5;
 .docs-icon {
   align-items: center;
   border-radius: $pt-border-radius;
-  padding: ($pt-grid-size * 2) 0;
   display: flex;
   flex-direction: column;
+  padding: ($pt-grid-size * 2) 0;
   transition: background-color $hover-transition;
 
   .docs-icon-svg {

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -29,7 +29,18 @@ $icons-per-row: 5;
   }
 }
 
-.docs-icon {
+.docs-icon-container,
+.docs-icon-spacer {
+  height: $pt-grid-size * 12;
+  width: math.div(100%, $icons-per-row);
+
+  // remove margin on last row of icons
+  &:nth-last-child(-n + #{$icons-per-row}) {
+    margin-bottom: 0;
+  }
+}
+
+.docs-icon-container {
   cursor: pointer;
   position: relative;
 
@@ -39,6 +50,8 @@ $icons-per-row: 5;
     border-radius: $pt-border-radius * 2;
     content: "";
     opacity: 0;
+    // must set this to avoid capturing hover events which should be sent to ClickToCopy element(s) instead
+    pointer-events: none;
     transform: scale(1);
     transition: transform $pt-transition-duration $pt-transition-ease,
                 opacity $pt-transition-duration $pt-transition-ease;
@@ -80,17 +93,13 @@ $icons-per-row: 5;
   }
 }
 
-.docs-icon,
-.docs-placeholder {
+.docs-icon {
   align-items: center;
   border-radius: $pt-border-radius;
+  padding: ($pt-grid-size * 2) 0;
   display: flex;
   flex-direction: column;
-  height: $pt-grid-size * 12;
-  padding: ($pt-grid-size * 2) 0;
-
   transition: background-color $hover-transition;
-  width: math.div(100%, $icons-per-row);
 
   .docs-icon-svg {
     max-height: $svg-icon-size;
@@ -111,11 +120,6 @@ $icons-per-row: 5;
       opacity: 1;
       transform: translateY(-1em);
     }
-  }
-
-  // remove margin on last row of icons
-  &:nth-last-child(-n + #{$icons-per-row}) {
-    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Migrate the `<DocsIcon>` component (used in the [Icons page](https://blueprintjs.com/docs/#icons)) from `@ContextMenuTarget` to `<ContextMenu2>`.