### PR TITLE
feat: migration APIs to drop 'I' interface prefix

### DIFF
--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -19,7 +19,7 @@ You can add one additional action button to a toast. You might use this to provi
 
 You can also apply the same visual intent styles to `Toast`s that you can to [`Button`s](#core/components/button.css).
 
-@interface IToastProps
+@interface ToastProps
 
 @### Toaster
 
@@ -30,7 +30,7 @@ horizontally aligned along the left edge, center, or right edge of its container
 
 There are three ways to use the `Toaster` component:
 
-1. `Toaster.create(props)` static method returns a new `IToaster` instance. Use the instance method `toaster.show()` to manipulate this instance. __(recommended)__
+1. `Toaster.create(props)` static method returns a new `ToasterInstance` instance. Use the instance method `toaster.show()` to manipulate this instance. __(recommended)__
 1. `<Toaster><Toast />...</Toaster>`: Render a `<Toaster>` element with React `children`.
 1. `<Toaster ref={ref => ref.show({ ...toast })} />`: Render a `<Toaster>` element and use the `ref` prop to access its instance methods.
 
@@ -62,13 +62,13 @@ element attached to `<body>`. A `Toaster` instance
 has a collection of methods to show and hide toasts in its given container.
 
 ```ts
-Toaster.create(props?: IToasterProps, container = document.body): IToaster
+Toaster.create(props?: IToasterProps, container = document.body): ToasterInstance
 ```
 
 The `Toaster` will be rendered into a new element appended to the given `container`.
 The `container` determines which element toasts are positioned relative to; the default value of `<body>` allows them to use the entire viewport.
 
-Note that the return type is `IToaster`, which is a minimal interface that exposes only the instance
+Note that the return type is `ToasterInstance`, which is a minimal interface that exposes only the instance
 methods detailed below. It can be thought of as `Toaster` minus the `React.Component` methods,
 because the `Toaster` should not be treated as a normal React component.
 
@@ -80,7 +80,7 @@ because the `Toaster` should not be treated as a normal React component.
 
 </div>
 
-@interface IToaster
+@interface ToasterInstance
 
 @### Example
 
@@ -131,7 +131,7 @@ import { Button, Position, Toast, Toaster } from "@blueprintjs/core";
 import * as React from "react";
 
 class MyComponent extends React.PureComponent {
-    public state = { toasts: [ /* IToastProps[] */ ] }
+    public state = { toasts: [ /* ToastProps[] */ ] }
 
     private toaster: Toaster;
     private refHandlers = {

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -23,8 +23,10 @@ import { ButtonGroup } from "../button/buttonGroup";
 import { AnchorButton, Button } from "../button/buttons";
 import { Icon, IconName } from "../icon/icon";
 
-export type ToastProps = IToastProps;
-export interface IToastProps extends Props, IntentProps {
+/** @deprecated use ToastProps */
+export type IToastProps = ToastProps;
+
+export interface ToastProps extends Props, IntentProps {
     /**
      * Action rendered as a minimal `AnchorButton`. The toast is dismissed automatically when the
      * user clicks the action button. Note that the `intent` prop is ignored (the action button
@@ -54,8 +56,8 @@ export interface IToastProps extends Props, IntentProps {
     timeout?: number;
 }
 
-export class Toast extends AbstractPureComponent2<IToastProps> {
-    public static defaultProps: IToastProps = {
+export class Toast extends AbstractPureComponent2<ToastProps> {
+    public static defaultProps: ToastProps = {
         className: "",
         message: "",
         timeout: 5000,
@@ -90,7 +92,7 @@ export class Toast extends AbstractPureComponent2<IToastProps> {
         this.startTimeout();
     }
 
-    public componentDidUpdate(prevProps: IToastProps) {
+    public componentDidUpdate(prevProps: ToastProps) {
         if (prevProps.timeout !== this.props.timeout) {
             if (this.props.timeout! > 0) {
                 this.startTimeout();

--- a/packages/core/src/components/toast/toaster.tsx
+++ b/packages/core/src/components/toast/toaster.tsx
@@ -24,9 +24,9 @@ import { ESCAPE } from "../../common/keys";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 import { isNodeEnv } from "../../common/utils";
 import { Overlay } from "../overlay/overlay";
-import { IToastProps, Toast } from "./toast";
+import { Toast, ToastProps } from "./toast";
 
-export type IToastOptions = IToastProps & { key: string };
+export type IToastOptions = ToastProps & { key: string };
 export type ToasterPosition =
     | typeof Position.TOP
     | typeof Position.TOP_LEFT
@@ -35,14 +35,17 @@ export type ToasterPosition =
     | typeof Position.BOTTOM_LEFT
     | typeof Position.BOTTOM_RIGHT;
 
-/** Instance methods available on a `<Toaster>` component instance. */
-export interface IToaster {
+/** @deprecated use ToasterInstance */
+export type IToaster = ToasterInstance;
+
+/** Public API methods available on a `<Toaster>` component instance. */
+export interface ToasterInstance {
     /**
      * Shows a new toast to the user, or updates an existing toast corresponding to the provided key (optional).
      *
      * Returns the unique key of the toast.
      */
-    show(props: IToastProps, key?: string): string;
+    show(props: ToastProps, key?: string): string;
 
     /** Dismiss the given toast instantly. */
     dismiss(key: string): void;
@@ -110,7 +113,7 @@ export interface IToasterState {
     toasts: IToastOptions[];
 }
 
-export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState> implements IToaster {
+export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState> implements ToasterInstance {
     public static displayName = `${DISPLAYNAME_PREFIX}.Toaster`;
 
     public static defaultProps: IToasterProps = {
@@ -124,7 +127,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
      * Create a new `Toaster` instance that can be shared around your application.
      * The `Toaster` will be rendered into a new element appended to the given container.
      */
-    public static create(props?: IToasterProps, container = document.body): IToaster {
+    public static create(props?: IToasterProps, container = document.body): ToasterInstance {
         if (props != null && props.usePortal != null && !isNodeEnv("production")) {
             console.warn(TOASTER_WARN_INLINE);
         }
@@ -147,7 +150,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
     // auto-incrementing identifier for un-keyed toasts
     private toastId = 0;
 
-    public show(props: IToastProps, key?: string) {
+    public show(props: ToastProps, key?: string) {
         if (this.props.maxToasts) {
             // check if active number of toasts are at the maxToasts limit
             this.dismissIfAtLimit();
@@ -232,7 +235,7 @@ export class Toaster extends AbstractPureComponent2<IToasterProps, IToasterState
         return <Toast {...toast} onDismiss={this.getDismissHandler(toast)} />;
     };
 
-    private createToastOptions(props: IToastProps, key = `toast-${this.toastId++}`) {
+    private createToastOptions(props: ToastProps, key = `toast-${this.toastId++}`) {
         // clone the object before adding the key prop to avoid leaking the mutation
         return { ...props, key };
     }

--- a/packages/core/test/toast/toasterTests.tsx
+++ b/packages/core/test/toast/toasterTests.tsx
@@ -22,12 +22,12 @@ import { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
-import { Classes, IToaster, Toaster } from "../../src";
+import { Classes, ToasterInstance, Toaster } from "../../src";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
 
 describe("Toaster", () => {
     let testsContainerElement: HTMLElement;
-    let toaster: IToaster;
+    let toaster: ToasterInstance;
 
     before(() => {
         testsContainerElement = document.createElement("div");

--- a/packages/core/test/toast/toasterTests.tsx
+++ b/packages/core/test/toast/toasterTests.tsx
@@ -22,7 +22,7 @@ import { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
-import { Classes, ToasterInstance, Toaster } from "../../src";
+import { Classes, Toaster, ToasterInstance } from "../../src";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
 
 describe("Toaster", () => {

--- a/packages/docs-app/src/common/films.tsx
+++ b/packages/docs-app/src/common/films.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { MenuItem, MenuItemProps } from "@blueprintjs/core";
-import { ItemRendererProps, ItemPredicate, ItemRenderer } from "@blueprintjs/select";
+import { ItemPredicate, ItemRenderer, ItemRendererProps } from "@blueprintjs/select";
 
 export interface IFilm {
     /** Title of film. */

--- a/packages/docs-app/src/common/films.tsx
+++ b/packages/docs-app/src/common/films.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { MenuItem, MenuItemProps } from "@blueprintjs/core";
-import { IItemRendererProps, ItemPredicate, ItemRenderer } from "@blueprintjs/select";
+import { ItemRendererProps, ItemPredicate, ItemRenderer } from "@blueprintjs/select";
 
 export interface IFilm {
     /** Title of film. */
@@ -139,7 +139,7 @@ export const TOP_100_FILMS: IFilm[] = [
  */
 export function getFilmItemProps(
     film: IFilm,
-    { handleClick, handleFocus, modifiers, query }: IItemRendererProps,
+    { handleClick, handleFocus, modifiers, query }: ItemRendererProps,
 ): MenuItemProps & React.Attributes & React.HTMLAttributes<HTMLAnchorElement> {
     return {
         active: modifiers.active,

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -16,8 +16,8 @@
 
 import * as React from "react";
 
-import { Alert, Button, H5, Intent, IToaster, Switch, Toaster } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Alert, Button, H5, Intent, Switch, Toaster, ToasterInstance } from "@blueprintjs/core";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { IBlueprintExampleData } from "../../tags/types";
 
@@ -30,7 +30,7 @@ export interface IAlertExampleState {
     willLoad: boolean;
 }
 
-export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IAlertExampleState> {
+export class AlertExample extends React.PureComponent<ExampleProps<IBlueprintExampleData>, IAlertExampleState> {
     public state: IAlertExampleState = {
         canEscapeKeyCancel: false,
         canOutsideClickCancel: false,
@@ -40,7 +40,7 @@ export class AlertExample extends React.PureComponent<IExampleProps<IBlueprintEx
         willLoad: false,
     };
 
-    private toaster: IToaster;
+    private toaster: ToasterInstance;
 
     private handleEscapeKeyChange = handleBooleanChange(canEscapeKeyCancel => this.setState({ canEscapeKeyCancel }));
 

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -35,7 +35,7 @@ import {
     RadioGroup,
     Slider,
 } from "@blueprintjs/core";
-import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 
 export interface IBreadcrumbsExampleState {
     collapseFrom: Boundary;
@@ -63,7 +63,7 @@ const ITEMS_FOR_ALWAYS_RENDER: BreadcrumbProps[] = [
     { icon: "document", text: "image.jpg", current: true },
 ];
 
-export class BreadcrumbsExample extends React.PureComponent<IExampleProps, IBreadcrumbsExampleState> {
+export class BreadcrumbsExample extends React.PureComponent<ExampleProps, IBreadcrumbsExampleState> {
     public state: IBreadcrumbsExampleState = {
         alwaysRenderOverflow: false,
         collapseFrom: Boundary.START,

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Alignment, AnchorButton, Button, ButtonGroup, Classes, H5, Icon, Intent, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 import { Tooltip2 } from "@blueprintjs/popover2";
 
 import { AlignmentSelect } from "./common/alignmentSelect";
@@ -33,7 +33,7 @@ export interface IButtonGroupExampleState {
     vertical: boolean;
 }
 
-export class ButtonGroupExample extends React.PureComponent<IExampleProps, IButtonGroupExampleState> {
+export class ButtonGroupExample extends React.PureComponent<ExampleProps, IButtonGroupExampleState> {
     public state: IButtonGroupExampleState = {
         alignText: Alignment.CENTER,
         fill: false,

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Alignment, Button, ButtonGroup, H5, IconName, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Popover2 } from "@blueprintjs/popover2";
 
 import { AlignmentSelect } from "./common/alignmentSelect";
@@ -31,7 +31,7 @@ export interface IButtonGroupPopoverExampleState {
     vertical: boolean;
 }
 
-export class ButtonGroupPopoverExample extends React.PureComponent<IExampleProps, IButtonGroupPopoverExampleState> {
+export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps, IButtonGroupPopoverExampleState> {
     public state: IButtonGroupPopoverExampleState = {
         alignText: Alignment.CENTER,
         fill: false,

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 import { Size, SizeSelect } from "./common/sizeSelect";
@@ -34,7 +34,7 @@ export interface IButtonsExampleState {
     wiggling: boolean;
 }
 
-export class ButtonsExample extends React.PureComponent<IExampleProps, IButtonsExampleState> {
+export class ButtonsExample extends React.PureComponent<ExampleProps, IButtonsExampleState> {
     public state: IButtonsExampleState = {
         active: false,
         disabled: false,

--- a/packages/docs-app/src/examples/core-examples/buttonsIconsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsIconsExample.tsx
@@ -17,9 +17,9 @@
 import * as React from "react";
 
 import { Button, Icon } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
-export class ButtonsIconsExample extends React.PureComponent<IExampleProps> {
+export class ButtonsIconsExample extends React.PureComponent<ExampleProps> {
     public render() {
         return (
             <Example options={false} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/cardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardExample.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 
 import { Button, Card, Classes, Elevation, H5, Label, Slider, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ICardExampleState {
     elevation: Elevation;
     interactive: boolean;
 }
 
-export class CardExample extends React.PureComponent<IExampleProps, ICardExampleState> {
+export class CardExample extends React.PureComponent<ExampleProps, ICardExampleState> {
     public state: ICardExampleState = {
         elevation: 0,
         interactive: false,

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Alignment, Checkbox, H5, Label, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { AlignmentSelect } from "./common/alignmentSelect";
 

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Alignment, Checkbox, H5, Label, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { AlignmentSelect } from "./common/alignmentSelect";
 
@@ -29,7 +29,7 @@ export interface ICheckboxExampleState {
     value?: string;
 }
 
-export class CheckboxExample extends React.PureComponent<IExampleProps, ICheckboxExampleState> {
+export class CheckboxExample extends React.PureComponent<ExampleProps, ICheckboxExampleState> {
     public state: ICheckboxExampleState = {
         alignIndicator: Alignment.LEFT,
         disabled: false,

--- a/packages/docs-app/src/examples/core-examples/collapseExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapseExample.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 
 import { Button, Collapse, H5, Pre, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface ICollapseExampleState {
     isOpen: boolean;
     keepChildrenMounted: boolean;
 }
 
-export class CollapseExample extends React.PureComponent<IExampleProps, ICollapseExampleState> {
+export class CollapseExample extends React.PureComponent<ExampleProps, ICollapseExampleState> {
     public state: ICollapseExampleState = {
         isOpen: false,
         keepChildrenMounted: false,

--- a/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsibleListExample.tsx
@@ -35,7 +35,7 @@ import {
     RadioGroup,
     Slider,
 } from "@blueprintjs/core";
-import { Example, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleValueChange } from "@blueprintjs/docs-theme";
 
 export interface ICollapsibleListExampleState {
     collapseFrom?: Boundary;
@@ -47,7 +47,7 @@ const COLLAPSE_FROM_RADIOS = [
     { label: "End", value: Boundary.END.toString() },
 ];
 
-export class CollapsibleListExample extends React.PureComponent<IExampleProps, ICollapsibleListExampleState> {
+export class CollapsibleListExample extends React.PureComponent<ExampleProps, ICollapsibleListExampleState> {
     public state: ICollapsibleListExampleState = {
         collapseFrom: Boundary.START,
         visibleItemCount: 3,

--- a/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenu2Example.tsx
@@ -18,10 +18,10 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { ContextMenu2, ContextMenu2ChildrenProps, ContextMenu2ContentProps, Tooltip2 } from "@blueprintjs/popover2";
 
-export const ContextMenu2Example: React.FC<IExampleProps> = props => {
+export const ContextMenu2Example: React.FC<ExampleProps> = props => {
     const renderContent = React.useCallback(
         ({ targetOffset }: ContextMenu2ContentProps) => (
             <Menu>

--- a/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
@@ -25,7 +25,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, ContextMenu, ContextMenuTarget, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 /**
  * This component uses the imperative ContextMenu API.
@@ -65,7 +65,7 @@ class GraphNode extends React.PureComponent<any, { isContextMenuOpen: boolean }>
  * This component uses the decorator API and implements the IContextMenuTarget interface.
  */
 @ContextMenuTarget
-export class ContextMenuExample extends React.PureComponent<IExampleProps> {
+export class ContextMenuExample extends React.PureComponent<ExampleProps> {
     public render() {
         return (
             <Example className="docs-context-menu-example" options={false} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Button, ControlGroup, HTMLSelect, InputGroup, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 const FILTER_OPTIONS = ["Filter", "Name - ascending", "Name - descending", "Price - ascending", "Price - descending"];
 
@@ -26,7 +26,7 @@ export interface IControlGroupExampleState {
     vertical: boolean;
 }
 
-export class ControlGroupExample extends React.PureComponent<IExampleProps, IControlGroupExampleState> {
+export class ControlGroupExample extends React.PureComponent<ExampleProps, IControlGroupExampleState> {
     public state: IControlGroupExampleState = {
         fill: false,
         vertical: false,

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { AnchorButton, Button, Classes, Code, Dialog, DialogProps, H5, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Tooltip2 } from "@blueprintjs/popover2";
 
 import { IBlueprintExampleData } from "../../tags/types";
@@ -31,7 +31,7 @@ export interface DialogExampleState {
     usePortal: boolean;
 }
 
-export class DialogExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, DialogExampleState> {
+export class DialogExample extends React.PureComponent<ExampleProps<IBlueprintExampleData>, DialogExampleState> {
     public state: DialogExampleState = {
         autoFocus: true,
         canEscapeKeyClose: true,

--- a/packages/docs-app/src/examples/core-examples/dividerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dividerExample.tsx
@@ -17,13 +17,13 @@
 import * as React from "react";
 
 import { Button, ButtonGroup, Divider, H5, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface IDividerExampleState {
     vertical: boolean;
 }
 
-export class DividerExample extends React.PureComponent<IExampleProps, IDividerExampleState> {
+export class DividerExample extends React.PureComponent<ExampleProps, IDividerExampleState> {
     public state: IDividerExampleState = { vertical: false };
 
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -37,7 +37,7 @@ import {
     handleBooleanChange,
     handleStringChange,
     handleValueChange,
-    IExampleProps,
+    ExampleProps,
 } from "@blueprintjs/docs-theme";
 import { ContextMenu2 } from "@blueprintjs/popover2";
 
@@ -54,7 +54,7 @@ export interface IDrawerExampleState {
     size: string;
     usePortal: boolean;
 }
-export class DrawerExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IDrawerExampleState> {
+export class DrawerExample extends React.PureComponent<ExampleProps<IBlueprintExampleData>, IDrawerExampleState> {
     public state: IDrawerExampleState = {
         autoFocus: true,
         canEscapeKeyClose: true,

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -34,10 +34,10 @@ import {
 } from "@blueprintjs/core";
 import {
     Example,
+    ExampleProps,
     handleBooleanChange,
     handleStringChange,
     handleValueChange,
-    ExampleProps,
 } from "@blueprintjs/docs-theme";
 import { ContextMenu2 } from "@blueprintjs/popover2";
 

--- a/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
@@ -17,10 +17,10 @@
 import * as React from "react";
 
 import { Button, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2 } from "@blueprintjs/popover2";
 
-export class DropdownMenuExample extends React.PureComponent<IExampleProps> {
+export class DropdownMenuExample extends React.PureComponent<ExampleProps> {
     public render() {
         const exampleMenu = (
             <Menu>

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Classes, EditableText, FormGroup, H1, H5, Intent, NumericInput, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -33,7 +33,7 @@ export interface IEditableTextExampleState {
     selectAllOnFocus?: boolean;
 }
 
-export class EditableTextExample extends React.PureComponent<IExampleProps, IEditableTextExampleState> {
+export class EditableTextExample extends React.PureComponent<ExampleProps, IEditableTextExampleState> {
     public state: IEditableTextExampleState = {
         alwaysRenderInput: false,
         confirmOnEnterKey: false,

--- a/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
@@ -16,14 +16,14 @@
 import * as React from "react";
 
 import { FileInput, FormGroup, H5, InputGroup } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 interface IFileInputExampleState {
     buttonText?: string;
     text?: string;
 }
 
-export class FileInputExample extends React.PureComponent<IExampleProps, IFileInputExampleState> {
+export class FileInputExample extends React.PureComponent<ExampleProps, IFileInputExampleState> {
     public state: IFileInputExampleState = {};
 
     public render() {

--- a/packages/docs-app/src/examples/core-examples/focusExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/focusExample.tsx
@@ -17,13 +17,13 @@
 import * as React from "react";
 
 import { Button, Classes, FocusStyleManager, InputGroup, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface IFocusExampleState {
     isFocusActive?: boolean;
 }
 
-export class FocusExample extends React.PureComponent<IExampleProps, IFocusExampleState> {
+export class FocusExample extends React.PureComponent<ExampleProps, IFocusExampleState> {
     public state = {
         isFocusActive: true,
     };

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { FormGroup, H5, InputGroup, Intent, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -31,7 +31,7 @@ export interface IFormGroupExampleState {
     requiredLabel: boolean;
 }
 
-export class FormGroupExample extends React.PureComponent<IExampleProps, IFormGroupExampleState> {
+export class FormGroupExample extends React.PureComponent<ExampleProps, IFormGroupExampleState> {
     public state: IFormGroupExampleState = {
         disabled: false,
         helperText: false,

--- a/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PianoKey } from "./audio";
 
@@ -30,7 +30,7 @@ const AUDIO_CONTEXT = (window as any)["AudioContext"] != null ? new AudioContext
 
 // eslint-disable-next-line deprecation/deprecation
 @HotkeysTarget
-export class HotkeyPiano extends React.PureComponent<IExampleProps, IHotkeyPianoState> {
+export class HotkeyPiano extends React.PureComponent<ExampleProps, IHotkeyPianoState> {
     public state: IHotkeyPianoState = {
         // Use feature detection to disable example if we have to
         keys: Array.apply(null, Array(24)).map(() => false),

--- a/packages/docs-app/src/examples/core-examples/hotkeyTester.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTester.tsx
@@ -17,13 +17,13 @@
 import * as React from "react";
 
 import { Code, getKeyComboString, KeyCombo } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface IHotkeyTesterState {
     combo: string;
 }
 
-export class HotkeyTester extends React.PureComponent<IExampleProps, IHotkeyTesterState> {
+export class HotkeyTester extends React.PureComponent<ExampleProps, IHotkeyTesterState> {
     public state: IHotkeyTesterState = {
         combo: null,
     };

--- a/packages/docs-app/src/examples/core-examples/hotkeysTarget2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeysTarget2Example.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { HotkeysTarget2, IHotkeyProps } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PianoKey } from "./audio";
 
@@ -31,7 +31,7 @@ export interface IHotkeysTarget2ExampleState {
  * Similar to UseHotkeysExample, but using a component class API pattern.
  * We may deprecate and remove this in the future if we encourage everyone to switch to hooks.
  */
-export class HotkeysTarget2Example extends React.PureComponent<IExampleProps, IHotkeysTarget2ExampleState> {
+export class HotkeysTarget2Example extends React.PureComponent<ExampleProps, IHotkeysTarget2ExampleState> {
     public state: IHotkeysTarget2ExampleState = {
         keys: Array.apply(null, Array(24)).map(() => false),
     };

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Icon, IconSize, Intent, Label, Slider } from "@blueprintjs/core";
-import { Example, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleValueChange } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 
 import { IconSelect } from "./common/iconSelect";
@@ -29,7 +29,7 @@ export interface IIconExampleState {
     intent: Intent;
 }
 
-export class IconExample extends React.PureComponent<IExampleProps, IIconExampleState> {
+export class IconExample extends React.PureComponent<ExampleProps, IIconExampleState> {
     public state: IIconExampleState = {
         icon: "calendar",
         iconSize: IconSize.STANDARD,

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -29,7 +29,7 @@ import {
     Switch,
     Tag,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
 export interface IInputGroupExampleState {
@@ -41,7 +41,7 @@ export interface IInputGroupExampleState {
     tagValue: string;
 }
 
-export class InputGroupExample extends React.PureComponent<IExampleProps, IInputGroupExampleState> {
+export class InputGroupExample extends React.PureComponent<ExampleProps, IInputGroupExampleState> {
     public state: IInputGroupExampleState = {
         disabled: false,
         filterValue: "",

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -29,7 +29,7 @@ import {
     Switch,
     Tag,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
 import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
 export interface IInputGroupExampleState {

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -19,9 +19,9 @@
 import * as React from "react";
 
 import { Classes, Icon, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
-export class MenuExample extends React.PureComponent<IExampleProps> {
+export class MenuExample extends React.PureComponent<ExampleProps> {
     public render() {
         return (
             <Example className="docs-menu-example" options={false} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -17,11 +17,11 @@
 import * as React from "react";
 
 import { Classes, H5, Intent, Menu, MenuItem, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
-export function MenuItemExample(props: IExampleProps) {
+export function MenuItemExample(props: ExampleProps) {
     const [large, setLarge] = React.useState(false);
     const [disabled, setDisabled] = React.useState(false);
     const [selected, setSelected] = React.useState(false);

--- a/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, HandleInteractionKind, Intent, MultiSlider, Radio, RadioGroup, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 interface ISliderValues {
     dangerStart: number;
@@ -36,7 +36,7 @@ interface IMultiSliderExampleState {
     vertical: boolean;
 }
 
-export class MultiSliderExample extends React.PureComponent<IExampleProps, IMultiSliderExampleState> {
+export class MultiSliderExample extends React.PureComponent<ExampleProps, IMultiSliderExampleState> {
     public state: IMultiSliderExampleState = {
         interactionKind: HandleInteractionKind.PUSH,
         showTrackFill: true,

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -35,10 +35,10 @@ import {
 } from "@blueprintjs/core";
 import {
     Example,
+    ExampleProps,
     handleBooleanChange,
     handleStringChange,
     handleValueChange,
-    IExampleProps,
 } from "@blueprintjs/docs-theme";
 
 import { IBlueprintExampleData } from "../../tags/types";
@@ -61,7 +61,7 @@ export interface IMultistepDialogExampleState {
 const NAV_POSITIONS = ["left", "top", "right"];
 
 export class MultistepDialogExample extends React.PureComponent<
-    IExampleProps<IBlueprintExampleData>,
+    ExampleProps<IBlueprintExampleData>,
     IMultistepDialogExampleState
 > {
     public state: IMultistepDialogExampleState = {

--- a/packages/docs-app/src/examples/core-examples/navbarExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/navbarExample.tsx
@@ -27,13 +27,13 @@ import {
     NavbarHeading,
     Switch,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface INavbarExampleState {
     alignRight: boolean;
 }
 
-export class NavbarExample extends React.PureComponent<IExampleProps, INavbarExampleState> {
+export class NavbarExample extends React.PureComponent<ExampleProps, INavbarExampleState> {
     public state: INavbarExampleState = {
         alignRight: false,
     };

--- a/packages/docs-app/src/examples/core-examples/navbarExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/navbarExample.tsx
@@ -27,7 +27,7 @@ import {
     NavbarHeading,
     Switch,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface INavbarExampleState {
     alignRight: boolean;

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -26,7 +26,7 @@ import {
     Spinner,
     Switch,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 
 import { IconSelect } from "./common/iconSelect";
@@ -55,7 +55,7 @@ export interface INonIdealStateExampleState {
     visual: VisualKind;
 }
 
-export class NonIdealStateExample extends React.PureComponent<IExampleProps, INonIdealStateExampleState> {
+export class NonIdealStateExample extends React.PureComponent<ExampleProps, INonIdealStateExampleState> {
     public state: INonIdealStateExampleState = {
         icon: defaultIcon,
         iconSize: NonIdealStateIconSize.STANDARD,

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -26,7 +26,7 @@ import {
     Spinner,
     Switch,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 
 import { IconSelect } from "./common/iconSelect";

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -31,11 +31,11 @@ import {
 } from "@blueprintjs/core";
 import {
     Example,
+    ExampleProps,
     handleBooleanChange,
     handleNumberChange,
     handleStringChange,
     handleValueChange,
-    IExampleProps,
 } from "@blueprintjs/docs-theme";
 import { IconNames } from "@blueprintjs/icons";
 import { Popover2 } from "@blueprintjs/popover2";
@@ -63,7 +63,7 @@ const BUTTON_POSITIONS = [
     { label: "Right", value: Position.RIGHT },
 ];
 
-export class NumericInputBasicExample extends React.PureComponent<IExampleProps, NumericInputProps> {
+export class NumericInputBasicExample extends React.PureComponent<ExampleProps, NumericInputProps> {
     public state: NumericInputProps = {
         allowNumericCharactersOnly: true,
         buttonPosition: "right",

--- a/packages/docs-app/src/examples/core-examples/numericInputExtendedExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputExtendedExample.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 
 import { Keys, NumericInput } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface INumericInputExtendedExampleState {
     value?: string;
@@ -31,7 +31,7 @@ const NumberAbbreviation = {
 const NUMBER_ABBREVIATION_REGEX = /((\.\d+)|(\d+(\.\d+)?))(k|m|b)\b/gi;
 const SCIENTIFIC_NOTATION_REGEX = /((\.\d+)|(\d+(\.\d+)?))(e\d+)\b/gi;
 
-export class NumericInputExtendedExample extends React.PureComponent<IExampleProps, INumericInputExtendedExampleState> {
+export class NumericInputExtendedExample extends React.PureComponent<ExampleProps, INumericInputExtendedExampleState> {
     public state: INumericInputExtendedExampleState = {
         value: "",
     };

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -17,7 +17,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Button, Classes, Code, H3, H5, Intent, Overlay, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { IBlueprintExampleData } from "../../tags/types";
 

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -17,7 +17,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Button, Classes, Code, H3, H5, Intent, Overlay, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { IBlueprintExampleData } from "../../tags/types";
 
@@ -35,7 +35,7 @@ export interface IOverlayExampleState {
     useTallContent: boolean;
 }
 
-export class OverlayExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IOverlayExampleState> {
+export class OverlayExample extends React.PureComponent<ExampleProps<IBlueprintExampleData>, IOverlayExampleState> {
     public state: IOverlayExampleState = {
         autoFocus: true,
         canEscapeKeyClose: true,

--- a/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
@@ -24,7 +24,7 @@
 import * as React from "react";
 
 import { Button, H5, Intent, NumericInput, Panel, PanelProps, PanelStack2, Switch, UL } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Panel1Info {
@@ -112,7 +112,7 @@ const initialPanel: Panel<Panel1Info> = {
     title: "Panel 1",
 };
 
-export const PanelStack2Example: React.FC<IExampleProps> = props => {
+export const PanelStack2Example: React.FC<ExampleProps> = props => {
     const [activePanelOnly, setActivePanelOnly] = React.useState(false);
     const [showHeader, setShowHeader] = React.useState(true);
     const [currentPanelStack, setCurrentPanelStack] = React.useState<

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -24,7 +24,7 @@
 import * as React from "react";
 
 import { Button, H5, Intent, IPanel, IPanelProps, NumericInput, PanelStack, Switch, UL } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface IPanelStackExampleState {
     activePanelOnly: boolean;
@@ -32,7 +32,7 @@ export interface IPanelStackExampleState {
     showHeader: boolean;
 }
 
-export class PanelStackExample extends React.PureComponent<IExampleProps, IPanelStackExampleState> {
+export class PanelStackExample extends React.PureComponent<ExampleProps, IPanelStackExampleState> {
     public initialPanel: IPanel<IPanelExampleProps> = {
         component: PanelExample,
         props: {

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -24,10 +24,10 @@
 import * as React from "react";
 
 import { Button, Callout, Classes, Popover, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export class PopoverDismissExample extends React.PureComponent<
-    IExampleProps,
+    ExampleProps,
     { captureDismiss: boolean; isOpen: boolean }
 > {
     public state = { captureDismiss: true, isOpen: true };

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -47,10 +47,10 @@ import {
 } from "@blueprintjs/core";
 import {
     Example,
+    ExampleProps,
     handleBooleanChange,
     handleNumberChange,
     handleValueChange,
-    IExampleProps,
 } from "@blueprintjs/docs-theme";
 
 const INTERACTION_KINDS = [
@@ -95,7 +95,7 @@ export interface IPopoverExampleState {
     usePortal?: boolean;
 }
 
-export class PopoverExample extends React.PureComponent<IExampleProps, IPopoverExampleState> {
+export class PopoverExample extends React.PureComponent<ExampleProps, IPopoverExampleState> {
     public state: IPopoverExampleState = {
         boundary: "viewport",
         canEscapeKeyClose: true,

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -24,11 +24,11 @@
 import * as React from "react";
 
 import { Button, Intent, Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { FileMenu } from "./common/fileMenu";
 
-export class PopoverInteractionKindExample extends React.PureComponent<IExampleProps> {
+export class PopoverInteractionKindExample extends React.PureComponent<ExampleProps> {
     public render() {
         return (
             <Example className="docs-popover-interaction-kind-example" options={false} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -24,11 +24,11 @@
 import * as React from "react";
 
 import { Button, Intent, IPopoverProps, Popover, Position } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { FileMenu } from "./common/fileMenu";
 
-export class PopoverMinimalExample extends React.PureComponent<IExampleProps> {
+export class PopoverMinimalExample extends React.PureComponent<ExampleProps> {
     public render() {
         const baseProps: IPopoverProps = { content: <FileMenu />, position: Position.BOTTOM_LEFT };
 

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -24,13 +24,13 @@
 import * as React from "react";
 
 import { Button, Code, H5, IPopoverProps, Popover, Position, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface IPopoverPortalExampleState {
     isOpen: boolean;
 }
 
-export class PopoverPortalExample extends React.PureComponent<IExampleProps, IPopoverPortalExampleState> {
+export class PopoverPortalExample extends React.PureComponent<ExampleProps, IPopoverPortalExampleState> {
     public state: IPopoverPortalExampleState = {
         isOpen: true,
     };

--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -24,14 +24,14 @@
 import * as React from "react";
 
 import { Button, Classes, Code, Popover, Position } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 const EXAMPLE_CLASS = "docs-popover-position-example";
 
 const SIDE_LABEL_CLASS = "docs-popover-position-label-side";
 const ALIGNMENT_LABEL_CLASS = "docs-popover-position-label-alignment";
 
-export class PopoverPositionExample extends React.PureComponent<IExampleProps> {
+export class PopoverPositionExample extends React.PureComponent<ExampleProps> {
     public render() {
         return (
             <Example className={EXAMPLE_CLASS} options={false} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -24,11 +24,11 @@
 import * as React from "react";
 
 import { Button, Popover, Position } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { FileMenu } from "./common/fileMenu";
 
-export class PopoverSizingExample extends React.PureComponent<IExampleProps> {
+export class PopoverSizingExample extends React.PureComponent<ExampleProps> {
     public render() {
         return (
             <Example options={false} {...this.props}>

--- a/packages/docs-app/src/examples/core-examples/progressExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/progressExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Intent, ProgressBar, Slider, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -27,7 +27,7 @@ export interface IProgressExampleState {
     value: number;
 }
 
-export class ProgressExample extends React.PureComponent<IExampleProps, IProgressExampleState> {
+export class ProgressExample extends React.PureComponent<ExampleProps, IProgressExampleState> {
     public state: IProgressExampleState = {
         hasValue: false,
         value: 0.7,

--- a/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 
 import { H5, NumberRange, RangeSlider, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface IRangeSliderExampleState {
     range: NumberRange;
     vertical: boolean;
 }
 
-export class RangeSliderExample extends React.PureComponent<IExampleProps, IRangeSliderExampleState> {
+export class RangeSliderExample extends React.PureComponent<ExampleProps, IRangeSliderExampleState> {
     public state: IRangeSliderExampleState = {
         range: [36, 72],
         vertical: false,

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Slider, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface ISliderExampleState {
     value1?: number;
@@ -26,7 +26,7 @@ export interface ISliderExampleState {
     vertical?: boolean;
 }
 
-export class SliderExample extends React.PureComponent<IExampleProps, ISliderExampleState> {
+export class SliderExample extends React.PureComponent<ExampleProps, ISliderExampleState> {
     public state: ISliderExampleState = {
         value1: 0,
         value2: 2.5,

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Intent, Label, Slider, Spinner, SpinnerSize, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, Intent, Label, Slider, Spinner, SpinnerSize, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -28,7 +28,7 @@ export interface ISpinnerExampleState {
     value: number;
 }
 
-export class SpinnerExample extends React.PureComponent<IExampleProps, ISpinnerExampleState> {
+export class SpinnerExample extends React.PureComponent<ExampleProps, ISpinnerExampleState> {
     public state: ISpinnerExampleState = {
         hasValue: false,
         size: SpinnerSize.STANDARD,

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Alignment, Classes, H3, H5, InputGroup, Navbar, Switch, Tab, TabId, Tabs } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface ITabsExampleState {
     activePanelOnly: boolean;
@@ -26,7 +26,7 @@ export interface ITabsExampleState {
     vertical: boolean;
 }
 
-export class TabsExample extends React.PureComponent<IExampleProps, ITabsExampleState> {
+export class TabsExample extends React.PureComponent<ExampleProps, ITabsExampleState> {
     public state: ITabsExampleState = {
         activePanelOnly: false,
         animate: true,

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Button, H5, Intent, Switch, Tag } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -34,7 +34,7 @@ export interface ITagExampleState {
     tags: string[];
 }
 
-export class TagExample extends React.PureComponent<IExampleProps, ITagExampleState> {
+export class TagExample extends React.PureComponent<ExampleProps, ITagExampleState> {
     public state: ITagExampleState = {
         fill: false,
         icon: false,

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Button, H5, Intent, Switch, TagInput, TagProps } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
 
@@ -47,7 +47,7 @@ export interface ITagInputExampleState {
     values: React.ReactNode[];
 }
 
-export class TagInputExample extends React.PureComponent<IExampleProps, ITagInputExampleState> {
+export class TagInputExample extends React.PureComponent<ExampleProps, ITagInputExampleState> {
     public state: ITagInputExampleState = {
         addOnBlur: false,
         addOnPaste: true,

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Text, TextArea } from "@blueprintjs/core";
-import { Example, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 
 export interface ITextExampleState {
     textContent: string;

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -17,13 +17,13 @@
 import * as React from "react";
 
 import { Text, TextArea } from "@blueprintjs/core";
-import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface ITextExampleState {
     textContent: string;
 }
 
-export class TextExample extends React.PureComponent<IExampleProps, ITextExampleState> {
+export class TextExample extends React.PureComponent<ExampleProps, ITextExampleState> {
     public state: ITextExampleState = {
         textContent:
             "You can change the text in the input below. Hover to see full text. " +

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -24,7 +24,6 @@ import {
     HTMLSelect,
     Intent,
     IToasterProps,
-    ToastProps,
     Label,
     NumericInput,
     Position,
@@ -32,6 +31,7 @@ import {
     Switch,
     Toaster,
     ToasterPosition,
+    ToastProps,
 } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -24,7 +24,7 @@ import {
     HTMLSelect,
     Intent,
     IToasterProps,
-    IToastProps,
+    ToastProps,
     Label,
     NumericInput,
     Position,
@@ -33,11 +33,11 @@ import {
     Toaster,
     ToasterPosition,
 } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { IBlueprintExampleData } from "../../tags/types";
 
-type IToastDemo = IToastProps & { button: string };
+type IToastDemo = ToastProps & { button: string };
 
 const POSITIONS = [
     Position.TOP_LEFT,
@@ -48,7 +48,7 @@ const POSITIONS = [
     Position.BOTTOM_RIGHT,
 ];
 
-export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintExampleData>, IToasterProps> {
+export class ToastExample extends React.PureComponent<ExampleProps<IBlueprintExampleData>, IToasterProps> {
     public state: IToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,
@@ -166,7 +166,7 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
         return <Button intent={toast.intent} key={index} text={toast.button} onClick={() => this.addToast(toast)} />;
     };
 
-    private renderProgress(amount: number): IToastProps {
+    private renderProgress(amount: number): ToastProps {
         return {
             className: this.props.data.themeName,
             icon: "cloud-upload",
@@ -189,7 +189,7 @@ export class ToastExample extends React.PureComponent<IExampleProps<IBlueprintEx
         };
     }
 
-    private addToast(toast: IToastProps) {
+    private addToast(toast: ToastProps) {
         toast.className = this.props.data.themeName;
         toast.timeout = 5000;
         this.toaster.show(toast);

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -24,9 +24,9 @@
 import * as React from "react";
 
 import { Button, Classes, H1, Intent, Popover, Position, Switch, Tooltip } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
-export class TooltipExample extends React.PureComponent<IExampleProps, { isOpen: boolean }> {
+export class TooltipExample extends React.PureComponent<ExampleProps, { isOpen: boolean }> {
     public state = {
         isOpen: false,
     };

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -18,7 +18,7 @@ import { cloneDeep } from "lodash-es";
 import * as React from "react";
 
 import { Classes, Icon, Intent, Tree, TreeNodeInfo } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { ContextMenu2, Classes as Popover2Classes, Tooltip2 } from "@blueprintjs/popover2";
 
 type NodePath = number[];
@@ -62,7 +62,7 @@ function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
     }
 }
 
-export const TreeExample: React.FC<IExampleProps> = props => {
+export const TreeExample: React.FC<ExampleProps> = props => {
     const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
 
     const handleNodeClick = React.useCallback(

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -17,11 +17,11 @@
 import * as React from "react";
 
 import { useHotkeys } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PianoKey } from "./audio";
 
-export const UseHotkeysExample: React.FC<IExampleProps> = props => {
+export const UseHotkeysExample: React.FC<ExampleProps> = props => {
     const [audioContext, setAudioContext] = React.useState<AudioContext>();
 
     const pianoRef = React.useRef<HTMLDivElement>();

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -25,7 +25,7 @@ import * as React from "react";
 
 import { H5, Position, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateInput, TimePrecision } from "@blueprintjs/datetime";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 import { MOMENT_FORMATS, MomentFormatSelector } from "./common/momentFormats";
@@ -43,7 +43,7 @@ export interface IDateInputExampleState {
     showTimeArrowButtons: boolean;
 }
 
-export class DateInputExample extends React.PureComponent<IExampleProps, IDateInputExampleState> {
+export class DateInputExample extends React.PureComponent<ExampleProps, IDateInputExampleState> {
     public state: IDateInputExampleState = {
         closeOnSelection: true,
         date: null,

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -25,7 +25,7 @@ import * as React from "react";
 
 import { H5, Position, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateInput, TimePrecision } from "@blueprintjs/datetime";
-import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 import { MOMENT_FORMATS, MomentFormatSelector } from "./common/momentFormats";

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Callout, Classes, H5, Switch } from "@blueprintjs/core";
 import { DatePicker, TimePrecision } from "@blueprintjs/datetime";
-import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 import { PrecisionSelect } from "./common/precisionSelect";

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Callout, Classes, H5, Switch } from "@blueprintjs/core";
 import { DatePicker, TimePrecision } from "@blueprintjs/datetime";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 import { PrecisionSelect } from "./common/precisionSelect";
@@ -37,7 +37,7 @@ export interface IDatePickerExampleState {
     showFooterElement: boolean;
 }
 
-export class DatePickerExample extends React.PureComponent<IExampleProps, IDatePickerExampleState> {
+export class DatePickerExample extends React.PureComponent<ExampleProps, IDatePickerExampleState> {
     public state: IDatePickerExampleState = {
         date: null,
         highlightCurrentDay: false,

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -25,7 +25,7 @@ import * as React from "react";
 
 import { H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, DateRangeInput, TimePrecision } from "@blueprintjs/datetime";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { MomentDateRange } from "./common/momentDate";
 import { MOMENT_FORMATS, MomentFormatSelector } from "./common/momentFormats";
@@ -45,7 +45,7 @@ export interface IDateRangeInputExampleState {
     showTimeArrowButtons: boolean;
 }
 
-export class DateRangeInputExample extends React.PureComponent<IExampleProps, IDateRangeInputExampleState> {
+export class DateRangeInputExample extends React.PureComponent<ExampleProps, IDateRangeInputExampleState> {
     public state: IDateRangeInputExampleState = {
         allowSingleDayRange: false,
         closeOnSelection: false,

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -25,7 +25,7 @@ import * as React from "react";
 
 import { H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, DateRangeInput, TimePrecision } from "@blueprintjs/datetime";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { MomentDateRange } from "./common/momentDate";
 import { MOMENT_FORMATS, MomentFormatSelector } from "./common/momentFormats";

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -21,10 +21,10 @@ import { Classes, H5, HTMLSelect, Label, Switch } from "@blueprintjs/core";
 import { DateRange, DateRangePicker, TimePrecision } from "@blueprintjs/datetime";
 import {
     Example,
+    ExampleProps,
     handleBooleanChange,
     handleNumberChange,
     handleValueChange,
-    ExampleProps,
 } from "@blueprintjs/docs-theme";
 
 import { MomentDateRange } from "./common/momentDate";

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -24,7 +24,7 @@ import {
     handleBooleanChange,
     handleNumberChange,
     handleValueChange,
-    IExampleProps,
+    ExampleProps,
 } from "@blueprintjs/docs-theme";
 
 import { MomentDateRange } from "./common/momentDate";
@@ -71,7 +71,7 @@ const MAX_DATE_OPTIONS: IDateOption[] = [
     },
 ];
 
-export class DateRangePickerExample extends React.PureComponent<IExampleProps, IDateRangePickerExampleState> {
+export class DateRangePickerExample extends React.PureComponent<ExampleProps, IDateRangePickerExampleState> {
     public state: IDateRangePickerExampleState = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,

--- a/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateTimePickerExample.tsx
@@ -25,11 +25,11 @@ import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { DateTimePicker } from "@blueprintjs/datetime";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { MomentDate } from "./common/momentDate";
 
-export class DateTimePickerExample extends React.PureComponent<IExampleProps, { date: Date }> {
+export class DateTimePickerExample extends React.PureComponent<ExampleProps, { date: Date }> {
     public state = { date: new Date() };
 
     public render() {

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -20,7 +20,7 @@ import { Classes, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { TimePicker, TimePrecision } from "@blueprintjs/datetime";
 // tslint:disable-next-line:no-submodule-imports
 import { getDefaultMaxTime, getDefaultMinTime } from "@blueprintjs/datetime/lib/esm/common/timeUnit";
-import { Example, handleNumberChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleNumberChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { PrecisionSelect } from "./common/precisionSelect";
 

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -20,7 +20,7 @@ import { Classes, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { TimePicker, TimePrecision } from "@blueprintjs/datetime";
 // tslint:disable-next-line:no-submodule-imports
 import { getDefaultMaxTime, getDefaultMinTime } from "@blueprintjs/datetime/lib/esm/common/timeUnit";
-import { Example, handleNumberChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleNumberChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PrecisionSelect } from "./common/precisionSelect";
 
@@ -47,7 +47,7 @@ enum MaximumHours {
     TWO_AM = 2,
 }
 
-export class TimePickerExample extends React.PureComponent<IExampleProps, ITimePickerExampleState> {
+export class TimePickerExample extends React.PureComponent<ExampleProps, ITimePickerExampleState> {
     public state = {
         autoFocus: true,
         disabled: false,

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { Classes, H5, Icon, Switch, Tag } from "@blueprintjs/core";
 import { DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { DateInput2 } from "@blueprintjs/datetime2";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
@@ -43,7 +43,7 @@ export interface DateInput2ExampleState {
     useAmPm: boolean;
 }
 
-export class DateInput2Example extends React.PureComponent<IExampleProps, DateInput2ExampleState> {
+export class DateInput2Example extends React.PureComponent<ExampleProps, DateInput2ExampleState> {
     public state: DateInput2ExampleState = {
         closeOnSelection: true,
         date: null,

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { Classes, H5, Icon, Switch, Tag } from "@blueprintjs/core";
 import { DateFormatProps, TimePrecision } from "@blueprintjs/datetime";
 import { DateInput2 } from "@blueprintjs/datetime2";
-import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangeInput2 } from "@blueprintjs/datetime2";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { DateFnsDateRange } from "./dateFnsDate";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "./dateFnsFormatSelector";
@@ -39,7 +39,7 @@ export interface DateRangeInput2ExampleState {
     showTimeArrowButtons: boolean;
 }
 
-export class DateRangeInput2Example extends React.PureComponent<IExampleProps, DateRangeInput2ExampleState> {
+export class DateRangeInput2Example extends React.PureComponent<ExampleProps, DateRangeInput2ExampleState> {
     public state: DateRangeInput2ExampleState = {
         allowSingleDayRange: false,
         closeOnSelection: false,

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangeInput2 } from "@blueprintjs/datetime2";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { DateFnsDateRange } from "./dateFnsDate";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "./dateFnsFormatSelector";

--- a/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { H5, Position, Switch } from "@blueprintjs/core";
 import { TimezoneSelect } from "@blueprintjs/datetime2";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export interface TimezoneSelectExampleState {
     disabled: boolean;

--- a/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { H5, Position, Switch } from "@blueprintjs/core";
 import { TimezoneSelect } from "@blueprintjs/datetime2";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface TimezoneSelectExampleState {
     disabled: boolean;
@@ -28,7 +28,7 @@ export interface TimezoneSelectExampleState {
     timezone: string;
 }
 
-export class TimezoneSelectExample extends React.PureComponent<IExampleProps, TimezoneSelectExampleState> {
+export class TimezoneSelectExample extends React.PureComponent<ExampleProps, TimezoneSelectExampleState> {
     public state: TimezoneSelectExampleState = {
         disabled: false,
         fill: false,

--- a/packages/docs-app/src/examples/popover2-examples/breadcrumbs2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/breadcrumbs2Example.tsx
@@ -27,7 +27,7 @@ import {
     RadioGroup,
     Slider,
 } from "@blueprintjs/core";
-import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { Breadcrumbs2 } from "@blueprintjs/popover2";
 
 export interface Breadcrumbs2ExampleState {
@@ -56,7 +56,7 @@ const ITEMS_FOR_ALWAYS_RENDER: BreadcrumbProps[] = [
     { icon: "document", text: "image.jpg", current: true },
 ];
 
-export class Breadcrumbs2Example extends React.PureComponent<IExampleProps, Breadcrumbs2ExampleState> {
+export class Breadcrumbs2Example extends React.PureComponent<ExampleProps, Breadcrumbs2ExampleState> {
     public state: Breadcrumbs2ExampleState = {
         alwaysRenderOverflow: false,
         collapseFrom: Boundary.START,

--- a/packages/docs-app/src/examples/popover2-examples/breadcrumbs2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/breadcrumbs2Example.tsx
@@ -27,7 +27,7 @@ import {
     RadioGroup,
     Slider,
 } from "@blueprintjs/core";
-import { Example, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 import { Breadcrumbs2 } from "@blueprintjs/popover2";
 
 export interface Breadcrumbs2ExampleState {

--- a/packages/docs-app/src/examples/popover2-examples/menuItem2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/menuItem2Example.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 
 import { Classes, Code, H5, HTMLSelect, Intent, Label, Menu, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { MenuItem2, MenuItem2Props } from "@blueprintjs/popover2";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { IntentSelect } from "../core-examples/common/intentSelect";
 import { BooleanOrUndefinedSelect } from "./booleanOrUndefinedSelect";
 
-export function MenuItem2Example(props: IExampleProps) {
+export function MenuItem2Example(props: ExampleProps) {
     const [large, setLarge] = React.useState(false);
     const [disabled, setDisabled] = React.useState(false);
     const [selected, setSelected] = React.useState<boolean | undefined>(undefined);

--- a/packages/docs-app/src/examples/popover2-examples/menuItem2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/menuItem2Example.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Classes, Code, H5, HTMLSelect, Intent, Label, Menu, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 import { MenuItem2, MenuItem2Props } from "@blueprintjs/popover2";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";

--- a/packages/docs-app/src/examples/popover2-examples/popover2DismissExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2DismissExample.tsx
@@ -17,11 +17,11 @@
 import * as React from "react";
 
 import { Button, Callout, Classes as CoreClasses, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Classes, Popover2 } from "@blueprintjs/popover2";
 
 export class Popover2DismissExample extends React.PureComponent<
-    IExampleProps,
+    ExampleProps,
     { captureDismiss: boolean; isOpen: boolean }
 > {
     public static displayName = "Popover2DismissExample";

--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -38,7 +38,7 @@ import {
     handleBooleanChange,
     handleNumberChange,
     handleValueChange,
-    IExampleProps,
+    ExampleProps,
 } from "@blueprintjs/docs-theme";
 import {
     Classes,
@@ -79,7 +79,7 @@ export interface IPopover2ExampleState {
     usePortal?: boolean;
 }
 
-export class Popover2Example extends React.PureComponent<IExampleProps, IPopover2ExampleState> {
+export class Popover2Example extends React.PureComponent<ExampleProps, IPopover2ExampleState> {
     public static displayName = "Popover2Example";
 
     public state: IPopover2ExampleState = {

--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -35,10 +35,10 @@ import {
 } from "@blueprintjs/core";
 import {
     Example,
+    ExampleProps,
     handleBooleanChange,
     handleNumberChange,
     handleValueChange,
-    ExampleProps,
 } from "@blueprintjs/docs-theme";
 import {
     Classes,

--- a/packages/docs-app/src/examples/popover2-examples/popover2InteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2InteractionKindExample.tsx
@@ -17,12 +17,12 @@
 import * as React from "react";
 
 import { Button, Intent } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2";
 
 import { FileMenu } from "../core-examples/common/fileMenu";
 
-export class Popover2InteractionKindExample extends React.PureComponent<IExampleProps> {
+export class Popover2InteractionKindExample extends React.PureComponent<ExampleProps> {
     public static displayName = "Popover2InteractionKindExample";
 
     public render() {

--- a/packages/docs-app/src/examples/popover2-examples/popover2MinimalExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2MinimalExample.tsx
@@ -17,12 +17,12 @@
 import * as React from "react";
 
 import { Button, Intent } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { FileMenu } from "../core-examples/common/fileMenu";
 
-export class Popover2MinimalExample extends React.PureComponent<IExampleProps> {
+export class Popover2MinimalExample extends React.PureComponent<ExampleProps> {
     public static displayName = "Popover2MinimalExample";
 
     public render() {

--- a/packages/docs-app/src/examples/popover2-examples/popover2PlacementExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2PlacementExample.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 
 import { Button, Classes, Code } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Placement, Popover2 } from "@blueprintjs/popover2";
 
 const EXAMPLE_CLASS = "docs-popover2-placement-example";
 const SIDE_LABEL_CLASS = "docs-popover2-placement-label-side";
 const ALIGNMENT_LABEL_CLASS = "docs-popover2-placement-label-alignment";
 
-export class Popover2PlacementExample extends React.PureComponent<IExampleProps> {
+export class Popover2PlacementExample extends React.PureComponent<ExampleProps> {
     public static displayName = "Popover2PlacementExample";
 
     public render() {

--- a/packages/docs-app/src/examples/popover2-examples/popover2PortalExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2PortalExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Button, Code, H5, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 const POPOVER2_PROPS: Partial<Popover2Props> = {
@@ -35,7 +35,7 @@ export interface IPopover2PortalExampleState {
     isOpen: boolean;
 }
 
-export class Popover2PortalExample extends React.PureComponent<IExampleProps, IPopover2PortalExampleState> {
+export class Popover2PortalExample extends React.PureComponent<ExampleProps, IPopover2PortalExampleState> {
     public static displayName = "Popover2PortalExample";
 
     public state: IPopover2PortalExampleState = {

--- a/packages/docs-app/src/examples/popover2-examples/popover2SizingExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2SizingExample.tsx
@@ -17,12 +17,12 @@
 import * as React from "react";
 
 import { Button } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2 } from "@blueprintjs/popover2";
 
 import { FileMenu } from "../core-examples/common/fileMenu";
 
-export class Popover2SizingExample extends React.PureComponent<IExampleProps> {
+export class Popover2SizingExample extends React.PureComponent<ExampleProps> {
     public static displayName = "Popover2SizingExample";
 
     public render() {

--- a/packages/docs-app/src/examples/popover2-examples/tooltip2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/tooltip2Example.tsx
@@ -17,14 +17,14 @@
 import * as React from "react";
 
 import { Button, ButtonGroup, H1, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Classes, Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
 export interface ITooltip2ExampleState {
     isOpen: boolean;
 }
 
-export class Tooltip2Example extends React.PureComponent<IExampleProps, ITooltip2ExampleState> {
+export class Tooltip2Example extends React.PureComponent<ExampleProps, ITooltip2ExampleState> {
     public static displayName = "Tooltip2Example";
 
     public state: ITooltip2ExampleState = {

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Code, H5, Intent, MenuItem, Switch, TagProps } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2 } from "@blueprintjs/popover2";
 import { ItemRenderer, MultiSelect2 } from "@blueprintjs/select";
 
@@ -56,7 +56,7 @@ export interface IMultiSelectExampleState {
     tagMinimal: boolean;
 }
 
-export class MultiSelectExample extends React.PureComponent<IExampleProps, IMultiSelectExampleState> {
+export class MultiSelectExample extends React.PureComponent<ExampleProps, IMultiSelectExampleState> {
     public state: IMultiSelectExampleState = {
         allowCreate: false,
         createdItems: [],

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -15,7 +15,7 @@
 import * as React from "react";
 
 import { Button, H5, HotkeysTarget2, KeyCombo, MenuItem, Position, Switch, Toaster } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Omnibar } from "@blueprintjs/select";
 
 import {
@@ -36,7 +36,7 @@ export interface IOmnibarExampleState {
     resetOnSelect: boolean;
 }
 
-export class OmnibarExample extends React.PureComponent<IExampleProps, IOmnibarExampleState> {
+export class OmnibarExample extends React.PureComponent<ExampleProps, IOmnibarExampleState> {
     public state: IOmnibarExampleState = {
         allowCreate: false,
         isOpen: false,

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, MenuItem, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { IFilm, TOP_100_FILMS } from "../../common/films";
 import FilmSelect from "../../common/filmSelect";
@@ -39,7 +39,7 @@ export interface ISelectExampleState {
 }
 
 /** Technically a Select2 example, since FilmSelect uses Select2. */
-export class SelectExample extends React.PureComponent<IExampleProps, ISelectExampleState> {
+export class SelectExample extends React.PureComponent<ExampleProps, ISelectExampleState> {
     public state: ISelectExampleState = {
         allowCreate: false,
         createFirst: false,

--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { H5, MenuItem, Switch } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Suggest2 } from "@blueprintjs/select";
 
 import {
@@ -50,7 +50,7 @@ export interface ISuggestExampleState {
     resetOnSelect: boolean;
 }
 
-export class SuggestExample extends React.PureComponent<IExampleProps, ISuggestExampleState> {
+export class SuggestExample extends React.PureComponent<ExampleProps, ISuggestExampleState> {
     public state: ISuggestExampleState = {
         allowCreate: false,
         closeOnSelect: true,

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 
 import { RadioGroup } from "@blueprintjs/core";
-import { Example, handleStringChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnHeaderCell2, RowHeaderCell2, Table2 } from "@blueprintjs/table";
 
 interface IBigSpaceRock {
@@ -49,7 +49,7 @@ export interface ICellLoadingExampleState {
     randomNumbers?: number[];
 }
 
-export class CellLoadingExample extends React.PureComponent<IExampleProps, ICellLoadingExampleState> {
+export class CellLoadingExample extends React.PureComponent<ExampleProps, ICellLoadingExampleState> {
     public state: ICellLoadingExampleState = {
         configuration: CellsLoadingConfiguration.ALL,
     };

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 
 import { RadioGroup } from "@blueprintjs/core";
-import { Example, handleStringChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnHeaderCell2, RowHeaderCell2, Table2 } from "@blueprintjs/table";
 
 interface IBigSpaceRock {

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { HTMLSelect, Label } from "@blueprintjs/core";
-import { Example, handleNumberChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleNumberChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnLoadingOption, Table2 } from "@blueprintjs/table";
 
 interface IBigSpaceRock {
@@ -31,7 +31,7 @@ export interface IColumnLoadingExampleState {
     loadingColumn?: number;
 }
 
-export class ColumnLoadingExample extends React.PureComponent<IExampleProps, IColumnLoadingExampleState> {
+export class ColumnLoadingExample extends React.PureComponent<ExampleProps, IColumnLoadingExampleState> {
     public state: IColumnLoadingExampleState = {
         loadingColumn: 1,
     };

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { HTMLSelect, Label } from "@blueprintjs/core";
-import { Example, handleNumberChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleNumberChange } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnLoadingOption, Table2 } from "@blueprintjs/table";
 
 interface IBigSpaceRock {

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -17,13 +17,13 @@
 import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnHeaderCell2, Table2 } from "@blueprintjs/table";
 
 // this will obviously get outdated, it's valid only as of August 2021
 const USD_TO_EURO_CONVERSION = 0.85;
 
-export class TableDollarExample extends React.PureComponent<IExampleProps> {
+export class TableDollarExample extends React.PureComponent<ExampleProps> {
     public render() {
         const dollarCellRenderer = (rowIndex: number) => <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>;
         const euroCellRenderer = (rowIndex: number) => (

--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Intent } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Column, ColumnHeaderCell2, EditableCell2, EditableName, Table2 } from "@blueprintjs/table";
 
 export interface ITableEditableExampleState {
@@ -27,7 +27,7 @@ export interface ITableEditableExampleState {
     sparseColumnIntents?: Intent[];
 }
 
-export class TableEditableExample extends React.PureComponent<IExampleProps, ITableEditableExampleState> {
+export class TableEditableExample extends React.PureComponent<ExampleProps, ITableEditableExampleState> {
     public static dataKey = (rowIndex: number, columnIndex: number) => {
         return `${rowIndex}-${columnIndex}`;
     };

--- a/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, JSONFormat2, Table2, TruncatedFormat2 } from "@blueprintjs/table";
 
 interface ITimezone {
@@ -77,7 +77,7 @@ const TIME_ZONES: ITimezone[] = (
     };
 });
 
-export class TableFormatsExample extends React.PureComponent<IExampleProps> {
+export class TableFormatsExample extends React.PureComponent<ExampleProps> {
     private data = TIME_ZONES;
 
     private date = new Date();

--- a/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2, Utils } from "@blueprintjs/table";
 
 export interface ITableFreezingExampleState {
@@ -29,7 +29,7 @@ const NUM_COLUMNS = 20;
 const NUM_FROZEN_ROWS = 2;
 const NUM_FROZEN_COLUMNS = 1;
 
-export class TableFreezingExample extends React.PureComponent<IExampleProps, ITableFreezingExampleState> {
+export class TableFreezingExample extends React.PureComponent<ExampleProps, ITableFreezingExampleState> {
     public render() {
         return (
             <Example options={false} showOptionsBelowExample={true} {...this.props}>

--- a/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2, TableLoadingOption } from "@blueprintjs/table";
 
 interface IBigSpaceRock {

--- a/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2, TableLoadingOption } from "@blueprintjs/table";
 
 interface IBigSpaceRock {
@@ -33,7 +33,7 @@ export interface ITableLoadingExampleState {
     rowHeadersLoading?: boolean;
 }
 
-export class TableLoadingExample extends React.PureComponent<IExampleProps, ITableLoadingExampleState> {
+export class TableLoadingExample extends React.PureComponent<ExampleProps, ITableLoadingExampleState> {
     public state: ITableLoadingExampleState = {
         cellsLoading: true,
         columnHeadersLoading: true,

--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IBaseExampleProps, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, IBaseExampleProps, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2, Utils } from "@blueprintjs/table";
 
 export interface ITableReorderableExampleState {
@@ -34,7 +34,7 @@ const REORDERABLE_TABLE_DATA = [
     ["E", "Eggplant", "Elk", "Eritrea", "El Paso"],
 ].map(([letter, fruit, animal, country, city]) => ({ letter, fruit, animal, country, city }));
 
-export class TableReorderableExample extends React.PureComponent<IExampleProps, ITableReorderableExampleState> {
+export class TableReorderableExample extends React.PureComponent<ExampleProps, ITableReorderableExampleState> {
     public state: ITableReorderableExampleState = {
         columns: [
             // these cellRenderers are only created once and then cloned on updates

--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IBaseExampleProps, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, IBaseExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2, Utils } from "@blueprintjs/table";
 
 export interface ITableReorderableExampleState {

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -19,7 +19,7 @@
 import * as React from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
-import { Example, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import {
     Cell,
     Column,
@@ -182,7 +182,7 @@ class RecordSortableColumn extends AbstractSortableColumn {
     };
 }
 
-export class TableSortableExample extends React.PureComponent<IExampleProps> {
+export class TableSortableExample extends React.PureComponent<ExampleProps> {
     public state = {
         columns: [
             new TextSortableColumn("Rikishi", 0),

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -24,7 +24,7 @@
 import * as React from "react";
 
 import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 import { TimezoneDisplayFormat, TimezonePicker } from "@blueprintjs/timezone";
 
 import { CustomTimezonePickerTarget } from "./components";

--- a/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
+++ b/packages/docs-app/src/examples/timezone-examples/timezonePickerExample.tsx
@@ -24,7 +24,7 @@
 import * as React from "react";
 
 import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, handleValueChange, IExampleProps } from "@blueprintjs/docs-theme";
+import { Example, handleBooleanChange, handleValueChange, ExampleProps } from "@blueprintjs/docs-theme";
 import { TimezoneDisplayFormat, TimezonePicker } from "@blueprintjs/timezone";
 
 import { CustomTimezonePickerTarget } from "./components";
@@ -37,7 +37,7 @@ export interface ITimezonePickerExampleState {
     timezone: string;
 }
 
-export class TimezonePickerExample extends React.PureComponent<IExampleProps, ITimezonePickerExampleState> {
+export class TimezonePickerExample extends React.PureComponent<ExampleProps, ITimezonePickerExampleState> {
     public state: ITimezonePickerExampleState = {
         disabled: false,
         showCustomTarget: false,

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { IExampleMap, ExampleProps } from "@blueprintjs/docs-theme";
+import { ExampleProps, IExampleMap } from "@blueprintjs/docs-theme";
 
 import { getTheme } from "../components/blueprintDocs";
 import * as CoreExamples from "../examples/core-examples";

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { IExampleMap, IExampleProps } from "@blueprintjs/docs-theme";
+import { IExampleMap, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { getTheme } from "../components/blueprintDocs";
 import * as CoreExamples from "../examples/core-examples";
@@ -32,7 +32,7 @@ const SRC_HREF_BASE = "https://github.com/palantir/blueprint/blob/develop/packag
 
 function getPackageExamples(
     packageName: string,
-    packageExamples: { [name: string]: React.ComponentClass<IExampleProps<IBlueprintExampleData>> },
+    packageExamples: { [name: string]: React.ComponentClass<ExampleProps<IBlueprintExampleData>> },
 ) {
     const ret: IExampleMap = {};
     for (const exampleName of Object.keys(packageExamples)) {

--- a/packages/docs-app/src/tags/types.ts
+++ b/packages/docs-app/src/tags/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/** Interface for `IExampleProps` `data` in this here Blueprint docs-app. */
+/** Interface for `ExampleProps` `data` in this here Blueprint docs-app. */
 export interface IBlueprintExampleData {
     /** CSS class of theme, typically `""` or `Classes.DARK`. */
     themeName: string;

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -19,8 +19,12 @@ import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 
+/** @deprecated use ExampleProps */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export interface IExampleProps<T = {}> extends Props {
+export type IExampleProps<T = {}> = ExampleProps<T>;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export interface ExampleProps<T = {}> extends Props {
     /**
      * Identifier of this example.
      * This will appear as the `data-example-id` attribute on the DOM element.
@@ -45,7 +49,7 @@ export interface IExampleProps<T = {}> extends Props {
  * Props supported by the `Example` component.
  * Additional props will be spread to the root `<div>` element.
  */
-export interface IDocsExampleProps extends IExampleProps {
+export interface IDocsExampleProps extends ExampleProps {
     children?: React.ReactNode;
 
     /**
@@ -85,10 +89,10 @@ export interface IDocsExampleProps extends IExampleProps {
  * Container for an example and its options.
  *
  * ```tsx
- * import { Example, IExampleProps } from "@blueprintjs/docs-theme";
- * // use IExampleProps as your props type,
+ * import { Example, ExampleProps } from "@blueprintjs/docs-theme";
+ * // use ExampleProps as your props type,
  * // then spread it to <Example> below
- * export class MyExample extends React.PureComponent<IExampleProps, [your state]> {
+ * export class MyExample extends React.PureComponent<ExampleProps, [your state]> {
  *     public render() {
  *         const options = (
  *             <>

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -19,11 +19,11 @@ import * as React from "react";
 
 import { AnchorButton, Intent } from "@blueprintjs/core";
 
-import { IExampleProps } from "../components/example";
+import { ExampleProps } from "../components/example";
 
 export interface IExample {
     sourceUrl: string;
-    render: (props: IExampleProps) => JSX.Element | undefined;
+    render: (props: ExampleProps) => JSX.Element | undefined;
 }
 
 // construct a map of package name to all examples defined in that package.

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -16,18 +16,21 @@
 
 import { IRef } from "@blueprintjs/core";
 
-import { ICreateNewItem } from "./listItemsUtils";
+import { CreateNewItem } from "./listItemsUtils";
+
+/** @deprecated use ItemListRendererProps */
+export type IItemListRendererProps<T> = ItemListRendererProps<T>;
 
 /**
  * An object describing how to render the list of items.
  * An `itemListRenderer` receives this object as its sole argument.
  */
-export interface IItemListRendererProps<T> {
+export interface ItemListRendererProps<T> {
     /**
      * The currently focused item (for keyboard interactions), or `null` to
      * indicate that no item is active.
      */
-    activeItem: T | ICreateNewItem | null;
+    activeItem: T | CreateNewItem | null;
 
     /**
      * Array of items filtered by `itemListPredicate` or `itemPredicate`.
@@ -77,7 +80,7 @@ export interface IItemListRendererProps<T> {
 }
 
 /** Type alias for a function that renders the list of items. */
-export type ItemListRenderer<T> = (itemListProps: IItemListRendererProps<T>) => JSX.Element | null;
+export type ItemListRenderer<T> = (itemListProps: ItemListRendererProps<T>) => JSX.Element | null;
 
 /**
  * `ItemListRenderer` helper method for rendering each item in `filteredItems`,
@@ -85,7 +88,7 @@ export type ItemListRenderer<T> = (itemListProps: IItemListRendererProps<T>) => 
  * and `initialContent` (when query is empty).
  */
 export function renderFilteredItems(
-    props: IItemListRendererProps<any>,
+    props: ItemListRendererProps<any>,
     noResults?: React.ReactNode,
     initialContent?: React.ReactNode | null,
 ): React.ReactNode {

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -16,7 +16,10 @@
 
 import { MouseEventHandler } from "react";
 
-export interface IItemModifiers {
+/** @deprecated use ItemModifiers */
+export type IItemModifiers = ItemModifiers;
+
+export interface ItemModifiers {
     /** Whether this is the "active" (focused) item, meaning keyboard interactions will act upon it. */
     active: boolean;
 
@@ -27,11 +30,14 @@ export interface IItemModifiers {
     matchesPredicate: boolean;
 }
 
+/** @deprecated use ItemRendererProps */
+export type IItemRendererProps = ItemRendererProps;
+
 /**
  * An object describing how to render a particular item.
  * An `itemRenderer` receives the item as its first argument, and this object as its second argument.
  */
-export interface IItemRendererProps {
+export interface ItemRendererProps {
     /** Click event handler to select this item. */
     handleClick: MouseEventHandler<HTMLElement>;
 
@@ -46,11 +52,11 @@ export interface IItemRendererProps {
     index: number;
 
     /** Modifiers that describe how to render this item, such as `active` or `disabled`. */
-    modifiers: IItemModifiers;
+    modifiers: ItemModifiers;
 
     /** The current query string used to filter the items. */
     query: string;
 }
 
 /** Type alias for a function that receives an item and props and renders a JSX element (or `null`). */
-export type ItemRenderer<T> = (item: T, itemProps: IItemRendererProps) => JSX.Element | null;
+export type ItemRenderer<T> = (item: T, itemProps: ItemRendererProps) => JSX.Element | null;

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -18,30 +18,33 @@ import { Props, Utils } from "@blueprintjs/core";
 
 import { ItemListRenderer } from "./itemListRenderer";
 import { ItemRenderer } from "./itemRenderer";
-import { ICreateNewItem } from "./listItemsUtils";
+import { CreateNewItem } from "./listItemsUtils";
 import { ItemListPredicate, ItemPredicate } from "./predicate";
 
 /**
- * Equality test comparator to determine if two {@link IListItemsProps} items are equivalent.
+ * Equality test comparator to determine if two {@link ListItemsProps} items are equivalent.
  *
  * @return `true` if the two items are equivalent.
  */
 export type ItemsEqualComparator<T> = (itemA: T, itemB: T) => boolean;
 
 /**
- * Union of all possible types for {@link IListItemsProps#itemsEqual}.
+ * Union of all possible types for {@link ListItemsProps#itemsEqual}.
  */
 export type ItemsEqualProp<T> = ItemsEqualComparator<T> | keyof T;
 
+/** @deprecated use ListItemsProps */
+export type IListItemsProps<T> = ListItemsProps<T>;
+
 /** Reusable generic props for a component that operates on a filterable, selectable list of `items`. */
-export interface IListItemsProps<T> extends Props {
+export interface ListItemsProps<T> extends Props {
     /**
      * The currently focused item for keyboard interactions, or `null` to
      * indicate that no item is active. If omitted or `undefined`, this prop will be
      * uncontrolled (managed by the component's state). Use `onActiveItemChange`
      * to listen for updates.
      */
-    activeItem?: T | ICreateNewItem | null;
+    activeItem?: T | CreateNewItem | null;
 
     /** Array of items in the list. */
     items: T[];
@@ -139,11 +142,11 @@ export interface IListItemsProps<T> extends Props {
      *
      * If the "Create Item" option is displayed and currently active, then
      * `isCreateNewItem` will be `true` and `activeItem` will be `null`. In this
-     * case, you should provide a valid `ICreateNewItem` object to the
+     * case, you should provide a valid `CreateNewItem` object to the
      * `activeItem` _prop_ in order for the "Create Item" option to appear as
      * active.
      *
-     * __Note:__ You can instantiate a `ICreateNewItem` object using the
+     * __Note:__ You can instantiate a `CreateNewItem` object using the
      * `getCreateNewItem()` utility exported from this package.
      */
     onActiveItemChange?: (activeItem: T | null, isCreateNewItem: boolean) => void;
@@ -228,7 +231,7 @@ export interface IListItemsProps<T> extends Props {
 }
 
 /**
- * Utility function for executing the {@link IListItemsProps#itemsEqual} prop to test
+ * Utility function for executing the {@link ListItemsProps#itemsEqual} prop to test
  * for equality between two items.
  *
  * @return `true` if the two items are equivalent according to `itemsEqualProp`.

--- a/packages/select/src/common/listItemsUtils.ts
+++ b/packages/select/src/common/listItemsUtils.ts
@@ -16,17 +16,20 @@
 
 /* eslint-disable no-underscore-dangle */
 
+/** @deprecated use CreateNewItem */
+export type ICreateNewItem = CreateNewItem;
+
 /**
  * The reserved type of the "Create Item" option in item lists. This is intended
  * not to conflict with any custom item type `T` that might be used in  item
  * list.
  */
-export interface ICreateNewItem {
+export interface CreateNewItem {
     __blueprintCreateNewItemBrand: "blueprint-create-new-item";
 }
 
 /** Returns an instance of a "Create Item" object. */
-export function getCreateNewItem(): ICreateNewItem {
+export function getCreateNewItem(): CreateNewItem {
     return { __blueprintCreateNewItemBrand: "blueprint-create-new-item" };
 }
 
@@ -34,18 +37,18 @@ export function getCreateNewItem(): ICreateNewItem {
  * Type guard returning `true` if the provided item (e.g. the current
  * `activeItem`) is a "Create Item" option.
  */
-export function isCreateNewItem<T>(item: T | ICreateNewItem | null | undefined): item is ICreateNewItem {
+export function isCreateNewItem<T>(item: T | CreateNewItem | null | undefined): item is CreateNewItem {
     if (item == null) {
         return false;
     }
 
-    // see if the provided item exactly matches the `ICreateNewItem` object,
+    // see if the provided item exactly matches the `CreateNewItem` object,
     // with no superfluous keys.
     const keys = Object.keys(item);
     if (keys.length !== 1 || keys[0] !== "__blueprintCreateNewItemBrand") {
         return false;
     }
-    return (item as ICreateNewItem).__blueprintCreateNewItemBrand === "blueprint-create-new-item";
+    return (item as CreateNewItem).__blueprintCreateNewItemBrand === "blueprint-create-new-item";
 }
 
 /**
@@ -53,6 +56,6 @@ export function isCreateNewItem<T>(item: T | ICreateNewItem | null | undefined):
  * the `activeItem` is `undefined` or a "Create Item" option, in which case
  * `null` will be returned instead.
  */
-export function getActiveItem<T>(activeItem: T | ICreateNewItem | null | undefined): T | null {
+export function getActiveItem<T>(activeItem: T | CreateNewItem | null | undefined): T | null {
     return activeItem == null || isCreateNewItem(activeItem) ? null : activeItem;
 }

--- a/packages/select/src/common/predicate.ts
+++ b/packages/select/src/common/predicate.ts
@@ -16,12 +16,12 @@
 
 /**
  * A custom predicate for returning an entirely new `items` array based on the provided query.
- * See usage sites in `IListItemsProps`.
+ * See usage sites in `ListItemsProps`.
  */
 export type ItemListPredicate<T> = (query: string, items: T[]) => T[];
 
 /**
  * A custom predicate for filtering items based on the provided query.
- * See usage sites in `IListItemsProps`.
+ * See usage sites in `ListItemsProps`.
  */
 export type ItemPredicate<T> = (query: string, item: T, index?: number, exactMatch?: boolean) => boolean;

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -39,14 +39,14 @@ import {
     TagInputProps,
 } from "@blueprintjs/core";
 
-import { Classes, IListItemsProps } from "../../common";
+import { Classes, ListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
 export type MultiSelectProps<T> = IMultiSelectProps<T>;
 /** @deprecated use MultiSelectProps */
-export interface IMultiSelectProps<T> extends IListItemsProps<T> {
+export interface IMultiSelectProps<T> extends ListItemsProps<T> {
     /**
      * Whether the component should take up the full width of its container.
      * This overrides `popoverProps.fill` and `tagInputProps.fill`.

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -32,10 +32,10 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
+import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
-export interface MultiSelect2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+export interface MultiSelect2Props<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
      * Whether the component is non-interactive.
      * If true, the list's item renderer will not be called.

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -19,13 +19,13 @@ import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, InputGroup, InputGroupProps2, Overlay, OverlayProps } from "@blueprintjs/core";
 
-import { Classes, IListItemsProps } from "../../common";
+import { Classes, ListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 // eslint-disable-next-line deprecation/deprecation
 export type OmnibarProps<T> = IOmnibarProps<T>;
 /** @deprecated use OmnibarProps */
-export interface IOmnibarProps<T> extends IListItemsProps<T> {
+export interface IOmnibarProps<T> extends ListItemsProps<T> {
     /**
      * Props to spread to the query `InputGroup`. Use `query` and
      * `onQueryChange` instead of `inputProps.value` and `inputProps.onChange`

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -19,21 +19,21 @@ import * as React from "react";
 import { AbstractComponent2, DISPLAYNAME_PREFIX, Keys, Menu, Props, Utils } from "@blueprintjs/core";
 
 import {
+    CreateNewItem,
     executeItemsEqual,
     getActiveItem,
     getCreateNewItem,
-    ICreateNewItem,
-    IItemListRendererProps,
-    ItemModifiers,
-    IListItemsProps,
     isCreateNewItem,
+    ItemListRendererProps,
+    ItemModifiers,
+    ListItemsProps,
     renderFilteredItems,
 } from "../../common";
 
 // eslint-disable-next-line deprecation/deprecation
 export type QueryListProps<T> = IQueryListProps<T>;
 /** @deprecated use QueryListProps */
-export interface IQueryListProps<T> extends IListItemsProps<T> {
+export interface IQueryListProps<T> extends ListItemsProps<T> {
     /**
      * Initial active item, useful if the parent component is controlling its selectedItem but
      * not activeItem.
@@ -128,7 +128,7 @@ export interface IQueryListRendererProps<T> // Omit `createNewItem`, because it'
 
 export interface IQueryListState<T> {
     /** The currently focused item (for keyboard interactions). */
-    activeItem: T | ICreateNewItem | null;
+    activeItem: T | CreateNewItem | null;
 
     /**
      * The item returned from `createNewItemFromQuery(this.state.query)`, cached
@@ -175,7 +175,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
      * or key interactions). When scrollToActiveItem = false, used to detect if
      * an unexpected external change to the active item has been made.
      */
-    private expectedNextActiveItem: T | ICreateNewItem | null = null;
+    private expectedNextActiveItem: T | CreateNewItem | null = null;
 
     /**
      * Flag which is set to true while in between an ENTER "keydown" event and its
@@ -332,7 +332,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
         }
     }
 
-    public setActiveItem(activeItem: T | ICreateNewItem | null) {
+    public setActiveItem(activeItem: T | CreateNewItem | null) {
         this.expectedNextActiveItem = activeItem;
         if (this.props.activeItem === undefined) {
             // indicate that the active item may need to be scrolled into view after update.
@@ -348,7 +348,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
     }
 
     /** default `itemListRenderer` implementation */
-    private renderItemList = (listProps: IItemListRendererProps<T>) => {
+    private renderItemList = (listProps: ItemListRendererProps<T>) => {
         const { initialContent, noResults } = this.props;
 
         // omit noResults if createNewItemFromQuery and createNewItemRenderer are both supplied, and query is not empty
@@ -549,7 +549,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
      * @param direction amount to move in each iteration, typically +/-1
      * @param startIndex item to start iteration
      */
-    private getNextActiveItem(direction: number, startIndex = this.getActiveIndex()): T | ICreateNewItem | null {
+    private getNextActiveItem(direction: number, startIndex = this.getActiveIndex()): T | CreateNewItem | null {
         if (this.isCreateItemRendered()) {
             const reachedCreate =
                 (startIndex === 0 && direction === -1) ||
@@ -633,7 +633,7 @@ function wrapNumber(value: number, min: number, max: number) {
     return value;
 }
 
-function isItemDisabled<T>(item: T | null, index: number, itemDisabled?: IListItemsProps<T>["itemDisabled"]) {
+function isItemDisabled<T>(item: T | null, index: number, itemDisabled?: ListItemsProps<T>["itemDisabled"]) {
     if (itemDisabled == null || item == null) {
         return false;
     } else if (Utils.isFunction(itemDisabled)) {
@@ -656,7 +656,7 @@ export function getFirstEnabledItem<T>(
     itemDisabled?: keyof T | ((item: T, index: number) => boolean),
     direction = 1,
     startIndex = items.length - 1,
-): T | ICreateNewItem | null {
+): T | CreateNewItem | null {
     if (items.length === 0) {
         return null;
     }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -24,7 +24,7 @@ import {
     getCreateNewItem,
     ICreateNewItem,
     IItemListRendererProps,
-    IItemModifiers,
+    ItemModifiers,
     IListItemsProps,
     isCreateNewItem,
     renderFilteredItems,
@@ -373,7 +373,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
         if (this.props.disabled !== true) {
             const { activeItem, query, filteredItems } = this.state;
 
-            const modifiers: IItemModifiers = {
+            const modifiers: ItemModifiers = {
                 active: executeItemsEqual(this.props.itemsEqual, getActiveItem(activeItem), item),
                 disabled: isItemDisabled(item, index, this.props.itemDisabled),
                 matchesPredicate: filteredItems.indexOf(item) >= 0,

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -39,12 +39,12 @@ import {
     setRef,
 } from "@blueprintjs/core";
 
-import { Classes, IListItemsProps } from "../../common";
+import { Classes, ListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export type SelectProps<T> = ISelectProps<T>;
 /** @deprecated use SelectProps */
-export interface ISelectProps<T> extends IListItemsProps<T> {
+export interface ISelectProps<T> extends ListItemsProps<T> {
     children?: React.ReactNode;
 
     /**

--- a/packages/select/src/components/select/select2.md
+++ b/packages/select/src/components/select/select2.md
@@ -132,7 +132,7 @@ in the list, based on the current query string. Use `createNewItemFromQuery` and
 <div class="@ns-callout @ns-intent-warning @ns-icon-info-sign">
     <h4 class="@ns-heading">Avoiding type conflicts</h4>
 
-The "Create Item" option is represented by the reserved type `ICreateNewItem`
+The "Create Item" option is represented by the reserved type `CreateNewItem`
 exported from this package. It is exceedingly unlikely but technically possible
 for your custom type `<T>` to conflict with this type. If your type conflicts,
 you may see unexpected behavior; to resolve, consider changing the schema for
@@ -205,11 +205,11 @@ activeItem={isCreateNewItemActive ? getCreateNewItem() : activeItem}
 Altogether, the code might look something like this:
 
 ```tsx
-const currentActiveItem: Film | ICreateNewItem | null;
-const isCreateNewItemActive: Film | ICreateNewItem | null;
+const currentActiveItem: Film | CreateNewItem | null;
+const isCreateNewItemActive: Film | CreateNewItem | null;
 
 function handleActiveItemChange(
-    activeItem: Film | ICreateNewItem | null,
+    activeItem: Film | CreateNewItem | null,
     isCreateNewItem: boolean,
 ) {
     currentActiveItem = activeItem;
@@ -305,4 +305,4 @@ const renderMenu: ItemListRenderer<Film> = ({ items, itemsParentRef, query, rend
 />
 ```
 
-@interface IItemListRendererProps
+@interface ItemListRendererProps

--- a/packages/select/src/components/select/select2.md
+++ b/packages/select/src/components/select/select2.md
@@ -273,7 +273,7 @@ const renderFilm: ItemRenderer<Film> = (film, { handleClick, handleFocus, modifi
 <FilmSelect itemPredicate={filterFilm} itemRenderer={renderFilm} items={...} onItemSelect={...} />
 ```
 
-@interface IItemRendererProps
+@interface ItemRendererProps
 
 @### Item list renderer
 

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -34,10 +34,10 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
+import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
-export interface Select2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+export interface Select2Props<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
      * Element which triggers the select popover. In most cases, you should display
      * the name or label of the curently selected item here.

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -39,12 +39,12 @@ import {
     setRef,
 } from "@blueprintjs/core";
 
-import { Classes, IListItemsProps } from "../../common";
+import { Classes, ListItemsProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
 export type SuggestProps<T> = ISuggestProps<T>;
 /** @deprecated use SuggestProps */
-export interface ISuggestProps<T> extends IListItemsProps<T> {
+export interface ISuggestProps<T> extends ListItemsProps<T> {
     /**
      * Whether the popover should close after selecting an item.
      *

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -33,10 +33,10 @@ import {
 } from "@blueprintjs/core";
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
-import { Classes, IListItemsProps, SelectPopoverProps } from "../../common";
+import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
 
-export interface Suggest2Props<T> extends IListItemsProps<T>, SelectPopoverProps {
+export interface Suggest2Props<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
      * Whether the popover should close after selecting an item.
      *

--- a/packages/select/test/listItemsPropsTests.ts
+++ b/packages/select/test/listItemsPropsTests.ts
@@ -19,7 +19,7 @@ import * as sinon from "sinon";
 
 import { executeItemsEqual } from "../src/common/listItemsProps";
 
-describe("IListItemsProps Utils", () => {
+describe("ListItemsProps Utils", () => {
     describe("executeItemsEqual", () => {
         // interface for a non-primitive item value
         interface IItemObject {

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -24,7 +24,7 @@ import { dispatchTestKeyboardEventWithCode } from "@blueprintjs/test-commons";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IItemRendererProps, MultiSelect2, MultiSelect2Props, MultiSelect2State } from "../src";
+import { ItemRendererProps, MultiSelect2, MultiSelect2Props, MultiSelect2State } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
@@ -39,7 +39,7 @@ describe("<MultiSelect2>", () => {
     };
     let handlers: {
         itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
-        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        itemRenderer: sinon.SinonSpy<[IFilm, ItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
     let testsContainerElement: HTMLElement | undefined;

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -31,7 +31,7 @@ import { dispatchTestKeyboardEventWithCode } from "@blueprintjs/test-commons";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { ItemRendererProps, IMultiSelectProps, IMultiSelectState, MultiSelect } from "../src";
+import { IMultiSelectProps, IMultiSelectState, ItemRendererProps, MultiSelect } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<MultiSelect>", () => {

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -31,7 +31,7 @@ import { dispatchTestKeyboardEventWithCode } from "@blueprintjs/test-commons";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IItemRendererProps, IMultiSelectProps, IMultiSelectState, MultiSelect } from "../src";
+import { ItemRendererProps, IMultiSelectProps, IMultiSelectState, MultiSelect } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<MultiSelect>", () => {
@@ -45,7 +45,7 @@ describe("<MultiSelect>", () => {
     };
     let handlers: {
         itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
-        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        itemRenderer: sinon.SinonSpy<[IFilm, ItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
 

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -18,10 +18,10 @@ import { assert } from "chai";
 import * as React from "react";
 import sinon from "sinon";
 
-import { IItemListRendererProps, renderFilteredItems } from "../src";
+import { ItemListRendererProps, renderFilteredItems } from "../src";
 
 describe("renderFilteredItems()", () => {
-    const PROPS: IItemListRendererProps<string> = {
+    const PROPS: ItemListRendererProps<string> = {
         activeItem: "one",
         filteredItems: ["one"],
         items: ["one", "two", "three"],

--- a/packages/select/test/select2Tests.tsx
+++ b/packages/select/test/select2Tests.tsx
@@ -23,7 +23,7 @@ import { InputGroup, Keys, MenuItem } from "@blueprintjs/core";
 import { Popover2 } from "@blueprintjs/popover2";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IItemRendererProps, Select2, Select2Props, Select2State } from "../src";
+import { ItemRendererProps, Select2, Select2Props, Select2State } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
@@ -36,7 +36,7 @@ describe("<Select2>", () => {
     };
     let handlers: {
         itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
-        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        itemRenderer: sinon.SinonSpy<[IFilm, ItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
     let testsContainerElement: HTMLElement | undefined;

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -29,10 +29,10 @@ import {
     renderFilm,
     TOP_100_FILMS,
 } from "../../docs-app/src/common/films";
-import { IListItemsProps } from "../src";
+import { ListItemsProps } from "../src";
 
-export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
-    render: (props: IListItemsProps<IFilm>) => ReactWrapper<P, S>,
+export function selectComponentSuite<P extends ListItemsProps<IFilm>, S>(
+    render: (props: ListItemsProps<IFilm>) => ReactWrapper<P, S>,
     findInput: (wrapper: ReactWrapper<P, S>) => ReactWrapper<HTMLInputProps> = wrapper =>
         wrapper.find("input") as ReactWrapper<HTMLInputProps>,
     findItems: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper => wrapper.find("a"),
@@ -227,7 +227,7 @@ export function selectComponentSuite<P extends IListItemsProps<IFilm>, S>(
             assert.equal(testProps.onActiveItemChange.lastCall.args[1], false);
         });
 
-        it("when create item is rendered, arrow up invokes onActiveItemChange with an `ICreateNewItem`", () => {
+        it("when create item is rendered, arrow up invokes onActiveItemChange with an `CreateNewItem`", () => {
             const wrapper = render({
                 ...testCreateProps,
                 query: TOP_100_FILMS[0].title,

--- a/packages/select/test/selectPopoverTestSuite.tsx
+++ b/packages/select/test/selectPopoverTestSuite.tsx
@@ -21,15 +21,15 @@ import * as sinon from "sinon";
 import { Classes as Popover2Classes } from "@blueprintjs/popover2";
 
 import { areFilmsEqual, filterFilm, IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IListItemsProps, SelectPopoverProps } from "../src";
+import { ListItemsProps, SelectPopoverProps } from "../src";
 
 /**
  * Common tests for popover functionality in select components which use Popover2.
  *
  * render() should ensure the component is attached to a DOM node so that we can get accurate DOM measurements.
  */
-export function selectPopoverTestSuite<P extends IListItemsProps<IFilm>, S>(
-    render: (props: IListItemsProps<IFilm> & SelectPopoverProps) => ReactWrapper<P, S>,
+export function selectPopoverTestSuite<P extends ListItemsProps<IFilm>, S>(
+    render: (props: ListItemsProps<IFilm> & SelectPopoverProps) => ReactWrapper<P, S>,
     findPopover: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper =>
         wrapper.find(`.${Popover2Classes.POPOVER2}`),
     findTarget: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper =>

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -29,7 +29,7 @@ import * as sinon from "sinon";
 import { Classes, InputGroup, Keys, Popover } from "@blueprintjs/core";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IItemRendererProps, ISelectProps, ISelectState, Select } from "../src";
+import { ItemRendererProps, ISelectProps, ISelectState, Select } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<Select>", () => {
@@ -41,7 +41,7 @@ describe("<Select>", () => {
     };
     let handlers: {
         itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
-        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        itemRenderer: sinon.SinonSpy<[IFilm, ItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
     let testsContainerElement: HTMLElement | undefined;

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -29,7 +29,7 @@ import * as sinon from "sinon";
 import { Classes, InputGroup, Keys, Popover } from "@blueprintjs/core";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { ItemRendererProps, ISelectProps, ISelectState, Select } from "../src";
+import { ISelectProps, ISelectState, ItemRendererProps, Select } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<Select>", () => {

--- a/packages/select/test/suggest2Tests.tsx
+++ b/packages/select/test/suggest2Tests.tsx
@@ -23,7 +23,7 @@ import { InputGroup, Keys, MenuItem } from "@blueprintjs/core";
 import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IItemRendererProps, QueryList } from "../src";
+import { ItemRendererProps, QueryList } from "../src";
 import { Suggest2, Suggest2Props, Suggest2State } from "../src/components/suggest/suggest2";
 import { selectComponentSuite } from "./selectComponentSuite";
 import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
@@ -38,7 +38,7 @@ describe("Suggest2", () => {
     let handlers: {
         inputValueRenderer: sinon.SinonSpy<[IFilm], string>;
         itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
-        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        itemRenderer: sinon.SinonSpy<[IFilm, ItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
     let testsContainerElement: HTMLElement | undefined;

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -29,7 +29,7 @@ import * as sinon from "sinon";
 import { InputGroup, IPopoverProps, Keys, MenuItem, Popover } from "@blueprintjs/core";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
-import { IItemRendererProps, QueryList } from "../src";
+import { ItemRendererProps, QueryList } from "../src";
 import { ISuggestProps, ISuggestState, Suggest } from "../src/components/suggest/suggest";
 import { selectComponentSuite } from "./selectComponentSuite";
 
@@ -43,7 +43,7 @@ describe("Suggest", () => {
     let handlers: {
         inputValueRenderer: sinon.SinonSpy<[IFilm], string>;
         itemPredicate: sinon.SinonSpy<[string, IFilm], boolean>;
-        itemRenderer: sinon.SinonSpy<[IFilm, IItemRendererProps], JSX.Element | null>;
+        itemRenderer: sinon.SinonSpy<[IFilm, ItemRendererProps], JSX.Element | null>;
         onItemSelect: sinon.SinonSpy;
     };
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

This PR adds the final remaining migration APIs which will allow us to fully drop the "I" interface name prefixes in Blueprint v5.0:

- [core] :x: `IToaster` -> `ToasterInstance`
- [core] :x: `IToastProps` -> `ToastProps`
  - N.B. this was already available before this PR, but the old name was not deprecated yet
- [docs-theme] :x: `IExampleProps` -> `ExampleProps`
- [select] :x: `IItemRendererProps` -> `ItemRendererProps`
- [select] :x: `IItemListRendererProps` -> `ItemListRendererProps`
- [select] :x: `IListItemsProps` -> `ListItemsProps`
- [select] :x: `ICreateNewItem` -> `CreateNewItem`

